### PR TITLE
refactor(scm): use scm for mergeBranch, mergeToLocal

### DIFF
--- a/lib/modules/platform/default-scm.spec.ts
+++ b/lib/modules/platform/default-scm.spec.ts
@@ -60,4 +60,16 @@ describe('modules/platform/default-scm', () => {
     await defaultGitScm.checkoutBranch('branchName');
     expect(git.checkoutBranch).toHaveBeenCalledTimes(1);
   });
+
+  it('delegate mergeAndPush to util/git', async () => {
+    git.mergeBranch.mockResolvedValueOnce();
+    await defaultGitScm.mergeAndPush('branchName');
+    expect(git.mergeBranch).toHaveBeenCalledWith('branchName');
+  });
+
+  it('delegate mergeBranch to util/git', async () => {
+    git.mergeToLocal.mockResolvedValueOnce();
+    await defaultGitScm.mergeToLocal('branchName');
+    expect(git.mergeToLocal).toHaveBeenCalledWith('branchName');
+  });
 });

--- a/lib/modules/platform/default-scm.ts
+++ b/lib/modules/platform/default-scm.ts
@@ -38,4 +38,12 @@ export class DefaultGitScm implements PlatformScm {
   checkoutBranch(branchName: string): Promise<CommitSha> {
     return git.checkoutBranch(branchName);
   }
+
+  mergeAndPush(branchName: string): Promise<void> {
+    return git.mergeBranch(branchName);
+  }
+
+  mergeToLocal(branchName: string): Promise<void> {
+    return git.mergeToLocal(branchName);
+  }
 }

--- a/lib/modules/platform/local/scm.spec.ts
+++ b/lib/modules/platform/local/scm.spec.ts
@@ -65,4 +65,12 @@ describe('modules/platform/local/scm', () => {
       expect(await localFs.getFileList()).toHaveLength(2);
     });
   });
+
+  it('mergeAndPush', async () => {
+    await expect(localFs.mergeAndPush('branchName')).resolves.toBeUndefined();
+  });
+
+  it('mergeBranch', async () => {
+    await expect(localFs.mergeToLocal('branchName')).resolves.toBeUndefined();
+  });
 });

--- a/lib/modules/platform/local/scm.ts
+++ b/lib/modules/platform/local/scm.ts
@@ -50,7 +50,7 @@ export class LocalFs implements PlatformScm {
   }
 
   mergeAndPush(branchName: string): Promise<void> {
-    return Promise.resolve(undefined);
+    return Promise.resolve();
   }
 
   mergeToLocal(branchName: string): Promise<void> {

--- a/lib/modules/platform/local/scm.ts
+++ b/lib/modules/platform/local/scm.ts
@@ -54,6 +54,6 @@ export class LocalFs implements PlatformScm {
   }
 
   mergeToLocal(branchName: string): Promise<void> {
-    return Promise.resolve(undefined);
+    return Promise.resolve();
   }
 }

--- a/lib/modules/platform/local/scm.ts
+++ b/lib/modules/platform/local/scm.ts
@@ -48,4 +48,12 @@ export class LocalFs implements PlatformScm {
   checkoutBranch(branchName: string): Promise<CommitSha> {
     return Promise.resolve('');
   }
+
+  mergeAndPush(branchName: string): Promise<void> {
+    return Promise.resolve(undefined);
+  }
+
+  mergeToLocal(branchName: string): Promise<void> {
+    return Promise.resolve(undefined);
+  }
 }

--- a/lib/modules/platform/types.ts
+++ b/lib/modules/platform/types.ts
@@ -235,4 +235,6 @@ export interface PlatformScm {
   commitAndPush(commitConfig: CommitFilesConfig): Promise<CommitSha | null>;
   getFileList(): Promise<string[]>;
   checkoutBranch(branchName: string): Promise<CommitSha>;
+  mergeToLocal(branchName: string): Promise<void>;
+  mergeAndPush(branchName: string): Promise<void>;
 }

--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -344,14 +344,24 @@ describe('util/git/index', () => {
       expect(merged.all).toContain('renovate/future_branch');
     });
 
-    it('does not push if localOnly=true', async () => {
+    it('should throw if branch merge throws', async () => {
+      await expect(git.mergeBranch('not_found')).rejects.toThrow();
+    });
+  });
+
+  describe('mergeToLocal(branchName)', () => {
+    it('should perform a branch merge without push', async () => {
+      expect(fs.existsSync(`${tmpDir.path}/future_file`)).toBeFalse();
       const pushSpy = jest.spyOn(SimpleGit.prototype, 'push');
-      await git.mergeBranch('renovate/future_branch', true);
+
+      await git.mergeToLocal('renovate/future_branch');
+
+      expect(fs.existsSync(`${tmpDir.path}/future_file`)).toBeTrue();
       expect(pushSpy).toHaveBeenCalledTimes(0);
     });
 
-    it('should throw if branch merge throws', async () => {
-      await expect(git.mergeBranch('not_found')).rejects.toThrow();
+    it('should throw', async () => {
+      await expect(git.mergeToLocal('not_found')).rejects.toThrow();
     });
   });
 

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -779,10 +779,38 @@ export async function deleteBranch(branchName: string): Promise<void> {
   delete config.branchCommits[branchName];
 }
 
-export async function mergeBranch(
-  branchName: string,
-  localOnly = false
-): Promise<void> {
+export async function mergeToLocal(refSpecToMerge: string): Promise<void> {
+  let status: StatusResult | undefined;
+  try {
+    await syncGit();
+    await writeGitAuthor();
+    await git.reset(ResetMode.HARD);
+    await gitRetry(() =>
+      git.checkout([
+        '-B',
+        config.currentBranch,
+        'origin/' + config.currentBranch,
+      ])
+    );
+    status = await git.status();
+    await fetchRevSpec(refSpecToMerge);
+    await gitRetry(() => git.merge(['FETCH_HEAD']));
+  } catch (err) {
+    logger.debug(
+      {
+        baseBranch: config.currentBranch,
+        baseSha: config.currentBranchSha,
+        refSpecToMerge,
+        status,
+        err,
+      },
+      'mergeLocally error'
+    );
+    throw err;
+  }
+}
+
+export async function mergeBranch(branchName: string): Promise<void> {
   let status: StatusResult | undefined;
   try {
     await syncGit();
@@ -799,13 +827,8 @@ export async function mergeBranch(
       ])
     );
     status = await git.status();
-    if (localOnly) {
-      // merge commit, don't push to origin
-      await gitRetry(() => git.merge([branchName]));
-    } else {
-      await gitRetry(() => git.merge(['--ff-only', branchName]));
-      await gitRetry(() => git.push('origin', config.currentBranch));
-    }
+    await gitRetry(() => git.merge(['--ff-only', branchName]));
+    await gitRetry(() => git.push('origin', config.currentBranch));
     incLimitedValue('Commits');
   } catch (err) {
     logger.debug(

--- a/lib/workers/repository/onboarding/branch/index.spec.ts
+++ b/lib/workers/repository/onboarding/branch/index.spec.ts
@@ -259,7 +259,7 @@ describe('workers/repository/onboarding/branch/index', () => {
       const res = await checkOnboardingBranch(config);
       expect(res.repoIsOnboarded).toBeFalse();
       expect(res.branchList).toEqual(['renovate/configure']);
-      expect(git.mergeBranch).toHaveBeenCalledOnce();
+      expect(scm.mergeToLocal).toHaveBeenCalledOnce();
       expect(scm.commitAndPush).toHaveBeenCalledTimes(0);
     });
 
@@ -287,7 +287,7 @@ describe('workers/repository/onboarding/branch/index', () => {
         .mockReturnValueOnce('onboarding-sha');
       config.onboardingRebaseCheckbox = true;
       await checkOnboardingBranch(config);
-      expect(git.mergeBranch).not.toHaveBeenCalled();
+      expect(scm.mergeToLocal).not.toHaveBeenCalled();
     });
 
     it('processes modified onboarding branch and invalidates extract cache', async () => {
@@ -312,7 +312,7 @@ describe('workers/repository/onboarding/branch/index', () => {
       onboardingCache.isOnboardingBranchConflicted.mockResolvedValueOnce(false);
       config.baseBranch = 'master';
       await checkOnboardingBranch(config);
-      expect(git.mergeBranch).toHaveBeenCalledOnce();
+      expect(scm.mergeToLocal).toHaveBeenCalledOnce();
       expect(onboardingCache.setOnboardingCache).toHaveBeenCalledWith(
         'default-sha',
         'new-onboarding-sha',
@@ -336,7 +336,7 @@ describe('workers/repository/onboarding/branch/index', () => {
       onboardingCache.hasOnboardingBranchChanged.mockReturnValueOnce(true);
       onboardingCache.isOnboardingBranchConflicted.mockResolvedValueOnce(true);
       await checkOnboardingBranch(config);
-      expect(git.mergeBranch).not.toHaveBeenCalled();
+      expect(scm.mergeToLocal).not.toHaveBeenCalled();
       expect(onboardingCache.setOnboardingCache).toHaveBeenCalledWith(
         'default-sha',
         'onboarding-sha',
@@ -354,7 +354,7 @@ describe('workers/repository/onboarding/branch/index', () => {
         .mockReturnValueOnce('onboarding-sha');
       onboardingCache.isOnboardingBranchModified.mockResolvedValueOnce(false);
       await checkOnboardingBranch(config);
-      expect(git.mergeBranch).toHaveBeenCalled();
+      expect(scm.mergeToLocal).toHaveBeenCalled();
       expect(onboardingCache.setOnboardingCache).toHaveBeenCalledWith(
         'default-sha',
         'onboarding-sha',
@@ -383,7 +383,7 @@ describe('workers/repository/onboarding/branch/index', () => {
           `Platform '${pl}' does not support extended markdown`
         );
         expect(OnboardingState.prUpdateRequested).toBeTrue();
-        expect(git.mergeBranch).toHaveBeenCalledOnce();
+        expect(scm.mergeToLocal).toHaveBeenCalledOnce();
         expect(scm.commitAndPush).toHaveBeenCalledTimes(0);
       });
 
@@ -397,7 +397,7 @@ describe('workers/repository/onboarding/branch/index', () => {
           `No rebase checkbox was found in the onboarding PR`
         );
         expect(OnboardingState.prUpdateRequested).toBeTrue();
-        expect(git.mergeBranch).toHaveBeenCalledOnce();
+        expect(scm.mergeToLocal).toHaveBeenCalledOnce();
         expect(scm.commitAndPush).toHaveBeenCalledTimes(0);
       });
 
@@ -411,7 +411,7 @@ describe('workers/repository/onboarding/branch/index', () => {
           `Manual onboarding PR update requested`
         );
         expect(OnboardingState.prUpdateRequested).toBeTrue();
-        expect(git.mergeBranch).toHaveBeenCalledOnce();
+        expect(scm.mergeToLocal).toHaveBeenCalledOnce();
         expect(scm.commitAndPush).toHaveBeenCalledTimes(0);
       });
 
@@ -422,7 +422,7 @@ describe('workers/repository/onboarding/branch/index', () => {
         await checkOnboardingBranch(config);
 
         expect(OnboardingState.prUpdateRequested).toBeFalse();
-        expect(git.mergeBranch).toHaveBeenCalledOnce();
+        expect(scm.mergeToLocal).toHaveBeenCalledOnce();
         expect(scm.commitAndPush).toHaveBeenCalledTimes(0);
       });
     });

--- a/lib/workers/repository/onboarding/branch/index.ts
+++ b/lib/workers/repository/onboarding/branch/index.ts
@@ -8,12 +8,9 @@ import {
 } from '../../../../constants/error-messages';
 import { logger } from '../../../../logger';
 import type { Pr } from '../../../../modules/platform';
+import { scm } from '../../../../modules/platform/scm';
 import { getCache } from '../../../../util/cache/repository';
-import {
-  getBranchCommit,
-  mergeBranch,
-  setGitAuthor,
-} from '../../../../util/git';
+import { getBranchCommit, setGitAuthor } from '../../../../util/git';
 import { extractAllDependencies } from '../../extract';
 import { mergeRenovateConfig } from '../../init/merge';
 import { OnboardingState } from '../common';
@@ -113,7 +110,7 @@ export async function checkOnboardingBranch(
     // TODO #7154
     if (!isConflicted) {
       logger.debug('Merge onboarding branch in default branch');
-      await mergeBranch(onboardingBranch!, true);
+      await scm.mergeToLocal(onboardingBranch!);
     }
   }
   setOnboardingCache(

--- a/lib/workers/repository/update/branch/automerge.spec.ts
+++ b/lib/workers/repository/update/branch/automerge.spec.ts
@@ -1,4 +1,4 @@
-import { git, partial, platform, scm } from '../../../../../test/util';
+import { partial, platform, scm } from '../../../../../test/util';
 import { GlobalConfig } from '../../../../config/global';
 import type { RenovateConfig } from '../../../../config/types';
 import type { Pr } from '../../../../modules/platform/types';
@@ -64,7 +64,7 @@ describe('workers/repository/update/branch/automerge', () => {
       config.automergeType = 'branch';
       config.baseBranch = 'test-branch';
       platform.getBranchStatus.mockResolvedValueOnce('green');
-      git.mergeBranch.mockImplementationOnce(() => {
+      scm.mergeAndPush.mockImplementationOnce(() => {
         throw new Error('merge error');
       });
 

--- a/lib/workers/repository/update/branch/automerge.ts
+++ b/lib/workers/repository/update/branch/automerge.ts
@@ -3,7 +3,6 @@ import type { RenovateConfig } from '../../../../config/types';
 import { logger } from '../../../../logger';
 import { platform } from '../../../../modules/platform';
 import { scm } from '../../../../modules/platform/scm';
-import { mergeBranch } from '../../../../util/git';
 import { isScheduledNow } from './schedule';
 import { resolveBranchStatus } from './status-checks';
 
@@ -44,7 +43,7 @@ export async function tryBranchAutomerge(
         logger.info(`DRY-RUN: Would automerge branch ${config.branchName!}`);
       } else {
         await scm.checkoutBranch(config.baseBranch!);
-        await mergeBranch(config.branchName!);
+        await scm.mergeAndPush(config.branchName!);
       }
       logger.info({ branch: config.branchName }, 'Branch automerged');
       return 'automerged'; // Branch no longer exists


### PR DESCRIPTION
## Changes

move `mergeBranch` behind the PlatformScm Interface to allow overriding.

I've split the `mergeBranch` into two separate functions, because i think a "fast-forward-only" merge + push and "merge-any" without push are different things.

I'm not 100% sure whats was the reason for the local=true (without push) `mergeBranch` refactoring from #20893 was necessary. 
It sounds like the result of this merge is only temporary needed (only merge some new files from a remote-branch).


## Context

The Gerrit implementation (#18961) don't work anymore (error during onboarding) after merging #20893 because it reintroduces a (low-level) util/git mergeBranch call instead of scm.checkoutBranch.


## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

