### PR TITLE
refactor: Better tests for `Result` class

### DIFF
--- a/lib/util/result.spec.ts
+++ b/lib/util/result.spec.ts
@@ -353,34 +353,6 @@ describe('util/result', () => {
 
         expect(res).toEqual(Result.ok('F-O-O'));
       });
-
-      it('handles transforming Result into AsyncResult', async () => {
-        const res = Result.ok('foo').transform((x) =>
-          AsyncResult.ok(x.toUpperCase())
-        );
-        expect(res).toBeInstanceOf(AsyncResult);
-        await expect(res).resolves.toEqual(Result.ok('FOO'));
-      });
-
-      it('handles transforming AsyncResult into AsyncResult', async () => {
-        const res = AsyncResult.ok('foo').transform((x) =>
-          AsyncResult.ok(x.toUpperCase())
-        );
-        expect(res).toBeInstanceOf(AsyncResult);
-        await expect(res).resolves.toEqual(Result.ok('FOO'));
-      });
-
-      it('handles uncaught error thrown on AsyncResult-to-AsyncResult transform', async () => {
-        const fn = (_: string) =>
-          new AsyncResult<string, string>((_, reject) => reject('oops'));
-        const res = Result.wrap(Promise.resolve('foo')).transform(fn);
-        expect(res).toBeInstanceOf(AsyncResult);
-        await expect(res).resolves.toEqual(Result._uncaught('oops'));
-        expect(logger.logger.warn).toHaveBeenCalledWith(
-          { err: 'oops' },
-          'AsyncResult: unhandled async transform error'
-        );
-      });
     });
   });
 });

--- a/lib/util/result.ts
+++ b/lib/util/result.ts
@@ -267,7 +267,6 @@ export class Result<T, E = Error> {
     ) =>
       | NonNullable<U>
       | Result<U, EE>
-      | Result<U, EE>
       | Promise<NonNullable<U>>
   ): Result<U, E | EE> | AsyncResult<U, E | EE> {
     if (!this.res.ok) {
@@ -276,6 +275,10 @@ export class Result<T, E = Error> {
 
     try {
       const res = fn(this.res.val);
+
+      if (res instanceof Result) {
+        return res;
+      }
 
       if (res instanceof Promise) {
         return new AsyncResult((resolve) => {
@@ -290,10 +293,6 @@ export class Result<T, E = Error> {
               resolve(Result._uncaught(err) as never);
             });
         });
-      }
-
-      if (res instanceof Result) {
-        return res;
       }
 
       return Result.ok(res);
@@ -318,6 +317,14 @@ export class AsyncResult<T, E> extends Promise<Result<T, E>> {
     ) => void
   ) {
     super(executor);
+  }
+
+  static ok<T>(val: NonNullable<T>): AsyncResult<T, never> {
+    return new AsyncResult((resolve) => resolve(Result.ok(val)));
+  }
+
+  static err<E>(err: NonNullable<E>): AsyncResult<never, E> {
+    return new AsyncResult((resolve) => resolve(Result.err(err)));
   }
 
   static wrap<T, E = Error, EE = never>(
@@ -440,6 +447,10 @@ export class AsyncResult<T, E> extends Promise<Result<T, E>> {
         try {
           const newResult = fn(value);
 
+          if (newResult instanceof Result) {
+            return resolve(newResult);
+          }
+
           if (newResult instanceof Promise) {
             return newResult
               .then((asyncRes) =>
@@ -456,18 +467,14 @@ export class AsyncResult<T, E> extends Promise<Result<T, E>> {
               });
           }
 
-          if (newResult instanceof Result) {
-            return resolve(newResult);
-          }
-
           return resolve(Result.ok(newResult));
         } catch (err) {
           logger.warn({ err }, 'AsyncResult: unhandled transform error');
           return resolve(Result._uncaught(err));
         }
       }).catch((err) => {
-        // Actually, this should never happen
-        resolve(Result.err(err));
+        // Happens when `.unwrap()` of `oldResult` throws
+        resolve(Result._uncaught(err));
       });
     });
   }

--- a/lib/util/result.ts
+++ b/lib/util/result.ts
@@ -264,10 +264,7 @@ export class Result<T, E = Error> {
   transform<U, EE>(
     fn: (
       value: NonNullable<T>
-    ) =>
-      | NonNullable<U>
-      | Result<U, EE>
-      | Promise<NonNullable<U>>
+    ) => NonNullable<U> | Result<U, EE> | Promise<NonNullable<U>>
   ): Result<U, E | EE> | AsyncResult<U, E | EE> {
     if (!this.res.ok) {
       return Result.err(this.res.err);

--- a/lib/util/result.ts
+++ b/lib/util/result.ts
@@ -264,7 +264,11 @@ export class Result<T, E = Error> {
   transform<U, EE>(
     fn: (
       value: NonNullable<T>
-    ) => NonNullable<U> | Result<U, EE> | Promise<NonNullable<U>>
+    ) =>
+      | Result<U, E | EE>
+      | Promise<Result<U, E | EE>>
+      | Promise<NonNullable<U>>
+      | NonNullable<U>
   ): Result<U, E | EE> | AsyncResult<U, E | EE> {
     if (!this.res.ok) {
       return Result.err(this.res.err);
@@ -433,7 +437,7 @@ export class AsyncResult<T, E> extends Promise<Result<T, E>> {
       | Promise<Result<U, EE>>
       | Promise<NonNullable<U>>
       | NonNullable<U>
-  ): AsyncResult<U, E | EE | Error> {
+  ): AsyncResult<U, E | EE> {
     return new AsyncResult((resolve) => {
       this.then((oldResult) => {
         const { ok, val: value, err: error } = oldResult.unwrap();


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Also adds proper handling for uncaught async transform error

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
