### PR TITLE
refactor: Make `AsyncResult` a `PromiseLike`

### DIFF
--- a/lib/util/result.ts
+++ b/lib/util/result.ts
@@ -420,13 +420,13 @@ export class AsyncResult<T, E> implements PromiseLike<Result<T, E>> {
    *   ```
    */
   transform<U, EE>(
-    fn: (value: NonNullable<T>) => Result<U, EE>
+    fn: (value: NonNullable<T>) => Result<U, E | EE>
   ): AsyncResult<U, E | EE>;
   transform<U, EE>(
-    fn: (value: NonNullable<T>) => AsyncResult<U, EE>
+    fn: (value: NonNullable<T>) => AsyncResult<U, E | EE>
   ): AsyncResult<U, E | EE>;
   transform<U, EE>(
-    fn: (value: NonNullable<T>) => Promise<Result<U, EE>>
+    fn: (value: NonNullable<T>) => Promise<Result<U, E | EE>>
   ): AsyncResult<U, E | EE>;
   transform<U>(
     fn: (value: NonNullable<T>) => Promise<NonNullable<U>>
@@ -438,9 +438,9 @@ export class AsyncResult<T, E> implements PromiseLike<Result<T, E>> {
     fn: (
       value: NonNullable<T>
     ) =>
-      | Result<U, EE>
-      | AsyncResult<U, EE>
-      | Promise<Result<U, EE>>
+      | Result<U, E | EE>
+      | AsyncResult<U, E | EE>
+      | Promise<Result<U, E | EE>>
       | Promise<NonNullable<U>>
       | NonNullable<U>
   ): AsyncResult<U, E | EE> {

--- a/lib/util/result.ts
+++ b/lib/util/result.ts
@@ -1,4 +1,3 @@
-/* eslint-disable promise/no-promise-in-callback */
 import { logger } from '../logger';
 
 interface Ok<T> {
@@ -327,6 +326,7 @@ export class AsyncResult<T, E> implements PromiseLike<Result<T, E>> {
   }
 
   static err<E>(err: NonNullable<E>): AsyncResult<never, E> {
+    // eslint-disable-next-line promise/no-promise-in-callback
     return new AsyncResult(Promise.resolve(Result.err(err)));
   }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
