### PR TITLE
feat: Support `.catch` method for `Result`

### DIFF
--- a/lib/util/result.ts
+++ b/lib/util/result.ts
@@ -420,13 +420,13 @@ export class AsyncResult<T, E> implements PromiseLike<Result<T, E>> {
    *   ```
    */
   transform<U, EE>(
-    fn: (value: NonNullable<T>) => Result<U, EE>
+    fn: (value: NonNullable<T>) => Result<U, E | EE>
   ): AsyncResult<U, E | EE>;
   transform<U, EE>(
-    fn: (value: NonNullable<T>) => AsyncResult<U, EE>
+    fn: (value: NonNullable<T>) => AsyncResult<U, E | EE>
   ): AsyncResult<U, E | EE>;
   transform<U, EE>(
-    fn: (value: NonNullable<T>) => Promise<Result<U, EE>>
+    fn: (value: NonNullable<T>) => Promise<Result<U, E | EE>>
   ): AsyncResult<U, E | EE>;
   transform<U>(
     fn: (value: NonNullable<T>) => Promise<NonNullable<U>>
@@ -438,9 +438,9 @@ export class AsyncResult<T, E> implements PromiseLike<Result<T, E>> {
     fn: (
       value: NonNullable<T>
     ) =>
-      | Result<U, EE>
-      | AsyncResult<U, EE>
-      | Promise<Result<U, EE>>
+      | Result<U, E | EE>
+      | AsyncResult<U, E | EE>
+      | Promise<Result<U, E | EE>>
       | Promise<NonNullable<U>>
       | NonNullable<U>
   ): AsyncResult<U, E | EE> {

--- a/lib/util/result.ts
+++ b/lib/util/result.ts
@@ -228,6 +228,17 @@ export class Result<T, E = Error> {
   }
 
   /**
+   * Returns the ok-value or throw the error.
+   */
+  unwrapOrThrow(): NonNullable<T> {
+    if (this.res.ok) {
+      return this.res.val;
+    }
+
+    throw this.res.err;
+  }
+
+  /**
    * Transforms the ok-value, sync or async way.
    *
    * Transform functions SHOULD NOT throw.
@@ -299,6 +310,48 @@ export class Result<T, E = Error> {
       return Result.ok(result);
     } catch (err) {
       logger.warn({ err }, 'Result: unhandled transform error');
+      return Result._uncaught(err);
+    }
+  }
+
+  catch<U = T, EE = E>(
+    fn: (err: NonNullable<E>) => Result<U, E | EE>
+  ): Result<T | U, E | EE>;
+  catch<U = T, EE = E>(
+    fn: (err: NonNullable<E>) => AsyncResult<U, E | EE>
+  ): AsyncResult<T | U, E | EE>;
+  catch<U = T, EE = E>(
+    fn: (err: NonNullable<E>) => Promise<Result<U, E | EE>>
+  ): AsyncResult<T | U, E | EE>;
+  catch<U = T, EE = E>(
+    fn: (
+      err: NonNullable<E>
+    ) => Result<U, E | EE> | AsyncResult<U, E | EE> | Promise<Result<U, E | EE>>
+  ): Result<T | U, E | EE> | AsyncResult<T | U, E | EE> {
+    if (this.res.ok) {
+      return this;
+    }
+
+    if (this.res._uncaught) {
+      return this;
+    }
+
+    try {
+      const result = fn(this.res.err);
+
+      if (result instanceof Promise) {
+        return AsyncResult.wrap(result, (err) => {
+          logger.warn(
+            { err },
+            'Result: unexpected error in async catch handler'
+          );
+          return Result._uncaught(err);
+        });
+      }
+
+      return result;
+    } catch (err) {
+      logger.warn({ err }, 'Result: unexpected error in catch handler');
       return Result._uncaught(err);
     }
   }
@@ -403,6 +456,14 @@ export class AsyncResult<T, E> implements PromiseLike<Result<T, E>> {
   }
 
   /**
+   * Returns the ok-value or throw the error.
+   */
+  async unwrapOrThrow(): Promise<NonNullable<T>> {
+    const result = await this.asyncResult;
+    return result.unwrapOrThrow();
+  }
+
+  /**
    * Transforms the ok-value, sync or async way.
    *
    * Transform functions SHOULD NOT throw.
@@ -484,5 +545,25 @@ export class AsyncResult<T, E> implements PromiseLike<Result<T, E>> {
           return Result._uncaught(err);
         })
     );
+  }
+
+  catch<U = T, EE = E>(
+    fn: (err: NonNullable<E>) => Result<U, E | EE>
+  ): AsyncResult<T | U, E | EE>;
+  catch<U = T, EE = E>(
+    fn: (err: NonNullable<E>) => AsyncResult<U, E | EE>
+  ): AsyncResult<T | U, E | EE>;
+  catch<U = T, EE = E>(
+    fn: (err: NonNullable<E>) => Promise<Result<U, E | EE>>
+  ): AsyncResult<T | U, E | EE>;
+  catch<U = T, EE = E>(
+    fn: (
+      err: NonNullable<E>
+    ) => Result<U, E | EE> | AsyncResult<U, E | EE> | Promise<Result<U, E | EE>>
+  ): AsyncResult<T | U, E | EE> {
+    const caughtAsyncResult = this.asyncResult.then((result) =>
+      result.catch(fn as never)
+    );
+    return AsyncResult.wrap(caughtAsyncResult);
   }
 }

--- a/lib/util/result.ts
+++ b/lib/util/result.ts
@@ -561,6 +561,7 @@ export class AsyncResult<T, E> implements PromiseLike<Result<T, E>> {
     ) => Result<U, E | EE> | AsyncResult<U, E | EE> | Promise<Result<U, E | EE>>
   ): AsyncResult<T | U, E | EE> {
     const caughtAsyncResult = this.asyncResult.then((result) =>
+      // eslint-disable-next-line promise/no-nesting
       result.catch(fn as never)
     );
     return AsyncResult.wrap(caughtAsyncResult);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Add `.catch()` method that allows to convert errors back to good result
- Also add `.unwrapOrThrow()` method which can be useful when all relevant errors are already handled by `.catch()`

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
