### PR TITLE
test(versioning/loose): add testcase for timestamp

### DIFF
--- a/lib/modules/versioning/loose/index.spec.ts
+++ b/lib/modules/versioning/loose/index.spec.ts
@@ -49,16 +49,19 @@ describe('modules/versioning/loose/index', () => {
   });
 
   it.each`
-    a             | b              | expected
-    ${'2.4.0'}    | ${'2.4'}       | ${true}
-    ${'2.4.2'}    | ${'2.4.1'}     | ${true}
-    ${'2.4.beta'} | ${'2.4.alpha'} | ${true}
-    ${'1.9'}      | ${'2'}         | ${false}
-    ${'1.9'}      | ${'1.9.1'}     | ${false}
-    ${'2.4'}      | ${'2.4.beta'}  | ${true}
-    ${'2.4.0'}    | ${'2.4.beta'}  | ${true}
-    ${'2.4.beta'} | ${'2.4'}       | ${false}
-    ${'2.4.beta'} | ${'2.4.0'}     | ${false}
+    a                               | b                               | expected
+    ${'2.4.0'}                      | ${'2.4'}                        | ${true}
+    ${'2.4.2'}                      | ${'2.4.1'}                      | ${true}
+    ${'2.4.beta'}                   | ${'2.4.alpha'}                  | ${true}
+    ${'1.9'}                        | ${'2'}                          | ${false}
+    ${'1.9'}                        | ${'1.9.1'}                      | ${false}
+    ${'2.4'}                        | ${'2.4.beta'}                   | ${true}
+    ${'2.4.0'}                      | ${'2.4.beta'}                   | ${true}
+    ${'2.4.beta'}                   | ${'2.4'}                        | ${false}
+    ${'2.4.beta'}                   | ${'2.4.0'}                      | ${false}
+    ${'2024-07-21T11-33-05.abc123'} | ${'2023-06-21T11-33-05.abc123'} | ${true}
+    ${'2023-07-21T11-33-05.abc123'} | ${'2023-07-21T11-33-04.abc123'} | ${true}
+    ${'2023-07-21-113305-abc123'}   | ${'2023-07-21-113304-abc123'}   | ${true}
   `('isGreaterThan("$a", "$b") === $expected', ({ a, b, expected }) => {
     expect(loose.isGreaterThan(a, b)).toBe(expected);
   });


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

No behavior is changed, only added a few test cases for the *loose* versioning, testing that the comparison of timestamps works.

## Context

Added so there is no doubt that timestamps can be used for versioning with *loose*. See discussion: https://github.com/renovatebot/renovate/discussions/23477#discussioncomment-6507232

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
