### PR TITLE
refactor(rubygems): Use `Result` class

### DIFF
--- a/lib/modules/datasource/rubygems/index.spec.ts
+++ b/lib/modules/datasource/rubygems/index.spec.ts
@@ -25,8 +25,6 @@ describe('modules/datasource/rubygems/index', () => {
     it('returns null for missing pkg', async () => {
       httpMock
         .scope('https://example.com')
-        .get('/versions')
-        .reply(404)
         .get('/api/v1/versions/foobar.json')
         .reply(200, [])
         .get('/api/v1/dependencies?gems=foobar')
@@ -117,8 +115,6 @@ describe('modules/datasource/rubygems/index', () => {
     it('uses multiple source urls', async () => {
       httpMock
         .scope('https://registry-1.com/')
-        .get('/versions')
-        .reply(404)
         .get('/api/v1/versions/foobar.json')
         .reply(400)
         .get('/api/v1/dependencies?gems=foobar')
@@ -126,8 +122,6 @@ describe('modules/datasource/rubygems/index', () => {
 
       httpMock
         .scope('https://registry-2.com/nested/path')
-        .get('/versions')
-        .reply(404)
         .get('/api/v1/versions/foobar.json')
         .reply(200, [
           { number: '1.0.0', created_at: '2021-01-01' },
@@ -160,8 +154,6 @@ describe('modules/datasource/rubygems/index', () => {
     it('falls back to dependencies API', async () => {
       httpMock
         .scope('https://example.com/')
-        .get('/versions')
-        .reply(404)
         .get('/api/v1/versions/foobar.json')
         .reply(400, {})
         .get('/api/v1/dependencies?gems=foobar')
@@ -194,10 +186,10 @@ describe('modules/datasource/rubygems/index', () => {
     it('errors when version request fails with anything other than 400 or 404', async () => {
       httpMock
         .scope('https://example.com/')
-        .get('/versions')
-        .reply(404)
         .get('/api/v1/versions/foobar.json')
-        .reply(500, {});
+        .reply(500, {})
+        .get('/api/v1/dependencies?gems=foobar')
+        .reply(500);
 
       await expect(
         getPkgReleases({
@@ -212,8 +204,6 @@ describe('modules/datasource/rubygems/index', () => {
     it('returns null for GitHub Packages package miss', async () => {
       httpMock
         .scope('https://rubygems.pkg.github.com/example')
-        .get('/versions')
-        .reply(404)
         .get('/api/v1/dependencies?gems=foobar')
         .reply(200, rubyMarshal([]));
 
@@ -230,8 +220,6 @@ describe('modules/datasource/rubygems/index', () => {
     it('returns a dep for GitHub Packages package hit', async () => {
       httpMock
         .scope('https://rubygems.pkg.github.com/example')
-        .get('/versions')
-        .reply(404)
         .get('/api/v1/dependencies?gems=foobar')
         .reply(
           200,

--- a/lib/modules/datasource/rubygems/index.ts
+++ b/lib/modules/datasource/rubygems/index.ts
@@ -1,4 +1,6 @@
 import { Marshal } from '@qnighy/marshal';
+import type { ZodError } from 'zod';
+import { logger } from '../../../logger';
 import { AsyncResult, Result } from '../../../util/result';
 import { getQueryString, joinUrlParts, parseUrl } from '../../../util/url';
 import * as rubyVersioning from '../../versioning/ruby';
@@ -9,8 +11,6 @@ import { RubygemsHttp } from './http';
 import { MetadataCache } from './metadata-cache';
 import { MarshalledVersionInfo } from './schema';
 import { VersionsEndpointCache } from './versions-endpoint-cache';
-import { logger } from '../../../logger';
-import type { ZodError } from 'zod';
 
 export class RubyGemsDatasource extends Datasource {
   static readonly id = 'rubygems';

--- a/lib/modules/datasource/rubygems/metadata-cache.ts
+++ b/lib/modules/datasource/rubygems/metadata-cache.ts
@@ -55,7 +55,9 @@ export class MetadataCache {
         getV1Releases(this.http, registryUrl, packageName).transform(saveCache)
       )
       .catch(() =>
-        Result.ok({ releases: versions.map((version) => ({ version })) })
+        Result.ok({
+          releases: versions.map((version) => ({ version })),
+        })
       )
       .unwrapOrThrow();
   }

--- a/lib/modules/datasource/rubygems/schema.spec.ts
+++ b/lib/modules/datasource/rubygems/schema.spec.ts
@@ -9,18 +9,11 @@ describe('modules/datasource/rubygems/schema', () => {
         { number: '3.0.0' },
       ];
       const output = MarshalledVersionInfo.parse(input);
-      expect(output).toEqual({
-        releases: [
-          { version: '1.0.0' },
-          { version: '2.0.0' },
-          { version: '3.0.0' },
-        ],
-      });
-    });
-
-    it('parses empty input', () => {
-      const output = MarshalledVersionInfo.parse([]);
-      expect(output).toBeNull();
+      expect(output).toEqual([
+        { version: '1.0.0' },
+        { version: '2.0.0' },
+        { version: '3.0.0' },
+      ]);
     });
   });
 

--- a/lib/modules/datasource/rubygems/schema.ts
+++ b/lib/modules/datasource/rubygems/schema.ts
@@ -9,10 +9,10 @@ export const MarshalledVersionInfo = LooseArray(
       number: z.string(),
     })
     .transform(({ number: version }) => ({ version }))
-)
-  .transform((releases) => (releases.length === 0 ? null : { releases }))
-  .nullable()
-  .catch(null);
+).refine(
+  (value) => !is.emptyArray(value),
+  'Empty response from `/v1/dependencies` endpoint'
+);
 
 export const GemMetadata = z
   .object({


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Change implementation to use `Result`/`AsyncResult` instances piped with `transform` and `catch` methods

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
