### PR TITLE
fix(rubygems): Use cascade of endpoints for unknown servers

### DIFF
--- a/lib/modules/datasource/rubygems/common.ts
+++ b/lib/modules/datasource/rubygems/common.ts
@@ -1,6 +1,6 @@
 import { assignKeys } from '../../../util/assign-keys';
-import { type Http, HttpError, type SafeJsonError } from '../../../util/http';
-import { type AsyncResult, Result } from '../../../util/result';
+import type { Http, SafeJsonError } from '../../../util/http';
+import type { AsyncResult } from '../../../util/result';
 import { joinUrlParts as join } from '../../../util/url';
 import type { ReleaseResult } from '../types';
 import { GemMetadata, GemVersions } from './schema';

--- a/lib/modules/datasource/rubygems/common.ts
+++ b/lib/modules/datasource/rubygems/common.ts
@@ -2,49 +2,48 @@ import { assignKeys } from '../../../util/assign-keys';
 import { type Http, HttpError, type SafeJsonError } from '../../../util/http';
 import { type AsyncResult, Result } from '../../../util/result';
 import { joinUrlParts as join } from '../../../util/url';
-import type { Release, ReleaseResult } from '../types';
+import type { ReleaseResult } from '../types';
 import { GemMetadata, GemVersions } from './schema';
+
+export function assignMetadata(
+  releases: ReleaseResult,
+  metadata: GemMetadata
+): ReleaseResult {
+  return assignKeys(releases, metadata, [
+    'changelogUrl',
+    'sourceUrl',
+    'homepage',
+  ]);
+}
+
+export function getV1Metadata(
+  http: Http,
+  registryUrl: string,
+  packageName: string
+): AsyncResult<GemMetadata, SafeJsonError> {
+  const metadataUrl = join(registryUrl, '/api/v1/gems', `${packageName}.json`);
+  return http.getJsonSafe(metadataUrl, GemMetadata);
+}
 
 export function getV1Releases(
   http: Http,
   registryUrl: string,
   packageName: string
-): AsyncResult<
-  ReleaseResult,
-  SafeJsonError | 'empty-releases' | 'unsupported-api'
-> {
-  const fileName = `${packageName}.json`;
-  const versionsUrl = join(registryUrl, '/api/v1/versions', fileName);
-  const metadataUrl = join(registryUrl, '/api/v1/gems', fileName);
+): AsyncResult<ReleaseResult, SafeJsonError | 'unsupported-api'> {
+  const versionsUrl = join(
+    registryUrl,
+    '/api/v1/versions',
+    `${packageName}.json`
+  );
 
-  const addMetadata = (releases: Release[]): Promise<ReleaseResult> =>
-    http
-      .getJsonSafe(metadataUrl, GemMetadata)
-      .transform((metadata) =>
-        assignKeys({ releases } as ReleaseResult, metadata, [
-          'changelogUrl',
-          'sourceUrl',
-          'homepage',
-        ])
-      )
-      .unwrap({ releases });
-
-  return http
-    .getJsonSafe(versionsUrl, GemVersions)
-    .catch((err) => {
-      if (err instanceof HttpError) {
-        const status = err.response?.statusCode;
-        if (status === 404 || status === 400) {
-          return Result.err('unsupported-api');
-        }
+  return http.getJsonSafe(versionsUrl, GemVersions).catch((err) => {
+    if (err instanceof HttpError) {
+      const status = err.response?.statusCode;
+      if (status === 404 || status === 400) {
+        return Result.err('unsupported-api');
       }
+    }
 
-      return Result.err(err);
-    })
-    .transform((releases) => {
-      return releases.length > 0
-        ? Result.ok(releases)
-        : Result.err('empty-releases');
-    })
-    .transform(addMetadata);
+    return Result.err(err);
+  });
 }

--- a/lib/modules/datasource/rubygems/common.ts
+++ b/lib/modules/datasource/rubygems/common.ts
@@ -36,14 +36,9 @@ export function getV1Releases(
     `${packageName}.json`
   );
 
-  return http.getJsonSafe(versionsUrl, GemVersions).catch((err) => {
-    if (err instanceof HttpError) {
-      const status = err.response?.statusCode;
-      if (status === 404 || status === 400) {
-        return Result.err('unsupported-api');
-      }
-    }
-
-    return Result.err(err);
-  });
+  return http.getJsonSafe(versionsUrl, GemVersions).transform((releaseResult) =>
+    getV1Metadata(http, registryUrl, packageName)
+      .transform((metadata) => assignMetadata(releaseResult, metadata))
+      .unwrap(releaseResult)
+  );
 }

--- a/lib/modules/datasource/rubygems/index.spec.ts
+++ b/lib/modules/datasource/rubygems/index.spec.ts
@@ -25,8 +25,6 @@ describe('modules/datasource/rubygems/index', () => {
     it('returns null for missing pkg', async () => {
       httpMock
         .scope('https://example.com')
-        .get('/versions')
-        .reply(404)
         .get('/api/v1/versions/foobar.json')
         .reply(200, [])
         .get('/api/v1/dependencies?gems=foobar')
@@ -117,8 +115,6 @@ describe('modules/datasource/rubygems/index', () => {
     it('uses multiple source urls', async () => {
       httpMock
         .scope('https://registry-1.com/')
-        .get('/versions')
-        .reply(404)
         .get('/api/v1/versions/foobar.json')
         .reply(400)
         .get('/api/v1/dependencies?gems=foobar')
@@ -126,8 +122,6 @@ describe('modules/datasource/rubygems/index', () => {
 
       httpMock
         .scope('https://registry-2.com/nested/path')
-        .get('/versions')
-        .reply(404)
         .get('/api/v1/versions/foobar.json')
         .reply(200, [
           { number: '1.0.0', created_at: '2021-01-01' },
@@ -160,8 +154,6 @@ describe('modules/datasource/rubygems/index', () => {
     it('falls back to dependencies API', async () => {
       httpMock
         .scope('https://example.com/')
-        .get('/versions')
-        .reply(404)
         .get('/api/v1/versions/foobar.json')
         .reply(400, {})
         .get('/api/v1/dependencies?gems=foobar')
@@ -194,10 +186,10 @@ describe('modules/datasource/rubygems/index', () => {
     it('errors when version request fails with anything other than 400 or 404', async () => {
       httpMock
         .scope('https://example.com/')
-        .get('/versions')
-        .reply(404)
         .get('/api/v1/versions/foobar.json')
-        .reply(500, {});
+        .reply(500, {})
+        .get('/api/v1/dependencies?gems=foobar')
+        .reply(500);
 
       await expect(
         getPkgReleases({
@@ -212,8 +204,6 @@ describe('modules/datasource/rubygems/index', () => {
     it('returns null for GitHub Packages package miss', async () => {
       httpMock
         .scope('https://rubygems.pkg.github.com/example')
-        .get('/versions')
-        .reply(404)
         .get('/api/v1/dependencies?gems=foobar')
         .reply(200, rubyMarshal([]));
 
@@ -230,8 +220,6 @@ describe('modules/datasource/rubygems/index', () => {
     it('returns a dep for GitHub Packages package hit', async () => {
       httpMock
         .scope('https://rubygems.pkg.github.com/example')
-        .get('/versions')
-        .reply(404)
         .get('/api/v1/dependencies?gems=foobar')
         .reply(
           200,

--- a/lib/modules/datasource/rubygems/index.spec.ts
+++ b/lib/modules/datasource/rubygems/index.spec.ts
@@ -25,6 +25,8 @@ describe('modules/datasource/rubygems/index', () => {
     it('returns null for missing pkg', async () => {
       httpMock
         .scope('https://example.com')
+        .get('/info/foobar')
+        .reply(200, '')
         .get('/api/v1/versions/foobar.json')
         .reply(200, [])
         .get('/api/v1/dependencies?gems=foobar')
@@ -115,6 +117,8 @@ describe('modules/datasource/rubygems/index', () => {
     it('uses multiple source urls', async () => {
       httpMock
         .scope('https://registry-1.com/')
+        .get('/info/foobar')
+        .reply(404)
         .get('/api/v1/versions/foobar.json')
         .reply(400)
         .get('/api/v1/dependencies?gems=foobar')
@@ -122,6 +126,8 @@ describe('modules/datasource/rubygems/index', () => {
 
       httpMock
         .scope('https://registry-2.com/nested/path')
+        .get('/info/foobar')
+        .reply(404)
         .get('/api/v1/versions/foobar.json')
         .reply(200, [
           { number: '1.0.0', created_at: '2021-01-01' },
@@ -154,6 +160,8 @@ describe('modules/datasource/rubygems/index', () => {
     it('falls back to dependencies API', async () => {
       httpMock
         .scope('https://example.com/')
+        .get('/info/foobar')
+        .reply(404)
         .get('/api/v1/versions/foobar.json')
         .reply(400, {})
         .get('/api/v1/dependencies?gems=foobar')
@@ -164,7 +172,9 @@ describe('modules/datasource/rubygems/index', () => {
             { number: '2.0.0' },
             { number: '3.0.0' },
           ])
-        );
+        )
+        .get('/api/v1/gems/foobar.json')
+        .reply(200, {});
 
       const res = await getPkgReleases({
         versioning: rubyVersioning.id,
@@ -186,6 +196,8 @@ describe('modules/datasource/rubygems/index', () => {
     it('errors when version request fails with anything other than 400 or 404', async () => {
       httpMock
         .scope('https://example.com/')
+        .get('/info/foobar')
+        .reply(404)
         .get('/api/v1/versions/foobar.json')
         .reply(500, {})
         .get('/api/v1/dependencies?gems=foobar')

--- a/lib/modules/datasource/rubygems/index.spec.ts
+++ b/lib/modules/datasource/rubygems/index.spec.ts
@@ -25,10 +25,10 @@ describe('modules/datasource/rubygems/index', () => {
     it('returns null for missing pkg', async () => {
       httpMock
         .scope('https://example.com')
-        .get('/info/foobar')
-        .reply(200, '')
         .get('/api/v1/versions/foobar.json')
         .reply(200, [])
+        .get('/info/foobar')
+        .reply(200, '')
         .get('/api/v1/dependencies?gems=foobar')
         .reply(200, rubyMarshal([]));
       expect(
@@ -117,25 +117,23 @@ describe('modules/datasource/rubygems/index', () => {
     it('uses multiple source urls', async () => {
       httpMock
         .scope('https://registry-1.com/')
+        .get('/api/v1/versions/foobar.json')
+        .reply(404)
         .get('/info/foobar')
         .reply(404)
-        .get('/api/v1/versions/foobar.json')
-        .reply(400)
         .get('/api/v1/dependencies?gems=foobar')
         .reply(404);
 
       httpMock
         .scope('https://registry-2.com/nested/path')
-        .get('/info/foobar')
-        .reply(404)
+        .get('/api/v1/gems/foobar.json')
+        .reply(200, {})
         .get('/api/v1/versions/foobar.json')
         .reply(200, [
           { number: '1.0.0', created_at: '2021-01-01' },
           { number: '2.0.0', created_at: '2022-01-01' },
           { number: '3.0.0', created_at: '2023-01-01' },
-        ])
-        .get('/api/v1/gems/foobar.json')
-        .reply(200, {});
+        ]);
 
       const res = await getPkgReleases({
         versioning: rubyVersioning.id,
@@ -160,10 +158,10 @@ describe('modules/datasource/rubygems/index', () => {
     it('falls back to dependencies API', async () => {
       httpMock
         .scope('https://example.com/')
+        .get('/api/v1/versions/foobar.json')
+        .reply(404, {})
         .get('/info/foobar')
         .reply(404)
-        .get('/api/v1/versions/foobar.json')
-        .reply(400, {})
         .get('/api/v1/dependencies?gems=foobar')
         .reply(
           200,
@@ -172,9 +170,7 @@ describe('modules/datasource/rubygems/index', () => {
             { number: '2.0.0' },
             { number: '3.0.0' },
           ])
-        )
-        .get('/api/v1/gems/foobar.json')
-        .reply(200, {});
+        );
 
       const res = await getPkgReleases({
         versioning: rubyVersioning.id,
@@ -196,17 +192,17 @@ describe('modules/datasource/rubygems/index', () => {
     it('supports /info endpoint', async () => {
       httpMock
         .scope('https://example.com/')
+        .get('/api/v1/versions/foobar.json')
+        .reply(404)
         .get('/info/foobar')
         .reply(
           200,
           codeBlock`
-          1.0.0 |checksum:aaa
-          2.0.0 |checksum:bbb
-          3.0.0 |checksum:ccc
-        `
-        )
-        .get('/api/v1/gems/foobar.json')
-        .reply(200, {});
+            1.0.0 |checksum:aaa
+            2.0.0 |checksum:bbb
+            3.0.0 |checksum:ccc
+          `
+        );
 
       const res = await getPkgReleases({
         versioning: rubyVersioning.id,
@@ -227,8 +223,6 @@ describe('modules/datasource/rubygems/index', () => {
     it('errors when version request fails with server error', async () => {
       httpMock
         .scope('https://example.com/')
-        .get('/info/foobar')
-        .reply(404)
         .get('/api/v1/versions/foobar.json')
         .reply(500);
 

--- a/lib/modules/datasource/rubygems/index.ts
+++ b/lib/modules/datasource/rubygems/index.ts
@@ -1,4 +1,6 @@
 import { Marshal } from '@qnighy/marshal';
+import type { ZodError } from 'zod';
+import { logger } from '../../../logger';
 import { AsyncResult, Result } from '../../../util/result';
 import { getQueryString, joinUrlParts, parseUrl } from '../../../util/url';
 import * as rubyVersioning from '../../versioning/ruby';
@@ -9,8 +11,6 @@ import { RubygemsHttp } from './http';
 import { MetadataCache } from './metadata-cache';
 import { MarshalledVersionInfo } from './schema';
 import { VersionsEndpointCache } from './versions-endpoint-cache';
-import { logger } from '../../../logger';
-import type { ZodError } from 'zod';
 
 export class RubyGemsDatasource extends Datasource {
   static readonly id = 'rubygems';

--- a/lib/modules/datasource/rubygems/index.ts
+++ b/lib/modules/datasource/rubygems/index.ts
@@ -80,11 +80,6 @@ export class RubyGemsDatasource extends Datasource {
           unlessServerSide(err, () =>
             this.getReleasesViaDeprecatedAPI(registryUrl, packageName)
           )
-        )
-        .transform((result) =>
-          getV1Metadata(this.http, registryUrl, packageName)
-            .transform((metadata) => assignMetadata(result, metadata))
-            .unwrap(result)
         );
     }
 

--- a/lib/modules/datasource/rubygems/index.ts
+++ b/lib/modules/datasource/rubygems/index.ts
@@ -7,7 +7,7 @@ import { getQueryString, joinUrlParts, parseUrl } from '../../../util/url';
 import * as rubyVersioning from '../../versioning/ruby';
 import { Datasource } from '../datasource';
 import type { GetReleasesConfig, ReleaseResult } from '../types';
-import { assignMetadata, getV1Metadata, getV1Releases } from './common';
+import { getV1Releases } from './common';
 import { RubygemsHttp } from './http';
 import { MetadataCache } from './metadata-cache';
 import { GemInfo, MarshalledVersionInfo } from './schema';
@@ -70,10 +70,10 @@ export class RubyGemsDatasource extends Datasource {
     ) {
       result = this.getReleasesViaDeprecatedAPI(registryUrl, packageName);
     } else {
-      result = this.getReleasesViaInfoEndpoint(registryUrl, packageName)
+      result = getV1Releases(this.http, registryUrl, packageName)
         .catch((err) =>
           unlessServerSide(err, () =>
-            getV1Releases(this.http, registryUrl, packageName)
+            this.getReleasesViaInfoEndpoint(registryUrl, packageName)
           )
         )
         .catch((err) =>

--- a/lib/modules/datasource/rubygems/metadata-cache.ts
+++ b/lib/modules/datasource/rubygems/metadata-cache.ts
@@ -52,13 +52,7 @@ export class MetadataCache {
 
     return await loadCache()
       .catch(() =>
-        getV1Releases(this.http, registryUrl, packageName)
-          .transform((releaseResult) =>
-            getV1Metadata(this.http, registryUrl, packageName)
-              .transform((metadata) => assignMetadata(releaseResult, metadata))
-              .unwrap(releaseResult)
-          )
-          .transform(saveCache)
+        getV1Releases(this.http, registryUrl, packageName).transform(saveCache)
       )
       .catch(() =>
         Result.ok({

--- a/lib/modules/datasource/rubygems/metadata-cache.ts
+++ b/lib/modules/datasource/rubygems/metadata-cache.ts
@@ -55,7 +55,9 @@ export class MetadataCache {
         getV1Releases(this.http, registryUrl, packageName).transform(saveCache)
       )
       .catch(() =>
-        Result.ok({ releases: versions.map((version) => ({ version })) })
+        Result.ok({
+          releases: versions.map((version) => ({ version })),
+        })
       )
       .unwrapOrThrow();
   }

--- a/lib/modules/datasource/rubygems/metadata-cache.ts
+++ b/lib/modules/datasource/rubygems/metadata-cache.ts
@@ -4,7 +4,7 @@ import type { Http } from '../../../util/http';
 import { AsyncResult, Result } from '../../../util/result';
 import { parseUrl } from '../../../util/url';
 import type { ReleaseResult } from '../types';
-import { assignMetadata, getV1Metadata, getV1Releases } from './common';
+import { getV1Releases } from './common';
 
 interface CacheRecord {
   hash: string;

--- a/lib/modules/datasource/rubygems/schema.spec.ts
+++ b/lib/modules/datasource/rubygems/schema.spec.ts
@@ -1,4 +1,10 @@
-import { GemMetadata, GemVersions, MarshalledVersionInfo } from './schema';
+import { codeBlock } from 'common-tags';
+import {
+  GemInfo,
+  GemMetadata,
+  GemVersions,
+  MarshalledVersionInfo,
+} from './schema';
 
 describe('modules/datasource/rubygems/schema', () => {
   describe('MarshalledVersionInfo', () => {
@@ -9,39 +15,39 @@ describe('modules/datasource/rubygems/schema', () => {
         { number: '3.0.0' },
       ];
       const output = MarshalledVersionInfo.parse(input);
-      expect(output).toEqual([
-        { version: '1.0.0' },
-        { version: '2.0.0' },
-        { version: '3.0.0' },
-      ]);
+      expect(output).toEqual({
+        releases: [
+          { version: '1.0.0' },
+          { version: '2.0.0' },
+          { version: '3.0.0' },
+        ],
+      });
+    });
+
+    it('errors on empty input', () => {
+      expect(() => MarshalledVersionInfo.parse([])).toThrow(
+        'Empty response from `/v1/dependencies` endpoint'
+      );
     });
   });
 
   describe('GemMetadata', () => {
-    it('requires only name field', () => {
-      const input = { name: 'foo' };
-      const output = GemMetadata.parse(input);
-      expect(output).toEqual({
-        packageName: 'foo',
+    it('parses empty object into undefined fields', () => {
+      expect(GemMetadata.parse({})).toEqual({
         changelogUrl: undefined,
         homepage: undefined,
-        latestVersion: undefined,
         sourceUrl: undefined,
       });
     });
 
     it('parses valid input', () => {
       const input = {
-        name: 'foo',
-        version: '1.0.0',
         changelog_uri: 'https://example.com',
         homepage_uri: 'https://example.com',
         source_code_uri: 'https://example.com',
       };
       const output = GemMetadata.parse(input);
       expect(output).toEqual({
-        packageName: 'foo',
-        latestVersion: '1.0.0',
         changelogUrl: 'https://example.com',
         homepage: 'https://example.com',
         sourceUrl: 'https://example.com',
@@ -87,41 +93,68 @@ describe('modules/datasource/rubygems/schema', () => {
         },
       ];
       const output = GemVersions.parse(input);
-      expect(output).toEqual([
-        {
-          version: '1.0.0',
-          releaseTimestamp: '2021-01-01',
-          changelogUrl: 'https://example.com',
-          sourceUrl: 'https://example.com',
-          constraints: {
-            platform: ['ruby'],
-            ruby: ['2.7.0'],
-            rubygems: ['3.2.0'],
+      expect(output).toEqual({
+        releases: [
+          {
+            version: '1.0.0',
+            releaseTimestamp: '2021-01-01',
+            changelogUrl: 'https://example.com',
+            sourceUrl: 'https://example.com',
+            constraints: {
+              platform: ['ruby'],
+              ruby: ['2.7.0'],
+              rubygems: ['3.2.0'],
+            },
           },
-        },
-        {
-          version: '2.0.0',
-          releaseTimestamp: '2022-01-01',
-          changelogUrl: 'https://example.com',
-          sourceUrl: 'https://example.com',
-          constraints: {
-            platform: ['ruby'],
-            ruby: ['2.7.0'],
-            rubygems: ['3.2.0'],
+          {
+            version: '2.0.0',
+            releaseTimestamp: '2022-01-01',
+            changelogUrl: 'https://example.com',
+            sourceUrl: 'https://example.com',
+            constraints: {
+              platform: ['ruby'],
+              ruby: ['2.7.0'],
+              rubygems: ['3.2.0'],
+            },
           },
-        },
-        {
-          version: '3.0.0',
-          releaseTimestamp: '2023-01-01',
-          changelogUrl: 'https://example.com',
-          sourceUrl: 'https://example.com',
-          constraints: {
-            platform: ['ruby'],
-            ruby: ['2.7.0'],
-            rubygems: ['3.2.0'],
+          {
+            version: '3.0.0',
+            releaseTimestamp: '2023-01-01',
+            changelogUrl: 'https://example.com',
+            sourceUrl: 'https://example.com',
+            constraints: {
+              platform: ['ruby'],
+              ruby: ['2.7.0'],
+              rubygems: ['3.2.0'],
+            },
           },
-        },
-      ]);
+        ],
+      });
+    });
+  });
+
+  describe('GemInfo', () => {
+    it('parses valid input', () => {
+      const input = codeBlock`
+        ---
+        1.1.1 |checksum:aaa
+        2.2.2 |checksum:bbb
+        3.3.3 |checksum:ccc
+      `;
+      const output = GemInfo.parse(input);
+      expect(output).toEqual({
+        releases: [
+          { version: '1.1.1' },
+          { version: '2.2.2' },
+          { version: '3.3.3' },
+        ],
+      });
+    });
+
+    it('errors on empty input', () => {
+      expect(() => GemInfo.parse('')).toThrow(
+        'Empty response from `/info` endpoint'
+      );
     });
   });
 });

--- a/lib/modules/datasource/rubygems/schema.spec.ts
+++ b/lib/modules/datasource/rubygems/schema.spec.ts
@@ -9,18 +9,11 @@ describe('modules/datasource/rubygems/schema', () => {
         { number: '3.0.0' },
       ];
       const output = MarshalledVersionInfo.parse(input);
-      expect(output).toEqual({
-        releases: [
-          { version: '1.0.0' },
-          { version: '2.0.0' },
-          { version: '3.0.0' },
-        ],
-      });
-    });
-
-    it('parses empty input', () => {
-      const output = MarshalledVersionInfo.parse([]);
-      expect(output).toBeNull();
+      expect(output).toEqual([
+        { version: '1.0.0' },
+        { version: '2.0.0' },
+        { version: '3.0.0' },
+      ]);
     });
   });
 

--- a/lib/modules/datasource/rubygems/schema.ts
+++ b/lib/modules/datasource/rubygems/schema.ts
@@ -9,10 +9,10 @@ export const MarshalledVersionInfo = LooseArray(
       number: z.string(),
     })
     .transform(({ number: version }) => ({ version }))
-)
-  .transform((releases) => (releases.length === 0 ? null : { releases }))
-  .nullable()
-  .catch(null);
+).refine(
+  (value) => !is.emptyArray(value),
+  'Empty response from `/v1/dependencies` endpoint'
+);
 
 export const GemMetadata = z
   .object({


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

For registries other than `rubygems.org`, `rubygems.pkg.github.com` or `gitlab.com`, following endpoints are queried:

- First request: `/api/v1/versions/{package}.json`
  - It's useful because it contains date for `releaseTimestamp` field
  - Optionally, metadata such as `homepageUrl` will be queried via `/api/v1/gems/{package}.json`
- Fallback 1: `/info/{package}` endpoint ([example](https://rubygems.org/info/faker))
- Fallback 2: `/api/v1/dependencies` ([obsolete](https://blog.rubygems.org/2023/02/22/dependency-api-deprecation.html) but [still working](https://blog.rubygems.org/2023/04/07/dependency-api-deprecation-delayed.html))

## Context

- Closes #15459

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
