### PR TITLE
fix(manager/nuget): don't bump version if already done 

### DIFF
--- a/lib/modules/manager/nuget/update.spec.ts
+++ b/lib/modules/manager/nuget/update.spec.ts
@@ -7,6 +7,10 @@ const minimumContent =
   '<Project Sdk="Microsoft.NET.Sdk"><PropertyGroup><Version>1</Version></PropertyGroup></Project>';
 const prereleaseContent =
   '<Project Sdk="Microsoft.NET.Sdk"><PropertyGroup><Version>1.0.0-1</Version></PropertyGroup></Project>';
+const issue23526InitialContent =
+  '<Project Sdk="Microsoft.NET.Sdk"><PropertyGroup><Version>4.9.0</Version></PropertyGroup></Project>';
+const issue23526ExpectedContent =
+  '<Project Sdk="Microsoft.NET.Sdk"><PropertyGroup><Version>4.10.0</Version></PropertyGroup></Project>';
 
 describe('modules/manager/nuget/update', () => {
   describe('bumpPackageVersion', () => {
@@ -34,6 +38,21 @@ describe('modules/manager/nuget/update', () => {
       );
 
       expect(bumpedContent).toEqual(bumpedContent2);
+    });
+
+    it('issue 23526 does not bump version incorrectly', () => {
+      const { bumpedContent } = bumpPackageVersion(
+        issue23526InitialContent,
+        '4.9.0',
+        'minor'
+      );
+      const { bumpedContent: bumpedContent2 } = bumpPackageVersion(
+        bumpedContent!,
+        '4.9.0',
+        'minor'
+      );
+
+      expect(bumpedContent2).toEqual(issue23526ExpectedContent);
     });
 
     it('does not bump version if version is not a semantic version', () => {

--- a/lib/modules/manager/nuget/update.ts
+++ b/lib/modules/manager/nuget/update.ts
@@ -40,12 +40,14 @@ export function bumpPackageVersion(
     }
 
     logger.debug(`newProjVersion: ${newProjVersion}`);
+    logger.debug(`original content: ${content}`);
     bumpedContent = replaceAt(
       content,
       versionPosition,
       currentValue,
       newProjVersion
     );
+    logger.debug(`bumped content: ${bumpedContent}`);
 
     if (bumpedContent === content) {
       logger.debug('Version was already bumped');

--- a/lib/modules/manager/nuget/update.ts
+++ b/lib/modules/manager/nuget/update.ts
@@ -48,7 +48,9 @@ export function bumpPackageVersion(
       return { bumpedContent };
     }
 
-    logger.debug(`newProjVersion: ${newProjVersion}, project content before bumpVersion(): ${content}`);
+    logger.debug(
+      `newProjVersion: ${newProjVersion}, project content before bumpVersion(): ${content}`
+    );
 
     bumpedContent = replaceAt(
       content,
@@ -57,7 +59,9 @@ export function bumpPackageVersion(
       newProjVersion
     );
 
-    logger.debug(`project version bumped, project content after bumpVersion(): ${bumpedContent}`);
+    logger.debug(
+      `project version bumped, project content after bumpVersion(): ${bumpedContent}`
+    );
   } catch (err) {
     logger.warn(
       {

--- a/lib/modules/manager/nuget/update.ts
+++ b/lib/modules/manager/nuget/update.ts
@@ -49,14 +49,12 @@ export function bumpPackageVersion(
     }
 
     logger.debug(`newProjVersion: ${newProjVersion}`);
-
     bumpedContent = replaceAt(
       content,
       versionPosition,
       currentValue,
       newProjVersion
     );
-
   } catch (err) {
     logger.warn(
       {

--- a/lib/modules/manager/nuget/update.ts
+++ b/lib/modules/manager/nuget/update.ts
@@ -49,6 +49,8 @@ export function bumpPackageVersion(
     }
 
     logger.debug(`newProjVersion: ${newProjVersion}`);
+    logger.debug(`project before bumpVersion(): ${content}`);
+
     bumpedContent = replaceAt(
       content,
       versionPosition,
@@ -56,11 +58,8 @@ export function bumpPackageVersion(
       newProjVersion
     );
 
-    if (bumpedContent === content) {
-      logger.debug('Version was already bumped');
-    } else {
-      logger.debug('project version bumped');
-    }
+    logger.debug('project version bumped');
+    logger.debug(`project after bumpVersion(): ${bumpedContent}`);
   } catch (err) {
     logger.warn(
       {

--- a/lib/modules/manager/nuget/update.ts
+++ b/lib/modules/manager/nuget/update.ts
@@ -48,8 +48,7 @@ export function bumpPackageVersion(
       return { bumpedContent };
     }
 
-    logger.debug(`newProjVersion: ${newProjVersion}`);
-    logger.debug(`project before bumpVersion(): ${content}`);
+    logger.debug(`newProjVersion: ${newProjVersion}, project content before bumpVersion(): ${content}`);
 
     bumpedContent = replaceAt(
       content,
@@ -58,8 +57,7 @@ export function bumpPackageVersion(
       newProjVersion
     );
 
-    logger.debug('project version bumped');
-    logger.debug(`project after bumpVersion(): ${bumpedContent}`);
+    logger.debug(`project version bumped, project content after bumpVersion(): ${bumpedContent}`);
   } catch (err) {
     logger.warn(
       {

--- a/lib/modules/manager/nuget/update.ts
+++ b/lib/modules/manager/nuget/update.ts
@@ -31,12 +31,21 @@ export function bumpPackageVersion(
   try {
     const project = new XmlDocument(content);
     const versionNode = project.descendantWithPath('PropertyGroup.Version')!;
+    const currentProjVersion = versionNode.val;
     const startTagPosition = versionNode.startTagPosition;
-    const versionPosition = content.indexOf(versionNode.val, startTagPosition);
+    const versionPosition = content.indexOf(
+      currentProjVersion,
+      startTagPosition
+    );
 
     const newProjVersion = semver.inc(currentValue, bumpVersion as ReleaseType);
     if (!newProjVersion) {
       throw new Error('semver inc failed');
+    }
+
+    if (currentProjVersion === newProjVersion) {
+      logger.debug('Version was already bumped');
+      return { bumpedContent };
     }
 
     logger.debug(`newProjVersion: ${newProjVersion}`);

--- a/lib/modules/manager/nuget/update.ts
+++ b/lib/modules/manager/nuget/update.ts
@@ -48,9 +48,7 @@ export function bumpPackageVersion(
       return { bumpedContent };
     }
 
-    logger.debug(
-      `newProjVersion: ${newProjVersion}, project content before bumpVersion(): ${content}`
-    );
+    logger.debug(`newProjVersion: ${newProjVersion}`);
 
     bumpedContent = replaceAt(
       content,
@@ -59,9 +57,6 @@ export function bumpPackageVersion(
       newProjVersion
     );
 
-    logger.debug(
-      `project version bumped, project content after bumpVersion(): ${bumpedContent}`
-    );
   } catch (err) {
     logger.warn(
       {

--- a/lib/modules/manager/nuget/update.ts
+++ b/lib/modules/manager/nuget/update.ts
@@ -1,7 +1,5 @@
 import semver, { ReleaseType } from 'semver';
-import { XmlDocument } from 'xmldoc';
 import { logger } from '../../../logger';
-import { replaceAt } from '../../../util/string';
 import type { BumpPackageVersionResult } from '../types';
 
 export function bumpPackageVersion(
@@ -29,11 +27,6 @@ export function bumpPackageVersion(
   }
 
   try {
-    const project = new XmlDocument(content);
-    const versionNode = project.descendantWithPath('PropertyGroup.Version')!;
-    const startTagPosition = versionNode.startTagPosition;
-    const versionPosition = content.indexOf(versionNode.val, startTagPosition);
-
     const newProjVersion = semver.inc(currentValue, bumpVersion as ReleaseType);
     if (!newProjVersion) {
       throw new Error('semver inc failed');
@@ -41,11 +34,10 @@ export function bumpPackageVersion(
 
     logger.debug(`newProjVersion: ${newProjVersion}`);
     logger.debug(`original content: ${content}`);
-    bumpedContent = replaceAt(
-      content,
-      versionPosition,
-      currentValue,
-      newProjVersion
+
+    bumpedContent = content.replace(
+      `<Version>${currentValue}</Version>`,
+      `<Version>${newProjVersion}</Version>`
     );
     logger.debug(`bumped content: ${bumpedContent}`);
 

--- a/lib/util/string.ts
+++ b/lib/util/string.ts
@@ -14,11 +14,13 @@ export function replaceAt(
   oldString: string,
   newString: string
 ): string {
-  return (
-    content.substring(0, index) +
-    newString +
-    content.substring(index + oldString.length)
-  );
+  const firstPart = content.slice(0, index);
+  const secondPart = content.slice(index);
+  if (secondPart.startsWith(oldString)) {
+    return firstPart + secondPart.replace(oldString, newString);
+  }
+
+  return content;
 }
 
 /**

--- a/lib/util/string.ts
+++ b/lib/util/string.ts
@@ -14,13 +14,11 @@ export function replaceAt(
   oldString: string,
   newString: string
 ): string {
-  const firstPart = content.slice(0, index);
-  const secondPart = content.slice(index);
-  if (secondPart.startsWith(oldString)) {
-    return firstPart + secondPart.replace(oldString, newString);
-  }
-
-  return content;
+  return (
+    content.substring(0, index) +
+    newString +
+    content.substring(index + oldString.length)
+  );
 }
 
 /**


### PR DESCRIPTION
## Changes
Added tests to reproduce issue #23526 
Provided a bugfix for the issue
Changes tested with [this workflow](https://github.com/bjuraga/renovate_add_bumpVersion_to_nuget/actions/runs/5648638535)

## Context
Closes #23526 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository