### PR TITLE
refactor(util/hash): replace sha256 hasha use cases

### DIFF
--- a/lib/modules/datasource/crate/index.ts
+++ b/lib/modules/datasource/crate/index.ts
@@ -1,4 +1,3 @@
-import hasha from 'hasha';
 import Git from 'simple-git';
 import upath from 'upath';
 import { GlobalConfig } from '../../../config/global';
@@ -7,6 +6,7 @@ import * as memCache from '../../../util/cache/memory';
 import { cache } from '../../../util/cache/package/decorator';
 import { privateCacheDir, readCacheFile } from '../../../util/fs';
 import { simpleGitConfig } from '../../../util/git/config';
+import { toSha256 } from '../../../util/hash';
 import { newlineRegex, regEx } from '../../../util/regex';
 import { joinUrlParts, parseUrl } from '../../../util/url';
 import * as cargoVersioning from '../../versioning/cargo';
@@ -214,9 +214,7 @@ export class CrateDatasource extends Datasource {
   private static cacheDirFromUrl(url: URL): string {
     const proto = url.protocol.replace(regEx(/:$/), '');
     const host = url.hostname;
-    const hash = hasha(url.pathname, {
-      algorithm: 'sha256',
-    }).substring(0, 7);
+    const hash = toSha256(url.pathname).substring(0, 7);
 
     return `crate-registry-${proto}-${host}-${hash}`;
   }

--- a/lib/modules/datasource/docker/common.ts
+++ b/lib/modules/datasource/docker/common.ts
@@ -1,6 +1,5 @@
 import is from '@sindresorhus/is';
 import { parse } from 'auth-header';
-import hasha from 'hasha';
 import {
   HOST_DISABLED,
   PAGE_NOT_FOUND_ERROR,
@@ -8,6 +7,7 @@ import {
 import { logger } from '../../../logger';
 import type { HostRule } from '../../../types';
 import { ExternalHostError } from '../../../types/errors/external-host-error';
+import { toSha256 } from '../../../util/hash';
 import * as hostRules from '../../../util/host-rules';
 import type { Http } from '../../../util/http';
 import type {
@@ -285,7 +285,7 @@ export function getRegistryRepository(
 export function extractDigestFromResponseBody(
   manifestResponse: HttpResponse
 ): string {
-  return 'sha256:' + hasha(manifestResponse.body, { algorithm: 'sha256' });
+  return 'sha256:' + toSha256(manifestResponse.body);
 }
 
 export function findLatestStable(tags: string[]): string | null {

--- a/lib/modules/datasource/github-release-attachments/digest.spec.ts
+++ b/lib/modules/datasource/github-release-attachments/digest.spec.ts
@@ -1,6 +1,6 @@
-import hasha from 'hasha';
 import * as httpMock from '../../../../test/http-mock';
 import type { GithubDigestFile } from '../../../util/github/types';
+import { toSha256 } from '../../../util/hash';
 import { GitHubReleaseAttachmentMocker } from './test';
 
 import { GithubReleaseAttachmentsDatasource } from '.';
@@ -55,7 +55,7 @@ describe('modules/datasource/github-release-attachments/digest', () => {
         'asset.zip': content,
         'smallest.zip': '1'.repeat(8 * 1024),
       });
-      const contentDigest = await hasha.async(content, { algorithm: 'sha256' });
+      const contentDigest = toSha256(content);
 
       const digestAsset = await githubReleaseAttachments.findDigestAsset(
         release,
@@ -147,9 +147,7 @@ describe('modules/datasource/github-release-attachments/digest', () => {
         const release = releaseMock.withAssets('v1.0.1', {
           'asset.zip': updatedContent,
         });
-        const contentDigest = await hasha.async(updatedContent, {
-          algorithm: 'sha256',
-        });
+        const contentDigest = toSha256(updatedContent);
 
         const digest = await githubReleaseAttachments.mapDigestAssetToRelease(
           digestAsset,

--- a/lib/modules/datasource/rubygems/metadata-cache.ts
+++ b/lib/modules/datasource/rubygems/metadata-cache.ts
@@ -1,4 +1,3 @@
-import hasha from 'hasha';
 import * as packageCache from '../../../util/cache/package';
 import { toSha256 } from '../../../util/hash';
 import type { Http } from '../../../util/http';

--- a/lib/modules/datasource/rubygems/metadata-cache.ts
+++ b/lib/modules/datasource/rubygems/metadata-cache.ts
@@ -1,5 +1,6 @@
 import hasha from 'hasha';
 import * as packageCache from '../../../util/cache/package';
+import { toSha256 } from '../../../util/hash';
 import type { Http } from '../../../util/http';
 import { AsyncResult, Result } from '../../../util/result';
 import { parseUrl } from '../../../util/url';
@@ -21,7 +22,7 @@ export class MetadataCache {
   ): Promise<ReleaseResult> {
     const cacheNs = `datasource-rubygems`;
     const cacheKey = `metadata-cache:${registryUrl}:${packageName}`;
-    const hash = hasha(versions, { algorithm: 'sha256' });
+    const hash = toSha256(versions.join(''));
 
     const loadCache = (): AsyncResult<ReleaseResult, unknown> =>
       Result.wrapNullable(

--- a/lib/modules/platform/pr-body.spec.ts
+++ b/lib/modules/platform/pr-body.spec.ts
@@ -1,4 +1,4 @@
-import hasha from 'hasha';
+import { toSha256 } from '../../util/hash';
 import { getPrBodyStruct, hashBody } from './pr-body';
 
 describe('modules/platform/pr-body', () => {
@@ -83,7 +83,7 @@ describe('modules/platform/pr-body', () => {
 
     it('returns raw config hash', () => {
       const config = '{}';
-      const rawConfigHash = hasha(config, { algorithm: 'sha256' });
+      const rawConfigHash = toSha256(config);
       const input = `<!--renovate-config-hash:${rawConfigHash}-->`;
       const hash = hashBody(input);
       expect(getPrBodyStruct(input)).toEqual({

--- a/lib/modules/platform/pr-body.ts
+++ b/lib/modules/platform/pr-body.ts
@@ -1,7 +1,7 @@
 import is from '@sindresorhus/is';
-import hasha from 'hasha';
 import { logger } from '../../logger';
 import { stripEmojis } from '../../util/emoji';
+import { toSha256 } from '../../util/hash';
 import { regEx } from '../../util/regex';
 import { fromBase64 } from '../../util/string';
 import type { PrBodyStruct } from './types';
@@ -31,7 +31,7 @@ export function hashBody(body: string | undefined): string {
   }
   result = stripEmojis(result);
   result = noWhitespaceOrHeadings(result);
-  result = hasha(result, { algorithm: 'sha256' });
+  result = toSha256(result);
   return result;
 }
 

--- a/lib/util/hasha.ts
+++ b/lib/util/hasha.ts
@@ -1,5 +1,0 @@
-import hasha from 'hasha';
-
-export function toSha256(input: string): string {
-  return hasha(input, { algorithm: 'sha256' });
-}

--- a/lib/workers/repository/onboarding/pr/index.ts
+++ b/lib/workers/repository/onboarding/pr/index.ts
@@ -9,7 +9,7 @@ import { hashBody } from '../../../../modules/platform/pr-body';
 import { scm } from '../../../../modules/platform/scm';
 import { emojify } from '../../../../util/emoji';
 import { getFile } from '../../../../util/git';
-import { toSha256 } from '../../../../util/hasha';
+import { toSha256 } from '../../../../util/hash';
 import * as template from '../../../../util/template';
 import type { BranchConfig } from '../../../types';
 import {


### PR DESCRIPTION
## Changes

Replace hasha sha256 instances with util/hash

## Context

- https://github.com/renovatebot/renovate/issues/23520

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
