### PR TITLE
refactor: use minimatch util

### DIFF
--- a/lib/modules/manager/hermit/default-config.spec.ts
+++ b/lib/modules/manager/hermit/default-config.spec.ts
@@ -1,12 +1,12 @@
-import { minimatch } from 'minimatch';
 import { regexMatches } from '../../../../test/util';
+import { minimatch } from '../../../util/minimatch';
 import { defaultConfig } from './default-config';
 
 describe('modules/manager/hermit/default-config', () => {
   describe('excludeCommitPaths', () => {
     function miniMatches(target: string, patterns: string[]): boolean {
       return patterns.some((patt: string) => {
-        return minimatch(target, patt, { dot: true });
+        return minimatch(patt, { dot: true }).match(target);
       });
     }
 

--- a/lib/modules/manager/hermit/extract.ts
+++ b/lib/modules/manager/hermit/extract.ts
@@ -1,7 +1,7 @@
-import { minimatch } from 'minimatch';
 import upath from 'upath';
 import { logger } from '../../../logger';
 import { readLocalDirectory } from '../../../util/fs';
+import { minimatch } from '../../../util/minimatch';
 import { regEx } from '../../../util/regex';
 import { HermitDatasource } from '../../datasource/hermit';
 import type { PackageDependency, PackageFileContent } from '../types';
@@ -68,7 +68,7 @@ async function listHermitPackages(
   const out = [] as HermitListItem[];
 
   for (const f of files) {
-    if (!minimatch(f, '.*.pkg')) {
+    if (!minimatch('.*.pkg').match(f)) {
       continue;
     }
 

--- a/lib/modules/manager/npm/extract/utils.ts
+++ b/lib/modules/manager/npm/extract/utils.ts
@@ -1,9 +1,10 @@
-import { minimatch } from 'minimatch';
 import { logger } from '../../../../logger';
+import { minimatch } from '../../../../util/minimatch';
 
 export function matchesAnyPattern(val: string, patterns: string[]): boolean {
   const res = patterns.some(
-    (pattern) => pattern === val + '/' || minimatch(val, pattern, { dot: true })
+    (pattern) =>
+      pattern === val + '/' || minimatch(pattern, { dot: true }).match(val)
   );
   logger.trace({ val, patterns, res }, `matchesAnyPattern`);
   return res;

--- a/lib/modules/manager/npm/extract/utils.ts
+++ b/lib/modules/manager/npm/extract/utils.ts
@@ -4,7 +4,7 @@ import { minimatch } from '../../../../util/minimatch';
 export function matchesAnyPattern(val: string, patterns: string[]): boolean {
   const res = patterns.some(
     (pattern) =>
-      pattern === val + '/' || minimatch(pattern, { dot: true }).match(val)
+      pattern === `${val}/` || minimatch(pattern, { dot: true }).match(val)
   );
   logger.trace({ val, patterns, res }, `matchesAnyPattern`);
   return res;

--- a/lib/modules/manager/npm/post-update/npm.ts
+++ b/lib/modules/manager/npm/post-update/npm.ts
@@ -1,6 +1,5 @@
 // TODO: types (#7154)
 import is from '@sindresorhus/is';
-import { minimatch } from 'minimatch';
 import upath from 'upath';
 import { GlobalConfig } from '../../../../config/global';
 import {
@@ -20,6 +19,7 @@ import {
   readLocalFile,
   renameLocalFile,
 } from '../../../../util/fs';
+import { minimatch } from '../../../../util/minimatch';
 import { trimSlashes } from '../../../../util/url';
 import type { PostUpdateConfig, Upgrade } from '../../types';
 import { composeLockFile, parseLockFile } from '../utils';
@@ -246,7 +246,7 @@ export function divideWorkspaceAndRootDeps(
         // stop when the first match is found and
         // add workspaceDir to workspaces set and upgrade object
         for (const workspacePattern of workspacePatterns ?? []) {
-          if (minimatch(workspaceDir, workspacePattern)) {
+          if (minimatch(workspacePattern).match(workspaceDir)) {
             workspaceName = workspaceDir;
             break;
           }

--- a/lib/util/package-rules/files.ts
+++ b/lib/util/package-rules/files.ts
@@ -1,6 +1,6 @@
 import is from '@sindresorhus/is';
-import { minimatch } from 'minimatch';
 import type { PackageRule, PackageRuleInputConfig } from '../../config/types';
+import { minimatch } from '../minimatch';
 import { Matcher } from './base';
 
 export class FileNamesMatcher extends Matcher {
@@ -17,10 +17,10 @@ export class FileNamesMatcher extends Matcher {
 
     return matchFileNames.some(
       (matchFileName) =>
-        minimatch(packageFile, matchFileName, { dot: true }) ||
+        minimatch(matchFileName, { dot: true }).match(packageFile) ||
         (is.array(lockFiles) &&
           lockFiles.some((lockFile) =>
-            minimatch(lockFile, matchFileName, { dot: true })
+            minimatch(matchFileName, { dot: true }).match(lockFile)
           ))
     );
   }

--- a/lib/util/package-rules/match.ts
+++ b/lib/util/package-rules/match.ts
@@ -1,6 +1,6 @@
 import is from '@sindresorhus/is';
-import { minimatch } from 'minimatch';
 import { logger } from '../../logger';
+import { minimatch } from '../minimatch';
 import { regEx } from '../regex';
 
 export function matchRegexOrMinimatch(pattern: string, input: string): boolean {
@@ -13,7 +13,8 @@ export function matchRegexOrMinimatch(pattern: string, input: string): boolean {
       return false;
     }
   }
-  return minimatch(input, pattern, { dot: true });
+
+  return minimatch(pattern, { dot: true }).match(input);
 }
 
 export function anyMatchRegexOrMinimatch(

--- a/lib/workers/repository/extract/file-match.ts
+++ b/lib/workers/repository/extract/file-match.ts
@@ -1,6 +1,6 @@
-import { minimatch } from 'minimatch';
 import type { RenovateConfig } from '../../../config/types';
 import { logger } from '../../../logger';
+import { minimatch } from '../../../util/minimatch';
 import { regEx } from '../../../util/regex';
 
 export function getIncludedFiles(
@@ -13,7 +13,8 @@ export function getIncludedFiles(
   return fileList.filter((file) =>
     includePaths.some(
       (includePath) =>
-        file === includePath || minimatch(file, includePath, { dot: true })
+        file === includePath ||
+        minimatch(includePath, { dot: true }).match(file)
     )
   );
 }
@@ -30,7 +31,7 @@ export function filterIgnoredFiles(
       !ignorePaths.some(
         (ignorePath) =>
           file.includes(ignorePath) ||
-          minimatch(file, ignorePath, { dot: true })
+          minimatch(ignorePath, { dot: true }).match(file)
       )
   );
 }

--- a/lib/workers/repository/update/branch/commit.ts
+++ b/lib/workers/repository/update/branch/commit.ts
@@ -1,10 +1,10 @@
 // TODO #7154
 import is from '@sindresorhus/is';
-import { minimatch } from 'minimatch';
 import { GlobalConfig } from '../../../../config/global';
 import { CONFIG_SECRETS_EXPOSED } from '../../../../constants/error-messages';
 import { logger } from '../../../../logger';
 import { scm } from '../../../../modules/platform/scm';
+import { minimatch } from '../../../../util/minimatch';
 import { sanitize } from '../../../../util/sanitize';
 import type { BranchConfig } from '../../../types';
 
@@ -18,7 +18,7 @@ export function commitFilesToBranch(
   if (is.nonEmptyArray(config.excludeCommitPaths)) {
     updatedFiles = updatedFiles.filter(({ path: filePath }) => {
       const matchesExcludePaths = config.excludeCommitPaths!.some(
-        (excludedPath) => minimatch(filePath, excludedPath, { dot: true })
+        (excludedPath) => minimatch(excludedPath, { dot: true }).match(filePath)
       );
       if (matchesExcludePaths) {
         logger.debug(`Excluding ${filePath} from commit`);

--- a/lib/workers/repository/update/branch/execute-post-upgrade-commands.ts
+++ b/lib/workers/repository/update/branch/execute-post-upgrade-commands.ts
@@ -1,6 +1,5 @@
 // TODO #7154
 import is from '@sindresorhus/is';
-import { minimatch } from 'minimatch';
 import { mergeChildConfig } from '../../../../config';
 import { GlobalConfig } from '../../../../config/global';
 import { addMeta, logger } from '../../../../logger';
@@ -13,6 +12,7 @@ import {
 } from '../../../../util/fs';
 import { getRepoStatus } from '../../../../util/git';
 import type { FileChange } from '../../../../util/git/types';
+import { minimatch } from '../../../../util/minimatch';
 import { regEx } from '../../../../util/regex';
 import { sanitize } from '../../../../util/sanitize';
 import { compile } from '../../../../util/template';
@@ -110,7 +110,7 @@ export async function postUpgradeCommandsExecutor(
 
       for (const relativePath of status.modified.concat(status.not_added)) {
         for (const pattern of fileFilters) {
-          if (minimatch(relativePath, pattern, { dot: true })) {
+          if (minimatch(pattern, { dot: true }).match(relativePath)) {
             logger.debug(
               { file: relativePath, pattern },
               'Post-upgrade file saved'
@@ -138,7 +138,7 @@ export async function postUpgradeCommandsExecutor(
 
       for (const relativePath of status.deleted || []) {
         for (const pattern of fileFilters) {
-          if (minimatch(relativePath, pattern, { dot: true })) {
+          if (minimatch(pattern, { dot: true }).match(relativePath)) {
             logger.debug(
               { file: relativePath, pattern },
               'Post-upgrade file removed'


### PR DESCRIPTION
## Changes

refactor minimatch match use-cases to use cacheable util

## Context

* https://github.com/renovatebot/renovate/issues/23491

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
