### PR TITLE
feat: Support Zod values in `Result` transforms

### DIFF
--- a/lib/modules/datasource/rubygems/index.ts
+++ b/lib/modules/datasource/rubygems/index.ts
@@ -101,10 +101,9 @@ export class RubyGemsDatasource extends Datasource {
     packageName: string
   ): AsyncResult<ReleaseResult, Error | ZodError> {
     const url = joinUrlParts(registryUrl, '/info', packageName);
-    return Result.wrap(this.http.get(url)).transform(({ body }) => {
-      const res = GemInfo.safeParse(body);
-      return res.success ? Result.ok(res.data) : Result.err(res.error);
-    });
+    return Result.wrap(this.http.get(url)).transform(({ body }) =>
+      GemInfo.safeParse(body)
+    );
   }
 
   private getReleasesViaDeprecatedAPI(
@@ -117,10 +116,7 @@ export class RubyGemsDatasource extends Datasource {
     const bufPromise = this.http.getBuffer(url);
     return Result.wrap(bufPromise).transform(({ body }) => {
       const data = Marshal.parse(body);
-      const releases = MarshalledVersionInfo.safeParse(data);
-      return releases.success
-        ? Result.ok(releases.data)
-        : Result.err(releases.error);
+      return MarshalledVersionInfo.safeParse(data);
     });
   }
 }

--- a/lib/util/http/index.ts
+++ b/lib/util/http/index.ts
@@ -372,7 +372,7 @@ export class Http<Opts extends HttpOptions = HttpOptions> {
   ): AsyncResult<ResT, SafeJsonError> {
     const args = this.resolveArgs<ResT>(arg1, arg2, arg3);
     return Result.wrap(this.requestJson<ResT>('get', args)).transform(
-      (response) => response.body
+      (response) => Result.ok(response.body)
     );
   }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
