### PR TITLE
feat(presets): rollup-babel is now scoped

### DIFF
--- a/lib/config/presets/internal/replacements.ts
+++ b/lib/config/presets/internal/replacements.ts
@@ -27,6 +27,7 @@ export const presets: Record<string, Preset> = {
       'replacements:react-query-to-scoped',
       'replacements:react-scripts-ts-to-react-scripts',
       'replacements:renovate-pep440-to-renovatebot-pep440',
+      'replacements:rollup-babel-to-scoped',
       'replacements:rollup-node-resolve-to-scoped',
       'replacements:vso-task-lib-to-azure-pipelines-task-lib',
       'replacements:vsts-task-lib-to-azure-pipelines-task-lib',
@@ -674,6 +675,17 @@ export const presets: Record<string, Preset> = {
         matchPackageNames: ['rollup-plugin-node-resolve'],
         replacementName: '@rollup/plugin-node-resolve',
         replacementVersion: '6.0.0',
+      },
+    ],
+  },
+  'rollup-babel-to-scoped': {
+    description: 'The babel plugin for rollup became scoped.',
+    packageRules: [
+      {
+        matchDatasources: ['npm'],
+        matchPackageNames: ['rollup-plugin-babel'],
+        replacementName: '@rollup/plugin-babel',
+        replacementVersion: '5.0.0',
       },
     ],
   },

--- a/lib/config/presets/internal/replacements.ts
+++ b/lib/config/presets/internal/replacements.ts
@@ -667,17 +667,6 @@ export const presets: Record<string, Preset> = {
       },
     ],
   },
-  'rollup-node-resolve-to-scoped': {
-    description: 'The node-resolve plugin for rollup became scoped.',
-    packageRules: [
-      {
-        matchDatasources: ['npm'],
-        matchPackageNames: ['rollup-plugin-node-resolve'],
-        replacementName: '@rollup/plugin-node-resolve',
-        replacementVersion: '6.0.0',
-      },
-    ],
-  },
   'rollup-babel-to-scoped': {
     description: 'The babel plugin for rollup became scoped.',
     packageRules: [
@@ -686,6 +675,17 @@ export const presets: Record<string, Preset> = {
         matchPackageNames: ['rollup-plugin-babel'],
         replacementName: '@rollup/plugin-babel',
         replacementVersion: '5.0.0',
+      },
+    ],
+  },
+  'rollup-node-resolve-to-scoped': {
+    description: 'The node-resolve plugin for rollup became scoped.',
+    packageRules: [
+      {
+        matchDatasources: ['npm'],
+        matchPackageNames: ['rollup-plugin-node-resolve'],
+        replacementName: '@rollup/plugin-node-resolve',
+        replacementVersion: '6.0.0',
       },
     ],
   },


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

added the switch to scoped for the rollup babel plugin to the replacements list

## Context

[`rollup-plugin-babel`](https://www.npmjs.com/package/rollup-plugin-babel), under that name, has been deprecated and renamed to [`@rollup/plugin-babel`](https://www.npmjs.com/package/@rollup/plugin-babel).

v5.0.0 is the first [version available after the name change](https://www.npmjs.com/package/@rollup/plugin-babel?activeTab=versions)

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
