### PR TITLE
docs(platform/bitbucket-server): wrong start commands

### DIFF
--- a/lib/modules/platform/bitbucket-server/index.md
+++ b/lib/modules/platform/bitbucket-server/index.md
@@ -47,7 +47,7 @@ Once it's running and initialized, the quickest way to testing with Renovate is:
 At this point you should have a project ready for Renovate, and the `@renovate-bot` account ready to run on it. You can then run like this:
 
 ```
-yarn start --platform=bitbucket-server --endpoint=http://localhost:7990 --git-fs=http --username=renovate-bot --password=abc123456789! --log-level=debug --autodiscover=true
+npx renovate --platform=bitbucket-server --endpoint=http://localhost:7990 --git-fs=http --username=renovate-bot --password=abc123456789! --log-level=debug --autodiscover=true
 ```
 
 Alternatively using env:
@@ -59,7 +59,7 @@ export RENOVATE_GIT_FS=http
 export RENOVATE_USERNAME=renovate-bot
 export RENOVATE_PASSWORD=abc123456789!
 export LOG_LEVEL=debug
-yarn start --autodiscover=true
+npx renovate --autodiscover=true
 ```
 
 You should then get a "Configure Renovate" onboarding PR in any projects that `@renovate-bot` has been invited to.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
The start command should be `npx renovate` instead of `yarn start`, because the latter only works on renovate source code.
And we shouldn't suggest running from source in docs as it's only meant to do on local testing.
<!-- Describe what behavior is changed by this PR. -->

## Context
- #23664
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
