### PR TITLE
fix: better validation before bumping package version

### DIFF
--- a/lib/modules/manager/helmv3/update.ts
+++ b/lib/modules/manager/helmv3/update.ts
@@ -14,6 +14,7 @@ export function bumpPackageVersion(
   );
   let newChartVersion: string | null;
   let bumpedContent = content;
+
   try {
     newChartVersion = semver.inc(currentValue, bumpVersion);
     if (!newChartVersion) {

--- a/lib/modules/manager/maven/update.ts
+++ b/lib/modules/manager/maven/update.ts
@@ -55,7 +55,7 @@ export function updateDependency({
 
 export function bumpPackageVersion(
   content: string,
-  currentValue: string | undefined,
+  currentValue: string,
   bumpVersion: ReleaseType
 ): BumpPackageVersionResult {
   logger.debug(
@@ -63,11 +63,6 @@ export function bumpPackageVersion(
     'Checking if we should bump pom.xml version'
   );
   let bumpedContent = content;
-
-  if (!currentValue) {
-    logger.warn('Unable to bump pom.xml version, pom.xml has no version');
-    return { bumpedContent };
-  }
 
   if (!semver.valid(currentValue)) {
     logger.warn(

--- a/lib/modules/manager/npm/update/package-version/index.ts
+++ b/lib/modules/manager/npm/update/package-version/index.ts
@@ -15,6 +15,7 @@ export function bumpPackageVersion(
   // TODO: types (#7154)
   let newPjVersion: string | null;
   let bumpedContent = content;
+
   try {
     if (bumpVersion.startsWith('mirror:')) {
       const mirrorPackage = bumpVersion.replace('mirror:', '');

--- a/lib/modules/manager/nuget/update.ts
+++ b/lib/modules/manager/nuget/update.ts
@@ -6,7 +6,7 @@ import type { BumpPackageVersionResult } from '../types';
 
 export function bumpPackageVersion(
   content: string,
-  currentValue: string | undefined,
+  currentValue: string,
   bumpVersion: ReleaseType
 ): BumpPackageVersionResult {
   logger.debug(
@@ -14,11 +14,6 @@ export function bumpPackageVersion(
     'Checking if we should bump project version'
   );
   let bumpedContent = content;
-
-  if (!currentValue) {
-    logger.warn('Unable to bump project version, project has no version');
-    return { bumpedContent };
-  }
 
   if (!semver.valid(currentValue)) {
     logger.warn(

--- a/lib/workers/repository/update/branch/get-updated.spec.ts
+++ b/lib/workers/repository/update/branch/get-updated.spec.ts
@@ -476,6 +476,7 @@ describe('workers/repository/update/branch/get-updated', () => {
         branchName: '',
         bumpVersion: 'patch',
         manager: 'npm',
+        packageFileVersion: 'old version',
       });
       npm.updateDependency.mockReturnValue('old version');
       npm.bumpPackageVersion.mockReturnValue({ bumpedContent: 'new version' });
@@ -497,6 +498,7 @@ describe('workers/repository/update/branch/get-updated', () => {
         branchName: '',
         bumpVersion: 'patch',
         manager: 'helmv3',
+        packageFileVersion: '0.0.1',
       });
       autoReplace.doAutoReplace.mockResolvedValueOnce('version: 0.0.1');
       helmv3.bumpPackageVersion.mockReturnValue({

--- a/lib/workers/repository/update/branch/get-updated.ts
+++ b/lib/workers/repository/update/branch/get-updated.ts
@@ -173,10 +173,14 @@ export async function getUpdatedPackageFiles(
         );
         firstUpdate = false;
         if (res) {
-          if (bumpPackageVersion && upgrade.bumpVersion) {
+          if (
+            bumpPackageVersion &&
+            upgrade.bumpVersion &&
+            upgrade.packageFileVersion
+          ) {
             const { bumpedContent } = await bumpPackageVersion(
               res,
-              upgrade.packageFileVersion!,
+              upgrade.packageFileVersion,
               upgrade.bumpVersion
             );
             res = bumpedContent;
@@ -202,10 +206,15 @@ export async function getUpdatedPackageFiles(
         fileContent: packageFileContent!,
         upgrade,
       });
-      if (bumpPackageVersion && upgrade.bumpVersion) {
+      if (
+        newContent &&
+        bumpPackageVersion &&
+        upgrade.bumpVersion &&
+        upgrade.packageFileVersion
+      ) {
         const { bumpedContent } = await bumpPackageVersion(
-          newContent!,
-          upgrade.packageFileVersion!,
+          newContent,
+          upgrade.packageFileVersion,
           upgrade.bumpVersion
         );
         newContent = bumpedContent;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
We should not pass undefined `currentValue` or `content` to `bumpPackageVersion`.
<!-- Describe what behavior is changed by this PR. -->

## Context
- #23464
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
