### PR TITLE
fix(npm): Types for `bumpVersion` parameter

### DIFF
--- a/lib/modules/manager/npm/update/package-version/index.ts
+++ b/lib/modules/manager/npm/update/package-version/index.ts
@@ -3,10 +3,18 @@ import { logger } from '../../../../../logger';
 import { regEx } from '../../../../../util/regex';
 import type { BumpPackageVersionResult } from '../../../types';
 
+type MirrorBumpVersion = `mirror:${string}`;
+
+function isMirrorBumpVersion(
+  bumpVersion: string
+): bumpVersion is MirrorBumpVersion {
+  return bumpVersion.startsWith('mirror:');
+}
+
 export function bumpPackageVersion(
   content: string,
   currentValue: string,
-  bumpVersion: ReleaseType
+  bumpVersion: ReleaseType | `mirror:${string}`
 ): BumpPackageVersionResult {
   logger.debug(
     { bumpVersion, currentValue },
@@ -16,7 +24,7 @@ export function bumpPackageVersion(
   let newPjVersion: string | null;
   let bumpedContent = content;
   try {
-    if (bumpVersion.startsWith('mirror:')) {
+    if (isMirrorBumpVersion(bumpVersion)) {
       const mirrorPackage = bumpVersion.replace('mirror:', '');
       const parsedContent = JSON.parse(content);
       newPjVersion =


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This was something that prevented me to perform type check after `pnpm` migration

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
