### PR TITLE
feat(result): Support wrapping Zod schemas

### DIFF
--- a/lib/util/result.spec.ts
+++ b/lib/util/result.spec.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { ZodError, z } from 'zod';
 import { logger } from '../../test/util';
 import { AsyncResult, Result } from './result';
 
@@ -83,6 +83,13 @@ describe('util/result', () => {
             ],
           })
         );
+      });
+
+      it('wraps Zod schema', () => {
+        const schema = z.string().transform((x) => x.toUpperCase());
+        const parse = Result.wrapSchema(schema);
+        expect(parse('foo')).toEqual(Result.ok('FOO'));
+        expect(parse(42)).toMatchObject(Result.err(expect.any(ZodError)));
       });
     });
 
@@ -258,6 +265,17 @@ describe('util/result', () => {
       it('handles rejected nullable promise', async () => {
         const res = Result.wrapNullable(Promise.reject('oops'), 'nullable');
         await expect(res).resolves.toEqual(Result.err('oops'));
+      });
+
+      it('wraps Zod async schema', async () => {
+        const schema = z
+          .string()
+          .transform((x) => Promise.resolve(x.toUpperCase()));
+        const parse = Result.wrapSchemaAsync(schema);
+        await expect(parse('foo')).resolves.toEqual(Result.ok('FOO'));
+        await expect(parse(42)).resolves.toMatchObject(
+          Result.err(expect.any(ZodError))
+        );
       });
     });
 

--- a/lib/util/result.ts
+++ b/lib/util/result.ts
@@ -54,11 +54,11 @@ function fromZodResult<ZodInput, ZodOutput extends Val>(
   return input.success ? Result.ok(input.data) : Result.err(input.error);
 }
 
-type SchemaParseFn<T extends Val, Input = any> = (
+type SchemaParseFn<T extends Val, Input = unknown> = (
   input: unknown
 ) => Result<T, ZodError<Input>>;
 
-type SchemaAsyncParseFn<T extends Val, Input = any> = (
+type SchemaAsyncParseFn<T extends Val, Input = unknown> = (
   input: unknown
 ) => AsyncResult<T, ZodError<Input>>;
 
@@ -123,7 +123,7 @@ export class Result<T extends Val, E extends Val = Error> {
    *
    *   ```
    */
-  static wrap<T extends Val, Input = any>(
+  static wrap<T extends Val, Input = unknown>(
     zodResult: SafeParseReturnType<Input, T>
   ): Result<T, ZodError<Input>>;
   static wrap<T extends Val, E extends Val = Error>(
@@ -139,7 +139,7 @@ export class Result<T extends Val, E extends Val = Error> {
     T extends Val,
     E extends Val = Error,
     EE extends Val = never,
-    Input = any
+    Input = unknown
   >(
     input:
       | SafeParseReturnType<Input, T>
@@ -285,7 +285,7 @@ export class Result<T extends Val, E extends Val = Error> {
   static wrapSchema<
     T extends Val,
     Schema extends ZodType<T, ZodTypeDef, Input>,
-    Input = any
+    Input = unknown
   >(schema: Schema): SchemaParseFn<T, Input> {
     return (input) => {
       const result = schema.safeParse(input);
@@ -299,7 +299,7 @@ export class Result<T extends Val, E extends Val = Error> {
   static wrapSchemaAsync<
     T extends Val,
     Schema extends ZodType<T, ZodTypeDef, Input>,
-    Input = any
+    Input = unknown
   >(schema: Schema): SchemaAsyncParseFn<T, Input> {
     return (input) => {
       const result = schema.safeParseAsync(input);
@@ -386,10 +386,10 @@ export class Result<T extends Val, E extends Val = Error> {
   transform<U extends Val, EE extends Val>(
     fn: (value: T) => AsyncResult<U, E | EE>
   ): AsyncResult<U, E | EE>;
-  transform<U extends Val, Input = any>(
+  transform<U extends Val, Input = unknown>(
     fn: (value: T) => SafeParseReturnType<Input, NonNullable<U>>
   ): Result<U, E | ZodError<Input>>;
-  transform<U extends Val, Input = any>(
+  transform<U extends Val, Input = unknown>(
     fn: (value: T) => Promise<SafeParseReturnType<Input, NonNullable<U>>>
   ): AsyncResult<U, E | ZodError<Input>>;
   transform<U extends Val, EE extends Val>(
@@ -399,7 +399,7 @@ export class Result<T extends Val, E extends Val = Error> {
     fn: (value: T) => Promise<RawValue<U>>
   ): AsyncResult<U, E>;
   transform<U extends Val>(fn: (value: T) => RawValue<U>): Result<U, E>;
-  transform<U extends Val, EE extends Val, Input = any>(
+  transform<U extends Val, EE extends Val, Input = unknown>(
     fn: (
       value: T
     ) =>
@@ -522,7 +522,7 @@ export class AsyncResult<T extends Val, E extends Val>
     T extends Val,
     E extends Val = Error,
     EE extends Val = never,
-    Input = any
+    Input = unknown
   >(
     promise:
       | Promise<SafeParseReturnType<Input, T>>
@@ -638,10 +638,10 @@ export class AsyncResult<T extends Val, E extends Val>
   transform<U extends Val, EE extends Val>(
     fn: (value: T) => AsyncResult<U, E | EE>
   ): AsyncResult<U, E | EE>;
-  transform<U extends Val, Input = any>(
+  transform<U extends Val, Input = unknown>(
     fn: (value: T) => SafeParseReturnType<Input, NonNullable<U>>
   ): AsyncResult<U, E | ZodError<Input>>;
-  transform<U extends Val, Input = any>(
+  transform<U extends Val, Input = unknown>(
     fn: (value: T) => Promise<SafeParseReturnType<Input, NonNullable<U>>>
   ): AsyncResult<U, E | ZodError<Input>>;
   transform<U extends Val, EE extends Val>(
@@ -651,7 +651,7 @@ export class AsyncResult<T extends Val, E extends Val>
     fn: (value: T) => Promise<RawValue<U>>
   ): AsyncResult<U, E>;
   transform<U extends Val>(fn: (value: T) => RawValue<U>): AsyncResult<U, E>;
-  transform<U extends Val, EE extends Val, Input = any>(
+  transform<U extends Val, EE extends Val, Input = unknown>(
     fn: (
       value: T
     ) =>


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Provide convenience methods for wrapping Zod schema into the parser functions that return `Result` and `AsyncResult`.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
