### PR TITLE
chore: add .pnpm-store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /node_modules
+/.pnpm-store
 /config.js*
 /coverage
 /dist


### PR DESCRIPTION
Since we have migrated to pnpm from yarn, /.pnpm-store gets created which needs to be added to .gitignore.