### PR TITLE
chore: better description for `best-practices` preset

### DIFF
--- a/lib/config/presets/internal/config.ts
+++ b/lib/config/presets/internal/config.ts
@@ -5,7 +5,7 @@ import type { Preset } from '../types';
 export const presets: Record<string, Preset> = {
   'best-practices': {
     configMigration: true,
-    description: 'Preset with best practices from the Renovate maintainers. Only for users that want to follow our best practices.',
+    description: 'Preset with best practices from the Renovate maintainers. Recommended for advanced users, who want to follow our best practices.',
     extends: [
       'config:recommended',
       'docker:pinDigests',

--- a/lib/config/presets/internal/config.ts
+++ b/lib/config/presets/internal/config.ts
@@ -5,7 +5,8 @@ import type { Preset } from '../types';
 export const presets: Record<string, Preset> = {
   'best-practices': {
     configMigration: true,
-    description: 'Preset with best practices from the Renovate maintainers. Recommended for advanced users, who want to follow our best practices.',
+    description:
+      'Preset with best practices from the Renovate maintainers. Recommended for advanced users, who want to follow our best practices.',
     extends: [
       'config:recommended',
       'docker:pinDigests',

--- a/lib/config/presets/internal/config.ts
+++ b/lib/config/presets/internal/config.ts
@@ -5,7 +5,7 @@ import type { Preset } from '../types';
 export const presets: Record<string, Preset> = {
   'best-practices': {
     configMigration: true,
-    description: 'Preset with best practices from the Renovate maintainers.',
+    description: 'Preset with best practices from the Renovate maintainers. Only for users that want to follow our best practices.',
     extends: [
       'config:recommended',
       'docker:pinDigests',


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Better `description` for `best-practices` preset

## Context

A new user did not know if `config:recommended` or `config:best-practices` was best for them, as beginners:

- https://github.com/renovatebot/renovate/discussions/23657#discussion-5466482

The goal of the new description is to make it easier to see which preset is for beginners, and which for advanced users.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
