### PR TITLE
fix(config-validator): don't ignore arguments after --strict option

### DIFF
--- a/lib/config-validator.ts
+++ b/lib/config-validator.ts
@@ -62,7 +62,7 @@ type PackageJson = {
   const strictArgIndex = process.argv.indexOf('--strict');
   const strict = strictArgIndex >= 0;
   if (strict) {
-    process.argv.splice(strictArgIndex);
+    process.argv.splice(strictArgIndex, 1);
   }
   if (process.argv.length > 2) {
     for (const file of process.argv.slice(2)) {


### PR DESCRIPTION
## Changes

Adds the `deleteCount` parameter to the `splice` call so that we only remove the `--strict` argument and keep the remaining ones 😳

## Context

Follow-up of https://github.com/renovatebot/renovate/pull/23677

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

🛠 with ❤️ by [Siemens](https://opensource.siemens.com/)