### PR TITLE
feat(manager/pub): extract Dart SDK

### DIFF
--- a/lib/modules/manager/pub/artifacts.spec.ts
+++ b/lib/modules/manager/pub/artifacts.spec.ts
@@ -20,7 +20,8 @@ process.env.CONTAINERBASE = 'true';
 const lockFile = 'pubspec.lock';
 const oldLockFileContent = 'Old pubspec.lock';
 const newLockFileContent = 'New pubspec.lock';
-const depNames = ['dep1', 'dep2', 'dart', 'flutter'];
+const depNames = ['dep1', 'dep2', 'dep3'];
+const depNamesWithSdks = [...depNames, ...['dart', 'flutter']];
 const depNamesWithSpace = depNames.join(' ');
 
 const datasource = mocked(_datasource);
@@ -35,7 +36,7 @@ const config: UpdateArtifactsConfig = {};
 
 const updateArtifact: UpdateArtifact = {
   packageFileName: 'pubspec.yaml',
-  updatedDeps: depNames.map((depName) => {
+  updatedDeps: depNamesWithSdks.map((depName) => {
     return { depName };
   }),
   newPackageFileContent: '',

--- a/lib/modules/manager/pub/artifacts.spec.ts
+++ b/lib/modules/manager/pub/artifacts.spec.ts
@@ -95,7 +95,7 @@ describe('modules/manager/pub/artifacts', () => {
     ]);
     expect(execSnapshots).toMatchObject([
       {
-        cmd: 'flutter pub get',
+        cmd: 'flutter pub get --no-precompile',
       },
     ]);
   });
@@ -169,7 +169,7 @@ describe('modules/manager/pub/artifacts', () => {
       ]);
       expect(execSnapshots).toMatchObject([
         {
-          cmd: `${params.sdk} pub get`,
+          cmd: `${params.sdk} pub get --no-precompile`,
         },
       ]);
     });

--- a/lib/modules/manager/pub/artifacts.spec.ts
+++ b/lib/modules/manager/pub/artifacts.spec.ts
@@ -1,10 +1,10 @@
+import { codeBlock } from 'common-tags';
 import { join } from 'upath';
 import { envMock, mockExecAll } from '../../../../test/exec-util';
 import { env, fs, mocked } from '../../../../test/util';
 import { GlobalConfig } from '../../../config/global';
 import type { RepoGlobalConfig } from '../../../config/types';
 import * as docker from '../../../util/exec/docker';
-import { range } from '../../../util/range';
 import * as _datasource from '../../datasource';
 import type { UpdateArtifact, UpdateArtifactsConfig } from '../types';
 import * as pub from '.';
@@ -20,9 +20,8 @@ process.env.CONTAINERBASE = 'true';
 const lockFile = 'pubspec.lock';
 const oldLockFileContent = 'Old pubspec.lock';
 const newLockFileContent = 'New pubspec.lock';
-const depNames = [...range(0, 3)].map((i) => `depName${i}`);
+const depNames = ['dep1', 'dep2', 'dart', 'flutter'];
 const depNamesWithSpace = depNames.join(' ');
-const depNamesWithFlutter = [...depNames, 'flutter'];
 
 const datasource = mocked(_datasource);
 
@@ -36,7 +35,7 @@ const config: UpdateArtifactsConfig = {};
 
 const updateArtifact: UpdateArtifact = {
   packageFileName: 'pubspec.yaml',
-  updatedDeps: depNamesWithFlutter.map((depName) => {
+  updatedDeps: depNames.map((depName) => {
     return { depName };
   }),
   newPackageFileContent: '',
@@ -70,13 +69,35 @@ describe('modules/manager/pub/artifacts', () => {
     ).toBeNull();
   });
 
-  it('returns null if updatedDeps only contains flutter', async () => {
+  it(`runs flutter pub get if only dart and flutter sdks are updated`, async () => {
+    const execSnapshots = mockExecAll();
+    fs.getSiblingFileName.mockReturnValueOnce(lockFile);
+    fs.readLocalFile.mockResolvedValueOnce(oldLockFileContent);
+    fs.readLocalFile.mockResolvedValueOnce(newLockFileContent);
     expect(
       await pub.updateArtifacts({
         ...updateArtifact,
-        updatedDeps: [{ depName: 'flutter' }],
+        newPackageFileContent: codeBlock`
+          environment:
+            sdk: ^3.0.0
+            flutter: 2.0.0
+        `,
+        updatedDeps: [{ depName: 'dart' }, { depName: 'flutter' }],
       })
-    ).toBeNull();
+    ).toEqual([
+      {
+        file: {
+          type: 'addition',
+          path: lockFile,
+          contents: newLockFileContent,
+        },
+      },
+    ]);
+    expect(execSnapshots).toMatchObject([
+      {
+        cmd: 'flutter pub get',
+      },
+    ]);
   });
 
   describe.each([
@@ -122,6 +143,33 @@ describe('modules/manager/pub/artifacts', () => {
       expect(execSnapshots).toMatchObject([
         {
           cmd: `${params.sdk} pub upgrade ${depNamesWithSpace}`,
+        },
+      ]);
+    });
+
+    it(`runs ${params.sdk} pub get if only the sdk is updated`, async () => {
+      const execSnapshots = mockExecAll();
+      fs.getSiblingFileName.mockReturnValueOnce(lockFile);
+      fs.readLocalFile.mockResolvedValueOnce(oldLockFileContent);
+      fs.readLocalFile.mockResolvedValueOnce(newLockFileContent);
+      expect(
+        await pub.updateArtifacts({
+          ...updateArtifact,
+          newPackageFileContent: params.packageFileContent,
+          updatedDeps: [{ depName: params.sdk }],
+        })
+      ).toEqual([
+        {
+          file: {
+            type: 'addition',
+            path: lockFile,
+            contents: newLockFileContent,
+          },
+        },
+      ]);
+      expect(execSnapshots).toMatchObject([
+        {
+          cmd: `${params.sdk} pub get`,
         },
       ]);
     });

--- a/lib/modules/manager/pub/artifacts.ts
+++ b/lib/modules/manager/pub/artifacts.ts
@@ -13,6 +13,7 @@ import type { UpdateArtifact, UpdateArtifactsResult } from '../types';
 import { parsePubspecLock } from './utils';
 
 const SDK_NAMES = ['dart', 'flutter'];
+const PUB_GET_COMMAND = 'pub get --no-precompile';
 
 export async function updateArtifacts({
   packageFileName,
@@ -51,7 +52,7 @@ export async function updateArtifacts({
         .map(quote);
 
       if (depNames.length === 1 && SDK_NAMES.includes(depNames[0])) {
-        cmd.push(`${toolName} pub get`);
+        cmd.push(`${toolName} ${PUB_GET_COMMAND}`);
       }
       // If there are two updated dependencies and both of them are SDK updates (Dart and Flutter),
       // we use Flutter over Dart to run `pub get` as it is a Flutter project.
@@ -59,7 +60,7 @@ export async function updateArtifacts({
         depNames.length === 2 &&
         depNames.filter((depName) => SDK_NAMES.includes(depName)).length === 2
       ) {
-        cmd.push(`flutter pub get`);
+        cmd.push(`flutter ${PUB_GET_COMMAND}`);
       } else {
         cmd.push(`${toolName} pub upgrade ${depNames.join(' ')}`);
       }

--- a/lib/modules/manager/pub/artifacts.ts
+++ b/lib/modules/manager/pub/artifacts.ts
@@ -95,14 +95,13 @@ function getExecCommand(
   toolName: string,
   updatedDeps: Upgrade<Record<string, unknown>>[],
   isLockFileMaintenance: boolean
-): string[] {
-  const cmd: string[] = [];
+): string {
   if (isLockFileMaintenance) {
-    cmd.push(`${toolName} pub upgrade`);
+    return `${toolName} pub upgrade`;
   } else {
     const depNames = updatedDeps.map((dep) => dep.depName).filter(is.string);
     if (depNames.length === 1 && SDK_NAMES.includes(depNames[0])) {
-      cmd.push(`${toolName} ${PUB_GET_COMMAND}`);
+      return `${toolName} ${PUB_GET_COMMAND}`;
     }
     // If there are two updated dependencies and both of them are SDK updates (Dart and Flutter),
     // we use Flutter over Dart to run `pub get` as it is a Flutter project.
@@ -110,15 +109,13 @@ function getExecCommand(
       depNames.length === 2 &&
       depNames.filter((depName) => SDK_NAMES.includes(depName)).length === 2
     ) {
-      cmd.push(`flutter ${PUB_GET_COMMAND}`);
+      return `flutter ${PUB_GET_COMMAND}`;
     } else {
       const depNamesCmd = depNames
         .filter((depName) => !SDK_NAMES.includes(depName))
         .map(quote)
         .join(' ');
-      cmd.push(`${toolName} pub upgrade ${depNamesCmd}`);
+      return `${toolName} pub upgrade ${depNamesCmd}`;
     }
   }
-
-  return cmd;
 }

--- a/lib/modules/manager/pub/extract.spec.ts
+++ b/lib/modules/manager/pub/extract.spec.ts
@@ -5,21 +5,29 @@ describe('modules/manager/pub/extract', () => {
   describe('extractPackageFile', () => {
     const packageFile = 'pubspec.yaml';
 
-    it('returns null if package does not contain any deps', () => {
-      const content = codeBlock`
-        environment:
-          sdk: ^3.0.0
-      `;
-      const actual = extractPackageFile(content, packageFile);
-      expect(actual).toBeNull();
-    });
-
     it('returns null for invalid pubspec file', () => {
       const content = codeBlock`
         clarly: "invalid" "yaml"
       `;
       const actual = extractPackageFile(content, packageFile);
       expect(actual).toBeNull();
+    });
+
+    it('returns dart sdk only', () => {
+      const content = codeBlock`
+        environment:
+          sdk: ^3.0.0
+      `;
+      const actual = extractPackageFile(content, packageFile);
+      expect(actual).toEqual({
+        deps: [
+          {
+            currentValue: '^3.0.0',
+            depName: 'dart',
+            datasource: 'dart-version',
+          },
+        ],
+      });
     });
 
     it('returns valid dependencies', () => {
@@ -73,6 +81,11 @@ describe('modules/manager/pub/extract', () => {
             depName: 'build',
             depType: 'dev_dependencies',
             datasource: dartDatasource,
+          },
+          {
+            currentValue: '^3.0.0',
+            depName: 'dart',
+            datasource: 'dart-version',
           },
           {
             currentValue: '2.0.0',

--- a/lib/modules/manager/pub/index.ts
+++ b/lib/modules/manager/pub/index.ts
@@ -1,11 +1,18 @@
 import type { Category } from '../../../constants';
 import { DartDatasource } from '../../datasource/dart';
+import { DartVersionDatasource } from '../../datasource/dart-version';
+import { FlutterVersionDatasource } from '../../datasource/flutter-version';
 import * as npmVersioning from '../../versioning/npm';
 
 export { updateArtifacts } from './artifacts';
 export { extractPackageFile } from './extract';
 
-export const supportedDatasources = [DartDatasource.id];
+export const supportedDatasources = [
+  DartDatasource.id,
+  DartVersionDatasource.id,
+  FlutterVersionDatasource.id,
+];
+
 export const supportsLockFileMaintenance = true;
 
 export const defaultConfig = {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Update `pub` manager to extract Dart SDK as a dependency
- Fix/update `updateArtifacts` to run the appropriate commands to update the lock file for the SDK updates

## Context

- The `pub` manager currently doesn't extract Dart SDK as a dependency
- https://github.com/renovatebot/renovate/pull/23759#discussion_r1289006693

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository
  - https://github.com/barriot/r2/pull/14 - the `updateArtifacts` actually failed because it requires bounded version constraint, not sure if this is configurable by Renovate
  - https://github.com/barriot/r0/pull/13 - you'll see a bunch of transitive dependencies being updated as well in the lock file as those are dependencies of Flutter

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
