### PR TITLE
docs: push new commit instead of amending Renovate's commit

### DIFF
--- a/docs/usage/updating-rebasing.md
+++ b/docs/usage/updating-rebasing.md
@@ -22,8 +22,13 @@ Instead, Renovate reapplies all updates into a new commit based off of the head 
 ## No rebasing if you have made edits
 
 First of all, here is the one time when Renovate _won't_ update branches.
-If you edit a Renovate branch directly (e.g. to make a code fix to allow tests to pass again) then Renovate stops all updates of that branch.
-It is up to you to either finish the job and merge the PR, or rename it and close it so that Renovate can take back over again.
+If you push a new commit to a Renovate branch, for example to fix your code so the tests pass, then Renovate stops all updates of that branch.
+It is up to you to either finish the job and merge the PR, or rename it and close it so that Renovate can take over again.
+
+<!-- prettier-ignore -->
+!!! warning
+    Do _not_ amend Renovate's commits, because Renovate will rebase over your amended commit.
+    Keep your work safe and always push your own _new_ commit to any Renovate branch.
 
 ## Rebasing conflicted PRs
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Explain that users should push a new commit, and never amend Renovate's commits
- Small style fixes

## Context

A user nearly lost some work, they ran `git commit --amend` on Renovate's commit, and pushed the amended commit to the Renovate branch. Renovate then clobbered over the changes the next time it updated the PR.

I'm adding a warning to the docs, so that other users have a better chance of keeping their work safe.

- #23823

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
