### PR TITLE
chore: post to mend slack when labeled

### DIFF
--- a/.github/workflows/mend-slack.yml
+++ b/.github/workflows/mend-slack.yml
@@ -1,0 +1,23 @@
+name: 'Mend Slack Notifier'
+
+on:
+  discussion:
+    types: [labeled]
+
+permissions:
+  discussions: read
+
+jobs:
+  slack:
+    if: contains(github.event.label.name, 'mend-app')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post to Slack
+        id: slack
+        uses: slackapi/slack-github-action@v1.24.0
+        with:
+          channel-id: 'C05NLTMGCJC'
+          # For posting a simple plain text message
+          slack-message: "${{ github.event.discussion.title }}\n${{ github.event.discussion.html_url }}"
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/mend-slack.yml
+++ b/.github/workflows/mend-slack.yml
@@ -18,6 +18,6 @@ jobs:
         with:
           channel-id: 'C05NLTMGCJC'
           # For posting a simple plain text message
-          slack-message: "${{ github.event.discussion.title }}\n${{ github.event.discussion.html_url }}"
+          slack-message: "<${{ github.event.discussion.html_url }}|${{ github.event.discussion.title }}>"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Post to Mend Slack whenever a Discussion is labeled with `mend-app`

## Context

A way for us to alert the relevant team to user-impacting issues in the app

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
