### PR TITLE
fix(nix): trim `x-access-token:` prefix from Github token

### DIFF
--- a/lib/modules/manager/nix/artifacts.ts
+++ b/lib/modules/manager/nix/artifacts.ts
@@ -1,6 +1,7 @@
 import is from '@sindresorhus/is';
 import { quote } from 'shlex';
 import { logger } from '../../../logger';
+import { findGithubToken } from '../../../util/check-token';
 import { exec } from '../../../util/exec';
 import type { ExecOptions } from '../../../util/exec/types';
 import { readLocalFile } from '../../../util/fs';
@@ -25,10 +26,10 @@ export async function updateArtifacts({
     --extra-experimental-features nix-command \
     --extra-experimental-features flakes `;
 
-  const { token } = hostRules.find({
+  const token = findGithubToken(hostRules.find({
     hostType: 'github',
     url: 'https://api.github.com/',
-  });
+  }));
 
   if (token) {
     cmd += `--extra-access-tokens github.com=${token} `;

--- a/lib/modules/manager/nix/artifacts.ts
+++ b/lib/modules/manager/nix/artifacts.ts
@@ -26,10 +26,12 @@ export async function updateArtifacts({
     --extra-experimental-features nix-command \
     --extra-experimental-features flakes `;
 
-  const token = findGithubToken(hostRules.find({
-    hostType: 'github',
-    url: 'https://api.github.com/',
-  }));
+  const token = findGithubToken(
+    hostRules.find({
+      hostType: 'github',
+      url: 'https://api.github.com/',
+    })
+  );
 
   if (token) {
     cmd += `--extra-access-tokens github.com=${token} `;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

When `x-access-token:` is missing, Renovate adds it, so the token in use is effectively something like `x-access-token:ghs_sDoQBOAIumFXRsSXHamjteqeOeIIzR0UjiOy`.

I found that there already is an utility to remove it (the `composer` manager uses it):

https://github.com/renovatebot/renovate/blob/d7058bd2e390e7d33cd58865d4133263c6da9f9b/lib/util/check-token.ts#L74-L78

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

https://github.com/renovatebot/renovate/discussions/21567#discussioncomment-6085407

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
