### PR TITLE
fix(mix): authenticate hex private repos configured in hostRules

### DIFF
--- a/lib/modules/manager/mix/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/modules/manager/mix/__snapshots__/artifacts.spec.ts.snap
@@ -1,47 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`modules/manager/mix/artifacts authenticates to private repositories configured in hostRules 1`] = `
-[
-  {
-    "file": {
-      "contents": "New mix.lock",
-      "path": "mix.lock",
-      "type": "addition",
-    },
-  },
-]
-`;
-
-exports[`modules/manager/mix/artifacts authenticates to private repositories configured in hostRules 2`] = `
-[
-  {
-    "cmd": "docker ps --filter name=renovate_sidecar -aq",
-    "options": {
-      "encoding": "utf-8",
-    },
-  },
-  {
-    "cmd": "docker run --rm --name=renovate_sidecar --label=renovate_child -v "/tmp/github/some/repo":"/tmp/github/some/repo" -v "/tmp/cache":"/tmp/cache" -e CONTAINERBASE_CACHE_DIR -w "/tmp/github/some/repo" ghcr.io/containerbase/sidecar bash -l -c "install-tool erlang 25.0.0.0 && install-tool elixir v1.13.4 && mix hex.organization auth an_organization --key an_organization_token && mix deps.update some_package"",
-    "options": {
-      "cwd": "/tmp/github/some/repo",
-      "encoding": "utf-8",
-      "env": {
-        "CONTAINERBASE_CACHE_DIR": "/tmp/cache/containerbase",
-        "HOME": "/home/user",
-        "HTTPS_PROXY": "https://example.com",
-        "HTTP_PROXY": "http://example.com",
-        "LANG": "en_US.UTF-8",
-        "LC_ALL": "en_US",
-        "NO_PROXY": "localhost",
-        "PATH": "/tmp/path",
-      },
-      "maxBuffer": 10485760,
-      "timeout": 900000,
-    },
-  },
-]
-`;
-
 exports[`modules/manager/mix/artifacts authenticates to private repositories in updated dependecies 1`] = `
 [
   {

--- a/lib/modules/manager/mix/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/modules/manager/mix/__snapshots__/artifacts.spec.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`modules/manager/mix/artifacts authenticates to private repositories 1`] = `
+exports[`modules/manager/mix/artifacts authenticates to private repositories configured in hostRules 1`] = `
 [
   {
     "file": {
@@ -12,7 +12,49 @@ exports[`modules/manager/mix/artifacts authenticates to private repositories 1`]
 ]
 `;
 
-exports[`modules/manager/mix/artifacts authenticates to private repositories 2`] = `
+exports[`modules/manager/mix/artifacts authenticates to private repositories configured in hostRules 2`] = `
+[
+  {
+    "cmd": "docker ps --filter name=renovate_sidecar -aq",
+    "options": {
+      "encoding": "utf-8",
+    },
+  },
+  {
+    "cmd": "docker run --rm --name=renovate_sidecar --label=renovate_child -v "/tmp/github/some/repo":"/tmp/github/some/repo" -v "/tmp/cache":"/tmp/cache" -e CONTAINERBASE_CACHE_DIR -w "/tmp/github/some/repo" ghcr.io/containerbase/sidecar bash -l -c "install-tool erlang 25.0.0.0 && install-tool elixir v1.13.4 && mix hex.organization auth an_organization --key an_organization_token && mix deps.update some_package"",
+    "options": {
+      "cwd": "/tmp/github/some/repo",
+      "encoding": "utf-8",
+      "env": {
+        "CONTAINERBASE_CACHE_DIR": "/tmp/cache/containerbase",
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+]
+`;
+
+exports[`modules/manager/mix/artifacts authenticates to private repositories in updated dependecies 1`] = `
+[
+  {
+    "file": {
+      "contents": "New mix.lock",
+      "path": "mix.lock",
+      "type": "addition",
+    },
+  },
+]
+`;
+
+exports[`modules/manager/mix/artifacts authenticates to private repositories in updated dependecies 2`] = `
 [
   {
     "cmd": "docker ps --filter name=renovate_sidecar -aq",

--- a/lib/modules/manager/mix/artifacts.spec.ts
+++ b/lib/modules/manager/mix/artifacts.spec.ts
@@ -135,7 +135,7 @@ describe('modules/manager/mix/artifacts', () => {
     expect(execSnapshots).toMatchSnapshot();
   });
 
-  it('uses constaints on install mode', async () => {
+  it('uses constraints on install mode', async () => {
     GlobalConfig.set({ ...adminConfig, binarySource: 'install' });
     fs.readLocalFile.mockResolvedValueOnce('Old mix.lock');
     fs.findLocalSiblingOrParent.mockResolvedValueOnce('mix.lock');

--- a/lib/modules/manager/mix/artifacts.ts
+++ b/lib/modules/manager/mix/artifacts.ts
@@ -10,12 +10,13 @@ import {
   writeLocalFile,
 } from '../../../util/fs';
 import * as hostRules from '../../../util/host-rules';
+import { regEx } from '../../../util/regex';
 
 import type { UpdateArtifact, UpdateArtifactsResult } from '../types';
 
 const hexRepoUrl = 'https://hex.pm/';
-const hexRepoOrgUrlRegex = new RegExp(
-  `${hexRepoUrl}api/repos/([a-z0-9_]+)/`,
+const hexRepoOrgUrlRegex = regEx(
+  `https://hex\\.pm/api/repos/(?<organization>[a-z0-9_]+)/$`,
   'g'
 );
 
@@ -66,8 +67,8 @@ export async function updateArtifacts({
     if (matchHost) {
       const result = hexRepoOrgUrlRegex.exec(matchHost);
 
-      if (result) {
-        const [, organization] = result;
+      if (result?.groups) {
+        const { organization } = result.groups;
         organizations.add(organization);
       }
     }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Always authenticate to private hex repositories in `hostRules` that are configured with a `matchHost` property. 

## Context

We were running into the issue today that renovate could not update the `mix.lock` file as it did not always authenticate to hex for private repositories. It only does this when a package from a private repo is updated. From a quick search an issue did already exist for this. One of the suggestions given in the issue, i.e. retrieve organizations from configured `hostRules` and always authenticate for those, is implemented in this PR.

Closes #20717.
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
