### PR TITLE
fix(azure): catch unavailable devops and throw ExternalHostError

### DIFF
--- a/lib/modules/platform/azure/index.ts
+++ b/lib/modules/platform/azure/index.ts
@@ -17,6 +17,7 @@ import {
 } from '../../../constants/error-messages';
 import { logger } from '../../../logger';
 import type { BranchStatus } from '../../../types';
+import { ExternalHostError } from '../../../types/errors/external-host-error';
 import * as git from '../../../util/git';
 import * as hostRules from '../../../util/host-rules';
 import { regEx } from '../../../util/regex';
@@ -53,7 +54,6 @@ import {
   getStorageExtraCloneOpts,
   max4000Chars,
 } from './util';
-import { ExternalHostError } from '../../../types/errors/external-host-error';
 
 interface Config {
   repoForceRebase: boolean;

--- a/lib/modules/platform/azure/index.ts
+++ b/lib/modules/platform/azure/index.ts
@@ -53,6 +53,7 @@ import {
   getStorageExtraCloneOpts,
   max4000Chars,
 } from './util';
+import { ExternalHostError } from '../../../types/errors/external-host-error';
 
 interface Config {
   repoForceRebase: boolean;
@@ -121,40 +122,52 @@ export async function getRawFile(
   repoName?: string,
   branchOrTag?: string
 ): Promise<string | null> {
-  const azureApiGit = await azureApi.gitApi();
+  try {
+    const azureApiGit = await azureApi.gitApi();
 
-  let repoId: string | undefined;
-  if (repoName) {
-    const repos = await azureApiGit.getRepositories();
-    const repo = getRepoByName(repoName, repos);
-    repoId = repo?.id;
-  } else {
-    repoId = config.repoId;
+    let repoId: string | undefined;
+    if (repoName) {
+      const repos = await azureApiGit.getRepositories();
+      const repo = getRepoByName(repoName, repos);
+      repoId = repo?.id;
+    } else {
+      repoId = config.repoId;
+    }
+
+    if (!repoId) {
+      logger.debug('No repoId so cannot getRawFile');
+      return null;
+    }
+
+    const versionDescriptor: GitVersionDescriptor = {
+      version: branchOrTag,
+    } satisfies GitVersionDescriptor;
+
+    const buf = await azureApiGit.getItemContent(
+      repoId,
+      fileName,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      branchOrTag ? versionDescriptor : undefined
+    );
+
+    const str = await streamToString(buf);
+    return str;
+  } catch (err) /* istanbul ignore next */ {
+    if (
+      err.message?.includes('<title>Azure DevOps Services Unavailable</title>')
+    ) {
+      logger.debug(
+        'Azure DevOps is currently unavailable when attempting to fetch file - throwing ExternalHostError'
+      );
+      throw new ExternalHostError(err, id);
+    }
+    throw err;
   }
-
-  if (!repoId) {
-    logger.debug('No repoId so cannot getRawFile');
-    return null;
-  }
-
-  const versionDescriptor: GitVersionDescriptor = {
-    version: branchOrTag,
-  } satisfies GitVersionDescriptor;
-
-  const buf = await azureApiGit.getItemContent(
-    repoId,
-    fileName,
-    undefined,
-    undefined,
-    undefined,
-    undefined,
-    undefined,
-    undefined,
-    branchOrTag ? versionDescriptor : undefined
-  );
-
-  const str = await streamToString(buf);
-  return str;
 }
 
 export async function getJsonFile(


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Catch when Azure Devops is unavailable for file fetching and throw ExternalHostError

## Context

Fixes #23419

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
