### PR TITLE
feat(presets)!: drop `renovate.json` fallback

### DIFF
--- a/lib/config/presets/gitlab/index.spec.ts
+++ b/lib/config/presets/gitlab/index.spec.ts
@@ -33,11 +33,8 @@ describe('config/presets/gitlab/index', () => {
       httpMock
         .scope(gitlabApiHost)
         .get(projectPath)
-        .twice()
         .reply(200, {})
         .get(`${basePath}/files/default.json/raw?ref=master`)
-        .reply(404)
-        .get(`${basePath}/files/renovate.json/raw?ref=master`)
         .reply(404);
       await expect(gitlab.getPreset({ repo: 'some/repo' })).rejects.toThrow(
         PRESET_DEP_NOT_FOUND

--- a/lib/config/presets/util.spec.ts
+++ b/lib/config/presets/util.spec.ts
@@ -1,5 +1,11 @@
 import type { FetchPresetConfig, Preset } from './types';
-import { PRESET_DEP_NOT_FOUND, PRESET_NOT_FOUND, fetchPreset } from './util';
+import {
+  PRESET_DEP_NOT_FOUND,
+  PRESET_INVALID_JSON,
+  PRESET_NOT_FOUND,
+  fetchPreset,
+  parsePreset,
+} from './util';
 
 const config: FetchPresetConfig = {
   repo: 'some/repo',
@@ -15,56 +21,80 @@ describe('config/presets/util', () => {
     fetch.mockReset();
   });
 
-  it('works', async () => {
-    fetch.mockResolvedValueOnce({ sub: { preset: { foo: true } } });
-    expect(await fetchPreset({ ...config, fetch })).toEqual({
-      sub: { preset: { foo: true } },
+  describe('fetchPreset', () => {
+    it('works', async () => {
+      fetch.mockResolvedValueOnce({ sub: { preset: { foo: true } } });
+      expect(await fetchPreset({ ...config, fetch })).toEqual({
+        sub: { preset: { foo: true } },
+      });
+
+      fetch.mockResolvedValueOnce({ sub: { preset: { foo: true } } });
+      expect(await fetchPreset({ ...config, fetch })).toEqual({
+        sub: { preset: { foo: true } },
+      });
+
+      fetch.mockResolvedValueOnce({ sub: { preset: { foo: true } } });
+      expect(
+        await fetchPreset({ ...config, filePreset: 'some/sub', fetch })
+      ).toEqual({ preset: { foo: true } });
+
+      fetch.mockResolvedValueOnce({ sub: { preset: { foo: true } } });
+      expect(
+        await fetchPreset({ ...config, filePreset: 'some/sub/preset', fetch })
+      ).toEqual({ foo: true });
+
+      fetch.mockResolvedValueOnce({ sub: { preset: { foo: true } } });
+      expect(
+        await fetchPreset({
+          ...config,
+          presetPath: 'some/sub',
+          filePreset: 'preset.json5',
+          fetch,
+        })
+      ).toEqual({ sub: { preset: { foo: true } } });
     });
 
-    fetch.mockRejectedValueOnce(new Error(PRESET_DEP_NOT_FOUND));
-    fetch.mockResolvedValueOnce({ sub: { preset: { foo: true } } });
-    expect(await fetchPreset({ ...config, fetch })).toEqual({
-      sub: { preset: { foo: true } },
+    it('fails', async () => {
+      fetch.mockRejectedValueOnce(new Error('fails'));
+      await expect(fetchPreset({ ...config, fetch })).rejects.toThrow('fails');
     });
 
-    fetch.mockResolvedValueOnce({ sub: { preset: { foo: true } } });
-    expect(
-      await fetchPreset({ ...config, filePreset: 'some/sub', fetch })
-    ).toEqual({ preset: { foo: true } });
+    it(PRESET_DEP_NOT_FOUND, async () => {
+      fetch.mockResolvedValueOnce(null);
+      await expect(fetchPreset({ ...config, fetch })).rejects.toThrow(
+        PRESET_DEP_NOT_FOUND
+      );
 
-    fetch.mockResolvedValueOnce({ sub: { preset: { foo: true } } });
-    expect(
-      await fetchPreset({ ...config, filePreset: 'some/sub/preset', fetch })
-    ).toEqual({ foo: true });
+      fetch.mockRejectedValueOnce(new Error(PRESET_DEP_NOT_FOUND));
+      fetch.mockRejectedValueOnce(new Error(PRESET_DEP_NOT_FOUND));
+      await expect(fetchPreset({ ...config, fetch })).rejects.toThrow(
+        PRESET_DEP_NOT_FOUND
+      );
+    });
+
+    it(PRESET_NOT_FOUND, async () => {
+      fetch.mockResolvedValueOnce({});
+      await expect(
+        fetchPreset({ ...config, filePreset: 'some/sub/preset', fetch })
+      ).rejects.toThrow(PRESET_NOT_FOUND);
+
+      fetch.mockResolvedValueOnce({ sub: {} });
+      await expect(
+        fetchPreset({ ...config, filePreset: 'some/sub/preset', fetch })
+      ).rejects.toThrow(PRESET_NOT_FOUND);
+    });
   });
 
-  it('fails', async () => {
-    fetch.mockRejectedValueOnce(new Error('fails'));
-    await expect(fetchPreset({ ...config, fetch })).rejects.toThrow('fails');
-  });
+  describe('parsePreset', () => {
+    it('parses', () => {
+      expect(parsePreset('{ it: true}')).toStrictEqual({ it: true });
+    });
 
-  it(PRESET_DEP_NOT_FOUND, async () => {
-    fetch.mockResolvedValueOnce(null);
-    await expect(fetchPreset({ ...config, fetch })).rejects.toThrow(
-      PRESET_DEP_NOT_FOUND
-    );
-
-    fetch.mockRejectedValueOnce(new Error(PRESET_DEP_NOT_FOUND));
-    fetch.mockRejectedValueOnce(new Error(PRESET_DEP_NOT_FOUND));
-    await expect(fetchPreset({ ...config, fetch })).rejects.toThrow(
-      PRESET_DEP_NOT_FOUND
-    );
-  });
-
-  it(PRESET_NOT_FOUND, async () => {
-    fetch.mockResolvedValueOnce({});
-    await expect(
-      fetchPreset({ ...config, filePreset: 'some/sub/preset', fetch })
-    ).rejects.toThrow(PRESET_NOT_FOUND);
-
-    fetch.mockResolvedValueOnce({ sub: {} });
-    await expect(
-      fetchPreset({ ...config, filePreset: 'some/sub/preset', fetch })
-    ).rejects.toThrow(PRESET_NOT_FOUND);
+    it('throws', () => {
+      expect(() => parsePreset('{')).toThrowWithMessage(
+        Error,
+        PRESET_INVALID_JSON
+      );
+    });
   });
 });

--- a/lib/config/presets/util.ts
+++ b/lib/config/presets/util.ts
@@ -1,5 +1,4 @@
 import JSON5 from 'json5';
-import { logger } from '../../logger';
 import { regEx } from '../../util/regex';
 import { ensureTrailingSlash } from '../../util/url';
 import type { FetchPresetConfig, Preset } from './types';
@@ -28,27 +27,12 @@ export async function fetchPreset({
   const buildFilePath = (name: string): string => `${pathPrefix}${name}`;
   let jsonContent: any;
   if (fileName === 'default') {
-    try {
-      jsonContent = await fetch(
-        repo,
-        buildFilePath('default.json'),
-        endpoint,
-        tag
-      );
-    } catch (err) {
-      if (err.message !== PRESET_DEP_NOT_FOUND) {
-        throw err;
-      }
-      jsonContent = await fetch(
-        repo,
-        buildFilePath('renovate.json'),
-        endpoint,
-        tag
-      );
-      logger.info(
-        'Fallback to renovate.json file as a preset is deprecated, please use a default.json file instead.'
-      );
-    }
+    jsonContent = await fetch(
+      repo,
+      buildFilePath('default.json'),
+      endpoint,
+      tag
+    );
   } else {
     jsonContent = await fetch(
       repo,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Remove the fallback to `renovate.json` preset when `default.json` is not found.

**NOTE**: Review with ignore whitespace changes. 😉 

<!-- Describe what behavior is changed by this PR. -->

**TODO**
- [ ] fix conflicts
- [ ] throw config error when fallback found

## Context
- #22212
- #23419
- #24263
- #27992
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
