### PR TITLE
fix(manager/pub): skip dependency `flutter_test` and path dependencies

### DIFF
--- a/lib/modules/manager/pub/extract.spec.ts
+++ b/lib/modules/manager/pub/extract.spec.ts
@@ -31,7 +31,10 @@ describe('modules/manager/pub/extract', () => {
     });
 
     it('returns valid dependencies', () => {
+      const dependenciesDepType = 'dependencies';
+      const devDependenciesDepType = 'dev_dependencies';
       const dartDatasource = 'dart';
+      const skipReason = undefined;
       const content = codeBlock`
         environment:
           sdk: ^3.0.0
@@ -44,10 +47,16 @@ describe('modules/manager/pub/extract', () => {
           baz:
             non-sense: true
           qux: false
+          path_dep:
+            path: path1
         dev_dependencies:
           test: ^0.1.0
           build:
             version: 0.0.1
+          flutter_test:
+            sdk: flutter
+          path_dev_dep:
+            path: path2
       `;
       const actual = extractPackageFile(content, packageFile);
       expect(actual).toEqual({
@@ -55,42 +64,63 @@ describe('modules/manager/pub/extract', () => {
           {
             currentValue: '1.0.0',
             depName: 'foo',
-            depType: 'dependencies',
+            depType: dependenciesDepType,
             datasource: dartDatasource,
+            skipReason,
           },
           {
             currentValue: '1.1.0',
             depName: 'bar',
-            depType: 'dependencies',
+            depType: dependenciesDepType,
             datasource: dartDatasource,
+            skipReason,
           },
           {
             currentValue: '',
             depName: 'baz',
-            depType: 'dependencies',
+            depType: dependenciesDepType,
             datasource: dartDatasource,
+            skipReason,
+          },
+          {
+            currentValue: '',
+            depName: 'path_dep',
+            depType: dependenciesDepType,
+            datasource: dartDatasource,
+            skipReason: 'path-dependency',
           },
           {
             currentValue: '^0.1.0',
             depName: 'test',
-            depType: 'dev_dependencies',
+            depType: devDependenciesDepType,
             datasource: dartDatasource,
+            skipReason,
           },
           {
             currentValue: '0.0.1',
             depName: 'build',
-            depType: 'dev_dependencies',
+            depType: devDependenciesDepType,
             datasource: dartDatasource,
+            skipReason,
+          },
+          {
+            currentValue: '',
+            depName: 'path_dev_dep',
+            depType: devDependenciesDepType,
+            datasource: dartDatasource,
+            skipReason: 'path-dependency',
           },
           {
             currentValue: '^3.0.0',
             depName: 'dart',
             datasource: 'dart-version',
+            skipReason,
           },
           {
             currentValue: '2.0.0',
             depName: 'flutter',
             datasource: 'flutter-version',
+            skipReason,
           },
         ],
       });

--- a/lib/modules/manager/pub/extract.ts
+++ b/lib/modules/manager/pub/extract.ts
@@ -1,4 +1,5 @@
 import is from '@sindresorhus/is';
+import type { SkipReason } from '../../../types';
 import { DartDatasource } from '../../datasource/dart';
 import { DartVersionDatasource } from '../../datasource/dart-version';
 import { FlutterVersionDatasource } from '../../datasource/flutter-version';
@@ -17,15 +18,21 @@ function extractFromSection(
 
   const deps: PackageDependency[] = [];
   for (const depName of Object.keys(sectionContent)) {
-    if (depName === 'meta') {
+    if (depName === 'meta' || depName === 'flutter_test') {
       continue;
     }
 
     let currentValue = sectionContent[depName];
+    let skipReason: SkipReason | undefined;
+
     if (!is.string(currentValue)) {
       const version = currentValue.version;
+      const path = currentValue.path;
       if (version) {
         currentValue = version;
+      } else if (path) {
+        currentValue = '';
+        skipReason = 'path-dependency';
       } else {
         currentValue = '';
       }
@@ -36,6 +43,7 @@ function extractFromSection(
       depType: sectionKey,
       currentValue,
       datasource: DartDatasource.id,
+      skipReason,
     });
   }
 

--- a/lib/modules/manager/pub/schema.ts
+++ b/lib/modules/manager/pub/schema.ts
@@ -3,7 +3,10 @@ import { LooseRecord, Yaml } from '../../../util/schema-utils';
 
 const PubspecDependencySchema = LooseRecord(
   z.string(),
-  z.union([z.string(), z.object({ version: z.string().optional() })])
+  z.union([
+    z.string(),
+    z.object({ version: z.string().optional(), path: z.string().optional() }),
+  ])
 );
 
 export const PubspecSchema = z.object({


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Skip dependency `flutter_test` as it's included within the Flutter SDK and there are no updates required
- Skip path dependencies

## Context

I'm seeing this warning on my Renovate dashboard:

> Renovate failed to look up the following dependencies: `Failed to look up dart package flutter_test`, `Failed to look up dart package appainter_annotations`, `Failed to look up dart package window_size`, `Failed to look up dart package appainter_builder`

See here for my `pubspec.yaml`: https://github.com/zeshuaro/appainter/blob/main/pubspec.yaml

- `flutter_test` is part of Flutter SDK as mentioned above
- `appainter_annotations` and `appainter_builder` are path dependencies
- `window_size` is a git dependency - I might also work on a fix/feature for this afterwards if I have time

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
