### PR TITLE
feat(result): Add helper for Zod schema parsing

### DIFF
--- a/lib/modules/datasource/cdnjs/index.ts
+++ b/lib/modules/datasource/cdnjs/index.ts
@@ -40,7 +40,7 @@ export class CdnJsDatasource extends Datasource {
   override readonly caching = true;
 
   async getReleases(config: GetReleasesConfig): Promise<ReleaseResult | null> {
-    const result = Result.wrap(ReleasesConfig.safeParse(config))
+    const result = Result.parse(ReleasesConfig, config)
       .transform(({ packageName, registryUrl }) => {
         const [library] = packageName.split('/');
         const assetName = packageName.replace(`${library}/`, '');

--- a/lib/modules/datasource/rubygems/index.ts
+++ b/lib/modules/datasource/rubygems/index.ts
@@ -114,8 +114,8 @@ export class RubyGemsDatasource extends Datasource {
     const query = getQueryString({ gems: packageName });
     const url = `${path}?${query}`;
     const bufPromise = this.http.getBuffer(url);
-    return Result.wrap(bufPromise)
-      .transform(({ body }) => Marshal.parse(body) as NonNullable<unknown>)
-      .parse(MarshalledVersionInfo);
+    return Result.wrap(bufPromise).transform(({ body }) =>
+      MarshalledVersionInfo.safeParse(Marshal.parse(body))
+    );
   }
 }

--- a/lib/modules/datasource/rubygems/index.ts
+++ b/lib/modules/datasource/rubygems/index.ts
@@ -101,9 +101,9 @@ export class RubyGemsDatasource extends Datasource {
     packageName: string
   ): AsyncResult<ReleaseResult, Error | ZodError> {
     const url = joinUrlParts(registryUrl, '/info', packageName);
-    return Result.wrap(this.http.get(url)).transform(({ body }) =>
-      GemInfo.safeParse(body)
-    );
+    return Result.wrap(this.http.get(url))
+      .transform(({ body }) => body)
+      .parse(GemInfo);
   }
 
   private getReleasesViaDeprecatedAPI(
@@ -114,9 +114,8 @@ export class RubyGemsDatasource extends Datasource {
     const query = getQueryString({ gems: packageName });
     const url = `${path}?${query}`;
     const bufPromise = this.http.getBuffer(url);
-    return Result.wrap(bufPromise).transform(({ body }) => {
-      const data = Marshal.parse(body);
-      return MarshalledVersionInfo.safeParse(data);
-    });
+    return Result.wrap(bufPromise)
+      .transform(({ body }) => Marshal.parse(body) as NonNullable<unknown>)
+      .parse(MarshalledVersionInfo);
   }
 }

--- a/lib/util/result.spec.ts
+++ b/lib/util/result.spec.ts
@@ -84,35 +84,6 @@ describe('util/result', () => {
           })
         );
       });
-
-      it('parses Zod schema', () => {
-        const schema = z
-          .string()
-          .transform((x) => x.toUpperCase())
-          .nullish();
-        expect(Result.parse(schema, 'foo')).toEqual(Result.ok('FOO'));
-        expect(Result.parse(schema, 42).unwrap()).toMatchObject({
-          err: { issues: [{ message: 'Expected string, received number' }] },
-        });
-        expect(Result.parse(schema, undefined).unwrap()).toMatchObject({
-          err: {
-            issues: [
-              {
-                message: `Result can't accept nullish values, but input was parsed by Zod schema to undefined`,
-              },
-            ],
-          },
-        });
-        expect(Result.parse(schema, null).unwrap()).toMatchObject({
-          err: {
-            issues: [
-              {
-                message: `Result can't accept nullish values, but input was parsed by Zod schema to null`,
-              },
-            ],
-          },
-        });
-      });
     });
 
     describe('Unwrapping', () => {
@@ -229,6 +200,56 @@ describe('util/result', () => {
           throw 'oops';
         });
         expect(result).toEqual(Result._uncaught('oops'));
+      });
+    });
+
+    describe('Parsing', () => {
+      it('parses Zod schema', () => {
+        const schema = z
+          .string()
+          .transform((x) => x.toUpperCase())
+          .nullish();
+
+        expect(Result.parse(schema, 'foo')).toEqual(Result.ok('FOO'));
+
+        expect(Result.parse(schema, 42).unwrap()).toMatchObject({
+          err: { issues: [{ message: 'Expected string, received number' }] },
+        });
+
+        expect(Result.parse(schema, undefined).unwrap()).toMatchObject({
+          err: {
+            issues: [
+              {
+                message: `Result can't accept nullish values, but input was parsed by Zod schema to undefined`,
+              },
+            ],
+          },
+        });
+
+        expect(Result.parse(schema, null).unwrap()).toMatchObject({
+          err: {
+            issues: [
+              {
+                message: `Result can't accept nullish values, but input was parsed by Zod schema to null`,
+              },
+            ],
+          },
+        });
+      });
+
+      it('parses Zod schema by piping from Result', () => {
+        const schema = z
+          .string()
+          .transform((x) => x.toUpperCase())
+          .nullish();
+
+        expect(Result.ok('foo').parse(schema)).toEqual(Result.ok('FOO'));
+
+        expect(Result.ok(42).parse(schema).unwrap()).toMatchObject({
+          err: { issues: [{ message: 'Expected string, received number' }] },
+        });
+
+        expect(Result.err('oops').parse(schema)).toEqual(Result.err('oops'));
       });
     });
   });
@@ -514,6 +535,33 @@ describe('util/result', () => {
         );
         expect(result).toEqual(Result.ok(42));
       });
+    });
+  });
+
+  describe('Parsing', () => {
+    it('parses Zod schema by piping from AsyncResult', async () => {
+      const schema = z
+        .string()
+        .transform((x) => x.toUpperCase())
+        .nullish();
+
+      expect(await AsyncResult.ok('foo').parse(schema)).toEqual(
+        Result.ok('FOO')
+      );
+
+      expect(await AsyncResult.ok(42).parse(schema).unwrap()).toMatchObject({
+        err: { issues: [{ message: 'Expected string, received number' }] },
+      });
+    });
+
+    it('handles uncaught error thrown in the steps before parsing', async () => {
+      const res = await AsyncResult.ok(42)
+        .transform(async (): Promise<number> => {
+          await Promise.resolve();
+          throw 'oops';
+        })
+        .parse(z.number().transform((x) => x + 1));
+      expect(res).toEqual(Result._uncaught('oops'));
     });
   });
 });

--- a/lib/util/result.ts
+++ b/lib/util/result.ts
@@ -279,7 +279,10 @@ export class Result<T extends Val, E extends Val = Error> {
     T,
     Schema extends ZodType<T, ZodTypeDef, Input>,
     Input = unknown
-  >(schema: Schema, input: unknown): Result<NonNullable<T>, ZodError<Input>> {
+  >(
+    schema: Schema,
+    input: unknown
+  ): Result<NonNullable<z.infer<Schema>>, ZodError<Input>> {
     const parseResult = schema
       .transform((result, ctx): NonNullable<T> => {
         if (result === undefined) {

--- a/lib/util/result.ts
+++ b/lib/util/result.ts
@@ -1,4 +1,4 @@
-import { SafeParseReturnType, ZodError, ZodType, ZodTypeDef } from 'zod';
+import { SafeParseReturnType, ZodError, ZodType, ZodTypeDef, z } from 'zod';
 import { logger } from '../logger';
 
 type Val = NonNullable<unknown>;
@@ -53,14 +53,6 @@ function fromZodResult<ZodInput, ZodOutput extends Val>(
 ): Result<ZodOutput, ZodError<ZodInput>> {
   return input.success ? Result.ok(input.data) : Result.err(input.error);
 }
-
-type SchemaParseFn<T extends Val, Input = unknown> = (
-  input: unknown
-) => Result<T, ZodError<Input>>;
-
-type SchemaAsyncParseFn<T extends Val, Input = unknown> = (
-  input: unknown
-) => AsyncResult<T, ZodError<Input>>;
 
 /**
  * All non-nullable values that also are not Promises nor Zod results.
@@ -280,31 +272,37 @@ export class Result<T extends Val, E extends Val = Error> {
   }
 
   /**
-   * Wraps a Zod schema and returns a parse function that returns a `Result`.
+   * Given a `schema` and `input`, returns a `Result` with `val` being the parsed value.
+   * Additionally, `null` and `undefined` values are converted into Zod error.
    */
-  static wrapSchema<
-    T extends Val,
+  static parse<
+    T,
     Schema extends ZodType<T, ZodTypeDef, Input>,
     Input = unknown
-  >(schema: Schema): SchemaParseFn<T, Input> {
-    return (input) => {
-      const result = schema.safeParse(input);
-      return fromZodResult(result);
-    };
-  }
+  >(schema: Schema, input: unknown): Result<NonNullable<T>, ZodError<Input>> {
+    const parseResult = schema
+      .transform((result, ctx): NonNullable<T> => {
+        if (result === undefined) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `Result can't accept nullish values, but input was parsed by Zod schema to undefined`,
+          });
+          return z.NEVER;
+        }
 
-  /**
-   * Wraps a Zod schema and returns a parse function that returns an `AsyncResult`.
-   */
-  static wrapSchemaAsync<
-    T extends Val,
-    Schema extends ZodType<T, ZodTypeDef, Input>,
-    Input = unknown
-  >(schema: Schema): SchemaAsyncParseFn<T, Input> {
-    return (input) => {
-      const result = schema.safeParseAsync(input);
-      return AsyncResult.wrap(result);
-    };
+        if (result === null) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `Result can't accept nullish values, but input was parsed by Zod schema to null`,
+          });
+          return z.NEVER;
+        }
+
+        return result;
+      })
+      .safeParse(input);
+
+    return fromZodResult(parseResult);
   }
 
   /**

--- a/lib/util/result.ts
+++ b/lib/util/result.ts
@@ -272,43 +272,6 @@ export class Result<T extends Val, E extends Val = Error> {
   }
 
   /**
-   * Given a `schema` and `input`, returns a `Result` with `val` being the parsed value.
-   * Additionally, `null` and `undefined` values are converted into Zod error.
-   */
-  static parse<
-    T,
-    Schema extends ZodType<T, ZodTypeDef, Input>,
-    Input = unknown
-  >(
-    schema: Schema,
-    input: unknown
-  ): Result<NonNullable<z.infer<Schema>>, ZodError<Input>> {
-    const parseResult = schema
-      .transform((result, ctx): NonNullable<T> => {
-        if (result === undefined) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            message: `Result can't accept nullish values, but input was parsed by Zod schema to undefined`,
-          });
-          return z.NEVER;
-        }
-
-        if (result === null) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            message: `Result can't accept nullish values, but input was parsed by Zod schema to null`,
-          });
-          return z.NEVER;
-        }
-
-        return result;
-      })
-      .safeParse(input);
-
-    return fromZodResult(parseResult);
-  }
-
-  /**
    * Returns a discriminated union for type-safe consumption of the result.
    * When `fallback` is provided, the error is discarded and value is returned directly.
    * When error was uncaught during transformation, it's being re-thrown here.
@@ -487,6 +450,63 @@ export class Result<T extends Val, E extends Val = Error> {
       logger.warn({ err }, 'Result: unexpected error in catch handler');
       return Result._uncaught(err);
     }
+  }
+
+  /**
+   * Given a `schema` and `input`, returns a `Result` with `val` being the parsed value.
+   * Additionally, `null` and `undefined` values are converted into Zod error.
+   */
+  static parse<
+    T,
+    Schema extends ZodType<T, ZodTypeDef, Input>,
+    Input = unknown
+  >(
+    schema: Schema,
+    input: unknown
+  ): Result<NonNullable<z.infer<Schema>>, ZodError<Input>> {
+    const parseResult = schema
+      .transform((result, ctx): NonNullable<T> => {
+        if (result === undefined) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `Result can't accept nullish values, but input was parsed by Zod schema to undefined`,
+          });
+          return z.NEVER;
+        }
+
+        if (result === null) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `Result can't accept nullish values, but input was parsed by Zod schema to null`,
+          });
+          return z.NEVER;
+        }
+
+        return result;
+      })
+      .safeParse(input);
+
+    return fromZodResult(parseResult);
+  }
+
+  /**
+   * Given a `schema`, returns a `Result` with `val` being the parsed value.
+   * Additionally, `null` and `undefined` values are converted into Zod error.
+   */
+  parse<T, Schema extends ZodType<T, ZodTypeDef, Input>, Input = unknown>(
+    schema: Schema
+  ): Result<NonNullable<z.infer<Schema>>, E | ZodError<Input>> {
+    if (this.res.ok) {
+      return Result.parse(schema, this.res.val);
+    }
+
+    const err = this.res.err;
+
+    if (this.res._uncaught) {
+      return Result._uncaught(err);
+    }
+
+    return Result.err(err);
   }
 }
 
@@ -729,5 +749,22 @@ export class AsyncResult<T extends Val, E extends Val>
       result.catch(fn as never)
     );
     return AsyncResult.wrap(caughtAsyncResult);
+  }
+
+  /**
+   * Given a `schema`, returns a `Result` with `val` being the parsed value.
+   * Additionally, `null` and `undefined` values are converted into Zod error.
+   */
+  parse<T, Schema extends ZodType<T, ZodTypeDef, Input>, Input = unknown>(
+    schema: Schema
+  ): AsyncResult<NonNullable<z.infer<Schema>>, E | ZodError<Input>> {
+    return new AsyncResult(
+      this.asyncResult
+        .then((oldResult) => oldResult.parse(schema))
+        .catch(
+          /* istanbul ignore next: should never happen */
+          (err) => Result._uncaught(err)
+        )
+    );
   }
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Remove unused methods for generating parsing functions
- Instead, introduce `Result.parse` method

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
