### PR TITLE
feat(manager/asdf): support multiple spaces in .tool-versions for rtx compatibility

### DIFF
--- a/lib/modules/manager/asdf/extract.spec.ts
+++ b/lib/modules/manager/asdf/extract.spec.ts
@@ -532,6 +532,39 @@ dummy 1.2.3
       });
     });
 
+    it('can handle multiple tools with indented versions in one file', () => {
+      const res = extractPackageFile(
+        codeBlock`
+adr-tools 3.0.0
+argocd    2.5.4
+awscli    2.8.6
+`
+      );
+      expect(res).toEqual({
+        deps: [
+          {
+            currentValue: '3.0.0',
+            datasource: 'github-tags',
+            packageName: 'npryce/adr-tools',
+            depName: 'adr-tools',
+          },
+          {
+            currentValue: '2.5.4',
+            datasource: 'github-releases',
+            packageName: 'argoproj/argo-cd',
+            depName: 'argocd',
+            extractVersion: '^v(?<version>\\S+)',
+          },
+          {
+            currentValue: '2.8.6',
+            datasource: 'github-tags',
+            packageName: 'aws/aws-cli',
+            depName: 'awscli',
+          },
+        ],
+      });
+    });
+
     it('can handle flutter version channel', () => {
       const withChannel = extractPackageFile('flutter 3.10.0-stable');
       expect(withChannel).toEqual({

--- a/lib/modules/manager/asdf/extract.ts
+++ b/lib/modules/manager/asdf/extract.ts
@@ -9,7 +9,7 @@ export function extractPackageFile(content: string): PackageFileContent | null {
   logger.trace(`asdf.extractPackageFile()`);
 
   const regex = regEx(
-    /^(?<toolName>([\w_-]+)) (?<version>[^\s#]+)(?: [^\s#]+)* *(?: #(?<comment>.*))?$/gm
+    /^(?<toolName>([\w_-]+)) +(?<version>[^\s#]+)(?: +[^\s#]+)* *(?: #(?<comment>.*))?$/gm
   );
 
   const deps: PackageDependency[] = [];


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
This PR adds support for multiple spaces between tool name and tool version in asdf `.tool-versions` files,
which brings compatibility with [rtx](https://github.com/jdxcode/rtx/) managed `.tool-versions` files as rtx aligns version numbers with spaces.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
