### PR TITLE
feat(codeowners): ignore inline comments in a CODEOWNERS file

### DIFF
--- a/lib/workers/repository/update/pr/code-owners.spec.ts
+++ b/lib/workers/repository/update/pr/code-owners.spec.ts
@@ -219,9 +219,9 @@ describe('workers/repository/update/pr/code-owners', () => {
         [
           '# comment line',
           '    \t    ',
-          '   * @jimmy     ',
+          '   * @jimmy     # inline comment     ',
           '        # comment line with leading whitespace',
-          ' package.json @john @maria  ',
+          ' package.json @john @maria#inline comment without leading whitespace  ',
         ].join('\n')
       );
       git.getBranchFiles.mockResolvedValueOnce(['package.json']);

--- a/lib/workers/repository/update/pr/code-owners.ts
+++ b/lib/workers/repository/update/pr/code-owners.ts
@@ -106,7 +106,7 @@ export async function codeOwnersForPr(pr: Pr): Promise<string[]> {
       .map((line) => line.split('#')[0])
       // Remove empty lines
       .map((line) => line.trim())
-      .filter((line) => line)
+      .filter(is.nonEmptyString)
       // Extract pattern & usernames
       .map(extractOwnersFromLine);
 

--- a/lib/workers/repository/update/pr/code-owners.ts
+++ b/lib/workers/repository/update/pr/code-owners.ts
@@ -1,3 +1,4 @@
+import is from '@sindresorhus/is';
 import ignore from 'ignore';
 import { logger } from '../../../../logger';
 import type { Pr } from '../../../../modules/platform';

--- a/lib/workers/repository/update/pr/code-owners.ts
+++ b/lib/workers/repository/update/pr/code-owners.ts
@@ -102,9 +102,11 @@ export async function codeOwnersForPr(pr: Pr): Promise<string[]> {
     // Convert CODEOWNERS file into list of matching rules
     const fileOwnerRules = codeOwnersFile
       .split(newlineRegex)
-      // Remove empty and commented lines
+      // Remove comments
+      .map((line) => line.split('#')[0])
+      // Remove empty lines
       .map((line) => line.trim())
-      .filter((line) => line && !line.startsWith('#'))
+      .filter((line) => line)
       // Extract pattern & usernames
       .map(extractOwnersFromLine);
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

This PR adds support for inline comments in CODEOWNERS files, which are supported by GitHub.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

Closes #23964.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
