### PR TITLE
fix(swift): return clean `newVersion` if other cases do not apply

### DIFF
--- a/lib/modules/versioning/swift/index.spec.ts
+++ b/lib/modules/versioning/swift/index.spec.ts
@@ -10,7 +10,7 @@ const {
   matches,
 } = swift;
 
-describe('modules/versioning/swift/index', () => {
+describe('Users/chuck/code/cgrindel/renovate/fix_spm_version_logic/lib/modules/versioning/swift/index', () => {
   it.each`
     version            | expected
     ${'from: "1.2.3"'} | ${false}
@@ -108,8 +108,8 @@ describe('modules/versioning/swift/index', () => {
 
   it.each`
     currentValue           | rangeStrategy | currentVersion | newVersion  | expected
-    ${'1.2.3'}             | ${'auto'}     | ${'1.2.3'}     | ${'1.2.4'}  | ${'1.2.3'}
-    ${'1.2.3'}             | ${'auto'}     | ${'1.2.3'}     | ${'v1.2.4'} | ${'1.2.3'}
+    ${'1.2.3'}             | ${'auto'}     | ${'1.2.3'}     | ${'1.2.4'}  | ${'1.2.4'}
+    ${'1.2.3'}             | ${'auto'}     | ${'1.2.3'}     | ${'v1.2.4'} | ${'1.2.4'}
     ${'from: "1.2.3"'}     | ${'auto'}     | ${'1.2.3'}     | ${'1.2.4'}  | ${'from: "1.2.4"'}
     ${'from: "1.2.3"'}     | ${'auto'}     | ${'1.2.3'}     | ${'v1.2.4'} | ${'from: "1.2.4"'}
     ${'from: "1.2.2"'}     | ${'auto'}     | ${'1.2.3'}     | ${'1.2.4'}  | ${'from: "1.2.4"'}

--- a/lib/modules/versioning/swift/index.spec.ts
+++ b/lib/modules/versioning/swift/index.spec.ts
@@ -10,7 +10,7 @@ const {
   matches,
 } = swift;
 
-describe('Users/chuck/code/cgrindel/renovate/fix_spm_version_logic/lib/modules/versioning/swift/index', () => {
+describe('modules/versioning/swift/index', () => {
   it.each`
     version            | expected
     ${'from: "1.2.3"'} | ${false}

--- a/lib/modules/versioning/swift/range.ts
+++ b/lib/modules/versioning/swift/range.ts
@@ -75,7 +75,7 @@ function getNewValue({ currentValue, newVersion }: NewValueConfig): string {
     return currentValue.replace(version, cleanNewVersion);
   }
 
-  return currentValue;
+  return cleanNewVersion;
 }
 
 export { toSemverRange, getNewValue };


### PR DESCRIPTION
## Changes

Update `getNewValue()` for the Swift versioning API to return the clean `newVersion` value.

## Context

While implementing #24004, I noticed that the `getNewValue()` for the Swift versioning API returned the current value if the other version format cases did not apply. This is incorrect. It should return the clean new version value.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Bug Fix: Updated the expected values in test cases for the `modules/versioning/swift/index` module to reflect accurate behavior.
- Refactor: Modified the `getNewValue` function in `modules/versioning/swift/range.ts` to return a cleaned version of the new value, improving the accuracy and consistency of the output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->