### PR TITLE
feat(ansible-galaxy): allow versions without any quotes in galaxy.yml

### DIFF
--- a/lib/modules/manager/ansible-galaxy/__fixtures__/galaxy.yml
+++ b/lib/modules/manager/ansible-galaxy/__fixtures__/galaxy.yml
@@ -14,8 +14,11 @@ tags:
   - backup
 dependencies:
   ansible.posix: "1.5.4"
+  ansible.posix_with_comment: "1.5.4" # This is a comment
   ansible.windows: '1.4.0'
+  ansible.windows_with_comment: '1.4.0' #   This is a comment
   community.general: 7.3.0
+  community.general_with_comment: 7.3.0   # This is a comment
   community.windows: '>=1.0.0,<2.0.0'
 repository: "https://github.com/foo/bar"
 issues: "https://github.com/foo/bar/issues"

--- a/lib/modules/manager/ansible-galaxy/__fixtures__/galaxy.yml
+++ b/lib/modules/manager/ansible-galaxy/__fixtures__/galaxy.yml
@@ -13,7 +13,9 @@ tags:
   - suite
   - backup
 dependencies:
+  ansible.posix: "1.5.4"
   ansible.windows: '1.4.0'
+  community.general: 7.3.0
   community.windows: '>=1.0.0,<2.0.0'
 repository: "https://github.com/foo/bar"
 issues: "https://github.com/foo/bar/issues"

--- a/lib/modules/manager/ansible-galaxy/__snapshots__/extract.spec.ts.snap
+++ b/lib/modules/manager/ansible-galaxy/__snapshots__/extract.spec.ts.snap
@@ -140,15 +140,33 @@ exports[`modules/manager/ansible-galaxy/extract extractPackageFile() check galax
     "depType": "galaxy-collection",
   },
   {
+    "currentValue": "1.5.4",
+    "datasource": "galaxy-collection",
+    "depName": "ansible.posix_with_comment",
+    "depType": "galaxy-collection",
+  },
+  {
     "currentValue": "1.4.0",
     "datasource": "galaxy-collection",
     "depName": "ansible.windows",
     "depType": "galaxy-collection",
   },
   {
+    "currentValue": "1.4.0",
+    "datasource": "galaxy-collection",
+    "depName": "ansible.windows_with_comment",
+    "depType": "galaxy-collection",
+  },
+  {
     "currentValue": "7.3.0",
     "datasource": "galaxy-collection",
     "depName": "community.general",
+    "depType": "galaxy-collection",
+  },
+  {
+    "currentValue": "7.3.0",
+    "datasource": "galaxy-collection",
+    "depName": "community.general_with_comment",
     "depType": "galaxy-collection",
   },
   {

--- a/lib/modules/manager/ansible-galaxy/__snapshots__/extract.spec.ts.snap
+++ b/lib/modules/manager/ansible-galaxy/__snapshots__/extract.spec.ts.snap
@@ -134,9 +134,21 @@ exports[`modules/manager/ansible-galaxy/extract extractPackageFile() check colle
 exports[`modules/manager/ansible-galaxy/extract extractPackageFile() check galaxy definition file 1`] = `
 [
   {
+    "currentValue": "1.5.4",
+    "datasource": "galaxy-collection",
+    "depName": "ansible.posix",
+    "depType": "galaxy-collection",
+  },
+  {
     "currentValue": "1.4.0",
     "datasource": "galaxy-collection",
     "depName": "ansible.windows",
+    "depType": "galaxy-collection",
+  },
+  {
+    "currentValue": "7.3.0",
+    "datasource": "galaxy-collection",
+    "depName": "community.general",
     "depType": "galaxy-collection",
   },
   {

--- a/lib/modules/manager/ansible-galaxy/extract.spec.ts
+++ b/lib/modules/manager/ansible-galaxy/extract.spec.ts
@@ -79,7 +79,7 @@ describe('modules/manager/ansible-galaxy/extract', () => {
     it('check galaxy definition file', () => {
       const res = extractPackageFile(galaxy, 'galaxy.yml');
       expect(res?.deps).toMatchSnapshot();
-      expect(res?.deps).toHaveLength(2);
+      expect(res?.deps).toHaveLength(4);
     });
   });
 

--- a/lib/modules/manager/ansible-galaxy/extract.spec.ts
+++ b/lib/modules/manager/ansible-galaxy/extract.spec.ts
@@ -79,7 +79,7 @@ describe('modules/manager/ansible-galaxy/extract', () => {
     it('check galaxy definition file', () => {
       const res = extractPackageFile(galaxy, 'galaxy.yml');
       expect(res?.deps).toMatchSnapshot();
-      expect(res?.deps).toHaveLength(4);
+      expect(res?.deps).toHaveLength(7);
     });
   });
 

--- a/lib/modules/manager/ansible-galaxy/util.ts
+++ b/lib/modules/manager/ansible-galaxy/util.ts
@@ -5,7 +5,7 @@ export const blockLineRegEx = /^\s*((\w+):\s*(\S+))\s*$/;
 export const galaxyDepRegex = /[\w-]+\.[\w-]+/;
 export const dependencyRegex = /^dependencies:/;
 export const galaxyRegEx = regEx(
-  /^\s+(?<packageName>[\w.]+):\s*["']?(?<version>.+?)["']?\s*/
+  /^\s+(?<packageName>[\w.]+):\s*["']?(?<version>.+?)["']?\s*$/
 );
 export const nameMatchRegex = regEx(
   /(?<source>((git\+)?(?:(git|ssh|https?):\/\/)?(.*@)?(?<hostname>[\w.-]+)(?:(:\d+)?\/|:))(?<depName>[\w./-]+)(?:\.git)?)(,(?<version>[\w.]*))?/

--- a/lib/modules/manager/ansible-galaxy/util.ts
+++ b/lib/modules/manager/ansible-galaxy/util.ts
@@ -5,7 +5,7 @@ export const blockLineRegEx = /^\s*((\w+):\s*(\S+))\s*$/;
 export const galaxyDepRegex = /[\w-]+\.[\w-]+/;
 export const dependencyRegex = /^dependencies:/;
 export const galaxyRegEx = regEx(
-  /^\s+(?<packageName>[\w.]+):\s*["']?(?<version>.+)["']?\s*/
+  /^\s+(?<packageName>[\w.]+):\s*["']?(?<version>.+?)["']?\s*/
 );
 export const nameMatchRegex = regEx(
   /(?<source>((git\+)?(?:(git|ssh|https?):\/\/)?(.*@)?(?<hostname>[\w.-]+)(?:(:\d+)?\/|:))(?<depName>[\w./-]+)(?:\.git)?)(,(?<version>[\w.]*))?/

--- a/lib/modules/manager/ansible-galaxy/util.ts
+++ b/lib/modules/manager/ansible-galaxy/util.ts
@@ -5,7 +5,7 @@ export const blockLineRegEx = /^\s*((\w+):\s*(\S+))\s*$/;
 export const galaxyDepRegex = /[\w-]+\.[\w-]+/;
 export const dependencyRegex = /^dependencies:/;
 export const galaxyRegEx = regEx(
-  /^\s+(?<packageName>[\w.]+):\s*["']?(?<version>.+?)["']?\s*$/
+  /^\s+(?<packageName>[\w.]+):\s*["']?(?<version>.+?)["']?(\s+#.+?)?$/
 );
 export const nameMatchRegex = regEx(
   /(?<source>((git\+)?(?:(git|ssh|https?):\/\/)?(.*@)?(?<hostname>[\w.-]+)(?:(:\d+)?\/|:))(?<depName>[\w./-]+)(?:\.git)?)(,(?<version>[\w.]*))?/

--- a/lib/modules/manager/ansible-galaxy/util.ts
+++ b/lib/modules/manager/ansible-galaxy/util.ts
@@ -5,7 +5,7 @@ export const blockLineRegEx = /^\s*((\w+):\s*(\S+))\s*$/;
 export const galaxyDepRegex = /[\w-]+\.[\w-]+/;
 export const dependencyRegex = /^dependencies:/;
 export const galaxyRegEx = regEx(
-  /^\s+(?<packageName>[\w.]+):\s*["']?(?<version>.+?)["']?(\s+#.+?)?$/
+  /^\s+(?<packageName>[\w.]+):\s*["']?(?<version>.+?)["']?\s*(\s#.+?)?$/
 );
 export const nameMatchRegex = regEx(
   /(?<source>((git\+)?(?:(git|ssh|https?):\/\/)?(.*@)?(?<hostname>[\w.-]+)(?:(:\d+)?\/|:))(?<depName>[\w./-]+)(?:\.git)?)(,(?<version>[\w.]*))?/

--- a/lib/modules/manager/ansible-galaxy/util.ts
+++ b/lib/modules/manager/ansible-galaxy/util.ts
@@ -5,7 +5,7 @@ export const blockLineRegEx = /^\s*((\w+):\s*(\S+))\s*$/;
 export const galaxyDepRegex = /[\w-]+\.[\w-]+/;
 export const dependencyRegex = /^dependencies:/;
 export const galaxyRegEx = regEx(
-  /^\s+(?<packageName>[\w.]+):\s*["']?(?<version>.+?)["']?\s*(\s#.+?)?$/
+  /^\s+(?<packageName>[\w.]+):\s*["']?(?<version>.+?)["']?\s*(\s#.*)?$/
 );
 export const nameMatchRegex = regEx(
   /(?<source>((git\+)?(?:(git|ssh|https?):\/\/)?(.*@)?(?<hostname>[\w.-]+)(?:(:\d+)?\/|:))(?<depName>[\w./-]+)(?:\.git)?)(,(?<version>[\w.]*))?/

--- a/lib/modules/manager/ansible-galaxy/util.ts
+++ b/lib/modules/manager/ansible-galaxy/util.ts
@@ -5,7 +5,7 @@ export const blockLineRegEx = /^\s*((\w+):\s*(\S+))\s*$/;
 export const galaxyDepRegex = /[\w-]+\.[\w-]+/;
 export const dependencyRegex = /^dependencies:/;
 export const galaxyRegEx = regEx(
-  /^\s+(?<packageName>[\w.]+):\s*["'](?<version>.+)["']\s*/
+  /^\s+(?<packageName>[\w.]+):\s*["']?(?<version>.+)["']?\s*/
 );
 export const nameMatchRegex = regEx(
   /(?<source>((git\+)?(?:(git|ssh|https?):\/\/)?(.*@)?(?<hostname>[\w.-]+)(?:(:\d+)?\/|:))(?<depName>[\w./-]+)(?:\.git)?)(,(?<version>[\w.]*))?/


### PR DESCRIPTION
## Changes

Allow to use versions without any quotes in galaxy.yml files parsed by the `anisble-galaxy` manager

## Context

Versions surrounded by single or double quotes are already working. Versions without any quotes are also valid in galaxy.yml files

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
