### PR TITLE
fix(mix): remove global flag in regex to match multiple organizations

### DIFF
--- a/lib/modules/manager/mix/artifacts.spec.ts
+++ b/lib/modules/manager/mix/artifacts.spec.ts
@@ -238,12 +238,14 @@ describe('modules/manager/mix/artifacts', () => {
     hostRules.getAll.mockReturnValueOnce([
       { matchHost: 'https://hex.pm/api/repos/an_organization/' },
       { matchHost: 'https://hex.pm/api/repos/unauthorized_organization/' },
+      { matchHost: 'https://hex.pm/api/repos/other_organization/' },
       { matchHost: 'https://hex.pm/api/repos/does_not_match_org/packages/' },
       { matchHost: 'https://example.com/api/repos/also_does_not_match_org/' },
       { matchHost: 'hex.pm' },
     ]);
     hostRules.find.mockReturnValueOnce({ token: 'an_organization_token' });
     hostRules.find.mockReturnValueOnce({}); // unauthorized_organization token missing
+    hostRules.find.mockReturnValueOnce({ token: 'other_org_token' });
     hostRules.find.mockReturnValueOnce({ token: 'does_not_match_org_token' });
 
     // erlang
@@ -282,6 +284,9 @@ describe('modules/manager/mix/artifacts', () => {
       { cmd: 'install-tool elixir v1.13.4' },
       {
         cmd: 'mix hex.organization auth an_organization --key an_organization_token',
+      },
+      {
+        cmd: 'mix hex.organization auth other_organization --key other_org_token',
       },
       { cmd: 'mix deps.update some_package' },
     ]);

--- a/lib/modules/manager/mix/artifacts.ts
+++ b/lib/modules/manager/mix/artifacts.ts
@@ -16,8 +16,7 @@ import type { UpdateArtifact, UpdateArtifactsResult } from '../types';
 
 const hexRepoUrl = 'https://hex.pm/';
 const hexRepoOrgUrlRegex = regEx(
-  `https://hex\\.pm/api/repos/(?<organization>[a-z0-9_]+)/$`,
-  'g'
+  `^https://hex\\.pm/api/repos/(?<organization>[a-z0-9_]+)/$`
 );
 
 export async function updateArtifacts({


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Fixes bug where only one organization url was matched using regex in global mode.

<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

Last week a [PR](https://github.com/renovatebot/renovate/pull/23901) was merged that fixes #20717. In this I wrongly added the global flag to regex. Right now it will only match one organization instead of all configured in your `hostRules` due to it keeping state. Also, people with an elixir umbrella app may run into the issue where for multiple `mix.lock` files the same single organization is not always authenticated.

I've added an extra test to check that more than one organization will be authenticated, if configured.

Sorry and thanks! Keep up the good work!

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
