### PR TITLE
fix(yarn): Handle escaping of pipe chars

### DIFF
--- a/lib/modules/manager/npm/update/locked-dependency/yarn-lock/replace.spec.ts
+++ b/lib/modules/manager/npm/update/locked-dependency/yarn-lock/replace.spec.ts
@@ -114,10 +114,9 @@ describe('modules/manager/npm/update/locked-dependency/yarn-lock/replace', () =>
         "
       `);
       expect(removedSections[0].value).toMatchInlineSnapshot(`
-        "string-width@^1.0.1:
-          version "1.0.2"
-          resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
-          integrity sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=
+        "  version "2.0.0"
+          resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
+          integrity sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==
         "
       `);
     });

--- a/lib/modules/manager/npm/update/locked-dependency/yarn-lock/replace.ts
+++ b/lib/modules/manager/npm/update/locked-dependency/yarn-lock/replace.ts
@@ -13,7 +13,7 @@ export function replaceConstraintVersion(
     return lockFileContent;
   }
   const depNameConstraint = `${depName}@${constraint}`;
-  const escaped = depNameConstraint.replace(/(@|\^|\.|\\)/g, '\\$1');
+  const escaped = depNameConstraint.replace(/(@|\^|\.|\\|\|)/g, '\\$1');
   const matchString = `(${escaped}(("|",|,)[^\n:]*)?:\n)(.*\n)*?(\\s+dependencies|\n[@a-z])`;
   // yarn will fill in the details later
   const matchResult = regEx(matchString).exec(lockFileContent);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Fix escaping for constraints like `@types/react@16 || 17 || 18`

## Context

- Fixes: #23527

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
