### PR TITLE
refactor(result): Reoder parameters for `Result.parse`

### DIFF
--- a/lib/modules/datasource/cdnjs/index.ts
+++ b/lib/modules/datasource/cdnjs/index.ts
@@ -40,7 +40,7 @@ export class CdnJsDatasource extends Datasource {
   override readonly caching = true;
 
   async getReleases(config: GetReleasesConfig): Promise<ReleaseResult | null> {
-    const result = Result.parse(ReleasesConfig, config)
+    const result = Result.parse(config, ReleasesConfig)
       .transform(({ packageName, registryUrl }) => {
         const [library] = packageName.split('/');
         const assetName = packageName.replace(`${library}/`, '');

--- a/lib/modules/manager/poetry/artifacts.ts
+++ b/lib/modules/manager/poetry/artifacts.ts
@@ -51,8 +51,8 @@ export function getPoetryRequirement(
   }
 
   const { val: lockfilePoetryConstraint } = Result.parse(
-    Lockfile.transform(({ poetryConstraint }) => poetryConstraint),
-    existingLockFileContent
+    existingLockFileContent,
+    Lockfile.transform(({ poetryConstraint }) => poetryConstraint)
   ).unwrap();
   if (lockfilePoetryConstraint) {
     logger.debug('Using poetry version from poetry.lock metadata');

--- a/lib/modules/manager/poetry/extract.ts
+++ b/lib/modules/manager/poetry/extract.ts
@@ -100,8 +100,8 @@ export async function extractPackageFile(
 ): Promise<PackageFileContent | null> {
   logger.trace(`poetry.extractPackageFile(${packageFile})`);
   const { val: pyprojectfile, err } = Result.parse(
-    PoetrySchemaToml,
-    content
+    content,
+    PoetrySchemaToml
   ).unwrap();
   if (err) {
     logger.debug({ packageFile, err }, `Poetry: error parsing pyproject.toml`);
@@ -114,8 +114,8 @@ export async function extractPackageFile(
   const lockContents = (await readLocalFile(lockfileName, 'utf8'))!;
 
   const lockfileMapping = Result.parse(
-    Lockfile.transform(({ lock }) => lock),
-    lockContents
+    lockContents,
+    Lockfile.transform(({ lock }) => lock)
   ).unwrapOrElse({});
 
   const deps = [

--- a/lib/modules/manager/poetry/update-locked.ts
+++ b/lib/modules/manager/poetry/update-locked.ts
@@ -13,7 +13,7 @@ export function updateLockedDependency(
   );
 
   const LockedVersionSchema = Lockfile.transform(({ lock }) => lock[depName]);
-  return Result.parse(LockedVersionSchema, lockFileContent)
+  return Result.parse(lockFileContent, LockedVersionSchema)
     .transform(
       (lockedVersion): UpdateLockedResult =>
         lockedVersion === newVersion

--- a/lib/util/result.spec.ts
+++ b/lib/util/result.spec.ts
@@ -257,13 +257,13 @@ describe('util/result', () => {
           .transform((x) => x.toUpperCase())
           .nullish();
 
-        expect(Result.parse(schema, 'foo')).toEqual(Result.ok('FOO'));
+        expect(Result.parse('foo', schema)).toEqual(Result.ok('FOO'));
 
-        expect(Result.parse(schema, 42).unwrap()).toMatchObject({
+        expect(Result.parse(42, schema).unwrap()).toMatchObject({
           err: { issues: [{ message: 'Expected string, received number' }] },
         });
 
-        expect(Result.parse(schema, undefined).unwrap()).toMatchObject({
+        expect(Result.parse(undefined, schema).unwrap()).toMatchObject({
           err: {
             issues: [
               {
@@ -273,7 +273,7 @@ describe('util/result', () => {
           },
         });
 
-        expect(Result.parse(schema, null).unwrap()).toMatchObject({
+        expect(Result.parse(null, schema).unwrap()).toMatchObject({
           err: {
             issues: [
               {

--- a/lib/util/result.ts
+++ b/lib/util/result.ts
@@ -521,8 +521,8 @@ export class Result<T extends Val, E extends Val = Error> {
     Schema extends ZodType<T, ZodTypeDef, Input>,
     Input = unknown
   >(
-    schema: Schema,
-    input: unknown
+    input: unknown,
+    schema: Schema
   ): Result<NonNullable<z.infer<Schema>>, ZodError<Input>> {
     const parseResult = schema
       .transform((result, ctx): NonNullable<T> => {
@@ -557,7 +557,7 @@ export class Result<T extends Val, E extends Val = Error> {
     schema: Schema
   ): Result<NonNullable<z.infer<Schema>>, E | ZodError<Input>> {
     if (this.res.ok) {
-      return Result.parse(schema, this.res.val);
+      return Result.parse(this.res.val, schema);
     }
 
     const err = this.res.err;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
