### PR TITLE
feat(cache): Introduce `fallbackTtlMinutes` parameter for decorator

### DIFF
--- a/lib/util/cache/package/decorator.spec.ts
+++ b/lib/util/cache/package/decorator.spec.ts
@@ -161,7 +161,7 @@ describe('util/cache/package/decorator', () => {
         namespace: 'namespace',
         key: 'key',
         ttlMinutes: 1,
-        fallbackTtlMinutes: 3,
+        fallbackTtlMinutes: 2,
       })
 
       // Hard TTL is enabled only for `getReleases` and `getDigest` methods
@@ -176,6 +176,7 @@ describe('util/cache/package/decorator', () => {
 
     afterEach(() => {
       jest.useRealTimers();
+      GlobalConfig.reset();
     });
 
     it('updates cached result', async () => {
@@ -191,7 +192,7 @@ describe('util/cache/package/decorator', () => {
         'namespace',
         'cache-decorator:key',
         { cachedAt: expect.any(String), value: '111' },
-        3
+        2
       );
 
       jest.advanceTimersByTime(1);
@@ -201,13 +202,14 @@ describe('util/cache/package/decorator', () => {
         'namespace',
         'cache-decorator:key',
         { cachedAt: expect.any(String), value: '222' },
-        3
+        2
       );
     });
 
     it('overrides soft ttl and updates result', async () => {
       GlobalConfig.set({
         cacheTtlOverride: { namespace: 2 },
+        cacheHardTtlMinutes: 3,
       });
       const obj = new Class();
 
@@ -220,7 +222,7 @@ describe('util/cache/package/decorator', () => {
         3
       );
 
-      jest.advanceTimersByTime(2 * 60 * 1000 - 1); // namespace default ttl is 1min
+      jest.advanceTimersByTime(120 * 1000 - 1); // namespace default ttl is 1min
       expect(await obj.getReleases()).toBe('111');
       expect(getValue).toHaveBeenCalledTimes(1);
       expect(setCache).toHaveBeenCalledTimes(1);
@@ -245,10 +247,10 @@ describe('util/cache/package/decorator', () => {
         'namespace',
         'cache-decorator:key',
         { cachedAt: expect.any(String), value: '111' },
-        3
+        2
       );
 
-      jest.advanceTimersByTime(2 * 60 * 1000);
+      jest.advanceTimersByTime(60 * 1000);
       getValue.mockRejectedValueOnce(new Error('test'));
       expect(await obj.getReleases()).toBe('111');
       expect(getValue).toHaveBeenCalledTimes(2);
@@ -264,10 +266,10 @@ describe('util/cache/package/decorator', () => {
         'namespace',
         'cache-decorator:key',
         { cachedAt: expect.any(String), value: '111' },
-        3
+        2
       );
 
-      jest.advanceTimersByTime(3 * 60 * 1000 - 1);
+      jest.advanceTimersByTime(2 * 60 * 1000 - 1);
       getValue.mockRejectedValueOnce(new Error('test'));
       expect(await obj.getReleases()).toBe('111');
 

--- a/lib/util/cache/package/decorator.spec.ts
+++ b/lib/util/cache/package/decorator.spec.ts
@@ -161,6 +161,7 @@ describe('util/cache/package/decorator', () => {
         namespace: 'namespace',
         key: 'key',
         ttlMinutes: 1,
+        fallbackTtlMinutes: 3,
       })
 
       // Hard TTL is enabled only for `getReleases` and `getDigest` methods
@@ -171,12 +172,10 @@ describe('util/cache/package/decorator', () => {
 
     beforeEach(() => {
       jest.useFakeTimers({ advanceTimers: false });
-      GlobalConfig.set({ cacheHardTtlMinutes: 2 });
     });
 
     afterEach(() => {
       jest.useRealTimers();
-      GlobalConfig.reset();
     });
 
     it('updates cached result', async () => {
@@ -192,7 +191,7 @@ describe('util/cache/package/decorator', () => {
         'namespace',
         'cache-decorator:key',
         { cachedAt: expect.any(String), value: '111' },
-        2
+        3
       );
 
       jest.advanceTimersByTime(1);
@@ -202,14 +201,13 @@ describe('util/cache/package/decorator', () => {
         'namespace',
         'cache-decorator:key',
         { cachedAt: expect.any(String), value: '222' },
-        2
+        3
       );
     });
 
     it('overrides soft ttl and updates result', async () => {
       GlobalConfig.set({
         cacheTtlOverride: { namespace: 2 },
-        cacheHardTtlMinutes: 3,
       });
       const obj = new Class();
 
@@ -222,7 +220,7 @@ describe('util/cache/package/decorator', () => {
         3
       );
 
-      jest.advanceTimersByTime(120 * 1000 - 1); // namespace default ttl is 1min
+      jest.advanceTimersByTime(2 * 60 * 1000 - 1); // namespace default ttl is 1min
       expect(await obj.getReleases()).toBe('111');
       expect(getValue).toHaveBeenCalledTimes(1);
       expect(setCache).toHaveBeenCalledTimes(1);
@@ -247,10 +245,10 @@ describe('util/cache/package/decorator', () => {
         'namespace',
         'cache-decorator:key',
         { cachedAt: expect.any(String), value: '111' },
-        2
+        3
       );
 
-      jest.advanceTimersByTime(60 * 1000);
+      jest.advanceTimersByTime(2 * 60 * 1000);
       getValue.mockRejectedValueOnce(new Error('test'));
       expect(await obj.getReleases()).toBe('111');
       expect(getValue).toHaveBeenCalledTimes(2);
@@ -266,10 +264,10 @@ describe('util/cache/package/decorator', () => {
         'namespace',
         'cache-decorator:key',
         { cachedAt: expect.any(String), value: '111' },
-        2
+        3
       );
 
-      jest.advanceTimersByTime(2 * 60 * 1000 - 1);
+      jest.advanceTimersByTime(3 * 60 * 1000 - 1);
       getValue.mockRejectedValueOnce(new Error('test'));
       expect(await obj.getReleases()).toBe('111');
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Without setting `GlobalConfig` parameter, this new option provides a way to selectively enable the fallback caches on per-datasource basis.

## Context

- Ref: #24052
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
