### PR TITLE
fix(datasource/kubernetes-api): flux kustomization k8s api

### DIFF
--- a/data/kubernetes-api.json5
+++ b/data/kubernetes-api.json5
@@ -116,8 +116,8 @@
     'source.toolkit.fluxcd.io/v1',
   ],
   Kustomization: [
-    'source.toolkit.fluxcd.io/v1beta2',
-    'source.toolkit.fluxcd.io/v1',
+    'kustomize.toolkit.fluxcd.io/v1beta2',
+    'kustomize.toolkit.fluxcd.io/v1',
   ],
   Receiver: [
     'notification.toolkit.fluxcd.io/v1beta2',


### PR DESCRIPTION
This PR sets the correct api for flux's Kustomization resource ([flux 2.0.0 release](https://github.com/fluxcd/flux2/releases/tag/v2.0.0#:~:text=apiVersion%3A%20kustomize.toolkit.fluxcd.io/v1))

## Context
Came across this issue while setting up a self hosted version of renovate to update some repos to the new GA versions of flux API, if I set the correct API there would be no changes, but if I used the same API as the source controller my Kustomization resources were updated.

![image](https://github.com/renovatebot/renovate/assets/45714268/cd636257-9da5-45c8-af02-a1011a0b2612)


## Documentation (please check one with an [x])
- [x] No documentation update is required
