### PR TITLE
refactor: use matching digest from currentVersion if found

### DIFF
--- a/lib/workers/repository/process/lookup/index.spec.ts
+++ b/lib/workers/repository/process/lookup/index.spec.ts
@@ -1793,6 +1793,7 @@ describe('workers/repository/process/lookup/index', () => {
         releases: [
           {
             version: '8.0.0',
+            newDigest: 'sha256:0123456789abcdef',
           },
           {
             version: '8.1.0',
@@ -1800,7 +1801,6 @@ describe('workers/repository/process/lookup/index', () => {
         ],
       });
       getDockerDigest.mockResolvedValueOnce('sha256:abcdef1234567890');
-      getDockerDigest.mockResolvedValueOnce('sha256:0123456789abcdef');
       const res = await lookup.lookupUpdates(config);
       expect(res).toMatchSnapshot({
         updates: [

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -367,6 +367,9 @@ export async function lookupUpdates(
             updateType: 'digest',
             // TODO #22198
             newValue: currentValue!,
+            newDigest: dependency?.releases.find(
+              (r) => r.version === currentValue
+            )?.newDigest,
           });
         }
       } else if (pinDigests) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Uses `newDigest` from `getPkgReleases()` result if found.

## Context

Related to #24177

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
