### PR TITLE
fix(github-tags): return hash as newDigest

### DIFF
--- a/lib/modules/datasource/github-tags/index.spec.ts
+++ b/lib/modules/datasource/github-tags/index.spec.ts
@@ -163,12 +163,14 @@ describe('modules/datasource/github-tags/index', () => {
             version: 'v1.0.0',
             releaseTimestamp: '2021-01-01T00:00:00.000Z',
             isStable: true,
+            newDigest: '123',
           },
           {
             gitRef: 'v2.0.0',
             version: 'v2.0.0',
             releaseTimestamp: '2022-01-01T00:00:00.000Z',
             isStable: false,
+            newDigest: 'abc',
           },
         ],
 

--- a/lib/modules/datasource/github-tags/index.ts
+++ b/lib/modules/datasource/github-tags/index.ts
@@ -69,7 +69,8 @@ export class GithubTagsDatasource extends Datasource {
     const sourceUrl = getSourceUrl(repo, registryUrl);
     const tagsResult = await queryTags(config, this.http);
     const releases: Release[] = tagsResult.map(
-      ({ version, releaseTimestamp, gitRef }) => ({
+      ({ version, releaseTimestamp, gitRef, hash }) => ({
+        newDigest: hash,
         version,
         releaseTimestamp,
         gitRef,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

The github-tags datasource now returns as well the hashes of found updates as newDigest

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

Moved out of #24175
Fixes partly https://github.com/renovatebot/renovate/discussions/24162

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
