### PR TITLE
fix(datasource/docker): improve label efficiency

### DIFF
--- a/lib/modules/datasource/docker/index.spec.ts
+++ b/lib/modules/datasource/docker/index.spec.ts
@@ -1086,11 +1086,7 @@ describe('modules/datasource/docker/index', () => {
           {
             link: `<${baseUrl}/library/node/tags/list?n=1&page=2>; rel="next", `,
           }
-        )
-        .get('/')
-        .reply(200)
-        .get('/library/node/manifests/1.0.1')
-        .reply(200);
+        );
 
       const config = {
         datasource: DockerDatasource.id,
@@ -1563,11 +1559,7 @@ describe('modules/datasource/docker/index', () => {
             'Bearer realm="https://auth.docker.io/token",service="registry.docker.io",scope="repository:library/node:pull"',
         })
         .get('/library/node/tags/list?n=10000')
-        .reply(200, { tags }, {})
-        .get('/')
-        .reply(200)
-        .get('/library/node/manifests/1.0.0')
-        .reply(200);
+        .reply(200, { tags }, {});
       httpMock
         .scope(authUrl)
         .get(
@@ -1604,12 +1596,6 @@ describe('modules/datasource/docker/index', () => {
             },
           ],
         });
-      httpMock
-        .scope(baseUrl)
-        .get('/')
-        .reply(200)
-        .get('/library/node/manifests/1.0.0')
-        .reply(200);
       const res = await getPkgReleases({
         datasource: DockerDatasource.id,
         packageName: 'docker.io/node',

--- a/lib/modules/datasource/docker/index.ts
+++ b/lib/modules/datasource/docker/index.ts
@@ -431,7 +431,7 @@ export class DockerDatasource extends Datasource {
     namespace: 'datasource-docker-labels',
     key: (registryHost: string, dockerRepository: string, tag: string) =>
       `${registryHost}:${dockerRepository}:${tag}`,
-    ttlMinutes: 60,
+    ttlMinutes: 24 * 60,
   })
   public async getLabels(
     registryHost: string,
@@ -439,6 +439,14 @@ export class DockerDatasource extends Datasource {
     tag: string
   ): Promise<Record<string, string> | undefined> {
     logger.debug(`getLabels(${registryHost}, ${dockerRepository}, ${tag})`);
+    // Docker Hub library images don't have labels we need
+    if (
+      registryHost === 'https://index.docker.io' &&
+      dockerRepository.startsWith('library/')
+    ) {
+      logger.debug('Docker Hub library image - skipping label lookup');
+      return {};
+    }
     try {
       let labels: Record<string, string> | undefined = {};
       const manifest = await this.getManifest(

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -367,9 +367,6 @@ export async function lookupUpdates(
             updateType: 'digest',
             // TODO #22198
             newValue: currentValue!,
-            newDigest: dependency?.releases.find(
-              (r) => r.version === currentValue
-            )?.newDigest,
           });
         }
       } else if (pinDigests) {
@@ -396,8 +393,10 @@ export async function lookupUpdates(
       for (const update of res.updates) {
         if (pinDigests === true || currentDigest) {
           // TODO #22198
-          update.newDigest =
-            update.newDigest ?? (await getDigest(config, update.newValue))!;
+          update.newDigest ??=
+            dependency?.releases?.find(
+              (release) => release.version === update.newVersion
+            )?.newDigest ?? (await getDigest(config, update.newValue))!;
 
           // If the digest could not be determined, report this as otherwise the
           // update will be omitted later on without notice.

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -394,9 +394,8 @@ export async function lookupUpdates(
         if (pinDigests === true || currentDigest) {
           // TODO #22198
           update.newDigest ??=
-            dependency?.releases?.find(
-              (release) => release.version === update.newVersion
-            )?.newDigest ?? (await getDigest(config, update.newValue))!;
+            dependency?.releases.find((r) => r.version === update.newValue)
+              ?.newDigest ?? (await getDigest(config, update.newValue))!;
 
           // If the digest could not be determined, report this as otherwise the
           // update will be omitted later on without notice.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Increases docker label caching to 24 hours
- Skips label fetching if it's a Docker Hub library image, as they don't contain source URLs or git refs

## Context

Efficiency!

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
