### PR TITLE
fix(datasource/docker): allow null in schema values

### DIFF
--- a/lib/modules/datasource/docker/schema.ts
+++ b/lib/modules/datasource/docker/schema.ts
@@ -10,7 +10,7 @@ import type { Release } from '../types';
  */
 export const ManifestObject = z.object({
   schemaVersion: z.literal(2),
-  mediaType: z.string().optional(),
+  mediaType: z.string().nullish(),
 });
 
 /**
@@ -20,7 +20,7 @@ export const ManifestObject = z.object({
 export const Descriptor = z.object({
   mediaType: z.string(),
   digest: z.string(),
-  size: z.number().int().gt(0).optional(),
+  size: z.number().int().gt(0).nullish(),
 });
 /**
  * OCI platform properties
@@ -28,9 +28,9 @@ export const Descriptor = z.object({
  */
 const OciPlatform = z
   .object({
-    architecture: z.string().optional(),
+    architecture: z.string().nullish(),
   })
-  .optional();
+  .nullish();
 
 /**
  * OCI Image Configuration.
@@ -40,8 +40,8 @@ const OciPlatform = z
  */
 export const OciImageConfig = z.object({
   // This is required by the spec, but probably not present in the wild.
-  architecture: z.string().optional(),
-  config: z.object({ Labels: z.record(z.string()).optional() }).optional(),
+  architecture: z.string().nullish(),
+  config: z.object({ Labels: z.record(z.string()).nullish() }).nullish(),
 });
 export type OciImageConfig = z.infer<typeof OciImageConfig>;
 
@@ -52,8 +52,8 @@ export type OciImageConfig = z.infer<typeof OciImageConfig>;
 export const OciHelmConfig = z.object({
   name: z.string(),
   version: z.string(),
-  home: z.string().optional(),
-  sources: z.array(z.string()).optional(),
+  home: z.string().nullish(),
+  sources: z.array(z.string()).nullish(),
 });
 export type OciHelmConfig = z.infer<typeof OciHelmConfig>;
 
@@ -70,7 +70,7 @@ export const OciImageManifest = ManifestObject.extend({
       'application/vnd.cncf.helm.config.v1+json',
     ]),
   }),
-  annotations: z.record(z.string()).optional(),
+  annotations: z.record(z.string()).nullish(),
 });
 export type OciImageManifest = z.infer<typeof OciImageManifest>;
 
@@ -90,7 +90,7 @@ export const OciImageIndexManifest = ManifestObject.extend({
       platform: OciPlatform,
     })
   ),
-  annotations: z.record(z.string()).optional(),
+  annotations: z.record(z.string()).nullish(),
 });
 
 // Old Docker manifests


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Allow `null` additional to `undefiend` on OCI schema 
<!-- Describe what behavior is changed by this PR. -->

## Context
Some registries send `null` instead of omit those objects
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
