### PR TITLE
feat(presets/merge-confidence): Merge Confidence badges on-by-default for .NET, PHP and Ruby

### DIFF
--- a/docs/usage/merge-confidence.md
+++ b/docs/usage/merge-confidence.md
@@ -33,7 +33,6 @@ Data is available for the following languages (from the noted data source):
 - .NET (nuget)
 - PHP (packagist)
 - Ruby (rubygems)
-- Scala (sbt-package)
 
 We plan to support more languages soon.
 

--- a/docs/usage/merge-confidence.md
+++ b/docs/usage/merge-confidence.md
@@ -30,7 +30,7 @@ Data is available for the following languages (from the noted data source):
 - JavaScript (npm)
 - Java (maven)
 - Python (pypi)
-- .Net (nuget)
+- .NET (nuget)
 - PHP (packagist)
 - Ruby (rubygems)
 - Scala (sbt-package)

--- a/docs/usage/merge-confidence.md
+++ b/docs/usage/merge-confidence.md
@@ -27,9 +27,11 @@ Merge Confidence badges for pull requests are available on any supported platfor
 
 Data is available for packages from:
 
-- npm
-- Maven
-- PyPI
+- npm (NodeJS)
+- Maven (Java)
+- PyPI (Python)
+- NuGet (.NET)
+- Packagist (PHP)
 
 We plan to support more languages soon.
 

--- a/docs/usage/merge-confidence.md
+++ b/docs/usage/merge-confidence.md
@@ -25,13 +25,15 @@ Merge Confidence badges for pull requests are available on any supported platfor
 
 ## Supported languages
 
-Data is available for packages from:
+Data is available for the following languages (from the noted data source):
 
-- npm (NodeJS)
-- Maven (Java)
-- PyPI (Python)
-- NuGet (.NET)
-- Packagist (PHP)
+- JavaScript (npm)
+- Java (maven)
+- Python (pypi)
+- .Net (nuget)
+- PHP (packagist)
+- Ruby (rubygems)
+- Scala (sbt-package)
 
 We plan to support more languages soon.
 

--- a/docs/usage/merge-confidence.md
+++ b/docs/usage/merge-confidence.md
@@ -25,14 +25,16 @@ Merge Confidence badges for pull requests are available on any supported platfor
 
 ## Supported languages
 
-Data is available for the following languages (from the noted data source):
+Renovate will show Merge Confidence badges for these languages:
 
-- JavaScript (npm)
-- Java (maven)
-- Python (pypi)
-- .NET (nuget)
-- PHP (packagist)
-- Ruby (rubygems)
+| Language   | Datasource  |
+| ---------- | ----------- |
+| JavaScript | `npm`       |
+| Java       | `maven`     |
+| Python     | `pypi`      |
+| .NET       | `nuget`     |
+| PHP        | `packagist` |
+| Ruby       | `rubygems`  |
 
 We plan to support more languages soon.
 

--- a/lib/config/presets/internal/merge-confidence.ts
+++ b/lib/config/presets/internal/merge-confidence.ts
@@ -5,7 +5,7 @@ export const presets: Record<string, Preset> = {
     description: 'Show all Merge Confidence badges for pull requests.',
     packageRules: [
       {
-        matchDatasources: ['maven', 'npm', 'pypi', 'nuget', 'packagist', 'rubygems'],
+        matchDatasources: ['maven', 'npm', 'nuget', 'packagist', 'pypi', 'rubygems'],
         matchUpdateTypes: ['patch', 'minor', 'major'],
         prBodyColumns: [
           'Package',
@@ -23,7 +23,7 @@ export const presets: Record<string, Preset> = {
       'Show only the Age and Confidence Merge Confidence badges for pull requests.',
     packageRules: [
       {
-        matchDatasources: ['maven', 'npm', 'pypi', 'nuget', 'packagist', 'rubygems'],
+        matchDatasources: ['maven', 'npm', 'nuget', 'packagist', 'pypi', 'rubygems'],
         matchUpdateTypes: ['patch', 'minor', 'major'],
         prBodyColumns: ['Package', 'Change', 'Age', 'Confidence'],
       },

--- a/lib/config/presets/internal/merge-confidence.ts
+++ b/lib/config/presets/internal/merge-confidence.ts
@@ -5,7 +5,14 @@ export const presets: Record<string, Preset> = {
     description: 'Show all Merge Confidence badges for pull requests.',
     packageRules: [
       {
-        matchDatasources: ['maven', 'npm', 'nuget', 'packagist', 'pypi', 'rubygems'],
+        matchDatasources: [
+          'maven',
+          'npm',
+          'nuget',
+          'packagist',
+          'pypi',
+          'rubygems',
+        ],
         matchUpdateTypes: ['patch', 'minor', 'major'],
         prBodyColumns: [
           'Package',
@@ -23,7 +30,14 @@ export const presets: Record<string, Preset> = {
       'Show only the Age and Confidence Merge Confidence badges for pull requests.',
     packageRules: [
       {
-        matchDatasources: ['maven', 'npm', 'nuget', 'packagist', 'pypi', 'rubygems'],
+        matchDatasources: [
+          'maven',
+          'npm',
+          'nuget',
+          'packagist',
+          'pypi',
+          'rubygems',
+        ],
         matchUpdateTypes: ['patch', 'minor', 'major'],
         prBodyColumns: ['Package', 'Change', 'Age', 'Confidence'],
       },

--- a/lib/config/presets/internal/merge-confidence.ts
+++ b/lib/config/presets/internal/merge-confidence.ts
@@ -5,7 +5,7 @@ export const presets: Record<string, Preset> = {
     description: 'Show all Merge Confidence badges for pull requests.',
     packageRules: [
       {
-        matchDatasources: ['maven', 'npm', 'pypi', 'nuget', 'packagist', 'rubygems', 'sbt-package'],
+        matchDatasources: ['maven', 'npm', 'pypi', 'nuget', 'packagist', 'rubygems'],
         matchUpdateTypes: ['patch', 'minor', 'major'],
         prBodyColumns: [
           'Package',
@@ -23,7 +23,7 @@ export const presets: Record<string, Preset> = {
       'Show only the Age and Confidence Merge Confidence badges for pull requests.',
     packageRules: [
       {
-        matchDatasources: ['maven', 'npm', 'pypi', 'nuget', 'packagist', 'rubygems', 'sbt-package'],
+        matchDatasources: ['maven', 'npm', 'pypi', 'nuget', 'packagist', 'rubygems'],
         matchUpdateTypes: ['patch', 'minor', 'major'],
         prBodyColumns: ['Package', 'Change', 'Age', 'Confidence'],
       },

--- a/lib/config/presets/internal/merge-confidence.ts
+++ b/lib/config/presets/internal/merge-confidence.ts
@@ -5,7 +5,7 @@ export const presets: Record<string, Preset> = {
     description: 'Show all Merge Confidence badges for pull requests.',
     packageRules: [
       {
-        matchDatasources: ['maven', 'npm', 'pypi'],
+        matchDatasources: ['maven', 'npm', 'pypi', 'nuget', 'packagist'],
         matchUpdateTypes: ['patch', 'minor', 'major'],
         prBodyColumns: [
           'Package',
@@ -23,7 +23,7 @@ export const presets: Record<string, Preset> = {
       'Show only the Age and Confidence Merge Confidence badges for pull requests.',
     packageRules: [
       {
-        matchDatasources: ['maven', 'npm', 'pypi'],
+        matchDatasources: ['maven', 'npm', 'pypi', 'nuget', 'packagist'],
         matchUpdateTypes: ['patch', 'minor', 'major'],
         prBodyColumns: ['Package', 'Change', 'Age', 'Confidence'],
       },

--- a/lib/config/presets/internal/merge-confidence.ts
+++ b/lib/config/presets/internal/merge-confidence.ts
@@ -5,7 +5,7 @@ export const presets: Record<string, Preset> = {
     description: 'Show all Merge Confidence badges for pull requests.',
     packageRules: [
       {
-        matchDatasources: ['maven', 'npm', 'pypi', 'nuget', 'packagist'],
+        matchDatasources: ['maven', 'npm', 'pypi', 'nuget', 'packagist', 'rubygems', 'sbt-package'],
         matchUpdateTypes: ['patch', 'minor', 'major'],
         prBodyColumns: [
           'Package',
@@ -23,7 +23,7 @@ export const presets: Record<string, Preset> = {
       'Show only the Age and Confidence Merge Confidence badges for pull requests.',
     packageRules: [
       {
-        matchDatasources: ['maven', 'npm', 'pypi', 'nuget', 'packagist'],
+        matchDatasources: ['maven', 'npm', 'pypi', 'nuget', 'packagist', 'rubygems', 'sbt-package'],
         matchUpdateTypes: ['patch', 'minor', 'major'],
         prBodyColumns: ['Package', 'Change', 'Age', 'Confidence'],
       },


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
Default package rules now provide Merge Confidence badges for .NET, PHP and Ruby updates.
Users of datasources NuGet, Packagist and RubyGems will have Merge Confidence badges shown in the PRs for the branch updates - as an on-by-default feature. Users can configure their own package rules to turn off the MC badges.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->
Data is now available for users of NuGet, Packagist and RubyGems data sources and this has been tested to the point where it is ready to be made available by default for all users.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
