### PR TITLE
feat(manager/poetry): extract python as a dependency from `pyproject.toml`

### DIFF
--- a/lib/modules/manager/poetry/__snapshots__/extract.spec.ts.snap
+++ b/lib/modules/manager/poetry/__snapshots__/extract.spec.ts.snap
@@ -472,6 +472,17 @@ exports[`modules/manager/poetry/extract extractPackageFile() extracts multiple d
     "versioning": "poetry",
   },
   {
+    "commitMessageTopic": "Python",
+    "currentValue": "~2.7 || ^3.4",
+    "datasource": "docker",
+    "depName": "python",
+    "depType": "dependencies",
+    "managerData": {
+      "nestedVersion": false,
+    },
+    "versioning": "docker",
+  },
+  {
     "currentValue": "^3.0",
     "datasource": "pypi",
     "depName": "dev_dep1",
@@ -554,6 +565,17 @@ exports[`modules/manager/poetry/extract extractPackageFile() handles multiple co
 exports[`modules/manager/poetry/extract extractPackageFile() resolves lockedVersions from the lockfile 1`] = `
 {
   "deps": [
+    {
+      "commitMessageTopic": "Python",
+      "currentValue": "^3.9",
+      "datasource": "docker",
+      "depName": "python",
+      "depType": "dependencies",
+      "managerData": {
+        "nestedVersion": false,
+      },
+      "versioning": "docker",
+    },
     {
       "currentValue": "*",
       "datasource": "pypi",

--- a/lib/modules/manager/poetry/__snapshots__/extract.spec.ts.snap
+++ b/lib/modules/manager/poetry/__snapshots__/extract.spec.ts.snap
@@ -480,7 +480,7 @@ exports[`modules/manager/poetry/extract extractPackageFile() extracts multiple d
     "managerData": {
       "nestedVersion": false,
     },
-    "versioning": "docker",
+    "versioning": "poetry",
   },
   {
     "currentValue": "^3.0",
@@ -574,7 +574,7 @@ exports[`modules/manager/poetry/extract extractPackageFile() resolves lockedVers
       "managerData": {
         "nestedVersion": false,
       },
-      "versioning": "docker",
+      "versioning": "poetry",
     },
     {
       "currentValue": "*",

--- a/lib/modules/manager/poetry/artifacts.spec.ts
+++ b/lib/modules/manager/poetry/artifacts.spec.ts
@@ -1,3 +1,4 @@
+import { codeBlock } from 'common-tags';
 import { join } from 'upath';
 import { envMock, mockExecAll } from '../../../../test/exec-util';
 import { Fixtures } from '../../../../test/fixtures';
@@ -8,7 +9,7 @@ import * as docker from '../../../util/exec/docker';
 import * as _hostRules from '../../../util/host-rules';
 import * as _datasource from '../../datasource';
 import type { UpdateArtifactsConfig } from '../types';
-import { getPoetryRequirement } from './artifacts';
+import { getPoetryRequirement, getPythonConstraint } from './artifacts';
 import { updateArtifacts } from '.';
 
 const pyproject1toml = Fixtures.get('pyproject.1.toml');
@@ -33,6 +34,29 @@ const adminConfig: RepoGlobalConfig = {
 const config: UpdateArtifactsConfig = {};
 
 describe('modules/manager/poetry/artifacts', () => {
+  describe('getPythonConstraint', () => {
+    const pythonVersion = '3.11.3';
+    const poetryLock = codeBlock`
+      [metadata]
+      python-versions = "${pythonVersion}"
+    `;
+
+    it('detects from pyproject.toml', () => {
+      const pythonVersion = '3.11.5';
+      const pyprojectContent = codeBlock`
+        [tool.poetry.dependencies]
+        python = "${pythonVersion}"
+      `;
+      expect(getPythonConstraint(pyprojectContent, poetryLock)).toBe(
+        pythonVersion
+      );
+    });
+
+    it('detects from poetry.ock', () => {
+      expect(getPythonConstraint('', poetryLock)).toBe(pythonVersion);
+    });
+  });
+
   describe('getPoetryRequirement', () => {
     const poetry12lock = Fixtures.get('poetry12.lock');
     const poetry142lock = Fixtures.get('poetry142.lock');

--- a/lib/modules/manager/poetry/extract.spec.ts
+++ b/lib/modules/manager/poetry/extract.spec.ts
@@ -48,7 +48,7 @@ describe('modules/manager/poetry/extract', () => {
     it('extracts multiple dependencies', async () => {
       const res = await extractPackageFile(pyproject1toml, filename);
       expect(res?.deps).toMatchSnapshot();
-      expect(res?.deps).toHaveLength(9);
+      expect(res?.deps).toHaveLength(10);
       expect(res?.extractedConstraints).toEqual({
         python: '~2.7 || ^3.4',
       });
@@ -74,7 +74,7 @@ describe('modules/manager/poetry/extract', () => {
     it('can parse TOML v1 heterogeneous arrays', async () => {
       const res = await extractPackageFile(pyproject12toml, filename);
       expect(res).not.toBeNull();
-      expect(res?.deps).toHaveLength(2);
+      expect(res?.deps).toHaveLength(3);
     });
 
     it('extracts registries', async () => {
@@ -184,7 +184,10 @@ describe('modules/manager/poetry/extract', () => {
       const res = await extractPackageFile(pyproject11toml, filename);
       expect(res).toMatchSnapshot({
         extractedConstraints: { python: '^3.9' },
-        deps: [{ lockedVersion: '1.17.5' }],
+        deps: [
+          { depName: 'python', currentValue: '^3.9' },
+          { depName: 'boto3', lockedVersion: '1.17.5' },
+        ],
       });
     });
 

--- a/lib/modules/manager/poetry/extract.ts
+++ b/lib/modules/manager/poetry/extract.ts
@@ -8,7 +8,6 @@ import {
 } from '../../../util/fs';
 import { Result } from '../../../util/result';
 import { DockerDatasource } from '../../datasource/docker';
-import * as dockerVersioning from '../../versioning/docker';
 import type { PackageFileContent } from '../types';
 import { Lockfile, PoetrySchemaToml } from './schema';
 
@@ -43,7 +42,6 @@ export async function extractPackageFile(
         ...dep,
         datasource: DockerDatasource.id,
         commitMessageTopic: 'Python',
-        versioning: dockerVersioning.id,
       };
     }
 

--- a/lib/modules/manager/poetry/extract.ts
+++ b/lib/modules/manager/poetry/extract.ts
@@ -7,6 +7,8 @@ import {
   readLocalFile,
 } from '../../../util/fs';
 import { Result } from '../../../util/result';
+import { DockerDatasource } from '../../datasource/docker';
+import * as dockerVersioning from '../../versioning/docker';
 import type { PackageFileContent } from '../types';
 import { Lockfile, PoetrySchemaToml } from './schema';
 
@@ -37,7 +39,12 @@ export async function extractPackageFile(
       if (dep.currentValue) {
         pythonVersion = dep.currentValue;
       }
-      return null;
+      return {
+        ...dep,
+        datasource: DockerDatasource.id,
+        commitMessageTopic: 'Python',
+        versioning: dockerVersioning.id,
+      };
     }
 
     const packageName = dep.packageName ?? dep.depName;

--- a/lib/modules/manager/poetry/index.ts
+++ b/lib/modules/manager/poetry/index.ts
@@ -1,4 +1,5 @@
 import type { Category } from '../../../constants';
+import { DockerDatasource } from '../../datasource/docker';
 import { GithubTagsDatasource } from '../../datasource/github-tags';
 import { PypiDatasource } from '../../datasource/pypi';
 
@@ -9,6 +10,7 @@ export { updateLockedDependency } from './update-locked';
 export const supportedDatasources = [
   PypiDatasource.id,
   GithubTagsDatasource.id,
+  DockerDatasource.id,
 ];
 
 export const supportsLockFileMaintenance = true;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Update `poetry` manager to extract python as a dependency from `pyproject.toml` so that its version can be updated
- Update `artifact.getPythonConstraint` to first attempt to read the python version from `pyproject.toml` first as it could have been updated then fallback to read from `poetry.lock`

## Context

https://github.com/renovatebot/renovate/discussions/19144

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository
  - https://github.com/barriot/r0/pull/16 - updated python version
  - https://github.com/barriot/r0/pull/11 - confirmed that existing package update still works

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
