### PR TITLE
feat(manager/github-actions): Support for Gitea and Forgejo actions within `github-actions` manager

### DIFF
--- a/lib/modules/manager/github-actions/index.ts
+++ b/lib/modules/manager/github-actions/index.ts
@@ -5,7 +5,7 @@ export { extractPackageFile } from './extract';
 
 export const defaultConfig = {
   fileMatch: [
-    '^(workflow-templates|\\.github/workflows|\\.gitea/workflows)/[^/]+\\.ya?ml$',
+    '^(workflow-templates|\\.(?:github|gitea|forgejo)/workflows)/[^/]+\\.ya?ml$',
     '(^|/)action\\.ya?ml$',
   ],
 };

--- a/lib/modules/manager/github-actions/index.ts
+++ b/lib/modules/manager/github-actions/index.ts
@@ -5,7 +5,7 @@ export { extractPackageFile } from './extract';
 
 export const defaultConfig = {
   fileMatch: [
-    '^(workflow-templates|\\.github/workflows)/[^/]+\\.ya?ml$',
+    '^(workflow-templates|\\.github/workflows|\\.gitea/workflows)/[^/]+\\.ya?ml$',
     '(^|/)action\\.ya?ml$',
   ],
 };

--- a/lib/modules/manager/github-actions/readme.md
+++ b/lib/modules/manager/github-actions/readme.md
@@ -1,5 +1,5 @@
 The `github-actions` manager extracts dependencies from GitHub Actions workflow and workflow template files.
-It can also be used for Gitea Actions workflows as such are compatible with GitHub Actions workflows.
+It can also be used for Gitea and Forgejo Actions workflows as such are compatible with GitHub Actions workflows.
 
 If you like to use digest pinning but want to follow the action version tag, you can use the following sample:
 

--- a/lib/modules/manager/github-actions/readme.md
+++ b/lib/modules/manager/github-actions/readme.md
@@ -1,4 +1,5 @@
 The `github-actions` manager extracts dependencies from GitHub Actions workflow and workflow template files.
+It can also be used for Gitea Actions workflows as such are compatible with GitHub Actions workflows.
 
 If you like to use digest pinning but want to follow the action version tag, you can use the following sample:
 


### PR DESCRIPTION

<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Add support for Gitea actions within `github-actions` manager.

## Context

Gitea actions is compatible with GitHub actions and using the same actions. Letting the existing manager also crawl the respective YAML files should be enough. 

One could also add a dedicated `gitea-actions` manager but that would essentially be a duplicate of `github-actions` then.

Gitea also has it's own actions such as https://gitea.com/actions/release-action but support for such could be added in a separate PR. 

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
