### PR TITLE
fix(platform/azure): Allows azure-got-wrapper to retry requests following connection failures

### DIFF
--- a/lib/modules/platform/azure/azure-got-wrapper.ts
+++ b/lib/modules/platform/azure/azure-got-wrapper.ts
@@ -4,6 +4,7 @@ import type { ICoreApi } from 'azure-devops-node-api/CoreApi';
 import type { IGitApi } from 'azure-devops-node-api/GitApi';
 import type { IPolicyApi } from 'azure-devops-node-api/PolicyApi';
 import type { IRequestHandler } from 'azure-devops-node-api/interfaces/common/VsoBaseInterfaces';
+import type { IRequestOptions } from 'azure-devops-node-api/interfaces/common/VsoBaseInterfaces';
 import type { HostRule } from '../../../types';
 import * as hostRules from '../../../util/host-rules';
 
@@ -18,13 +19,21 @@ function getAuthenticationHandler(config: HostRule): IRequestHandler {
   return getHandlerFromToken(config.token!, true);
 }
 
+function getRequestOptions() : IRequestOptions {
+  let options: IRequestOptions = <IRequestOptions>{};
+  options.allowRetries = true;
+  options.maxRetries = 2;
+  return options;
+}
+
 export function azureObj(): azure.WebApi {
   const config = hostRules.find({ hostType, url: endpoint });
   if (!config.token && !(config.username && config.password)) {
     throw new Error(`No config found for azure`);
   }
   const authHandler = getAuthenticationHandler(config);
-  return new azure.WebApi(endpoint, authHandler);
+  const requestOptions = getRequestOptions();
+  return new azure.WebApi(endpoint, authHandler, requestOptions);
 }
 
 export function gitApi(): Promise<IGitApi> {

--- a/lib/modules/platform/azure/azure-got-wrapper.ts
+++ b/lib/modules/platform/azure/azure-got-wrapper.ts
@@ -4,7 +4,6 @@ import type { ICoreApi } from 'azure-devops-node-api/CoreApi';
 import type { IGitApi } from 'azure-devops-node-api/GitApi';
 import type { IPolicyApi } from 'azure-devops-node-api/PolicyApi';
 import type { IRequestHandler } from 'azure-devops-node-api/interfaces/common/VsoBaseInterfaces';
-import type { IRequestOptions } from 'azure-devops-node-api/interfaces/common/VsoBaseInterfaces';
 import type { HostRule } from '../../../types';
 import * as hostRules from '../../../util/host-rules';
 
@@ -19,21 +18,16 @@ function getAuthenticationHandler(config: HostRule): IRequestHandler {
   return getHandlerFromToken(config.token!, true);
 }
 
-function getRequestOptions() : IRequestOptions {
-  let options: IRequestOptions = <IRequestOptions>{};
-  options.allowRetries = true;
-  options.maxRetries = 2;
-  return options;
-}
-
 export function azureObj(): azure.WebApi {
   const config = hostRules.find({ hostType, url: endpoint });
   if (!config.token && !(config.username && config.password)) {
     throw new Error(`No config found for azure`);
   }
   const authHandler = getAuthenticationHandler(config);
-  const requestOptions = getRequestOptions();
-  return new azure.WebApi(endpoint, authHandler, requestOptions);
+  return new azure.WebApi(endpoint, authHandler, {
+    allowRetries: true,
+    maxRetries: 2,
+  });
 }
 
 export function gitApi(): Promise<IGitApi> {


### PR DESCRIPTION
## Changes

Allows `azure-got-wrapper` to retry requests in the event of a connection failure.  A maximum of 2 retries is defined, giving a maximum of 3 requests in total.

## Context

- #24315 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

I run renovate via docker in production.  For the last 4 days I have run a manually updated docker image with the above change applied.  It is impossible to say that the this change works as it is a very flakey failure mode, but I can say that I haven't seen any errors and that this change hasn't caused new issues within renovate.