### PR TITLE
fix(manager/argocd): allow the apiVersion to be quoted

### DIFF
--- a/lib/modules/manager/argocd/extract.spec.ts
+++ b/lib/modules/manager/argocd/extract.spec.ts
@@ -31,6 +31,60 @@ describe('modules/manager/argocd/extract', () => {
       expect(result).toBeNull();
     });
 
+    it('return result for double quoted argoproj.io apiVersion reference', () => {
+      const result = extractPackageFile(
+        `
+apiVersion: "argoproj.io/v1alpha1"
+kind: Application
+spec:
+  source:
+    chart: kube-state-metrics
+    repoURL: https://prometheus-community.github.io/helm-charts
+    targetRevision: 2.4.1
+        `,
+        'applications.yml'
+      );
+      expect(result).toMatchObject({
+        deps: [
+          {
+            currentValue: '2.4.1',
+            datasource: 'helm',
+            depName: 'kube-state-metrics',
+            registryUrls: [
+              'https://prometheus-community.github.io/helm-charts',
+            ],
+          },
+        ],
+      });
+    });
+
+    it('return result for single quoted argoproj.io apiVersion reference', () => {
+      const result = extractPackageFile(
+        `
+apiVersion: 'argoproj.io/v1alpha1'
+kind: Application
+spec:
+  source:
+    chart: kube-state-metrics
+    repoURL: https://prometheus-community.github.io/helm-charts
+    targetRevision: 2.4.1
+        `,
+        'applications.yml'
+      );
+      expect(result).toMatchObject({
+        deps: [
+          {
+            currentValue: '2.4.1',
+            datasource: 'helm',
+            depName: 'kube-state-metrics',
+            registryUrls: [
+              'https://prometheus-community.github.io/helm-charts',
+            ],
+          },
+        ],
+      });
+    });
+
     it('full test', () => {
       const result = extractPackageFile(validApplication, 'applications.yml');
       expect(result).toEqual({

--- a/lib/modules/manager/argocd/extract.ts
+++ b/lib/modules/manager/argocd/extract.ts
@@ -25,6 +25,9 @@ export function extractPackageFile(
 ): PackageFileContent | null {
   // check for argo reference. API version for the kind attribute is used
   if (fileTestRegex.test(content) === false) {
+    logger.debug(
+      `Skip file ${packageFile} as no argoproj.io apiVersion could be found in matched file`
+    );
     return null;
   }
 

--- a/lib/modules/manager/argocd/util.ts
+++ b/lib/modules/manager/argocd/util.ts
@@ -3,5 +3,5 @@ import { regEx } from '../../../util/regex';
 export const keyValueExtractionRegex = regEx(
   /^\s*(?<key>[^\s]+):\s+"?(?<value>[^"\s]+)"?\s*$/
 );
-// looks for `apiVersion: argoproj.io/
-export const fileTestRegex = regEx(/\s*apiVersion:\s*argoproj.io\/\s*/);
+// looks for `apiVersion: argoproj.io/` with optional quoting of the value
+export const fileTestRegex = regEx(/\s*apiVersion:\s*'?"?argoproj.io\//);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Allow the apiVersion value of ArgoCD manifests to be quoted. 
Further add debug log if the file is found using fileMatch tough is skipped by this railguard. 

<!-- Describe what behavior is changed by this PR. -->

## Context
https://github.com/renovatebot/renovate/discussions/24353

Reproduction https://github.com/renovate-reproductions/24353
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
