### PR TITLE
feat(manager/gradle): add support for `listOf` directives in Kotlin objects

### DIFF
--- a/lib/modules/manager/gradle/parser.spec.ts
+++ b/lib/modules/manager/gradle/parser.spec.ts
@@ -940,6 +940,11 @@ describe('modules/manager/gradle/parser', () => {
 
         object Libraries {
           val deps = mapOf("api" to "org.slf4j:slf4j-api:\${Versions.baz}")
+          val deps2 = listOf(
+            "androidx.appcompat:appcompat:4.5.6",
+            "androidx.core:core-ktx:\${Versions.baz}",
+            listOf("androidx.webkit:webkit:\${Versions.baz}")
+          )
           val dep: String = "foo:bar:" + Versions.baz
         }
       `;
@@ -955,6 +960,20 @@ describe('modules/manager/gradle/parser', () => {
         deps: [
           {
             depName: 'org.slf4j:slf4j-api',
+            groupName: 'Versions.baz',
+            currentValue: '1.2.3',
+          },
+          {
+            depName: 'androidx.appcompat:appcompat',
+            currentValue: '4.5.6',
+          },
+          {
+            depName: 'androidx.core:core-ktx',
+            groupName: 'Versions.baz',
+            currentValue: '1.2.3',
+          },
+          {
+            depName: 'androidx.webkit:webkit',
             groupName: 'Versions.baz',
             currentValue: '1.2.3',
           },

--- a/lib/modules/manager/gradle/parser/dependencies.ts
+++ b/lib/modules/manager/gradle/parser/dependencies.ts
@@ -31,7 +31,7 @@ const qVersion = qValueMatcher.handler((ctx) =>
 // "foo:bar:1.2.3"
 // "foo:bar:$baz"
 // "foo" + "${bar}" + baz
-const qDependencyStrings = qTemplateString
+export const qDependencyStrings = qTemplateString
   .opt(q.op<Ctx>('+').join(qValueMatcher))
   .handler((ctx: Ctx) => storeInTokenMap(ctx, 'templateStringTokens'))
   .handler(handleDepString)

--- a/lib/modules/manager/gradle/parser/objects.ts
+++ b/lib/modules/manager/gradle/parser/objects.ts
@@ -12,21 +12,33 @@ import {
   storeInTokenMap,
   storeVarToken,
 } from './common';
+import { qDependencyStrings } from './dependencies';
 import { handleAssignment } from './handlers';
+
+const qKotlinListOfAssignment = q.sym<Ctx>('listOf').tree({
+  type: 'wrapped-tree',
+  startsWith: '(',
+  endsWith: ')',
+  search: qDependencyStrings,
+});
 
 const qKotlinSingleObjectVarAssignment = q.alt(
   // val dep = mapOf("qux" to "foo:bar:\${Versions.baz}")
   qKotlinMultiMapOfVarAssignment,
-  // val dep: String = "foo:bar:" + Versions.baz
   qVariableAssignmentIdentifier
     .opt(q.op<Ctx>(':').sym('String'))
     .op('=')
     .handler(prependNestingDepth)
     .handler(coalesceVariable)
     .handler((ctx) => storeInTokenMap(ctx, 'keyToken'))
-    .join(qValueMatcher)
-    .handler((ctx) => storeInTokenMap(ctx, 'valToken'))
-    .handler(handleAssignment)
+    .alt(
+      // val deps = listOf("androidx.appcompat:appcompat:$baz", listOf("androidx.webkit:webkit:${Versions.baz}"))
+      qKotlinListOfAssignment,
+      // val dep: String = "foo:bar:" + Versions.baz
+      qValueMatcher
+        .handler((ctx) => storeInTokenMap(ctx, 'valToken'))
+        .handler(handleAssignment)
+    )
     .handler(cleanupTempVars)
 );
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds functionality to parse dependencies in `listOf` declarations.

_Note_: This PR specifically targets objects in Kotlin source files. `listOf` declarations in regular `.gradle.kts` files are already extracted via the `qDependencyStrings` matcher.

<!-- Describe what behavior is changed by this PR. -->

## Context

- Closes https://github.com/renovatebot/renovate/issues/24279

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

Test repo: https://github.com/renovate-demo/24246/issues/5

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
