### PR TITLE
fix(bundler): Set exec cwd to lock file

### DIFF
--- a/lib/modules/manager/bundler/artifacts.spec.ts
+++ b/lib/modules/manager/bundler/artifacts.spec.ts
@@ -103,6 +103,29 @@ describe('modules/manager/bundler/artifacts', () => {
       ]);
     });
 
+    it('executes commands from lockFile path', async () => {
+      fs.readLocalFile.mockResolvedValueOnce('Current Gemfile.lock');
+      fs.writeLocalFile.mockResolvedValueOnce();
+      const execSnapshots = mockExecAll();
+      git.getRepoStatus.mockResolvedValueOnce(
+        partial<StatusResult>({
+          modified: [],
+        })
+      );
+      fs.readLocalFile.mockResolvedValueOnce('Updated Gemfile.lock');
+      expect(
+        await updateArtifacts({
+          packageFileName: 'teamA/Gemfile',
+          updatedDeps: [{ depName: 'foo' }, { depName: 'bar' }],
+          newPackageFileContent: 'Updated Gemfile content',
+          config,
+        })
+      ).toBeNull();
+      expect(execSnapshots).toMatchObject([
+        { options: { cwd: '/tmp/github/some/repo' } },
+      ]);
+    });
+
     it('works for default binarySource', async () => {
       fs.readLocalFile.mockResolvedValueOnce('Current Gemfile.lock');
       fs.readLocalFile.mockResolvedValueOnce(null);

--- a/lib/modules/manager/bundler/artifacts.ts
+++ b/lib/modules/manager/bundler/artifacts.ts
@@ -77,8 +77,8 @@ export async function updateArtifacts(
     logger.debug('Aborting Bundler artifacts due to previous failed attempt');
     throw new Error(existingError);
   }
-  const lockFilePath = await getLockFilePath(packageFileName);
-  const existingLockFileContent = await readLocalFile(lockFilePath, 'utf8');
+  const lockFileName = await getLockFilePath(packageFileName);
+  const existingLockFileContent = await readLocalFile(lockFileName, 'utf8');
   if (!existingLockFileContent) {
     logger.debug('No Gemfile.lock found');
     return null;
@@ -174,7 +174,7 @@ export async function updateArtifacts(
     }
 
     const execOptions: ExecOptions = {
-      cwdFile: lockFilePath,
+      cwdFile: packageFileName,
       extraEnv: {
         ...bundlerHostRulesVariables,
         GEM_HOME: await ensureCacheDir('bundler'),
@@ -195,16 +195,16 @@ export async function updateArtifacts(
     await exec(commands, execOptions);
 
     const status = await getRepoStatus();
-    if (!status.modified.includes(lockFilePath)) {
+    if (!status.modified.includes(lockFileName)) {
       return null;
     }
     logger.debug('Returning updated Gemfile.lock');
-    const lockFileContent = await readLocalFile(lockFilePath);
+    const lockFileContent = await readLocalFile(lockFileName);
     return [
       {
         file: {
           type: 'addition',
-          path: lockFilePath,
+          path: lockFileName,
           contents: lockFileContent,
         },
       },
@@ -221,7 +221,7 @@ export async function updateArtifacts(
       return [
         {
           artifactError: {
-            lockFile: lockFilePath,
+            lockFile: lockFileName,
             stderr: output,
           },
         },
@@ -275,7 +275,7 @@ export async function updateArtifacts(
     return [
       {
         artifactError: {
-          lockFile: lockFilePath,
+          lockFile: lockFileName,
           stderr: `${String(err.stdout)}\n${String(err.stderr)}`,
         },
       },

--- a/lib/modules/manager/bundler/artifacts.ts
+++ b/lib/modules/manager/bundler/artifacts.ts
@@ -77,8 +77,8 @@ export async function updateArtifacts(
     logger.debug('Aborting Bundler artifacts due to previous failed attempt');
     throw new Error(existingError);
   }
-  const lockFileName = await getLockFilePath(packageFileName);
-  const existingLockFileContent = await readLocalFile(lockFileName, 'utf8');
+  const lockFilePath = await getLockFilePath(packageFileName);
+  const existingLockFileContent = await readLocalFile(lockFilePath, 'utf8');
   if (!existingLockFileContent) {
     logger.debug('No Gemfile.lock found');
     return null;
@@ -174,7 +174,7 @@ export async function updateArtifacts(
     }
 
     const execOptions: ExecOptions = {
-      cwdFile: packageFileName,
+      cwdFile: lockFilePath,
       extraEnv: {
         ...bundlerHostRulesVariables,
         GEM_HOME: await ensureCacheDir('bundler'),
@@ -195,16 +195,16 @@ export async function updateArtifacts(
     await exec(commands, execOptions);
 
     const status = await getRepoStatus();
-    if (!status.modified.includes(lockFileName)) {
+    if (!status.modified.includes(lockFilePath)) {
       return null;
     }
     logger.debug('Returning updated Gemfile.lock');
-    const lockFileContent = await readLocalFile(lockFileName);
+    const lockFileContent = await readLocalFile(lockFilePath);
     return [
       {
         file: {
           type: 'addition',
-          path: lockFileName,
+          path: lockFilePath,
           contents: lockFileContent,
         },
       },
@@ -221,7 +221,7 @@ export async function updateArtifacts(
       return [
         {
           artifactError: {
-            lockFile: lockFileName,
+            lockFile: lockFilePath,
             stderr: output,
           },
         },
@@ -275,7 +275,7 @@ export async function updateArtifacts(
     return [
       {
         artifactError: {
-          lockFile: lockFileName,
+          lockFile: lockFilePath,
           stderr: `${String(err.stdout)}\n${String(err.stderr)}`,
         },
       },

--- a/lib/modules/manager/bundler/artifacts.ts
+++ b/lib/modules/manager/bundler/artifacts.ts
@@ -174,7 +174,7 @@ export async function updateArtifacts(
     }
 
     const execOptions: ExecOptions = {
-      cwdFile: packageFileName,
+      cwdFile: lockFileName,
       extraEnv: {
         ...bundlerHostRulesVariables,
         GEM_HOME: await ensureCacheDir('bundler'),

--- a/lib/modules/manager/bundler/common.ts
+++ b/lib/modules/manager/bundler/common.ts
@@ -76,8 +76,9 @@ export function getBundlerConstraint(
 export async function getLockFilePath(
   packageFilePath: string
 ): Promise<string> {
-  logger.debug(`Looking for lockfile for ${packageFilePath}`);
-  return (await localPathExists(`${packageFilePath}.lock`))
+  const lockFilePath = (await localPathExists(`${packageFilePath}.lock`))
     ? `${packageFilePath}.lock`
     : `Gemfile.lock`;
+  logger.debug(`Lockfile for ${packageFilePath} found in ${lockFilePath}`);
+  return lockFilePath;
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Execute bundler commands for artifacts based on lock file path.

## Context

Given that Gemfile.lock is in the root directory of the project and Gemfile or Gemfiles are in subdirectories (e.g.: `teamA/Gemfile`) then bundler would have been executed under `./teamA` path missing the root folder lock file and therefore only updating the Gemfile and not the lock file

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [X] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

Tested against: https://github.com/jorge-wonolo/renovate-test/pull/12

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
