### PR TITLE
fix: skip writing symlinks before postUpgradeTasks execution

### DIFF
--- a/lib/workers/repository/update/branch/execute-post-upgrade-commands.spec.ts
+++ b/lib/workers/repository/update/branch/execute-post-upgrade-commands.spec.ts
@@ -26,6 +26,12 @@ describe('workers/repository/update/branch/execute-post-upgrade-commands', () =>
         updatedArtifacts: [
           { type: 'addition', path: 'some-existing-dir', contents: '' },
           { type: 'addition', path: 'artifact', contents: '' },
+          {
+            type: 'addition',
+            path: 'symlink',
+            contents: 'dest',
+            isSymlink: true,
+          },
         ],
         artifactErrors: [],
         upgrades: [],
@@ -45,8 +51,10 @@ describe('workers/repository/update/branch/execute-post-upgrade-commands', () =>
       });
       fs.localPathIsFile
         .mockResolvedValueOnce(true)
-        .mockResolvedValueOnce(false);
+        .mockResolvedValueOnce(false)
+        .mockResolvedValueOnce(true);
       fs.localPathExists
+        .mockResolvedValueOnce(true)
         .mockResolvedValueOnce(true)
         .mockResolvedValueOnce(true);
 
@@ -55,7 +63,7 @@ describe('workers/repository/update/branch/execute-post-upgrade-commands', () =>
         config
       );
 
-      expect(res.updatedArtifacts).toHaveLength(2);
+      expect(res.updatedArtifacts).toHaveLength(3);
       expect(fs.writeLocalFile).toHaveBeenCalledTimes(1);
     });
   });

--- a/lib/workers/repository/update/branch/execute-post-upgrade-commands.ts
+++ b/lib/workers/repository/update/branch/execute-post-upgrade-commands.ts
@@ -51,7 +51,7 @@ export async function postUpgradeCommandsExecutor(
       // Persist updated files in file system so any executed commands can see them
       for (const file of config.updatedPackageFiles!.concat(updatedArtifacts)) {
         const canWriteFile = await localPathIsFile(file.path);
-        if (file.type === 'addition' && canWriteFile) {
+        if (file.type === 'addition' && !file.isSymlink && canWriteFile) {
           let contents: Buffer | null;
           if (typeof file.contents === 'string') {
             contents = Buffer.from(file.contents);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
Skips writing symlink as normal files before executing the postUpgradeTasks. When dealing with a symlink, the current behavior will writhe the content of a symlink to the destination followed by the symlink, which causes error for the postUpgradeTasks execution. 

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

This bug was reported for repositories that have postUpgradeTasks defined. On branches that has done some hermit dependency update, the current function behavior will causes the content of symlink, say for example `.openjdk-17.0.3.pkg` being written into the destination of the link, which is the `bin/hermit` file. This breaks hermit start script and causes postUpgradeTasks execution failure.

```bash
./hermit: 1: .openjdk-17.0.3.pkg: not found
```

By applying this change, the `bin/hermit` file was not broken anymore and the following postUpgradeTasks execution was done successfully. 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [X] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
