### PR TITLE
feat(manager/bitbucket-pipelines): support registry aliases

### DIFF
--- a/lib/modules/manager/bitbucket-pipelines/extract.spec.ts
+++ b/lib/modules/manager/bitbucket-pipelines/extract.spec.ts
@@ -5,7 +5,7 @@ describe('modules/manager/bitbucket-pipelines/extract', () => {
   describe('extractPackageFile()', () => {
     it('returns null for empty', () => {
       expect(
-        extractPackageFile('nothing here', 'bitbucket-pipelines.yaml')
+        extractPackageFile('nothing here', 'bitbucket-pipelines.yaml', {})
       ).toBeNull();
     });
 
@@ -13,7 +13,8 @@ describe('modules/manager/bitbucket-pipelines/extract', () => {
       expect(
         extractPackageFile(
           'image:\n  username: ccc',
-          'bitbucket-pipelines.yaml'
+          'bitbucket-pipelines.yaml',
+          {}
         )
       ).toBeNull();
     });

--- a/lib/modules/manager/bitbucket-pipelines/extract.spec.ts
+++ b/lib/modules/manager/bitbucket-pipelines/extract.spec.ts
@@ -21,7 +21,8 @@ describe('modules/manager/bitbucket-pipelines/extract', () => {
     it('extracts dependencies', () => {
       const res = extractPackageFile(
         Fixtures.get('bitbucket-pipelines.yaml'),
-        'bitbucket-pipelines.yaml'
+        'bitbucket-pipelines.yaml',
+        {}
       );
       expect(res).toMatchObject({
         deps: [
@@ -65,6 +66,70 @@ describe('modules/manager/bitbucket-pipelines/extract', () => {
             currentValue: '2.0.2',
             datasource: 'docker',
             depName: 'jfrogecosystem/jfrog-setup-cli',
+            depType: 'docker',
+          },
+          {
+            currentValue: '0.2.1',
+            datasource: 'bitbucket-tags',
+            depName: 'atlassian/aws-s3-deploy',
+            depType: 'bitbucket-tags',
+          },
+        ],
+      });
+    });
+
+    it('extracts dependencies with registryAlias', () => {
+      const res = extractPackageFile(
+        Fixtures.get('bitbucket-pipelines.yaml'),
+        'bitbucket-pipelines.yaml',
+        {
+          registryAliases: {
+            jfrogecosystem: 'some.jfrog.mirror',
+          },
+        }
+      );
+      expect(res).toMatchObject({
+        deps: [
+          {
+            currentDigest: undefined,
+            currentValue: '10.15.1',
+            datasource: 'docker',
+            depName: 'node',
+            depType: 'docker',
+          },
+          {
+            currentDigest: undefined,
+            currentValue: '18.15.0',
+            datasource: 'docker',
+            depName: 'node',
+            depType: 'docker',
+          },
+          {
+            currentDigest: undefined,
+            currentValue: '18.15.1',
+            datasource: 'docker',
+            depName: 'node',
+            depType: 'docker',
+          },
+          {
+            currentDigest: undefined,
+            currentValue: '18.15.2',
+            datasource: 'docker',
+            depName: 'node',
+            depType: 'docker',
+          },
+          {
+            currentDigest: undefined,
+            currentValue: '10.15.2',
+            datasource: 'docker',
+            depName: 'node',
+            depType: 'docker',
+          },
+          {
+            currentDigest: undefined,
+            currentValue: '2.0.2',
+            datasource: 'docker',
+            depName: 'some.jfrog.mirror/jfrog-setup-cli',
             depType: 'docker',
           },
           {

--- a/lib/modules/manager/bitbucket-pipelines/extract.ts
+++ b/lib/modules/manager/bitbucket-pipelines/extract.ts
@@ -1,6 +1,10 @@
 import { logger } from '../../../logger';
 import { newlineRegex } from '../../../util/regex';
-import type { PackageDependency, PackageFileContent } from '../types';
+import type {
+  ExtractConfig,
+  PackageDependency,
+  PackageFileContent,
+} from '../types';
 import {
   addDepAsBitbucketTag,
   addDepAsDockerImage,
@@ -12,7 +16,8 @@ import {
 
 export function extractPackageFile(
   content: string,
-  packageFile: string
+  packageFile: string,
+  config: ExtractConfig
 ): PackageFileContent | null {
   const deps: PackageDependency[] = [];
 
@@ -31,6 +36,7 @@ export function extractPackageFile(
         // https://support.atlassian.com/bitbucket-cloud/docs/docker-image-options/
         lineIdx = addDepFromObject(
           deps,
+          config,
           lines,
           lineIdx,
           len,
@@ -45,7 +51,7 @@ export function extractPackageFile(
 
         if (pipe.startsWith('docker://')) {
           const currentPipe = pipe.replace('docker://', '');
-          addDepAsDockerImage(deps, currentPipe);
+          addDepAsDockerImage(deps, config, currentPipe);
         } else {
           addDepAsBitbucketTag(deps, pipe);
         }
@@ -55,7 +61,7 @@ export function extractPackageFile(
       const dockerImageMatch = dockerImageRegex.exec(line);
       if (dockerImageMatch) {
         const currentFrom = dockerImageMatch[1];
-        addDepAsDockerImage(deps, currentFrom);
+        addDepAsDockerImage(deps, config, currentFrom);
       }
     }
   } catch (err) /* istanbul ignore next */ {

--- a/lib/modules/manager/bitbucket-pipelines/extract.ts
+++ b/lib/modules/manager/bitbucket-pipelines/extract.ts
@@ -36,11 +36,11 @@ export function extractPackageFile(
         // https://support.atlassian.com/bitbucket-cloud/docs/docker-image-options/
         lineIdx = addDepFromObject(
           deps,
-          config,
           lines,
           lineIdx,
           len,
-          dockerImageObjectGroups.spaces
+          dockerImageObjectGroups.spaces,
+          config.registryAliases
         );
         continue;
       }
@@ -51,7 +51,7 @@ export function extractPackageFile(
 
         if (pipe.startsWith('docker://')) {
           const currentPipe = pipe.replace('docker://', '');
-          addDepAsDockerImage(deps, config, currentPipe);
+          addDepAsDockerImage(deps, currentPipe, config.registryAliases);
         } else {
           addDepAsBitbucketTag(deps, pipe);
         }
@@ -61,7 +61,7 @@ export function extractPackageFile(
       const dockerImageMatch = dockerImageRegex.exec(line);
       if (dockerImageMatch) {
         const currentFrom = dockerImageMatch[1];
-        addDepAsDockerImage(deps, config, currentFrom);
+        addDepAsDockerImage(deps, currentFrom, config.registryAliases);
       }
     }
   } catch (err) /* istanbul ignore next */ {

--- a/lib/modules/manager/bitbucket-pipelines/util.ts
+++ b/lib/modules/manager/bitbucket-pipelines/util.ts
@@ -1,7 +1,7 @@
 import { regEx } from '../../../util/regex';
 import { BitbucketTagsDatasource } from '../../datasource/bitbucket-tags';
 import { getDep } from '../dockerfile/extract';
-import type { PackageDependency } from '../types';
+import type { ExtractConfig, PackageDependency } from '../types';
 
 export const pipeRegex = regEx(`^\\s*-\\s?pipe:\\s*'?"?([^\\s'"]+)'?"?\\s*$`);
 export const dockerImageRegex = regEx(
@@ -25,15 +25,17 @@ export function addDepAsBitbucketTag(
 
 export function addDepAsDockerImage(
   deps: PackageDependency[],
+  config: ExtractConfig,
   currentDockerImage: string
 ): void {
-  const dep = getDep(currentDockerImage);
+  const dep = getDep(currentDockerImage, true, config.registryAliases);
   dep.depType = 'docker';
   deps.push(dep);
 }
 
 export function addDepFromObject(
   deps: PackageDependency[],
+  config: ExtractConfig,
   lines: string[],
   start: number,
   len: number,
@@ -54,7 +56,7 @@ export function addDepFromObject(
 
     const groups = nameRegex.exec(line)?.groups;
     if (groups) {
-      const dep = getDep(groups.image);
+      const dep = getDep(groups.image, true, config.registryAliases);
       dep.depType = 'docker';
       deps.push(dep);
       return idx;

--- a/lib/modules/manager/bitbucket-pipelines/util.ts
+++ b/lib/modules/manager/bitbucket-pipelines/util.ts
@@ -1,7 +1,7 @@
 import { regEx } from '../../../util/regex';
 import { BitbucketTagsDatasource } from '../../datasource/bitbucket-tags';
 import { getDep } from '../dockerfile/extract';
-import type { ExtractConfig, PackageDependency } from '../types';
+import type { PackageDependency } from '../types';
 
 export const pipeRegex = regEx(`^\\s*-\\s?pipe:\\s*'?"?([^\\s'"]+)'?"?\\s*$`);
 export const dockerImageRegex = regEx(
@@ -25,21 +25,21 @@ export function addDepAsBitbucketTag(
 
 export function addDepAsDockerImage(
   deps: PackageDependency[],
-  config: ExtractConfig,
-  currentDockerImage: string
+  currentDockerImage: string,
+  registryAliases?: Record<string, string>
 ): void {
-  const dep = getDep(currentDockerImage, true, config.registryAliases);
+  const dep = getDep(currentDockerImage, true, registryAliases);
   dep.depType = 'docker';
   deps.push(dep);
 }
 
 export function addDepFromObject(
   deps: PackageDependency[],
-  config: ExtractConfig,
   lines: string[],
   start: number,
   len: number,
-  spaces: string
+  spaces: string,
+  registryAliases?: Record<string, string>
 ): number {
   const nameRegex = regEx(
     `^${spaces}\\s+name:\\s*['"]?(?<image>[^\\s'"]+)['"]?\\s*$`
@@ -56,7 +56,7 @@ export function addDepFromObject(
 
     const groups = nameRegex.exec(line)?.groups;
     if (groups) {
-      const dep = getDep(groups.image, true, config.registryAliases);
+      const dep = getDep(groups.image, true, registryAliases);
       dep.depType = 'docker';
       deps.push(dep);
       return idx;


### PR DESCRIPTION
## Changes

Adds `registryAliases` support for manager bitbucket-pipelines

## Context

See #24409


## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
