### PR TITLE
feat(manager/helmv3): add support for ECR credentials

### DIFF
--- a/lib/modules/manager/helmfile/artifacts.ts
+++ b/lib/modules/manager/helmfile/artifacts.ts
@@ -75,7 +75,7 @@ export async function updateArtifacts({
     const doc = parseDoc(newPackageFileContent);
 
     for (const value of coerceArray(doc.repositories).filter(isOCIRegistry)) {
-      const loginCmd = generateRegistryLoginCmd(
+      const loginCmd = await generateRegistryLoginCmd(
         value.name,
         `https://${value.url}`,
         // this extracts the hostname from url like format ghcr.ip/helm-charts

--- a/lib/modules/manager/helmfile/utils.ts
+++ b/lib/modules/manager/helmfile/utils.ts
@@ -45,7 +45,7 @@ export function isOCIRegistry(repository: Repository): boolean {
   return repository.oci === true;
 }
 
-export function generateRegistryLoginCmd(
+export async function generateRegistryLoginCmd(
   repositoryName: string,
   repositoryBaseURL: string,
   repositoryHost: string
@@ -59,5 +59,5 @@ export function generateRegistryLoginCmd(
     }),
   };
 
-  return generateLoginCmd(repositoryRule, 'helm registry login');
+  return await generateLoginCmd(repositoryRule, 'helm registry login');
 }

--- a/lib/modules/manager/helmfile/utils.ts
+++ b/lib/modules/manager/helmfile/utils.ts
@@ -49,7 +49,7 @@ export function generateRegistryLoginCmd(
   repositoryName: string,
   repositoryBaseURL: string,
   repositoryHost: string
-): string | null {
+): Promise<string | null> {
   const repositoryRule: RepositoryRule = {
     name: repositoryName,
     repository: repositoryHost,

--- a/lib/modules/manager/helmv3/__fixtures__/ChartECR.yaml
+++ b/lib/modules/manager/helmv3/__fixtures__/ChartECR.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: app
+version: 0.1.0
+dependencies:
+  - name: some-ecr-chart
+    version: 1.2.3
+    repository: oci://123456789.dkr.ecr.us-east-1.amazonaws.com

--- a/lib/modules/manager/helmv3/__fixtures__/oci_1_ecr.lock
+++ b/lib/modules/manager/helmv3/__fixtures__/oci_1_ecr.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: some-ecr-chart
+  repository: oci://123456789.dkr.ecr.us-east-1.amazonaws.com
+  version: 1.2.3
+digest: sha256:886f204516ea48785fe615d22071d742f7fb0d6519ed3cd274f4ec0978d8b82b
+generated: "2022-01-20T17:48:47.610371241+01:00"

--- a/lib/modules/manager/helmv3/__fixtures__/oci_2_ecr.lock
+++ b/lib/modules/manager/helmv3/__fixtures__/oci_2_ecr.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: some-ecr-chart
+  repository: oci://123456789.dkr.ecr.us-east-1.amazonaws.com
+  version: 1.3.4
+digest: sha256:886f204516ea48785fe615d22071d742f7fb0d6519ed3cd274f4ec0978d8b82b
+generated: "2022-01-20T17:48:47.610371241+01:00"

--- a/lib/modules/manager/helmv3/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/modules/manager/helmv3/__snapshots__/artifacts.spec.ts.snap
@@ -49,60 +49,6 @@ exports[`modules/manager/helmv3/artifacts alias name is picked, when repository 
 ]
 `;
 
-exports[`modules/manager/helmv3/artifacts continues without token if ECR authentication fails 1`] = `
-[
-  {
-    "cmd": "helm dependency update ''",
-    "options": {
-      "cwd": "/tmp/github/some/repo",
-      "encoding": "utf-8",
-      "env": {
-        "HELM_EXPERIMENTAL_OCI": "1",
-        "HELM_REGISTRY_CONFIG": "/tmp/renovate/cache/__renovate-private-cache/registry.json",
-        "HELM_REPOSITORY_CACHE": "/tmp/renovate/cache/__renovate-private-cache/repositories",
-        "HELM_REPOSITORY_CONFIG": "/tmp/renovate/cache/__renovate-private-cache/repositories.yaml",
-        "HOME": "/home/user",
-        "HTTPS_PROXY": "https://example.com",
-        "HTTP_PROXY": "http://example.com",
-        "LANG": "en_US.UTF-8",
-        "LC_ALL": "en_US",
-        "NO_PROXY": "localhost",
-        "PATH": "/tmp/path",
-      },
-      "maxBuffer": 10485760,
-      "timeout": 900000,
-    },
-  },
-]
-`;
-
-exports[`modules/manager/helmv3/artifacts continues without token if ECR token is invalid 1`] = `
-[
-  {
-    "cmd": "helm dependency update ''",
-    "options": {
-      "cwd": "/tmp/github/some/repo",
-      "encoding": "utf-8",
-      "env": {
-        "HELM_EXPERIMENTAL_OCI": "1",
-        "HELM_REGISTRY_CONFIG": "/tmp/renovate/cache/__renovate-private-cache/registry.json",
-        "HELM_REPOSITORY_CACHE": "/tmp/renovate/cache/__renovate-private-cache/repositories",
-        "HELM_REPOSITORY_CONFIG": "/tmp/renovate/cache/__renovate-private-cache/repositories.yaml",
-        "HOME": "/home/user",
-        "HTTPS_PROXY": "https://example.com",
-        "HTTP_PROXY": "http://example.com",
-        "LANG": "en_US.UTF-8",
-        "LC_ALL": "en_US",
-        "NO_PROXY": "localhost",
-        "PATH": "/tmp/path",
-      },
-      "maxBuffer": 10485760,
-      "timeout": 900000,
-    },
-  },
-]
-`;
-
 exports[`modules/manager/helmv3/artifacts do not add registryAliases to repository list 1`] = `
 [
   {
@@ -661,55 +607,6 @@ exports[`modules/manager/helmv3/artifacts sets repositories from registryAliases
       "encoding": "utf-8",
       "env": {
         "CONTAINERBASE_CACHE_DIR": "/tmp/renovate/cache/containerbase",
-        "HELM_EXPERIMENTAL_OCI": "1",
-        "HELM_REGISTRY_CONFIG": "/tmp/renovate/cache/__renovate-private-cache/registry.json",
-        "HELM_REPOSITORY_CACHE": "/tmp/renovate/cache/__renovate-private-cache/repositories",
-        "HELM_REPOSITORY_CONFIG": "/tmp/renovate/cache/__renovate-private-cache/repositories.yaml",
-        "HOME": "/home/user",
-        "HTTPS_PROXY": "https://example.com",
-        "HTTP_PROXY": "http://example.com",
-        "LANG": "en_US.UTF-8",
-        "LC_ALL": "en_US",
-        "NO_PROXY": "localhost",
-        "PATH": "/tmp/path",
-      },
-      "maxBuffer": 10485760,
-      "timeout": 900000,
-    },
-  },
-]
-`;
-
-exports[`modules/manager/helmv3/artifacts supports ECR authentication 1`] = `
-[
-  {
-    "cmd": "helm registry login --username token-username --password token-password 123456789.dkr.ecr.us-east-1.amazonaws.com",
-    "options": {
-      "cwd": "/tmp/github/some/repo",
-      "encoding": "utf-8",
-      "env": {
-        "HELM_EXPERIMENTAL_OCI": "1",
-        "HELM_REGISTRY_CONFIG": "/tmp/renovate/cache/__renovate-private-cache/registry.json",
-        "HELM_REPOSITORY_CACHE": "/tmp/renovate/cache/__renovate-private-cache/repositories",
-        "HELM_REPOSITORY_CONFIG": "/tmp/renovate/cache/__renovate-private-cache/repositories.yaml",
-        "HOME": "/home/user",
-        "HTTPS_PROXY": "https://example.com",
-        "HTTP_PROXY": "http://example.com",
-        "LANG": "en_US.UTF-8",
-        "LC_ALL": "en_US",
-        "NO_PROXY": "localhost",
-        "PATH": "/tmp/path",
-      },
-      "maxBuffer": 10485760,
-      "timeout": 900000,
-    },
-  },
-  {
-    "cmd": "helm dependency update ''",
-    "options": {
-      "cwd": "/tmp/github/some/repo",
-      "encoding": "utf-8",
-      "env": {
         "HELM_EXPERIMENTAL_OCI": "1",
         "HELM_REGISTRY_CONFIG": "/tmp/renovate/cache/__renovate-private-cache/registry.json",
         "HELM_REPOSITORY_CACHE": "/tmp/renovate/cache/__renovate-private-cache/repositories",

--- a/lib/modules/manager/helmv3/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/modules/manager/helmv3/__snapshots__/artifacts.spec.ts.snap
@@ -49,6 +49,60 @@ exports[`modules/manager/helmv3/artifacts alias name is picked, when repository 
 ]
 `;
 
+exports[`modules/manager/helmv3/artifacts continues without token if ECR authentication fails 1`] = `
+[
+  {
+    "cmd": "helm dependency update ''",
+    "options": {
+      "cwd": "/tmp/github/some/repo",
+      "encoding": "utf-8",
+      "env": {
+        "HELM_EXPERIMENTAL_OCI": "1",
+        "HELM_REGISTRY_CONFIG": "/tmp/renovate/cache/__renovate-private-cache/registry.json",
+        "HELM_REPOSITORY_CACHE": "/tmp/renovate/cache/__renovate-private-cache/repositories",
+        "HELM_REPOSITORY_CONFIG": "/tmp/renovate/cache/__renovate-private-cache/repositories.yaml",
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+]
+`;
+
+exports[`modules/manager/helmv3/artifacts continues without token if ECR token is invalid 1`] = `
+[
+  {
+    "cmd": "helm dependency update ''",
+    "options": {
+      "cwd": "/tmp/github/some/repo",
+      "encoding": "utf-8",
+      "env": {
+        "HELM_EXPERIMENTAL_OCI": "1",
+        "HELM_REGISTRY_CONFIG": "/tmp/renovate/cache/__renovate-private-cache/registry.json",
+        "HELM_REPOSITORY_CACHE": "/tmp/renovate/cache/__renovate-private-cache/repositories",
+        "HELM_REPOSITORY_CONFIG": "/tmp/renovate/cache/__renovate-private-cache/repositories.yaml",
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+]
+`;
+
 exports[`modules/manager/helmv3/artifacts do not add registryAliases to repository list 1`] = `
 [
   {
@@ -607,6 +661,55 @@ exports[`modules/manager/helmv3/artifacts sets repositories from registryAliases
       "encoding": "utf-8",
       "env": {
         "CONTAINERBASE_CACHE_DIR": "/tmp/renovate/cache/containerbase",
+        "HELM_EXPERIMENTAL_OCI": "1",
+        "HELM_REGISTRY_CONFIG": "/tmp/renovate/cache/__renovate-private-cache/registry.json",
+        "HELM_REPOSITORY_CACHE": "/tmp/renovate/cache/__renovate-private-cache/repositories",
+        "HELM_REPOSITORY_CONFIG": "/tmp/renovate/cache/__renovate-private-cache/repositories.yaml",
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+]
+`;
+
+exports[`modules/manager/helmv3/artifacts supports ECR authentication 1`] = `
+[
+  {
+    "cmd": "helm registry login --username token-username --password token-password 123456789.dkr.ecr.us-east-1.amazonaws.com",
+    "options": {
+      "cwd": "/tmp/github/some/repo",
+      "encoding": "utf-8",
+      "env": {
+        "HELM_EXPERIMENTAL_OCI": "1",
+        "HELM_REGISTRY_CONFIG": "/tmp/renovate/cache/__renovate-private-cache/registry.json",
+        "HELM_REPOSITORY_CACHE": "/tmp/renovate/cache/__renovate-private-cache/repositories",
+        "HELM_REPOSITORY_CONFIG": "/tmp/renovate/cache/__renovate-private-cache/repositories.yaml",
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+  {
+    "cmd": "helm dependency update ''",
+    "options": {
+      "cwd": "/tmp/github/some/repo",
+      "encoding": "utf-8",
+      "env": {
         "HELM_EXPERIMENTAL_OCI": "1",
         "HELM_REGISTRY_CONFIG": "/tmp/renovate/cache/__renovate-private-cache/registry.json",
         "HELM_REPOSITORY_CACHE": "/tmp/renovate/cache/__renovate-private-cache/repositories",

--- a/lib/modules/manager/helmv3/artifacts.spec.ts
+++ b/lib/modules/manager/helmv3/artifacts.spec.ts
@@ -799,8 +799,14 @@ describe('modules/manager/helmv3/artifacts', () => {
       sessionToken: 'some-session-token',
     });
 
-    expect(execSnapshots).toBeArrayOfSize(2);
-    expect(execSnapshots).toMatchSnapshot();
+    expect(execSnapshots).toMatchObject([
+      {
+        cmd: 'helm registry login --username token-username --password token-password 123456789.dkr.ecr.us-east-1.amazonaws.com',
+      },
+      {
+        cmd: "helm dependency update ''",
+      },
+    ]);
   });
 
   it('continues without token if ECR token is invalid', async () => {
@@ -854,8 +860,11 @@ describe('modules/manager/helmv3/artifacts', () => {
       sessionToken: 'some-session-token',
     });
 
-    expect(execSnapshots).toBeArrayOfSize(1);
-    expect(execSnapshots).toMatchSnapshot();
+    expect(execSnapshots).toMatchObject([
+      {
+        cmd: "helm dependency update ''",
+      },
+    ]);
   });
 
   it('continues without token if ECR authentication fails', async () => {
@@ -907,8 +916,11 @@ describe('modules/manager/helmv3/artifacts', () => {
       sessionToken: 'some-session-token',
     });
 
-    expect(execSnapshots).toBeArrayOfSize(1);
-    expect(execSnapshots).toMatchSnapshot();
+    expect(execSnapshots).toMatchObject([
+      {
+        cmd: "helm dependency update ''",
+      },
+    ]);
   });
 
   it('alias name is picked, when repository is as alias and dependency defined', async () => {

--- a/lib/modules/manager/helmv3/artifacts.spec.ts
+++ b/lib/modules/manager/helmv3/artifacts.spec.ts
@@ -866,7 +866,7 @@ describe('modules/manager/helmv3/artifacts', () => {
     ]);
   });
 
-  it('continues without token if ECR token is invalid', async () => {
+  it('falls back to username + password if the ECR token is invalid', async () => {
     mockEcrAuthResolve({
       authorizationData: [{ authorizationToken: ':' }],
     });
@@ -919,12 +919,15 @@ describe('modules/manager/helmv3/artifacts', () => {
 
     expect(execSnapshots).toMatchObject([
       {
+        cmd: 'helm registry login --username some-username --password some-password 123456789.dkr.ecr.us-east-1.amazonaws.com',
+      },
+      {
         cmd: "helm dependency update ''",
       },
     ]);
   });
 
-  it('continues without token if ECR authentication fails', async () => {
+  it('falls back to username + password if ECR authentication fails', async () => {
     mockEcrAuthReject('some error');
 
     hostRules.add({
@@ -974,6 +977,9 @@ describe('modules/manager/helmv3/artifacts', () => {
     });
 
     expect(execSnapshots).toMatchObject([
+      {
+        cmd: 'helm registry login --username some-username --password some-password 123456789.dkr.ecr.us-east-1.amazonaws.com',
+      },
       {
         cmd: "helm dependency update ''",
       },

--- a/lib/modules/manager/helmv3/artifacts.spec.ts
+++ b/lib/modules/manager/helmv3/artifacts.spec.ts
@@ -866,7 +866,7 @@ describe('modules/manager/helmv3/artifacts', () => {
     ]);
   });
 
-  it('falls back to username + password if the ECR token is invalid', async () => {
+  it('continues without auth if the ECR token is invalid', async () => {
     mockEcrAuthResolve({
       authorizationData: [{ authorizationToken: ':' }],
     });
@@ -919,15 +919,12 @@ describe('modules/manager/helmv3/artifacts', () => {
 
     expect(execSnapshots).toMatchObject([
       {
-        cmd: 'helm registry login --username some-username --password some-password 123456789.dkr.ecr.us-east-1.amazonaws.com',
-      },
-      {
         cmd: "helm dependency update ''",
       },
     ]);
   });
 
-  it('falls back to username + password if ECR authentication fails', async () => {
+  it('continues without auth if ECR authentication fails', async () => {
     mockEcrAuthReject('some error');
 
     hostRules.add({
@@ -977,9 +974,6 @@ describe('modules/manager/helmv3/artifacts', () => {
     });
 
     expect(execSnapshots).toMatchObject([
-      {
-        cmd: 'helm registry login --username some-username --password some-password 123456789.dkr.ecr.us-east-1.amazonaws.com',
-      },
       {
         cmd: "helm dependency update ''",
       },

--- a/lib/modules/manager/helmv3/artifacts.ts
+++ b/lib/modules/manager/helmv3/artifacts.ts
@@ -46,12 +46,14 @@ async function helmCommands(
     });
 
   // if credentials for the registry have been found, log into it
-  registries.forEach((value) => {
-    const loginCmd = generateLoginCmd(value, 'helm registry login');
-    if (loginCmd) {
-      cmd.push(loginCmd);
-    }
-  });
+  await Promise.all(
+    registries.map(async (value) => {
+      const loginCmd = await generateLoginCmd(value, 'helm registry login');
+      if (loginCmd) {
+        cmd.push(loginCmd);
+      }
+    })
+  );
 
   // find classic Chart repositories and fitting host rules
   const classicRepositories: RepositoryRule[] = repositories

--- a/lib/modules/manager/helmv3/artifacts.ts
+++ b/lib/modules/manager/helmv3/artifacts.ts
@@ -1,5 +1,6 @@
 import is from '@sindresorhus/is';
 import yaml from 'js-yaml';
+import pMap from 'p-map';
 import { quote } from 'shlex';
 import { TEMPORARY_ERROR } from '../../../constants/error-messages';
 import { logger } from '../../../logger';
@@ -46,14 +47,12 @@ async function helmCommands(
     });
 
   // if credentials for the registry have been found, log into it
-  await Promise.all(
-    registries.map(async (value) => {
-      const loginCmd = await generateLoginCmd(value, 'helm registry login');
-      if (loginCmd) {
-        cmd.push(loginCmd);
-      }
-    })
-  );
+  await pMap(registries, async (value) => {
+    const loginCmd = await generateLoginCmd(value, 'helm registry login');
+    if (loginCmd) {
+      cmd.push(loginCmd);
+    }
+  });
 
   // find classic Chart repositories and fitting host rules
   const classicRepositories: RepositoryRule[] = repositories

--- a/lib/modules/manager/helmv3/common.ts
+++ b/lib/modules/manager/helmv3/common.ts
@@ -20,16 +20,18 @@ export async function generateLoginCmd(
     logger.trace({ repository }, `Using ecr auth for Helm registry`);
     const [, region] = coerceArray(ecrRegex.exec(repository));
     const auth = await getECRAuthToken(region, hostRule);
-    if (auth) {
-      const [username, password] = fromBase64(auth).split(':');
-      if (username && password) {
-        addSecretForSanitizing(username);
-        addSecretForSanitizing(password);
-        return `${loginCMD} --username ${quote(username)} --password ${quote(
-          password
-        )} ${repository}`;
-      }
+    if (!auth) {
+      return null;
     }
+    const [username, password] = fromBase64(auth).split(':');
+    if (!username || !password) {
+      return null;
+    }
+    addSecretForSanitizing(username);
+    addSecretForSanitizing(password);
+    return `${loginCMD} --username ${quote(username)} --password ${quote(
+      password
+    )} ${repository}`;
   }
   if (username && password) {
     logger.trace({ repository }, `Using basic auth for Helm registry`);

--- a/lib/modules/manager/helmv3/common.ts
+++ b/lib/modules/manager/helmv3/common.ts
@@ -16,7 +16,7 @@ export async function generateLoginCmd(
 ): Promise<string | null> {
   const { hostRule, repository } = repositoryRule;
   const { username, password } = hostRule;
-  if (ecrRegex.test(repository)) {
+  if (username !== 'AWS' && ecrRegex.test(repository)) {
     logger.trace({ repository }, `Using ecr auth for Helm registry`);
     const [, region] = coerceArray(ecrRegex.exec(repository));
     const auth = await getECRAuthToken(region, hostRule);

--- a/lib/modules/manager/helmv3/common.ts
+++ b/lib/modules/manager/helmv3/common.ts
@@ -1,19 +1,40 @@
 import { quote } from 'shlex';
 import upath from 'upath';
 
+import { logger } from '../../../logger';
+import { coerceArray } from '../../../util/array';
 import type { ExtraEnv } from '../../../util/exec/types';
 import { privateCacheDir } from '../../../util/fs';
+import { addSecretForSanitizing } from '../../../util/sanitize';
+import { fromBase64 } from '../../../util/string';
+import { ecrRegex, getECRAuthToken } from '../../datasource/docker/ecr';
 import type { RepositoryRule } from './types';
 
-export function generateLoginCmd(
+export async function generateLoginCmd(
   repositoryRule: RepositoryRule,
   loginCMD: string
-): string | null {
-  const { username, password } = repositoryRule.hostRule;
-  if (username && password) {
+): Promise<string | null> {
+  const { hostRule, repository } = repositoryRule;
+  const { username, password } = hostRule;
+  if (ecrRegex.test(repository)) {
+    logger.trace({ repository }, `Using ecr auth for Helm registry`);
+    const [, region] = coerceArray(ecrRegex.exec(repository));
+    const auth = await getECRAuthToken(region, hostRule);
+    if (auth) {
+      const [username, password] = fromBase64(auth).split(':');
+      if (username && password) {
+        addSecretForSanitizing(username);
+        addSecretForSanitizing(password);
+        return `${loginCMD} --username ${quote(username)} --password ${quote(
+          password
+        )} ${repository}`;
+      }
+    }
+  } else if (username && password) {
+    logger.trace({ repository }, `Using basic auth for Helm registry`);
     return `${loginCMD} --username ${quote(username)} --password ${quote(
       password
-    )} ${repositoryRule.repository}`;
+    )} ${repository}`;
   }
   return null;
 }

--- a/lib/modules/manager/helmv3/common.ts
+++ b/lib/modules/manager/helmv3/common.ts
@@ -30,7 +30,8 @@ export async function generateLoginCmd(
         )} ${repository}`;
       }
     }
-  } else if (username && password) {
+  }
+  if (username && password) {
     logger.trace({ repository }, `Using basic auth for Helm registry`);
     return `${loginCMD} --username ${quote(username)} --password ${quote(
       password


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

This PR allows Renovate to use `helm registry login` to sign in with an AWS ECR token when updating Helm dependencies.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

Addresses the discussion in #19241.

Prior to this change, Helm library chart updates from AWS ECR could be detected by Renovate so long as AWS credentials were configured in `hostRules`, but when attempting to run `helm dependency update`, the update would always fail, because Helm itself was not signed in to the registry. This PR re-uses some code from the `docker` manager for acquiring an ECR token, and uses the token to sign in to the registry.

We have Helm library charts in an AWS ECR registry at my workplace, and I have run this code against one of our repos which was previously failing with an error like:

```
Command failed: helm dependency update charts
Error: could not download oci://123456789.dkr.ecr.us-east-1.amazonaws.com/some-library: unexpected status from HEAD request to https://123456789.dkr.ecr.us-east-1.amazonaws.com/v2/some-library/manifests/1.0.6: 401 Unauthorized
```

After these changes, the Renovate PR was successfully created.

- fixes #19241

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
