### PR TITLE
fix(manager/poetry): use containerbase python as datasource

### DIFF
--- a/lib/modules/manager/poetry/__snapshots__/extract.spec.ts.snap
+++ b/lib/modules/manager/poetry/__snapshots__/extract.spec.ts.snap
@@ -474,12 +474,13 @@ exports[`modules/manager/poetry/extract extractPackageFile() extracts multiple d
   {
     "commitMessageTopic": "Python",
     "currentValue": "~2.7 || ^3.4",
-    "datasource": "docker",
+    "datasource": "github-tags",
     "depName": "python",
     "depType": "dependencies",
     "managerData": {
       "nestedVersion": false,
     },
+    "packageName": "containerbase/python-prebuild",
     "registryUrls": null,
     "versioning": "poetry",
   },
@@ -569,12 +570,13 @@ exports[`modules/manager/poetry/extract extractPackageFile() resolves lockedVers
     {
       "commitMessageTopic": "Python",
       "currentValue": "^3.9",
-      "datasource": "docker",
+      "datasource": "github-tags",
       "depName": "python",
       "depType": "dependencies",
       "managerData": {
         "nestedVersion": false,
       },
+      "packageName": "containerbase/python-prebuild",
       "registryUrls": null,
       "versioning": "poetry",
     },

--- a/lib/modules/manager/poetry/__snapshots__/extract.spec.ts.snap
+++ b/lib/modules/manager/poetry/__snapshots__/extract.spec.ts.snap
@@ -474,7 +474,7 @@ exports[`modules/manager/poetry/extract extractPackageFile() extracts multiple d
   {
     "commitMessageTopic": "Python",
     "currentValue": "~2.7 || ^3.4",
-    "datasource": "github-tags",
+    "datasource": "github-releases",
     "depName": "python",
     "depType": "dependencies",
     "managerData": {
@@ -570,7 +570,7 @@ exports[`modules/manager/poetry/extract extractPackageFile() resolves lockedVers
     {
       "commitMessageTopic": "Python",
       "currentValue": "^3.9",
-      "datasource": "github-tags",
+      "datasource": "github-releases",
       "depName": "python",
       "depType": "dependencies",
       "managerData": {

--- a/lib/modules/manager/poetry/extract.spec.ts
+++ b/lib/modules/manager/poetry/extract.spec.ts
@@ -1,6 +1,7 @@
 import { codeBlock } from 'common-tags';
 import { Fixtures } from '../../../../test/fixtures';
 import { fs } from '../../../../test/util';
+import { GithubReleasesDatasource } from '../../datasource/github-releases';
 import { GithubTagsDatasource } from '../../datasource/github-tags';
 import { extractPackageFile } from '.';
 
@@ -299,7 +300,7 @@ describe('modules/manager/poetry/extract', () => {
         depName: 'python',
         packageName: 'containerbase/python-prebuild',
         currentValue: '^3.11',
-        datasource: GithubTagsDatasource.id,
+        datasource: GithubReleasesDatasource.id,
         commitMessageTopic: 'Python',
         registryUrls: null,
       });

--- a/lib/modules/manager/poetry/extract.spec.ts
+++ b/lib/modules/manager/poetry/extract.spec.ts
@@ -1,7 +1,6 @@
 import { codeBlock } from 'common-tags';
 import { Fixtures } from '../../../../test/fixtures';
 import { fs } from '../../../../test/util';
-import { DockerDatasource } from '../../datasource/docker';
 import { GithubTagsDatasource } from '../../datasource/github-tags';
 import { extractPackageFile } from '.';
 

--- a/lib/modules/manager/poetry/extract.spec.ts
+++ b/lib/modules/manager/poetry/extract.spec.ts
@@ -298,8 +298,9 @@ describe('modules/manager/poetry/extract', () => {
       expect(res).toHaveLength(1);
       expect(res[0]).toMatchObject({
         depName: 'python',
+        packageName: 'containerbase/python-prebuild',
         currentValue: '^3.11',
-        datasource: DockerDatasource.id,
+        datasource: GithubTagsDatasource.id,
         commitMessageTopic: 'Python',
         registryUrls: null,
       });

--- a/lib/modules/manager/poetry/extract.ts
+++ b/lib/modules/manager/poetry/extract.ts
@@ -7,7 +7,7 @@ import {
   readLocalFile,
 } from '../../../util/fs';
 import { Result } from '../../../util/result';
-import { GithubTagsDatasource } from '../../datasource/github-tags';
+import { GithubReleasesDatasource } from '../../datasource/github-releases';
 import type { PackageFileContent } from '../types';
 import { Lockfile, PoetrySchemaToml } from './schema';
 
@@ -43,7 +43,7 @@ export async function extractPackageFile(
         // We use containerbase python as source, as there are a lot docker tags which can cause
         // issues with poetry versioning.
         packageName: 'containerbase/python-prebuild',
-        datasource: GithubTagsDatasource.id,
+        datasource: GithubReleasesDatasource.id,
         commitMessageTopic: 'Python',
         registryUrls: null,
       };

--- a/lib/modules/manager/poetry/extract.ts
+++ b/lib/modules/manager/poetry/extract.ts
@@ -7,7 +7,7 @@ import {
   readLocalFile,
 } from '../../../util/fs';
 import { Result } from '../../../util/result';
-import { DockerDatasource } from '../../datasource/docker';
+import { GithubTagsDatasource } from '../../datasource/github-tags';
 import type { PackageFileContent } from '../types';
 import { Lockfile, PoetrySchemaToml } from './schema';
 
@@ -40,7 +40,10 @@ export async function extractPackageFile(
       }
       return {
         ...dep,
-        datasource: DockerDatasource.id,
+        // We use containerbase python as source, as there are a lot docker tags which can cause
+        // issues with poetry versioning.
+        packageName: 'containerbase/python-prebuild',
+        datasource: GithubTagsDatasource.id,
         commitMessageTopic: 'Python',
         registryUrls: null,
       };

--- a/lib/modules/manager/poetry/index.ts
+++ b/lib/modules/manager/poetry/index.ts
@@ -1,5 +1,4 @@
 import type { Category } from '../../../constants';
-import { DockerDatasource } from '../../datasource/docker';
 import { GithubTagsDatasource } from '../../datasource/github-tags';
 import { PypiDatasource } from '../../datasource/pypi';
 
@@ -10,7 +9,6 @@ export { updateLockedDependency } from './update-locked';
 export const supportedDatasources = [
   PypiDatasource.id,
   GithubTagsDatasource.id,
-  DockerDatasource.id,
 ];
 
 export const supportsLockFileMaintenance = true;

--- a/lib/modules/manager/poetry/index.ts
+++ b/lib/modules/manager/poetry/index.ts
@@ -1,4 +1,5 @@
 import type { Category } from '../../../constants';
+import { GithubReleasesDatasource } from '../../datasource/github-releases';
 import { GithubTagsDatasource } from '../../datasource/github-tags';
 import { PypiDatasource } from '../../datasource/pypi';
 
@@ -9,6 +10,7 @@ export { updateLockedDependency } from './update-locked';
 export const supportedDatasources = [
   PypiDatasource.id,
   GithubTagsDatasource.id,
+  GithubReleasesDatasource.id,
 ];
 
 export const supportsLockFileMaintenance = true;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Update poetry manager to use containerbase python as the datasource for the extracted python dependency

## Context

https://github.com/renovatebot/renovate/pull/24335#discussion_r1327936803

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository: https://github.com/barriot/r0/pull/16

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
