### PR TITLE
fix(npm): remove invalid extractedConstraints

### DIFF
--- a/lib/modules/manager/npm/extract/__snapshots__/index.spec.ts.snap
+++ b/lib/modules/manager/npm/extract/__snapshots__/index.spec.ts.snap
@@ -131,7 +131,6 @@ exports[`modules/manager/npm/extract/index .extractPackageFile() extracts engine
     "npm": "^8.0.0",
     "pnpm": "^1.2.0",
     "vscode": ">=1.49.3",
-    "yarn": "disabled",
   },
   "managerData": {
     "hasPackageManager": false,

--- a/lib/modules/manager/npm/extract/index.spec.ts
+++ b/lib/modules/manager/npm/extract/index.spec.ts
@@ -444,7 +444,6 @@ describe('modules/manager/npm/extract/index', () => {
           npm: '^8.0.0',
           pnpm: '^1.2.0',
           vscode: '>=1.49.3',
-          yarn: 'disabled',
         },
         deps: [
           { depName: 'angular', currentValue: '1.6.0' },

--- a/lib/modules/manager/npm/extract/index.ts
+++ b/lib/modules/manager/npm/extract/index.ts
@@ -501,6 +501,15 @@ export async function extractPackageFile(
     }
   }
 
+  for (const [constraintName, constaintValue] of Object.entries(
+    extractedConstraints
+  )) {
+    // delete any extracted constraints which aren't valid semver ranges
+    if (!isValid(constaintValue)) {
+      delete extractedConstraints[constraintName];
+    }
+  }
+
   return {
     deps,
     packageFileVersion,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Filter out any `extractedConstraints` which aren't valid npm syntax.

## Context

Found when preparing for splitting managers.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
