### PR TITLE
docs(semantic commits): explain `config:recommended` prefixes

### DIFF
--- a/docs/usage/semantic-commits.md
+++ b/docs/usage/semantic-commits.md
@@ -19,8 +19,8 @@ By default, Renovate uses the `chore` prefix.
 If you extend from `config:recommended` then Renovate uses the `chore` prefix for nearly all updates.
 There are some exceptions:
 
-- if `matchDepTypes=dependencies` or `matchDepTypes=require`, then Renovate uses the `fix` prefix
-- if a update uses the `maven` datasource _and_ `matchDepTypes` is `compile`, `provided`, `runtime`, `system`, `import` or `parent` then Renovate uses the `fix` prefix
+- if the `depType` is a known "production dependency" type (e.g. `dependencies` or `require`), then Renovate uses the `fix` prefix
+- if an update uses the `maven` datasource _and_ `matchDepTypes` is a known production type (e.g. `compile`, `provided`, `runtime`, `system`, `import` or `parent`) then Renovate uses the `fix` prefix
 
 ## Manually enabling or disabling semantic commits
 

--- a/docs/usage/semantic-commits.md
+++ b/docs/usage/semantic-commits.md
@@ -16,11 +16,11 @@ When Renovate finds Angular-style commits, Renovate creates commit messages and 
 
 By default, Renovate uses the `chore` prefix.
 
-If you extend from `config:recommended` then Renovate:
+If you extend from `config:recommended` then Renovate uses the `chore` prefix for nearly all updates.
+There are some exceptions:
 
-- still defaults to the `chore` prefix
-- uses the `fix` prefix for npm production dependencies
-- uses the `chore` prefix for npm development dependencies (`devDependencies`)
+- if `matchDepTypes=dependencies` or `matchDepTypes=require`, then Renovate uses the `fix` prefix
+- if a update uses the `maven` datasource _and_ `matchDepTypes` is `compile`, `provided`, `runtime`, `system`, `import` or `parent` then Renovate uses the `fix` prefix
 
 ## Manually enabling or disabling semantic commits
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Semantic Commit docs explanation matches `config:recommended` prefix behavior

## Context

`config:recommended` extends from the `":semanticPrefixFixDepsChoreOthers"` preset, which has this code:

```json
{
  "packageRules": [
    {
      "matchPackagePatterns": [
        "*"
      ],
      "semanticCommitType": "chore"
    },
    {
      "matchDepTypes": [
        "dependencies",
        "require"
      ],
      "semanticCommitType": "fix"
    },
    {
      "matchDatasources": [
        "maven"
      ],
      "matchDepTypes": [
        "compile",
        "provided",
        "runtime",
        "system",
        "import",
        "parent"
      ],
      "semanticCommitType": "fix"
    }
  ]
}
```

The current docs only say that `npm` prefixes are different, but the `:semanticPrefixFixDepsChoreOthers` preset applies to all managers, with some extra rules for `maven` datasource.

Please check that my docs update matches the actual behavior! 😉 

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
