### PR TITLE
docs: bump `actions/checkout` version in examples

### DIFF
--- a/docs/usage/user-stories/maintaining-aur-packages-with-renovate.md
+++ b/docs/usage/user-stories/maintaining-aur-packages-with-renovate.md
@@ -101,7 +101,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
         with:
           fetch-depth: 0
           ref: ${{ github.ref }}

--- a/lib/modules/manager/github-actions/readme.md
+++ b/lib/modules/manager/github-actions/readme.md
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@af513c7a016048ae468971c52ed77d9562c7c819 # v1.0.0
+      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
 ```
 
 Renovate will update the commit SHA but follow the GitHub tag you specified.


### PR DESCRIPTION
## Changes

- Bump `actions/checkout` version in our docs examples

## Context

We should show a reasonably current version of `actions/checkout` in our docs.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository