### PR TITLE
feat(presets): add security group and openssf badge preset

### DIFF
--- a/lib/config/presets/index.ts
+++ b/lib/config/presets/index.ts
@@ -148,6 +148,7 @@ export function parsePreset(input: string): ParsedPreset {
     'regexManagers',
     'replacements',
     'schedule',
+    'security',
     'workarounds',
   ];
   if (

--- a/lib/config/presets/internal/index.ts
+++ b/lib/config/presets/internal/index.ts
@@ -12,6 +12,7 @@ import * as previewPreset from './preview';
 import * as regexManagersPreset from './regex-managers';
 import * as replacements from './replacements';
 import * as schedulePreset from './schedule';
+import * as securityPreset from './security';
 import * as workaroundsPreset from './workarounds';
 
 /* eslint sort-keys: ["error", "asc", {caseSensitive: false, natural: true}] */
@@ -30,6 +31,7 @@ export const groups: Record<string, Record<string, Preset>> = {
   regexManagers: regexManagersPreset.presets,
   replacements: replacements.presets,
   schedule: schedulePreset.presets,
+  security: securityPreset.presets,
   workarounds: workaroundsPreset.presets,
 };
 

--- a/lib/config/presets/internal/security.ts
+++ b/lib/config/presets/internal/security.ts
@@ -1,0 +1,24 @@
+import type { Preset } from '../types';
+
+export const presets: Record<string, Preset> = {
+  'openssf-scorecard': {
+    description: 'Show OpenSSF badge on pull requests',
+    packageRules: [
+      {
+        matchSourceUrlPrefixes: ['https://github.com/'],
+        prBodyDefinitions: {
+          OpenSSF:
+            '[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/{{sourceRepo}}/badge)](https://securityscorecards.dev/viewer/?uri=github.com/{{sourceRepo}})',
+        },
+        prBodyColumns: [
+          'Package',
+          'Type',
+          'Update',
+          'Change',
+          'Pending',
+          'OpenSSF',
+        ],
+      },
+    ],
+  },
+};


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
This PR add a new `security` group of presets and adds `openssf-scoreboard` preset. 
If enabled, a new column is added which shows the badge per dependency. 

The column is only added if there is a github.com sourceUrl  

<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

https://github.com/secustor/renovate-meetup/pull/27

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
