### PR TITLE
chore: fix spelling of Buildkite

### DIFF
--- a/lib/modules/manager/buildkite/extract.ts
+++ b/lib/modules/manager/buildkite/extract.ts
@@ -24,7 +24,7 @@ export function extractPackageFile(
         logger.trace('depLineMatch');
         let skipReason: SkipReason | undefined;
         let repo: string | undefined;
-        logger.trace(`Found BuildKite plugin ${depName}`);
+        logger.trace(`Found Buildkite plugin ${depName}`);
         // Plugins may simply be git repos. If so, we need to parse out the registry.
         const gitPluginMatch = regEx(
           /(ssh:\/\/git@|https:\/\/)(?<registry>[^/]+)\/(?<gitPluginName>.*)/
@@ -50,13 +50,13 @@ export function extractPackageFile(
           } else {
             logger.warn(
               { dependency: depName },
-              'Something is wrong with BuildKite plugin name'
+              'Something is wrong with Buildkite plugin name'
             );
             skipReason = 'invalid-dependency-specification';
           }
         } else {
           logger.debug(
-            `Skipping non-pinned buildkite current version ${currentValue}`
+            `Skipping non-pinned Buildkite current version ${currentValue}`
           );
           skipReason = 'invalid-version';
         }
@@ -73,7 +73,7 @@ export function extractPackageFile(
       }
     }
   } catch (err) /* istanbul ignore next */ {
-    logger.debug({ err, packageFile }, 'Error extracting BuildKite plugins');
+    logger.debug({ err, packageFile }, 'Error extracting Buildkite plugins');
   }
 
   if (!deps.length) {


### PR DESCRIPTION
Hi I just came across this [documentation](https://docs.renovatebot.com/modules/manager/buildkite/) and notice the spelling of [Buildkite](https://buildkite.com), so I fix it.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

