### PR TITLE
feat(github): Use fast short-term cache for GraphQL

### DIFF
--- a/lib/util/github/graphql/index.ts
+++ b/lib/util/github/graphql/index.ts
@@ -1,3 +1,4 @@
+import { LRUCache } from 'lru-cache';
 import type { GithubHttp } from '../../http/github';
 import { GithubGraphqlDatasourceFetcher } from './datasource-fetcher';
 import { adapter as releasesAdapter } from './query-adapters/releases-query-adapter';
@@ -8,6 +9,16 @@ import type {
   GithubTagItem,
 } from './types';
 
+let fastCache: LRUCache<string, any> | null = null;
+
+export function setupCache(opts: LRUCache.Options<string, any, unknown>): void {
+  fastCache = new LRUCache<string, any>(opts);
+}
+
+export function resetCache(): void {
+  fastCache = null;
+}
+
 export async function queryTags(
   config: GithubPackageConfig,
   http: GithubHttp
@@ -15,7 +26,8 @@ export async function queryTags(
   const res = await GithubGraphqlDatasourceFetcher.query(
     config,
     http,
-    tagsAdapter
+    tagsAdapter,
+    fastCache
   );
   return res;
 }
@@ -27,7 +39,8 @@ export async function queryReleases(
   const res = await GithubGraphqlDatasourceFetcher.query(
     config,
     http,
-    releasesAdapter
+    releasesAdapter,
+    fastCache
   );
   return res;
 }

--- a/lib/util/github/graphql/types.ts
+++ b/lib/util/github/graphql/types.ts
@@ -1,3 +1,5 @@
+import type { LRUCache } from 'lru-cache';
+
 export interface GithubDatasourceItem {
   version: string;
   releaseTimestamp: string;
@@ -100,3 +102,5 @@ export interface GithubGraphqlCacheStrategy<
   reconcile(items: GithubItem[]): Promise<boolean>;
   finalize(): Promise<GithubItem[]>;
 }
+
+export type FastCache = LRUCache<string, any>;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This could help to avoid sequential requests to the GraphQL API during release notes fetch

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
