### PR TITLE
fix(datasource/go): hold onto the latest tag in case no other proxies have better info

### DIFF
--- a/lib/modules/datasource/go/releases-goproxy.spec.ts
+++ b/lib/modules/datasource/go/releases-goproxy.spec.ts
@@ -754,5 +754,28 @@ describe('modules/datasource/go/releases-goproxy', () => {
 
       expect(res).toBeNull();
     });
+
+    it('returns latest even if package has no releases', async () => {
+      process.env.GOPROXY = baseUrl;
+
+      httpMock
+        .scope(`${baseUrl}/github.com/google/btree`)
+        .get('/@v/list')
+        .reply(200)
+        .get('/@latest')
+        .reply(200, { Version: 'v0.0.0-20230905200255-921286631fa9' })
+        .get('/v2/@v/list')
+        .reply(404);
+
+      const res = await datasource.getReleases({
+        packageName: 'github.com/google/btree',
+      });
+
+      expect(res).toEqual({
+        releases: [],
+        sourceUrl: 'https://github.com/google/btree',
+        tags: { latest: 'v0.0.0-20230905200255-921286631fa9' },
+      });
+    });
   });
 });

--- a/lib/modules/datasource/go/releases-goproxy.ts
+++ b/lib/modules/datasource/go/releases-goproxy.ts
@@ -64,7 +64,7 @@ export class GoProxyDatasource extends Datasource {
           break;
         }
         if (res.tags?.latest) {
-          result = res
+          result = res;
         }
       } catch (err) {
         const statusCode = err?.response?.statusCode;
@@ -80,17 +80,15 @@ export class GoProxyDatasource extends Datasource {
       }
     }
 
-    if (result && ! result.sourceUrl) {
+    if (result && !result.sourceUrl) {
       try {
-        const datasource = await BaseGoDatasource.getDatasource(
-          packageName
-        );
+        const datasource = await BaseGoDatasource.getDatasource(packageName);
         const sourceUrl = getSourceUrl(datasource);
         if (sourceUrl) {
           result.sourceUrl = sourceUrl;
         }
       } catch (err) {
-        logger.trace({err}, `Can't get datasource for ${packageName}`);
+        logger.trace({ err }, `Can't get datasource for ${packageName}`);
       }
     }
 

--- a/lib/modules/datasource/go/releases-goproxy.ts
+++ b/lib/modules/datasource/go/releases-goproxy.ts
@@ -59,22 +59,12 @@ export class GoProxyDatasource extends Datasource {
         }
 
         const res = await this.getVersionsWithInfo(url, packageName);
-        if (res.releases.length || res.tags?.latest) {
+        if (res.releases.length) {
           result = res;
-          try {
-            const datasource = await BaseGoDatasource.getDatasource(
-              packageName
-            );
-            const sourceUrl = getSourceUrl(datasource);
-            if (sourceUrl) {
-              result.sourceUrl = sourceUrl;
-            }
-          } catch (err) {
-            logger.trace({ err }, `Can't get datasource for ${packageName}`);
-          }
-          if (result.releases.length) {
-            break;
-          }
+          break;
+        }
+        if (res.tags?.latest) {
+          result = res
         }
       } catch (err) {
         const statusCode = err?.response?.statusCode;
@@ -87,6 +77,20 @@ export class GoProxyDatasource extends Datasource {
         if (!canFallback) {
           break;
         }
+      }
+    }
+
+    if (result && ! result.sourceUrl) {
+      try {
+        const datasource = await BaseGoDatasource.getDatasource(
+          packageName
+        );
+        const sourceUrl = getSourceUrl(datasource);
+        if (sourceUrl) {
+          result.sourceUrl = sourceUrl;
+        }
+      } catch (err) {
+        logger.trace({err}, `Can't get datasource for ${packageName}`);
       }
     }
 

--- a/lib/modules/datasource/go/releases-goproxy.ts
+++ b/lib/modules/datasource/go/releases-goproxy.ts
@@ -59,7 +59,7 @@ export class GoProxyDatasource extends Datasource {
         }
 
         const res = await this.getVersionsWithInfo(url, packageName);
-        if (res.releases.length) {
+        if (res.releases.length || res.tags?.latest) {
           result = res;
           try {
             const datasource = await BaseGoDatasource.getDatasource(
@@ -72,7 +72,9 @@ export class GoProxyDatasource extends Datasource {
           } catch (err) {
             logger.trace({ err }, `Can't get datasource for ${packageName}`);
           }
-          break;
+          if (result.releases.length) {
+            break;
+          }
         }
       } catch (err) {
         const statusCode = err?.response?.statusCode;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This PR makes `GoProxyDatasource` temporarily hold onto any result that contains a latest version but no release information, and returns it if no other proxy finds better data.  This ensures that the lookup process doesn't short-circuit (and avoid digest lookups) for dependencies with no tagged releases.

## Context

Resolves the issue described in #24577

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
