### PR TITLE
chore: rename and extend auto label actions

### DIFF
--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -233,10 +233,11 @@
     Hi there,
 
 
-    This discusion is being closed because it's missing some details, or something else about it has made it difficult or impossible for us to help resolve the issue.
+    We're closing this discussion because it's missing some details, or because something else about it made it hard or impossible for us to help resolve the issue.
 
 
-    We choose to close and later delete such discussions in order to keep a high quality of discussions in this repository for users who search for answers.
+    We want high quality discussions, so users can search them for answers.
+    This means we'll close (and later delete) low quality discussions.
 
 
     You are welcome to create a new discussion with more details in future.
@@ -253,13 +254,15 @@
     A maintainer has flagged this discussion as giving off some bad vibes. **Maintainers will no longer participate in this discussion unless/until such "vibes" are resolved.**
 
 
-    This is typically when someone is overly critical of the product or the assistance they're receiving, or being unreasonably demanding or lazy, such as refusing to provide logs or other information which they're asked.
+    This is typically when someone is overly critical of the product or the assistance they're receiving.
+    Or being unreasonably demanding or lazy, such as refusing to provide logs, or other information, when asked.
 
 
-    Open Source means you're welcome to use the software with few limits applied, but it does not mean you are welcome to give maintainers a bad day or contribute to Open Source burnout.
+    Open Source means you're welcome to use the software with few limits applied.
+    But you should _not_ give maintainers a bad day or contribute to Open Source burnout.
 
 
-    If you feel this is in error or a misunderstanding, please let us know. If you see this message but don't take it as a sign to cool off or back off, we may close the discussion and block you from the repository.
+    If you feel this message is wrong or due to a misunderstanding, please let us know. If you see this message but don't take it as a sign to cool off or back off, we may close the discussion and block you from the repository.
 
 
     If you see this message and want to get the discussion back on track, it would be appreciated if you can:
@@ -267,7 +270,7 @@
     - Acknowledge that you understand the problem (no lengthy apology is needed, we just want to know it won't continue)
 
 
-    If you're unhappy with this, we suggest simply stop using the repository discussions or the product altogether.
+    If you're unhappy with this, we suggest you stop using the repository discussions or the product altogether.
 
 
     Thanks, the Renovate team

--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -265,9 +265,10 @@
     If you feel this message is wrong or due to a misunderstanding, please let us know. If you see this message but don't take it as a sign to cool off or back off, we may close the discussion and block you from the repository.
 
 
-    If you see this message and want to get the discussion back on track, it would be appreciated if you can:
-    - Edit any previous comments which may have given off any bad vibes
-    - Acknowledge that you understand the problem (no lengthy apology is needed, we just want to know it won't continue)
+    If you want to get the discussion back on track, we would like you to:
+    - Remove, or edit, the bad vibes parts of your comments
+    - Say that you understand the problem (we don't need a lengthy apology)
+    - Stop giving off more bad vibes
 
 
     If you're unhappy with this, we suggest you stop using the repository discussions or the product altogether.

--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -1,4 +1,4 @@
-'reproduction:needed':
+'auto:reproduction':
   comment: >
     Hi there,
 
@@ -23,7 +23,7 @@
 
     The Renovate team
 
-'needs-logs':
+'auto:logs':
   comment: >
     Hi there,
 
@@ -119,7 +119,7 @@
 
     The Renovate team
 
-'retry latest version':
+'auto:retry-latest':
   comment: >
     Hi there,
 
@@ -133,7 +133,7 @@
 
     The Renovate team
 
-'pr:no-coverage-ignore':
+'auto:no-coverage-ignore':
   comment: >
     Hi there,
 
@@ -163,7 +163,7 @@
 
     The Renovate team
 
-'pr:no-done-comments':
+'auto:no-done-comments':
   comment: >
     Hi there,
 
@@ -178,7 +178,7 @@
 
     The Renovate team
 
-'pr:discussion-first':
+'auto:discussion-first':
   comment: >
     **Please create a GitHub Discussion before continuing with this PR.**
 
@@ -190,7 +190,7 @@
     Thanks, the Renovate team
   close: true
 
-'needs-details':
+'auto:more-details':
   comment: >
     Hi there,
 
@@ -217,15 +217,57 @@
     Thanks, the Renovate team
   close: true
   close-reason: 'not planned'
-  lock: true
-  lock-reason: 'resolved'
 
-'format-code-comments':
+'auto:format-code':
   comment: >
     Hi, please format any copy/pasted code or logs so they're readable.
 
 
     You can find a Markdown code formatting guide [here](https://www.markdownguide.org/basic-syntax/#code) as well as some GitHub-specific information formatting code blocks [here](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks).
+
+
+    Thanks, the Renovate team
+
+'auto:discussion-closed':
+  comment: >
+    Hi there,
+
+
+    This discusion is being closed because it's missing some details, or something else about it has made it difficult or impossible for us to help resolve the issue.
+
+
+    We choose to close and later delete such discussions in order to keep a high quality of discussions in this repository for users who search for answers.
+
+
+    You are welcome to create a new discussion with more details in future.
+
+
+    Thanks, the Renovate team.
+  close: true
+  close-reason: 'not planned'
+
+'auto:bad-vibes':
+  comment: >
+    Hi there,
+
+    A maintainer has flagged this discussion as giving off some bad vibes. **Maintainers will no longer participate in this discussion unless/until such "vibes" are resolved.**
+
+
+    This is typically when someone is overly critical of the product or the assistance they're receiving, or being unreasonably demanding or lazy, such as refusing to provide logs or other information which they're asked.
+
+
+    Open Source means you're welcome to use the software with few limits applied, but it does not mean you are welcome to give maintainers a bad day or contribute to Open Source burnout.
+
+
+    If you feel this is in error or a misunderstanding, please let us know. If you see this message but don't take it as a sign to cool off or back off, we may close the discussion and block you from the repository.
+
+
+    If you see this message and want to get the discussion back on track, it would be appreciated if you can:
+    - Edit any previous comments which may have given off any bad vibes
+    - Acknowledge that you understand the problem (no lengthy apology is needed, we just want to know it won't continue)
+
+
+    If you're unhappy with this, we suggest simply stop using the repository discussions or the product altogether.
 
 
     Thanks, the Renovate team


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Renames some auto actions to use a consistent prefix, and adds two new ones for discussion closing and bad vibes warning

## Context

Trying to make us more efficient and transparent

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
