### PR TITLE
docs: use new GitHub alert syntax

### DIFF
--- a/docs/development/readme.md
+++ b/docs/development/readme.md
@@ -1,6 +1,6 @@
 # Renovate Developer Docs
 
-> **Note**
+> [!NOTE]
 > If you're an end-user of Renovate, please read the [Renovate documentation](https://docs.renovatebot.com).
 
 The `docs/development` directory is for developers and contributors.

--- a/readme.md
+++ b/readme.md
@@ -86,7 +86,7 @@ There are two ways to run Renovate on Azure DevOps:
 Go to the Visual Studio Marketplace and install the [Renovate Me](https://marketplace.visualstudio.com/items?itemName=jyc.vsts-extensions-renovate-me) extension in your organization.
 From there you can create a pipeline with the `RenovateMe` task.
 
-> **Note**
+> [!NOTE]
 > This extension is created and maintained personally by a Renovate developer/user so support requests relating to the extension itself cannot be answered directly in the main Renovate repository.
 
 #### Custom pipeline


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Replace beta-style alerts with the new `>[!ALERT-TYPE]` syntax

## Context

The [GitHub docs, alert syntax](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts) says the beta-style alerts are deprecated, and that we should use the `>[!ALERT-TYPE]` syntax instead:

> **Note:** The Markdown syntax used during the beta testing period is now deprecated and will be removed. You can use the syntax as described in this section.

So this PR makes it so we use the new alert-syntax in our docs.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
