### PR TITLE
fix(kustomize): validate name is a string

### DIFF
--- a/lib/modules/manager/kustomize/extract.spec.ts
+++ b/lib/modules/manager/kustomize/extract.spec.ts
@@ -186,6 +186,14 @@ describe('modules/manager/kustomize/extract', () => {
       expect(pkg).toBeNull();
     });
 
+    it('should return null on invalid input', () => {
+      const pkg = extractImage({
+        name: 3,
+        newTag: '',
+      });
+      expect(pkg).toBeNull();
+    });
+
     it('should correctly extract a default image', () => {
       const sample = {
         currentDigest: undefined,

--- a/lib/modules/manager/kustomize/extract.spec.ts
+++ b/lib/modules/manager/kustomize/extract.spec.ts
@@ -188,7 +188,7 @@ describe('modules/manager/kustomize/extract', () => {
 
     it('should return null on invalid input', () => {
       const pkg = extractImage({
-        // @ts-expect-error
+        // @ts-expect-error: for testing
         name: 3,
         newTag: '',
       });

--- a/lib/modules/manager/kustomize/extract.spec.ts
+++ b/lib/modules/manager/kustomize/extract.spec.ts
@@ -188,6 +188,7 @@ describe('modules/manager/kustomize/extract', () => {
 
     it('should return null on invalid input', () => {
       const pkg = extractImage({
+        // @ts-expect-error
         name: 3,
         newTag: '',
       });

--- a/lib/modules/manager/kustomize/extract.ts
+++ b/lib/modules/manager/kustomize/extract.ts
@@ -67,7 +67,12 @@ export function extractImage(image: Image): PackageDependency | null {
   if (!image.name) {
     return null;
   }
-  const nameDep = splitImageParts(image.newName ?? image.name);
+  const nameToSplit = image.newName ?? image.name;
+  if (!is.string(nameToSplit)) {
+    logger.debug({ image }, 'Invalid image name');
+    return null;
+  }
+  const nameDep = splitImageParts(nameToSplit);
   const { depName } = nameDep;
   const { digest, newTag } = image;
   if (digest && newTag) {


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Validate that image name is a string before parsing.

## Context

Closes #20055

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
