### PR TITLE
fix: UpdateTypesMatcher should return null when updateType has not been specified

### DIFF
--- a/lib/util/package-rules/index.spec.ts
+++ b/lib/util/package-rules/index.spec.ts
@@ -521,9 +521,7 @@ describe('util/package-rules/index', () => {
     const config: TestConfig = {
       packageRules: [
         {
-          matchPackagePrefixes: [
-            'foo'
-          ],
+          matchPackagePrefixes: ['foo'],
           matchUpdateTypes: ['minor', 'patch'],
           enabled: true,
         },
@@ -535,7 +533,7 @@ describe('util/package-rules/index', () => {
     };
     const res = applyPackageRules({ ...config, ...dep });
     expect(res.enabled).toBeTrue();
-  })
+  });
 
   it('matches matchSourceUrlPrefixes', () => {
     const config: TestConfig = {

--- a/lib/util/package-rules/index.spec.ts
+++ b/lib/util/package-rules/index.spec.ts
@@ -517,6 +517,26 @@ describe('util/package-rules/index', () => {
     expect(res.y).toBeUndefined();
   });
 
+  it('skip matchUpdateType if updateType has not been specified', () => {
+    const config: TestConfig = {
+      packageRules: [
+        {
+          matchPackagePrefixes: [
+            'foo'
+          ],
+          matchUpdateTypes: ['minor', 'patch'],
+          enabled: true,
+        },
+      ],
+    };
+    const dep = {
+      depName: 'foo.bar',
+      enabled: false,
+    };
+    const res = applyPackageRules({ ...config, ...dep });
+    expect(res.enabled).toBeTrue();
+  })
+
   it('matches matchSourceUrlPrefixes', () => {
     const config: TestConfig = {
       packageRules: [

--- a/lib/util/package-rules/update-types.ts
+++ b/lib/util/package-rules/update-types.ts
@@ -7,7 +7,7 @@ export class UpdateTypesMatcher extends Matcher {
     { updateType, isBump }: PackageRuleInputConfig,
     { matchUpdateTypes }: PackageRule
   ): boolean | null {
-    if (is.undefined(matchUpdateTypes)) {
+    if (is.undefined(updateType) || is.undefined(matchUpdateTypes)) {
       return null;
     }
     return (


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
UpdateTypesMatcher.matches should return null when `updateType` has not been specified.

<!-- Describe what behavior is changed by this PR. -->

## Context
I was tracing down a bug where packages under a specific package rule with both `matchPackagePrefixes` & `matchUpdateTypes` specified are disabled.

The config looks like the following:

```json5
{ 
  packageRules: [
    { // this rule is mainly for being able to do rollout in chunks for large monorepo
      matchManagers: [
        'gradle'
      ],
      enabled: false
    },
   {
      "groupName": "some group name",
      matchManagers: [
        'gradle'
      ],
      matchPackagePrefixes: [
        'packageA',
        'packageB',
        'packageC',
      ],
      matchUpdateTypes: [
        'minor',
        'patch',
      ],
      enabled: true
    },
  ]
}
```

With the current logic, `packageA`, `packageB` and `packageC` result in `Dependency {{packageName}} is disabled` just after dependencies have been extracted and right before [fetchDepUpdates](https://github.com/renovatebot/renovate/blob/848a0b03763f79eb3546a4993cd78e8994d00577/lib/workers/repository/process/fetch.ts#L66)  happens.

tracing down to why this happens leads me to the [`UpdateTypesMatcher`](https://github.com/renovatebot/renovate/blob/848a0b03763f79eb3546a4993cd78e8994d00577/lib/util/package-rules/update-types.ts#L10).  `updateType` is `undefined` at that particular point in time. And the matcher should not have been applied. 

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [X] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [X] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
