### PR TITLE
fix: allow more than 99 PRs/branches per repository

### DIFF
--- a/lib/workers/repository/process/limits.spec.ts
+++ b/lib/workers/repository/process/limits.spec.ts
@@ -46,10 +46,10 @@ describe('workers/repository/process/limits', () => {
       expect(res).toBe(5);
     });
 
-    it('returns 99 if no hourly limit', async () => {
+    it('returns MAX_SAFE_INTEGER if no hourly limit', async () => {
       config.prHourlyLimit = 0;
       const res = await limits.getPrHourlyRemaining(config);
-      expect(res).toBe(99);
+      expect(res).toBe(Number.MAX_SAFE_INTEGER);
     });
   });
 
@@ -74,10 +74,10 @@ describe('workers/repository/process/limits', () => {
       expect(res).toBe(19);
     });
 
-    it('returns 99 if no concurrent limit', async () => {
+    it('returns MAX_SAFE_INTEGER if no concurrent limit', async () => {
       config.prConcurrentLimit = 0;
       const res = await limits.getConcurrentPrsRemaining(config, []);
-      expect(res).toBe(99);
+      expect(res).toBe(Number.MAX_SAFE_INTEGER);
     });
   });
 
@@ -120,7 +120,7 @@ describe('workers/repository/process/limits', () => {
       config.branchConcurrentLimit = 0;
       config.prConcurrentLimit = 20;
       const res = await limits.getConcurrentBranchesRemaining(config, []);
-      expect(res).toBe(99);
+      expect(res).toBe(Number.MAX_SAFE_INTEGER);
     });
 
     it('returns 10 if no limits are set', async () => {

--- a/lib/workers/repository/process/limits.ts
+++ b/lib/workers/repository/process/limits.ts
@@ -36,7 +36,7 @@ export async function getPrHourlyRemaining(
       return config.prHourlyLimit;
     }
   }
-  return 99;
+  return Number.MAX_SAFE_INTEGER;
 }
 
 export async function getConcurrentPrsRemaining(
@@ -78,7 +78,7 @@ export async function getConcurrentPrsRemaining(
       return config.prConcurrentLimit;
     }
   }
-  return 99;
+  return Number.MAX_SAFE_INTEGER;
 }
 
 export async function getPrsRemaining(
@@ -124,7 +124,7 @@ export async function getConcurrentBranchesRemaining(
       return limit;
     }
   }
-  return 99;
+  return Number.MAX_SAFE_INTEGER;
 }
 
 export async function getBranchesRemaining(


### PR DESCRIPTION

## Changes

Increases the maximum number of PRs/branches per repository from 99 to the largest integer number if no limits are configured. This is clearly a corner case, but [it's documented like that](https://docs.renovatebot.com/configuration-options/#prconcurrentlimit).

## Context

- https://github.com/renovatebot/renovate/discussions/24598

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
