### PR TITLE
feat: add gitea folder support

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -114,7 +114,7 @@ Must be valid usernames on the platform in use.
 
 If enabled Renovate tries to determine PR assignees by matching rules defined in a CODEOWNERS file against the changes in the PR.
 
-See [GitHub](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) or [GitLab](https://docs.gitlab.com/ee/user/project/code_owners.html) documentation for details on syntax and possible file locations.
+See [GitHub](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners), [GitLab](https://docs.gitlab.com/ee/user/project/code_owners.html) or [Gitea](https://docs.gitea.com/next/usage/code-owners) documentation for details on syntax and possible file locations.
 
 ## assigneesSampleSize
 
@@ -3398,7 +3398,7 @@ For example: if the username or team name is `bar` then you would set the config
 
 If enabled Renovate tries to determine PR reviewers by matching rules defined in a CODEOWNERS file against the changes in the PR.
 
-See [GitHub](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners) or [GitLab](https://docs.gitlab.com/ee/user/project/code_owners.html) documentation for details on syntax and possible file locations.
+See [GitHub](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners), [GitLab](https://docs.gitlab.com/ee/user/project/code_owners.html) or [Gitea](https://docs.gitea.com/next/usage/code-owners) documentation for details on syntax and possible file locations.
 
 ## reviewersSampleSize
 

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -16,6 +16,8 @@ You can store your Renovate configuration file in one of these locations:
 1. `.github/renovate.json5`
 1. `.gitlab/renovate.json`
 1. `.gitlab/renovate.json5`
+1. `.gitea/renovate.json`
+1. `.gitea/renovate.json5`
 1. `.renovaterc`
 1. `.renovaterc.json`
 1. `.renovaterc.json5`

--- a/docs/usage/getting-started/installing-onboarding.md
+++ b/docs/usage/getting-started/installing-onboarding.md
@@ -79,6 +79,8 @@ If you don't want a `renovate.json` file in your repository you can use one of t
 - `.github/renovate.json5`
 - `.gitlab/renovate.json`
 - `.gitlab/renovate.json5`
+- `.gitea/renovate.json`
+- `.gitea/renovate.json5`
 - `.renovaterc`
 - `.renovaterc.json`
 - `.renovaterc.json5`

--- a/lib/config/app-strings.ts
+++ b/lib/config/app-strings.ts
@@ -5,6 +5,8 @@ export const configFileNames = [
   '.github/renovate.json5',
   '.gitlab/renovate.json',
   '.gitlab/renovate.json5',
+  '.gitea/renovate.json',
+  '.gitea/renovate.json5',
   '.renovaterc',
   '.renovaterc.json',
   '.renovaterc.json5',

--- a/lib/workers/repository/init/merge.spec.ts
+++ b/lib/workers/repository/init/merge.spec.ts
@@ -229,6 +229,19 @@ describe('workers/repository/init/merge', () => {
       });
     });
 
+    it('finds .gitea/renovate.json', async () => {
+      scm.getFileList.mockResolvedValue([
+        'package.json',
+        '.gitea/renovate.json',
+      ]);
+      fs.readLocalFile.mockResolvedValue('{}');
+      expect(await detectRepoFileConfig()).toEqual({
+        configFileName: '.gitea/renovate.json',
+        configFileParsed: {},
+        configFileRaw: '{}',
+      });
+    });
+
     it('finds .renovaterc.json', async () => {
       scm.getFileList.mockResolvedValue(['package.json', '.renovaterc.json']);
       fs.readLocalFile.mockResolvedValue('{}');

--- a/lib/workers/repository/update/pr/code-owners.spec.ts
+++ b/lib/workers/repository/update/pr/code-owners.spec.ts
@@ -254,6 +254,7 @@ describe('workers/repository/update/pr/code-owners', () => {
       'CODEOWNERS',
       '.github/CODEOWNERS',
       '.gitlab/CODEOWNERS',
+      '.gitea/CODEOWNERS',
       'docs/CODEOWNERS',
     ];
     codeOwnerFilePaths.forEach((codeOwnerFilePath) => {

--- a/lib/workers/repository/update/pr/code-owners.ts
+++ b/lib/workers/repository/update/pr/code-owners.ts
@@ -83,6 +83,7 @@ export async function codeOwnersForPr(pr: Pr): Promise<string[]> {
       (await readLocalFile('CODEOWNERS', 'utf8')) ??
       (await readLocalFile('.github/CODEOWNERS', 'utf8')) ??
       (await readLocalFile('.gitlab/CODEOWNERS', 'utf8')) ??
+      (await readLocalFile('.gitea/CODEOWNERS', 'utf8')) ??
       (await readLocalFile('docs/CODEOWNERS', 'utf8'));
 
     if (!codeOwnersFile) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
I've added `.gitea/` folder support for the renovate config location and for the `CODEOWNERS` file location.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->
Starting with Gitea version 1.19, Gitea has added support for Actions, whose folder is `.gitea` by default.
Since there is support for Github and Gitlab folders as well, I wanted to propose support for the Gitea folder as an option.

In the soon to be released Gitea version 1.21, support for [`CODEOWNERS`](https://docs.gitea.com/next/usage/code-owners) files in gitea will also be added, which is why I would extend the file search to the .gitea location here as well.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
