### PR TITLE
docs(config options): explain `prCreation=approval`

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -3123,29 +3123,33 @@ This limit is enforced on a per-repository basis.
 
 ## prCreation
 
-This setting tells Renovate when you would like it to raise PRs:
+This setting tells Renovate _when_ to create PRs:
 
-- `immediate` (default): Renovate will create PRs immediately after creating the corresponding branch
-- `not-pending`: Renovate will wait until status checks have completed (passed or failed) before raising the PR
-- `status-success`: Renovate won't raise PRs unless tests pass
-- `approval`: Renovate creates branches for updates, but only creates the PR _after_ Dependency Dashboard approval
+- `immediate` (default): Renovate creates PRs immediately after creating the corresponding branch
+- `not-pending`: Renovate waits until status checks have completed (passed or failed) before raising the PR
+- `status-success`: Renovate only creates PRs when the the test pass
+- `approval`: Renovate creates branches for updates immediately, but creates the PR _after_ getting Dependency Dashboard approval
 
-Renovate defaults to `immediate` but you might want to change this to `not-pending` instead.
+When prCreation is set to `immediate`, you'll get a Pull Request and possible associated notification right away when a new update is available.
+You'll have to wait until the checks have been performed, before you can decide if you want to merge the PR.
 
-With prCreation set to `immediate`, you'll get a Pull Request and possible associated notification right away when a new update is available.
-You'll have to wait until the checks have been performed, before you can decide if you want to merge the PR or not.
-
-With prCreation set to `not-pending`, Renovate creates the PR only once all tests have passed or failed.
+When prCreation is set to `not-pending`, Renovate creates the PR only once all tests have passed or failed.
 When you get the PR notification, you can take action immediately, as you have the full test results.
-If there are no checks associated, Renovate will create the PR once 24 hrs have elapsed since creation of the commit.
+If there are no checks associated, Renovate will create the PR once 24 hours have elapsed since creation of the commit.
 
-With prCreation set to `status-success`, Renovate creates the PR only if/ once all tests have passed.
+When prCreation is set to `status-success`, Renovate creates the PR only if all tests have passed.
 
-With prCreation set to `approval`, Renovate creates the PR only when approved via the Dependency Dashboard.
-It does not prevent the creation of the _branch_.
+When prCreation is set to `approval`, Renovate creates the PR only when approved via the Dependency Dashboard.
+Renovate still creates the _branch_ immediately.
 
-For all cases of non-immediate PR creation, Renovate doesn't run instantly once tests complete.
-Instead, Renovate can create the PR on its next run after relevant tests have completed, so there will be some delay.
+<!-- prettier-ignore -->
+!!! note
+    For all cases of non-immediate PR creation, Renovate doesn't run instantly once tests complete.
+    Instead, Renovate create the PR on its _next_ run after the relevant tests have completed, so there will be some delay.
+
+<!-- prettier-ignore -->
+!!! warning
+    If you set `prCreation=approval` you must _not_ use `dependencyDashboardApproval=true`!
 
 ## prFooter
 

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -3127,7 +3127,7 @@ This setting tells Renovate _when_ to create PRs:
 
 - `immediate` (default): Renovate creates PRs immediately after creating the corresponding branch
 - `not-pending`: Renovate waits until status checks have completed (passed or failed) before raising the PR
-- `status-success`: Renovate only creates PRs when the the test pass
+- `status-success`: Renovate only creates PRs if/when the the test pass
 - `approval`: Renovate creates branches for updates immediately, but creates the PR _after_ getting Dependency Dashboard approval
 
 When prCreation is set to `immediate`, you'll get a Pull Request and possible associated notification right away when a new update is available.

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -3138,6 +3138,7 @@ When you get the PR notification, you can take action immediately, as you have t
 If there are no checks associated, Renovate will create the PR once 24 hours have elapsed since creation of the commit.
 
 When prCreation is set to `status-success`, Renovate creates the PR only if all tests have passed.
+When a branch remains without PR due to a failing test: select the corresponding PR from the Dependency Dashboard, and push your fixes to the branch.
 
 When prCreation is set to `approval`, Renovate creates the PR only when approved via the Dependency Dashboard.
 Renovate still creates the _branch_ immediately.

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -3142,6 +3142,7 @@ If there are no checks associated, Renovate will create the PR once 24 hrs have 
 With prCreation set to `status-success`, Renovate creates the PR only if/ once all tests have passed.
 
 With prCreation set to `approval`, Renovate creates the PR only when approved via the Dependency Dashboard.
+It does not prevent the creation of the _branch_.
 
 For all cases of non-immediate PR creation, Renovate doesn't run instantly once tests complete.
 Instead, Renovate can create the PR on its next run after relevant tests have completed, so there will be some delay.

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -3128,6 +3128,7 @@ This setting tells Renovate when you would like it to raise PRs:
 - `immediate` (default): Renovate will create PRs immediately after creating the corresponding branch
 - `not-pending`: Renovate will wait until status checks have completed (passed or failed) before raising the PR
 - `status-success`: Renovate won't raise PRs unless tests pass
+- `approval`: Renovate waits until getting approval for the update via the Dependency Dashboard
 
 Renovate defaults to `immediate` but you might want to change this to `not-pending` instead.
 
@@ -3139,6 +3140,8 @@ When you get the PR notification, you can take action immediately, as you have t
 If there are no checks associated, Renovate will create the PR once 24 hrs have elapsed since creation of the commit.
 
 With prCreation set to `status-success`, Renovate creates the PR only if/ once all tests have passed.
+
+With prCreation set to `approval`, Renovate creates the PR only when approved via the Dependency Dashboard.
 
 For all cases of non-immediate PR creation, Renovate doesn't run instantly once tests complete.
 Instead, Renovate can create the PR on its next run after relevant tests have completed, so there will be some delay.

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -3128,7 +3128,7 @@ This setting tells Renovate when you would like it to raise PRs:
 - `immediate` (default): Renovate will create PRs immediately after creating the corresponding branch
 - `not-pending`: Renovate will wait until status checks have completed (passed or failed) before raising the PR
 - `status-success`: Renovate won't raise PRs unless tests pass
-- `approval`: Renovate waits until getting approval for the update via the Dependency Dashboard
+- `approval`: Renovate creates branches for updates, but only creates the PR _after_ Dependency Dashboard approval
 
 Renovate defaults to `immediate` but you might want to change this to `not-pending` instead.
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Explain what happens when you set `prCreation` to `approval`

## Context

The current docs list `approval` as a valid `allowedValues`, but lacks a proper explanation.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
