### PR TITLE
fix(package-rules): matchCurrentVersion with null versioning

### DIFF
--- a/lib/modules/versioning/index.ts
+++ b/lib/modules/versioning/index.ts
@@ -17,7 +17,9 @@ export const getVersionings = (): Map<
 > => versionings;
 
 export function get(versioning: string | null | undefined): VersioningApi {
-  const res = Versioning.safeParse(versioning ? versioning : '');
+  const res = Versioning.safeParse(
+    versioning ? versioning : defaultVersioning.id
+  );
 
   if (!res.success) {
     const [issue] = res.error.issues;

--- a/lib/modules/versioning/index.ts
+++ b/lib/modules/versioning/index.ts
@@ -16,8 +16,8 @@ export const getVersionings = (): Map<
   VersioningApi | VersioningApiConstructor
 > => versionings;
 
-export function get(versioning = ''): VersioningApi {
-  const res = Versioning.safeParse(versioning);
+export function get(versioning: string | null | undefined): VersioningApi {
+  const res = Versioning.safeParse(versioning ? versioning : '');
 
   if (!res.success) {
     const [issue] = res.error.issues;

--- a/lib/util/package-rules/current-version.spec.ts
+++ b/lib/util/package-rules/current-version.spec.ts
@@ -39,8 +39,7 @@ describe('util/package-rules/current-version', () => {
     it('return false for regex version non match', () => {
       const result = matcher.matches(
         {
-          // @ts-expect-error: for testing
-          versioning: null,
+          versioning: 'ruby',
           currentValue: '"~> 1.1.0"',
           lockedVersion: '1.1.4',
         },

--- a/lib/util/package-rules/current-version.spec.ts
+++ b/lib/util/package-rules/current-version.spec.ts
@@ -39,7 +39,8 @@ describe('util/package-rules/current-version', () => {
     it('return false for regex version non match', () => {
       const result = matcher.matches(
         {
-          versioning: 'ruby',
+          // @ts-expect-error: for testing
+          versioning: null,
           currentValue: '"~> 1.1.0"',
           lockedVersion: '1.1.4',
         },

--- a/lib/util/package-rules/current-version.spec.ts
+++ b/lib/util/package-rules/current-version.spec.ts
@@ -5,6 +5,20 @@ describe('util/package-rules/current-version', () => {
   const matcher = new CurrentVersionMatcher();
 
   describe('match', () => {
+    it('returns true for null versioning', () => {
+      const result = matcher.matches(
+        {
+          // @ts-expect-error: for testing
+          versioning: null,
+          currentValue: '1.2.3',
+        },
+        {
+          matchCurrentVersion: '1.2.3',
+        }
+      );
+      expect(result).toBeTrue();
+    });
+
     it('return false on version exception', () => {
       const spy = jest.spyOn(pep440, 'matches').mockImplementationOnce(() => {
         throw new Error();
@@ -39,8 +53,7 @@ describe('util/package-rules/current-version', () => {
     it('return false for regex version non match', () => {
       const result = matcher.matches(
         {
-          // @ts-expect-error: for testing
-          versioning: null,
+          versioning: 'ruby',
           currentValue: '"~> 1.1.0"',
           lockedVersion: '1.1.4',
         },

--- a/lib/util/package-rules/current-version.ts
+++ b/lib/util/package-rules/current-version.ts
@@ -20,7 +20,7 @@ export class CurrentVersionMatcher extends Matcher {
     }
     const isUnconstrainedValue =
       !!lockedVersion && is.nullOrUndefined(currentValue);
-    const version = allVersioning.get(versioning ? versioning : undefined);
+    const version = allVersioning.get(versioning)
     const matchCurrentVersionStr = matchCurrentVersion.toString();
     const matchCurrentVersionPred = configRegexPredicate(
       matchCurrentVersionStr

--- a/lib/util/package-rules/current-version.ts
+++ b/lib/util/package-rules/current-version.ts
@@ -20,7 +20,7 @@ export class CurrentVersionMatcher extends Matcher {
     }
     const isUnconstrainedValue =
       !!lockedVersion && is.nullOrUndefined(currentValue);
-    const version = allVersioning.get(versioning)
+    const version = allVersioning.get(versioning);
     const matchCurrentVersionStr = matchCurrentVersion.toString();
     const matchCurrentVersionPred = configRegexPredicate(
       matchCurrentVersionStr

--- a/lib/util/package-rules/current-version.ts
+++ b/lib/util/package-rules/current-version.ts
@@ -20,7 +20,7 @@ export class CurrentVersionMatcher extends Matcher {
     }
     const isUnconstrainedValue =
       !!lockedVersion && is.nullOrUndefined(currentValue);
-    const version = allVersioning.get(versioning);
+    const version = allVersioning.get(versioning ? versioning : undefined);
     const matchCurrentVersionStr = matchCurrentVersion.toString();
     const matchCurrentVersionPred = configRegexPredicate(
       matchCurrentVersionStr


### PR DESCRIPTION
Fixes #24964

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
