### PR TITLE
feat: support extracting buildkite plugins from Bitbucket Cloud

### DIFF
--- a/lib/modules/manager/buildkite/__fixtures__/pipeline9.yml
+++ b/lib/modules/manager/buildkite/__fixtures__/pipeline9.yml
@@ -1,0 +1,4 @@
+steps:
+  - plugins:
+      - ssh://git@bitbucket.org/some-org/some-plugin.git#v3.2.7:
+      - docker-compose#v1.3.2:

--- a/lib/modules/manager/buildkite/extract.spec.ts
+++ b/lib/modules/manager/buildkite/extract.spec.ts
@@ -71,5 +71,22 @@ describe('modules/manager/buildkite/extract', () => {
       };
       expect(res).toEqual([expectedPackageDependency]);
     });
+
+    it('extracts plugin tags from bitbucket', () => {
+      const res = extractPackageFile(Fixtures.get('pipeline9.yml'))?.deps;
+      const githubDependency: PackageDependency = {
+        currentValue: 'v1.3.2',
+        datasource: 'github-tags',
+        depName: 'docker-compose',
+        packageName: 'buildkite-plugins/docker-compose-buildkite-plugin',
+      };
+      const bitbucketDependency: PackageDependency = {
+        currentValue: 'v3.2.7',
+        datasource: 'bitbucket-tags',
+        depName: 'some-org/some-plugin',
+        registryUrls: ['https://bitbucket.org'],
+      };
+      expect(res).toEqual([bitbucketDependency, githubDependency]);
+    });
   });
 });

--- a/lib/modules/manager/buildkite/extract.ts
+++ b/lib/modules/manager/buildkite/extract.ts
@@ -36,15 +36,15 @@ export function extractPackageFile(
           const { registry, gitPluginName } = gitPluginMatch.groups;
           const gitDepName = gitPluginName.replace(regEx('\\.git$'), '');
 
-          let dataSource: string = GithubTagsDatasource.id;
+          let datasource: string = GithubTagsDatasource.id;
           if (registry.includes('bitbucket.org')) {
-            dataSource = BitbucketTagsDatasource.id;
+            datasource = BitbucketTagsDatasource.id;
           }
           const dep: PackageDependency = {
             depName: gitDepName,
             currentValue,
             registryUrls: ['https://' + registry],
-            datasource: dataSource,
+            datasource,
           };
           deps.push(dep);
           continue;

--- a/lib/modules/manager/buildkite/extract.ts
+++ b/lib/modules/manager/buildkite/extract.ts
@@ -37,7 +37,7 @@ export function extractPackageFile(
           const gitDepName = gitPluginName.replace(regEx('\\.git$'), '');
 
           let datasource: string = GithubTagsDatasource.id;
-          if (registry.includes('bitbucket.org')) {
+          if (registry.startsWith('bitbucket.org')) {
             datasource = BitbucketTagsDatasource.id;
           }
           const dep: PackageDependency = {

--- a/lib/modules/manager/buildkite/extract.ts
+++ b/lib/modules/manager/buildkite/extract.ts
@@ -36,7 +36,7 @@ export function extractPackageFile(
           const gitDepName = gitPluginName.replace(regEx('\\.git$'), '');
 
           let datasource: string = GithubTagsDatasource.id;
-          if (registry.startsWith('bitbucket.org')) {
+          if (registry === 'bitbucket.org') {
             datasource = BitbucketTagsDatasource.id;
           }
           const dep: PackageDependency = {

--- a/lib/modules/manager/buildkite/extract.ts
+++ b/lib/modules/manager/buildkite/extract.ts
@@ -3,7 +3,6 @@ import type { SkipReason } from '../../../types';
 import { newlineRegex, regEx } from '../../../util/regex';
 import { BitbucketTagsDatasource } from '../../datasource/bitbucket-tags';
 import { GithubTagsDatasource } from '../../datasource/github-tags';
-
 import { isVersion } from '../../versioning/semver';
 import type { PackageDependency, PackageFileContent } from '../types';
 

--- a/lib/modules/manager/buildkite/extract.ts
+++ b/lib/modules/manager/buildkite/extract.ts
@@ -1,7 +1,9 @@
 import { logger } from '../../../logger';
 import type { SkipReason } from '../../../types';
 import { newlineRegex, regEx } from '../../../util/regex';
+import { BitbucketTagsDatasource } from '../../datasource/bitbucket-tags';
 import { GithubTagsDatasource } from '../../datasource/github-tags';
+
 import { isVersion } from '../../versioning/semver';
 import type { PackageDependency, PackageFileContent } from '../types';
 
@@ -33,11 +35,16 @@ export function extractPackageFile(
           logger.debug('Examining git plugin');
           const { registry, gitPluginName } = gitPluginMatch.groups;
           const gitDepName = gitPluginName.replace(regEx('\\.git$'), '');
+
+          let dataSource: string = GithubTagsDatasource.id;
+          if (registry.includes('bitbucket.org')) {
+            dataSource = BitbucketTagsDatasource.id;
+          }
           const dep: PackageDependency = {
             depName: gitDepName,
             currentValue,
             registryUrls: ['https://' + registry],
-            datasource: GithubTagsDatasource.id,
+            datasource: dataSource,
           };
           deps.push(dep);
           continue;

--- a/lib/modules/manager/buildkite/index.ts
+++ b/lib/modules/manager/buildkite/index.ts
@@ -1,4 +1,5 @@
 import type { Category } from '../../../constants';
+import { BitbucketTagsDatasource } from '../../datasource/bitbucket-tags';
 import { GithubTagsDatasource } from '../../datasource/github-tags';
 import { extractPackageFile } from './extract';
 
@@ -13,4 +14,7 @@ export const defaultConfig = {
 
 export const categories: Category[] = ['ci'];
 
-export const supportedDatasources = [GithubTagsDatasource.id];
+export const supportedDatasources = [
+  GithubTagsDatasource.id,
+  BitbucketTagsDatasource.id,
+];


### PR DESCRIPTION
## Changes
Add support for extracting buildkite plugin tag information from Bitbucket Cloud as well as from Github.

## Context
Since Buildkite plugins might be self-hosted (or on a another provider than Github.com), in this particular case Bitbucket Cloud, all created Pull Requests contains warnings about missing dependency information.

## Documentation

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository
