### PR TITLE
refactor: remove duplicate dependency names in warning

### DIFF
--- a/lib/util/check-token.ts
+++ b/lib/util/check-token.ts
@@ -50,8 +50,9 @@ export function checkGithubToken(
       'github-token-required-warning-logged'
     );
     if (!warningLogged) {
+      const withoutDuplicates = [...new Set(githubDeps)];
       logger.warn(
-        { githubDeps },
+        { githubDeps: withoutDuplicates },
         `GitHub token is required for some dependencies`
       );
       memCache.set('github-token-required-warning-logged', true);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

When reporting dependencies that cannot be retrieved without a
`GITHUB_COM_TOKEN`, we can end up with duplicated dependencies which
results in a longer log message than it needs to be.

Via [0] we can use the `Set` constructor to de-duplicate entries.

[0]: https://stackoverflow.com/a/9229821


<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
