### PR TITLE
feat: Allow configuring `extraCloneOpts`

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -1439,6 +1439,30 @@ Development Bot <dev-bot@my-software-company.com>
     We strongly recommend that the Git author email you use is unique to Renovate.
     Otherwise, if another bot or human shares the same email and pushes to one of Renovate's branches then Renovate will mistake the branch as unmodified and potentially force push over the changes.
 
+## gitExtraCloneOpts
+
+You can specify additional arguments that are passed to `git` when cloning a repository.
+
+For instance:
+
+```json
+{
+  "gitExtraCloneOpts": {
+    "--depth": "1"
+  }
+}
+```
+
+Would amend the `git clone` command like so:
+
+```sh
+git clone --depth 1 ...
+```
+
+<!-- prettier-ignore -->
+!!! danger
+  Mis-configuring this option could lead to your `git clone`s failing.
+
 ## gitIgnoredAuthors
 
 Specify commit authors ignored by Renovate.

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -868,6 +868,13 @@ const options: RenovateOptions[] = [
     stage: 'global',
   },
   {
+    name: 'gitExtraCloneOpts',
+    description:
+      'Configuration that can be used to amend the `git clone` operation',
+    type: 'object',
+    stage: 'repository',
+  },
+  {
     name: 'gitIgnoredAuthors',
     description:
       'Git authors which are ignored by Renovate. Must conform to [RFC5322](https://datatracker.ietf.org/doc/html/rfc5322).',

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -2,6 +2,7 @@ import type { LogLevel } from 'bunyan';
 import type { PlatformId } from '../constants';
 import type { CustomManager } from '../modules/manager/custom/types';
 import type { HostRule } from '../types';
+import type { GitOptions } from '../types/git';
 import type { GitNoVerifyOption } from '../util/git/types';
 import type { MergeConfidence } from '../util/merge-confidence/types';
 
@@ -87,6 +88,7 @@ export interface RenovateSharedConfig {
   suppressNotifications?: string[];
   timezone?: string;
   unicodeEmoji?: boolean;
+  gitExtraCloneOpts?: GitOptions;
   gitIgnoredAuthors?: string[];
   platformCommit?: boolean;
 }

--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -803,6 +803,24 @@ describe('util/git/index', () => {
       const res = (await repo.raw(['config', 'extra.clone.config'])).trim();
       expect(res).toBe('test-extra-config-value');
     });
+
+    it('should use extra clone configuration, when configured through setUserRepoConfig', async () => {
+      await fs.emptyDir(tmpDir.path);
+      await git.initRepo({
+        url: origin.path,
+        fullClone: true,
+      });
+      git.setUserRepoConfig({
+        gitExtraCloneOpts: {
+          '-c': 'extra.clone.config=test-extra-config-value',
+        },
+      });
+      git.getBranchCommit(defaultBranch);
+      await git.syncGit();
+      const repo = Git(tmpDir.path);
+      const res = (await repo.raw(['config', 'extra.clone.config'])).trim();
+      expect(res).toBe('test-extra-config-value');
+    });
   });
 
   describe('setGitAuthor()', () => {

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -325,8 +325,10 @@ export async function writeGitAuthor(): Promise<void> {
 export function setUserRepoConfig({
   gitIgnoredAuthors,
   gitAuthor,
+  gitExtraCloneOpts,
 }: RenovateConfig): void {
   config.ignoredAuthors = gitIgnoredAuthors ?? [];
+  config.extraCloneOpts = gitExtraCloneOpts ?? undefined;
   setGitAuthor(gitAuthor);
 }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

- Adds a new `gitExtraCloneOpts` configuration option
- Wire this in with `setUserRepoConfig`

## Context

As highlighted in #24985, there doesn't seem to be a way right now to
configure the `extraCloneOpts`.

This allows a user to specify the `gitExtraCloneOpts` object in their
configuration to tune how the repository they're working with is
configured, for instance performing additional configuration, or
tweaking the clone depth.


<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
