### PR TITLE
chore(lookup): include package name in warning message

### DIFF
--- a/lib/workers/repository/process/lookup/index.spec.ts
+++ b/lib/workers/repository/process/lookup/index.spec.ts
@@ -1257,7 +1257,7 @@ describe('workers/repository/process/lookup/index', () => {
       expect(res.warnings).toHaveLength(1);
       expect(res.warnings[0]).toEqual({
         message:
-          'Could not determine new digest for update (datasource: github-tags)',
+          'Could not determine new digest for update (github-tags package angular/angular)',
         topic: 'angular/angular',
       });
     });

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -490,7 +490,7 @@ export async function lookupUpdates(
             // Context: https://github.com/renovatebot/renovate/pull/20175#discussion_r1102615059.
             if (config.currentDigest) {
               res.warnings.push({
-                message: `Could not determine new digest for update (datasource: ${config.datasource})`,
+                message: `Could not determine new digest for update (${config.datasource} package ${config.packageName})`,
                 topic: config.packageName,
               });
             }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Revises the warning message to ensure the affected package name is shown to end users.

## Context

This warning message is currently presented to end users like this:

<img width="949" alt="image" src="https://github.com/renovatebot/renovate/assets/202034/bf79699b-bd8a-4528-9590-b79696e3a815">

Note that users aren't told which package(s) are the culprit.  Finding that out requires access to Renovate's logging.

I therefore propose we include the package name in the warning, just like we do for all other warning messages:

https://github.com/renovatebot/renovate/blob/adca94e9649c364883f08d630bc5f799fe47e04d/lib/workers/repository/process/lookup/index.ts#L127-L139

https://github.com/renovatebot/renovate/blob/adca94e9649c364883f08d630bc5f799fe47e04d/lib/workers/repository/process/lookup/index.ts#L186-L189

https://github.com/renovatebot/renovate/blob/adca94e9649c364883f08d630bc5f799fe47e04d/lib/workers/repository/process/lookup/index.ts#L215-L221

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
