### PR TITLE
feat: Add support for container image tags

### DIFF
--- a/lib/modules/versioning/ubuntu/index.spec.ts
+++ b/lib/modules/versioning/ubuntu/index.spec.ts
@@ -5,82 +5,84 @@ describe('modules/versioning/ubuntu/index', () => {
   const dt = DateTime.fromISO('2022-04-20');
 
   it.each`
-    version        | expected
-    ${undefined}   | ${false}
-    ${null}        | ${false}
-    ${''}          | ${false}
-    ${'xenial'}    | ${true}
-    ${'04.10'}     | ${true}
-    ${'05.04'}     | ${true}
-    ${'05.10'}     | ${true}
-    ${'6.06'}      | ${true}
-    ${'6.10'}      | ${true}
-    ${'7.04'}      | ${true}
-    ${'7.10'}      | ${true}
-    ${'8.04'}      | ${true}
-    ${'8.10'}      | ${true}
-    ${'9.04'}      | ${true}
-    ${'9.10'}      | ${true}
-    ${'10.04.4'}   | ${true}
-    ${'10.10'}     | ${true}
-    ${'11.04'}     | ${true}
-    ${'11.10'}     | ${true}
-    ${'12.04.5'}   | ${true}
-    ${'12.10'}     | ${true}
-    ${'13.04'}     | ${true}
-    ${'13.10'}     | ${true}
-    ${'14.04.6'}   | ${true}
-    ${'14.10'}     | ${true}
-    ${'15.04'}     | ${true}
-    ${'15.10'}     | ${true}
-    ${'16.04.7'}   | ${true}
-    ${'16.10'}     | ${true}
-    ${'17.04'}     | ${true}
-    ${'17.10'}     | ${true}
-    ${'18.04.5'}   | ${true}
-    ${'18.10'}     | ${true}
-    ${'19.04'}     | ${true}
-    ${'19.10'}     | ${true}
-    ${'20.04'}     | ${true}
-    ${'20.10'}     | ${true}
-    ${'2020.04'}   | ${false}
-    ${'xenial'}    | ${true}
-    ${'warty'}     | ${true}
-    ${'hoary'}     | ${true}
-    ${'breezy'}    | ${true}
-    ${'dapper'}    | ${true}
-    ${'edgy'}      | ${true}
-    ${'feisty'}    | ${true}
-    ${'gutsy'}     | ${true}
-    ${'hardy'}     | ${true}
-    ${'intrepid'}  | ${true}
-    ${'jaunty'}    | ${true}
-    ${'karmic'}    | ${true}
-    ${'lucid.4'}   | ${false}
-    ${'maverick'}  | ${true}
-    ${'natty'}     | ${true}
-    ${'oneiric'}   | ${true}
-    ${'precise.5'} | ${false}
-    ${'quantal'}   | ${true}
-    ${'raring'}    | ${true}
-    ${'saucy'}     | ${true}
-    ${'trusty.6'}  | ${false}
-    ${'utopic'}    | ${true}
-    ${'vivid'}     | ${true}
-    ${'wily'}      | ${true}
-    ${'xenial.7'}  | ${false}
-    ${'yakkety'}   | ${true}
-    ${'zesty'}     | ${true}
-    ${'artful'}    | ${true}
-    ${'bionic.5'}  | ${false}
-    ${'cosmic'}    | ${true}
-    ${'disco'}     | ${true}
-    ${'eoan'}      | ${true}
-    ${'focal'}     | ${true}
-    ${'groovy'}    | ${true}
-    ${'hirsute'}   | ${true}
-    ${'impish'}    | ${true}
-    ${'jammy'}     | ${true}
+    version             | expected
+    ${undefined}        | ${false}
+    ${null}             | ${false}
+    ${''}               | ${false}
+    ${'xenial'}         | ${true}
+    ${'04.10'}          | ${true}
+    ${'05.04'}          | ${true}
+    ${'05.10'}          | ${true}
+    ${'6.06'}           | ${true}
+    ${'6.10'}           | ${true}
+    ${'7.04'}           | ${true}
+    ${'7.10'}           | ${true}
+    ${'8.04'}           | ${true}
+    ${'8.10'}           | ${true}
+    ${'9.04'}           | ${true}
+    ${'9.10'}           | ${true}
+    ${'10.04.4'}        | ${true}
+    ${'10.10'}          | ${true}
+    ${'11.04'}          | ${true}
+    ${'11.10'}          | ${true}
+    ${'12.04.5'}        | ${true}
+    ${'12.10'}          | ${true}
+    ${'13.04'}          | ${true}
+    ${'13.10'}          | ${true}
+    ${'14.04.6'}        | ${true}
+    ${'14.10'}          | ${true}
+    ${'15.04'}          | ${true}
+    ${'15.10'}          | ${true}
+    ${'16.04.7'}        | ${true}
+    ${'16.10'}          | ${true}
+    ${'17.04'}          | ${true}
+    ${'17.10'}          | ${true}
+    ${'18.04.5'}        | ${true}
+    ${'18.10'}          | ${true}
+    ${'19.04'}          | ${true}
+    ${'19.10'}          | ${true}
+    ${'20.04'}          | ${true}
+    ${'20.10'}          | ${true}
+    ${'2020.04'}        | ${false}
+    ${'xenial'}         | ${true}
+    ${'warty'}          | ${true}
+    ${'hoary'}          | ${true}
+    ${'breezy'}         | ${true}
+    ${'dapper'}         | ${true}
+    ${'edgy'}           | ${true}
+    ${'feisty'}         | ${true}
+    ${'gutsy'}          | ${true}
+    ${'hardy'}          | ${true}
+    ${'intrepid'}       | ${true}
+    ${'jaunty'}         | ${true}
+    ${'karmic'}         | ${true}
+    ${'lucid.4'}        | ${false}
+    ${'maverick'}       | ${true}
+    ${'natty'}          | ${true}
+    ${'oneiric'}        | ${true}
+    ${'precise.5'}      | ${false}
+    ${'quantal'}        | ${true}
+    ${'raring'}         | ${true}
+    ${'saucy'}          | ${true}
+    ${'trusty.6'}       | ${false}
+    ${'utopic'}         | ${true}
+    ${'vivid'}          | ${true}
+    ${'wily'}           | ${true}
+    ${'xenial.7'}       | ${false}
+    ${'yakkety'}        | ${true}
+    ${'zesty'}          | ${true}
+    ${'artful'}         | ${true}
+    ${'bionic.5'}       | ${false}
+    ${'cosmic'}         | ${true}
+    ${'disco'}          | ${true}
+    ${'eoan'}           | ${true}
+    ${'focal'}          | ${true}
+    ${'groovy'}         | ${true}
+    ${'hirsute'}        | ${true}
+    ${'impish'}         | ${true}
+    ${'jammy'}          | ${true}
+    ${'jammy-20230816'} | ${true}
+    ${'jammy-2023086'}  | ${false}
   `('isValid("$version") === $expected', ({ version, expected }) => {
     expect(ubuntu.isValid(version)).toBe(expected);
   });
@@ -247,18 +249,19 @@ describe('modules/versioning/ubuntu/index', () => {
   });
 
   it.each`
-    version       | major   | minor   | patch
-    ${undefined}  | ${null} | ${null} | ${null}
-    ${null}       | ${null} | ${null} | ${null}
-    ${''}         | ${null} | ${null} | ${null}
-    ${'42'}       | ${null} | ${null} | ${null}
-    ${'2020.04'}  | ${null} | ${null} | ${null}
-    ${'04.10'}    | ${4}    | ${10}   | ${null}
-    ${'18.04.5'}  | ${18}   | ${4}    | ${5}
-    ${'20.04'}    | ${20}   | ${4}    | ${null}
-    ${'intrepid'} | ${8}    | ${10}   | ${null}
-    ${'bionic'}   | ${18}   | ${4}    | ${null}
-    ${'focal'}    | ${20}   | ${4}    | ${null}
+    version             | major   | minor   | patch
+    ${undefined}        | ${null} | ${null} | ${null}
+    ${null}             | ${null} | ${null} | ${null}
+    ${''}               | ${null} | ${null} | ${null}
+    ${'42'}             | ${null} | ${null} | ${null}
+    ${'2020.04'}        | ${null} | ${null} | ${null}
+    ${'04.10'}          | ${4}    | ${10}   | ${null}
+    ${'18.04.5'}        | ${18}   | ${4}    | ${5}
+    ${'20.04'}          | ${20}   | ${4}    | ${null}
+    ${'intrepid'}       | ${8}    | ${10}   | ${null}
+    ${'bionic'}         | ${18}   | ${4}    | ${null}
+    ${'focal'}          | ${20}   | ${4}    | ${null}
+    ${'jammy-20230816'} | ${22}   | ${4}    | ${null}
   `(
     'getMajor, getMinor, getPatch for "$version"',
     ({ version, major, minor, patch }) => {
@@ -269,43 +272,50 @@ describe('modules/versioning/ubuntu/index', () => {
   );
 
   it.each`
-    a           | b            | expected
-    ${'20.04'}  | ${'2020.04'} | ${false}
-    ${'17.10'}  | ${'artful'}  | ${true}
-    ${'xenial'} | ${'artful'}  | ${false}
-    ${'17.04'}  | ${'artful'}  | ${false}
-    ${'artful'} | ${'17.10'}   | ${true}
-    ${'16.04'}  | ${'xenial'}  | ${true}
-    ${'focal'}  | ${'20.04'}   | ${true}
-    ${'20.04'}  | ${'focal'}   | ${true}
-    ${'19.10'}  | ${'19.10'}   | ${true}
+    a                   | b                   | expected
+    ${'20.04'}          | ${'2020.04'}        | ${false}
+    ${'17.10'}          | ${'artful'}         | ${true}
+    ${'xenial'}         | ${'artful'}         | ${false}
+    ${'17.04'}          | ${'artful'}         | ${false}
+    ${'artful'}         | ${'17.10'}          | ${true}
+    ${'16.04'}          | ${'xenial'}         | ${true}
+    ${'focal'}          | ${'20.04'}          | ${true}
+    ${'20.04'}          | ${'focal'}          | ${true}
+    ${'19.10'}          | ${'19.10'}          | ${true}
+    ${'jammy'}          | ${'jammy-20230816'} | ${true}
+    ${'jammy-20230816'} | ${'jammy-20230816'} | ${true}
+    ${'jammy-20230716'} | ${'jammy-20230816'} | ${false}
   `('equals($a, $b) === $expected', ({ a, b, expected }) => {
     expect(ubuntu.equals(a, b)).toBe(expected);
   });
 
   it.each`
-    a            | b            | expected
-    ${'20.04'}   | ${'20.10'}   | ${false}
-    ${'20.10'}   | ${'20.04'}   | ${true}
-    ${'19.10'}   | ${'20.04'}   | ${false}
-    ${'20.04'}   | ${'19.10'}   | ${true}
-    ${'16.04'}   | ${'16.04.7'} | ${false}
-    ${'16.04.7'} | ${'16.04'}   | ${true}
-    ${'16.04.1'} | ${'16.04.7'} | ${false}
-    ${'16.04.7'} | ${'16.04.1'} | ${true}
-    ${'19.10.1'} | ${'20.04.1'} | ${false}
-    ${'20.04.1'} | ${'19.10.1'} | ${true}
-    ${'xxx'}     | ${'yyy'}     | ${false}
-    ${'focal'}   | ${'groovy'}  | ${false}
-    ${'groovy'}  | ${'focal'}   | ${true}
-    ${'eoan'}    | ${'focal'}   | ${false}
-    ${'focal'}   | ${'eoan'}    | ${true}
-    ${'vivid'}   | ${'saucy'}   | ${true}
-    ${'impish'}  | ${'focal'}   | ${true}
-    ${'eoan'}    | ${'quantal'} | ${true}
-    ${'focal'}   | ${'lucid'}   | ${true}
-    ${'eoan'}    | ${'focal'}   | ${false}
-    ${'focal'}   | ${'eoan'}    | ${true}
+    a                   | b                   | expected
+    ${'20.04'}          | ${'20.10'}          | ${false}
+    ${'20.10'}          | ${'20.04'}          | ${true}
+    ${'19.10'}          | ${'20.04'}          | ${false}
+    ${'20.04'}          | ${'19.10'}          | ${true}
+    ${'16.04'}          | ${'16.04.7'}        | ${false}
+    ${'16.04.7'}        | ${'16.04'}          | ${true}
+    ${'16.04.1'}        | ${'16.04.7'}        | ${false}
+    ${'16.04.7'}        | ${'16.04.1'}        | ${true}
+    ${'19.10.1'}        | ${'20.04.1'}        | ${false}
+    ${'20.04.1'}        | ${'19.10.1'}        | ${true}
+    ${'xxx'}            | ${'yyy'}            | ${false}
+    ${'focal'}          | ${'groovy'}         | ${false}
+    ${'groovy'}         | ${'focal'}          | ${true}
+    ${'eoan'}           | ${'focal'}          | ${false}
+    ${'focal'}          | ${'eoan'}           | ${true}
+    ${'vivid'}          | ${'saucy'}          | ${true}
+    ${'impish'}         | ${'focal'}          | ${true}
+    ${'eoan'}           | ${'quantal'}        | ${true}
+    ${'focal'}          | ${'lucid'}          | ${true}
+    ${'eoan'}           | ${'focal'}          | ${false}
+    ${'focal'}          | ${'eoan'}           | ${true}
+    ${'jammy'}          | ${'focal'}          | ${true}
+    ${'jammy-20230816'} | ${'focal'}          | ${true}
+    ${'jammy-20230816'} | ${'jammy-20230716'} | ${true}
+    ${'focal-20230816'} | ${'jammy-20230716'} | ${false}
   `('isGreaterThan("$a", "$b") === $expected', ({ a, b, expected }) => {
     expect(ubuntu.isGreaterThan(a, b)).toBe(expected);
   });


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds support for Ubuntu container image tags

<!-- Describe what behavior is changed by this PR. -->

## Context

Want to automatically update Ubuntu image tags when major versions change.

Created after I started this discussion - https://github.com/renovatebot/renovate/discussions/25001

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
