### PR TITLE
fix: add httpsCertificate, httpsPrivateKey and httpsCertificateAuthority into redactedFields

### DIFF
--- a/lib/util/sanitize.ts
+++ b/lib/util/sanitize.ts
@@ -15,6 +15,9 @@ export const redactedFields = [
   'gitPrivateKey',
   'forkToken',
   'password',
+  'httpsCertificate',
+  'httpsPrivateKey',
+  'httpsCertificateAuthority',
 ];
 
 // TODO: returns null or undefined only when input is null or undefined.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
add `httpsCertificate`, `httpsPrivateKey` and `httpsCertificateAuthority` into redactedFields so that they don't show up in the logger

<!-- Describe what behavior is changed by this PR. -->

## Context
When using the [https options to hostRules](https://github.com/renovatebot/renovate/pull/24155) on developing on the discussion of [moving setGlobalHostRules before platform initialisation](https://github.com/renovatebot/renovate/discussions/24660), I realised that those sensitive options might appears in the log as clear text (e.g. when log level = trace). Hence adding those fields to redactedFields.  here is an example output 

```json
           {
             "hostType": "github",
             "matchHost": "some.ghe.host",
             "httpsCertificate": "***********",
             "httpsCertificateAuthority": "***********",
             "httpsPrivateKey": "***********"
           },
```

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [X] No unit tests but ran on a real repository, or
- [] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
