### PR TITLE
chore: allow null value and undefined for validateURL

### DIFF
--- a/lib/util/url.spec.ts
+++ b/lib/util/url.spec.ts
@@ -100,7 +100,7 @@ describe('util/url', () => {
   it('validates URLs', () => {
     expect(validateUrl(undefined)).toBeFalse();
     expect(validateUrl('')).toBeFalse();
-    expect(validateUrl(null as never)).toBeFalse();
+    expect(validateUrl(null)).toBeFalse();
     expect(validateUrl('foo')).toBeFalse();
     expect(validateUrl('ssh://github.com')).toBeFalse();
     expect(validateUrl('http://github.com')).toBeTrue();

--- a/lib/util/url.spec.ts
+++ b/lib/util/url.spec.ts
@@ -98,7 +98,8 @@ describe('util/url', () => {
   });
 
   it('validates URLs', () => {
-    expect(validateUrl()).toBeFalse();
+    expect(validateUrl(undefined)).toBeFalse();
+    expect(validateUrl('')).toBeFalse();
     expect(validateUrl(null as never)).toBeFalse();
     expect(validateUrl('foo')).toBeFalse();
     expect(validateUrl('ssh://github.com')).toBeFalse();

--- a/lib/util/url.ts
+++ b/lib/util/url.ts
@@ -85,8 +85,11 @@ export function getQueryString(params: Record<string, any>): string {
   return usp.toString();
 }
 
-export function validateUrl(url?: string, httpOnly = true): boolean {
-  if (!url) {
+export function validateUrl(
+  url: string | null | undefined,
+  httpOnly = true
+): boolean {
+  if (!is.nonEmptyString(url)) {
     return false;
   }
   try {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Allow null and undefined as parameter for validateURL
<!-- Describe what behavior is changed by this PR. -->

## Context
This is to so simplify usage such as in this case https://github.com/renovatebot/renovate/pull/25008/files#diff-608c92a4a728105c3f92f0c56b45282e40142409b13e5876426118b5eafb7e9dR165
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
