### PR TITLE
feat(hostRules): support https options and platform in host rules from env

### DIFF
--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -277,7 +277,7 @@ Periods (`.`) in host names must be replaced with a single underscore (`_`).
 
 <!-- prettier-ignore -->
 !!! note
-    You can't use these prefixes with the `detectHostRulesFromEnv` config option: `npm_config_`, `npm_lifecycle_`, `npm_package_`.
+    You can't use these prefixes with the `detectHostRulesFromEnv` config option: `npm_config_`, `npm_lifecycle_`, `npm_package_`. In addition, platform host rules will only be picked up when `matchHost` is supplied.
 
 ### npmjs registry token example
 

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -266,11 +266,11 @@ If found, it will be imported into `config.npmrc` with `config.npmrcMerge` set t
 
 The format of the environment variables must follow:
 
-- Datasource name (e.g. `NPM`, `PYPI`)
+- Datasource name (e.g. `NPM`, `PYPI`) or Platform name (e.g. `GITHUB`)
 - Underscore (`_`)
 - `matchHost`
 - Underscore (`_`)
-- Field name (`TOKEN`, `USERNAME`, or `PASSWORD`)
+- Field name (`TOKEN`, `USERNAME`, `PASSWORD`, `HTTPSPRIVATEKEY`, `HTTPSCERTIFICATE`, `HTTPSCERTIFICATEAUTHORITY`)
 
 Hyphens (`-`) in datasource or host name must be replaced with double underscores (`__`).
 Periods (`.`) in host names must be replaced with a single underscore (`_`).
@@ -325,6 +325,24 @@ You can skip the host part, and use only the datasource and credentials.
       "hostType": "docker",
       "username": "bot",
       "password": "botpass123"
+    }
+  ]
+}
+```
+
+### Platform with https authentication options
+
+`GITHUB_SOME_GITHUB__ENTERPRISE_HOST_HTTPSCERTIFICATE=certificate GITHUB_SOME_GITHUB__ENTERPRISE_HOST_HTTPSPRIVATEKEY=private-key GITHUB_SOME_GITHUB__ENTERPRISE_HOST_HTTPSCERTIFICATEAUTHORITY=certificate-authority`:
+
+```json
+{
+  "hostRules": [
+    {
+      "hostType": "github",
+      "matchHost": "some.github-enterprise.host",
+      "httpsPrivateKey": "private-key",
+      "httpsCertificate": "certificate",
+      "httpsCertificateAuthority": "certificate-authority"
     }
   ]
 }

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -266,7 +266,7 @@ If found, it will be imported into `config.npmrc` with `config.npmrcMerge` set t
 
 The format of the environment variables must follow:
 
-- Datasource name (e.g. `NPM`, `PYPI`) or Platform name (e.g. `GITHUB`)
+- Datasource name (e.g. `NPM`, `PYPI`) or Platform name (only  `GITHUB`)
 - Underscore (`_`)
 - `matchHost`
 - Underscore (`_`)

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -277,7 +277,8 @@ Periods (`.`) in host names must be replaced with a single underscore (`_`).
 
 <!-- prettier-ignore -->
 !!! note
-    You can't use these prefixes with the `detectHostRulesFromEnv` config option: `npm_config_`, `npm_lifecycle_`, `npm_package_`. In addition, platform host rules will only be picked up when `matchHost` is supplied.
+    You can't use these prefixes with the `detectHostRulesFromEnv` config option: `npm_config_`, `npm_lifecycle_`, `npm_package_`.
+    In addition, platform host rules will only be picked up when `matchHost` is supplied.
 
 ### npmjs registry token example
 

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -266,7 +266,7 @@ If found, it will be imported into `config.npmrc` with `config.npmrcMerge` set t
 
 The format of the environment variables must follow:
 
-- Datasource name (e.g. `NPM`, `PYPI`) or Platform name (only  `GITHUB`)
+- Datasource name (e.g. `NPM`, `PYPI`) or Platform name (only `GITHUB`)
 - Underscore (`_`)
 - `matchHost`
 - Underscore (`_`)

--- a/lib/types/host-rules.ts
+++ b/lib/types/host-rules.ts
@@ -1,4 +1,4 @@
-export interface HostRuleSearchResult extends Record<string, any> {
+export interface HostRuleSearchResult {
   authType?: string;
   token?: string;
   username?: string;

--- a/lib/types/host-rules.ts
+++ b/lib/types/host-rules.ts
@@ -1,4 +1,4 @@
-export interface HostRuleSearchResult {
+export interface HostRuleSearchResult extends Record<string, any> {
   authType?: string;
   token?: string;
   username?: string;

--- a/lib/workers/global/config/parse/host-rules-from-env.spec.ts
+++ b/lib/workers/global/config/parse/host-rules-from-env.spec.ts
@@ -1,8 +1,4 @@
-import { mockedFunction } from '../../../../../test/util';
-import { getPlatformList as _getPlatformList } from '../../../../modules/platform';
 import { hostRulesFromEnv } from './host-rules-from-env';
-
-const getPlatformList = mockedFunction(_getPlatformList);
 
 describe('workers/global/config/parse/host-rules-from-env', () => {
   it('supports docker username/password', () => {
@@ -56,7 +52,6 @@ describe('workers/global/config/parse/host-rules-from-env', () => {
   });
 
   it('support https authentication options', () => {
-    getPlatformList.mockReturnValue(['github']);
     const envParam: NodeJS.ProcessEnv = {
       GITHUB_SOME_GITHUB__ENTERPRISE_HOST_HTTPSPRIVATEKEY: 'private-key',
       GITHUB_SOME_GITHUB__ENTERPRISE_HOST_HTTPSCERTIFICATE: 'certificate',
@@ -77,8 +72,6 @@ describe('workers/global/config/parse/host-rules-from-env', () => {
   it('make sure {{PLATFORM}}_TOKEN will not be picked up', () => {
     const unsupportedEnv = ['GITHUB_TOKEN'];
 
-    getPlatformList.mockReturnValue(['github']);
-
     for (const e of unsupportedEnv) {
       const envParam: NodeJS.ProcessEnv = {
         [e]: 'private-key',
@@ -97,7 +90,6 @@ describe('workers/global/config/parse/host-rules-from-env', () => {
   });
 
   it('supports platform env token', () => {
-    getPlatformList.mockReturnValue(['github']);
     const envParam: NodeJS.ProcessEnv = {
       GITHUB_SOME_GITHUB__ENTERPRISE_HOST_TOKEN: 'some-token',
     };

--- a/lib/workers/global/config/parse/host-rules-from-env.spec.ts
+++ b/lib/workers/global/config/parse/host-rules-from-env.spec.ts
@@ -75,9 +75,9 @@ describe('workers/global/config/parse/host-rules-from-env', () => {
   });
 
   it('make sure {{PLATFORM}}_TOKEN will not be picked up', () => {
-    const unsupportedEnv = ['BITBUCKET_TOKEN', 'GITHUB_TOKEN', 'GITLAB_TOKEN'];
+    const unsupportedEnv = ['GITHUB_TOKEN'];
 
-    getPlatformList.mockReturnValue(['github', 'bitbucket', 'gitlab']);
+    getPlatformList.mockReturnValue(['github']);
 
     for (const e of unsupportedEnv) {
       const envParam: NodeJS.ProcessEnv = {

--- a/lib/workers/global/config/parse/host-rules-from-env.spec.ts
+++ b/lib/workers/global/config/parse/host-rules-from-env.spec.ts
@@ -1,4 +1,8 @@
+import { mockedFunction } from '../../../../../test/util';
+import { getPlatformList as _getPlatformList } from '../../../../modules/platform';
 import { hostRulesFromEnv } from './host-rules-from-env';
+
+const getPlatformList = mockedFunction(_getPlatformList);
 
 describe('workers/global/config/parse/host-rules-from-env', () => {
   it('supports docker username/password', () => {
@@ -51,12 +55,45 @@ describe('workers/global/config/parse/host-rules-from-env', () => {
     ]);
   });
 
+  it('support https authentication options', () => {
+    getPlatformList.mockReturnValue(['github']);
+    const envParam: NodeJS.ProcessEnv = {
+      GITHUB_SOME_GITHUB__ENTERPRISE_HOST_HTTPSPRIVATEKEY: 'private-key',
+      GITHUB_SOME_GITHUB__ENTERPRISE_HOST_HTTPSCERTIFICATE: 'certificate',
+      GITHUB_SOME_GITHUB__ENTERPRISE_HOST_HTTPSCERTIFICATEAUTHORITY:
+        'certificate-authority',
+    };
+    expect(hostRulesFromEnv(envParam)).toMatchObject([
+      {
+        hostType: 'github',
+        matchHost: 'some.github-enterprise.host',
+        httpsPrivateKey: 'private-key',
+        httpsCertificate: 'certificate',
+        httpsCertificateAuthority: 'certificate-authority',
+      },
+    ]);
+  });
+
   it('supports datasource env token', () => {
     const envParam: NodeJS.ProcessEnv = {
       PYPI_TOKEN: 'some-token',
     };
     expect(hostRulesFromEnv(envParam)).toMatchObject([
       { hostType: 'pypi', token: 'some-token' },
+    ]);
+  });
+
+  it('supports platform env token', () => {
+    getPlatformList.mockReturnValue(['github']);
+    const envParam: NodeJS.ProcessEnv = {
+      GITHUB_SOME_GITHUB__ENTERPRISE_HOST_TOKEN: 'some-token',
+    };
+    expect(hostRulesFromEnv(envParam)).toMatchObject([
+      {
+        hostType: 'github',
+        matchHost: 'some.github-enterprise.host',
+        token: 'some-token',
+      },
     ]);
   });
 

--- a/lib/workers/global/config/parse/host-rules-from-env.spec.ts
+++ b/lib/workers/global/config/parse/host-rules-from-env.spec.ts
@@ -74,6 +74,19 @@ describe('workers/global/config/parse/host-rules-from-env', () => {
     ]);
   });
 
+  it('make sure {{PLATFORM}}_TOKEN will not be picked up', () => {
+    const unsupportedEnv = ['BITBUCKET_TOKEN', 'GITHUB_TOKEN', 'GITLAB_TOKEN'];
+
+    getPlatformList.mockReturnValue(['github', 'bitbucket', 'gitlab']);
+
+    for (const e of unsupportedEnv) {
+      const envParam: NodeJS.ProcessEnv = {
+        [e]: 'private-key',
+      };
+      expect(hostRulesFromEnv(envParam)).toMatchObject([]);
+    }
+  });
+
   it('supports datasource env token', () => {
     const envParam: NodeJS.ProcessEnv = {
       PYPI_TOKEN: 'some-token',

--- a/lib/workers/global/config/parse/host-rules-from-env.ts
+++ b/lib/workers/global/config/parse/host-rules-from-env.ts
@@ -1,5 +1,6 @@
 import { logger } from '../../../../logger';
 import { getDatasourceList } from '../../../../modules/datasource';
+import { getPlatformList } from '../../../../modules/platform';
 import type { HostRule } from '../../../../types';
 
 type AuthField = 'token' | 'username' | 'password';
@@ -36,6 +37,7 @@ function restoreHttpsArgs(x: HttpsAuthField): string {
 
 export function hostRulesFromEnv(env: NodeJS.ProcessEnv): HostRule[] {
   const datasources = new Set(getDatasourceList());
+  const platforms = new Set(getPlatformList());
 
   const hostRules: HostRule[] = [];
 
@@ -49,7 +51,7 @@ export function hostRulesFromEnv(env: NodeJS.ProcessEnv): HostRule[] {
     // Double underscore __ is used in place of hyphen -
     const splitEnv = envName.toLowerCase().replace(/__/g, '-').split('_');
     const hostType = splitEnv.shift()!;
-    if (datasources.has(hostType)) {
+    if (datasources.has(hostType) || platforms.has(hostType)) {
       let suffix = splitEnv.pop()!;
       if (isAuthField(suffix) || isHttpsAuthField(suffix)) {
         if (isHttpsAuthField(suffix)) {

--- a/lib/workers/global/config/parse/host-rules-from-env.ts
+++ b/lib/workers/global/config/parse/host-rules-from-env.ts
@@ -21,7 +21,7 @@ function isHttpsAuthField(x: unknown): x is HttpsAuthField {
   );
 }
 
-function restoreHttpsAuthField(x: HttpsAuthField): string {
+function restoreHttpsAuthField(x: HttpsAuthField | AuthField): string {
   switch (x) {
     case 'httpsprivatekey':
       return 'httpsPrivateKey';
@@ -30,6 +30,8 @@ function restoreHttpsAuthField(x: HttpsAuthField): string {
     case 'httpscertificateauthority':
       return 'httpsCertificateAuthority';
   }
+
+  return x;
 }
 
 function setHostRuleValue(
@@ -71,7 +73,7 @@ export function hostRulesFromEnv(env: NodeJS.ProcessEnv): HostRule[] {
       (platforms.has(hostType) && splitEnv.length > 1)
     ) {
       let suffix = splitEnv.pop()!;
-      if (isHttpsAuthField(suffix)) {
+      if (isAuthField(suffix) || isHttpsAuthField(suffix)) {
         suffix = restoreHttpsAuthField(suffix);
 
         let matchHost: string | undefined = undefined;

--- a/lib/workers/global/config/parse/host-rules-from-env.ts
+++ b/lib/workers/global/config/parse/host-rules-from-env.ts
@@ -30,8 +30,6 @@ function restoreHttpsAuthField(x: HttpsAuthField): string {
       return 'httpsCertificate';
     case 'httpscertificateauthority':
       return 'httpsCertificateAuthority';
-    default:
-      return x;
   }
 }
 

--- a/lib/workers/global/config/parse/host-rules-from-env.ts
+++ b/lib/workers/global/config/parse/host-rules-from-env.ts
@@ -22,7 +22,7 @@ function isHttpsAuthField(x: unknown): x is HttpsAuthField {
   );
 }
 
-function restoreHttpsArgs(x: HttpsAuthField): string {
+function restoreHttpsAuthField(x: HttpsAuthField): string {
   switch (x) {
     case 'httpsprivatekey':
       return 'httpsPrivateKey';
@@ -55,7 +55,7 @@ export function hostRulesFromEnv(env: NodeJS.ProcessEnv): HostRule[] {
       let suffix = splitEnv.pop()!;
       if (isAuthField(suffix) || isHttpsAuthField(suffix)) {
         if (isHttpsAuthField(suffix)) {
-          suffix = restoreHttpsArgs(suffix);
+          suffix = restoreHttpsAuthField(suffix);
         }
 
         let matchHost: string | undefined = undefined;

--- a/lib/workers/global/config/parse/host-rules-from-env.ts
+++ b/lib/workers/global/config/parse/host-rules-from-env.ts
@@ -49,7 +49,10 @@ export function hostRulesFromEnv(env: NodeJS.ProcessEnv): HostRule[] {
     // Double underscore __ is used in place of hyphen -
     const splitEnv = envName.toLowerCase().replace(/__/g, '-').split('_');
     const hostType = splitEnv.shift()!;
-    if (datasources.has(hostType) || platforms.has(hostType)) {
+    if (
+      datasources.has(hostType) ||
+      (platforms.has(hostType) && splitEnv.length > 1)
+    ) {
       let suffix = splitEnv.pop()!;
       if (isAuthField(suffix) || isHttpsAuthField(suffix)) {
         if (isHttpsAuthField(suffix)) {

--- a/lib/workers/global/config/parse/host-rules-from-env.ts
+++ b/lib/workers/global/config/parse/host-rules-from-env.ts
@@ -37,17 +37,16 @@ function setHostRuleValue(
   key: string,
   value: string | undefined
 ): void {
-  if (value === undefined) {
-    return;
-  }
-  switch (key) {
-    case 'token':
-    case 'username':
-    case 'password':
-    case 'httpsCertificateAuthority':
-    case 'httpsCertificate':
-    case 'httpsPrivateKey':
-      rule[key] = value!;
+  if (value !== undefined) {
+    switch (key) {
+      case 'token':
+      case 'username':
+      case 'password':
+      case 'httpsCertificateAuthority':
+      case 'httpsCertificate':
+      case 'httpsPrivateKey':
+        rule[key] = value!;
+    }
   }
 }
 

--- a/lib/workers/global/config/parse/host-rules-from-env.ts
+++ b/lib/workers/global/config/parse/host-rules-from-env.ts
@@ -32,6 +32,25 @@ function restoreHttpsAuthField(x: HttpsAuthField): string {
   }
 }
 
+function setHostRuleValue(
+  rule: HostRule,
+  key: string,
+  value: string | undefined
+): void {
+  if (value === undefined) {
+    return;
+  }
+  switch (key) {
+    case 'token':
+    case 'username':
+    case 'password':
+    case 'httpsCertificateAuthority':
+    case 'httpsCertificate':
+    case 'httpsPrivateKey':
+      rule[key] = value!;
+  }
+}
+
 export function hostRulesFromEnv(env: NodeJS.ProcessEnv): HostRule[] {
   const datasources = new Set(getDatasourceList());
   const platforms = new Set(['github']);
@@ -60,7 +79,7 @@ export function hostRulesFromEnv(env: NodeJS.ProcessEnv): HostRule[] {
 
         let matchHost: string | undefined = undefined;
         const rule: HostRule = {};
-        rule[suffix] = env[envName];
+        setHostRuleValue(rule, suffix, env[envName]);
         if (splitEnv.length === 0) {
           // host-less rule
         } else if (splitEnv.length === 1) {
@@ -75,7 +94,7 @@ export function hostRulesFromEnv(env: NodeJS.ProcessEnv): HostRule[] {
         logger.debug(`Converting ${envName} into a global host rule`);
         if (existingRule) {
           // Add current field to existing rule
-          existingRule[suffix] = env[envName];
+          setHostRuleValue(existingRule, suffix, env[envName]);
         } else {
           // Create a new rule
           const newRule: HostRule = {
@@ -84,7 +103,7 @@ export function hostRulesFromEnv(env: NodeJS.ProcessEnv): HostRule[] {
           if (matchHost) {
             newRule.matchHost = matchHost;
           }
-          newRule[suffix] = env[envName];
+          setHostRuleValue(newRule, suffix, env[envName]);
           hostRules.push(newRule);
         }
       }

--- a/lib/workers/global/config/parse/host-rules-from-env.ts
+++ b/lib/workers/global/config/parse/host-rules-from-env.ts
@@ -1,6 +1,5 @@
 import { logger } from '../../../../logger';
 import { getDatasourceList } from '../../../../modules/datasource';
-import { getPlatformList } from '../../../../modules/platform';
 import type { HostRule } from '../../../../types';
 
 type AuthField = 'token' | 'username' | 'password';
@@ -35,7 +34,7 @@ function restoreHttpsAuthField(x: HttpsAuthField): string {
 
 export function hostRulesFromEnv(env: NodeJS.ProcessEnv): HostRule[] {
   const datasources = new Set(getDatasourceList());
-  const platforms = new Set(getPlatformList());
+  const platforms = new Set(['github']);
 
   const hostRules: HostRule[] = [];
 

--- a/lib/workers/global/config/parse/host-rules-from-env.ts
+++ b/lib/workers/global/config/parse/host-rules-from-env.ts
@@ -45,7 +45,7 @@ function setHostRuleValue(
       case 'httpsCertificateAuthority':
       case 'httpsCertificate':
       case 'httpsPrivateKey':
-        rule[key] = value!;
+        rule[key] = value;
     }
   }
 }
@@ -71,10 +71,8 @@ export function hostRulesFromEnv(env: NodeJS.ProcessEnv): HostRule[] {
       (platforms.has(hostType) && splitEnv.length > 1)
     ) {
       let suffix = splitEnv.pop()!;
-      if (isAuthField(suffix) || isHttpsAuthField(suffix)) {
-        if (isHttpsAuthField(suffix)) {
-          suffix = restoreHttpsAuthField(suffix);
-        }
+      if (isHttpsAuthField(suffix)) {
+        suffix = restoreHttpsAuthField(suffix);
 
         let matchHost: string | undefined = undefined;
         const rule: HostRule = {};


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
<!-- Describe what behavior is changed by this PR. -->
made `hostRulesFromEnv` able to:

* pick up https options from environment variables.
* pick up credentials for platform in additional to datasource

## Context
As per changes for [discussion of moving setGlobalHostRules before platform initialisation](https://github.com/renovatebot/renovate/discussions/24660). Renovate needs to be able to pickup [https options](https://github.com/renovatebot/renovate/pull/24155) from environment variable and apply before platform initialisation.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [X] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [X] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
