### PR TITLE
chore: drop `priority-5-triage` label

### DIFF
--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -202,7 +202,6 @@
   unlabel:
     - 'type:bug'
     - 'type:feature'
-    - 'priority-5-triage'
     - 'status:requirements'
   comment: >
     **Please create a GitHub Discussion instead of this issue.**

--- a/docs/development/issue-labeling.md
+++ b/docs/development/issue-labeling.md
@@ -72,17 +72,15 @@ Add the `breaking` label for Issues or PRs which have changes that are not backw
     priority-2-high
     priority-3-medium
     priority-4-low
-    priority-5-triage
 
 </details>
 
 Use these to assign a priority level to an issue.
-Incoming issues are labeled `priority-5-triage` by default, this label should be replaced with a proper priority (low/medium/high/critical).
 Try to select the proper priority.
 Nothing bad will happen if you select a "wrong" priority.
 At a high level: critical = needs immediate fix, high = to be prioritized ahead of others, medium = default priority, low = trivial issue, or impacts a very small percentage of the user base.
 
-Use [this search](https://github.com/renovatebot/renovate/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+-label%3Apriority-1-critical+-label%3Apriority-2-high+-label%3Apriority-3-medium+-label%3Apriority-4-low++-label%3Apriority-5-triage) to find any issues which are missing a priority label.
+Use [this search](https://github.com/renovatebot/renovate/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+-label%3Apriority-1-critical+-label%3Apriority-2-high+-label%3Apriority-3-medium+-label%3Apriority-4-low) to find any issues which are missing a priority label.
 
 ### Platform
 

--- a/tools/docs/github-query-items.ts
+++ b/tools/docs/github-query-items.ts
@@ -46,7 +46,7 @@ export interface Items {
 }
 
 export async function getOpenGitHubItems(): Promise<RenovateOpenItems> {
-  const q = `repo:renovatebot/renovate type:issue is:open -label:priority-5-triage`;
+  const q = `repo:renovatebot/renovate type:issue is:open`;
   const per_page = 100;
   try {
     const query = getQueryString({ q, per_page });


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Drop `priority-5-triage` label

## Context

Closes #25022.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
