### PR TITLE
fix: add `remark-html` to `monorepo:remark`

### DIFF
--- a/lib/config/presets/internal/monorepo.ts
+++ b/lib/config/presets/internal/monorepo.ts
@@ -391,7 +391,10 @@ const repoGroups = {
   redwood: 'https://github.com/redwoodjs/redwood',
   refit: 'https://github.com/reactiveui/refit',
   'reg-suit': 'https://github.com/reg-viz/reg-suit',
-  remark: 'https://github.com/remarkjs/remark',
+  remark: [
+    'https://github.com/remarkjs/remark',
+    'https://github.com/remarkjs/remark-html',
+  ],
   remix: 'https://github.com/remix-run/remix',
   rjsf: 'https://github.com/rjsf-team/react-jsonschema-form',
   router5: 'https://github.com/router5/router5',


### PR DESCRIPTION
`monorepo:remark` in docs https://docs.renovatebot.com/presets-monorepo/#monoreporemark

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Add `remark-html` to the `monorepo:remark` preset

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

It seems that upgrading `remark-html` to the major version `16.0.1` caused breakages in the types, which are mitigated by also upgrading `remark`

@wooorm would you suggest any other package repos be added as part of Renovate's `monorepo:remark`?

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required (I believe the docs page is autogenerated)

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
