### PR TITLE
feat(nuget): adds package source mapping and generate cached NuGet.config without CLI commands

### DIFF
--- a/lib/modules/manager/nuget/artifacts.ts
+++ b/lib/modules/manager/nuget/artifacts.ts
@@ -19,23 +19,28 @@ import type {
   UpdateArtifactsConfig,
   UpdateArtifactsResult,
 } from '../types';
+import { createNuGetConfigXml } from './config-formatter';
 import {
   MSBUILD_CENTRAL_FILE,
   NUGET_CENTRAL_FILE,
   getDependentPackageFiles,
 } from './package-tree';
-import { formatNuGetConfigXmlContents } from './util';
+import { getConfiguredRegistries, getDefaultRegistries } from './util';
 
 async function createCachedNuGetConfigFile(
   nugetCacheDir: string,
   packageFileName: string
 ): Promise<string> {
-  const nugetConfigFile = join(nugetCacheDir, `nuget.config`);
-  await ensureDir(nugetCacheDir);
-  const contents = await formatNuGetConfigXmlContents(packageFileName);
-  await outputCacheFile(nugetConfigFile, contents);
+  const registries =
+    (await getConfiguredRegistries(packageFileName)) ?? getDefaultRegistries();
 
-  return nugetConfigFile;
+  const contents = createNuGetConfigXml(registries);
+
+  const cachedNugetConfigFile = join(nugetCacheDir, `nuget.config`);
+  await ensureDir(nugetCacheDir);
+  await outputCacheFile(cachedNugetConfigFile, contents);
+
+  return cachedNugetConfigFile;
 }
 
 async function runDotnetRestore(

--- a/lib/modules/manager/nuget/artifacts.ts
+++ b/lib/modules/manager/nuget/artifacts.ts
@@ -13,10 +13,7 @@ import {
   writeLocalFile,
 } from '../../../util/fs';
 import { getFiles } from '../../../util/git';
-import * as hostRules from '../../../util/host-rules';
 import { regEx } from '../../../util/regex';
-import { NugetDatasource } from '../../datasource/nuget';
-import { parseRegistryUrl } from '../../datasource/nuget/common';
 import type {
   UpdateArtifact,
   UpdateArtifactsConfig,
@@ -27,43 +24,18 @@ import {
   NUGET_CENTRAL_FILE,
   getDependentPackageFiles,
 } from './package-tree';
-import { getConfiguredRegistries, getDefaultRegistries } from './util';
+import { formatNuGetConfigXmlContents } from './util';
 
-async function addSourceCmds(
-  packageFileName: string,
-  _config: UpdateArtifactsConfig,
-  nugetConfigFile: string
-): Promise<string[]> {
-  const registries =
-    (await getConfiguredRegistries(packageFileName)) ?? getDefaultRegistries();
-  const result: string[] = [];
-  for (const registry of registries) {
-    const { password, username } = hostRules.find({
-      hostType: NugetDatasource.id,
-      url: registry.url,
-    });
-    const registryInfo = parseRegistryUrl(registry.url);
-    let addSourceCmd = `dotnet nuget add source ${quote(
-      registryInfo.feedUrl
-    )} --configfile ${quote(nugetConfigFile)}`;
-    if (registry.name) {
-      // Add name for registry, if known.
-      addSourceCmd += ` --name ${quote(registry.name)}`;
-    }
-    // Add registry credentials from host rules, if configured.
-    if (username) {
-      // Add username from host rules, if configured.
-      addSourceCmd += ` --username ${quote(username)}`;
-    }
-    if (password) {
-      // Add password from host rules, if configured.
-      addSourceCmd += ` --password ${quote(
-        password
-      )} --store-password-in-clear-text`;
-    }
-    result.push(addSourceCmd);
-  }
-  return result;
+async function createCachedNuGetConfigFile(
+  nugetCacheDir: string,
+  packageFileName: string
+): Promise<string> {
+  const nugetConfigFile = join(nugetCacheDir, `nuget.config`);
+  await ensureDir(nugetCacheDir);
+  const contents = await formatNuGetConfigXmlContents(packageFileName);
+  await outputCacheFile(nugetConfigFile, contents);
+
+  return nugetConfigFile;
 }
 
 async function runDotnetRestore(
@@ -72,6 +44,11 @@ async function runDotnetRestore(
   config: UpdateArtifactsConfig
 ): Promise<void> {
   const nugetCacheDir = join(privateCacheDir(), 'nuget');
+
+  const nugetConfigFile = await createCachedNuGetConfigFile(
+    nugetCacheDir,
+    packageFileName
+  );
 
   const execOptions: ExecOptions = {
     docker: {},
@@ -84,17 +61,7 @@ async function runDotnetRestore(
     ],
   };
 
-  const nugetConfigFile = join(nugetCacheDir, `nuget.config`);
-
-  await ensureDir(nugetCacheDir);
-
-  await outputCacheFile(
-    nugetConfigFile,
-    `<?xml version="1.0" encoding="utf-8"?>\n<configuration>\n</configuration>\n`
-  );
-
   const cmds = [
-    ...(await addSourceCmds(packageFileName, config, nugetConfigFile)),
     ...dependentPackageFileNames.map(
       (fileName) =>
         `dotnet restore ${quote(

--- a/lib/modules/manager/nuget/config-formatter.spec.ts
+++ b/lib/modules/manager/nuget/config-formatter.spec.ts
@@ -48,7 +48,6 @@ describe('modules/manager/nuget/config-formatter', () => {
         'key',
         'myRegistry2'
       );
-      expect(myRegistry2).toBeDefined();
       expect(myRegistry2?.name).toBe('add');
       expect(myRegistry2?.attr['value']).toBe(
         'https://my-registry2.example.org/index.json'

--- a/lib/modules/manager/nuget/config-formatter.spec.ts
+++ b/lib/modules/manager/nuget/config-formatter.spec.ts
@@ -39,7 +39,7 @@ describe('modules/manager/nuget/config-formatter', () => {
         'myRegistry'
       );
       expect(myRegistry).toBeDefined();
-      expect(myRegistry?.name).toBe('packageSource');
+      expect(myRegistry?.name).toBe('add');
       expect(myRegistry?.attr['value']).toBe(
         'https://my-registry.example.org/'
       );
@@ -50,7 +50,7 @@ describe('modules/manager/nuget/config-formatter', () => {
         'myRegistry2'
       );
       expect(myRegistry2).toBeDefined();
-      expect(myRegistry2?.name).toBe('packageSource');
+      expect(myRegistry2?.name).toBe('add');
       expect(myRegistry2?.attr['value']).toBe(
         'https://my-registry2.example.org/index.json'
       );
@@ -95,13 +95,13 @@ describe('modules/manager/nuget/config-formatter', () => {
         'myRegistry'
       );
       expect(myRegistry).toBeDefined();
-      expect(myRegistry?.name).toBe('packageSource');
+      expect(myRegistry?.name).toBe('add');
 
       const myRegistry2 = packageSources?.childWithAttribute(
         'key',
         'myRegistry2'
       );
-      expect(myRegistry2?.name).toBe('packageSource');
+      expect(myRegistry2?.name).toBe('add');
       expect(myRegistry2).toBeDefined();
 
       const myRegistryCredentials = xmlDocument.descendantWithPath(

--- a/lib/modules/manager/nuget/config-formatter.spec.ts
+++ b/lib/modules/manager/nuget/config-formatter.spec.ts
@@ -92,7 +92,6 @@ describe('modules/manager/nuget/config-formatter', () => {
         'key',
         'myRegistry'
       );
-      expect(myRegistry).toBeDefined();
       expect(myRegistry?.name).toBe('add');
 
       const myRegistry2 = packageSources?.childWithAttribute(

--- a/lib/modules/manager/nuget/config-formatter.spec.ts
+++ b/lib/modules/manager/nuget/config-formatter.spec.ts
@@ -102,7 +102,6 @@ describe('modules/manager/nuget/config-formatter', () => {
         'myRegistry2'
       );
       expect(myRegistry2?.name).toBe('add');
-      expect(myRegistry2).toBeDefined();
 
       const myRegistryCredentials = xmlDocument.descendantWithPath(
         'packageSourceCredentials.myRegistry'

--- a/lib/modules/manager/nuget/config-formatter.spec.ts
+++ b/lib/modules/manager/nuget/config-formatter.spec.ts
@@ -174,7 +174,6 @@ describe('modules/manager/nuget/config-formatter', () => {
         'key',
         'myRegistry'
       );
-      expect(myRegistry).toBeDefined();
       expect(myRegistry?.attr['value']).toBe(
         'https://my-registry.example.org/'
       );

--- a/lib/modules/manager/nuget/config-formatter.spec.ts
+++ b/lib/modules/manager/nuget/config-formatter.spec.ts
@@ -227,7 +227,6 @@ describe('modules/manager/nuget/config-formatter', () => {
         'key',
         'myRegistry'
       );
-      expect(myRegistryMaps).toBeDefined();
       expect(myRegistryMaps?.name).toBe('packageSource');
       expect(myRegistryMaps?.childNamed('package')?.attr['pattern']).toBe('*');
 

--- a/lib/modules/manager/nuget/config-formatter.spec.ts
+++ b/lib/modules/manager/nuget/config-formatter.spec.ts
@@ -1,5 +1,5 @@
 import { XmlDocument } from 'xmldoc';
-import * as _hostRules from '../../../util/host-rules';
+import * as hostRules from '../../../util/host-rules';
 import { createNuGetConfigXml } from './config-formatter';
 import type { Registry } from './types';
 

--- a/lib/modules/manager/nuget/config-formatter.spec.ts
+++ b/lib/modules/manager/nuget/config-formatter.spec.ts
@@ -1,3 +1,4 @@
+import { execUtils } from '@yarnpkg/core';
 import { mockDeep } from 'jest-mock-extended';
 import { XmlDocument } from 'xmldoc';
 import { mocked } from '../../../../test/util';
@@ -39,6 +40,7 @@ describe('modules/manager/nuget/config-formatter', () => {
         'myRegistry'
       );
       expect(myRegistry).toBeDefined();
+      expect(myRegistry?.name).toBe('packageSource');
       expect(myRegistry?.attr['value']).toBe(
         'https://my-registry.example.org/'
       );
@@ -49,6 +51,7 @@ describe('modules/manager/nuget/config-formatter', () => {
         'myRegistry2'
       );
       expect(myRegistry2).toBeDefined();
+      expect(myRegistry2?.name).toBe('packageSource');
       expect(myRegistry2?.attr['value']).toBe(
         'https://my-registry2.example.org/index.json'
       );
@@ -93,11 +96,13 @@ describe('modules/manager/nuget/config-formatter', () => {
         'myRegistry'
       );
       expect(myRegistry).toBeDefined();
+      expect(myRegistry?.name).toBe('packageSource');
 
       const myRegistry2 = packageSources?.childWithAttribute(
         'key',
         'myRegistry2'
       );
+      expect(myRegistry2?.name).toBe('packageSource');
       expect(myRegistry2).toBeDefined();
 
       const myRegistryCredentials = xmlDocument.descendantWithPath(
@@ -228,6 +233,7 @@ describe('modules/manager/nuget/config-formatter', () => {
         'myRegistry'
       );
       expect(myRegistryMaps).toBeDefined();
+      expect(myRegistryMaps?.name).toBe('packageSource');
       expect(myRegistryMaps?.childNamed('package')?.attr['pattern']).toBe('*');
 
       const myRegistry2Maps = packageSourceMapping?.childWithAttribute(
@@ -235,6 +241,7 @@ describe('modules/manager/nuget/config-formatter', () => {
         'myRegistry2'
       );
       expect(myRegistry2Maps).toBeDefined();
+      expect(myRegistry2Maps?.name).toBe('packageSource');
       expect(
         myRegistry2Maps
           ?.childrenNamed('package')

--- a/lib/modules/manager/nuget/config-formatter.spec.ts
+++ b/lib/modules/manager/nuget/config-formatter.spec.ts
@@ -142,7 +142,6 @@ describe('modules/manager/nuget/config-formatter', () => {
           'my__x0020__very__x003f____x0020__weird__x0021__-regi__x0024__try_name'
         );
 
-      expect(registryCredentialsWithSpecialName).toBeDefined();
       expect(
         registryCredentialsWithSpecialName?.childWithAttribute(
           'key',

--- a/lib/modules/manager/nuget/config-formatter.spec.ts
+++ b/lib/modules/manager/nuget/config-formatter.spec.ts
@@ -1,4 +1,3 @@
-import { execUtils } from '@yarnpkg/core';
 import { mockDeep } from 'jest-mock-extended';
 import { XmlDocument } from 'xmldoc';
 import { mocked } from '../../../../test/util';

--- a/lib/modules/manager/nuget/config-formatter.spec.ts
+++ b/lib/modules/manager/nuget/config-formatter.spec.ts
@@ -19,6 +19,9 @@ describe('modules/manager/nuget/config-formatter', () => {
           name: 'myRegistry2',
           url: 'https://my-registry2.example.org/index.json',
         },
+        {
+          url: 'https://my-unnamed-registry.example.org/index.json',
+        },
       ];
 
       const xml = createNuGetConfigXml(registries);
@@ -45,6 +48,13 @@ describe('modules/manager/nuget/config-formatter', () => {
         'https://my-registry2.example.org/index.json'
       );
       expect(myRegistry2?.attr['protocolVersion']).toBe('3');
+
+      const myUnnamedRegistry = packageSources?.childWithAttribute(
+        'value',
+        'https://my-unnamed-registry.example.org/index.json'
+      );
+      expect(myUnnamedRegistry?.name).toBe('add');
+      expect(myUnnamedRegistry?.attr['key']).toBe('Package source 1');
     });
 
     it('returns xml with authenticated registries', () => {

--- a/lib/modules/manager/nuget/config-formatter.spec.ts
+++ b/lib/modules/manager/nuget/config-formatter.spec.ts
@@ -38,7 +38,6 @@ describe('modules/manager/nuget/config-formatter', () => {
         'key',
         'myRegistry'
       );
-      expect(myRegistry).toBeDefined();
       expect(myRegistry?.name).toBe('add');
       expect(myRegistry?.attr['value']).toBe(
         'https://my-registry.example.org/'

--- a/lib/modules/manager/nuget/config-formatter.spec.ts
+++ b/lib/modules/manager/nuget/config-formatter.spec.ts
@@ -1,20 +1,12 @@
-import { mockDeep } from 'jest-mock-extended';
 import { XmlDocument } from 'xmldoc';
-import { mocked } from '../../../../test/util';
 import * as _hostRules from '../../../util/host-rules';
 import { createNuGetConfigXml } from './config-formatter';
 import type { Registry } from './types';
 
-jest.mock('../../../util/host-rules', () => mockDeep());
-
-const hostRules = mocked(_hostRules);
-
 describe('modules/manager/nuget/config-formatter', () => {
   describe('createNuGetConfigXml', () => {
     beforeEach(() => {
-      hostRules.find.mockImplementation((search) => {
-        return {};
-      });
+      _hostRules.clear();
     });
 
     it('returns xml with registries', () => {
@@ -56,20 +48,16 @@ describe('modules/manager/nuget/config-formatter', () => {
     });
 
     it('returns xml with authenticated registries', () => {
-      hostRules.find.mockImplementation((search) => {
-        if (search.hostType === 'nuget') {
-          if (search.url === 'https://my-registry.example.org') {
-            return {
-              username: 'some-username',
-              password: 'some-password',
-            };
-          } else {
-            return {
-              password: 'some-password',
-            };
-          }
-        }
-        return {};
+      _hostRules.add({
+        hostType: 'nuget',
+        matchHost: 'my-registry.example.org',
+        username: 'some-username',
+        password: 'some-password',
+      });
+      _hostRules.add({
+        hostType: 'nuget',
+        matchHost: 'my-registry2.example.org',
+        password: 'some-password',
       });
 
       const registries: Registry[] = [
@@ -129,14 +117,11 @@ describe('modules/manager/nuget/config-formatter', () => {
     });
 
     it('escapes registry credential names containing special characters', () => {
-      hostRules.find.mockImplementation((search) => {
-        if (search.hostType === 'nuget') {
-          return {
-            username: 'some-username',
-            password: 'some-password',
-          };
-        }
-        return {};
+      _hostRules.add({
+        hostType: 'nuget',
+        matchHost: 'my-registry.example.org',
+        username: 'some-username',
+        password: 'some-password',
       });
 
       const registries: Registry[] = [

--- a/lib/modules/manager/nuget/config-formatter.spec.ts
+++ b/lib/modules/manager/nuget/config-formatter.spec.ts
@@ -1,0 +1,265 @@
+import { mockDeep } from 'jest-mock-extended';
+import { XmlDocument } from 'xmldoc';
+import { mocked } from '../../../../test/util';
+import * as _hostRules from '../../../util/host-rules';
+import { createNuGetConfigXml } from './config-formatter';
+import type { Registry } from './types';
+
+jest.mock('../../../util/host-rules', () => mockDeep());
+
+const hostRules = mocked(_hostRules);
+
+describe('modules/manager/nuget/config-formatter', () => {
+  describe('createNuGetConfigXml', () => {
+    beforeEach(() => {
+      hostRules.find.mockImplementation((search) => {
+        return {};
+      });
+    });
+
+    it('returns xml with registries', () => {
+      const registries: Registry[] = [
+        {
+          name: 'myRegistry',
+          url: 'https://my-registry.example.org',
+        },
+        {
+          name: 'myRegistry2',
+          url: 'https://my-registry2.example.org/index.json',
+        },
+      ];
+
+      const xml = createNuGetConfigXml(registries);
+      const xmlDocument = new XmlDocument(xml);
+      const packageSources = xmlDocument.childNamed('packageSources');
+      expect(packageSources).toBeDefined();
+
+      const myRegistry = packageSources?.childWithAttribute(
+        'key',
+        'myRegistry'
+      );
+      expect(myRegistry).toBeDefined();
+      expect(myRegistry?.attr['value']).toBe(
+        'https://my-registry.example.org/'
+      );
+      expect(myRegistry?.attr['protocolVersion']).toBe('2');
+
+      const myRegistry2 = packageSources?.childWithAttribute(
+        'key',
+        'myRegistry2'
+      );
+      expect(myRegistry2).toBeDefined();
+      expect(myRegistry2?.attr['value']).toBe(
+        'https://my-registry2.example.org/index.json'
+      );
+      expect(myRegistry2?.attr['protocolVersion']).toBe('3');
+    });
+
+    it('returns xml with authenticated registries', () => {
+      hostRules.find.mockImplementation((search) => {
+        if (search.hostType === 'nuget') {
+          if (search.url === 'https://my-registry.example.org') {
+            return {
+              username: 'some-username',
+              password: 'some-password',
+            };
+          } else {
+            return {
+              password: 'some-password',
+            };
+          }
+        }
+        return {};
+      });
+
+      const registries: Registry[] = [
+        {
+          name: 'myRegistry',
+          url: 'https://my-registry.example.org',
+        },
+        {
+          name: 'myRegistry2',
+          url: 'https://my-registry2.example.org',
+        },
+      ];
+
+      const xml = createNuGetConfigXml(registries);
+      const xmlDocument = new XmlDocument(xml);
+      const packageSources = xmlDocument.childNamed('packageSources');
+      expect(packageSources).toBeDefined();
+
+      const myRegistry = packageSources?.childWithAttribute(
+        'key',
+        'myRegistry'
+      );
+      expect(myRegistry).toBeDefined();
+
+      const myRegistry2 = packageSources?.childWithAttribute(
+        'key',
+        'myRegistry2'
+      );
+      expect(myRegistry2).toBeDefined();
+
+      const myRegistryCredentials = xmlDocument.descendantWithPath(
+        'packageSourceCredentials.myRegistry'
+      );
+      expect(myRegistryCredentials).toBeDefined();
+      expect(
+        myRegistryCredentials?.childWithAttribute('key', 'Username')?.attr[
+          'value'
+        ]
+      ).toBe('some-username');
+
+      expect(
+        myRegistryCredentials?.childWithAttribute('key', 'ClearTextPassword')
+          ?.attr['value']
+      ).toBe('some-password');
+
+      const myRegistry2Credentials = xmlDocument.descendantWithPath(
+        'packageSourceCredentials.myRegistry2'
+      );
+      expect(myRegistry2Credentials).toBeDefined();
+      expect(
+        myRegistry2Credentials?.childWithAttribute('key', 'Username')
+      ).toBeUndefined();
+      expect(
+        myRegistry2Credentials?.childWithAttribute('key', 'ClearTextPassword')
+          ?.attr['value']
+      ).toBe('some-password');
+    });
+
+    it('escapes registry credential names containing special characters', () => {
+      hostRules.find.mockImplementation((search) => {
+        if (search.hostType === 'nuget') {
+          return {
+            username: 'some-username',
+            password: 'some-password',
+          };
+        }
+        return {};
+      });
+
+      const registries: Registry[] = [
+        {
+          name: 'my very? weird!-regi$try_name',
+          url: 'https://my-registry.example.org',
+        },
+      ];
+
+      const xml = createNuGetConfigXml(registries);
+      const xmlDocument = new XmlDocument(xml);
+
+      const packageSourceCredentials = xmlDocument.childNamed(
+        'packageSourceCredentials'
+      );
+      expect(packageSourceCredentials).toBeDefined();
+
+      const registryCredentialsWithSpecialName =
+        packageSourceCredentials?.childNamed(
+          'my__x0020__very__x003f____x0020__weird__x0021__-regi__x0024__try_name'
+        );
+
+      expect(registryCredentialsWithSpecialName).toBeDefined();
+      expect(
+        registryCredentialsWithSpecialName?.childWithAttribute(
+          'key',
+          'Username'
+        )?.attr['value']
+      ).toBe('some-username');
+
+      expect(
+        registryCredentialsWithSpecialName?.childWithAttribute(
+          'key',
+          'ClearTextPassword'
+        )?.attr['value']
+      ).toBe('some-password');
+    });
+
+    it('strips protocol version from feed url', () => {
+      const registries: Registry[] = [
+        {
+          name: 'myRegistry',
+          url: 'https://my-registry.example.org#protocolVersion=3',
+        },
+      ];
+
+      const xml = createNuGetConfigXml(registries);
+      const xmlDocument = new XmlDocument(xml);
+      const packageSources = xmlDocument.childNamed('packageSources');
+      expect(packageSources).toBeDefined();
+
+      const myRegistry = packageSources?.childWithAttribute(
+        'key',
+        'myRegistry'
+      );
+      expect(myRegistry).toBeDefined();
+      expect(myRegistry?.attr['value']).toBe(
+        'https://my-registry.example.org/'
+      );
+      expect(myRegistry?.attr['protocolVersion']).toBe('3');
+    });
+
+    it('includes packageSourceMapping when defined', () => {
+      const registries: Registry[] = [
+        {
+          name: 'myRegistry',
+          url: 'https://my-registry.example.org',
+          sourceMappedPackagePatterns: ['*'],
+        },
+        {
+          name: 'myRegistry2',
+          url: 'https://my-registry2.example.org/index.json',
+          sourceMappedPackagePatterns: [
+            'LimitedPackages.*',
+            'MySpecialPackage',
+          ],
+        },
+      ];
+
+      const xml = createNuGetConfigXml(registries);
+      const xmlDocument = new XmlDocument(xml);
+      const packageSourceMapping = xmlDocument.childNamed(
+        'packageSourceMapping'
+      );
+      expect(packageSourceMapping).toBeDefined();
+
+      const myRegistryMaps = packageSourceMapping?.childWithAttribute(
+        'key',
+        'myRegistry'
+      );
+      expect(myRegistryMaps).toBeDefined();
+      expect(myRegistryMaps?.childNamed('package')?.attr['pattern']).toBe('*');
+
+      const myRegistry2Maps = packageSourceMapping?.childWithAttribute(
+        'key',
+        'myRegistry2'
+      );
+      expect(myRegistry2Maps).toBeDefined();
+      expect(
+        myRegistry2Maps
+          ?.childrenNamed('package')
+          .map((child) => child.attr['pattern'])
+      ).toEqual(['LimitedPackages.*', 'MySpecialPackage']);
+    });
+
+    it('excludes packageSourceMapping when undefined', () => {
+      const registries: Registry[] = [
+        {
+          name: 'myRegistry',
+          url: 'https://my-registry.example.org',
+        },
+        {
+          name: 'myRegistry2',
+          url: 'https://my-registry2.example.org/index.json',
+        },
+      ];
+
+      const xml = createNuGetConfigXml(registries);
+      const xmlDocument = new XmlDocument(xml);
+      const packageSourceMapping = xmlDocument.childNamed(
+        'packageSourceMapping'
+      );
+      expect(packageSourceMapping).toBeUndefined();
+    });
+  });
+});

--- a/lib/modules/manager/nuget/config-formatter.spec.ts
+++ b/lib/modules/manager/nuget/config-formatter.spec.ts
@@ -91,7 +91,6 @@ describe('modules/manager/nuget/config-formatter', () => {
       const myRegistryCredentials = xmlDocument.descendantWithPath(
         'packageSourceCredentials.myRegistry'
       );
-      expect(myRegistryCredentials).toBeDefined();
       expect(
         myRegistryCredentials?.childWithAttribute('key', 'Username')?.attr[
           'value'

--- a/lib/modules/manager/nuget/config-formatter.spec.ts
+++ b/lib/modules/manager/nuget/config-formatter.spec.ts
@@ -105,7 +105,6 @@ describe('modules/manager/nuget/config-formatter', () => {
       const myRegistry2Credentials = xmlDocument.descendantWithPath(
         'packageSourceCredentials.myRegistry2'
       );
-      expect(myRegistry2Credentials).toBeDefined();
       expect(
         myRegistry2Credentials?.childWithAttribute('key', 'Username')
       ).toBeUndefined();

--- a/lib/modules/manager/nuget/config-formatter.spec.ts
+++ b/lib/modules/manager/nuget/config-formatter.spec.ts
@@ -54,7 +54,7 @@ describe('modules/manager/nuget/config-formatter', () => {
         username: 'some-username',
         password: 'some-password',
       });
-      _hostRules.add({
+      hostRules.add({
         hostType: 'nuget',
         matchHost: 'my-registry2.example.org',
         password: 'some-password',

--- a/lib/modules/manager/nuget/config-formatter.spec.ts
+++ b/lib/modules/manager/nuget/config-formatter.spec.ts
@@ -115,7 +115,7 @@ describe('modules/manager/nuget/config-formatter', () => {
     });
 
     it('escapes registry credential names containing special characters', () => {
-      _hostRules.add({
+      hostRules.add({
         hostType: 'nuget',
         matchHost: 'my-registry.example.org',
         username: 'some-username',

--- a/lib/modules/manager/nuget/config-formatter.spec.ts
+++ b/lib/modules/manager/nuget/config-formatter.spec.ts
@@ -48,7 +48,7 @@ describe('modules/manager/nuget/config-formatter', () => {
     });
 
     it('returns xml with authenticated registries', () => {
-      _hostRules.add({
+      hostRules.add({
         hostType: 'nuget',
         matchHost: 'my-registry.example.org',
         username: 'some-username',

--- a/lib/modules/manager/nuget/config-formatter.spec.ts
+++ b/lib/modules/manager/nuget/config-formatter.spec.ts
@@ -215,7 +215,6 @@ describe('modules/manager/nuget/config-formatter', () => {
         'key',
         'myRegistry2'
       );
-      expect(myRegistry2Maps).toBeDefined();
       expect(myRegistry2Maps?.name).toBe('packageSource');
       expect(
         myRegistry2Maps

--- a/lib/modules/manager/nuget/config-formatter.spec.ts
+++ b/lib/modules/manager/nuget/config-formatter.spec.ts
@@ -6,7 +6,7 @@ import type { Registry } from './types';
 describe('modules/manager/nuget/config-formatter', () => {
   describe('createNuGetConfigXml', () => {
     beforeEach(() => {
-      _hostRules.clear();
+      hostRules.clear();
     });
 
     it('returns xml with registries', () => {

--- a/lib/modules/manager/nuget/config-formatter.ts
+++ b/lib/modules/manager/nuget/config-formatter.ts
@@ -76,7 +76,7 @@ function formatPackageSourceElement(
   let element = `<add key="${name}" value="${registryInfo.feedUrl}" `;
 
   if (registryInfo.protocolVersion) {
-    element += `protocolVersion="${registryInfo.protocolVersion.toString()}" `;
+    element += `protocolVersion="${registryInfo.protocolVersion}" `;
   }
 
   return  `${element}/>\n`;

--- a/lib/modules/manager/nuget/config-formatter.ts
+++ b/lib/modules/manager/nuget/config-formatter.ts
@@ -1,0 +1,119 @@
+import * as hostRules from '../../../util/host-rules';
+import { NugetDatasource } from '../../datasource/nuget';
+import { parseRegistryUrl } from '../../datasource/nuget/common';
+import type { ParsedRegistryUrl } from '../../datasource/nuget/types';
+import type {
+  PackageSourceCredential,
+  PackageSourceMap,
+  Registry,
+} from './types';
+
+export function createNuGetConfigXml(registries: Registry[]): string {
+  let contents = `<?xml version="1.0" encoding="utf-8"?>\n<configuration>\n<packageSources>\n`;
+  let unnamedRegistryCount = 0;
+
+  const credentials: PackageSourceCredential[] = [];
+  const packageSourceMaps: PackageSourceMap[] = [];
+
+  for (const registry of registries) {
+    const registryName =
+      registry.name ?? `Package source ${++unnamedRegistryCount}`;
+    const registryInfo = parseRegistryUrl(registry.url);
+
+    contents += formatPackageSourceElement(registryInfo, registryName);
+
+    const { password, username } = hostRules.find({
+      hostType: NugetDatasource.id,
+      url: registry.url,
+    });
+
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+    if (password || username) {
+      credentials.push({
+        name: registryName,
+        password,
+        username,
+      });
+    }
+
+    if (registry.sourceMappedPackagePatterns) {
+      packageSourceMaps.push({
+        name: registryName,
+        patterns: registry.sourceMappedPackagePatterns,
+      });
+    }
+  }
+
+  contents += '</packageSources>\n';
+
+  if (credentials.length > 0) {
+    contents += '<packageSourceCredentials>\n';
+
+    for (const credential of credentials) {
+      contents += formatPackageSourceCredentialElement(credential);
+    }
+
+    contents += '</packageSourceCredentials>\n';
+  }
+
+  if (packageSourceMaps.length > 0) {
+    contents += '<packageSourceMapping>\n';
+    for (const packageSourceMap of packageSourceMaps) {
+      contents += formatPackageSourceMap(packageSourceMap);
+    }
+    contents += '</packageSourceMapping>';
+  }
+
+  contents += '</configuration>\n';
+
+  return contents;
+}
+
+function formatPackageSourceElement(
+  registryInfo: ParsedRegistryUrl,
+  name: string
+): string {
+  let element = `<add key="${name}" value="${registryInfo.feedUrl}" `;
+
+  if (registryInfo.protocolVersion) {
+    element += `protocolVersion="${registryInfo.protocolVersion.toString()}" `;
+  }
+
+  return (element += '/>\n');
+}
+
+function formatPackageSourceCredentialElement(
+  credential: PackageSourceCredential
+): string {
+  const escapedName = credential.name.replace(
+    /(?!(\d|\w|-|\.))./g,
+    function (match) {
+      return '__x' + match.codePointAt(0)?.toString(16).padStart(4, '0') + '__';
+    }
+  );
+
+  let packageSourceCredential = `<${escapedName}>\n`;
+
+  if (credential.username) {
+    packageSourceCredential += `<add key="Username" value="${credential.username}" />\n`;
+  }
+
+  if (credential.password) {
+    packageSourceCredential += `<add key="ClearTextPassword" value="${credential.password}" />\n`;
+  }
+
+  packageSourceCredential += `</${escapedName}>\n`;
+
+  return packageSourceCredential;
+}
+
+function formatPackageSourceMap(map: PackageSourceMap): string {
+  let packageSourceMap = `<packageSourceMap key="${map.name}">\n`;
+
+  for (const pattern of map.patterns) {
+    packageSourceMap += `<package pattern="${pattern}" />\n`;
+  }
+
+  packageSourceMap += '</packageSourceMap>\n';
+  return packageSourceMap;
+}

--- a/lib/modules/manager/nuget/config-formatter.ts
+++ b/lib/modules/manager/nuget/config-formatter.ts
@@ -28,7 +28,7 @@ export function createNuGetConfigXml(registries: Registry[]): string {
     });
 
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-    if (password || username) {
+    if (is.nonEmptyString(password) || is.nonEmptyString(username)) {
       credentials.push({
         name: registryName,
         password,

--- a/lib/modules/manager/nuget/config-formatter.ts
+++ b/lib/modules/manager/nuget/config-formatter.ts
@@ -1,4 +1,6 @@
+import is from '@sindresorhus/is';
 import * as hostRules from '../../../util/host-rules';
+import { regEx } from '../../../util/regex';
 import { NugetDatasource } from '../../datasource/nuget';
 import { parseRegistryUrl } from '../../datasource/nuget/common';
 import type { ParsedRegistryUrl } from '../../datasource/nuget/types';
@@ -84,12 +86,7 @@ function formatPackageSourceElement(
 function formatPackageSourceCredentialElement(
   credential: PackageSourceCredential
 ): string {
-  const escapedName = credential.name.replace(
-    /(?!(\d|\w|-|\.))./g,
-    function (match) {
-      return `__x${match.codePointAt(0)!.toString(16).padStart(4, '0')}__`;
-    }
-  );
+  const escapedName = escapeName(credential.name);
 
   let packageSourceCredential = `<${escapedName}>\n`;
 
@@ -114,4 +111,23 @@ function formatPackageSource(packageSourceMap: PackageSourceMap): string {
   }
 
   return `${packageSource}</packageSource>\n`;
+}
+
+const charactersToEscape = regEx(/[^A-Za-z0-9\-_.]/);
+
+function escapeName(name: string): string {
+  let escapedName = '';
+  for (let i = 0; i < name.length; i++) {
+    const char = name[i];
+    if (char.match(charactersToEscape)) {
+      escapedName += `__x${char
+        .codePointAt(0)!
+        .toString(16)
+        .padStart(4, '0')}__`;
+    } else {
+      escapedName += char;
+    }
+  }
+
+  return escapedName;
 }

--- a/lib/modules/manager/nuget/config-formatter.ts
+++ b/lib/modules/manager/nuget/config-formatter.ts
@@ -59,7 +59,7 @@ export function createNuGetConfigXml(registries: Registry[]): string {
   if (packageSourceMaps.length > 0) {
     contents += '<packageSourceMapping>\n';
     for (const packageSourceMap of packageSourceMaps) {
-      contents += formatPackageSourceMap(packageSourceMap);
+      contents += formatPackageSource(packageSourceMap);
     }
     contents += '</packageSourceMapping>';
   }
@@ -107,13 +107,13 @@ function formatPackageSourceCredentialElement(
   return packageSourceCredential;
 }
 
-function formatPackageSourceMap(map: PackageSourceMap): string {
-  let packageSourceMap = `<packageSourceMap key="${map.name}">\n`;
+function formatPackageSource(packageSourceMap: PackageSourceMap): string {
+  let packageSource = `<packageSource key="${packageSourceMap.name}">\n`;
 
-  for (const pattern of map.patterns) {
-    packageSourceMap += `<package pattern="${pattern}" />\n`;
+  for (const pattern of packageSourceMap.patterns) {
+    packageSource += `<package pattern="${pattern}" />\n`;
   }
 
-  packageSourceMap += '</packageSourceMap>\n';
-  return packageSourceMap;
+  packageSource += '</packageSource>\n';
+  return packageSource;
 }

--- a/lib/modules/manager/nuget/config-formatter.ts
+++ b/lib/modules/manager/nuget/config-formatter.ts
@@ -87,7 +87,7 @@ function formatPackageSourceCredentialElement(
   const escapedName = credential.name.replace(
     /(?!(\d|\w|-|\.))./g,
     function (match) {
-      return '__x' + match.codePointAt(0)?.toString(16).padStart(4, '0') + '__';
+      return `__x${match.codePointAt(0)!.toString(16).padStart(4, '0')}__`;
     }
   );
 

--- a/lib/modules/manager/nuget/config-formatter.ts
+++ b/lib/modules/manager/nuget/config-formatter.ts
@@ -78,7 +78,7 @@ function formatPackageSourceElement(
     element += `protocolVersion="${registryInfo.protocolVersion}" `;
   }
 
-  return  `${element}/>\n`;
+  return `${element}/>\n`;
 }
 
 function formatPackageSourceCredentialElement(

--- a/lib/modules/manager/nuget/config-formatter.ts
+++ b/lib/modules/manager/nuget/config-formatter.ts
@@ -79,7 +79,7 @@ function formatPackageSourceElement(
     element += `protocolVersion="${registryInfo.protocolVersion.toString()}" `;
   }
 
-  return (element += '/>\n');
+  return  `${element}/>\n`;
 }
 
 function formatPackageSourceCredentialElement(

--- a/lib/modules/manager/nuget/config-formatter.ts
+++ b/lib/modules/manager/nuget/config-formatter.ts
@@ -27,7 +27,6 @@ export function createNuGetConfigXml(registries: Registry[]): string {
       url: registry.url,
     });
 
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     if (is.nonEmptyString(password) || is.nonEmptyString(username)) {
       credentials.push({
         name: registryName,

--- a/lib/modules/manager/nuget/config-formatter.ts
+++ b/lib/modules/manager/nuget/config-formatter.ts
@@ -114,6 +114,5 @@ function formatPackageSource(packageSourceMap: PackageSourceMap): string {
     packageSource += `<package pattern="${pattern}" />\n`;
   }
 
-  packageSource += '</packageSource>\n';
-  return packageSource;
+  return `${packageSource}</packageSource>\n`;
 }

--- a/lib/modules/manager/nuget/types.ts
+++ b/lib/modules/manager/nuget/types.ts
@@ -29,3 +29,9 @@ export interface ProjectFile {
   readonly isLeaf: boolean;
   readonly name: string;
 }
+
+export interface PackageSourceCredential {
+  readonly name: string;
+  readonly username: string | undefined;
+  readonly password: string | undefined;
+}

--- a/lib/modules/manager/nuget/types.ts
+++ b/lib/modules/manager/nuget/types.ts
@@ -13,6 +13,7 @@ export interface DotnetTool {
 export interface Registry {
   readonly url: string;
   readonly name?: string;
+  readonly sourceMappedPackagePatterns?: string[];
 }
 
 export interface MsbuildGlobalManifest {
@@ -34,4 +35,9 @@ export interface PackageSourceCredential {
   readonly name: string;
   readonly username: string | undefined;
   readonly password: string | undefined;
+}
+
+export interface PackageSourceMap {
+  readonly name: string;
+  readonly patterns: string[];
 }

--- a/lib/modules/manager/nuget/util.spec.ts
+++ b/lib/modules/manager/nuget/util.spec.ts
@@ -31,7 +31,7 @@ describe('modules/manager/nuget/util', () => {
   });
 
   describe('getConfiguredRegistries', () => {
-    it('reads package source mapping from config file', async () => {
+    it('reads nuget config file', async () => {
       fs.findUpLocal.mockReturnValue(
         Promise.resolve<string | null>('NuGet.config')
       );
@@ -47,9 +47,11 @@ describe('modules/manager/nuget/util', () => {
       const registries = await getConfiguredRegistries('NuGet.config');
       expect(registries?.length).toBe(2);
       expect(registries![0].name).toBe('nuget.org');
+      expect(registries![0].url).toBe('https://api.nuget.org/v3/index.json');
       expect(registries![0].sourceMappedPackagePatterns).toEqual(['*']);
 
       expect(registries![1].name).toBe('contoso.com');
+      expect(registries![1].url).toBe('https://contoso.com/packages/');
       expect(registries![1].sourceMappedPackagePatterns).toEqual([
         'Contoso.*',
         'NuGet.Common',

--- a/lib/modules/manager/nuget/util.ts
+++ b/lib/modules/manager/nuget/util.ts
@@ -29,14 +29,14 @@ export function getDefaultRegistries(): Registry[] {
 }
 
 export async function getConfiguredRegistries(
-  packageFileName: string
+  packageFile: string
 ): Promise<Registry[] | undefined> {
   // Valid file names taken from https://github.com/NuGet/NuGet.Client/blob/f64621487c0b454eda4b98af853bf4a528bef72a/src/NuGet.Core/NuGet.Configuration/Settings/Settings.cs#L34
   const nuGetConfigFileNames = ['nuget.config', 'NuGet.config', 'NuGet.Config'];
   // normalize paths, otherwise startsWith can fail because of path delimitter mismatch
   const nuGetConfigPath = await findUpLocal(
     nuGetConfigFileNames,
-    upath.dirname(packageFileName)
+    upath.dirname(packageFile)
   );
   if (!nuGetConfigPath) {
     return undefined;

--- a/lib/modules/manager/nuget/util.ts
+++ b/lib/modules/manager/nuget/util.ts
@@ -73,7 +73,16 @@ export async function getConfiguredRegistries(
             ?.childWithAttribute('key', child.attr.key)
             ?.childrenNamed('package')
             .map((packagePattern) => packagePattern.attr['pattern']);
-          logger.debug(`Adding registry URL ${registryUrl}`);
+
+          logger.debug(
+            {
+              name: child.attr.key,
+              registryUrl,
+              sourceMappedPackagePatterns,
+            },
+            `Adding registry URL ${registryUrl}`
+          );
+
           registries.push({
             name: child.attr.key,
             url: registryUrl,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This changes the way the cached nuget config gets generated, it no longer runs CLI commands to add sources but generates a NuGet.config XML using the `createNuGetConfigXml` inside the config-formatter.ts file. This was done so it can support packageSourceMapping which cannot be set using the CLI commands.

The getConfiguredRegistries now also picks up any package patterns that are mapped to a repository.

## Context
- closes #17562 

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

[Test run on a real repo](https://dev.azure.com/wesselterpstra/RenovatePlayground/_build/results?buildId=169&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=35f53584-79fc-539f-463c-6471d0663a3a)
[The resulting PR](https://dev.azure.com/wesselterpstra/RenovatePlayground/_git/PackageSourceMapping/pullrequest/31)

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
