### PR TITLE
feat: Add support for ubuntu dated container image tags

### DIFF
--- a/lib/modules/versioning/ubuntu/common.ts
+++ b/lib/modules/versioning/ubuntu/common.ts
@@ -1,0 +1,18 @@
+function getDatedContainerImageCodename(version: string): null | string {
+  const groups = /^(?<codename>\w+)-(?<date>\d{8})$/.exec(version);
+  if (!groups?.groups) {
+    return null;
+  }
+  return groups.groups.codename;
+}
+
+function getDatedContainerImageVersion(version: string): null | number {
+  const groups = /^(?<codename>\w+)-(?<date>\d{8})$/.exec(version);
+  if (!groups?.groups) {
+    return null;
+  }
+
+  return parseInt(groups.groups.date, 10);
+}
+
+export { getDatedContainerImageCodename, getDatedContainerImageVersion };

--- a/lib/modules/versioning/ubuntu/common.ts
+++ b/lib/modules/versioning/ubuntu/common.ts
@@ -1,5 +1,11 @@
+import { regEx } from '../../../util/regex';
+
+function isDatedCodeName(input: string): boolean {
+  return regEx(/^(?<codename>\w+)-(?<date>\d{8})$/).test(input);
+}
+
 function getDatedContainerImageCodename(version: string): null | string {
-  const groups = /^(?<codename>\w+)-(?<date>\d{8})$/.exec(version);
+  const groups = regEx(/^(?<codename>\w+)-(?<date>\d{8})$/).exec(version);
   if (!groups?.groups) {
     return null;
   }
@@ -7,7 +13,7 @@ function getDatedContainerImageCodename(version: string): null | string {
 }
 
 function getDatedContainerImageVersion(version: string): null | number {
-  const groups = /^(?<codename>\w+)-(?<date>\d{8})$/.exec(version);
+  const groups = regEx(/^(?<codename>\w+)-(?<date>\d{8})$/).exec(version);
   if (!groups?.groups) {
     return null;
   }
@@ -15,4 +21,8 @@ function getDatedContainerImageVersion(version: string): null | number {
   return parseInt(groups.groups.date, 10);
 }
 
-export { getDatedContainerImageCodename, getDatedContainerImageVersion };
+export {
+  isDatedCodeName,
+  getDatedContainerImageCodename,
+  getDatedContainerImageVersion,
+};

--- a/lib/modules/versioning/ubuntu/index.spec.ts
+++ b/lib/modules/versioning/ubuntu/index.spec.ts
@@ -282,7 +282,7 @@ describe('modules/versioning/ubuntu/index', () => {
     ${'focal'}          | ${'20.04'}          | ${true}
     ${'20.04'}          | ${'focal'}          | ${true}
     ${'19.10'}          | ${'19.10'}          | ${true}
-    ${'jammy'}          | ${'jammy-20230816'} | ${true}
+    ${'jammy'}          | ${'jammy-20230816'} | ${false}
     ${'jammy-20230816'} | ${'jammy-20230816'} | ${true}
     ${'jammy-20230716'} | ${'jammy-20230816'} | ${false}
   `('equals($a, $b) === $expected', ({ a, b, expected }) => {

--- a/lib/modules/versioning/ubuntu/index.spec.ts
+++ b/lib/modules/versioning/ubuntu/index.spec.ts
@@ -315,6 +315,7 @@ describe('modules/versioning/ubuntu/index', () => {
     ${'jammy'}          | ${'focal'}          | ${true}
     ${'jammy-20230816'} | ${'focal'}          | ${true}
     ${'jammy-20230816'} | ${'jammy-20230716'} | ${true}
+    ${'jammy-20230716'} | ${'jammy-20230816'} | ${false}
     ${'focal-20230816'} | ${'jammy-20230716'} | ${false}
   `('isGreaterThan("$a", "$b") === $expected', ({ a, b, expected }) => {
     expect(ubuntu.isGreaterThan(a, b)).toBe(expected);

--- a/lib/modules/versioning/ubuntu/index.spec.ts
+++ b/lib/modules/versioning/ubuntu/index.spec.ts
@@ -5,82 +5,84 @@ describe('modules/versioning/ubuntu/index', () => {
   const dt = DateTime.fromISO('2022-04-20');
 
   it.each`
-    version        | expected
-    ${undefined}   | ${false}
-    ${null}        | ${false}
-    ${''}          | ${false}
-    ${'xenial'}    | ${true}
-    ${'04.10'}     | ${true}
-    ${'05.04'}     | ${true}
-    ${'05.10'}     | ${true}
-    ${'6.06'}      | ${true}
-    ${'6.10'}      | ${true}
-    ${'7.04'}      | ${true}
-    ${'7.10'}      | ${true}
-    ${'8.04'}      | ${true}
-    ${'8.10'}      | ${true}
-    ${'9.04'}      | ${true}
-    ${'9.10'}      | ${true}
-    ${'10.04.4'}   | ${true}
-    ${'10.10'}     | ${true}
-    ${'11.04'}     | ${true}
-    ${'11.10'}     | ${true}
-    ${'12.04.5'}   | ${true}
-    ${'12.10'}     | ${true}
-    ${'13.04'}     | ${true}
-    ${'13.10'}     | ${true}
-    ${'14.04.6'}   | ${true}
-    ${'14.10'}     | ${true}
-    ${'15.04'}     | ${true}
-    ${'15.10'}     | ${true}
-    ${'16.04.7'}   | ${true}
-    ${'16.10'}     | ${true}
-    ${'17.04'}     | ${true}
-    ${'17.10'}     | ${true}
-    ${'18.04.5'}   | ${true}
-    ${'18.10'}     | ${true}
-    ${'19.04'}     | ${true}
-    ${'19.10'}     | ${true}
-    ${'20.04'}     | ${true}
-    ${'20.10'}     | ${true}
-    ${'2020.04'}   | ${false}
-    ${'xenial'}    | ${true}
-    ${'warty'}     | ${true}
-    ${'hoary'}     | ${true}
-    ${'breezy'}    | ${true}
-    ${'dapper'}    | ${true}
-    ${'edgy'}      | ${true}
-    ${'feisty'}    | ${true}
-    ${'gutsy'}     | ${true}
-    ${'hardy'}     | ${true}
-    ${'intrepid'}  | ${true}
-    ${'jaunty'}    | ${true}
-    ${'karmic'}    | ${true}
-    ${'lucid.4'}   | ${false}
-    ${'maverick'}  | ${true}
-    ${'natty'}     | ${true}
-    ${'oneiric'}   | ${true}
-    ${'precise.5'} | ${false}
-    ${'quantal'}   | ${true}
-    ${'raring'}    | ${true}
-    ${'saucy'}     | ${true}
-    ${'trusty.6'}  | ${false}
-    ${'utopic'}    | ${true}
-    ${'vivid'}     | ${true}
-    ${'wily'}      | ${true}
-    ${'xenial.7'}  | ${false}
-    ${'yakkety'}   | ${true}
-    ${'zesty'}     | ${true}
-    ${'artful'}    | ${true}
-    ${'bionic.5'}  | ${false}
-    ${'cosmic'}    | ${true}
-    ${'disco'}     | ${true}
-    ${'eoan'}      | ${true}
-    ${'focal'}     | ${true}
-    ${'groovy'}    | ${true}
-    ${'hirsute'}   | ${true}
-    ${'impish'}    | ${true}
-    ${'jammy'}     | ${true}
+    version             | expected
+    ${undefined}        | ${false}
+    ${null}             | ${false}
+    ${''}               | ${false}
+    ${'xenial'}         | ${true}
+    ${'04.10'}          | ${true}
+    ${'05.04'}          | ${true}
+    ${'05.10'}          | ${true}
+    ${'6.06'}           | ${true}
+    ${'6.10'}           | ${true}
+    ${'7.04'}           | ${true}
+    ${'7.10'}           | ${true}
+    ${'8.04'}           | ${true}
+    ${'8.10'}           | ${true}
+    ${'9.04'}           | ${true}
+    ${'9.10'}           | ${true}
+    ${'10.04.4'}        | ${true}
+    ${'10.10'}          | ${true}
+    ${'11.04'}          | ${true}
+    ${'11.10'}          | ${true}
+    ${'12.04.5'}        | ${true}
+    ${'12.10'}          | ${true}
+    ${'13.04'}          | ${true}
+    ${'13.10'}          | ${true}
+    ${'14.04.6'}        | ${true}
+    ${'14.10'}          | ${true}
+    ${'15.04'}          | ${true}
+    ${'15.10'}          | ${true}
+    ${'16.04.7'}        | ${true}
+    ${'16.10'}          | ${true}
+    ${'17.04'}          | ${true}
+    ${'17.10'}          | ${true}
+    ${'18.04.5'}        | ${true}
+    ${'18.10'}          | ${true}
+    ${'19.04'}          | ${true}
+    ${'19.10'}          | ${true}
+    ${'20.04'}          | ${true}
+    ${'20.10'}          | ${true}
+    ${'2020.04'}        | ${false}
+    ${'xenial'}         | ${true}
+    ${'warty'}          | ${true}
+    ${'hoary'}          | ${true}
+    ${'breezy'}         | ${true}
+    ${'dapper'}         | ${true}
+    ${'edgy'}           | ${true}
+    ${'feisty'}         | ${true}
+    ${'gutsy'}          | ${true}
+    ${'hardy'}          | ${true}
+    ${'intrepid'}       | ${true}
+    ${'jaunty'}         | ${true}
+    ${'karmic'}         | ${true}
+    ${'lucid.4'}        | ${false}
+    ${'maverick'}       | ${true}
+    ${'natty'}          | ${true}
+    ${'oneiric'}        | ${true}
+    ${'precise.5'}      | ${false}
+    ${'quantal'}        | ${true}
+    ${'raring'}         | ${true}
+    ${'saucy'}          | ${true}
+    ${'trusty.6'}       | ${false}
+    ${'utopic'}         | ${true}
+    ${'vivid'}          | ${true}
+    ${'wily'}           | ${true}
+    ${'xenial.7'}       | ${false}
+    ${'yakkety'}        | ${true}
+    ${'zesty'}          | ${true}
+    ${'artful'}         | ${true}
+    ${'bionic.5'}       | ${false}
+    ${'cosmic'}         | ${true}
+    ${'disco'}          | ${true}
+    ${'eoan'}           | ${true}
+    ${'focal'}          | ${true}
+    ${'groovy'}         | ${true}
+    ${'hirsute'}        | ${true}
+    ${'impish'}         | ${true}
+    ${'jammy'}          | ${true}
+    ${'jammy-20230816'} | ${true}
+    ${'jammy-2023086'}  | ${false}
   `('isValid("$version") === $expected', ({ version, expected }) => {
     expect(ubuntu.isValid(version)).toBe(expected);
   });
@@ -247,18 +249,19 @@ describe('modules/versioning/ubuntu/index', () => {
   });
 
   it.each`
-    version       | major   | minor   | patch
-    ${undefined}  | ${null} | ${null} | ${null}
-    ${null}       | ${null} | ${null} | ${null}
-    ${''}         | ${null} | ${null} | ${null}
-    ${'42'}       | ${null} | ${null} | ${null}
-    ${'2020.04'}  | ${null} | ${null} | ${null}
-    ${'04.10'}    | ${4}    | ${10}   | ${null}
-    ${'18.04.5'}  | ${18}   | ${4}    | ${5}
-    ${'20.04'}    | ${20}   | ${4}    | ${null}
-    ${'intrepid'} | ${8}    | ${10}   | ${null}
-    ${'bionic'}   | ${18}   | ${4}    | ${null}
-    ${'focal'}    | ${20}   | ${4}    | ${null}
+    version             | major   | minor   | patch
+    ${undefined}        | ${null} | ${null} | ${null}
+    ${null}             | ${null} | ${null} | ${null}
+    ${''}               | ${null} | ${null} | ${null}
+    ${'42'}             | ${null} | ${null} | ${null}
+    ${'2020.04'}        | ${null} | ${null} | ${null}
+    ${'04.10'}          | ${4}    | ${10}   | ${null}
+    ${'18.04.5'}        | ${18}   | ${4}    | ${5}
+    ${'20.04'}          | ${20}   | ${4}    | ${null}
+    ${'intrepid'}       | ${8}    | ${10}   | ${null}
+    ${'bionic'}         | ${18}   | ${4}    | ${null}
+    ${'focal'}          | ${20}   | ${4}    | ${null}
+    ${'jammy-20230816'} | ${22}   | ${4}    | ${null}
   `(
     'getMajor, getMinor, getPatch for "$version"',
     ({ version, major, minor, patch }) => {
@@ -269,43 +272,50 @@ describe('modules/versioning/ubuntu/index', () => {
   );
 
   it.each`
-    a           | b            | expected
-    ${'20.04'}  | ${'2020.04'} | ${false}
-    ${'17.10'}  | ${'artful'}  | ${true}
-    ${'xenial'} | ${'artful'}  | ${false}
-    ${'17.04'}  | ${'artful'}  | ${false}
-    ${'artful'} | ${'17.10'}   | ${true}
-    ${'16.04'}  | ${'xenial'}  | ${true}
-    ${'focal'}  | ${'20.04'}   | ${true}
-    ${'20.04'}  | ${'focal'}   | ${true}
-    ${'19.10'}  | ${'19.10'}   | ${true}
+    a                   | b                   | expected
+    ${'20.04'}          | ${'2020.04'}        | ${false}
+    ${'17.10'}          | ${'artful'}         | ${true}
+    ${'xenial'}         | ${'artful'}         | ${false}
+    ${'17.04'}          | ${'artful'}         | ${false}
+    ${'artful'}         | ${'17.10'}          | ${true}
+    ${'16.04'}          | ${'xenial'}         | ${true}
+    ${'focal'}          | ${'20.04'}          | ${true}
+    ${'20.04'}          | ${'focal'}          | ${true}
+    ${'19.10'}          | ${'19.10'}          | ${true}
+    ${'jammy'}          | ${'jammy-20230816'} | ${true}
+    ${'jammy-20230816'} | ${'jammy-20230816'} | ${true}
+    ${'jammy-20230716'} | ${'jammy-20230816'} | ${false}
   `('equals($a, $b) === $expected', ({ a, b, expected }) => {
     expect(ubuntu.equals(a, b)).toBe(expected);
   });
 
   it.each`
-    a            | b            | expected
-    ${'20.04'}   | ${'20.10'}   | ${false}
-    ${'20.10'}   | ${'20.04'}   | ${true}
-    ${'19.10'}   | ${'20.04'}   | ${false}
-    ${'20.04'}   | ${'19.10'}   | ${true}
-    ${'16.04'}   | ${'16.04.7'} | ${false}
-    ${'16.04.7'} | ${'16.04'}   | ${true}
-    ${'16.04.1'} | ${'16.04.7'} | ${false}
-    ${'16.04.7'} | ${'16.04.1'} | ${true}
-    ${'19.10.1'} | ${'20.04.1'} | ${false}
-    ${'20.04.1'} | ${'19.10.1'} | ${true}
-    ${'xxx'}     | ${'yyy'}     | ${false}
-    ${'focal'}   | ${'groovy'}  | ${false}
-    ${'groovy'}  | ${'focal'}   | ${true}
-    ${'eoan'}    | ${'focal'}   | ${false}
-    ${'focal'}   | ${'eoan'}    | ${true}
-    ${'vivid'}   | ${'saucy'}   | ${true}
-    ${'impish'}  | ${'focal'}   | ${true}
-    ${'eoan'}    | ${'quantal'} | ${true}
-    ${'focal'}   | ${'lucid'}   | ${true}
-    ${'eoan'}    | ${'focal'}   | ${false}
-    ${'focal'}   | ${'eoan'}    | ${true}
+    a                   | b                   | expected
+    ${'20.04'}          | ${'20.10'}          | ${false}
+    ${'20.10'}          | ${'20.04'}          | ${true}
+    ${'19.10'}          | ${'20.04'}          | ${false}
+    ${'20.04'}          | ${'19.10'}          | ${true}
+    ${'16.04'}          | ${'16.04.7'}        | ${false}
+    ${'16.04.7'}        | ${'16.04'}          | ${true}
+    ${'16.04.1'}        | ${'16.04.7'}        | ${false}
+    ${'16.04.7'}        | ${'16.04.1'}        | ${true}
+    ${'19.10.1'}        | ${'20.04.1'}        | ${false}
+    ${'20.04.1'}        | ${'19.10.1'}        | ${true}
+    ${'xxx'}            | ${'yyy'}            | ${false}
+    ${'focal'}          | ${'groovy'}         | ${false}
+    ${'groovy'}         | ${'focal'}          | ${true}
+    ${'eoan'}           | ${'focal'}          | ${false}
+    ${'focal'}          | ${'eoan'}           | ${true}
+    ${'vivid'}          | ${'saucy'}          | ${true}
+    ${'impish'}         | ${'focal'}          | ${true}
+    ${'eoan'}           | ${'quantal'}        | ${true}
+    ${'focal'}          | ${'lucid'}          | ${true}
+    ${'eoan'}           | ${'focal'}          | ${false}
+    ${'focal'}          | ${'eoan'}           | ${true}
+    ${'jammy'}          | ${'focal'}          | ${true}
+    ${'jammy-20230816'} | ${'focal'}          | ${true}
+    ${'jammy-20230816'} | ${'jammy-20230716'} | ${true}
+    ${'focal-20230816'} | ${'jammy-20230716'} | ${false}
   `('isGreaterThan("$a", "$b") === $expected', ({ a, b, expected }) => {
     expect(ubuntu.isGreaterThan(a, b)).toBe(expected);
   });

--- a/lib/modules/versioning/ubuntu/index.ts
+++ b/lib/modules/versioning/ubuntu/index.ts
@@ -84,14 +84,9 @@ function getDatedContainerImageVersion(version: string): null | number {
 }
 
 function getVersionByCodename(version: string): string {
-  let rVer = version;
-  if (isDatedCodeName(version)) {
-    const ver = getDatedContainerImageCodename(version);
-    if (ver !== null) {
-      rVer = ver;
-    }
-  }
-  return di.getVersionByCodename(rVer);
+  const datedImgVersion = getDatedContainerImageCodename(version);
+  const getVersion = datedImgVersion ? datedImgVersion : version;
+  return di.getVersionByCodename(getVersion);
 }
 
 function getMajor(version: string): null | number {
@@ -157,16 +152,13 @@ function isGreaterThan(version: string, other: string): boolean {
     return false;
   }
 
-  if (isDatedCodeName(version)) {
-    const xImageVersion = getDatedContainerImageVersion(version) ?? 0;
-    const yImageVersion = getDatedContainerImageVersion(other) ?? 0;
-
-    if (xImageVersion > yImageVersion) {
-      return true;
-    }
-    if (xImageVersion < yImageVersion) {
-      return false;
-    }
+  const xImageVersion = getDatedContainerImageVersion(version) ?? 0;
+  const yImageVersion = getDatedContainerImageVersion(other) ?? 0;
+  if (xImageVersion > yImageVersion) {
+    return true;
+  }
+  if (xImageVersion < yImageVersion) {
+    return false;
   }
 
   const xPatch = getPatch(version) ?? 0;

--- a/lib/modules/versioning/ubuntu/index.ts
+++ b/lib/modules/versioning/ubuntu/index.ts
@@ -16,10 +16,6 @@ const di = new DistroInfo('data/ubuntu-distro-info.json');
 // validation
 
 function isValid(input: string): boolean {
-  if (typeof input !== 'string') {
-    return false;
-  }
-
   if (
     regEx(/^(0[4-5]|[6-9]|[1-9][0-9])\.[0-9][0-9](\.[0-9]{1,2})?$/).test(input)
   ) {

--- a/lib/modules/versioning/ubuntu/index.ts
+++ b/lib/modules/versioning/ubuntu/index.ts
@@ -119,17 +119,14 @@ function getPatch(version: string): null | number {
 // comparison
 
 function equals(version: string, other: string): boolean {
-  const ver = getVersionByCodename(version);
-  const otherVer = getVersionByCodename(other);
-
-  if (isDatedCodeName(version)) {
-    const verImage = getDatedContainerImageVersion(version);
-    const otherImageVer = getDatedContainerImageVersion(other);
-    if (verImage !== otherImageVer) {
-      return false;
-    }
+  const verImage = getDatedContainerImageVersion(version);
+  const otherImageVer = getDatedContainerImageVersion(other);
+  if (verImage !== otherImageVer) {
+    return false;
   }
 
+  const ver = getVersionByCodename(version);
+  const otherVer = getVersionByCodename(other);
   return isVersion(ver) && isVersion(otherVer) && ver === otherVer;
 }
 

--- a/lib/modules/versioning/ubuntu/index.ts
+++ b/lib/modules/versioning/ubuntu/index.ts
@@ -16,13 +16,25 @@ const di = new DistroInfo('data/ubuntu-distro-info.json');
 // validation
 
 function isValid(input: string): boolean {
-  return (
-    (typeof input === 'string' &&
-      regEx(/^(0[4-5]|[6-9]|[1-9][0-9])\.[0-9][0-9](\.[0-9]{1,2})?$/).test(
-        input
-      )) ||
-    di.isCodename(input)
-  );
+  if (typeof input !== 'string') {
+    return false;
+  }
+
+  if (
+    regEx(/^(0[4-5]|[6-9]|[1-9][0-9])\.[0-9][0-9](\.[0-9]{1,2})?$/).test(input)
+  ) {
+    return true;
+  }
+
+  if (di.isCodename(input)) {
+    return true;
+  }
+
+  return isDatedCodeName(input);
+}
+
+function isDatedCodeName(input: string): boolean {
+  return typeof input === 'string' && regEx(/^(\w+)-(\d{8})$/).test(input);
 }
 
 function isVersion(input: string): boolean {
@@ -54,8 +66,36 @@ function isStable(version: string): boolean {
 
 // digestion of version
 
+function getContainerImageCodename(version: string): null | string {
+  const groups = /^(\w+)-(\d{8})$/.exec(version);
+  if (groups === null) {
+    return null;
+  }
+  return groups[1];
+}
+
+function getContainerImageVersion(version: string): null | number {
+  const groups = /^(\w+)-(\d{8})$/.exec(version);
+  if (groups === null) {
+    return null;
+  }
+
+  return parseInt(groups[2]);
+}
+
+function getVersionByCodename(version: string): string {
+  let rVer = version;
+  if (isDatedCodeName(version)) {
+    const ver = getContainerImageCodename(version);
+    if (ver !== null) {
+      rVer = ver;
+    }
+  }
+  return di.getVersionByCodename(rVer);
+}
+
 function getMajor(version: string): null | number {
-  const ver = di.getVersionByCodename(version);
+  const ver = getVersionByCodename(version);
   if (isValid(ver)) {
     const [major] = ver.split('.');
     return parseInt(major, 10);
@@ -64,7 +104,7 @@ function getMajor(version: string): null | number {
 }
 
 function getMinor(version: string): null | number {
-  const ver = di.getVersionByCodename(version);
+  const ver = getVersionByCodename(version);
   if (isValid(ver)) {
     const [, minor] = ver.split('.');
     return parseInt(minor, 10);
@@ -73,7 +113,7 @@ function getMinor(version: string): null | number {
 }
 
 function getPatch(version: string): null | number {
-  const ver = di.getVersionByCodename(version);
+  const ver = getVersionByCodename(version);
   if (isValid(ver)) {
     const [, , patch] = ver.split('.');
     return patch ? parseInt(patch, 10) : null;
@@ -84,8 +124,17 @@ function getPatch(version: string): null | number {
 // comparison
 
 function equals(version: string, other: string): boolean {
-  const ver = di.getVersionByCodename(version);
-  const otherVer = di.getVersionByCodename(other);
+  const ver = getVersionByCodename(version);
+  const otherVer = getVersionByCodename(other);
+
+  if (isDatedCodeName(version)) {
+    const verImage = getContainerImageVersion(version);
+    const otherImageVer = getContainerImageVersion(other);
+    if (verImage !== otherImageVer) {
+      return false;
+    }
+  }
+
   return isVersion(ver) && isVersion(otherVer) && ver === otherVer;
 }
 
@@ -106,6 +155,18 @@ function isGreaterThan(version: string, other: string): boolean {
   }
   if (xMinor < yMinor) {
     return false;
+  }
+
+  if (isDatedCodeName(version)) {
+    const xImageVersion = getContainerImageVersion(version) ?? 0;
+    const yImageVersion = getContainerImageVersion(other) ?? 0;
+
+    if (xImageVersion > yImageVersion) {
+      return true;
+    }
+    if (xImageVersion < yImageVersion) {
+      return false;
+    }
   }
 
   const xPatch = getPatch(version) ?? 0;

--- a/lib/modules/versioning/ubuntu/index.ts
+++ b/lib/modules/versioning/ubuntu/index.ts
@@ -66,7 +66,7 @@ function isStable(version: string): boolean {
 
 // digestion of version
 
-function getContainerImageCodename(version: string): null | string {
+function getDatedContainerImageCodename(version: string): null | string {
   const groups = /^(\w+)-(\d{8})$/.exec(version);
   if (groups === null) {
     return null;
@@ -74,7 +74,7 @@ function getContainerImageCodename(version: string): null | string {
   return groups[1];
 }
 
-function getContainerImageVersion(version: string): null | number {
+function getDatedContainerImageVersion(version: string): null | number {
   const groups = /^(\w+)-(\d{8})$/.exec(version);
   if (groups === null) {
     return null;
@@ -86,7 +86,7 @@ function getContainerImageVersion(version: string): null | number {
 function getVersionByCodename(version: string): string {
   let rVer = version;
   if (isDatedCodeName(version)) {
-    const ver = getContainerImageCodename(version);
+    const ver = getDatedContainerImageCodename(version);
     if (ver !== null) {
       rVer = ver;
     }
@@ -128,8 +128,8 @@ function equals(version: string, other: string): boolean {
   const otherVer = getVersionByCodename(other);
 
   if (isDatedCodeName(version)) {
-    const verImage = getContainerImageVersion(version);
-    const otherImageVer = getContainerImageVersion(other);
+    const verImage = getDatedContainerImageVersion(version);
+    const otherImageVer = getDatedContainerImageVersion(other);
     if (verImage !== otherImageVer) {
       return false;
     }
@@ -158,8 +158,8 @@ function isGreaterThan(version: string, other: string): boolean {
   }
 
   if (isDatedCodeName(version)) {
-    const xImageVersion = getContainerImageVersion(version) ?? 0;
-    const yImageVersion = getContainerImageVersion(other) ?? 0;
+    const xImageVersion = getDatedContainerImageVersion(version) ?? 0;
+    const yImageVersion = getDatedContainerImageVersion(other) ?? 0;
 
     if (xImageVersion > yImageVersion) {
       return true;

--- a/lib/modules/versioning/ubuntu/index.ts
+++ b/lib/modules/versioning/ubuntu/index.ts
@@ -5,6 +5,7 @@ import type { NewValueConfig, VersioningApi } from '../types';
 import {
   getDatedContainerImageCodename,
   getDatedContainerImageVersion,
+  isDatedCodeName,
 } from './common';
 
 export const id = 'ubuntu';
@@ -31,10 +32,6 @@ function isValid(input: string): boolean {
   }
 
   return isDatedCodeName(input);
-}
-
-function isDatedCodeName(input: string): boolean {
-  return regEx(/^(?<codename>\w+)-(?<date>\d{8})$/).test(input);
 }
 
 function isVersion(input: string): boolean {

--- a/lib/modules/versioning/ubuntu/index.ts
+++ b/lib/modules/versioning/ubuntu/index.ts
@@ -2,6 +2,10 @@ import { regEx } from '../../../util/regex';
 import { coerceString } from '../../../util/string';
 import { DistroInfo } from '../distro';
 import type { NewValueConfig, VersioningApi } from '../types';
+import {
+  getDatedContainerImageCodename,
+  getDatedContainerImageVersion,
+} from './common';
 
 export const id = 'ubuntu';
 export const displayName = 'Ubuntu';
@@ -61,23 +65,6 @@ function isStable(version: string): boolean {
 }
 
 // digestion of version
-
-function getDatedContainerImageCodename(version: string): null | string {
-  const groups = /^(?<codename>\w+)-(?<date>\d{8})$/.exec(version);
-  if (!groups?.groups) {
-    return null;
-  }
-  return groups.groups.codename;
-}
-
-function getDatedContainerImageVersion(version: string): null | number {
-  const groups = /^(?<codename>\w+)-(?<date>\d{8})$/.exec(version);
-  if (!groups?.groups) {
-    return null;
-  }
-
-  return parseInt(groups.groups.date, 10);
-}
 
 function getVersionByCodename(version: string): string {
   const datedImgVersion = getDatedContainerImageCodename(version);

--- a/lib/modules/versioning/ubuntu/index.ts
+++ b/lib/modules/versioning/ubuntu/index.ts
@@ -34,7 +34,7 @@ function isValid(input: string): boolean {
 }
 
 function isDatedCodeName(input: string): boolean {
-  return typeof input === 'string' && regEx(/^(\w+)-(\d{8})$/).test(input);
+  return regEx(/^(?<codename>\w+)-(?<date>\d{8})$/).test(input);
 }
 
 function isVersion(input: string): boolean {
@@ -67,20 +67,20 @@ function isStable(version: string): boolean {
 // digestion of version
 
 function getDatedContainerImageCodename(version: string): null | string {
-  const groups = /^(\w+)-(\d{8})$/.exec(version);
-  if (groups === null) {
+  const groups = /^(?<codename>\w+)-(?<date>\d{8})$/.exec(version);
+  if (!groups?.groups) {
     return null;
   }
-  return groups[1];
+  return groups.groups.codename;
 }
 
 function getDatedContainerImageVersion(version: string): null | number {
-  const groups = /^(\w+)-(\d{8})$/.exec(version);
-  if (groups === null) {
+  const groups = /^(?<codename>\w+)-(?<date>\d{8})$/.exec(version);
+  if (!groups?.groups) {
     return null;
   }
 
-  return parseInt(groups[2]);
+  return parseInt(groups.groups.date, 10);
 }
 
 function getVersionByCodename(version: string): string {

--- a/lib/modules/versioning/ubuntu/readme.md
+++ b/lib/modules/versioning/ubuntu/readme.md
@@ -1,4 +1,3 @@
 Ubuntu versioning is used for Ubuntu container images that are referenced by their release version or a codename.
 
-Versions to which this scheme applies are e.g. `22.04` and `jammy`.
-Container image tags such as `jammy-20220815` or `focal-20220826` are not compliant with the current implementation.
+Versions to which this scheme applies are e.g. `22.04`, `jammy` and `jammy-20220815`.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds support for Ubuntu dated container image tags

## Context

Want to automatically update Ubuntu image tags when major versions change and date versions change.
Discussed https://github.com/renovatebot/renovate/discussions/25042

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
