### PR TITLE
fix(nix): Allow nixpkgs with no ref

### DIFF
--- a/lib/modules/manager/nix/extract.spec.ts
+++ b/lib/modules/manager/nix/extract.spec.ts
@@ -52,7 +52,7 @@ describe('modules/manager/nix/extract', () => {
     ]);
   });
 
-  it('ignores nixpkgs with no explicit ref', () => {
+  it('includes nixpkgs with no explicit ref', () => {
     const content = `{
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs";
@@ -61,6 +61,16 @@ describe('modules/manager/nix/extract', () => {
 
     const res = extractPackageFile(content);
 
-    expect(res).toBeNull();
+    expect(res).toMatchObject({
+      deps: [
+        {
+          currentValue: undefined,
+          datasource: 'git-refs',
+          depName: 'nixpkgs',
+          packageName: 'https://github.com/NixOS/nixpkgs',
+          versioning: 'nixpkgs',
+        },
+      ],
+    });
   });
 });

--- a/lib/modules/manager/nix/extract.ts
+++ b/lib/modules/manager/nix/extract.ts
@@ -3,7 +3,7 @@ import { GitRefsDatasource } from '../../datasource/git-refs';
 import { id as nixpkgsVersioning } from '../../versioning/nixpkgs';
 import type { PackageDependency, PackageFileContent } from '../types';
 
-const nixpkgsRegex = regEx(/"github:nixos\/nixpkgs\/(?<ref>[a-z0-9-.]+)"/i);
+const nixpkgsRegex = regEx(/"github:nixos\/nixpkgs(\/(?<ref>[a-z0-9-.]+))?"/i);
 
 export function extractPackageFile(content: string): PackageFileContent | null {
   const deps: PackageDependency[] = [];


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Allow nixpkgs with no ref

## Context

#24655

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
