### PR TITLE
feat(presets): map PHP linters in default `linters` group

### DIFF
--- a/lib/config/presets/__snapshots__/index.spec.ts.snap
+++ b/lib/config/presets/__snapshots__/index.spec.ts.snap
@@ -8,6 +8,7 @@ exports[`config/presets/index getPreset gets linters 1`] = `
   "extends": [
     "packages:emberTemplateLint",
     "packages:eslint",
+    "packages:phpLinters",
     "packages:stylelint",
     "packages:tslint",
   ],
@@ -134,6 +135,9 @@ exports[`config/presets/index resolvePreset resolves linters 1`] = `
   "matchPackageNames": [
     "@types/eslint",
     "babel-eslint",
+    "friendsofphp/php-cs-fixer",
+    "squizlabs/php_codesniffer",
+    "symplify/easy-coding-standard",
     "codelyzer",
     "prettier",
     "remark-lint",
@@ -165,6 +169,9 @@ exports[`config/presets/index resolvePreset resolves nested groups 1`] = `
       "matchPackageNames": [
         "@types/eslint",
         "babel-eslint",
+        "friendsofphp/php-cs-fixer",
+        "squizlabs/php_codesniffer",
+        "symplify/easy-coding-standard",
         "codelyzer",
         "prettier",
         "remark-lint",

--- a/lib/config/presets/index.spec.ts
+++ b/lib/config/presets/index.spec.ts
@@ -245,7 +245,7 @@ describe('config/presets/index', () => {
       config.extends = ['packages:linters'];
       const res = await presets.resolveConfigPresets(config);
       expect(res).toMatchSnapshot();
-      expect(res.matchPackageNames).toHaveLength(6);
+      expect(res.matchPackageNames).toHaveLength(9);
       expect(res.matchPackagePatterns).toHaveLength(1);
       expect(res.matchPackagePrefixes).toHaveLength(4);
     });
@@ -256,7 +256,7 @@ describe('config/presets/index', () => {
       expect(res).toMatchSnapshot();
       const rule = res.packageRules![0];
       expect(rule.automerge).toBeTrue();
-      expect(rule.matchPackageNames).toHaveLength(6);
+      expect(rule.matchPackageNames).toHaveLength(9);
       expect(rule.matchPackagePatterns).toHaveLength(1);
       expect(rule.matchPackagePrefixes).toHaveLength(4);
     });
@@ -894,7 +894,7 @@ describe('config/presets/index', () => {
       const res = await presets.getPreset('packages:linters', {});
       expect(res).toMatchSnapshot();
       expect(res.matchPackageNames).toHaveLength(3);
-      expect(res.extends).toHaveLength(4);
+      expect(res.extends).toHaveLength(5);
     });
 
     it('gets parameterised configs', async () => {

--- a/lib/config/presets/internal/packages.ts
+++ b/lib/config/presets/internal/packages.ts
@@ -98,7 +98,7 @@ export const presets: Record<string, Preset> = {
   phpLinters: {
     description: 'All PHP lint-related packages.',
     matchPackageNames: ['friendsofphp/php-cs-fixer', 'squizlabs/php_codesniffer', 'symplify/easy-coding-standard'],
-  }
+  },
   postcss: {
     description: 'All PostCSS packages.',
     matchPackageNames: ['postcss'],

--- a/lib/config/presets/internal/packages.ts
+++ b/lib/config/presets/internal/packages.ts
@@ -97,7 +97,11 @@ export const presets: Record<string, Preset> = {
   },
   phpLinters: {
     description: 'All PHP lint-related packages.',
-    matchPackageNames: ['friendsofphp/php-cs-fixer', 'squizlabs/php_codesniffer', 'symplify/easy-coding-standard'],
+    matchPackageNames: [
+      'friendsofphp/php-cs-fixer',
+      'squizlabs/php_codesniffer',
+      'symplify/easy-coding-standard',
+    ],
   },
   postcss: {
     description: 'All PostCSS packages.',

--- a/lib/config/presets/internal/packages.ts
+++ b/lib/config/presets/internal/packages.ts
@@ -85,6 +85,7 @@ export const presets: Record<string, Preset> = {
     extends: [
       'packages:emberTemplateLint',
       'packages:eslint',
+      'packages:phpLinters',
       'packages:stylelint',
       'packages:tslint',
     ],
@@ -94,6 +95,10 @@ export const presets: Record<string, Preset> = {
     description: 'All Mapbox-related packages.',
     matchPackagePrefixes: ['leaflet', 'mapbox'],
   },
+  phpLinters: {
+    description: 'All PHP lint-related packages.',
+    matchPackageNames: ['friendsofphp/php-cs-fixer', 'squizlabs/php_codesniffer', 'symplify/easy-coding-standard'],
+  }
   postcss: {
     description: 'All PostCSS packages.',
     matchPackageNames: ['postcss'],


### PR DESCRIPTION
## Changes

This maps the 3 most used linters in the PHP ecosystem, so that presets like `:automergeLinters` work for them too.

## Context

Related discussion: https://github.com/renovatebot/renovate/discussions/24978

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
