### PR TITLE
fix(changelogs): wrong release url

### DIFF
--- a/lib/workers/repository/update/pr/changelog/gitea/index.spec.ts
+++ b/lib/workers/repository/update/pr/changelog/gitea/index.spec.ts
@@ -208,7 +208,7 @@ describe('workers/repository/update/pr/changelog/gitea/index', () => {
               notesSourceUrl:
                 'https://gitea.com/api/v1/repos/meno/dropzone/releases',
               tag: 'v5.6.1',
-              url: 'https://gitea.com/api/v1/repos/meno/dropzone/releases/tag/v5.6.1',
+              url: 'https://gitea.com/meno/dropzone/releases/tag/v5.6.1',
             },
           },
           { version: '5.6.0' },

--- a/lib/workers/repository/update/pr/changelog/gitea/index.ts
+++ b/lib/workers/repository/update/pr/changelog/gitea/index.ts
@@ -83,7 +83,7 @@ export async function getReleaseList(
     ReleasesSchema
   );
   return res.body.map((release) => ({
-    url: `${apiUrl}/tag/${release.tag_name}`,
+    url: `${project.baseUrl}${project.repository}/releases/tag/${release.tag_name}`,
     notesSourceUrl: apiUrl,
     name: release.name,
     body: release.body,

--- a/lib/workers/repository/update/pr/changelog/github/index.ts
+++ b/lib/workers/repository/update/pr/changelog/github/index.ts
@@ -82,7 +82,7 @@ export async function getReleaseList(
   _release: ChangeLogRelease
 ): Promise<ChangeLogNotes[]> {
   logger.trace('github.getReleaseList()');
-  const apiBaseUrl = project.apiBaseUrl!; // TODO #22198
+  const apiBaseUrl = project.apiBaseUrl;
   const repository = project.repository;
   const notesSourceUrl = joinUrlParts(
     apiBaseUrl,

--- a/lib/workers/repository/update/pr/changelog/gitlab/index.ts
+++ b/lib/workers/repository/update/pr/changelog/gitlab/index.ts
@@ -3,7 +3,6 @@ import { logger } from '../../../../../../logger';
 import type { GitlabRelease } from '../../../../../../modules/datasource/gitlab-releases/types';
 import type { GitlabTreeNode } from '../../../../../../types/platform/gitlab';
 import { GitlabHttp } from '../../../../../../util/http/gitlab';
-import { ensureTrailingSlash } from '../../../../../../util/url';
 import type {
   ChangeLogFile,
   ChangeLogNotes,
@@ -21,9 +20,7 @@ export async function getReleaseNotesMd(
 ): Promise<ChangeLogFile | null> {
   logger.trace('gitlab.getReleaseNotesMd()');
   const urlEncodedRepo = encodeURIComponent(repository);
-  const apiPrefix = `${ensureTrailingSlash(
-    apiBaseUrl
-  )}projects/${urlEncodedRepo}/repository/`;
+  const apiPrefix = `${apiBaseUrl}projects/${urlEncodedRepo}/repository/`;
 
   // https://docs.gitlab.com/13.2/ee/api/repositories.html#list-repository-tree
   const tree = (
@@ -64,20 +61,16 @@ export async function getReleaseList(
   _release: ChangeLogRelease
 ): Promise<ChangeLogNotes[]> {
   logger.trace('gitlab.getReleaseNotesMd()');
-  // TODO #22198
-  const apiBaseUrl = project.apiBaseUrl!;
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-  const repository = project.repository!;
+  const apiBaseUrl = project.apiBaseUrl;
+  const repository = project.repository;
   const urlEncodedRepo = encodeURIComponent(repository);
-  const apiUrl = `${ensureTrailingSlash(
-    apiBaseUrl
-  )}projects/${urlEncodedRepo}/releases`;
+  const apiUrl = `${apiBaseUrl}projects/${urlEncodedRepo}/releases`;
 
   const res = await http.getJson<GitlabRelease[]>(`${apiUrl}?per_page=100`, {
     paginate: true,
   });
   return res.body.map((release) => ({
-    url: `${apiUrl}/${release.tag_name}`,
+    url: `${project.baseUrl}${repository}/-/releases/${release.tag_name}`,
     notesSourceUrl: apiUrl,
     name: release.name,
     body: release.description,

--- a/lib/workers/repository/update/pr/changelog/release-notes.spec.ts
+++ b/lib/workers/repository/update/pr/changelog/release-notes.spec.ts
@@ -141,11 +141,21 @@ describe('workers/repository/update/pr/changelog/release-notes', () => {
     });
 
     it('returns ChangeLogResult without release notes', async () => {
+      httpMock
+        .scope(
+          'https://gitlab.com/api/v4/projects/gitlab-org%2Fgitter%2Fwebapp'
+        )
+        .get('/repository/tree?per_page=100&path=lib')
+        .reply(200, [])
+        .get('/releases?per_page=100')
+        .reply(200, []);
       const input = {
         project: partial<ChangeLogProject>({
           type: 'gitlab',
-          repository: 'https://gitlab.com/gitlab-org/gitter/webapp/',
+          repository: 'gitlab-org/gitter/webapp',
           sourceDirectory: 'lib',
+          apiBaseUrl: 'https://gitlab.com/api/v4/',
+          baseUrl: 'https://gitlab.com/',
         }),
         versions: [
           partial<ChangeLogRelease>({
@@ -159,9 +169,11 @@ describe('workers/repository/update/pr/changelog/release-notes', () => {
       ).toEqual({
         hasReleaseNotes: false,
         project: {
-          repository: 'https://gitlab.com/gitlab-org/gitter/webapp/',
+          repository: 'gitlab-org/gitter/webapp',
           type: 'gitlab',
           sourceDirectory: 'lib',
+          apiBaseUrl: 'https://gitlab.com/api/v4/',
+          baseUrl: 'https://gitlab.com/',
         },
         versions: [
           {
@@ -252,13 +264,13 @@ describe('workers/repository/update/pr/changelog/release-notes', () => {
           notesSourceUrl:
             'https://gitlab.com/api/v4/projects/some%2Fyet-other-repository/releases',
           tag: 'v1.0.0',
-          url: 'https://gitlab.com/api/v4/projects/some%2Fyet-other-repository/releases/v1.0.0',
+          url: 'https://gitlab.com/some/yet-other-repository/-/releases/v1.0.0',
         },
         {
           notesSourceUrl:
             'https://gitlab.com/api/v4/projects/some%2Fyet-other-repository/releases',
           tag: 'v1.0.1',
-          url: 'https://gitlab.com/api/v4/projects/some%2Fyet-other-repository/releases/v1.0.1',
+          url: 'https://gitlab.com/some/yet-other-repository/-/releases/v1.0.1',
         },
       ]);
     });
@@ -291,13 +303,13 @@ describe('workers/repository/update/pr/changelog/release-notes', () => {
           notesSourceUrl:
             'https://my.custom.domain/api/v4/projects/some%2Fyet-other-repository/releases',
           tag: 'v1.0.0',
-          url: 'https://my.custom.domain/api/v4/projects/some%2Fyet-other-repository/releases/v1.0.0',
+          url: 'https://my.custom.domain/some/yet-other-repository/-/releases/v1.0.0',
         },
         {
           notesSourceUrl:
             'https://my.custom.domain/api/v4/projects/some%2Fyet-other-repository/releases',
           tag: 'v1.0.1',
-          url: 'https://my.custom.domain/api/v4/projects/some%2Fyet-other-repository/releases/v1.0.1',
+          url: 'https://my.custom.domain/some/yet-other-repository/-/releases/v1.0.1',
         },
       ]);
     });

--- a/lib/workers/repository/update/pr/changelog/release-notes.ts
+++ b/lib/workers/repository/update/pr/changelog/release-notes.ts
@@ -66,7 +66,7 @@ export function getCachedReleaseList(
 ): Promise<ChangeLogNotes[]> {
   const { repository, apiBaseUrl } = project;
   // TODO: types (#22198)
-  const cacheKey = `getReleaseList-${apiBaseUrl!}-${repository}`;
+  const cacheKey = `getReleaseList-${apiBaseUrl}-${repository}`;
   const cachedResult = memCache.get<Promise<ChangeLogNotes[]>>(cacheKey);
   // istanbul ignore if
   if (cachedResult !== undefined) {
@@ -241,7 +241,7 @@ export async function getReleaseNotesMdFileInner(
   project: ChangeLogProject
 ): Promise<ChangeLogFile | null> {
   const { repository, type } = project;
-  const apiBaseUrl = project.apiBaseUrl!;
+  const apiBaseUrl = project.apiBaseUrl;
   const sourceDirectory = project.sourceDirectory!;
   try {
     switch (type) {
@@ -295,8 +295,8 @@ export function getReleaseNotesMdFile(
   const { sourceDirectory, repository, apiBaseUrl } = project;
   // TODO: types (#22198)
   const cacheKey = sourceDirectory
-    ? `getReleaseNotesMdFile@v2-${repository}-${sourceDirectory}-${apiBaseUrl!}`
-    : `getReleaseNotesMdFile@v2-${repository}-${apiBaseUrl!}`;
+    ? `getReleaseNotesMdFile@v2-${repository}-${sourceDirectory}-${apiBaseUrl}`
+    : `getReleaseNotesMdFile@v2-${repository}-${apiBaseUrl}`;
   const cachedResult = memCache.get<Promise<ChangeLogFile | null>>(cacheKey);
   // istanbul ignore if
   if (cachedResult !== undefined) {

--- a/lib/workers/repository/update/pr/changelog/types.ts
+++ b/lib/workers/repository/update/pr/changelog/types.ts
@@ -28,7 +28,7 @@ export type ChangeLogPlatform = 'bitbucket' | 'gitea' | 'github' | 'gitlab';
 export interface ChangeLogProject {
   packageName?: string;
   type: ChangeLogPlatform;
-  apiBaseUrl?: string;
+  apiBaseUrl: string;
   baseUrl: string;
   repository: string;
   sourceUrl: string;

--- a/lib/workers/repository/update/pr/index.spec.ts
+++ b/lib/workers/repository/update/pr/index.spec.ts
@@ -685,6 +685,7 @@ describe('workers/repository/update/pr/index', () => {
             type: 'github',
             repository: 'some/repo',
             baseUrl: 'https://github.com',
+            apiBaseUrl: 'https://api.github.com/',
             sourceUrl: 'https://github.com/some/repo',
           },
           versions: [


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
The url for the release in changelogs is pointing to the api for gitlab and gitea.
It should point to the HTML page instead, so a user is redirected to that on click instead of the api url.
<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
