### PR TITLE
feat: improved warning markdown

### DIFF
--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -1770,7 +1770,8 @@ export function massageMarkdown(input: string): string {
       'href="https://togithub.com/'
     )
     .replace(regEx(/]\(https:\/\/github\.com\//g), '](https://togithub.com/')
-    .replace(regEx(/]: https:\/\/github\.com\//g), ']: https://togithub.com/');
+    .replace(regEx(/]: https:\/\/github\.com\//g), ']: https://togithub.com/')
+    .replace('> ⚠ **Warning**\n> \n', '> [!WARNING]\n');
   return smartTruncate(massagedInput, GitHubMaxPrBodyLen);
 }
 

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -1771,7 +1771,8 @@ export function massageMarkdown(input: string): string {
     )
     .replace(regEx(/]\(https:\/\/github\.com\//g), '](https://togithub.com/')
     .replace(regEx(/]: https:\/\/github\.com\//g), ']: https://togithub.com/')
-    .replace('> ⚠ **Warning**\n> \n', '> [!WARNING]\n');
+    .replace('> ⚠ **Warning**\n> \n', '> [!WARNING]\n')
+    .replace('> ❗ **Important**\n> \n', '> [!IMPORTANT]\n');
   return smartTruncate(massagedInput, GitHubMaxPrBodyLen);
 }
 

--- a/lib/workers/repository/__snapshots__/dependency-dashboard.spec.ts.snap
+++ b/lib/workers/repository/__snapshots__/dependency-dashboard.spec.ts.snap
@@ -6,11 +6,10 @@ exports[`workers/repository/dependency-dashboard ensureDependencyDashboard() che
 
 ---
 
-### ⚠ Dependency Lookup Warnings ⚠
-
--   Renovate failed to look up the following dependencies: \`dependency-2\`.
-
-Files affected: \`package.json\`
+> [!WARNING]
+> Renovate failed to look up the following dependencies: \`dependency-2\`.
+> 
+> Files affected: \`package.json\`
 
 ---
 

--- a/lib/workers/repository/errors-warnings.spec.ts
+++ b/lib/workers/repository/errors-warnings.spec.ts
@@ -85,9 +85,9 @@ describe('workers/repository/errors-warnings', () => {
         "
         ---
 
-        ### ⚠ Dependency Lookup Warnings ⚠
-
-        Warnings were logged while processing this repo. Please check the Dependency Dashboard for more information.
+        > ⚠ **Warning**
+        > 
+        > Some dependencies could not be looked up. Check the Dependency Dashboard for more information.
 
         "
       `);
@@ -133,9 +133,9 @@ describe('workers/repository/errors-warnings', () => {
         "
         ---
 
-        ### ⚠ Dependency Lookup Warnings ⚠
-
-        Warnings were logged while processing this repo. Please check the logs for more information.
+        > ⚠ **Warning**
+        > 
+        > Some dependencies could not be looked up. Check the warning logs for more information.
 
         "
       `);
@@ -197,11 +197,11 @@ describe('workers/repository/errors-warnings', () => {
         "
         ---
 
-        ### ⚠ Dependency Lookup Warnings ⚠
-
-        -   Renovate failed to look up the following dependencies: \`dependency-1\`, \`dependency-2\`.
-
-        Files affected: \`package.json\`, \`backend/package.json\`, \`Dockerfile\`
+        > ⚠ **Warning**
+        > 
+        > Renovate failed to look up the following dependencies: \`dependency-1\`, \`dependency-2\`.
+        > 
+        > Files affected: \`package.json\`, \`backend/package.json\`, \`Dockerfile\`
 
         ---
 
@@ -304,15 +304,15 @@ describe('workers/repository/errors-warnings', () => {
       expect(res).toMatchInlineSnapshot(`
         "
         ---
-
-        ### ⚠ Dependency Lookup Warnings ⚠
-
-        Please correct - or verify that you can safely ignore - these lookup failures before you merge this PR.
-
-        -   \`Warning 1\`
-        -   \`Warning 2\`
-
-        Files affected: \`package.json\`, \`backend/package.json\`, \`Dockerfile\`
+        > 
+        > ⚠ **Warning**
+        > 
+        > Please correct - or verify that you can safely ignore - these dependency lookup failures before you merge this PR.
+        > 
+        > -   \`Warning 1\`
+        > -   \`Warning 2\`
+        > 
+        > Files affected: \`package.json\`, \`backend/package.json\`, \`Dockerfile\`
 
         "
       `);

--- a/lib/workers/repository/errors-warnings.ts
+++ b/lib/workers/repository/errors-warnings.ts
@@ -74,15 +74,13 @@ export function getDepWarningsOnboardingPR(
   if (!warnings.length) {
     return '';
   }
-  warningText = emojify(
-    `\n---\n\n### :warning: Dependency Lookup Warnings :warning:\n\n`
-  );
-  warningText += `Please correct - or verify that you can safely ignore - these lookup failures before you merge this PR.\n\n`;
+  warningText = emojify(`\n---\n> \n> :warning: **Warning**\n> \n`);
+  warningText += `> Please correct - or verify that you can safely ignore - these dependency lookup failures before you merge this PR.\n> \n`;
   for (const w of warnings) {
-    warningText += `-   \`${w}\`\n`;
+    warningText += `> -   \`${w}\`\n`;
   }
   warningText +=
-    '\nFiles affected: ' +
+    '> \n> Files affected: ' +
     warningFiles.map((f) => '`' + f + '`').join(', ') +
     '\n\n';
   return warningText;
@@ -101,14 +99,12 @@ export function getDepWarningsPR(
   if (!warnings.length) {
     return '';
   }
-  warningText = emojify(
-    `\n---\n\n### :warning: Dependency Lookup Warnings :warning:\n\n`
-  );
-  warningText += 'Warnings were logged while processing this repo. ';
+  warningText = emojify(`\n---\n\n> :warning: **Warning**\n> \n`);
+  warningText += '> Some dependencies could not be looked up. ';
   if (dependencyDashboard) {
-    warningText += `Please check the Dependency Dashboard for more information.\n\n`;
+    warningText += `Check the Dependency Dashboard for more information.\n\n`;
   } else {
-    warningText += `Please check the logs for more information.\n\n`;
+    warningText += `Check the warning logs for more information.\n\n`;
   }
   return warningText;
 }
@@ -133,11 +129,10 @@ export function getDepWarningsDashboard(
     .join(', ');
 
   let warningText = emojify(
-    `\n---\n\n### :warning: Dependency Lookup Warnings :warning:\n\n`
+    `\n---\n\n> :warning: **Warning**\n> \n> Renovate failed to look up the following dependencies: `
   );
-  warningText += `-   Renovate failed to look up the following dependencies: `;
   warningText += depWarnings;
-  warningText += '.\n\nFiles affected: ';
+  warningText += '.\n> \n> Files affected: ';
   warningText += warningFiles.map((f) => '`' + f + '`').join(', ');
   warningText += '\n\n---\n\n';
   return warningText;

--- a/lib/workers/repository/update/pr/index.ts
+++ b/lib/workers/repository/update/pr/index.ts
@@ -280,9 +280,10 @@ export async function ensurePr(
         upgrade.prBodyNotes = [
           ...upgrade.prBodyNotes,
           [
-            '\n',
-            ':warning: Release Notes retrieval for this PR were skipped because no github.com credentials were available.',
-            'If you are self-hosted, please see [this instruction](https://github.com/renovatebot/renovate/blob/master/docs/usage/examples/self-hosting.md#githubcom-token-for-release-notes).',
+            '> :exclamation: **Important**',
+            '> ',
+            '> Release Notes retrieval for this PR were skipped because no github.com credentials were available. ',
+            '> If you are self-hosted, please see [this instruction](https://github.com/renovatebot/renovate/blob/master/docs/usage/examples/self-hosting.md#githubcom-token-for-release-notes).',
             '\n',
           ].join('\n'),
         ];


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Refactors markdown warnings plus adds a massage function to have them use GitHub's custom warning markdown approach.

## Context

Closes #24550

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
