### PR TITLE
feat(woodpecker): support `services:` key

### DIFF
--- a/lib/modules/manager/woodpecker/__fixtures__/.woodpecker.yml
+++ b/lib/modules/manager/woodpecker/__fixtures__/.woodpecker.yml
@@ -1,6 +1,6 @@
- clone:
-   git:
-     image: woodpeckerci/plugin-git:2.0.3
+clone:
+  git:
+    image: woodpeckerci/plugin-git:2.0.3
 
 steps:
   redis:
@@ -29,4 +29,4 @@ steps:
 
 services:
   service-postgres:
-    image: "postgres:9.5.0"
+    image: postgres:9.5.0

--- a/lib/modules/manager/woodpecker/__fixtures__/.woodpecker.yml
+++ b/lib/modules/manager/woodpecker/__fixtures__/.woodpecker.yml
@@ -1,3 +1,7 @@
+ clone:
+   git:
+     image: woodpeckerci/plugin-git:2.0.3
+
 steps:
   redis:
     image: quay.io/something/redis:alpine
@@ -25,4 +29,4 @@ steps:
 
 services:
   service-postgres:
-    image: "postgres:9.4.0"
+    image: "postgres:9.5.0"

--- a/lib/modules/manager/woodpecker/__fixtures__/.woodpecker.yml
+++ b/lib/modules/manager/woodpecker/__fixtures__/.woodpecker.yml
@@ -1,4 +1,4 @@
-pipeline:
+steps:
   redis:
     image: quay.io/something/redis:alpine
 
@@ -22,3 +22,7 @@ pipeline:
 
   debugapp:
     image: app-local-debug
+
+services:
+  service-postgres:
+    image: "postgres:9.4.0"

--- a/lib/modules/manager/woodpecker/extract.spec.ts
+++ b/lib/modules/manager/woodpecker/extract.spec.ts
@@ -23,6 +23,15 @@ describe('modules/manager/woodpecker/extract', () => {
       expect(res).toEqual({
         deps: [
           {
+            depName: 'woodpeckerci/plugin-git',
+            currentValue: '2.0.3',
+            currentDigest: undefined,
+            replaceString: 'woodpeckerci/plugin-git:2.0.3',
+            autoReplaceStringTemplate:
+              '{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}',
+            datasource: 'docker',
+          },
+          {
             depName: 'quay.io/something/redis',
             currentValue: 'alpine',
             currentDigest: undefined,
@@ -90,6 +99,15 @@ describe('modules/manager/woodpecker/extract', () => {
             currentValue: undefined,
             currentDigest: undefined,
             replaceString: 'app-local-debug',
+            autoReplaceStringTemplate:
+              '{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}',
+            datasource: 'docker',
+          },
+          {
+            depName: 'postgres',
+            currentValue: '9.5.0',
+            currentDigest: undefined,
+            replaceString: 'postgres:9.5.0',
             autoReplaceStringTemplate:
               '{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}',
             datasource: 'docker',

--- a/lib/modules/manager/woodpecker/extract.ts
+++ b/lib/modules/manager/woodpecker/extract.ts
@@ -8,7 +8,7 @@ import type { WoodpeckerConfig } from './types';
 function woodpeckerVersionDecider(
   woodpeckerConfig: WoodpeckerConfig
 ): (keyof WoodpeckerConfig)[] {
-  const keys = ['clone', 'steps', 'pipeline'];
+  const keys = ['clone', 'steps', 'pipeline', 'services'];
   return Object.keys(woodpeckerConfig).filter((key) =>
     keys.includes(key)
   ) as (keyof WoodpeckerConfig)[];


### PR DESCRIPTION
## Changes

Support the extraction of `docker` versions within the `services` section in Woodpecker YAML files.

## Context

So far, images nested under `services:` are ignored.

Besides, I updated the fixture YAML to Woodpecker v1 syntax (`pipeline:` is old syntax).


## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

