### PR TITLE
fix: deep merge config and platformInfo to avoid losing hostRules

### DIFF
--- a/lib/modules/platform/index.spec.ts
+++ b/lib/modules/platform/index.spec.ts
@@ -119,34 +119,81 @@ describe('modules/platform/index', () => {
     });
   });
 
-  it('merges platform hostRules with additionalHostRules', async () => {
-    const config = {
-      platform: 'github' as PlatformId,
-      endpoint: 'https://api.github.com',
-      gitAuthor: 'user@domain.com',
-      username: 'abc',
-      token: '123',
-    };
+  describe('when platform endpoint is https://api.github.com/', () => {
+    it('merges config hostRules with platform hostRules', async () => {
+      const config = {
+        platform: 'github' as PlatformId,
+        endpoint: 'https://api.github.com',
+        gitAuthor: 'user@domain.com',
+        username: 'abc',
+        token: '123',
+        hostRules: [
+          {
+            hostType: 'github',
+            matchHost: 'github.com',
+            token: '456',
+            username: 'def',
+          },
+        ],
+      };
 
-    expect(await platform.initPlatform(config)).toEqual({
-      endpoint: 'https://api.github.com/',
-      gitAuthor: 'user@domain.com',
-      hostRules: [
-        {
-          hostType: 'docker',
-          matchHost: 'ghcr.io',
-          password: '123',
-          username: 'USERNAME',
-        },
-        {
-          hostType: 'github',
-          matchHost: 'api.github.com',
-          token: '123',
-          username: 'abc',
-        },
-      ],
-      platform: 'github',
-      renovateUsername: 'abc',
+      expect(await platform.initPlatform(config)).toEqual({
+        endpoint: 'https://api.github.com/',
+        gitAuthor: 'user@domain.com',
+        hostRules: [
+          {
+            hostType: 'github',
+            matchHost: 'github.com',
+            token: '456',
+            username: 'def',
+          },
+          {
+            hostType: 'docker',
+            matchHost: 'ghcr.io',
+            password: '123',
+            username: 'USERNAME',
+          },
+          {
+            hostType: 'github',
+            matchHost: 'api.github.com',
+            token: '123',
+            username: 'abc',
+          },
+        ],
+        platform: 'github',
+        renovateUsername: 'abc',
+      });
+    });
+
+    it('merges platform hostRules with additionalHostRules', async () => {
+      const config = {
+        platform: 'github' as PlatformId,
+        endpoint: 'https://api.github.com',
+        gitAuthor: 'user@domain.com',
+        username: 'abc',
+        token: '123',
+      };
+
+      expect(await platform.initPlatform(config)).toEqual({
+        endpoint: 'https://api.github.com/',
+        gitAuthor: 'user@domain.com',
+        hostRules: [
+          {
+            hostType: 'docker',
+            matchHost: 'ghcr.io',
+            password: '123',
+            username: 'USERNAME',
+          },
+          {
+            hostType: 'github',
+            matchHost: 'api.github.com',
+            token: '123',
+            username: 'abc',
+          },
+        ],
+        platform: 'github',
+        renovateUsername: 'abc',
+      });
     });
   });
 });

--- a/lib/modules/platform/index.ts
+++ b/lib/modules/platform/index.ts
@@ -1,4 +1,5 @@
 import URL from 'node:url';
+import deepmerge from 'deepmerge';
 import type { AllConfig } from '../../config/types';
 import type { PlatformId } from '../../constants';
 import { PLATFORM_NOT_FOUND } from '../../constants/error-messages';
@@ -47,7 +48,7 @@ export async function initPlatform(config: AllConfig): Promise<AllConfig> {
   setPlatformApi(config.platform!);
   // TODO: types
   const platformInfo = await platform.initPlatform(config);
-  const returnConfig: any = { ...config, ...platformInfo };
+  const returnConfig: any = deepmerge(config, platformInfo);
   // istanbul ignore else
   if (config?.gitAuthor) {
     logger.debug(`Using configured gitAuthor (${config.gitAuthor})`);

--- a/lib/modules/platform/index.ts
+++ b/lib/modules/platform/index.ts
@@ -50,7 +50,7 @@ export async function initPlatform(config: AllConfig): Promise<AllConfig> {
   const returnConfig: any = {
     ...config,
     ...platformInfo,
-    hostRules: [...(config.hostRules ?? []), ...(platformInfo.hostRules ?? [])],
+    hostRules: [...(config.hostRules ?? []), ...(platformInfo?.hostRules ?? [])],
   };
   // istanbul ignore else
   if (config?.gitAuthor) {

--- a/lib/modules/platform/index.ts
+++ b/lib/modules/platform/index.ts
@@ -50,7 +50,10 @@ export async function initPlatform(config: AllConfig): Promise<AllConfig> {
   const returnConfig: any = {
     ...config,
     ...platformInfo,
-    hostRules: [...(config.hostRules ?? []), ...(platformInfo?.hostRules ?? [])],
+    hostRules: [
+      ...(config.hostRules ?? []),
+      ...(platformInfo?.hostRules ?? []),
+    ],
   };
   // istanbul ignore else
   if (config?.gitAuthor) {

--- a/lib/modules/platform/index.ts
+++ b/lib/modules/platform/index.ts
@@ -82,7 +82,6 @@ export async function initPlatform(config: AllConfig): Promise<AllConfig> {
       delete returnConfig[field];
     }
   });
-  returnConfig.hostRules = returnConfig.hostRules || [];
   const typedPlatformRule = {
     ...platformRule,
     hostType: returnConfig.platform,

--- a/lib/modules/platform/index.ts
+++ b/lib/modules/platform/index.ts
@@ -1,5 +1,4 @@
 import URL from 'node:url';
-import deepmerge from 'deepmerge';
 import type { AllConfig } from '../../config/types';
 import type { PlatformId } from '../../constants';
 import { PLATFORM_NOT_FOUND } from '../../constants/error-messages';
@@ -48,7 +47,11 @@ export async function initPlatform(config: AllConfig): Promise<AllConfig> {
   setPlatformApi(config.platform!);
   // TODO: types
   const platformInfo = await platform.initPlatform(config);
-  const returnConfig: any = deepmerge(config, platformInfo);
+  const returnConfig: any = {
+    ...config,
+    ...platformInfo,
+    hostRules: [...(config.hostRules ?? []), ...(platformInfo.hostRules ?? [])],
+  };
   // istanbul ignore else
   if (config?.gitAuthor) {
     logger.debug(`Using configured gitAuthor (${config.gitAuthor})`);


### PR DESCRIPTION
## Changes

Deep merge config and platformInfo to avoid losing hostRules.

## Context

Since commit 22709f4 merging of config hostRules and platform hostRules broke in case the platform endpoint equals 'https://api.github.com/'. The two were merged using a shallow commit where the last one (i.e. `platformInfo` took precedence. This resulted in the config hostRules being overriden.

Closes: #25115

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
