### PR TITLE
docs(config options): heading for GitHub/Azure required reviewers

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -3380,7 +3380,7 @@ By default, `renovate` will update to a version greater than `latest` only if th
 
 Must be valid usernames.
 
-**Required reviewers on GitHub**
+### Required reviewers on GitHub
 
 If you're assigning a team to review on GitHub, you must use the prefix `team:` and add the _last part_ of the team name.
 Say the full team name on GitHub is `@organization/foo`, then you'd set the config option like this:
@@ -3391,7 +3391,7 @@ Say the full team name on GitHub is `@organization/foo`, then you'd set the conf
 }
 ```
 
-**Required reviewers on Azure DevOps**
+### Required reviewers on Azure DevOps
 
 To mark a reviewer as required on Azure DevOps, you must use the prefix `required:`.
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Create `h3` heading for GitHub required reviewers section
- Create `h3` heading for Azure required reviewers section

## Context

The current docs use `**Bold text as heading**`. If we convert those to a `h3`, Material for MkDocs will:

- Use the heading style
- Create a link to the heading
- Put the heading in the table of contents (sidebar)

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
