### PR TITLE
fix(yarn): do not set registryUrls from yarnrc on non-npm dependencies

### DIFF
--- a/lib/modules/manager/npm/extract/__snapshots__/index.spec.ts.snap
+++ b/lib/modules/manager/npm/extract/__snapshots__/index.spec.ts.snap
@@ -26,6 +26,62 @@ exports[`modules/manager/npm/extract/index .extractPackageFile() catches invalid
 }
 `;
 
+exports[`modules/manager/npm/extract/index .extractPackageFile() does not set registryUrls for non-npmjs 1`] = `
+{
+  "deps": [
+    {
+      "currentRawValue": "github:owner/a#v1.1.0",
+      "currentValue": "v1.1.0",
+      "datasource": "github-tags",
+      "depName": "a",
+      "depType": "dependencies",
+      "gitRef": true,
+      "packageName": "owner/a",
+      "pinDigests": false,
+      "prettyDepType": "dependency",
+      "sourceUrl": "https://github.com/owner/a",
+    },
+    {
+      "commitMessageTopic": "Node.js",
+      "currentValue": "8.9.2",
+      "datasource": "github-tags",
+      "depName": "node",
+      "depType": "engines",
+      "packageName": "nodejs/node",
+      "prettyDepType": "engine",
+      "versioning": "node",
+    },
+    {
+      "commitMessageTopic": "Yarn",
+      "currentValue": "3.2.4",
+      "datasource": "npm",
+      "depName": "yarn",
+      "depType": "volta",
+      "packageName": "@yarnpkg/cli",
+      "prettyDepType": "volta",
+      "registryUrls": [
+        "https://registry.example.com",
+      ],
+    },
+  ],
+  "extractedConstraints": {
+    "node": "8.9.2",
+  },
+  "managerData": {
+    "hasPackageManager": false,
+    "npmLock": undefined,
+    "packageJsonName": undefined,
+    "pnpmShrinkwrap": undefined,
+    "workspacesPackages": undefined,
+    "yarnLock": undefined,
+    "yarnZeroInstall": false,
+  },
+  "npmrc": undefined,
+  "packageFileVersion": undefined,
+  "skipInstalls": true,
+}
+`;
+
 exports[`modules/manager/npm/extract/index .extractPackageFile() extracts engines 1`] = `
 {
   "deps": [

--- a/lib/modules/manager/npm/extract/index.spec.ts
+++ b/lib/modules/manager/npm/extract/index.spec.ts
@@ -646,6 +646,63 @@ describe('modules/manager/npm/extract/index', () => {
       });
     });
 
+    it('does not set registryUrls for non-npmjs', async () => {
+      fs.readLocalFile.mockImplementation((fileName): Promise<any> => {
+        if (fileName === '.yarnrc.yml') {
+          return Promise.resolve(
+            'npmRegistryServer: https://registry.example.com'
+          );
+        }
+        return Promise.resolve(null);
+      });
+      const pJson = {
+        dependencies: {
+          a: 'github:owner/a#v1.1.0',
+        },
+        engines: {
+          node: '8.9.2',
+        },
+        volta: {
+          yarn: '3.2.4',
+        },
+      };
+      const pJsonStr = JSON.stringify(pJson);
+      const res = await npmExtract.extractPackageFile(
+        pJsonStr,
+        'package.json',
+        defaultExtractConfig
+      );
+      expect(res).toMatchSnapshot({
+        deps: [
+          {
+            depName: 'a',
+            currentValue: 'v1.1.0',
+            datasource: 'github-tags',
+            sourceUrl: 'https://github.com/owner/a',
+          },
+          {
+            commitMessageTopic: 'Node.js',
+            currentValue: '8.9.2',
+            datasource: 'github-tags',
+            depName: 'node',
+            depType: 'engines',
+            packageName: 'nodejs/node',
+            prettyDepType: 'engine',
+            versioning: 'node',
+          },
+          {
+            commitMessageTopic: 'Yarn',
+            currentValue: '3.2.4',
+            datasource: 'npm',
+            depName: 'yarn',
+            depType: 'volta',
+            prettyDepType: 'volta',
+            packageName: '@yarnpkg/cli',
+          },
+        ],
+      });
+    });
+
     it('extracts npm package alias', async () => {
       fs.readLocalFile.mockImplementation((fileName: string): Promise<any> => {
         if (fileName === 'package-lock.json') {

--- a/lib/modules/manager/npm/extract/index.ts
+++ b/lib/modules/manager/npm/extract/index.ts
@@ -3,6 +3,7 @@ import { GlobalConfig } from '../../../../config/global';
 import { logger } from '../../../../logger';
 import { getSiblingFileName, readLocalFile } from '../../../../util/fs';
 import { newlineRegex, regEx } from '../../../../util/regex';
+import { NpmDatasource } from '../../../datasource/npm';
 
 import type {
   ExtractConfig,
@@ -179,7 +180,7 @@ export async function extractPackageFile(
           dep.depName,
           yarnConfig
         );
-        if (registryUrlFromYarnConfig) {
+        if (registryUrlFromYarnConfig && dep.datasource === NpmDatasource.id) {
           dep.registryUrls = [registryUrlFromYarnConfig];
         }
       }


### PR DESCRIPTION
## Changes

Set registryUrls only if datasource is npm. Some npm dependencies are using github-tags as datasource. The lookups of the github-tags are not requested from github but from the first registryUrl (eg private artifactory registry).

## Context

This but was introduced with #24455. The non-npm dependencies were returned before the registryUrls was set
https://github.com/renovatebot/renovate/pull/24455/files#diff-43bee6aaab05445cea15363ac769893671dc75dcc55db59b50801e1a6c97e8f5L257

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
