### PR TITLE
fix(pre-commit): use detectPlatform for self-hosted github, gitlab

### DIFF
--- a/lib/modules/manager/terraform/lockfile/index.ts
+++ b/lib/modules/manager/terraform/lockfile/index.ts
@@ -19,6 +19,7 @@ import {
 async function updateAllLocks(
   locks: ProviderLock[]
 ): Promise<ProviderLockUpdate[]> {
+  debugger;
   const updates = await p.map(
     locks,
     async (lock) => {
@@ -74,6 +75,8 @@ export async function updateArtifacts({
     logger.debug('No .terraform.lock.hcl found');
     return null;
   }
+
+  debugger;
 
   try {
     const lockFileContent = await readLockFile(lockFilePath);

--- a/lib/modules/manager/terraform/lockfile/index.ts
+++ b/lib/modules/manager/terraform/lockfile/index.ts
@@ -19,7 +19,6 @@ import {
 async function updateAllLocks(
   locks: ProviderLock[]
 ): Promise<ProviderLockUpdate[]> {
-  debugger;
   const updates = await p.map(
     locks,
     async (lock) => {
@@ -75,8 +74,6 @@ export async function updateArtifacts({
     logger.debug('No .terraform.lock.hcl found');
     return null;
   }
-
-  debugger;
 
   try {
     const lockFileContent = await readLockFile(lockFilePath);


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Use `detectPlatform()` in pre-commit manager to detect self-hosted GitLab

## Context

Fixes #25157

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
