### PR TITLE
feat(go): Add support for Go host `code.cloudfoundry.org`

### DIFF
--- a/lib/modules/datasource/go/base.spec.ts
+++ b/lib/modules/datasource/go/base.spec.ts
@@ -15,11 +15,12 @@ const hostRules = mocked(_hostRules);
 describe('modules/datasource/go/base', () => {
   describe('simple cases', () => {
     it.each`
-      module                     | datasource          | packageName
-      ${'gopkg.in/foo'}          | ${'github-tags'}    | ${'go-foo/foo'}
-      ${'gopkg.in/foo/bar'}      | ${'github-tags'}    | ${'foo/bar'}
-      ${'github.com/foo/bar'}    | ${'github-tags'}    | ${'foo/bar'}
-      ${'bitbucket.org/foo/bar'} | ${'bitbucket-tags'} | ${'foo/bar'}
+      module                           | datasource          | packageName
+      ${'gopkg.in/foo'}                | ${'github-tags'}    | ${'go-foo/foo'}
+      ${'gopkg.in/foo/bar'}            | ${'github-tags'}    | ${'foo/bar'}
+      ${'github.com/foo/bar'}          | ${'github-tags'}    | ${'foo/bar'}
+      ${'bitbucket.org/foo/bar'}       | ${'bitbucket-tags'} | ${'foo/bar'}
+      ${'code.cloudfoundry.org/lager'} | ${'github-tags'}    | ${'cloudfoundry/lager'}
     `(
       '$module -> $datasource: $packageName',
       async ({ module, datasource, packageName }) => {

--- a/lib/modules/datasource/go/base.ts
+++ b/lib/modules/datasource/go/base.ts
@@ -58,6 +58,16 @@ export class BaseGoDatasource {
       };
     }
 
+    if (goModule.startsWith('code.cloudfoundry.org/')) {
+      const split = goModule.split('/');
+      const packageName = 'cloudfoundry/' + split[1];
+      return {
+        datasource: GithubTagsDatasource.id,
+        packageName,
+        registryUrl: 'https://github.com',
+      };
+    }
+
     return await BaseGoDatasource.goGetDatasource(goModule);
   }
 

--- a/lib/modules/datasource/go/base.ts
+++ b/lib/modules/datasource/go/base.ts
@@ -59,8 +59,10 @@ export class BaseGoDatasource {
     }
 
     if (goModule.startsWith('code.cloudfoundry.org/')) {
-      const split = goModule.split('/');
-      const packageName = 'cloudfoundry/' + split[1];
+      const packageName = goModule.replace(
+        'code.cloudfoundry.org',
+        'cloudfoundry'
+      );
       return {
         datasource: GithubTagsDatasource.id,
         packageName,


### PR DESCRIPTION
## Changes

Dependency updates for Go libraries from `code.cloudfoundry.org` are now supported.

## Context

In #18246 it was discussed that the error message
```
Unsupported go host - cannot look up versions
```

is not a bug when using Go dependencies from `code.cloudfoundry.org`, however in our daily work on `app-autoscaler-release` it is unfortunate [such dependencies are not automatically updated by Renovate](https://github.com/cloudfoundry/app-autoscaler-release/issues/1100)

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository
