### PR TITLE
fix(config/presets): exclude docker.io/calico/node from Node.JS group

### DIFF
--- a/lib/config/presets/internal/group.ts
+++ b/lib/config/presets/internal/group.ts
@@ -301,7 +301,11 @@ const staticGroups = {
     packageRules: [
       {
         commitMessageTopic: 'Node.js',
-        excludePackageNames: ['calico/node', 'docker.io/calico/node', 'kindest/node'],
+        excludePackageNames: [
+          'calico/node',
+          'docker.io/calico/node',
+          'kindest/node',
+        ],
         matchDatasources: ['docker'],
         matchDepNames: ['node'],
         matchPackagePatterns: ['/node$'],

--- a/lib/config/presets/internal/group.ts
+++ b/lib/config/presets/internal/group.ts
@@ -301,7 +301,7 @@ const staticGroups = {
     packageRules: [
       {
         commitMessageTopic: 'Node.js',
-        excludePackageNames: ['calico/node', 'kindest/node'],
+        excludePackageNames: ['calico/node', 'docker.io/calico/node', 'kindest/node'],
         matchDatasources: ['docker'],
         matchDepNames: ['node'],
         matchPackagePatterns: ['/node$'],


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
Recent version of calico manifests are using the docker.io prefix to reference their container images on dockerhub, e.g. see https://raw.githubusercontent.com/projectcalico/calico/v3.26.3/manifests/calico-typha.yaml and search for `docker.io`

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

We are seeing MRs created by renovate-bot that update Calico images but use Node.js in their title, e.g. `Update Node.js to v3.26.3 `.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
