### PR TITLE
fix(datasource/galaxy): use new hostname for existing API implementation

### DIFF
--- a/lib/modules/datasource/galaxy-collection/__snapshots__/index.spec.ts.snap
+++ b/lib/modules/datasource/galaxy-collection/__snapshots__/index.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`modules/datasource/galaxy-collection/index getReleases processes real data 1`] = `
 {
-  "registryUrl": "https://galaxy.ansible.com/",
+  "registryUrl": "https://old-galaxy.ansible.com/",
   "releases": [
     {
       "dependencies": {},
@@ -41,7 +41,7 @@ exports[`modules/datasource/galaxy-collection/index getReleases processes real d
 
 exports[`modules/datasource/galaxy-collection/index getReleases returns only valid versions if a version detail fails 1`] = `
 {
-  "registryUrl": "https://galaxy.ansible.com/",
+  "registryUrl": "https://old-galaxy.ansible.com/",
   "releases": [
     {
       "dependencies": {},

--- a/lib/modules/datasource/galaxy-collection/index.spec.ts
+++ b/lib/modules/datasource/galaxy-collection/index.spec.ts
@@ -18,7 +18,7 @@ const communityKubernetesDetails0111 = Fixtures.get(
   'community_kubernetes_version_details_0.11.1.json'
 );
 
-const baseUrl = 'https://galaxy.ansible.com';
+const baseUrl = 'https://old-galaxy.ansible.com';
 
 const datasource = GalaxyCollectionDatasource.id;
 

--- a/lib/modules/datasource/galaxy-collection/index.ts
+++ b/lib/modules/datasource/galaxy-collection/index.ts
@@ -21,7 +21,7 @@ export class GalaxyCollectionDatasource extends Datasource {
 
   override readonly customRegistrySupport = false;
 
-  override readonly defaultRegistryUrls = ['https://galaxy.ansible.com/'];
+  override readonly defaultRegistryUrls = ['https://old-galaxy.ansible.com/'];
 
   override readonly defaultVersioning = pep440Versioning.id;
 

--- a/lib/modules/datasource/galaxy/__snapshots__/index.spec.ts.snap
+++ b/lib/modules/datasource/galaxy/__snapshots__/index.spec.ts.snap
@@ -2,8 +2,8 @@
 
 exports[`modules/datasource/galaxy/index getReleases processes real data 1`] = `
 {
-  "dependencyUrl": "https://galaxy.ansible.com/yatesr/timezone",
-  "registryUrl": "https://galaxy.ansible.com/",
+  "dependencyUrl": "https://old-galaxy.ansible.com/yatesr/timezone",
+  "registryUrl": "https://old-galaxy.ansible.com/",
   "releases": [
     {
       "releaseTimestamp": "2015-11-17T00:43:42.000Z",

--- a/lib/modules/datasource/galaxy/index.spec.ts
+++ b/lib/modules/datasource/galaxy/index.spec.ts
@@ -4,7 +4,7 @@ import * as httpMock from '../../../../test/http-mock';
 import { EXTERNAL_HOST_ERROR } from '../../../constants/error-messages';
 import { GalaxyDatasource } from '.';
 
-const baseUrl = 'https://galaxy.ansible.com/';
+const baseUrl = 'https://old-galaxy.ansible.com/';
 
 describe('modules/datasource/galaxy/index', () => {
   describe('getReleases', () => {

--- a/lib/modules/datasource/galaxy/index.ts
+++ b/lib/modules/datasource/galaxy/index.ts
@@ -15,7 +15,7 @@ export class GalaxyDatasource extends Datasource {
 
   override readonly customRegistrySupport = false;
 
-  override readonly defaultRegistryUrls = ['https://galaxy.ansible.com/'];
+  override readonly defaultRegistryUrls = ['https://old-galaxy.ansible.com/'];
 
   override readonly defaultVersioning = pep440Versioning.id;
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Changes the defaultRegistryUrl from https://galaxy.ansible.com to https://old-galaxy.ansible.com

<!-- Describe what behavior is changed by this PR. -->

## Context
https://github.com/renovatebot/renovate/issues/24981#issuecomment-1761384738

The Galaxy team has moved the domain during the introduction of Galaxy Next which has a completly new API 
Therefore we default to the old domain to fix behaviour for users. 

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
