### PR TITLE
fix(gradle): add dependency-verification to gradle commands

### DIFF
--- a/lib/modules/manager/gradle/artifacts.spec.ts
+++ b/lib/modules/manager/gradle/artifacts.spec.ts
@@ -159,13 +159,13 @@ describe('modules/manager/gradle/artifacts', () => {
       ]);
       expect(execSnapshots).toMatchObject([
         {
-          cmd: './gradlew --console=plain -q properties',
+          cmd: './gradlew --console=plain --dependency-verification lenient -q properties',
           options: {
             cwd: '/tmp/github/some/repo',
           },
         },
         {
-          cmd: './gradlew --console=plain -q :dependencies --update-locks org.junit.jupiter:junit-jupiter-api,org.junit.jupiter:junit-jupiter-engine',
+          cmd: './gradlew --console=plain --dependency-verification lenient -q :dependencies --update-locks org.junit.jupiter:junit-jupiter-api,org.junit.jupiter:junit-jupiter-engine',
           options: {
             cwd: '/tmp/github/some/repo',
             stdio: ['pipe', 'ignore', 'pipe'],
@@ -202,13 +202,13 @@ describe('modules/manager/gradle/artifacts', () => {
       // In win32, gradle.bat will be used and /dev/null redirection isn't used yet
       expect(execSnapshots).toMatchObject([
         {
-          cmd: 'gradlew.bat --console=plain -q properties',
+          cmd: 'gradlew.bat --console=plain --dependency-verification lenient -q properties',
           options: {
             cwd: '/tmp/github/some/repo',
           },
         },
         {
-          cmd: 'gradlew.bat --console=plain -q :dependencies --update-locks org.junit.jupiter:junit-jupiter-api,org.junit.jupiter:junit-jupiter-engine',
+          cmd: 'gradlew.bat --console=plain --dependency-verification lenient -q :dependencies --update-locks org.junit.jupiter:junit-jupiter-api,org.junit.jupiter:junit-jupiter-engine',
           options: {
             cwd: '/tmp/github/some/repo',
             stdio: ['pipe', 'ignore', 'pipe'],
@@ -245,13 +245,13 @@ describe('modules/manager/gradle/artifacts', () => {
       ]);
       expect(execSnapshots).toMatchObject([
         {
-          cmd: './gradlew --console=plain -q properties',
+          cmd: './gradlew --console=plain --dependency-verification lenient -q properties',
           options: {
             cwd: '/tmp/github/some/repo',
           },
         },
         {
-          cmd: './gradlew --console=plain -q :dependencies --update-locks org.springframework.boot:org.springframework.boot.gradle.plugin',
+          cmd: './gradlew --console=plain --dependency-verification lenient -q :dependencies --update-locks org.springframework.boot:org.springframework.boot.gradle.plugin',
           options: {
             cwd: '/tmp/github/some/repo',
             stdio: ['pipe', 'ignore', 'pipe'],
@@ -296,13 +296,13 @@ describe('modules/manager/gradle/artifacts', () => {
       ]);
       expect(execSnapshots).toMatchObject([
         {
-          cmd: './gradlew --console=plain -q properties',
+          cmd: './gradlew --console=plain --dependency-verification lenient -q properties',
           options: {
             cwd: '/tmp/github/some/repo',
           },
         },
         {
-          cmd: './gradlew --console=plain -q :dependencies --write-locks',
+          cmd: './gradlew --console=plain --dependency-verification lenient -q :dependencies --write-locks',
           options: {
             cwd: '/tmp/github/some/repo',
             stdio: ['pipe', 'ignore', 'pipe'],
@@ -346,7 +346,7 @@ describe('modules/manager/gradle/artifacts', () => {
             ' bash -l -c "' +
             'install-tool java 16.0.1' +
             ' && ' +
-            './gradlew --console=plain -q properties' +
+            './gradlew --console=plain --dependency-verification lenient -q properties' +
             '"',
           options: { cwd: '/tmp/github/some/repo' },
         },
@@ -363,7 +363,7 @@ describe('modules/manager/gradle/artifacts', () => {
             ' bash -l -c "' +
             'install-tool java 16.0.1' +
             ' && ' +
-            './gradlew --console=plain -q :dependencies --write-locks' +
+            './gradlew --console=plain --dependency-verification lenient -q :dependencies --write-locks' +
             '"',
           options: {
             cwd: '/tmp/github/some/repo',
@@ -396,12 +396,12 @@ describe('modules/manager/gradle/artifacts', () => {
       expect(execSnapshots).toMatchObject([
         { cmd: 'install-tool java 16.0.1' },
         {
-          cmd: './gradlew --console=plain -q properties',
+          cmd: './gradlew --console=plain --dependency-verification lenient -q properties',
           options: { cwd: '/tmp/github/some/repo' },
         },
         { cmd: 'install-tool java 16.0.1' },
         {
-          cmd: './gradlew --console=plain -q :dependencies --write-locks',
+          cmd: './gradlew --console=plain --dependency-verification lenient -q :dependencies --write-locks',
           options: {
             cwd: '/tmp/github/some/repo',
             stdio: ['pipe', 'ignore', 'pipe'],
@@ -437,13 +437,13 @@ describe('modules/manager/gradle/artifacts', () => {
       ]);
       expect(execSnapshots).toMatchObject([
         {
-          cmd: './gradlew --console=plain -q properties',
+          cmd: './gradlew --console=plain --dependency-verification lenient -q properties',
           options: {
             cwd: '/tmp/github/some/repo',
           },
         },
         {
-          cmd: './gradlew --console=plain -q :dependencies :sub1:dependencies :sub2:dependencies --write-locks',
+          cmd: './gradlew --console=plain --dependency-verification lenient -q :dependencies :sub1:dependencies :sub2:dependencies --write-locks',
           options: {
             cwd: '/tmp/github/some/repo',
             stdio: ['pipe', 'ignore', 'pipe'],
@@ -487,7 +487,7 @@ describe('modules/manager/gradle/artifacts', () => {
 
       expect(execSnapshots).toMatchObject([
         {
-          cmd: './gradlew --console=plain -q properties',
+          cmd: './gradlew --console=plain --dependency-verification lenient -q properties',
           options: {
             cwd: '/tmp/github/some/repo',
           },
@@ -540,12 +540,12 @@ describe('modules/manager/gradle/artifacts', () => {
       expect(execSnapshots).toMatchObject([
         { cmd: 'install-tool java 11.0.1' },
         {
-          cmd: './gradlew --console=plain -q properties',
+          cmd: './gradlew --console=plain --dependency-verification lenient -q properties',
           options: { cwd: '/tmp/github/some/repo' },
         },
         { cmd: 'install-tool java 11.0.1' },
         {
-          cmd: './gradlew --console=plain -q :dependencies --write-locks',
+          cmd: './gradlew --console=plain --dependency-verification lenient -q :dependencies --write-locks',
           options: {
             cwd: '/tmp/github/some/repo',
             stdio: ['pipe', 'ignore', 'pipe'],
@@ -592,7 +592,7 @@ describe('modules/manager/gradle/artifacts', () => {
       ]);
       expect(execSnapshots).toMatchObject([
         {
-          cmd: './gradlew --console=plain -q --write-verification-metadata sha256 help',
+          cmd: './gradlew --console=plain --dependency-verification lenient -q --write-verification-metadata sha256 help',
           options: {
             cwd: '/tmp/github/some/repo',
             stdio: ['pipe', 'ignore', 'pipe'],
@@ -649,20 +649,20 @@ describe('modules/manager/gradle/artifacts', () => {
       ]);
       expect(execSnapshots).toMatchObject([
         {
-          cmd: './gradlew --console=plain -q properties',
+          cmd: './gradlew --console=plain --dependency-verification lenient -q properties',
           options: {
             cwd: '/tmp/github/some/repo',
           },
         },
         {
-          cmd: './gradlew --console=plain -q :dependencies --update-locks org.junit.jupiter:junit-jupiter-api,org.junit.jupiter:junit-jupiter-engine',
+          cmd: './gradlew --console=plain --dependency-verification lenient -q :dependencies --update-locks org.junit.jupiter:junit-jupiter-api,org.junit.jupiter:junit-jupiter-engine',
           options: {
             cwd: '/tmp/github/some/repo',
             stdio: ['pipe', 'ignore', 'pipe'],
           },
         },
         {
-          cmd: './gradlew --console=plain -q --write-verification-metadata sha256 help',
+          cmd: './gradlew --console=plain --dependency-verification lenient -q --write-verification-metadata sha256 help',
           options: {
             cwd: '/tmp/github/some/repo',
             stdio: ['pipe', 'ignore', 'pipe'],
@@ -705,7 +705,7 @@ describe('modules/manager/gradle/artifacts', () => {
 
       expect(execSnapshots).toMatchObject([
         {
-          cmd: './gradlew --console=plain -q --write-verification-metadata sha256 help',
+          cmd: './gradlew --console=plain --dependency-verification lenient -q --write-verification-metadata sha256 help',
           options: {
             cwd: '/tmp/github/some/repo',
             stdio: ['pipe', 'ignore', 'pipe'],
@@ -747,7 +747,7 @@ describe('modules/manager/gradle/artifacts', () => {
 
       expect(execSnapshots).toMatchObject([
         {
-          cmd: './gradlew --console=plain -q --write-verification-metadata sha256,pgp help',
+          cmd: './gradlew --console=plain --dependency-verification lenient -q --write-verification-metadata sha256,pgp help',
           options: {
             cwd: '/tmp/github/some/repo',
             stdio: ['pipe', 'ignore', 'pipe'],

--- a/lib/modules/manager/gradle/artifacts.ts
+++ b/lib/modules/manager/gradle/artifacts.ts
@@ -177,7 +177,7 @@ export async function updateArtifacts({
     const oldLockFileContentMap = await getFiles(lockFiles);
     await prepareGradleCommand(gradlewFile);
 
-    const baseCmd = `${gradlewName} --console=plain -q`;
+    const baseCmd = `${gradlewName} --console=plain --dependency-verification lenient -q`;
     const execOptions: ExecOptions = {
       cwdFile: gradlewFile,
       docker: {},


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Include param to force Gradle build even when the checksum verification fails. 

See: https://docs.gradle.org/current/userguide/dependency_verification.html#sec:disabling-verification

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

Closes #25194 

Forcing the build should not be a problem since Renovate regenerates the `verification-metadata.xml`.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
