### PR TITLE
fix(manager/npm): use `--config.ignore-scripts=true` for `pnpm dedupe`

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2973,7 +2973,7 @@ Table with options:
 | `gomodUpdateImportPaths`     | Update source import paths on major module updates, using [mod](https://github.com/marwan-at-work/mod).                                                    |
 | `helmUpdateSubChartArchives` | Update subchart archives in the `/charts` folder.                                                                                                          |
 | `npmDedupe`                  | Run `npm dedupe` after `package-lock.json` updates.                                                                                                        |
-| `pnpmDedupe`                 | Run `pnpm dedupe --ignore-scripts` after `pnpm-lock.yaml` updates.                                                                                         |
+| `pnpmDedupe`                 | Run `pnpm dedupe --config.ignore-scripts=true` after `pnpm-lock.yaml` updates.                                                                                         |
 | `yarnDedupeFewer`            | Run `yarn-deduplicate --strategy fewer` after `yarn.lock` updates.                                                                                         |
 | `yarnDedupeHighest`          | Run `yarn-deduplicate --strategy highest` (`yarn dedupe --strategy highest` for Yarn >=2.2.0) after `yarn.lock` updates.                                   |
 

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2973,7 +2973,7 @@ Table with options:
 | `gomodUpdateImportPaths`     | Update source import paths on major module updates, using [mod](https://github.com/marwan-at-work/mod).                                                    |
 | `helmUpdateSubChartArchives` | Update subchart archives in the `/charts` folder.                                                                                                          |
 | `npmDedupe`                  | Run `npm dedupe` after `package-lock.json` updates.                                                                                                        |
-| `pnpmDedupe`                 | Run `pnpm dedupe` after `pnpm-lock.yaml` updates.                                                                                                          |
+| `pnpmDedupe`                 | Run `pnpm dedupe --ignore-scripts` after `pnpm-lock.yaml` updates.                                                                                         |
 | `yarnDedupeFewer`            | Run `yarn-deduplicate --strategy fewer` after `yarn.lock` updates.                                                                                         |
 | `yarnDedupeHighest`          | Run `yarn-deduplicate --strategy highest` (`yarn dedupe --strategy highest` for Yarn >=2.2.0) after `yarn.lock` updates.                                   |
 

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2973,7 +2973,7 @@ Table with options:
 | `gomodUpdateImportPaths`     | Update source import paths on major module updates, using [mod](https://github.com/marwan-at-work/mod).                                                    |
 | `helmUpdateSubChartArchives` | Update subchart archives in the `/charts` folder.                                                                                                          |
 | `npmDedupe`                  | Run `npm dedupe` after `package-lock.json` updates.                                                                                                        |
-| `pnpmDedupe`                 | Run `pnpm dedupe --config.ignore-scripts=true` after `pnpm-lock.yaml` updates.                                                                                         |
+| `pnpmDedupe`                 | Run `pnpm dedupe --config.ignore-scripts=true` after `pnpm-lock.yaml` updates.                                                                             |
 | `yarnDedupeFewer`            | Run `yarn-deduplicate --strategy fewer` after `yarn.lock` updates.                                                                                         |
 | `yarnDedupeHighest`          | Run `yarn-deduplicate --strategy highest` (`yarn dedupe --strategy highest` for Yarn >=2.2.0) after `yarn.lock` updates.                                   |
 

--- a/lib/modules/manager/npm/post-update/__fixtures__/dedupe-ignore-scripts/package.json
+++ b/lib/modules/manager/npm/post-update/__fixtures__/dedupe-ignore-scripts/package.json
@@ -1,8 +1,0 @@
-{
-  "name": "dedupe-ignore-scripts",
-  "version": "1.0.0",
-  "engines": {
-    "pnpm": ">=8.8.0"
-  },
-  "engine-strict": true
-}

--- a/lib/modules/manager/npm/post-update/__fixtures__/dedupe-ignore-scripts/package.json
+++ b/lib/modules/manager/npm/post-update/__fixtures__/dedupe-ignore-scripts/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "dedupe-ignore-scripts",
+  "version": "1.0.0",
+  "engines": {
+    "pnpm": ">=8.8.0"
+  },
+  "engine-strict": true
+}

--- a/lib/modules/manager/npm/post-update/pnpm.spec.ts
+++ b/lib/modules/manager/npm/post-update/pnpm.spec.ts
@@ -77,38 +77,14 @@ describe('modules/manager/npm/post-update/pnpm', () => {
       {},
       { ...config, postUpdateOptions }
     );
-    expect(fs.readLocalFile).toHaveBeenCalledTimes(2);
+    expect(fs.readLocalFile).toHaveBeenCalledTimes(1);
     expect(res.lockFile).toBe('package-lock-contents');
     expect(execSnapshots).toMatchObject([
       {
         cmd: 'pnpm install --recursive --lockfile-only --ignore-scripts --ignore-pnpmfile',
       },
       {
-        cmd: 'pnpm dedupe',
-      },
-    ]);
-  });
-
-  it('performs dedupe --ignore-scripts for pnpm >= 8.8.0', async () => {
-    const execSnapshots = mockExecAll();
-    const fileContent = Fixtures.get('dedupe-ignore-scripts/package.json');
-    fs.readLocalFile
-      .mockResolvedValueOnce(fileContent)
-      .mockResolvedValue('package-lock-contents');
-    const postUpdateOptions = ['pnpmDedupe'];
-    const res = await pnpmHelper.generateLockFile(
-      'some-dir',
-      {},
-      { ...config, postUpdateOptions }
-    );
-    expect(fs.readLocalFile).toHaveBeenCalledTimes(2);
-    expect(res.lockFile).toBe('package-lock-contents');
-    expect(execSnapshots).toMatchObject([
-      {
-        cmd: 'pnpm install --recursive --lockfile-only --ignore-scripts --ignore-pnpmfile',
-      },
-      {
-        cmd: 'pnpm dedupe --ignore-scripts',
+        cmd: 'pnpm dedupe --config.ignore-scripts=true',
       },
     ]);
   });

--- a/lib/modules/manager/npm/post-update/pnpm.spec.ts
+++ b/lib/modules/manager/npm/post-update/pnpm.spec.ts
@@ -77,7 +77,7 @@ describe('modules/manager/npm/post-update/pnpm', () => {
       {},
       { ...config, postUpdateOptions }
     );
-    expect(fs.readLocalFile).toHaveBeenCalledTimes(1);
+    expect(fs.readLocalFile).toHaveBeenCalledTimes(2);
     expect(res.lockFile).toBe('package-lock-contents');
     expect(execSnapshots).toMatchObject([
       {
@@ -85,6 +85,30 @@ describe('modules/manager/npm/post-update/pnpm', () => {
       },
       {
         cmd: 'pnpm dedupe',
+      },
+    ]);
+  });
+
+  it('performs dedupe --ignore-scripts for pnpm >= 8.8.0', async () => {
+    const execSnapshots = mockExecAll();
+    const fileContent = Fixtures.get('dedupe-ignore-scripts/package.json');
+    fs.readLocalFile
+      .mockResolvedValueOnce(fileContent)
+      .mockResolvedValue('package-lock-contents');
+    const postUpdateOptions = ['pnpmDedupe'];
+    const res = await pnpmHelper.generateLockFile(
+      'some-dir',
+      {},
+      { ...config, postUpdateOptions }
+    );
+    expect(fs.readLocalFile).toHaveBeenCalledTimes(2);
+    expect(res.lockFile).toBe('package-lock-contents');
+    expect(execSnapshots).toMatchObject([
+      {
+        cmd: 'pnpm install --recursive --lockfile-only --ignore-scripts --ignore-pnpmfile',
+      },
+      {
+        cmd: 'pnpm dedupe --ignore-scripts',
       },
     ]);
   });

--- a/lib/modules/manager/npm/post-update/pnpm.ts
+++ b/lib/modules/manager/npm/post-update/pnpm.ts
@@ -80,7 +80,7 @@ export async function generateLockFile(
 
     // postUpdateOptions
     if (config.postUpdateOptions?.includes('pnpmDedupe')) {
-        commands.push('pnpm dedupe --config.ignore-scripts=true');
+      commands.push('pnpm dedupe --config.ignore-scripts=true');
     }
 
     if (upgrades.find((upgrade) => upgrade.isLockFileMaintenance)) {

--- a/lib/modules/manager/npm/post-update/pnpm.ts
+++ b/lib/modules/manager/npm/post-update/pnpm.ts
@@ -1,6 +1,5 @@
 import is from '@sindresorhus/is';
 import { load } from 'js-yaml';
-import semver from 'semver';
 import upath from 'upath';
 import { GlobalConfig } from '../../../../config/global';
 import { TEMPORARY_ERROR } from '../../../../constants/error-messages';
@@ -81,17 +80,7 @@ export async function generateLockFile(
 
     // postUpdateOptions
     if (config.postUpdateOptions?.includes('pnpmDedupe')) {
-      const pnpmVersionFromPackageJson = getPackageManagerVersion(
-        'pnpm',
-        await lazyPgkJson.getValue()
-      );
-      const cleanedVersion = semver.coerce(pnpmVersionFromPackageJson);
-
-      if (cleanedVersion && semver.gte(cleanedVersion, '8.8.0')) {
-        commands.push('pnpm dedupe --ignore-scripts');
-      } else {
-        commands.push('pnpm dedupe');
-      }
+        commands.push('pnpm dedupe --config.ignore-scripts=true');
     }
 
     if (upgrades.find((upgrade) => upgrade.isLockFileMaintenance)) {

--- a/lib/modules/manager/npm/post-update/pnpm.ts
+++ b/lib/modules/manager/npm/post-update/pnpm.ts
@@ -39,7 +39,6 @@ export async function generateLockFile(
   let cmd = 'pnpm';
   try {
     const lazyPgkJson = lazyLoadPackageJson(lockFileDir);
-
     const pnpmToolConstraint: ToolConstraint = {
       toolName: 'pnpm',
       constraint:

--- a/lib/modules/manager/npm/post-update/pnpm.ts
+++ b/lib/modules/manager/npm/post-update/pnpm.ts
@@ -87,10 +87,7 @@ export async function generateLockFile(
       );
       const cleanedVersion = semver.coerce(pnpmVersionFromPackageJson);
 
-      if (
-        cleanedVersion &&
-        semver.gte(cleanedVersion, '8.8.0')
-      ) {
+      if (cleanedVersion && semver.gte(cleanedVersion, '8.8.0')) {
         commands.push('pnpm dedupe --ignore-scripts');
       } else {
         commands.push('pnpm dedupe');


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

- Reverted the revert commit 3609cddbbeb204ff53ceccc395216256340121e3.
- Adjusted the `pnpm dedupe` command to use `--config.ignore-scripts=true` to circumvent potential issues brought about by having to determine the `pnpm` version.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->
The initial strategy was to employ `semver.coerce` to manage version ranges when verifying the `pnpm` version. The goal was to apply `pnpm dedupe --ignore-scripts` only for `pnpm` versions `8.8.0` and above, as lower versions would throw an error.

However, a new approach was discovered which allows for script ignoring during deduplication in all `pnpm` versions by using the `--config.ignore-scripts=true` flag with the `pnpm dedupe` command. 

Not only does this prevent the aforementioned error in versions lower than `8.8.0`, but it also ensures consistent behavior across different `pnpm` versions regarding script execution during the `pnpm dedupe` process. 

This approach eliminates the need for additional checks to determine the `pnpm` version, reducing the potential for other issues that might arise from unhandled special cases. The inspiration for this solution came from a [comment](https://github.com/pnpm/pnpm/issues/5851#issuecomment-1367033903) on a related `pnpm` GitHub issue.

Relevant Issues:
- #25201
- #24417

I have tested the changes in a separate repository to ensure the fix works as expected. The test repository can be found here: [Test Repository](https://github.com/liby/renovate-test-pnpm-version-parse).

Please let me know if there are any additional changes needed or if there's anything else I can do to assist.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
