### PR TITLE
feat(manager/pep621): support hatch environments

### DIFF
--- a/lib/modules/manager/pep621/__fixtures__/pyproject_with_hatch.toml
+++ b/lib/modules/manager/pep621/__fixtures__/pyproject_with_hatch.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "hatch"
+dependencies = [
+  "requests==2.30.0"
+]
+
+[tool.hatch.envs.default]
+dependencies = [
+  "coverage[toml]==6.5",
+  "pytest",
+]
+
+[[tool.hatch.envs.all.matrix]]
+python = ["3.7", "3.8", "3.9", "3.10", "3.11"]
+
+[tool.hatch.envs.lint]
+detached = true
+dependencies = [
+  "black>=23.1.0",
+]

--- a/lib/modules/manager/pep621/__fixtures__/pyproject_with_hatch.toml
+++ b/lib/modules/manager/pep621/__fixtures__/pyproject_with_hatch.toml
@@ -22,3 +22,8 @@ detached = true
 dependencies = [
   "black>=23.1.0",
 ]
+
+[tool.hatch.envs.experimental]
+extra-dependencies = [
+  "baz",
+]

--- a/lib/modules/manager/pep621/extract.spec.ts
+++ b/lib/modules/manager/pep621/extract.spec.ts
@@ -4,6 +4,7 @@ import { extractPackageFile } from '.';
 
 const pdmPyProject = Fixtures.get('pyproject_with_pdm.toml');
 const pdmSourcesPyProject = Fixtures.get('pyproject_pdm_sources.toml');
+const hatchPyProject = Fixtures.get('pyproject_with_hatch.toml');
 
 describe('modules/manager/pep621/extract', () => {
   describe('extractPackageFile()', () => {
@@ -265,6 +266,41 @@ describe('modules/manager/pep621/extract', () => {
             'https://pypi.org/pypi/',
             'https://private-site.org/pypi/simple',
           ],
+        },
+      ]);
+    });
+
+    it('should extract dependencies from hatch environments', function () {
+      const result = extractPackageFile(hatchPyProject, 'pyproject.toml');
+
+      expect(result?.deps).toEqual([
+        {
+          currentValue: '==2.30.0',
+          datasource: 'pypi',
+          depName: 'requests',
+          depType: 'project.dependencies',
+          packageName: 'requests',
+        },
+        {
+          currentValue: '==6.5',
+          datasource: 'pypi',
+          depName: 'coverage',
+          depType: 'tool.hatch.envs.default',
+          packageName: 'coverage',
+        },
+        {
+          datasource: 'pypi',
+          depName: 'pytest',
+          depType: 'tool.hatch.envs.default',
+          packageName: 'pytest',
+          skipReason: 'unspecified-version',
+        },
+        {
+          currentValue: '>=23.1.0',
+          datasource: 'pypi',
+          depName: 'black',
+          depType: 'tool.hatch.envs.lint',
+          packageName: 'black',
         },
       ]);
     });

--- a/lib/modules/manager/pep621/extract.spec.ts
+++ b/lib/modules/manager/pep621/extract.spec.ts
@@ -4,7 +4,6 @@ import { extractPackageFile } from '.';
 
 const pdmPyProject = Fixtures.get('pyproject_with_pdm.toml');
 const pdmSourcesPyProject = Fixtures.get('pyproject_pdm_sources.toml');
-const hatchPyProject = Fixtures.get('pyproject_with_hatch.toml');
 
 describe('modules/manager/pep621/extract', () => {
   describe('extractPackageFile()', () => {
@@ -271,6 +270,7 @@ describe('modules/manager/pep621/extract', () => {
     });
 
     it('should extract dependencies from hatch environments', function () {
+      const hatchPyProject = Fixtures.get('pyproject_with_hatch.toml');
       const result = extractPackageFile(hatchPyProject, 'pyproject.toml');
 
       expect(result?.deps).toEqual([

--- a/lib/modules/manager/pep621/extract.spec.ts
+++ b/lib/modules/manager/pep621/extract.spec.ts
@@ -302,6 +302,13 @@ describe('modules/manager/pep621/extract', () => {
           depType: 'tool.hatch.envs.lint',
           packageName: 'black',
         },
+        {
+          datasource: 'pypi',
+          depName: 'baz',
+          depType: 'tool.hatch.envs.experimental',
+          packageName: 'baz',
+          skipReason: 'unspecified-version',
+        },
       ]);
     });
   });

--- a/lib/modules/manager/pep621/processors/hatch.ts
+++ b/lib/modules/manager/pep621/processors/hatch.ts
@@ -42,6 +42,6 @@ export class HatchProcessor implements PyProjectProcessor {
   ): Promise<UpdateArtifactsResult[] | null> {
     // Hatch does not have lock files at the moment
     // https://github.com/pypa/hatch/issues/749
-    return await null;
+    return Promise.resolve(null);
   }
 }

--- a/lib/modules/manager/pep621/processors/hatch.ts
+++ b/lib/modules/manager/pep621/processors/hatch.ts
@@ -37,7 +37,7 @@ export class HatchProcessor implements PyProjectProcessor {
   }
 
   updateArtifacts(
-    updateArtifact: UpdateArtifact<Record<string, unknown>>,
+    updateArtifact: UpdateArtifact,
     project: PyProject
   ): Promise<UpdateArtifactsResult[] | null> {
     // Hatch does not have lock files at the moment

--- a/lib/modules/manager/pep621/processors/hatch.ts
+++ b/lib/modules/manager/pep621/processors/hatch.ts
@@ -36,7 +36,7 @@ export class HatchProcessor implements PyProjectProcessor {
     return deps;
   }
 
-  async updateArtifacts(
+  updateArtifacts(
     updateArtifact: UpdateArtifact<Record<string, unknown>>,
     project: PyProject
   ): Promise<UpdateArtifactsResult[] | null> {

--- a/lib/modules/manager/pep621/processors/hatch.ts
+++ b/lib/modules/manager/pep621/processors/hatch.ts
@@ -8,10 +8,6 @@ import type { PyProject } from '../schema';
 import { parseDependencyList } from '../utils';
 import type { PyProjectProcessor } from './types';
 
-function depTypeFromEnv(envName: string): string {
-  return `tool.hatch.envs.${envName}`;
-}
-
 export class HatchProcessor implements PyProjectProcessor {
   process(
     pyproject: PyProject,
@@ -23,7 +19,7 @@ export class HatchProcessor implements PyProjectProcessor {
     }
 
     for (const [envName, env] of Object.entries(hatch_envs)) {
-      const depType = depTypeFromEnv(envName);
+      const depType = `tool.hatch.envs.${envName}`;
       const envDeps = parseDependencyList(depType, env?.dependencies);
       deps.push(...envDeps);
       const extraDeps = parseDependencyList(

--- a/lib/modules/manager/pep621/processors/hatch.ts
+++ b/lib/modules/manager/pep621/processors/hatch.ts
@@ -1,0 +1,45 @@
+import is from '@sindresorhus/is';
+import type {
+  PackageDependency,
+  UpdateArtifact,
+  UpdateArtifactsResult,
+} from '../../types';
+import type { PyProject } from '../schema';
+import type { PyProjectProcessor } from './types';
+import { parseDependencyList } from '../utils';
+
+function depTypeFromEnv(envName: string): string {
+  return `tool.hatch.envs.${envName}`;
+}
+
+export class HatchProcessor implements PyProjectProcessor {
+  process(
+    pyproject: PyProject,
+    deps: PackageDependency[]
+  ): PackageDependency[] {
+    const hatch_envs = pyproject.tool?.hatch?.envs;
+    if (is.nullOrUndefined(hatch_envs)) return deps;
+
+    for (const [envName, env] of Object.entries(hatch_envs)) {
+      const depType = depTypeFromEnv(envName);
+      const envDeps = parseDependencyList(depType, env?.dependencies);
+      deps.push(...envDeps);
+      const extraDeps = parseDependencyList(
+        depType,
+        env?.['extra-dependencies']
+      );
+      deps.push(...extraDeps);
+    }
+
+    return deps;
+  }
+
+  async updateArtifacts(
+    updateArtifact: UpdateArtifact<Record<string, unknown>>,
+    project: PyProject
+  ): Promise<UpdateArtifactsResult[] | null> {
+    // Hatch does not have lock files at the moment
+    // https://github.com/pypa/hatch/issues/749
+    return null;
+  }
+}

--- a/lib/modules/manager/pep621/processors/hatch.ts
+++ b/lib/modules/manager/pep621/processors/hatch.ts
@@ -5,8 +5,8 @@ import type {
   UpdateArtifactsResult,
 } from '../../types';
 import type { PyProject } from '../schema';
-import type { PyProjectProcessor } from './types';
 import { parseDependencyList } from '../utils';
+import type { PyProjectProcessor } from './types';
 
 function depTypeFromEnv(envName: string): string {
   return `tool.hatch.envs.${envName}`;
@@ -18,7 +18,9 @@ export class HatchProcessor implements PyProjectProcessor {
     deps: PackageDependency[]
   ): PackageDependency[] {
     const hatch_envs = pyproject.tool?.hatch?.envs;
-    if (is.nullOrUndefined(hatch_envs)) return deps;
+    if (is.nullOrUndefined(hatch_envs)) {
+      return deps;
+    }
 
     for (const [envName, env] of Object.entries(hatch_envs)) {
       const depType = depTypeFromEnv(envName);
@@ -40,6 +42,6 @@ export class HatchProcessor implements PyProjectProcessor {
   ): Promise<UpdateArtifactsResult[] | null> {
     // Hatch does not have lock files at the moment
     // https://github.com/pypa/hatch/issues/749
-    return null;
+    return await null;
   }
 }

--- a/lib/modules/manager/pep621/processors/index.ts
+++ b/lib/modules/manager/pep621/processors/index.ts
@@ -1,3 +1,4 @@
+import { HatchProcessor } from './hatch';
 import { PdmProcessor } from './pdm';
 
-export const processors = [new PdmProcessor()];
+export const processors = [new HatchProcessor(), new PdmProcessor()];

--- a/lib/modules/manager/pep621/readme.md
+++ b/lib/modules/manager/pep621/readme.md
@@ -2,10 +2,12 @@ This manager supports updating dependencies inside `pyproject.toml` files.
 
 In addition to standard dependencies, these toolsets are also supported:
 
-- `pdm` ( including `pdm.lock` files )
+- `pdm` (including `pdm.lock` files)
+- `hatch`
 
 Available `depType`s:
 
 - `project.dependencies`
 - `project.optional-dependencies`
 - `tool.pdm.dev-dependencies`
+- `tool.hatch.envs.<env-name>`

--- a/lib/modules/manager/pep621/schema.ts
+++ b/lib/modules/manager/pep621/schema.ts
@@ -31,6 +31,21 @@ export const PyProjectSchema = z.object({
             .optional(),
         })
         .optional(),
+      hatch: z
+        .object({
+          envs: z
+            .record(
+              z.string(),
+              z
+                .object({
+                  dependencies: DependencyListSchema,
+                  'extra-dependencies': DependencyListSchema,
+                })
+                .optional()
+            )
+            .optional(),
+        })
+        .optional(),
     })
     .optional(),
 });


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This PR extends the PEP621 manager to add support for updating dependencies specified in [`hatch` environments](https://hatch.pypa.io/latest/config/environment/overview/#dependencies).

This work builds on top of #22082 by adding a new processor. Note that `hatch` does not have lock files.

## Context

Closes #24956.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
