### PR TITLE
test(npm): remove snapshot for does not set registryUrls for non-npmjs test

### DIFF
--- a/lib/modules/manager/npm/extract/__snapshots__/index.spec.ts.snap
+++ b/lib/modules/manager/npm/extract/__snapshots__/index.spec.ts.snap
@@ -26,62 +26,6 @@ exports[`modules/manager/npm/extract/index .extractPackageFile() catches invalid
 }
 `;
 
-exports[`modules/manager/npm/extract/index .extractPackageFile() does not set registryUrls for non-npmjs 1`] = `
-{
-  "deps": [
-    {
-      "currentRawValue": "github:owner/a#v1.1.0",
-      "currentValue": "v1.1.0",
-      "datasource": "github-tags",
-      "depName": "a",
-      "depType": "dependencies",
-      "gitRef": true,
-      "packageName": "owner/a",
-      "pinDigests": false,
-      "prettyDepType": "dependency",
-      "sourceUrl": "https://github.com/owner/a",
-    },
-    {
-      "commitMessageTopic": "Node.js",
-      "currentValue": "8.9.2",
-      "datasource": "github-tags",
-      "depName": "node",
-      "depType": "engines",
-      "packageName": "nodejs/node",
-      "prettyDepType": "engine",
-      "versioning": "node",
-    },
-    {
-      "commitMessageTopic": "Yarn",
-      "currentValue": "3.2.4",
-      "datasource": "npm",
-      "depName": "yarn",
-      "depType": "volta",
-      "packageName": "@yarnpkg/cli",
-      "prettyDepType": "volta",
-      "registryUrls": [
-        "https://registry.example.com",
-      ],
-    },
-  ],
-  "extractedConstraints": {
-    "node": "8.9.2",
-  },
-  "managerData": {
-    "hasPackageManager": false,
-    "npmLock": undefined,
-    "packageJsonName": undefined,
-    "pnpmShrinkwrap": undefined,
-    "workspacesPackages": undefined,
-    "yarnLock": undefined,
-    "yarnZeroInstall": false,
-  },
-  "npmrc": undefined,
-  "packageFileVersion": undefined,
-  "skipInstalls": true,
-}
-`;
-
 exports[`modules/manager/npm/extract/index .extractPackageFile() extracts engines 1`] = `
 {
   "deps": [

--- a/lib/modules/manager/npm/extract/index.spec.ts
+++ b/lib/modules/manager/npm/extract/index.spec.ts
@@ -672,7 +672,7 @@ describe('modules/manager/npm/extract/index', () => {
         'package.json',
         defaultExtractConfig
       );
-      expect(res).toMatchSnapshot({
+      expect(res).toMatchObject({
         deps: [
           {
             depName: 'a',


### PR DESCRIPTION
## Changes

remove snapshot because its not needed

## Context

introduced with #25146 and suggested https://github.com/renovatebot/renovate/pull/25146#discussion_r1357220725
