### PR TITLE
fix(config): make force option mergeable

### DIFF
--- a/lib/config/index.spec.ts
+++ b/lib/config/index.spec.ts
@@ -56,6 +56,25 @@ describe('config/index', () => {
       expect(config.constraints.node).toBe('<15');
     });
 
+    it('merges forced options', () => {
+      const parentConfig = { ...defaultConfig };
+      Object.assign(parentConfig, {
+        force: {
+          schedule: 'at any time',
+        },
+      });
+      const childConfig = {
+        force: {
+          constraints: {
+            node: '<15',
+          },
+        },
+      };
+      const config = mergeChildConfig(parentConfig, childConfig);
+      expect(config.force.schedule).toBe('at any time');
+      expect(config.force.constraints.node).toBe('<15');
+    });
+
     it('handles null parent packageRules', async () => {
       const parentConfig = { ...defaultConfig };
       Object.assign(parentConfig, {

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -262,6 +262,7 @@ const options: RenovateOptions[] = [
     globalOnly: true,
     type: 'object',
     cli: false,
+    mergeable: true,
   },
   {
     name: 'forceCli',


### PR DESCRIPTION
## Changes

Makes the `force` option mergeable so that it can be set a multiple levels.

## Context

#25253

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

---

⚒️ with ❤️ by [Siemens](https://opensource.siemens.com/)

