### PR TITLE
docs: Updated GettingStarted docs for Renovate CE and EE

### DIFF
--- a/docs/usage/getting-started/running.md
+++ b/docs/usage/getting-started/running.md
@@ -3,7 +3,7 @@
 As end user, you can choose from these ways to run Renovate:
 
 - You use the Mend Renovate App
-- You self-host Renovate - e.g. Renovate CLI, Renovate Docker image, or Renovate Community Edition / Enterprise Edition
+- You self-administer/host your own Renovate instance
 - Someone else is hosting Renovate, and you install/configure it for the repositories you choose
 
 If you're using the Mend Renovate App, or if someone else is hosting Renovate for you, skip ahead to the [installing & onboarding](./installing-onboarding.md) page.
@@ -19,7 +19,7 @@ When self-hosting Renovate you're the "administrator" of the bot, this means you
 
 If you're self-hosting Renovate on Windows, read [Self-hosting on Windows](./installing-onboarding.md#self-hosting-on-windows) to prevent line endings from confusing Renovate bot.
 
-If you're running Renovate Community Edition or Renovate Enterprise Edition, refer to the documentation on the public GitHub repository [`mend/renovate-ce-ee`](https://github.com/mend/renovate-ce-ee).
+If you're running Renovate Community Edition or Renovate Enterprise Edition, refer to the documentation on the [`mend/renovate-ce-ee` GitHub repository ](https://github.com/mend/renovate-ce-ee).
 
 ### Available distributions
 
@@ -85,7 +85,7 @@ Details for how it works can be found in the project.
 
 #### Mend Renovate Community Edition / Enterprise Edition
 
-Mend Renovate Community Edition (Renovate CE) and Enterprise Edition (Renovate EE) are non-Open Source offerings of Renovate for self-hosted users.
+Mend Renovate Community Edition (Renovate CE) and Enterprise Edition (Renovate EE) are closed-source offerings of Renovate for self-hosted users.
 Renovate CE and Renovate EE have support for GitHub (both `github.com` and GitHub Enterprise Server) as well as GitLab self-hosted.
 It is built similarly to the default "full" Renovate image described above, but with these differences:
 
@@ -101,9 +101,9 @@ Plus, the Enterprise Edition has:
 - Dedicated support from Mend.io
 - Premium features, including Smart Merge Control
 
-Note: Visit the Mend.io website to learn more about [Renovate Enterprise Edition](https://www.mend.io/renovate-enterprise/).
+Go to the Mend.io website to learn more about [Renovate Enterprise Edition](https://www.mend.io/renovate-enterprise/).
 
-For help configuring Renovate CE or Renovate EE, refer to the documentation on the public GitHub repository [`mend/renovate-ce-ee`](https://github.com/mend/renovate-ce-ee).
+To learn how to configure Renovate CE or Renovate EE, read the documentation on the public GitHub repository [`mend/renovate-ce-ee`](https://github.com/mend/renovate-ce-ee).
 
 #### Mend Remediate
 

--- a/docs/usage/getting-started/running.md
+++ b/docs/usage/getting-started/running.md
@@ -19,7 +19,7 @@ When self-hosting Renovate you're the "administrator" of the bot, this means you
 
 If you're self-hosting Renovate on Windows, read [Self-hosting on Windows](./installing-onboarding.md#self-hosting-on-windows) to prevent line endings from confusing Renovate bot.
 
-If you're running Renovate Community Edition or Renovate Enterprise Edition, refer to the documentation on the [`mend/renovate-ce-ee` GitHub repository ](https://github.com/mend/renovate-ce-ee).
+If you're running Renovate Community Edition or Renovate Enterprise Edition, refer to the documentation on the [`mend/renovate-ce-ee` GitHub repository](https://github.com/mend/renovate-ce-ee).
 
 ### Available distributions
 

--- a/docs/usage/getting-started/running.md
+++ b/docs/usage/getting-started/running.md
@@ -2,8 +2,8 @@
 
 As end user, you can choose from these ways to run Renovate:
 
-- You use the Mend Renovate App, or
-- You self-host Renovate, for example by running the pre-built Docker image, or
+- You use the Mend Renovate App
+- You self-host Renovate - eg. Renovate CLI, Renovate Docker image, or Renovate Community Edition / Enterprise Edition containers
 - Someone else is hosting Renovate, and you install/configure it for the repositories you choose
 
 If you're using the Mend Renovate App, or if someone else is hosting Renovate for you, skip ahead to the [installing & onboarding](./installing-onboarding.md) page.
@@ -18,6 +18,8 @@ When self-hosting Renovate you're the "administrator" of the bot, this means you
 - make sure Renovate bot itself is updated
 
 If you're self-hosting Renovate on Windows, read [Self-hosting on Windows](./installing-onboarding.md#self-hosting-on-windows) to prevent line endings from confusing Renovate bot.
+
+If you're running Renovate Community Edition or Renovate Enterprise Edition, refer to the documentation on the public GitHub repository [`mend/renovate-ce-ee`](https://github.com/mend/renovate-ce-ee).
 
 ### Available distributions
 
@@ -81,9 +83,10 @@ The Renovate team provide a ["Renovate Runner"](https://gitlab.com/renovate-bot/
 This supports both `gitlab.com` and self-hosted GitLab.
 Details for how it works can be found in the project.
 
-#### Mend Renovate On-Premises
+#### Mend Renovate Community Edition / Enterprise Edition
 
-Mend Renovate On-Premises (WSOP) started out as a commercial product "Renovate Pro", but was renamed and made free to use when Renovate became a part of Mend (formerly WhiteSource) in 2019.
+Mend Renovate Community Edition (Renovate CE) and Enterprise Edition (Renovate EE) are commercial offerings of Renovate for self-hosted users.
+Renovate CE and Renovate EE have support for GitHub (both `github.com` and GitHub Enterprise Server) as well as GitLab self-hosted.
 It is built similarly to the default "full" Renovate image described above, but with these differences:
 
 - It is a stateful app and does not exit after processing all repositories
@@ -92,8 +95,14 @@ It is built similarly to the default "full" Renovate image described above, but 
 - It is released every 1-2 months in a slower, more stable cadence than Renovate OSS, which releases on every commit
 - It's licensed using an end-user license agreement (EULA) and not the Affero General Public License (AGPL)
 
-WSOP supports GitHub (both `github.com` and GitHub Enterprise Server) as well as GitLab self-hosted.
-Documentation can be found in its public GitHub repository [`whitesource/renovate-on-prem`](https://github.com/whitesource/renovate-on-prem).
+Plus, the Enterprise Edition has:
+- Unlimited horizontal scaling to run multiple 'worker' containers
+- Dedicated support from Mend.io
+- Premium features, including Smart Merge Control
+
+Note: Visit the Mend.io website to learn more about [Renovate Enterprise Edition](https://www.mend.io/renovate-enterprise/).
+
+For help configuring Renovate CE or Renovate EE, refer to the documentation on the public GitHub repository [`mend/renovate-ce-ee`](https://github.com/mend/renovate-ce-ee).
 
 #### Mend Remediate
 

--- a/docs/usage/getting-started/running.md
+++ b/docs/usage/getting-started/running.md
@@ -3,7 +3,7 @@
 As end user, you can choose from these ways to run Renovate:
 
 - You use the Mend Renovate App
-- You self-host Renovate - eg. Renovate CLI, Renovate Docker image, or Renovate Community Edition / Enterprise Edition containers
+- You self-host Renovate - e.g. Renovate CLI, Renovate Docker image, or Renovate Community Edition / Enterprise Edition
 - Someone else is hosting Renovate, and you install/configure it for the repositories you choose
 
 If you're using the Mend Renovate App, or if someone else is hosting Renovate for you, skip ahead to the [installing & onboarding](./installing-onboarding.md) page.
@@ -85,7 +85,7 @@ Details for how it works can be found in the project.
 
 #### Mend Renovate Community Edition / Enterprise Edition
 
-Mend Renovate Community Edition (Renovate CE) and Enterprise Edition (Renovate EE) are commercial offerings of Renovate for self-hosted users.
+Mend Renovate Community Edition (Renovate CE) and Enterprise Edition (Renovate EE) are non-Open Source offerings of Renovate for self-hosted users.
 Renovate CE and Renovate EE have support for GitHub (both `github.com` and GitHub Enterprise Server) as well as GitLab self-hosted.
 It is built similarly to the default "full" Renovate image described above, but with these differences:
 
@@ -97,7 +97,7 @@ It is built similarly to the default "full" Renovate image described above, but 
 
 Plus, the Enterprise Edition has:
 
-- Unlimited horizontal scaling to run multiple 'worker' containers
+- Horizontal scaling to run multiple 'worker' containers
 - Dedicated support from Mend.io
 - Premium features, including Smart Merge Control
 

--- a/docs/usage/getting-started/running.md
+++ b/docs/usage/getting-started/running.md
@@ -96,6 +96,7 @@ It is built similarly to the default "full" Renovate image described above, but 
 - It's licensed using an end-user license agreement (EULA) and not the Affero General Public License (AGPL)
 
 Plus, the Enterprise Edition has:
+
 - Unlimited horizontal scaling to run multiple 'worker' containers
 - Dedicated support from Mend.io
 - Premium features, including Smart Merge Control


### PR DESCRIPTION
Updated GettingStarted docs for Renovate CE and EE and provide a link to the GitHub documentation.

## Changes

Updated docs. Added content and links for Renovate CE and Renovate EE.

## Context

Update required since Renovate On-Premises was renamed to Renovate Community Edition and a new product, Renovate Enterprise Edition, was released.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
