### PR TITLE
refactor: improve log when no repository found based on autodiscovery options

### DIFF
--- a/lib/workers/global/autodiscover.ts
+++ b/lib/workers/global/autodiscover.ts
@@ -42,9 +42,19 @@ export async function autodiscoverRepositories(
   });
   if (!discovered?.length) {
     // Soft fail (no error thrown) if no accessible repositories
-    logger.debug(
-      'The account associated with your token does not have access to any repos'
-    );
+    let debugMessage = 'The account associated with your token didn\'t allow to find any repositories. This can be caused by the token\'s permissions';
+
+    const autodiscoverFilterOptions = Object.entries({
+        autodiscoverTopics: config.autodiscoverTopics, 
+        autodiscoverNamespaces: config.autodiscoverNamespaces
+    }).filter(([_, value]) => value?.length);
+
+    if(autodiscoverFilterOptions.length) {
+        debugMessage += ", or the option" + (autodiscoverFilterOptions.length > 1 ? "s": "") + " ";
+        debugMessage += autodiscoverFilterOptions.map(([key, value]) => `${key} (set to '${value}')`).join(" or ");
+    }
+    
+    logger.debug(debugMessage);
     return config;
   }
 


### PR DESCRIPTION
## Changes

refactor: improve log when no repository found based on autodiscovery options

 Closes https://github.com/renovatebot/renovate/discussions/25289

<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository



Sample outputs 
```
config { autodiscoverTopics: [], autodiscoverNamespaces: undefined }
... This can be caused by the token's permissions 

=====
config { autodiscoverTopics: undefined, autodiscoverNamespaces: undefined }
... This can be caused by the token's permissions 

=====
config { autodiscoverTopics: [], autodiscoverNamespaces: [] }
... This can be caused by the token's permissions 

=====
config { autodiscoverTopics: [ 'foo' ], autodiscoverNamespaces: [] }
... This can be caused by the token's permissions, or the option autodiscoverTopics (set to 'foo') 

=====
config { autodiscoverTopics: [], autodiscoverNamespaces: [ 'foo', 'foo' ] }
... This can be caused by the token's permissions, or the option autodiscoverNamespaces (set to 'foo,foo') 

=====
config {
  autodiscoverTopics: [ 'foo' ],
  autodiscoverNamespaces: [ 'foo', 'foo' ]
}
... This can be caused by the token's permissions, or the options autodiscoverTopics (set to 'foo') or autodiscoverNamespaces (set to 'foo,foo') 
```