### PR TITLE
fix(github): make automatic hostRules opt-in experimental

### DIFF
--- a/lib/modules/platform/github/__snapshots__/index.spec.ts.snap
+++ b/lib/modules/platform/github/__snapshots__/index.spec.ts.snap
@@ -31,37 +31,6 @@ exports[`modules/platform/github/index initPlatform() should support default end
 {
   "endpoint": "https://api.github.com/",
   "gitAuthor": undefined,
-  "hostRules": [
-    {
-      "hostType": "docker",
-      "matchHost": "ghcr.io",
-      "password": "123test",
-      "username": "USERNAME",
-    },
-    {
-      "hostType": "npm",
-      "matchHost": "npm.pkg.github.com",
-      "token": "123test",
-    },
-    {
-      "hostType": "rubygems",
-      "matchHost": "rubygems.pkg.github.com",
-      "password": "123test",
-      "username": "renovate-bot",
-    },
-    {
-      "hostType": "maven",
-      "matchHost": "maven.pkg.github.com",
-      "password": "123test",
-      "username": "renovate-bot",
-    },
-    {
-      "hostType": "nuget",
-      "matchHost": "nuget.pkg.github.com",
-      "password": "123test",
-      "username": "renovate-bot",
-    },
-  ],
   "renovateUsername": "renovate-bot",
   "token": "123test",
 }
@@ -71,37 +40,6 @@ exports[`modules/platform/github/index initPlatform() should support default end
 {
   "endpoint": "https://api.github.com/",
   "gitAuthor": undefined,
-  "hostRules": [
-    {
-      "hostType": "docker",
-      "matchHost": "ghcr.io",
-      "password": "123test",
-      "username": "USERNAME",
-    },
-    {
-      "hostType": "npm",
-      "matchHost": "npm.pkg.github.com",
-      "token": "123test",
-    },
-    {
-      "hostType": "rubygems",
-      "matchHost": "rubygems.pkg.github.com",
-      "password": "123test",
-      "username": "renovate-bot",
-    },
-    {
-      "hostType": "maven",
-      "matchHost": "maven.pkg.github.com",
-      "password": "123test",
-      "username": "renovate-bot",
-    },
-    {
-      "hostType": "nuget",
-      "matchHost": "nuget.pkg.github.com",
-      "password": "123test",
-      "username": "renovate-bot",
-    },
-  ],
   "renovateUsername": "renovate-bot",
   "token": "123test",
 }
@@ -111,37 +49,6 @@ exports[`modules/platform/github/index initPlatform() should support default end
 {
   "endpoint": "https://api.github.com/",
   "gitAuthor": "undefined <user@domain.com>",
-  "hostRules": [
-    {
-      "hostType": "docker",
-      "matchHost": "ghcr.io",
-      "password": "123test",
-      "username": "USERNAME",
-    },
-    {
-      "hostType": "npm",
-      "matchHost": "npm.pkg.github.com",
-      "token": "123test",
-    },
-    {
-      "hostType": "rubygems",
-      "matchHost": "rubygems.pkg.github.com",
-      "password": "123test",
-      "username": "renovate-bot",
-    },
-    {
-      "hostType": "maven",
-      "matchHost": "maven.pkg.github.com",
-      "password": "123test",
-      "username": "renovate-bot",
-    },
-    {
-      "hostType": "nuget",
-      "matchHost": "nuget.pkg.github.com",
-      "password": "123test",
-      "username": "renovate-bot",
-    },
-  ],
   "renovateUsername": "renovate-bot",
   "token": "123test",
 }
@@ -151,37 +58,6 @@ exports[`modules/platform/github/index initPlatform() should support gitAuthor a
 {
   "endpoint": "https://api.github.com/",
   "gitAuthor": "renovate@whitesourcesoftware.com",
-  "hostRules": [
-    {
-      "hostType": "docker",
-      "matchHost": "ghcr.io",
-      "password": "123test",
-      "username": "USERNAME",
-    },
-    {
-      "hostType": "npm",
-      "matchHost": "npm.pkg.github.com",
-      "token": "123test",
-    },
-    {
-      "hostType": "rubygems",
-      "matchHost": "rubygems.pkg.github.com",
-      "password": "123test",
-      "username": "renovate-bot",
-    },
-    {
-      "hostType": "maven",
-      "matchHost": "maven.pkg.github.com",
-      "password": "123test",
-      "username": "renovate-bot",
-    },
-    {
-      "hostType": "nuget",
-      "matchHost": "nuget.pkg.github.com",
-      "password": "123test",
-      "username": "renovate-bot",
-    },
-  ],
   "renovateUsername": "renovate-bot",
   "token": "123test",
 }

--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -48,6 +48,7 @@ describe('modules/platform/github/index', () => {
 
     const repoCache = repository.getCache();
     delete repoCache.platform;
+    delete process.env.RENOVATE_X_GITHUB_HOST_RULES;
   });
 
   describe('initPlatform()', () => {
@@ -162,6 +163,7 @@ describe('modules/platform/github/index', () => {
     });
 
     it('should autodetect email/user on default endpoint with GitHub App', async () => {
+      process.env.RENOVATE_X_GITHUB_HOST_RULES = 'true';
       httpMock
         .scope(githubApiHost, {
           reqheaders: {

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -204,7 +204,10 @@ export async function initPlatform({
     renovateUsername,
     token,
   };
-  if (platformResult.endpoint === 'https://api.github.com/') {
+  if (
+    process.env.RENOVATE_X_GITHUB_HOST_RULES &&
+    platformResult.endpoint === 'https://api.github.com/'
+  ) {
     logger.debug('Adding GitHub token as GHCR password');
     platformResult.hostRules = [
       {

--- a/lib/modules/platform/github/readme.md
+++ b/lib/modules/platform/github/readme.md
@@ -87,13 +87,16 @@ A way to get the user id of a GitHub app is to [query the user API](https://docs
 
 ## Package Registry Credentials
 
-When Renovate runs against repositories on `github.com`, it automatically provisions `hostRules` for these GitHub Packages registries using the platform token:
+When Renovate runs against repositories on `github.com`, and the environment variable `RENOVATE_X_GITHUB_HOST_RULES` is set, then Renovate automatically provisions `hostRules` for these GitHub Packages registries using the platform token:
 
 - `ghcr.io`
 - `maven.pkg.github.com`
 - `npm.pkg.github.com`
 - `nuget.pkg.github.com`
 - `rubygems.pkg.github.com`
+
+<!-- prettier-ignore -->
+!!! warning Users have reported that this feature is not working correctly, so it has been reverted to experimental mode.
 
 ## Features awaiting implementation
 

--- a/lib/modules/platform/index.spec.ts
+++ b/lib/modules/platform/index.spec.ts
@@ -11,6 +11,7 @@ jest.unmock('./scm');
 describe('modules/platform/index', () => {
   beforeEach(() => {
     jest.resetModules();
+    process.env.RENOVATE_X_GITHUB_HOST_RULES = 'true';
   });
 
   it('validates', () => {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Gates the recently added implicit github hostRules behind an experimental env value

## Context

#25344
#25359

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
