### PR TITLE
fix(manager/nuget): add source mappings for default registry

### DIFF
--- a/lib/modules/datasource/nuget/index.ts
+++ b/lib/modules/datasource/nuget/index.ts
@@ -7,12 +7,12 @@ import * as v2 from './v2';
 import * as v3 from './v3';
 
 // https://api.nuget.org/v3/index.json is a default official nuget feed
-export const defaultRegistryUrls = ['https://api.nuget.org/v3/index.json'];
+export const nugetOrg = 'https://api.nuget.org/v3/index.json';
 
 export class NugetDatasource extends Datasource {
   static readonly id = 'nuget';
 
-  override readonly defaultRegistryUrls = defaultRegistryUrls;
+  override readonly defaultRegistryUrls = [nugetOrg];
 
   override readonly defaultVersioning = nugetVersioning.id;
 

--- a/lib/modules/manager/nuget/types.ts
+++ b/lib/modules/manager/nuget/types.ts
@@ -13,7 +13,7 @@ export interface DotnetTool {
 export interface Registry {
   readonly url: string;
   readonly name?: string;
-  readonly sourceMappedPackagePatterns?: string[];
+  sourceMappedPackagePatterns?: string[];
 }
 
 export interface MsbuildGlobalManifest {

--- a/lib/modules/manager/nuget/util.spec.ts
+++ b/lib/modules/manager/nuget/util.spec.ts
@@ -69,6 +69,7 @@ describe('modules/manager/nuget/util', () => {
         'NuGet.Common',
       ]);
     });
+
     it('reads nuget config file with default registry', async () => {
       fs.findUpLocal.mockReturnValue(
         Promise.resolve<string | null>('NuGet.config')

--- a/lib/modules/manager/nuget/util.spec.ts
+++ b/lib/modules/manager/nuget/util.spec.ts
@@ -2,6 +2,7 @@ import { XmlDocument } from 'xmldoc';
 import { fs } from '../../../../test/util';
 import { bumpPackageVersion } from './update';
 import { findVersion, getConfiguredRegistries } from './util';
+import { codeBlock } from 'common-tags';
 
 jest.mock('../../../util/fs');
 
@@ -35,14 +36,60 @@ describe('modules/manager/nuget/util', () => {
       fs.findUpLocal.mockReturnValue(
         Promise.resolve<string | null>('NuGet.config')
       );
-      fs.readLocalFile.mockImplementation((file): Promise<any> => {
-        const content: string | null =
-          '<configuration><packageSources><clear /><add key="nuget.org" value="https://api.nuget.org/v3/index.json" /><add key="contoso.com" value="https://contoso.com/packages/" /></packageSources><packageSourceMapping><packageSource key="nuget.org"><package pattern="*" /></packageSource><packageSource key="contoso.com"><package pattern="Contoso.*" /><package pattern="NuGet.Common" /></packageSource></packageSourceMapping></configuration>';
-        if (file !== 'NuGet.config') {
-          return Promise.reject(new Error(`Unexpected file: ${file}`));
-        }
-        return Promise.resolve(content);
-      });
+      fs.readLocalFile.mockResolvedValueOnce(
+        codeBlock`
+          <configuration>
+            <packageSources>
+              <clear/>
+              <add key="nuget.org" value="https://api.nuget.org/v3/index.json"/>
+              <add key="contoso.com" value="https://contoso.com/packages/"/>
+            </packageSources>
+            <packageSourceMapping>
+              <packageSource key="nuget.org">
+                <package pattern="*"/>
+              </packageSource>
+              <packageSource key="contoso.com">
+                <package pattern="Contoso.*"/>
+                <package pattern="NuGet.Common"/>
+              </packageSource>
+            </packageSourceMapping>
+          </configuration>`
+      );
+
+      const registries = await getConfiguredRegistries('NuGet.config');
+      expect(registries?.length).toBe(2);
+      expect(registries![0].name).toBe('nuget.org');
+      expect(registries![0].url).toBe('https://api.nuget.org/v3/index.json');
+      expect(registries![0].sourceMappedPackagePatterns).toEqual(['*']);
+
+      expect(registries![1].name).toBe('contoso.com');
+      expect(registries![1].url).toBe('https://contoso.com/packages/');
+      expect(registries![1].sourceMappedPackagePatterns).toEqual([
+        'Contoso.*',
+        'NuGet.Common',
+      ]);
+    });
+    it('reads nuget config file with default registry', async () => {
+      fs.findUpLocal.mockReturnValue(
+        Promise.resolve<string | null>('NuGet.config')
+      );
+      fs.readLocalFile.mockResolvedValueOnce(
+        codeBlock`
+        <configuration>
+          <packageSources>
+            <add key="contoso.com" value="https://contoso.com/packages/"/>
+          </packageSources>
+          <packageSourceMapping>
+            <packageSource key="nuget.org">
+              <package pattern="*"/>
+            </packageSource>
+            <packageSource key="contoso.com">
+              <package pattern="Contoso.*"/>
+              <package pattern="NuGet.Common"/>
+            </packageSource>
+          </packageSourceMapping>
+        </configuration>`
+      );
 
       const registries = await getConfiguredRegistries('NuGet.config');
       expect(registries?.length).toBe(2);

--- a/lib/modules/manager/nuget/util.spec.ts
+++ b/lib/modules/manager/nuget/util.spec.ts
@@ -1,8 +1,8 @@
+import { codeBlock } from 'common-tags';
 import { XmlDocument } from 'xmldoc';
 import { fs } from '../../../../test/util';
 import { bumpPackageVersion } from './update';
 import { findVersion, getConfiguredRegistries } from './util';
-import { codeBlock } from 'common-tags';
 
 jest.mock('../../../util/fs');
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- add optional source mappings for default nuget.org package source
<!-- Describe what behavior is changed by this PR. -->

## Context
- fixes #25395
- test repo: https://github.com/renovate-reproductions/25395-nuget-source-mapping
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
