### PR TITLE
docs(minimal reproductions): forcing pending updates

### DIFF
--- a/docs/development/minimal-reproductions.md
+++ b/docs/development/minimal-reproductions.md
@@ -86,3 +86,23 @@ After a while, issues without a reproduction may be closed unfixed.
 
 Thank you for describing your issue in detail.
 But we still need a minimal reproduction in a repository, and we'd like you to be the one to make sure it matches both your description as well as expected behavior.
+
+### Forcing Renovate to create a lot of pending updates
+
+Put a old version of a frequently updated dependency in your repository.
+Set a high `minimumReleaseAge` for that dependency, for example:
+
+```json
+{
+  "extends": ["config:best-practices"],
+  "packageRules": [
+    {
+      "description": "Force lots of pending updates for the Prettier package",
+      "matchPackageNames": ["prettier"],
+      "minimumReleaseAge": "365 days"
+    }
+  ]
+}
+```
+
+You'll get a lot of pending updates, which you can see on the Dependency Dashboard.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Explain how to force a lot of pending upgrades

## Context

Should we have more of these "how do I force Renovate to do `x` to help me reproduce" tutorials?

Inspired by a comment from @rarkins [^1]

> Also, this could be a easily reproduced - just take a dependency which updates frequently and then set a high minimumReleaseAge and you're guaranteed of always having pending releases

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

[^1]: https://github.com/renovatebot/renovate/discussions/25316#discussioncomment-7369809
