### PR TITLE
chore: expand label-actions about one topic and no mentions

### DIFF
--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -281,7 +281,7 @@
 
     Please stick to one topic/question per Discussion. Start a new discussion per topic.
 
-    This is to benefit future users who may search and find this discussion and not be confused because there's multiple questions and answers within. One question and answer per Discussion works best.
+    This prevents future users from finding this discussion and getting confused by multiple questions and answers. One question and answer per Discussion works best.
 
     For example:
      - Don't create a discussion with multiple questions requiring multiple answers
@@ -291,8 +291,8 @@
   comment: >
     Hi there,
 
-    Please do not unnecessarily `@` maintainers like `@rarkins` or `@viceice`. Doing so causes annoying notifications and make maintaining a repo of this size difficult.
+    Please do not unnecessarily `@` mention maintainers like `@rarkins` or `@viceice`. Doing so causes annoying notifications and makes it harder to maintain this repository.
 
-    For example, never `@` mention a maintainer when you are creating a discussion if your desire is to get attention. This is inconsiderate behavior, just like shouting out your coffee order in a Starbucks before it's your turn.
+    For example, never `@` mention a maintainer when you are creating a discussion if your desire is to get attention. This is rude behavior, just like shouting out your coffee order in a Starbucks before it's your turn.
 
-    If there's an existing issue or discussion which you were hoping for a follow-up to but multiple days or weeks have elapsed, it's ok for you to comment, but please still do not `@` people. The maintainers do not promise to answer every Discussion but do answer most. If you're not getting an answer then take a look at the informatio you've provided and see if you can improve it.
+    It's OK to comment in an issue or discussion after multiple days or weeks. But please, still don't `@` mention people. The maintainers try to answer most discussions, but they can't answer all discussions. If you're still not getting an answer, take a look at the information you've given us and see if you can improve it.

--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -274,3 +274,25 @@
 
 
     Thanks, the Renovate team
+
+'auto:one-topic':
+  comment: >
+    Hi there,
+
+    Please stick to one topic/question per Discussion. Start a new discussion per topic.
+
+    This is to benefit future users who may search and find this discussion and not be confused because there's multiple questions and answers within. One question and answer per Discussion works best.
+
+    For example:
+     - Don't create a discussion with multiple questions requiring multiple answers
+     - If you got an answer to your first question, don't change topic like "Can I also ask you how I might..." which would then require a different answer. Mark the current discussion as answered and open a new one.
+
+'auto:no-mentions':
+  comment: >
+    Hi there,
+
+    Please do not unnecessarily `@` maintainers like `@rarkins` or `@viceice`. Doing so causes annoying notifications and make maintaining a repo of this size difficult.
+
+    For example, never `@` mention a maintainer when you are creating a discussion if your desire is to get attention. This is inconsiderate behavior, just like shouting out your coffee order in a Starbucks before it's your turn.
+
+    If there's an existing issue or discussion which you were hoping for a follow-up to but multiple days or weeks have elapsed, it's ok for you to comment, but please still do not `@` people. The maintainers do not promise to answer every Discussion but do answer most. If you're not getting an answer then take a look at the informatio you've provided and see if you can improve it.

--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -287,6 +287,9 @@
      - Don't create a discussion with multiple questions requiring multiple answers
      - If you got an answer to your first question, don't change topic like "Can I also ask you how I might..." which would then require a different answer. Mark the current discussion as answered and open a new one.
 
+
+    Thanks, the Renovate team
+
 'auto:no-mentions':
   comment: >
     Hi there,
@@ -296,3 +299,6 @@
     For example, never `@` mention a maintainer when you are creating a discussion if your desire is to get attention. This is rude behavior, just like shouting out your coffee order in a Starbucks before it's your turn.
 
     It's OK to comment in an issue or discussion after multiple days or weeks. But please, still don't `@` mention people. The maintainers try to answer most discussions, but they can't answer all discussions. If you're still not getting an answer, take a look at the information you've given us and see if you can improve it.
+
+
+    Thanks, the Renovate team


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds two new label actions

## Context

These are frequent problems we should automate

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
