### PR TITLE
feat: add AWS SDK monorepo preset

### DIFF
--- a/lib/config/presets/internal/monorepo.ts
+++ b/lib/config/presets/internal/monorepo.ts
@@ -48,6 +48,10 @@ const repoGroups = {
   ],
   'aws-sdk-js-v3': 'https://github.com/aws/aws-sdk-js-v3',
   'aws-sdk-net': 'https://github.com/aws/aws-sdk-net',
+  'aws-sdk-rust': [
+    'https://github.com/awslabs/smithy-rs',
+    'https://github.com/awslabs/aws-sdk-rust',
+  ],
   awsappsync: 'https://github.com/awslabs/aws-mobile-appsync-sdk-js',
   'azure azure-libraries-for-net':
     'https://github.com/Azure/azure-libraries-for-net',
@@ -397,10 +401,6 @@ const repoGroups = {
   router5: 'https://github.com/router5/router5',
   'rust-futures': 'https://github.com/rust-lang/futures-rs',
   'rust-wasm-bindgen': 'https://github.com/rustwasm/wasm-bindgen',
-  'aws-sdk-rust': [
-    'https://github.com/awslabs/smithy-rs',
-    'https://github.com/awslabs/aws-sdk-rust',
-  ],
   sanity: 'https://github.com/sanity-io/sanity',
   scaffdog: 'https://github.com/scaffdog/scaffdog',
   'sendgrid-nodejs': 'https://github.com/sendgrid/sendgrid-nodejs',

--- a/lib/config/presets/internal/monorepo.ts
+++ b/lib/config/presets/internal/monorepo.ts
@@ -397,6 +397,10 @@ const repoGroups = {
   router5: 'https://github.com/router5/router5',
   'rust-futures': 'https://github.com/rust-lang/futures-rs',
   'rust-wasm-bindgen': 'https://github.com/rustwasm/wasm-bindgen',
+  'aws-sdk-rust': [
+    'https://github.com/awslabs/smithy-rs',
+    'https://github.com/awslabs/aws-sdk-rust',
+  ],
   sanity: 'https://github.com/sanity-io/sanity',
   scaffdog: 'https://github.com/scaffdog/scaffdog',
   'sendgrid-nodejs': 'https://github.com/sendgrid/sendgrid-nodejs',


### PR DESCRIPTION
## Changes

Adds support for AWS SDK monorepo grouping for rust projects

## Context

AWS has multiple SDKs which are frequently updated together, this allows the AWS SDK updates to be grouped together. This is equivalent to the current functionality implemented for the .NET and javascript SDK.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

Note: I'm [upstreaming a similar config](https://github.com/Isawan/terrashine/blob/main/renovate.json5) I currently use on a project of mine. [Example PR](https://github.com/Isawan/terrashine/pull/86)