### PR TITLE
docs: move bot comparison page to all other section

### DIFF
--- a/docs/usage/.pages
+++ b/docs/usage/.pages
@@ -1,6 +1,5 @@
 nav:
   - Home: 'index.md'
-  - Bot comparison: 'bot-comparison.md'
   - Reading List: 'reading-list.md'
   - ... | getting-started
   - Troubleshooting: 'troubleshooting.md'
@@ -54,5 +53,6 @@ nav:
       - 'Frequently Asked Questions': 'faq.md'
       - 'Known Limitations': 'known-limitations.md'
       - 'Release notes for major versions': 'release-notes-for-major-versions.md'
+      - Bot comparison: 'bot-comparison.md'
   - About Us: 'about-us.md'
   - Contributing to Renovate: 'contributing-to-renovate.md'


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Move Bot comparison page to All Other section of the sidebar

## Context

The bot comparison page is nice, but it should _not_ be the second page after our homepage. The reading list should be the second page (_again_).

I suspect this change also "fixes" a failing Cypress test on our docs repository. 🙃 

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
