### PR TITLE
chore: capitalize Dependency Dashboard in docs and config option description

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -940,7 +940,7 @@ You may use the `customizeDashboard` object to customize the Dependency Dashboar
 
 Supported fields:
 
-- `repoProblemsHeader`: This field will replace the header of the Repository Problems in Dependency Dashboard issue.
+- `repoProblemsHeader`: This field will replace the header of the Repository Problems in the Dependency Dashboard issue.
 
 ### defaultRegistryUrlTemplate
 

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -940,7 +940,7 @@ You may use the `customizeDashboard` object to customize the Dependency Dashboar
 
 Supported fields:
 
-- `repoProblemsHeader`: This field will replace the header of the Repository Problems in dependency dashboard issue.
+- `repoProblemsHeader`: This field will replace the header of the Repository Problems in Dependency Dashboard issue.
 
 ### defaultRegistryUrlTemplate
 

--- a/docs/usage/security-and-permissions.md
+++ b/docs/usage/security-and-permissions.md
@@ -38,7 +38,7 @@ These permissions are always needed to run the respective app.
 | Checks            |  `read` and `write`   |   not applicable   | Read and write status checks                                  |
 | Code              |  `read` and `write`   |       `read`       | Read for repository content and write for creating branches   |
 | Commit statuses   |  `read` and `write`   | `read` and `write` | Read and write commit statuses for Renovate PRs               |
-| Issues            |  `read` and `write`   | `read` and `write` | Create dependency dashboard or Config Warning issues          |
+| Issues            |  `read` and `write`   | `read` and `write` | Create Dependency Dashboard or Config Warning issues          |
 | Pull Requests     |  `read` and `write`   | `read` and `write` | Create update PRs                                             |
 | Workflows         |  `read` and `write`   |   not applicable   | Explicit permission needed to update workflows                |
 

--- a/lib/config/presets/internal/default.ts
+++ b/lib/config/presets/internal/default.ts
@@ -3,7 +3,7 @@ import type { Preset } from '../types';
 /* eslint sort-keys: ["error", "asc", {caseSensitive: false, natural: true}] */
 export const presets: Record<string, Preset> = {
   approveMajorUpdates: {
-    description: 'Require dependency dashboard approval for `major` updates.',
+    description: 'Require Dependency Dashboard approval for `major` updates.',
     packageRules: [
       {
         dependencyDashboardApproval: true,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Capitalize the "proper noun" Dependency Dashboard in the docs and in a config option `description`

## Context

We should capitalize the proper nouns. There are more hits for `dependency dashboard` in lowercase in other code like fixtures and test descriptions, but I'm leaving those for somebody else. 😉 

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
