### PR TITLE
docs: list sbt as not supported in replacement managers

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2826,6 +2826,7 @@ Managers which do not support replacement:
 - `homebrew`
 - `maven`
 - `regex`
+- `sbt`
 
 Use the `replacementName` config option to set the name of a replacement package.
 


### PR DESCRIPTION
## Changes

Add explicit info about sbt not being supported for replacement feature (see https://github.com/renovatebot/renovate/issues/25643)

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

