### PR TITLE
fix(kustomize): disable digest pinning for image newName

### DIFF
--- a/lib/modules/manager/kustomize/__snapshots__/extract.spec.ts.snap
+++ b/lib/modules/manager/kustomize/__snapshots__/extract.spec.ts.snap
@@ -118,6 +118,7 @@ exports[`modules/manager/kustomize/extract extractPackageFile() extracts newName
       "datasource": "docker",
       "depName": "awesome/postgres",
       "depType": "Kustomization",
+      "pinDigests": false,
       "replaceString": "awesome/postgres:11@sha256:b0cfe264cb1143c7c660ddfd5c482464997d62d6bc9f97f8fdf3deefce881a8c",
     },
     {
@@ -126,6 +127,7 @@ exports[`modules/manager/kustomize/extract extractPackageFile() extracts newName
       "datasource": "docker",
       "depName": "awesome/postgres",
       "depType": "Kustomization",
+      "pinDigests": false,
       "replaceString": "awesome/postgres:11",
     },
     {
@@ -134,6 +136,7 @@ exports[`modules/manager/kustomize/extract extractPackageFile() extracts newName
       "datasource": "docker",
       "depName": "awesome/postgres",
       "depType": "Kustomization",
+      "pinDigests": false,
       "replaceString": "awesome/postgres@sha256:b0cfe264cb1143c7c660ddfd5c482464997d62d6bc9f97f8fdf3deefce881a8c",
     },
   ],

--- a/lib/modules/manager/kustomize/extract.ts
+++ b/lib/modules/manager/kustomize/extract.ts
@@ -131,6 +131,7 @@ export function extractImage(image: Image): PackageDependency | null {
       ...nameDep,
       datasource: DockerDatasource.id,
       replaceString: image.newName,
+      pinDigests: false,
     };
   }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
**This change is ineffective**

An attempt at disabling digest pinning for the `images[].newName` field, any pointer about how it could be achieved for this specific case would be appreciated :pray:

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

The `newName` field does not support pinning digest with `autoReplaceStringTemplate`, because the usage of the field is ambiguous to Renovate, but any manager not configured properly regarding pinning digest breaks the `renovate/pin-dependencies` branch

Similar issue to #24942 and #25327
Follow up to #25596
Related discussion #24767

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
