### PR TITLE
test(http): Disable http retries for tests inside constructor

### DIFF
--- a/lib/util/http/index.ts
+++ b/lib/util/http/index.ts
@@ -132,6 +132,10 @@ export class Http<Opts extends HttpOptions = HttpOptions> {
     options: HttpOptions = {},
   ) {
     this.options = merge<GotOptions>(options, { context: { hostType } });
+
+    if (process.env.NODE_ENV === 'test') {
+      this.options.retry = 0;
+    }
   }
 
   protected getThrottle(url: string): Throttle | null {
@@ -167,9 +171,6 @@ export class Http<Opts extends HttpOptions = HttpOptions> {
       };
     }
 
-    if (process.env.NODE_ENV === 'test') {
-      options.retry = 0;
-    }
     options.hooks = {
       beforeRedirect: [removeAuthorization],
     };


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Changing code behavior based on `NODE_ENV` is the code smell.
However, we do this for disabling http retry behavior by default.
This PR moves this `NODE_ENV` checks to constructor, instead of checking this variable in each request.

## Context

- Ref: #25499
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
