### PR TITLE
fix(datasource/galaxy): loosen schema

### DIFF
--- a/lib/modules/datasource/galaxy/index.ts
+++ b/lib/modules/datasource/galaxy/index.ts
@@ -73,12 +73,14 @@ export class GalaxyDatasource extends Datasource {
     }
 
     result.releases = versions.map(
-      (version: { name: string; created: string }) => {
+      (version: { name: string; created?: string }) => {
         const release: Release = {
           version: version.name,
-          releaseTimestamp: version.created,
         };
 
+        if (is.nonEmptyString(version.created)) {
+          release.releaseTimestamp = version.created;
+        }
         return release;
       },
     );

--- a/lib/modules/datasource/galaxy/schema.ts
+++ b/lib/modules/datasource/galaxy/schema.ts
@@ -8,7 +8,7 @@ export const GalaxyV1 = z.object({
         versions: z.array(
           z.object({
             name: z.string(),
-            created: z.string(),
+            created: z.string().optional(),
           }),
         ),
       }),


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
makes the creation timestamp field optional as it seems not to be added on every package.
<!-- Describe what behavior is changed by this PR. -->

## Context
https://github.com/renovatebot/renovate/discussions/25696

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

https://github.com/renovate-reproductions/25696
<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
