### PR TITLE
fix(galaxy-collection): return `sourceUrl` of `highest_version` in `getReleases()`

### DIFF
--- a/lib/modules/datasource/galaxy-collection/__fixtures__/community_kubernetes_base.json
+++ b/lib/modules/datasource/galaxy-collection/__fixtures__/community_kubernetes_base.json
@@ -5,8 +5,8 @@
   "deprecated": false,
   "versions_url": "/api/v3/plugin/ansible/content/published/collections/index/community/kubernetes/versions/",
   "highest_version": {
-    "href": "/api/v3/plugin/ansible/content/published/collections/index/community/kubernetes/versions/2.0.1/",
-    "version": "2.0.1"
+    "href": "/api/v3/plugin/ansible/content/published/collections/index/community/kubernetes/versions/1.2.1/",
+    "version": "1.2.1"
   },
   "created_at": "2023-05-08T20:27:28.514620Z",
   "updated_at": "2023-10-15T22:54:12.688681Z",

--- a/lib/modules/datasource/galaxy-collection/__snapshots__/index.spec.ts.snap
+++ b/lib/modules/datasource/galaxy-collection/__snapshots__/index.spec.ts.snap
@@ -29,5 +29,6 @@ exports[`modules/datasource/galaxy-collection/index getReleases processes real d
       "version": "1.2.1",
     },
   ],
+  "sourceUrl": "https://github.com/ansible-collections/community.kubernetes",
 }
 `;

--- a/lib/modules/datasource/galaxy-collection/index.ts
+++ b/lib/modules/datasource/galaxy-collection/index.ts
@@ -86,8 +86,14 @@ export class GalaxyCollectionDatasource extends Datasource {
     const filteredReleases = enrichedReleases.filter(is.truthy);
     // extract base information which are only provided on the release from the newest release
 
+    // Find the source URL of the highest version release
+    const sourceUrlOfHighestRelease = enrichedReleases.find(
+      (release) => baseProject.highest_version.version === release.version,
+    )?.sourceUrl;
+
     return {
       releases: filteredReleases,
+      sourceUrl: sourceUrlOfHighestRelease,
     };
   }
 


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This PR finds the highest (as determined by `galaxy-collection`) version and uses the `sourceUrl` of this version as the overall package version.

In the tests the version is adjusted from `2.0.1`  to `1.2.1` as that is the highest mocked result.

## Context

Fixes #25767
Fixes #25768

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
