### PR TITLE
feat(presets): Add release-it group

### DIFF
--- a/lib/config/presets/internal/group.ts
+++ b/lib/config/presets/internal/group.ts
@@ -414,6 +414,7 @@ const staticGroups = {
       'group:polymer',
       'group:react',
       'group:resilience4j',
+      'group:releaseIt',
       'group:rubyOnRails',
       'group:rubyOmniauth',
       'group:socketio',
@@ -443,6 +444,15 @@ const staticGroups = {
       'group:symfony',
     ],
     ignoreDeps: [], // Hack to improve onboarding PR description
+  },
+  releaseIt: {
+    description: 'Group all packages published by release-it together.',
+    packageRules: [
+      {
+        extends: 'packages:releaseIt',
+        groupName: 'release-it packages',
+      },
+    ],
   },
   resilience4j: {
     description: 'Group Java Resilience4j packages.',

--- a/lib/config/presets/internal/packages.ts
+++ b/lib/config/presets/internal/packages.ts
@@ -127,6 +127,10 @@ export const presets: Record<string, Preset> = {
     matchPackageNames: ['@types/react'],
     matchPackagePrefixes: ['react'],
   },
+  releaseIt: {
+    description: 'All packages published by release-it.',
+    matchSourceUrlPrefixes: ['https://github.com/release-it/'],
+  },
   stylelint: {
     description: 'All Stylelint packages.',
     matchPackagePrefixes: ['stylelint'],


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adding a group for release-it packages

## Context

Currently release-it PRs are created separately so when there is a major breaking change, neither PR is able to merge cleanly. This requires manual intervention each time.

As of creating this PR, this repo has an example of the issue:
https://github.com/snowcoders/sortier/pulls?q=is%3Apr+is%3Aopen+release-it

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
