### PR TITLE
fix(config): do not replace RegExp objects with empty objects

### DIFF
--- a/lib/config/migration.spec.ts
+++ b/lib/config/migration.spec.ts
@@ -246,6 +246,18 @@ describe('config/migration', () => {
       expect(isMigrated).toBeFalse();
     });
 
+    it('does not migrate RegExp objects in arrays', () => {
+      const config = {
+        allowedPostUpgradeCommands: [/my regex/],
+      };
+      const { isMigrated, migratedConfig } =
+        configMigration.migrateConfig(config);
+      expect(migratedConfig.allowedPostUpgradeCommands).toEqual(
+        config.allowedPostUpgradeCommands,
+      );
+      expect(isMigrated).toBeFalse();
+    });
+
     it('migrates packages', () => {
       const config = {
         packages: [

--- a/lib/config/migration.ts
+++ b/lib/config/migration.ts
@@ -71,7 +71,7 @@ export function migrateConfig(config: RenovateConfig): MigratedConfig {
         if (is.array(migratedConfig?.[key])) {
           const newArray = [];
           for (const item of migratedConfig[key] as unknown[]) {
-            if (is.object(item) && !is.array(item)) {
+            if (is.object(item) && !is.array(item) && !is.regExp(item)) {
               const arrMigrate = migrateConfig(item as RenovateConfig);
               newArray.push(arrMigrate.migratedConfig);
             } else {


### PR DESCRIPTION
## Changes

* Added an additional check for array items, so that RegExp items are not "migrated" together with other objects.
* Added test to verify correct implementation.

## Context

When configuring self-hosted Renovate using `config.js`. It was not possible to use RegExp objects, e.g. `/my regex/` directly (for example in the `allowedPostUpgradeCommands` array).
The migration mechanism would replace them with empty objects, which lead to an invalid regex exception.

See discussion #25792 for more details.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository