### PR TITLE
docs(config options): `automerge` and GitHub branch protection rule

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -200,15 +200,20 @@ So for example you could choose to automerge all (passing) `devDependencies` onl
     Renovate won't automerge on GitHub if a PR has a negative review.
 
 <!-- prettier-ignore -->
-!!! warning "Renovate automerge and GitHub branch protection rule: Require status checks to pass before merging branch protection rule"
-    If you set `automerge: true` _and_ use `platformAutomerge=true` (Renovate defaults to true) _and_ use GitHub's **Require status checks to pass before merging** branch protection rule, then you must select at least one status check in that section.
-    If you don't, and platform automerge is in use, then GitHub might automerge PRs with failing tests!
-
-<!-- prettier-ignore -->
 !!! note
     On Azure there can be a delay between a PR being set as completed by Renovate, and Azure merging the PR / finishing its tasks.
     Renovate tries to delay until Azure is in the expected state, but it will continue if it takes too long.
     In some cases this can result in a dependency not being merged, and a fresh PR being created for the dependency.
+
+### Automerge and GitHub branch protection rules
+
+You must select at least one status check in the **Require status checks to pass before merging** section of your branch protection rules on GitHub, if you match all three conditions:
+
+- `automerge=true`
+- `platformAutomerge=true`, Renovate defaults to `true`
+- you use use GitHub's **Require status checks to pass before merging** branch protection rule
+
+If you don't select any status check, and you use platform automerge, then GitHub might automerge PRs with failing tests!
 
 ## automergeComment
 

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -202,7 +202,7 @@ So for example you could choose to automerge all (passing) `devDependencies` onl
 <!-- prettier-ignore -->
 !!! warning "Renovate automerge and GitHub branch protection rule: Require status checks to pass before merging branch protection rule"
     If you set `automerge: true` _and_ use GitHub's **Require status checks to pass before merging** branch protection rule, then you must select at least one status check in that section.
-    If you don't GitHub allows Renovate to automerge PPs with failing tests!
+    If you don't GitHub allows Renovate to automerge PRs with failing tests!
 
 <!-- prettier-ignore -->
 !!! note

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -205,13 +205,13 @@ So for example you could choose to automerge all (passing) `devDependencies` onl
     Renovate tries to delay until Azure is in the expected state, but it will continue if it takes too long.
     In some cases this can result in a dependency not being merged, and a fresh PR being created for the dependency.
 
-### Automerge and GitHub branch protection rules
+**Automerge and GitHub branch protection rules**
 
-You must select at least one status check in the **Require status checks to pass before merging** section of your branch protection rules on GitHub, if you match all three conditions:
+You must select at least one status check in the _Require status checks to pass before merging_ section of your branch protection rules on GitHub, if you match all three conditions:
 
 - `automerge=true`
 - `platformAutomerge=true`, Renovate defaults to `true`
-- you use use GitHub's **Require status checks to pass before merging** branch protection rule
+- You use use GitHub's _Require status checks to pass before merging_ branch protection rule
 
 If you don't select any status check, and you use platform automerge, then GitHub might automerge PRs with failing tests!
 

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -200,6 +200,11 @@ So for example you could choose to automerge all (passing) `devDependencies` onl
     Renovate won't automerge on GitHub if a PR has a negative review.
 
 <!-- prettier-ignore -->
+!!! warning "Renovate automerge and GitHub branch protection rule: Require status checks to pass before merging branch protection rule"
+    If you set `automerge: true` _and_ use GitHub's **Require status checks to pass before merging** branch protection rule, then you must select at least one status check in that section.
+    If you don't GitHub allows Renovate to automerge PPs with failing tests!
+
+<!-- prettier-ignore -->
 !!! note
     On Azure there can be a delay between a PR being set as completed by Renovate, and Azure merging the PR / finishing its tasks.
     Renovate tries to delay until Azure is in the expected state, but it will continue if it takes too long.

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -201,7 +201,7 @@ So for example you could choose to automerge all (passing) `devDependencies` onl
 
 <!-- prettier-ignore -->
 !!! warning "Renovate automerge and GitHub branch protection rule: Require status checks to pass before merging branch protection rule"
-    If you set `automerge: true` _and_ use GitHub's **Require status checks to pass before merging** branch protection rule, then you must select at least one status check in that section.
+    If you set `automerge: true` _and_ use `platformAutomerge=true` (Renovate defaults to true) _and_ use GitHub's **Require status checks to pass before merging** branch protection rule, then you must select at least one status check in that section.
     If you don't, and platform automerge is in use, then GitHub might automerge PRs with failing tests!
 
 <!-- prettier-ignore -->

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -202,7 +202,7 @@ So for example you could choose to automerge all (passing) `devDependencies` onl
 <!-- prettier-ignore -->
 !!! warning "Renovate automerge and GitHub branch protection rule: Require status checks to pass before merging branch protection rule"
     If you set `automerge: true` _and_ use GitHub's **Require status checks to pass before merging** branch protection rule, then you must select at least one status check in that section.
-    If you don't GitHub allows Renovate to automerge PRs with failing tests!
+    If you don't, and platform automerge is in use, then GitHub might automerge PRs with failing tests!
 
 <!-- prettier-ignore -->
 !!! note


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Add warning admonition, if you use GitHub's **Require status checks to pass before merging** branch protection rule, then you must select at least one status check in that section

## Context

Users who select the **Require status checks to pass before merging** checkbox expect GitHub to block Renovate PRs with any failing check. But for GitHub's feature to work properly, you must actually select _at least one status check_.

Examples of users confused by this behavior:

- #25750
- https://github.com/orgs/community/discussions/63427

I don't know when/if GitHub will improve the form's text and layout. In the meantime we can warn our own users about this behavior.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
