### PR TITLE
fix(npm): use lockfileVersion to determine npm version

### DIFF
--- a/lib/modules/manager/npm/post-update/npm.spec.ts
+++ b/lib/modules/manager/npm/post-update/npm.spec.ts
@@ -26,8 +26,12 @@ describe('modules/manager/npm/post-update/npm', () => {
     const execSnapshots = mockExecAll();
     // package.json
     fs.readLocalFile.mockResolvedValueOnce('{}');
-    fs.readLocalFile.mockResolvedValueOnce('package-lock-contents');
-    fs.readLocalFile.mockResolvedValueOnce('package-lock-contents');
+    const packageLockContents = JSON.stringify({
+      packages: {},
+      lockfileVersion: 3,
+    });
+    fs.readLocalFile.mockResolvedValueOnce(packageLockContents);
+    fs.readLocalFile.mockResolvedValueOnce(packageLockContents);
     const skipInstalls = true;
     const postUpdateOptions = ['npmDedupe'];
     const updates = [
@@ -42,7 +46,7 @@ describe('modules/manager/npm/post-update/npm', () => {
     );
     expect(fs.readLocalFile).toHaveBeenCalledTimes(3);
     expect(res.error).toBeFalse();
-    expect(res.lockFile).toBe('package-lock-contents');
+    expect(res.lockFile).toBe(packageLockContents);
     expect(execSnapshots).toMatchSnapshot();
   });
 
@@ -167,7 +171,10 @@ describe('modules/manager/npm/post-update/npm', () => {
     const execSnapshots = mockExecAll();
     // package.json
     fs.readLocalFile.mockResolvedValueOnce('{}');
-    const packageLockContents = JSON.stringify({ lockfileVersion: 2 });
+    const packageLockContents = JSON.stringify({
+      dependencies: {},
+      lockfileVersion: 2,
+    });
     fs.readLocalFile.mockResolvedValueOnce(packageLockContents);
     fs.readLocalFile.mockResolvedValueOnce(packageLockContents);
     const postUpdateOptions = ['npmDedupe'];
@@ -196,7 +203,10 @@ describe('modules/manager/npm/post-update/npm', () => {
     const execSnapshots = mockExecAll();
     // package.json
     fs.readLocalFile.mockResolvedValueOnce('{}');
-    const packageLockContents = JSON.stringify({ lockfileVersion: 1 });
+    const packageLockContents = JSON.stringify({
+      dependencies: {},
+      lockfileVersion: 1,
+    });
     fs.readLocalFile.mockResolvedValueOnce(packageLockContents);
     fs.readLocalFile.mockResolvedValueOnce(packageLockContents);
     const postUpdateOptions = ['npmDedupe'];

--- a/lib/modules/manager/npm/post-update/npm.spec.ts
+++ b/lib/modules/manager/npm/post-update/npm.spec.ts
@@ -167,7 +167,7 @@ describe('modules/manager/npm/post-update/npm', () => {
     const execSnapshots = mockExecAll();
     // package.json
     fs.readLocalFile.mockResolvedValueOnce('{}');
-    const packageLockContents = JSON.stringify({lockfileVersion:2});
+    const packageLockContents = JSON.stringify({ lockfileVersion: 2 });
     fs.readLocalFile.mockResolvedValueOnce(packageLockContents);
     fs.readLocalFile.mockResolvedValueOnce(packageLockContents);
     const postUpdateOptions = ['npmDedupe'];
@@ -196,7 +196,7 @@ describe('modules/manager/npm/post-update/npm', () => {
     const execSnapshots = mockExecAll();
     // package.json
     fs.readLocalFile.mockResolvedValueOnce('{}');
-    const packageLockContents = JSON.stringify({lockfileVersion:1});
+    const packageLockContents = JSON.stringify({ lockfileVersion: 1 });
     fs.readLocalFile.mockResolvedValueOnce(packageLockContents);
     fs.readLocalFile.mockResolvedValueOnce(packageLockContents);
     const postUpdateOptions = ['npmDedupe'];

--- a/lib/modules/manager/npm/post-update/npm.spec.ts
+++ b/lib/modules/manager/npm/post-update/npm.spec.ts
@@ -27,6 +27,7 @@ describe('modules/manager/npm/post-update/npm', () => {
     // package.json
     fs.readLocalFile.mockResolvedValueOnce('{}');
     fs.readLocalFile.mockResolvedValueOnce('package-lock-contents');
+    fs.readLocalFile.mockResolvedValueOnce('package-lock-contents');
     const skipInstalls = true;
     const postUpdateOptions = ['npmDedupe'];
     const updates = [
@@ -39,7 +40,7 @@ describe('modules/manager/npm/post-update/npm', () => {
       { skipInstalls, postUpdateOptions },
       updates,
     );
-    expect(fs.readLocalFile).toHaveBeenCalledTimes(2);
+    expect(fs.readLocalFile).toHaveBeenCalledTimes(3);
     expect(res.error).toBeFalse();
     expect(res.lockFile).toBe('package-lock-contents');
     expect(execSnapshots).toMatchSnapshot();
@@ -166,7 +167,9 @@ describe('modules/manager/npm/post-update/npm', () => {
     const execSnapshots = mockExecAll();
     // package.json
     fs.readLocalFile.mockResolvedValueOnce('{}');
-    fs.readLocalFile.mockResolvedValueOnce('package-lock-contents');
+    const packageLockContents = JSON.stringify({lockfileVersion:2});
+    fs.readLocalFile.mockResolvedValueOnce(packageLockContents);
+    fs.readLocalFile.mockResolvedValueOnce(packageLockContents);
     const postUpdateOptions = ['npmDedupe'];
     const updates = [
       { packageName: 'some-dep', newVersion: '1.0.1', isLockfileUpdate: false },
@@ -178,9 +181,9 @@ describe('modules/manager/npm/post-update/npm', () => {
       { postUpdateOptions },
       updates,
     );
-    expect(fs.readLocalFile).toHaveBeenCalledTimes(2);
+    expect(fs.readLocalFile).toHaveBeenCalledTimes(3);
     expect(res.error).toBeFalse();
-    expect(res.lockFile).toBe('package-lock-contents');
+    expect(res.lockFile).toBe(packageLockContents);
     expect(execSnapshots).toHaveLength(1);
     expect(execSnapshots).toMatchObject([
       {
@@ -192,7 +195,10 @@ describe('modules/manager/npm/post-update/npm', () => {
   it('deduplicates dependencies after installation with npm <= 6', async () => {
     const execSnapshots = mockExecAll();
     // package.json
-    fs.readLocalFile.mockResolvedValueOnce('package-lock-contents');
+    fs.readLocalFile.mockResolvedValueOnce('{}');
+    const packageLockContents = JSON.stringify({lockfileVersion:1});
+    fs.readLocalFile.mockResolvedValueOnce(packageLockContents);
+    fs.readLocalFile.mockResolvedValueOnce(packageLockContents);
     const postUpdateOptions = ['npmDedupe'];
     const updates = [
       { packageName: 'some-dep', newVersion: '1.0.1', isLockfileUpdate: false },
@@ -201,12 +207,12 @@ describe('modules/manager/npm/post-update/npm', () => {
       'some-dir',
       {},
       'package-lock.json',
-      { postUpdateOptions, constraints: { npm: '^6.0.0' } },
+      { postUpdateOptions },
       updates,
     );
-    expect(fs.readLocalFile).toHaveBeenCalledTimes(1);
+    expect(fs.readLocalFile).toHaveBeenCalledTimes(3);
     expect(res.error).toBeFalse();
-    expect(res.lockFile).toBe('package-lock-contents');
+    expect(res.lockFile).toBe(packageLockContents);
     expect(execSnapshots).toHaveLength(2);
     expect(execSnapshots).toMatchObject([
       {
@@ -261,7 +267,7 @@ describe('modules/manager/npm/post-update/npm', () => {
       {},
       'package-lock.json',
     );
-    expect(fs.readLocalFile).toHaveBeenCalledTimes(2);
+    expect(fs.readLocalFile).toHaveBeenCalledTimes(3);
     expect(res.lockFile).toBe('package-lock-contents');
     // TODO: is that right?
     expect(execSnapshots).toEqual([]);
@@ -294,7 +300,7 @@ describe('modules/manager/npm/post-update/npm', () => {
       {},
       [{ isLockFileMaintenance: true }],
     );
-    expect(fs.readLocalFile).toHaveBeenCalledTimes(2);
+    expect(fs.readLocalFile).toHaveBeenCalledTimes(3);
     expect(fs.deleteLocalFile).toHaveBeenCalledTimes(1);
     expect(res.lockFile).toBe('package-lock-contents');
     expect(execSnapshots).toMatchSnapshot();
@@ -485,7 +491,7 @@ describe('modules/manager/npm/post-update/npm', () => {
         { skipInstalls },
         updates,
       );
-      expect(fs.readLocalFile).toHaveBeenCalledTimes(2);
+      expect(fs.readLocalFile).toHaveBeenCalledTimes(3);
       expect(res.error).toBeFalse();
       expect(execSnapshots).toMatchObject([
         {
@@ -520,7 +526,7 @@ describe('modules/manager/npm/post-update/npm', () => {
         { skipInstalls },
         modifiedUpdates,
       );
-      expect(fs.readLocalFile).toHaveBeenCalledTimes(2);
+      expect(fs.readLocalFile).toHaveBeenCalledTimes(3);
       expect(res.error).toBeFalse();
       expect(execSnapshots).toMatchObject([
         {

--- a/lib/modules/manager/npm/post-update/npm.ts
+++ b/lib/modules/manager/npm/post-update/npm.ts
@@ -21,8 +21,10 @@ import {
   renameLocalFile,
 } from '../../../../util/fs';
 import { minimatch } from '../../../../util/minimatch';
+import { Result } from '../../../../util/result';
 import { trimSlashes } from '../../../../util/url';
 import type { PostUpdateConfig, Upgrade } from '../../types';
+import { PackageLock } from '../schema';
 import { composeLockFile, parseLockFile } from '../utils';
 import { getNodeToolConstraint } from './node-version';
 import type { GenerateLockFileResult } from './types';
@@ -30,36 +32,30 @@ import { getPackageManagerVersion, lazyLoadPackageJson } from './utils';
 
 async function getNpmConstraintFromPackageLock(
   lockFileDir: string,
-): Promise<string | undefined> {
-  const lockFileName = upath.join(lockFileDir, 'package-lock.json');
-  const lockFile = await readLocalFile(lockFileName, 'utf8');
-  // istanbul ignore if: should not happen
-  if (!lockFile) {
-    return undefined;
+): Promise<string | null> {
+  const packageLockFileName = upath.join(lockFileDir, 'package-lock.json');
+  const packageLockContents = await readLocalFile(packageLockFileName, 'utf8');
+  const packageLockJson = Result.parse(
+    packageLockContents,
+    PackageLock,
+  ).unwrapOrNull();
+  if (!packageLockJson) {
+    logger.debug(`Could not parse ${packageLockFileName}`);
+    return null;
   }
-  try {
-    const lockFileJson = JSON.parse(lockFile);
-    const { lockfileVersion } = lockFileJson;
-    if (!lockfileVersion) {
-      logger.debug(`Could not determine lockfileVersion`);
-    }
-    if (lockfileVersion === 1) {
-      logger.debug(`Using npm constraint <7 for lockfileVersion=1`);
-      return `<7`;
-    }
-    if (lockfileVersion === 2) {
-      logger.debug(`Using npm constraint <9 for lockfileVersion=2`);
-      return `<9`;
-    }
-    logger.debug(
-      `Using npm constraint >=9 for lockfileVersion=${lockfileVersion}`,
-    );
-    return `>=9`;
-  } catch (err) {
-    logger.debug(`Error parsing ${lockFileName}`);
+  const { lockfileVersion } = packageLockJson;
+  if (lockfileVersion === 1) {
+    logger.debug(`Using npm constraint <7 for lockfileVersion=1`);
+    return `<7`;
   }
-  logger.debug('No npm constraint found for package-lock.json');
-  return undefined;
+  if (lockfileVersion === 2) {
+    logger.debug(`Using npm constraint <9 for lockfileVersion=2`);
+    return `<9`;
+  }
+  logger.debug(
+    `Using npm constraint >=9 for lockfileVersion=${lockfileVersion}`,
+  );
+  return `>=9`;
 }
 
 export async function generateLockFile(

--- a/lib/modules/manager/npm/post-update/npm.ts
+++ b/lib/modules/manager/npm/post-update/npm.ts
@@ -77,12 +77,12 @@ export async function generateLockFile(
 
   let lockFile: string | null = null;
   try {
-    const lazyPgkJson = lazyLoadPackageJson(lockFileDir);
+    const lazyPkgJson = lazyLoadPackageJson(lockFileDir);
     const npmToolConstraint: ToolConstraint = {
       toolName: 'npm',
       constraint:
         config.constraints?.npm ??
-        getPackageManagerVersion('npm', await lazyPgkJson.getValue()) ??
+        getPackageManagerVersion('npm', await lazyPkgJson.getValue()) ??
         (await getNpmConstraintFromPackageLock(lockFileDir)) ??
         null,
     };
@@ -120,7 +120,7 @@ export async function generateLockFile(
       cwdFile: lockFileName,
       extraEnv,
       toolConstraints: [
-        await getNodeToolConstraint(config, upgrades, lockFileDir, lazyPgkJson),
+        await getNodeToolConstraint(config, upgrades, lockFileDir, lazyPkgJson),
         npmToolConstraint,
       ],
       docker: {},

--- a/lib/modules/manager/npm/post-update/utils.ts
+++ b/lib/modules/manager/npm/post-update/utils.ts
@@ -28,12 +28,12 @@ export async function loadPackageJson(
 export function getPackageManagerVersion(
   name: string,
   pkg: PackageJsonSchema,
-): string | undefined {
+): string | null {
   if (pkg.packageManager?.name === name) {
     return pkg.packageManager.version;
   }
   if (pkg.engines?.[name]) {
     return pkg.engines[name];
   }
-  return undefined;
+  return null;
 }

--- a/lib/modules/manager/npm/post-update/utils.ts
+++ b/lib/modules/manager/npm/post-update/utils.ts
@@ -28,12 +28,12 @@ export async function loadPackageJson(
 export function getPackageManagerVersion(
   name: string,
   pkg: PackageJsonSchema,
-): string | null {
+): string | undefined {
   if (pkg.packageManager?.name === name) {
     return pkg.packageManager.version;
   }
   if (pkg.engines?.[name]) {
     return pkg.engines[name];
   }
-  return null;
+  return undefined;
 }


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Use lockfileVersion in package-lock.json to determine npm version if no constraints are previously found

## Context

Fixes #25817

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
