### PR TITLE
feat(datasource/docker): Use `org.opencontainers.image.url` as homepage

### DIFF
--- a/lib/modules/datasource/docker/common.ts
+++ b/lib/modules/datasource/docker/common.ts
@@ -34,6 +34,8 @@ import type { RegistryRepository } from './types';
 
 export const dockerDatasourceId = 'docker' as const;
 
+export const imageUrlLabel = 'org.opencontainers.image.url' as const;
+
 export const sourceLabel = 'org.opencontainers.image.source' as const;
 export const sourceLabels = [sourceLabel, 'org.label-schema.vcs-url'] as const;
 

--- a/lib/modules/datasource/docker/index.spec.ts
+++ b/lib/modules/datasource/docker/index.spec.ts
@@ -1976,6 +1976,8 @@ describe('modules/datasource/docker/index', () => {
                 'https://github.com/renovatebot/renovate',
               'org.opencontainers.image.revision':
                 'ab7ddb5e3c5c3b402acd7c3679d4e415f8092dde',
+              'org.opencontainers.image.url':
+                'https://www.mend.io/renovate/'
             },
           },
         });
@@ -2006,6 +2008,7 @@ describe('modules/datasource/docker/index', () => {
           },
         ],
         sourceUrl: 'https://github.com/renovatebot/renovate',
+        homepage: 'https://www.mend.io/renovate/',
         gitRef: 'ab7ddb5e3c5c3b402acd7c3679d4e415f8092dde',
       });
     });

--- a/lib/modules/datasource/docker/index.spec.ts
+++ b/lib/modules/datasource/docker/index.spec.ts
@@ -1976,8 +1976,7 @@ describe('modules/datasource/docker/index', () => {
                 'https://github.com/renovatebot/renovate',
               'org.opencontainers.image.revision':
                 'ab7ddb5e3c5c3b402acd7c3679d4e415f8092dde',
-              'org.opencontainers.image.url':
-                'https://www.mend.io/renovate/'
+              'org.opencontainers.image.url': 'https://www.mend.io/renovate/',
             },
           },
         });

--- a/lib/modules/datasource/docker/index.ts
+++ b/lib/modules/datasource/docker/index.ts
@@ -32,6 +32,7 @@ import {
   getAuthHeaders,
   getRegistryRepository,
   gitRefLabel,
+  imageUrlLabel,
   isDockerHost,
   sourceLabel,
   sourceLabels,
@@ -1027,6 +1028,9 @@ export class DockerDatasource extends Datasource {
           ret.sourceUrl = labels[label];
           break;
         }
+      }
+      if (is.nonEmptyString(labels[imageUrlLabel])) {
+        ret.homepage = labels[imageUrlLabel];
       }
     }
     return ret;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This PR allows the Docker datasource to extract the `org.opencontainers.image.url` label as the dependency's homepage.

## Context

According to the OCI Image Format Specification, the `org.opencontainers.image.url` label may contain a "URL to find more information on the image" ([source](https://github.com/opencontainers/image-spec/blob/56fb7838abe52ee259e37ece4b314c08bd45997f/annotations.md)).

Renovate already supports extracting `org.opencontainers.image.source` ("URL to get source code for building the image") as the dependency's `sourceUrl` so this seems like a natural extension.

Notably, [the labels for Mend Renovate CE recently changed](https://github.com/mend/renovate-ce-ee/issues/365#issuecomment-1817953795) as of 6.6.0:

```diff
Before:
 "Labels": {
-  "maintainer": "Rhys Arkins <rhys@arkins.net>",
+  "maintainer": "Mend.io",
   "org.opencontainers.image.ref.name": "ubuntu",
-  "org.opencontainers.image.source": "https://github.com/containerbase/base",
+  "org.opencontainers.image.source": "",
+  "org.opencontainers.image.url": "https://github.com/mend/renovate-ce-ee",
-  "org.opencontainers.image.version": "9.23.6"
   "org.opencontainers.image.version": ""
 },
```

So for those using Renovate to keep Renovate CE updated, this change will ensure the dependency is linked to `https://github.com/mend/renovate-ce-ee` where users can find more information about the available update.

(See https://github.com/mend/renovate-ce-ee/issues/365 for more on this)

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
