### PR TITLE
fix(onboarding/pr): include retry/refresh checkbox message only if onboardingRebaseCheckbox is true

### DIFF
--- a/lib/workers/repository/onboarding/pr/__snapshots__/config-description.spec.ts.snap
+++ b/lib/workers/repository/onboarding/pr/__snapshots__/config-description.spec.ts.snap
@@ -9,7 +9,7 @@ Based on the default config's presets, Renovate will:
   - Start dependency updates only once this onboarding PR is merged
   - Run Renovate on following schedule: before 5am
 
-🔡 Would you like to change the way Renovate is upgrading your dependencies? Simply edit the \`.github/renovate.json\` in this branch with your custom config and the list of Pull Requests in the "What to Expect" section below will be updated the next time Renovate runs.
+🔡 Do you want to change how Renovate upgrades your dependencies? Add your custom config to \`.github/renovate.json\` in this branch. Renovate will update the Pull Request description the next time it runs.
 
 ---
 "
@@ -24,7 +24,7 @@ Based on the default config's presets, Renovate will:
   - Start dependency updates only once this onboarding PR is merged
   - Run Renovate on following schedule: before 5am
 
-🔡 Would you like to change the way Renovate is upgrading your dependencies? Simply edit the \`renovate.json\` in this branch with your custom config and the list of Pull Requests in the "What to Expect" section below will be updated the next time Renovate runs.
+🔡 Do you want to change how Renovate upgrades your dependencies? Add your custom config to \`renovate.json\` in this branch. Renovate will update the Pull Request description the next time it runs.
 
 ---
 "
@@ -39,7 +39,7 @@ Based on the default config's presets, Renovate will:
   - Start dependency updates only once this onboarding PR is merged
   - Run Renovate on following schedule: before 5am
 
-🔡 Would you like to change the way Renovate is upgrading your dependencies? Simply edit the \`renovate.json\` in this branch with your custom config and the list of Pull Requests in the "What to Expect" section below will be updated the next time Renovate runs.
+🔡 Do you want to change how Renovate upgrades your dependencies? Add your custom config to \`renovate.json\` in this branch. Renovate will update the Pull Request description the next time it runs.
 
 ---
 "
@@ -57,7 +57,22 @@ Based on the default config's presets, Renovate will:
   - something else
   - this is Docker-only
 
-🔡 Would you like to change the way Renovate is upgrading your dependencies? Simply edit the \`renovate.json\` in this branch with your custom config and the list of Pull Requests in the "What to Expect" section below will be updated the next time Renovate runs.
+🔡 Do you want to change how Renovate upgrades your dependencies? Add your custom config to \`renovate.json\` in this branch. Renovate will update the Pull Request description the next time it runs.
+
+---
+"
+`;
+
+exports[`workers/repository/onboarding/pr/config-description getConfigDesc() include button selection if onboardingRebaseCheckbox is set to true 1`] = `
+"
+### Configuration Summary
+
+Based on the default config's presets, Renovate will:
+
+  - Start dependency updates only once this onboarding PR is merged
+  - Run Renovate on following schedule: before 5am
+
+🔡 Do you want to change how Renovate upgrades your dependencies? Add your custom config to \`.github/renovate.json\` in this branch and select the Retry/Rebase checkbox below. Renovate will update the Pull Request description the next time it runs.
 
 ---
 "

--- a/lib/workers/repository/onboarding/pr/__snapshots__/config-description.spec.ts.snap
+++ b/lib/workers/repository/onboarding/pr/__snapshots__/config-description.spec.ts.snap
@@ -63,7 +63,7 @@ Based on the default config's presets, Renovate will:
 "
 `;
 
-exports[`workers/repository/onboarding/pr/config-description getConfigDesc() include button selection if onboardingRebaseCheckbox is set to true 1`] = `
+exports[`workers/repository/onboarding/pr/config-description getConfigDesc() include retry/refresh checkbox only if onboardingRebaseCheckbox is true 1`] = `
 "
 ### Configuration Summary
 

--- a/lib/workers/repository/onboarding/pr/__snapshots__/config-description.spec.ts.snap
+++ b/lib/workers/repository/onboarding/pr/__snapshots__/config-description.spec.ts.snap
@@ -63,7 +63,7 @@ Based on the default config's presets, Renovate will:
 "
 `;
 
-exports[`workers/repository/onboarding/pr/config-description getConfigDesc() include retry/refresh checkbox only if onboardingRebaseCheckbox is true 1`] = `
+exports[`workers/repository/onboarding/pr/config-description getConfigDesc() include retry/refresh checkbox message only if onboardingRebaseCheckbox is true 1`] = `
 "
 ### Configuration Summary
 

--- a/lib/workers/repository/onboarding/pr/config-description.spec.ts
+++ b/lib/workers/repository/onboarding/pr/config-description.spec.ts
@@ -48,7 +48,7 @@ describe('workers/repository/onboarding/pr/config-description', () => {
           - Start dependency updates only once this onboarding PR is merged
           - Run Renovate on following schedule: before 5am
 
-        🔡 Would you like to change the way Renovate is upgrading your dependencies? Simply edit the \`renovate.json\` in this branch with your custom config and the list of Pull Requests in the "What to Expect" section below will be updated the next time Renovate runs.
+        🔡 Do you want to change how Renovate upgrades your dependencies? Add your custom config to \`renovate.json\` in this branch. Renovate will update the Pull Request description the next time it runs.
 
         ---
         "
@@ -81,6 +81,16 @@ describe('workers/repository/onboarding/pr/config-description', () => {
       const res = getConfigDesc(config);
       expect(res).toMatchSnapshot();
       expect(res.indexOf('`renovate.json`')).not.toBe(-1);
+    });
+
+    it('include button selection if onboardingRebaseCheckbox is set to true', () => {
+      delete config.description;
+      config.schedule = ['before 5am'];
+      config.onboardingConfigFileName = '.github/renovate.json';
+      config.onboardingRebaseCheckbox = true;
+      const res = getConfigDesc(config);
+      expect(res).toMatchSnapshot();
+      expect(res.indexOf('Retry/Rebase')).not.toBe(-1);
     });
   });
 });

--- a/lib/workers/repository/onboarding/pr/config-description.spec.ts
+++ b/lib/workers/repository/onboarding/pr/config-description.spec.ts
@@ -83,14 +83,13 @@ describe('workers/repository/onboarding/pr/config-description', () => {
       expect(res.indexOf('`renovate.json`')).not.toBe(-1);
     });
 
-    it('include button selection if onboardingRebaseCheckbox is set to true', () => {
+    it('include retry/refresh checkbox message only if onboardingRebaseCheckbox is true', () => {
       delete config.description;
       config.schedule = ['before 5am'];
       config.onboardingConfigFileName = '.github/renovate.json';
       config.onboardingRebaseCheckbox = true;
       const res = getConfigDesc(config);
       expect(res).toMatchSnapshot();
-      expect(res.indexOf('Retry/Rebase')).not.toBe(-1);
     });
   });
 });

--- a/lib/workers/repository/onboarding/pr/config-description.ts
+++ b/lib/workers/repository/onboarding/pr/config-description.ts
@@ -55,10 +55,10 @@ export function getConfigDesc(
     `:abcd: Do you want to change how Renovate upgrades your dependencies?`,
   );
   desc += ` Add your custom config to \`${configFile}\` in this branch${
-	    config.onboardingRebaseCheckbox
-	      ? ' and select the Retry/Rebase checkbox below'
-	      : ''
-	  }. Renovate will update the Pull Request description the next time it runs.`;
+    config.onboardingRebaseCheckbox
+      ? ' and select the Retry/Rebase checkbox below'
+      : ''
+  }. Renovate will update the Pull Request description the next time it runs.`;
   desc += '\n\n---\n';
   return desc;
 }

--- a/lib/workers/repository/onboarding/pr/config-description.ts
+++ b/lib/workers/repository/onboarding/pr/config-description.ts
@@ -52,9 +52,13 @@ export function getConfigDesc(
   });
   desc += '\n';
   desc += emojify(
-    `:abcd: Would you like to change the way Renovate is upgrading your dependencies?`,
+    `:abcd: Do you want to change how Renovate upgrades your dependencies?`,
   );
-  desc += ` Simply edit the \`${configFile}\` in this branch with your custom config and the list of Pull Requests in the "What to Expect" section below will be updated the next time Renovate runs.`;
+  desc += ` Add your custom config to \`${configFile}\` in this branch${
+	    config.onboardingRebaseCheckbox
+	      ? ' and select the Retry/Rebase checkbox below'
+	      : ''
+	  }. Renovate will update the Pull Request description the next time it runs.`;
   desc += '\n\n---\n';
   return desc;
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
Updated the default onboarding PR description template to provide clearer instructions. Now explicitly mentions that the retry/rebase checkbox must be ticked for the custom configuration to be considered on next Renovate run and for it to update the PR description.
This applies when the `onboardingRebaseCheckbox` config option is enabled.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->
It is not obvious that the box should be ticked.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
