### PR TITLE
docs: removing the redundant word

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -211,7 +211,7 @@ You must select at least one status check in the _Require status checks to pass 
 
 - `automerge=true`
 - `platformAutomerge=true`, Renovate defaults to `true`
-- You use use GitHub's _Require status checks to pass before merging_ branch protection rule
+- You use GitHub's _Require status checks to pass before merging_ branch protection rule
 
 If you don't select any status check, and you use platform automerge, then GitHub might automerge PRs with failing tests!
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the 'Allow edits and access to secrets by maintainers' checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Corrected a typographical error in the documentation. The phrase "you use use GitHub's **Require status checks to pass before merging** branch protection rule" has been changed to "you use GitHub's **Require status checks to pass before merging** branch protection rule" removing the redundant word "use."

## Context

This PR is related this following PR.
#25810

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
