### PR TITLE
fix(loose-versioning): support capital V in version

### DIFF
--- a/lib/modules/versioning/loose/index.spec.ts
+++ b/lib/modules/versioning/loose/index.spec.ts
@@ -13,6 +13,7 @@ describe('modules/versioning/loose/index', () => {
   it.each`
     version                                        | expected
     ${'v1.4'}                                      | ${true}
+    ${'V0.5'}                                      | ${true}
     ${'3.5.0'}                                     | ${true}
     ${'4.2.21.Final'}                              | ${true}
     ${'0.6.5.1'}                                   | ${true}

--- a/lib/modules/versioning/loose/index.ts
+++ b/lib/modules/versioning/loose/index.ts
@@ -7,7 +7,7 @@ export const displayName = 'Loose';
 export const urls = [];
 export const supportsRanges = false;
 
-const versionPattern = regEx(/^(v|V)?(\d+(?:\.\d+)*)(.*)$/);
+const versionPattern = regEx(/^[vV]?(\d+(?:\.\d+)*)(.*)$/);
 const commitHashPattern = regEx(/^[a-f0-9]{7,40}$/);
 const numericPattern = regEx(/^[0-9]+$/);
 

--- a/lib/modules/versioning/loose/index.ts
+++ b/lib/modules/versioning/loose/index.ts
@@ -7,7 +7,7 @@ export const displayName = 'Loose';
 export const urls = [];
 export const supportsRanges = false;
 
-const versionPattern = regEx(/^v?(\d+(?:\.\d+)*)(.*)$/);
+const versionPattern = regEx(/^(v|V)?(\d+(?:\.\d+)*)(.*)$/);
 const commitHashPattern = regEx(/^[a-f0-9]{7,40}$/);
 const numericPattern = regEx(/^[0-9]+$/);
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Extend loose versioning to packages that version beginning with `V` rather than `v`, for example: https://github.com/cmhughes/latexindent.pl.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

Following discussion in
- renovatebot/renovate#25894

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [X] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
