### PR TITLE
feat(config): add gitlabPlatformAutomergeStatusRetries option

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -1473,6 +1473,11 @@ Under the hood, it creates a MR-level approval rule where `approvals_required` i
 This option works only when `automerge=true`, `automergeType=pr` or `automergeType=branch`, and `platformAutomerge=true`.
 Also, approval rules overriding should not be [prevented in GitLab settings](https://docs.gitlab.com/ee/user/project/merge_requests/approvals/settings.html#prevent-editing-approval-rules-in-merge-requests).
 
+## gitlabPlatformAutomergeStatusRetries
+
+When using `platformAutomerge=true` in Gitlab, Renovate tries to merge a merge request immediately after creating it which will activate the `auto-merge` option of the merge request in Gitlab. The `auto-merge` option in Gitlab is only available when the merge request has a pipeline associated to it. By default Renovate checks 5 times if a pipeline exists while increasing the timeout between attempts. After running into the timeout Renovate tries to set `auto-merge` anyways. In some Gitlab installations the default timeout is too short to get a merge request pipeline up and running. In this case the merge from Renovat will result in a 405 'Method not allowed' error.
+By setting `gitlabPlatformAutomergeStatusRetries` to a number greater than 5 you can increase the timeout.
+
 ## goGetDirs
 
 By default, Renovate will run `go get -d -t ./...` to update the `go.sum`.

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -2507,6 +2507,12 @@ const options: RenovateOptions[] = [
     default: false,
   },
   {
+    name: 'gitlabPlatformAutomergeStatusRetries',
+    description: `Maximum number of retries when retrieving merge request pipeline status.`,
+    type: 'integer',
+    default: 5,
+  },
+  {
     name: 'customManagers',
     description: 'Custom managers using regex matching.',
     type: 'array',

--- a/lib/modules/platform/gitlab/index.ts
+++ b/lib/modules/platform/gitlab/index.ts
@@ -644,14 +644,14 @@ async function tryPrAutomerge(
       }
 
       const desiredStatus = 'can_be_merged';
-      const retryTimes = 5;
+      const retryTimes = platformOptions.gitlabPlatformAutomergeStatusRetries ?? 5;
 
       // Check for correct merge request status before setting `merge_when_pipeline_succeeds` to  `true`.
       for (let attempt = 1; attempt <= retryTimes; attempt += 1) {
         const { body } = await gitlabApi.getJson<{
           merge_status: string;
           pipeline: string;
-        }>(`projects/${config.repository}/merge_requests/${pr}`);
+        }>(`projects/${config.repository}/merge_requests/${pr}`, {memCache: false});
         // Only continue if the merge request can be merged and has a pipeline.
         if (body.merge_status === desiredStatus && body.pipeline !== null) {
           break;

--- a/lib/modules/platform/gitlab/index.ts
+++ b/lib/modules/platform/gitlab/index.ts
@@ -644,14 +644,17 @@ async function tryPrAutomerge(
       }
 
       const desiredStatus = 'can_be_merged';
-      const retryTimes = platformOptions.gitlabPlatformAutomergeStatusRetries ?? 5;
+      const retryTimes =
+        platformOptions.gitlabPlatformAutomergeStatusRetries ?? 5;
 
       // Check for correct merge request status before setting `merge_when_pipeline_succeeds` to  `true`.
       for (let attempt = 1; attempt <= retryTimes; attempt += 1) {
         const { body } = await gitlabApi.getJson<{
           merge_status: string;
           pipeline: string;
-        }>(`projects/${config.repository}/merge_requests/${pr}`, {memCache: false});
+        }>(`projects/${config.repository}/merge_requests/${pr}`, {
+          memCache: false,
+        });
         // Only continue if the merge request can be merged and has a pipeline.
         if (body.merge_status === desiredStatus && body.pipeline !== null) {
           break;

--- a/lib/modules/platform/types.ts
+++ b/lib/modules/platform/types.ts
@@ -101,6 +101,7 @@ export type PlatformPrOptions = {
   gitLabIgnoreApprovals?: boolean;
   usePlatformAutomerge?: boolean;
   forkModeDisallowMaintainerEdits?: boolean;
+  gitlabPlatformAutomergeStatusRetries?: number;
 };
 
 export interface CreatePRConfig {

--- a/lib/workers/repository/update/pr/index.ts
+++ b/lib/workers/repository/update/pr/index.ts
@@ -60,7 +60,8 @@ export function getPlatformPrOptions(
     gitLabIgnoreApprovals: !!config.gitLabIgnoreApprovals,
     forkModeDisallowMaintainerEdits: !!config.forkModeDisallowMaintainerEdits,
     usePlatformAutomerge,
-    gitlabPlatformAutomergeStatusRetries: config.gitlabPlatformAutomergeStatusRetries,
+    gitlabPlatformAutomergeStatusRetries:
+      config.gitlabPlatformAutomergeStatusRetries,
   };
 }
 

--- a/lib/workers/repository/update/pr/index.ts
+++ b/lib/workers/repository/update/pr/index.ts
@@ -60,6 +60,7 @@ export function getPlatformPrOptions(
     gitLabIgnoreApprovals: !!config.gitLabIgnoreApprovals,
     forkModeDisallowMaintainerEdits: !!config.forkModeDisallowMaintainerEdits,
     usePlatformAutomerge,
+    gitlabPlatformAutomergeStatusRetries: config.gitlabPlatformAutomergeStatusRetries,
   };
 }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This PR sets memCache: false option when requesting merge request status in Gitlab. Otherwise the condition can never be met because subsequent responses where delivered from memCache and the relevant values never change.

Second part is implementing an option to set the maximum number of retries for getting merge request status to ensure there is enough time to create a merge request pipeline. Otherwise in gitlab installations which needs more than 7.5 sec to create a pipeline platformAutomerge is never activated.

## Context

We use Renovate docker images in Gitlab CI/CD pipeline in one of the large mobility enterprises in Germany. We have a very huge Gitlab installation with a lot of workload during office times. Gitlab Runners are hosted on internal Kubernetes clusters or AWS EC2 instances. Most of the pipelines need more than the current timeout to be created when creating a MR. Therefore we need some configuration options to increase the timeout.

Closes #25945
Closes #25946 

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
