### PR TITLE
feat(gitlab): increase merge request status check timeout to 300 sec

### DIFF
--- a/lib/modules/platform/gitlab/index.ts
+++ b/lib/modules/platform/gitlab/index.ts
@@ -644,7 +644,7 @@ async function tryPrAutomerge(
       }
 
       const desiredStatus = 'can_be_merged';
-      const retryTimes = 5;
+      const retryTimes = 35; // results in max. 5 min. timeout if no pipeline created
 
       // Check for correct merge request status before setting `merge_when_pipeline_succeeds` to  `true`.
       for (let attempt = 1; attempt <= retryTimes; attempt += 1) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Increase retry times to 35 when requesting merge request status from gitlab when platform automerge is enabled.

## Context

In some self-hosted Gitlab installation with self-hosted Gitlab Runners and a lot of workload most of the times pipelines need more than the very short timeout set before (7.5 sec) to be created when creating a MR. This results in 405 Method not allowed failure responses when trying to set a merge request to auto-merge. Increasing the timeout to a large enough number solves this issue. See discussion in this issue:

Closes #25946 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
