### PR TITLE
fix: swap pending and approval order in dashboard display

### DIFF
--- a/lib/workers/repository/update/branch/index.ts
+++ b/lib/workers/repository/update/branch/index.ts
@@ -171,6 +171,17 @@ export async function processBranch(
         result: 'already-existed',
       };
     }
+    if (
+      !branchExists &&
+      branchConfig.pendingChecks &&
+      !dependencyDashboardCheck
+    ) {
+      return {
+        branchExists: false,
+        prNo: branchPr?.number,
+        result: 'pending',
+      };
+    }
     // istanbul ignore if
     if (!branchExists && config.dependencyDashboardApproval) {
       if (dependencyDashboardCheck) {
@@ -207,17 +218,6 @@ export async function processBranch(
         branchExists,
         prNo: branchPr?.number,
         result: 'commit-limit-reached',
-      };
-    }
-    if (
-      !branchExists &&
-      branchConfig.pendingChecks &&
-      !dependencyDashboardCheck
-    ) {
-      return {
-        branchExists: false,
-        prNo: branchPr?.number,
-        result: 'pending',
       };
     }
     if (branchExists) {


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Move pending status checks earlier so that the dashboard category makes more sense

## Context

Closes #25664

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
