### PR TITLE
feat(dart): allow custom registryUrls

### DIFF
--- a/lib/modules/datasource/dart/__snapshots__/index.spec.ts.snap
+++ b/lib/modules/datasource/dart/__snapshots__/index.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`modules/datasource/dart/index getReleases processes real data 1`] = `
 {
   "homepage": "https://github.com/flutter/plugins/tree/master/packages/shared_preferences/shared_preferences",
-  "registryUrl": "https://pub.dartlang.org/",
+  "registryUrl": "https://pub.dartlang.org",
   "releases": [
     {
       "releaseTimestamp": "2017-05-09T18:25:24.268Z",

--- a/lib/modules/datasource/dart/index.ts
+++ b/lib/modules/datasource/dart/index.ts
@@ -1,4 +1,5 @@
 import type { HttpResponse } from '../../../util/http/types';
+import { ensureTrailingSlash } from '../../../util/url';
 import { Datasource } from '../datasource';
 import type { GetReleasesConfig, ReleaseResult } from '../types';
 import type { DartResult } from './types';
@@ -23,7 +24,9 @@ export class DartDatasource extends Datasource {
       return null;
     }
     let result: ReleaseResult | null = null;
-    const pkgUrl = `${registryUrl}api/packages/${packageName}`;
+    const pkgUrl = `${ensureTrailingSlash(
+      registryUrl,
+    )}api/packages/${packageName}`;
 
     let raw: HttpResponse<DartResult> | null = null;
     try {

--- a/lib/modules/datasource/dart/index.ts
+++ b/lib/modules/datasource/dart/index.ts
@@ -10,7 +10,7 @@ export class DartDatasource extends Datasource {
     super(DartDatasource.id);
   }
 
-  override readonly customRegistrySupport = false;
+  override readonly customRegistrySupport = true;
 
   override readonly defaultRegistryUrls = ['https://pub.dartlang.org/'];
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Allow custom registryUrls for dart datasource

## Context

#25984

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
