### PR TITLE
feat(poetry): add POETRY_PYPI_TOKEN possibility as poetry credential

### DIFF
--- a/docs/usage/getting-started/private-packages.md
+++ b/docs/usage/getting-started/private-packages.md
@@ -457,7 +457,7 @@ name = "pypi"
 
 ### poetry
 
-For every Poetry source, a `hostRules` search is done and then any found credentials are added to env like `POETRY_HTTP_BASIC_X_USERNAME` and `POETRY_HTTP_BASIC_X_PASSWORD`, where `X` represents the normalized name of the source in `pyproject.toml`.
+For every Poetry source, a `hostRules` search is done and then any found credentials are added to env like `POETRY_HTTP_BASIC_X_USERNAME` and `POETRY_HTTP_BASIC_X_PASSWORD`, or `POETRY_PYPI_TOKEN_X`, where `X` represents the normalized name of the source in `pyproject.toml`.
 
 ```js
 module.exports = {
@@ -467,6 +467,13 @@ module.exports = {
       hostType: 'pypi',
       username: process.env.PYPI_USERNAME,
       password: process.env.PYPI_PASSWORD,
+    },
+  ],
+  hostRules: [
+    {
+      matchHost: 'pypi-token.example.com',
+      hostType: 'pypi',
+      token: process.env.PYPI_TOKEN,
     },
   ],
 };

--- a/lib/modules/manager/poetry/artifacts.spec.ts
+++ b/lib/modules/manager/poetry/artifacts.spec.ts
@@ -181,6 +181,7 @@ describe('modules/manager/poetry/artifacts', () => {
       hostRules.find.mockReturnValueOnce({ username: 'usernameTwo' });
       hostRules.find.mockReturnValueOnce({});
       hostRules.find.mockReturnValueOnce({ password: 'passwordFour' });
+      hostRules.find.mockReturnValueOnce({ token: 'tokenOne' });
       const updatedDeps = [{ depName: 'dep1' }];
       expect(
         await updateArtifacts({

--- a/lib/modules/manager/poetry/artifacts.ts
+++ b/lib/modules/manager/poetry/artifacts.ts
@@ -133,6 +133,10 @@ function getSourceCredentialVars(
       envVars[`POETRY_HTTP_BASIC_${formattedSourceName}_PASSWORD`] =
         matchingHostRule.password;
     }
+    if (matchingHostRule.token) {
+      envVars[`POETRY_PYPI_TOKEN_${formattedSourceName}`] =
+        matchingHostRule.token;
+    }
   }
   return envVars;
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
Adding a new env var to use a token as poetry credential for a private repo

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->
Today, with poetry, we can use username/password possibility to set a credential for a private repository on Renovate (cf [doc](https://docs.renovatebot.com/getting-started/private-packages/#poetry)). Poetry also allow you to use a token, like explain in the [documentation](https://python-poetry.org/docs/repositories/#configuring-credentials:~:text=Alternatively%2C%20you%20can%20use%20environment%20variables%20to%20provide%20the%20credentials%3A). It could be interesting to support both solutions and not only username/password one.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
