### PR TITLE
feat(datasource/custom): expose newDigest in result

### DIFF
--- a/lib/modules/datasource/custom/index.spec.ts
+++ b/lib/modules/datasource/custom/index.spec.ts
@@ -94,7 +94,7 @@ describe('modules/datasource/custom/index', () => {
         releases: [
           {
             version: 'v1.0.0',
-            newDigest: '0123456789abcdef'
+            newDigest: '0123456789abcdef',
           },
         ],
       };
@@ -102,7 +102,7 @@ describe('modules/datasource/custom/index', () => {
         releases: [
           {
             version: 'v1.0.0',
-            digest: '0123456789abcdef'
+            digest: '0123456789abcdef',
           },
         ],
       };

--- a/lib/modules/datasource/custom/index.spec.ts
+++ b/lib/modules/datasource/custom/index.spec.ts
@@ -89,6 +89,36 @@ describe('modules/datasource/custom/index', () => {
       expect(result).toEqual(expected);
     });
 
+    it('return releases with digests for api directly exposing in renovate format', async () => {
+      const expected = {
+        releases: [
+          {
+            version: 'v1.0.0',
+            newDigest: '0123456789abcdef'
+          },
+        ],
+      };
+      const content = {
+        releases: [
+          {
+            version: 'v1.0.0',
+            digest: '0123456789abcdef'
+          },
+        ],
+      };
+      httpMock.scope('https://example.com').get('/v1').reply(200, content);
+      const result = await getPkgReleases({
+        datasource: `${CustomDatasource.id}.foo`,
+        packageName: 'myPackage',
+        customDatasources: {
+          foo: {
+            defaultRegistryUrlTemplate: 'https://example.com/v1',
+          },
+        },
+      });
+      expect(result).toEqual(expected);
+    });
+
     it('return releases for plain text API directly exposing in Renovate format', async () => {
       const expected = {
         releases: [

--- a/lib/modules/datasource/custom/readme.md
+++ b/lib/modules/datasource/custom/readme.md
@@ -68,7 +68,8 @@ All available options:
       "releaseTimestamp": "2022-12-24T18:21Z",
       "changelogUrl": "https://github.com/demo-org/demo/blob/main/CHANGELOG.md#v0710",
       "sourceUrl": "https://github.com/demo-org/demo",
-      "sourceDirectory": "monorepo/folder"
+      "sourceDirectory": "monorepo/folder",
+      "digest": "c667f758f9e46e1d8111698e8d3a181c0b10f430"
     }
   ],
   "sourceUrl": "https://github.com/demo-org/demo",

--- a/lib/modules/datasource/custom/schema.ts
+++ b/lib/modules/datasource/custom/schema.ts
@@ -2,21 +2,23 @@ import { z } from 'zod';
 
 export const ReleaseResultZodSchema = z.object({
   releases: z.array(
-    z.object({
-      version: z.string(),
-      isDeprecated: z.boolean().optional(),
-      releaseTimestamp: z.string().optional(),
-      sourceUrl: z.string().optional(),
-      sourceDirectory: z.string().optional(),
-      changelogUrl: z.string().optional(),
-      digest: z.string().optional(),
-    }).transform((input) => {
-      return {
-        ...input,
-        newDigest: input.digest,
-        digest: undefined
-      }
-    }),
+    z
+      .object({
+        version: z.string(),
+        isDeprecated: z.boolean().optional(),
+        releaseTimestamp: z.string().optional(),
+        sourceUrl: z.string().optional(),
+        sourceDirectory: z.string().optional(),
+        changelogUrl: z.string().optional(),
+        digest: z.string().optional(),
+      })
+      .transform((input) => {
+        return {
+          ...input,
+          newDigest: input.digest,
+          digest: undefined,
+        };
+      }),
   ),
   sourceUrl: z.string().optional(),
   sourceDirectory: z.string().optional(),

--- a/lib/modules/datasource/custom/schema.ts
+++ b/lib/modules/datasource/custom/schema.ts
@@ -9,6 +9,13 @@ export const ReleaseResultZodSchema = z.object({
       sourceUrl: z.string().optional(),
       sourceDirectory: z.string().optional(),
       changelogUrl: z.string().optional(),
+      digest: z.string().optional(),
+    }).transform((input) => {
+      return {
+        ...input,
+        newDigest: input.digest,
+        digest: undefined
+      }
     }),
   ),
   sourceUrl: z.string().optional(),


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Allow the user to provide `newDigest` from custom datasource.

## Context

Closes #25197

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
