### PR TITLE
feat(gitlab): allow override mergeable check attemps and use exponential backoff

### DIFF
--- a/docs/usage/self-hosted-experimental.md
+++ b/docs/usage/self-hosted-experimental.md
@@ -40,6 +40,21 @@ If set to any string, Renovate will use this as the `user-agent` it sends with H
 If set to an integer, Renovate will use this as max page number for docker tags lookup on docker registries, instead of the default 20 pages.
 This is useful for registries which ignores the `n` parameter in the query string and only return 50 tags per page.
 
+## `RENOVATE_X_GITLAB_AUTO_MERGEABLE_CHECK_ATTEMPS`
+
+If set to an positive integer, Renovate will use this as the number of attempts to check if a merge request on GitLab is mergable before trying to automerge.
+The formula for the delay between attempts is `250 * attempt * attempt` milliseconds.
+
+Default value: `5` (attempts results in max. 13.75 seconds timeout).
+
+## `RENOVATE_X_GITLAB_BRANCH_STATUS_DELAY`
+
+Adjust default time (in milliseconds) given to GitLab to create pipelines for a commit pushed by Renovate.
+
+Can be useful for slow-running, self-hosted GitLab instances that don't react fast enough for the default delay to help.
+
+Default value: `1000` (milliseconds).
+
 ## `RENOVATE_X_HARD_EXIT`
 
 If set to any value, Renovate will use a "hard" `process.exit()` once all work is done, even if a sub-process is otherwise delaying Node.js from exiting.
@@ -128,14 +143,6 @@ If set, Renovate will rewrite GitHub Enterprise Server's pagination responses to
 <!-- prettier-ignore -->
 !!! note
     For the GitHub Enterprise Server platform only.
-
-## `RENOVATE_X_GITLAB_BRANCH_STATUS_DELAY`
-
-Adjust default time (in milliseconds) given to GitLab to create pipelines for a commit pushed by Renovate.
-
-Can be useful for slow-running, self-hosted GitLab instances that don't react fast enough for the default delay to help.
-
-Default value: `1000` (milliseconds).
 
 ## `OTEL_EXPORTER_OTLP_ENDPOINT`
 

--- a/lib/modules/platform/gitlab/index.ts
+++ b/lib/modules/platform/gitlab/index.ts
@@ -23,6 +23,7 @@ import * as git from '../../../util/git';
 import * as hostRules from '../../../util/host-rules';
 import { setBaseUrl } from '../../../util/http/gitlab';
 import type { HttpResponse } from '../../../util/http/types';
+import { parseInteger } from '../../../util/number';
 import * as p from '../../../util/promises';
 import { regEx } from '../../../util/regex';
 import { sanitize } from '../../../util/sanitize';
@@ -644,7 +645,11 @@ async function tryPrAutomerge(
       }
 
       const desiredStatus = 'can_be_merged';
-      const retryTimes = 8; // results in max. 5 min. timeout if no pipeline created
+      // The default value of 5 attempts results in max. 13.75 seconds timeout if no pipeline created.
+      const retryTimes = parseInteger(
+        process.env.RENOVATE_X_GITLAB_AUTO_MERGEABLE_CHECK_ATTEMPS,
+        5,
+      );
 
       // Check for correct merge request status before setting `merge_when_pipeline_succeeds` to  `true`.
       for (let attempt = 1; attempt <= retryTimes; attempt += 1) {
@@ -658,7 +663,7 @@ async function tryPrAutomerge(
         if (body.merge_status === desiredStatus && body.pipeline !== null) {
           break;
         }
-        await setTimeout(500 * attempt);
+        await setTimeout(250 * attempt ** 2); // exponential backoff
       }
 
       await gitlabApi.putJson(
@@ -938,9 +943,7 @@ export async function setBranchStatus({
   try {
     // give gitlab some time to create pipelines for the sha
     await setTimeout(
-      process.env.RENOVATE_X_GITLAB_BRANCH_STATUS_DELAY
-        ? parseInt(process.env.RENOVATE_X_GITLAB_BRANCH_STATUS_DELAY, 10)
-        : 1000,
+      parseInteger(process.env.RENOVATE_X_GITLAB_BRANCH_STATUS_DELAY, 1000),
     );
 
     await gitlabApi.postJson(url, { body: options });

--- a/lib/util/number.spec.ts
+++ b/lib/util/number.spec.ts
@@ -1,4 +1,4 @@
-import { coerceNumber } from './number';
+import { coerceNumber, parseInteger } from './number';
 
 describe('util/number', () => {
   it.each`
@@ -8,5 +8,19 @@ describe('util/number', () => {
     ${undefined} | ${undefined} | ${0}
   `('coerceNumber($val, $def) = $expected', ({ val, def, expected }) => {
     expect(coerceNumber(val, def)).toBe(expected);
+  });
+
+  it.each`
+    val          | def          | expected
+    ${1}         | ${2}         | ${2}
+    ${undefined} | ${2}         | ${2}
+    ${undefined} | ${undefined} | ${0}
+    ${''}        | ${undefined} | ${0}
+    ${'-1'}      | ${undefined} | ${0}
+    ${'1.1'}     | ${undefined} | ${0}
+    ${'a'}       | ${undefined} | ${0}
+    ${'5'}       | ${undefined} | ${5}
+  `('parseInteger($val, $def) = $expected', ({ val, def, expected }) => {
+    expect(parseInteger(val, def)).toBe(expected);
   });
 });

--- a/lib/util/number.ts
+++ b/lib/util/number.ts
@@ -1,3 +1,5 @@
+import is from '@sindresorhus/is';
+
 /**
  * Coerces a value to a number with optional default value.
  * @param val the value to coerce
@@ -9,4 +11,21 @@ export function coerceNumber(
   def?: number,
 ): number {
   return val ?? def ?? 0;
+}
+
+/**
+ * Parses a value as a finite positive integer with optional default value.
+ * If no default value is provided, the default value is 0.
+ * @param val Value to parse as finite integer.
+ * @param def Optional default value.
+ * @returns The parsed value or the default value if the parsed value is not finite.
+ */
+export function parseInteger(
+  val: string | undefined | null,
+  def?: number,
+): number {
+  // Number.parseInt returns NaN if the value is not a finite integer.
+  const parsed =
+    is.string(val) && /^\d+$/.test(val) ? Number.parseInt(val, 10) : Number.NaN;
+  return Number.isFinite(parsed) ? parsed : def ?? 0;
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

- Allow overriding the merge check attempts via experimental env.
- Use exponential backoff time to delay api calls:

  Old delays where: `500, 1000, 1500, 2000, 2500, ...`.
  New delays are: `250, 1000, 2250, 4000, 6250, ...`.

  So the default max timeout is now 13750 ms instead of 7500 ms.

## Context
- #25953
- #25994
- @fullstackcreatives
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
