### PR TITLE
docs(templates): `replace` helper uses its argument as a regex

### DIFF
--- a/docs/usage/templates.md
+++ b/docs/usage/templates.md
@@ -61,12 +61,12 @@ Read the [MDN Web Docs, decodeURIComponent()](https://developer.mozilla.org/en-U
 
 ### replace
 
-The `replace` helper replaces _all_ found strings with the replacement string.
+The `replace` helper replaces _all_ found strings matching the given regex with the replacement string.
 If you want to replace some characters in a string, use the built-in function `replace` like this:
 
-`{{{replace 'github.com' 'ghc' depName}}}`
+`{{{replace '[a-z]+\.github\.com' 'ghc' depName}}}`
 
-In the example above all matches of `github.com` will be replaced by `ghc` in `depName`.
+In the example above all matches of the regex `[a-z]+\.github\.com` will be replaced by `ghc` in `depName`.
 
 Read the [MDN Web Docs, String.prototype.replace()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace) to learn more.
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
This PR changes the documentation about the `replace` template helper. This helper always uses the given string as a regex, this was not specified.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

The helper definition is [here](https://github.com/renovatebot/renovate/blob/main/lib/util/template/index.ts#L18C31-L18C31).

As the current doc only refers to the javascript `replace` function documentation, I had a hard time trying to give it a regex like this: `{{{replace /something\\/.*\\// myParam}}}`, while I just needed to give it a string `'something/.*/'`.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
