### PR TITLE
feat(workers/pr): add source with folder to `depNameLinked`

### DIFF
--- a/lib/workers/repository/update/pr/body/index.spec.ts
+++ b/lib/workers/repository/update/pr/body/index.spec.ts
@@ -75,10 +75,17 @@ describe('workers/repository/update/pr/body/index', () => {
         manager: 'some-manager',
         branchName: 'some-branch',
         dependencyUrl: 'https://github.com/foo/bar',
-        sourceUrl: 'https://github.com/foo/bar.git',
+        sourceUrl: 'https://github.com/foo/bar',
         sourceDirectory: '/baz',
         changelogUrl:
           'https://raw.githubusercontent.com/foo/bar/tree/main/CHANGELOG.md',
+        homepage: 'https://example.com',
+      };
+
+      const upgrade1 = {
+        manager: 'some-manager',
+        branchName: 'some-branch',
+        sourceUrl: 'https://github.com/foo/bar',
         homepage: 'https://example.com',
       };
 
@@ -87,7 +94,7 @@ describe('workers/repository/update/pr/body/index', () => {
           manager: 'some-manager',
           baseBranch: 'base',
           branchName: 'some-branch',
-          upgrades: [upgrade],
+          upgrades: [upgrade, upgrade1],
         },
         {
           debugData: {
@@ -104,13 +111,22 @@ describe('workers/repository/update/pr/body/index', () => {
         changelogUrl:
           'https://raw.githubusercontent.com/foo/bar/tree/main/CHANGELOG.md',
         depNameLinked:
-          '[undefined](https://example.com) ([source](https://github.com/foo/bar.git), [changelog](https://raw.githubusercontent.com/foo/bar/tree/main/CHANGELOG.md))',
+          '[undefined](https://example.com) ([source](https://github.com/foo/bar/tree/HEAD/baz), [changelog](https://raw.githubusercontent.com/foo/bar/tree/main/CHANGELOG.md))',
         dependencyUrl: 'https://github.com/foo/bar',
         homepage: 'https://example.com',
         references:
-          '[homepage](https://example.com), [source](https://github.com/foo/bar.git/tree/HEAD/baz), [changelog](https://raw.githubusercontent.com/foo/bar/tree/main/CHANGELOG.md)',
+          '[homepage](https://example.com), [source](https://github.com/foo/bar/tree/HEAD/baz), [changelog](https://raw.githubusercontent.com/foo/bar/tree/main/CHANGELOG.md)',
         sourceDirectory: '/baz',
-        sourceUrl: 'https://github.com/foo/bar.git',
+        sourceUrl: 'https://github.com/foo/bar',
+      });
+      expect(upgrade1).toMatchObject({
+        branchName: 'some-branch',
+        depNameLinked:
+          '[undefined](https://example.com) ([source](https://github.com/foo/bar))',
+        references:
+          '[homepage](https://example.com), [source](https://github.com/foo/bar)',
+        homepage: 'https://example.com',
+        sourceUrl: 'https://github.com/foo/bar',
       });
     });
 

--- a/lib/workers/repository/update/pr/body/index.ts
+++ b/lib/workers/repository/update/pr/body/index.ts
@@ -29,9 +29,16 @@ function massageUpdateMetadata(config: BranchConfig): void {
     if (primaryLink) {
       depNameLinked = `[${depNameLinked}](${primaryLink})`;
     }
+
     const otherLinks = [];
-    if (homepage && sourceUrl) {
-      otherLinks.push(`[source](${sourceUrl})`);
+    if (sourceUrl && (!!sourceDirectory || homepage)) {
+      otherLinks.push(
+        `[source](${
+          sourceDirectory
+            ? joinUrlParts(sourceUrl, 'tree/HEAD/', sourceDirectory)
+            : sourceUrl
+        })`,
+      );
     }
     if (changelogUrl) {
       otherLinks.push(`[changelog](${changelogUrl})`);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Add a source link to the `depNameLinked` column when there is no `homepage` but a `sourceUrl` and a `sourceDirectory`.
This is useful for helm charts, as they often have no `homepage` but a `sourceDirectory` when they come from oci datasource.
<!-- Describe what behavior is changed by this PR. -->

## Context
- https://github.com/renovate-reproductions/source-directory/pull/2
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
