### PR TITLE
feat(config): custom status checks

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -3566,11 +3566,11 @@ If this setting is true then you would get one PR for webpack@v2 and one for web
 
 ## statusCheckNames
 
-This feature allows users to customize the context of the staus checks added by Renovate to the update branches.
+You can customize the context of the status check that Renovate adds to its update branches.
 
-1. You can modify existing status checks, but adding entirely new ones is not supported
-2. Setting the value to `null` or an empty string, will effectively disable/skip that particular status check
-3. This option is mergeable, meaning you only have to specify the status checks you want to modify
+- You can modify existing status checks, but adding new status checks is _not_ supported
+- Setting the value to `null` or an empty string, effectively disables or skips that status check
+- This option is mergeable, which means you only have to specify the status checks that you want to modify
 
 ```json
 {

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -3564,21 +3564,6 @@ Configure this to `true` if you wish to get one PR for every separate major vers
 e.g. if you are on webpack@v1 currently then default behavior is a PR for upgrading to webpack@v3 and not for webpack@v2.
 If this setting is true then you would get one PR for webpack@v2 and one for webpack@v3.
 
-## stopUpdatingLabel
-
-This feature only works on supported platforms, check the table above.
-
-If you want Renovate to stop updating a PR, you can apply a label to the PR.
-By default, Renovate listens to the label: `"stop-updating"`.
-
-You can set your own label name with the `"stopUpdatingLabel"` field:
-
-```json
-{
-  "stopUpdatingLabel": "take-a-break-renovate"
-}
-```
-
 ## statusCheckNames
 
 This feature allows users to customize the context of the staus checks added by Renovate to the update branches.
@@ -3593,6 +3578,21 @@ This feature allows users to customize the context of the staus checks added by 
     "minimumReleaseAge": "custom/stability-days",
     "mergeConfidence": "custom/merge-confidence-level"
   }
+}
+```
+
+## stopUpdatingLabel
+
+This feature only works on supported platforms, check the table above.
+
+If you want Renovate to stop updating a PR, you can apply a label to the PR.
+By default, Renovate listens to the label: `"stop-updating"`.
+
+You can set your own label name with the `"stopUpdatingLabel"` field:
+
+```json
+{
+  "stopUpdatingLabel": "take-a-break-renovate"
 }
 ```
 

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -3566,9 +3566,9 @@ If this setting is true then you would get one PR for webpack@v2 and one for web
 
 ## statusCheckNames
 
-You can customize the context of the status check that Renovate adds to its update branches.
+You can customize the name/context of status checks that Renovate adds to commits/branches/PRs.
 
-You can modify existing status checks, but adding new status checks is _not_ supported.
+This option enables you to modify any existing status checks name/context, but adding new status checks this way is _not_ supported.
 Setting the value to `null` or an empty string, effectively disables or skips that status check.
 This option is mergeable, which means you only have to specify the status checks that you want to modify.
 

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -3572,7 +3572,7 @@ You can customize the context of the status check that Renovate adds to its upda
 - Setting the value to `null` or an empty string, effectively disables or skips that status check
 - This option is mergeable, which means you only have to specify the status checks that you want to modify
 
-```json
+```json title="Example of overriding status check strings"
 {
   "statusCheckNames": {
     "minimumReleaseAge": "custom/stability-days",

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -3590,8 +3590,8 @@ This feature allows users to customize the context of the staus checks added by 
 ```json
 {
   "statusCheckNames": {
-    "minimumReleaseAge": "custom/stability-days", // default value
-    "mergeConfidence": "custom/merge-confidence-level" // custom string
+    "minimumReleaseAge": "custom/stability-days",
+    "mergeConfidence": "custom/merge-confidence-level"
   }
 }
 ```

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -3568,9 +3568,9 @@ If this setting is true then you would get one PR for webpack@v2 and one for web
 
 You can customize the context of the status check that Renovate adds to its update branches.
 
-- You can modify existing status checks, but adding new status checks is _not_ supported
-- Setting the value to `null` or an empty string, effectively disables or skips that status check
-- This option is mergeable, which means you only have to specify the status checks that you want to modify
+You can modify existing status checks, but adding new status checks is _not_ supported.
+Setting the value to `null` or an empty string, effectively disables or skips that status check.
+This option is mergeable, which means you only have to specify the status checks that you want to modify.
 
 ```json title="Example of overriding status check strings"
 {

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -3579,6 +3579,23 @@ You can set your own label name with the `"stopUpdatingLabel"` field:
 }
 ```
 
+## statusCheckNames
+
+This feature allows users to customize the context of the staus checks added by Renovate to the update branches.
+
+1. You can modify existing status checks, but adding entirely new ones is not supported
+2. Setting the value to `null` or an empty string, will effectively disable/skip that particular status check
+3. This option is mergeable, meaning you only have to specify the status checks you want to modify
+
+```json
+{
+  "statusCheckNames": {
+    "minimumReleaseAge": "custom/stability-days", // default value
+    "mergeConfidence": "custom/merge-confidence-level" // custom string
+  }
+}
+```
+
 ## suppressNotifications
 
 Use this field to suppress various types of warnings and other notifications from Renovate.

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -171,6 +171,20 @@ const options: RenovateOptions[] = [
     },
   },
   {
+    name: 'statusCheckNames',
+    description: 'Custom strings to use as status check names',
+    type: 'object',
+    default: {
+      minimumReleaseAge: 'renovate/stability-days',
+      mergeConfidence: 'renovate/merge-confidence',
+      configValidation: 'renovate/config-validation',
+    },
+    additionalProperties: {
+      type: 'string',
+      format: 'string',
+    },
+  },
+  {
     name: 'extends',
     description: 'Configuration presets to use or extend.',
     stage: 'package',

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -172,7 +172,7 @@ const options: RenovateOptions[] = [
   },
   {
     name: 'statusCheckNames',
-    description: 'Custom strings to use as status check names',
+    description: 'Custom strings to use as status check names.',
     type: 'object',
     mergeable: true,
     default: {

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -177,10 +177,10 @@ const options: RenovateOptions[] = [
     mergeable: true,
     advancedUse: true,
     default: {
-      minimumReleaseAge: 'renovate/stability-days',
-      mergeConfidence: 'renovate/merge-confidence',
-      configValidation: 'renovate/config-validation',
       artifactError: 'renovate/artifacts',
+      configValidation: 'renovate/config-validation',
+      mergeConfidence: 'renovate/merge-confidence',
+      minimumReleaseAge: 'renovate/stability-days',
     },
   },
   {

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -175,6 +175,7 @@ const options: RenovateOptions[] = [
     description: 'Custom strings to use as status check names.',
     type: 'object',
     mergeable: true,
+    advancedUse: true,
     default: {
       minimumReleaseAge: 'renovate/stability-days',
       mergeConfidence: 'renovate/merge-confidence',

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -174,14 +174,12 @@ const options: RenovateOptions[] = [
     name: 'statusCheckNames',
     description: 'Custom strings to use as status check names',
     type: 'object',
+    mergeable: true,
     default: {
       minimumReleaseAge: 'renovate/stability-days',
       mergeConfidence: 'renovate/merge-confidence',
       configValidation: 'renovate/config-validation',
-    },
-    additionalProperties: {
-      type: 'string',
-      format: 'string',
+      artifactError: 'renovate/artifacts',
     },
   },
   {

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -260,6 +260,8 @@ export interface RenovateConfig
 
   checkedBranches?: string[];
   customizeDashboard?: Record<string, string>;
+
+  statusCheckNames?: Record<string, string>;
 }
 
 export interface CustomDatasourceConfig {

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -267,7 +267,7 @@ export interface RenovateConfig
   checkedBranches?: string[];
   customizeDashboard?: Record<string, string>;
 
-  statusCheckNames?: Partial<Record<StatusCheckKey, string>>;
+  statusCheckNames?: Partial<Record<StatusCheckKey, string | null>>;
 }
 
 export interface CustomDatasourceConfig {

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -189,6 +189,12 @@ export type RenovateRepository =
 export type UseBaseBranchConfigType = 'merge' | 'none';
 export type ConstraintsFilter = 'strict' | 'none';
 
+export type StatusCheckKey =
+  | 'minimumReleaseAge'
+  | 'mergeConfidence'
+  | 'configValidation'
+  | 'artifactError';
+
 // TODO: Proper typings
 export interface RenovateConfig
   extends LegacyAdminConfig,
@@ -261,7 +267,7 @@ export interface RenovateConfig
   checkedBranches?: string[];
   customizeDashboard?: Record<string, string>;
 
-  statusCheckNames?: Record<string, string>;
+  statusCheckNames?: Partial<Record<StatusCheckKey, string>>;
 }
 
 export interface CustomDatasourceConfig {

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -189,11 +189,13 @@ export type RenovateRepository =
 export type UseBaseBranchConfigType = 'merge' | 'none';
 export type ConstraintsFilter = 'strict' | 'none';
 
-export type StatusCheckKey =
-  | 'minimumReleaseAge'
-  | 'mergeConfidence'
-  | 'configValidation'
-  | 'artifactError';
+export const allowedStatusCheckStrings = [
+  'minimumReleaseAge',
+  'mergeConfidence',
+  'configValidation',
+  'artifactError',
+] as const;
+export type StatusCheckKey = (typeof allowedStatusCheckStrings)[number];
 
 // TODO: Proper typings
 export interface RenovateConfig
@@ -267,7 +269,7 @@ export interface RenovateConfig
   checkedBranches?: string[];
   customizeDashboard?: Record<string, string>;
 
-  statusCheckNames?: Partial<Record<StatusCheckKey, string | null>>;
+  statusCheckNames?: Record<StatusCheckKey, string | null>;
 }
 
 export interface CustomDatasourceConfig {

--- a/lib/config/validation.spec.ts
+++ b/lib/config/validation.spec.ts
@@ -152,7 +152,8 @@ describe('config/validation', () => {
           configValidation: '',
           artifactError: null,
         },
-      } as any;
+      };
+      // @ts-expect-error invalid options
       const { errors } = await configValidation.validateConfig(config);
       expect(errors).toMatchObject([
         {

--- a/lib/config/validation.spec.ts
+++ b/lib/config/validation.spec.ts
@@ -157,13 +157,14 @@ describe('config/validation', () => {
       expect(errors).toMatchObject([
         {
           message:
-            'Invalid `statusCheckNames.mergeConfidence` configuration: status check is not a string',
+            'Invalid `statusCheckNames.mergeConfidence` configuration: status check is not a string.',
         },
         {
           message:
-            'Invalid `statusCheckNames.statusCheckNames.randomKey` configuration: key is not allowed',
+            'Invalid `statusCheckNames.statusCheckNames.randomKey` configuration: key is not allowed.',
         },
       ]);
+      expect(errors).toHaveLength(2);
     });
 
     it('catches invalid customDatasources record type', async () => {

--- a/lib/config/validation.spec.ts
+++ b/lib/config/validation.spec.ts
@@ -144,6 +144,28 @@ describe('config/validation', () => {
       ]);
     });
 
+    it('validates invalid statusCheckNames', async () => {
+      const config = {
+        statusCheckNames: {
+          randomKey: '',
+          mergeConfidence: 10,
+          configValidation: '',
+          artifactError: null,
+        },
+      } as any;
+      const { errors } = await configValidation.validateConfig(config);
+      expect(errors).toMatchObject([
+        {
+          message:
+            'Invalid `statusCheckNames.mergeConfidence` configuration: status check is not a string',
+        },
+        {
+          message:
+            'Invalid `statusCheckNames.statusCheckNames.randomKey` configuration: key is not allowed',
+        },
+      ]);
+    });
+
     it('catches invalid customDatasources record type', async () => {
       const config = {
         customDatasources: {

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -562,6 +562,32 @@ export async function validateConfig(
                   message: `Invalid \`${currentPath}.${key}.${res}\` configuration: value is not a string`,
                 });
               }
+            } else if (key === 'statusCheckNames') {
+              const allowedStatusStrings = [
+                'minimumReleaseAge',
+                'artifactError',
+                'mergeConfidence',
+                'configValidation',
+              ];
+              for (const [statusCheckKey, statusCheckValue] of Object.entries(
+                val,
+              )) {
+                if (!allowedStatusStrings.includes(statusCheckKey)) {
+                  errors.push({
+                    topic: 'Configuration Error',
+                    message: `Invalid \`${currentPath}.${key}.${statusCheckKey}\` configuration: key is not allowed`,
+                  });
+                }
+                if (
+                  !(is.string(statusCheckValue) || is.null_(statusCheckValue))
+                ) {
+                  errors.push({
+                    topic: 'Configuration Error',
+                    message: `Invalid \`${currentPath}.${statusCheckKey}\` configuration: status check is not a string`,
+                  });
+                  continue;
+                }
+              }
             } else if (key === 'customDatasources') {
               const allowedKeys = [
                 'description',

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -18,6 +18,7 @@ import { resolveConfigPresets } from './presets';
 import type {
   RenovateConfig,
   RenovateOptions,
+  StatusCheckKey,
   ValidationMessage,
   ValidationResult,
 } from './types';
@@ -563,16 +564,20 @@ export async function validateConfig(
                 });
               }
             } else if (key === 'statusCheckNames') {
-              const allowedStatusStrings = [
+              const allowedStatusStrings: StatusCheckKey[] = [
                 'minimumReleaseAge',
-                'artifactError',
                 'mergeConfidence',
                 'configValidation',
+                'artifactError',
               ];
               for (const [statusCheckKey, statusCheckValue] of Object.entries(
                 val,
               )) {
-                if (!allowedStatusStrings.includes(statusCheckKey)) {
+                if (
+                  !allowedStatusStrings.includes(
+                    statusCheckKey as StatusCheckKey,
+                  )
+                ) {
                   errors.push({
                     topic: 'Configuration Error',
                     message: `Invalid \`${currentPath}.${key}.${statusCheckKey}\` configuration: key is not allowed`,

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -15,12 +15,13 @@ import {
 import { migrateConfig } from './migration';
 import { getOptions } from './options';
 import { resolveConfigPresets } from './presets';
-import type {
-  RenovateConfig,
-  RenovateOptions,
-  StatusCheckKey,
-  ValidationMessage,
-  ValidationResult,
+import {
+  type RenovateConfig,
+  type RenovateOptions,
+  type StatusCheckKey,
+  type ValidationMessage,
+  type ValidationResult,
+  allowedStatusCheckStrings,
 } from './types';
 import * as managerValidator from './validation-helpers/managers';
 
@@ -564,17 +565,11 @@ export async function validateConfig(
                 });
               }
             } else if (key === 'statusCheckNames') {
-              const allowedStatusStrings: StatusCheckKey[] = [
-                'minimumReleaseAge',
-                'mergeConfidence',
-                'configValidation',
-                'artifactError',
-              ];
               for (const [statusCheckKey, statusCheckValue] of Object.entries(
                 val,
               )) {
                 if (
-                  !allowedStatusStrings.includes(
+                  !allowedStatusCheckStrings.includes(
                     statusCheckKey as StatusCheckKey,
                   )
                 ) {

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -580,7 +580,7 @@ export async function validateConfig(
                 ) {
                   errors.push({
                     topic: 'Configuration Error',
-                    message: `Invalid \`${currentPath}.${key}.${statusCheckKey}\` configuration: key is not allowed`,
+                    message: `Invalid \`${currentPath}.${key}.${statusCheckKey}\` configuration: key is not allowed.`,
                   });
                 }
                 if (
@@ -588,7 +588,7 @@ export async function validateConfig(
                 ) {
                   errors.push({
                     topic: 'Configuration Error',
-                    message: `Invalid \`${currentPath}.${statusCheckKey}\` configuration: status check is not a string`,
+                    message: `Invalid \`${currentPath}.${statusCheckKey}\` configuration: status check is not a string.`,
                   });
                   continue;
                 }

--- a/lib/workers/repository/init/index.ts
+++ b/lib/workers/repository/init/index.ts
@@ -1,4 +1,3 @@
-import fs from 'fs/promises';
 import { GlobalConfig } from '../../../config/global';
 import { applySecretsToConfig } from '../../../config/secrets';
 import type { RenovateConfig } from '../../../config/types';
@@ -58,7 +57,6 @@ export async function initRepo(
   config = await detectVulnerabilityAlerts(config);
   // istanbul ignore if
   if (config.printConfig) {
-    await fs.writeFile('config.json', JSON.stringify(config));
     logger.info(
       { config, hostRules: getAll() },
       'Full resolved config and hostRules including presets',

--- a/lib/workers/repository/init/index.ts
+++ b/lib/workers/repository/init/index.ts
@@ -1,3 +1,4 @@
+import fs from 'fs/promises';
 import { GlobalConfig } from '../../../config/global';
 import { applySecretsToConfig } from '../../../config/secrets';
 import type { RenovateConfig } from '../../../config/types';
@@ -57,6 +58,7 @@ export async function initRepo(
   config = await detectVulnerabilityAlerts(config);
   // istanbul ignore if
   if (config.printConfig) {
+    await fs.writeFile('config.json', JSON.stringify(config));
     logger.info(
       { config, hostRules: getAll() },
       'Full resolved config and hostRules including presets',

--- a/lib/workers/repository/reconfigure/index.spec.ts
+++ b/lib/workers/repository/reconfigure/index.spec.ts
@@ -4,6 +4,7 @@ import {
   fs,
   git,
   mocked,
+  partial,
   platform,
   scm,
 } from '../../../../test/util';
@@ -26,9 +27,9 @@ describe('workers/repository/reconfigure/index', () => {
   const config: RenovateConfig = {
     branchPrefix: 'prefix/',
     baseBranch: 'base',
-    statusCheckNames: {
+    statusCheckNames: partial<RenovateConfig['statusCheckNames']>({
       configValidation: 'renovate/config-validation',
-    },
+    }),
   };
 
   beforeEach(() => {
@@ -164,9 +165,9 @@ describe('workers/repository/reconfigure/index', () => {
 
     await validateReconfigureBranch({
       ...config,
-      statusCheckNames: {
+      statusCheckNames: partial<RenovateConfig['statusCheckNames']>({
         configValidation: null,
-      },
+      }),
     });
     expect(logger.debug).toHaveBeenCalledWith(
       'Status check is null or an empty string, skipping status check addition.',
@@ -184,9 +185,9 @@ describe('workers/repository/reconfigure/index', () => {
 
     await validateReconfigureBranch({
       ...config,
-      statusCheckNames: {
+      statusCheckNames: partial<RenovateConfig['statusCheckNames']>({
         configValidation: '',
-      },
+      }),
     });
     expect(logger.debug).toHaveBeenCalledWith(
       'Status check is null or an empty string, skipping status check addition.',

--- a/lib/workers/repository/reconfigure/index.spec.ts
+++ b/lib/workers/repository/reconfigure/index.spec.ts
@@ -217,7 +217,7 @@ describe('workers/repository/reconfigure/index', () => {
     platform.getBranchStatusCheck.mockResolvedValueOnce('green');
     await validateReconfigureBranch(config);
     expect(logger.debug).toHaveBeenCalledWith(
-      'Skipping validation check as status check already exists',
+      'Skipping validation check because status check already exists.',
     );
   });
 

--- a/lib/workers/repository/reconfigure/index.spec.ts
+++ b/lib/workers/repository/reconfigure/index.spec.ts
@@ -26,6 +26,9 @@ describe('workers/repository/reconfigure/index', () => {
   const config: RenovateConfig = {
     branchPrefix: 'prefix/',
     baseBranch: 'base',
+    statusCheckNames: {
+      configValidation: 'renovate/config-validation',
+    },
   };
 
   beforeEach(() => {

--- a/lib/workers/repository/reconfigure/index.spec.ts
+++ b/lib/workers/repository/reconfigure/index.spec.ts
@@ -154,6 +154,46 @@ describe('workers/repository/reconfigure/index', () => {
     });
   });
 
+  it('skips adding status check if statusCheckNames.configValidation is null', async () => {
+    cache.getCache.mockReturnValueOnce({
+      reconfigureBranchCache: {
+        reconfigureBranchSha: 'new-sha',
+        isConfigValid: false,
+      },
+    });
+
+    await validateReconfigureBranch({
+      ...config,
+      statusCheckNames: {
+        configValidation: null,
+      },
+    });
+    expect(logger.debug).toHaveBeenCalledWith(
+      'Status check is null or an empty string, skipping status check addition',
+    );
+    expect(platform.setBranchStatus).not.toHaveBeenCalled();
+  });
+
+  it('skips adding status check if statusCheckNames.configValidation is empty string', async () => {
+    cache.getCache.mockReturnValueOnce({
+      reconfigureBranchCache: {
+        reconfigureBranchSha: 'new-sha',
+        isConfigValid: false,
+      },
+    });
+
+    await validateReconfigureBranch({
+      ...config,
+      statusCheckNames: {
+        configValidation: '',
+      },
+    });
+    expect(logger.debug).toHaveBeenCalledWith(
+      'Status check is null or an empty string, skipping status check addition',
+    );
+    expect(platform.setBranchStatus).not.toHaveBeenCalled();
+  });
+
   it('skips validation if cache is valid', async () => {
     cache.getCache.mockReturnValueOnce({
       reconfigureBranchCache: {

--- a/lib/workers/repository/reconfigure/index.spec.ts
+++ b/lib/workers/repository/reconfigure/index.spec.ts
@@ -169,7 +169,7 @@ describe('workers/repository/reconfigure/index', () => {
       },
     });
     expect(logger.debug).toHaveBeenCalledWith(
-      'Status check is null or an empty string, skipping status check addition',
+      'Status check is null or an empty string, skipping status check addition.',
     );
     expect(platform.setBranchStatus).not.toHaveBeenCalled();
   });
@@ -189,7 +189,7 @@ describe('workers/repository/reconfigure/index', () => {
       },
     });
     expect(logger.debug).toHaveBeenCalledWith(
-      'Status check is null or an empty string, skipping status check addition',
+      'Status check is null or an empty string, skipping status check addition.',
     );
     expect(platform.setBranchStatus).not.toHaveBeenCalled();
   });

--- a/lib/workers/repository/reconfigure/index.ts
+++ b/lib/workers/repository/reconfigure/index.ts
@@ -77,7 +77,9 @@ export async function validateReconfigureBranch(
 
     // if old status check is present skip validation
     if (is.nonEmptyString(validationStatus)) {
-      logger.debug('Skipping validation check because status check already exists.');
+      logger.debug(
+        'Skipping validation check because status check already exists.',
+      );
       return;
     }
   }

--- a/lib/workers/repository/reconfigure/index.ts
+++ b/lib/workers/repository/reconfigure/index.ts
@@ -24,7 +24,7 @@ async function setBranchStatus(
 ): Promise<void> {
   if (!is.nonEmptyString(context)) {
     logger.debug(
-      'Status check is null or an empty string, skipping status check addition',
+      'Status check is null or an empty string, skipping status check addition.',
     );
     return;
   }
@@ -77,7 +77,7 @@ export async function validateReconfigureBranch(
 
     // if old status check is present skip validation
     if (is.nonEmptyString(validationStatus)) {
-      logger.debug('Skipping validation check as status check already exists');
+      logger.debug('Skipping validation check because status check already exists.');
       return;
     }
   }

--- a/lib/workers/repository/reconfigure/index.ts
+++ b/lib/workers/repository/reconfigure/index.ts
@@ -6,6 +6,7 @@ import { logger } from '../../../logger';
 import { platform } from '../../../modules/platform';
 import { ensureComment } from '../../../modules/platform/comment';
 import { scm } from '../../../modules/platform/scm';
+import type { BranchStatus } from '../../../types';
 import { getCache } from '../../../util/cache/repository';
 import { readLocalFile } from '../../../util/fs';
 import { getBranchCommit } from '../../../util/git';
@@ -19,7 +20,7 @@ import {
 async function setBranchStatus(
   branchName: string,
   description: string,
-  state: string,
+  state: BranchStatus,
   context?: string | null,
 ): Promise<void> {
   if (!is.nonEmptyString(context)) {
@@ -31,7 +32,7 @@ async function setBranchStatus(
     branchName,
     context,
     description,
-    state: state as any,
+    state,
   });
 }
 

--- a/lib/workers/repository/reconfigure/index.ts
+++ b/lib/workers/repository/reconfigure/index.ts
@@ -23,6 +23,9 @@ async function setBranchStatus(
   context: string | undefined,
 ): Promise<void> {
   if (!is.nonEmptyString(context)) {
+    logger.debug(
+      'Status check is null or an empty string, skipping status check addition',
+    );
     return;
   }
 

--- a/lib/workers/repository/reconfigure/index.ts
+++ b/lib/workers/repository/reconfigure/index.ts
@@ -20,7 +20,7 @@ async function setBranchStatus(
   branchName: string,
   description: string,
   state: string,
-  context: string | undefined,
+  context?: string | null,
 ): Promise<void> {
   if (!is.nonEmptyString(context)) {
     logger.debug(

--- a/lib/workers/repository/reconfigure/index.ts
+++ b/lib/workers/repository/reconfigure/index.ts
@@ -23,9 +23,7 @@ async function setBranchStatus(
   context?: string | null,
 ): Promise<void> {
   if (!is.nonEmptyString(context)) {
-    logger.debug(
-      'Status check is null or an empty string, skipping status check addition.',
-    );
+    // already logged this case when validating the status check
     return;
   }
 
@@ -82,6 +80,10 @@ export async function validateReconfigureBranch(
       );
       return;
     }
+  } else {
+    logger.debug(
+      'Status check is null or an empty string, skipping status check addition.',
+    );
   }
 
   try {

--- a/lib/workers/repository/update/branch/artifacts.spec.ts
+++ b/lib/workers/repository/update/branch/artifacts.spec.ts
@@ -42,7 +42,7 @@ describe('workers/repository/update/branch/artifacts', () => {
         },
       });
       expect(logger.debug).toHaveBeenCalledWith(
-        'Status check is null or an empty string, skipping status check addition',
+        'Status check is null or an empty string, skipping status check addition.',
       );
       expect(platform.setBranchStatus).not.toHaveBeenCalled();
     });
@@ -55,7 +55,7 @@ describe('workers/repository/update/branch/artifacts', () => {
         },
       });
       expect(logger.debug).toHaveBeenCalledWith(
-        'Status check is null or an empty string, skipping status check addition',
+        'Status check is null or an empty string, skipping status check addition.',
       );
       expect(platform.setBranchStatus).not.toHaveBeenCalled();
     });
@@ -66,7 +66,7 @@ describe('workers/repository/update/branch/artifacts', () => {
         statusCheckNames: undefined as never,
       });
       expect(logger.debug).toHaveBeenCalledWith(
-        'Status check is null or an empty string, skipping status check addition',
+        'Status check is null or an empty string, skipping status check addition.',
       );
       expect(platform.setBranchStatus).not.toHaveBeenCalled();
     });

--- a/lib/workers/repository/update/branch/artifacts.spec.ts
+++ b/lib/workers/repository/update/branch/artifacts.spec.ts
@@ -14,6 +14,9 @@ describe('workers/repository/update/branch/artifacts', () => {
       branchName: 'renovate/pin',
       upgrades: [],
       artifactErrors: [{ lockFile: 'some' }],
+      statusCheckNames: {
+        artifactError: 'renovate/artifact',
+      },
     } satisfies BranchConfig;
   });
 

--- a/lib/workers/repository/update/branch/artifacts.spec.ts
+++ b/lib/workers/repository/update/branch/artifacts.spec.ts
@@ -1,5 +1,6 @@
 import { platform } from '../../../../../test/util';
 import { GlobalConfig } from '../../../../config/global';
+import { logger } from '../../../../logger';
 import type { BranchConfig } from '../../../types';
 import { setArtifactErrorStatus } from './artifacts';
 
@@ -33,15 +34,50 @@ describe('workers/repository/update/branch/artifacts', () => {
       expect(platform.setBranchStatus).not.toHaveBeenCalled();
     });
 
+    it('skips status if statusCheckNames.artifactError is null', async () => {
+      await setArtifactErrorStatus({
+        ...config,
+        statusCheckNames: {
+          artifactError: null,
+        },
+      });
+      expect(logger.debug).toHaveBeenCalledWith(
+        'Status check is null or an empty string, skipping status check addition',
+      );
+      expect(platform.setBranchStatus).not.toHaveBeenCalled();
+    });
+
+    it('skips status if statusCheckNames.artifactError is empty string', async () => {
+      await setArtifactErrorStatus({
+        ...config,
+        statusCheckNames: {
+          artifactError: '',
+        },
+      });
+      expect(logger.debug).toHaveBeenCalledWith(
+        'Status check is null or an empty string, skipping status check addition',
+      );
+      expect(platform.setBranchStatus).not.toHaveBeenCalled();
+    });
+
+    it('skips status if statusCheckNames is undefined', async () => {
+      await setArtifactErrorStatus({
+        ...config,
+        statusCheckNames: undefined as never,
+      });
+      expect(logger.debug).toHaveBeenCalledWith(
+        'Status check is null or an empty string, skipping status check addition',
+      );
+      expect(platform.setBranchStatus).not.toHaveBeenCalled();
+    });
+
     it('skips status (dry-run)', async () => {
       GlobalConfig.set({ dryRun: 'full' });
-      platform.getBranchStatusCheck.mockResolvedValueOnce(null);
       await setArtifactErrorStatus(config);
       expect(platform.setBranchStatus).not.toHaveBeenCalled();
     });
 
     it('skips status (no errors)', async () => {
-      platform.getBranchStatusCheck.mockResolvedValueOnce(null);
       config.artifactErrors = [];
       await setArtifactErrorStatus(config);
       expect(platform.setBranchStatus).not.toHaveBeenCalled();

--- a/lib/workers/repository/update/branch/artifacts.spec.ts
+++ b/lib/workers/repository/update/branch/artifacts.spec.ts
@@ -1,4 +1,4 @@
-import { platform } from '../../../../../test/util';
+import { RenovateConfig, partial, platform } from '../../../../../test/util';
 import { GlobalConfig } from '../../../../config/global';
 import { logger } from '../../../../logger';
 import type { BranchConfig } from '../../../types';
@@ -15,9 +15,9 @@ describe('workers/repository/update/branch/artifacts', () => {
       branchName: 'renovate/pin',
       upgrades: [],
       artifactErrors: [{ lockFile: 'some' }],
-      statusCheckNames: {
+      statusCheckNames: partial<RenovateConfig['statusCheckNames']>({
         artifactError: 'renovate/artifact',
-      },
+      }),
     } satisfies BranchConfig;
   });
 
@@ -37,9 +37,9 @@ describe('workers/repository/update/branch/artifacts', () => {
     it('skips status if statusCheckNames.artifactError is null', async () => {
       await setArtifactErrorStatus({
         ...config,
-        statusCheckNames: {
+        statusCheckNames: partial<RenovateConfig['statusCheckNames']>({
           artifactError: null,
-        },
+        }),
       });
       expect(logger.debug).toHaveBeenCalledWith(
         'Status check is null or an empty string, skipping status check addition.',
@@ -50,9 +50,9 @@ describe('workers/repository/update/branch/artifacts', () => {
     it('skips status if statusCheckNames.artifactError is empty string', async () => {
       await setArtifactErrorStatus({
         ...config,
-        statusCheckNames: {
+        statusCheckNames: partial<RenovateConfig['statusCheckNames']>({
           artifactError: '',
-        },
+        }),
       });
       expect(logger.debug).toHaveBeenCalledWith(
         'Status check is null or an empty string, skipping status check addition.',
@@ -63,7 +63,7 @@ describe('workers/repository/update/branch/artifacts', () => {
     it('skips status if statusCheckNames is undefined', async () => {
       await setArtifactErrorStatus({
         ...config,
-        statusCheckNames: undefined as never,
+        statusCheckNames: undefined,
       });
       expect(logger.debug).toHaveBeenCalledWith(
         'Status check is null or an empty string, skipping status check addition.',

--- a/lib/workers/repository/update/branch/artifacts.ts
+++ b/lib/workers/repository/update/branch/artifacts.ts
@@ -1,4 +1,3 @@
-import is from '@sindresorhus/is';
 import { GlobalConfig } from '../../../../config/global';
 import { logger } from '../../../../logger';
 import { platform } from '../../../../modules/platform';
@@ -11,17 +10,15 @@ export async function setArtifactErrorStatus(
     // no errors
     return;
   }
-  if (
-    !config.statusCheckNames ||
-    !is.nonEmptyString(config.statusCheckNames?.artifactError)
-  ) {
+
+  const context = config.statusCheckNames?.artifactError;
+  if (!context) {
     logger.debug(
       'Status check is null or an empty string, skipping status check addition.',
     );
     return;
   }
 
-  const context = config.statusCheckNames.artifactError;
   const description = 'Artifact file update failure';
   const state = 'red';
   const existingState = await platform.getBranchStatusCheck(

--- a/lib/workers/repository/update/branch/artifacts.ts
+++ b/lib/workers/repository/update/branch/artifacts.ts
@@ -7,15 +7,21 @@ import type { BranchConfig } from '../../../types';
 export async function setArtifactErrorStatus(
   config: BranchConfig,
 ): Promise<void> {
-  if (
-    !config.artifactErrors?.length ||
-    !is.nonEmptyString(config.statusCheckNames?.artifactError)
-  ) {
+  if (!config.artifactErrors?.length) {
     // no errors
     return;
   }
+  if (
+    !config.statusCheckNames ||
+    !is.nonEmptyString(config.statusCheckNames?.artifactError)
+  ) {
+    logger.debug(
+      'Status check is null or an empty string, skipping status check addition',
+    );
+    return;
+  }
 
-  const context = config.statusCheckNames!.artifactError;
+  const context = config.statusCheckNames.artifactError;
   const description = 'Artifact file update failure';
   const state = 'red';
   const existingState = await platform.getBranchStatusCheck(

--- a/lib/workers/repository/update/branch/artifacts.ts
+++ b/lib/workers/repository/update/branch/artifacts.ts
@@ -1,3 +1,4 @@
+import is from '@sindresorhus/is';
 import { GlobalConfig } from '../../../../config/global';
 import { logger } from '../../../../logger';
 import { platform } from '../../../../modules/platform';
@@ -6,12 +7,15 @@ import type { BranchConfig } from '../../../types';
 export async function setArtifactErrorStatus(
   config: BranchConfig,
 ): Promise<void> {
-  if (!config.artifactErrors?.length) {
+  if (
+    !config.artifactErrors?.length ||
+    !is.nonEmptyString(config.statusCheckNames?.artifactError)
+  ) {
     // no errors
     return;
   }
 
-  const context = `renovate/artifacts`;
+  const context = config.statusCheckNames!.artifactError;
   const description = 'Artifact file update failure';
   const state = 'red';
   const existingState = await platform.getBranchStatusCheck(

--- a/lib/workers/repository/update/branch/artifacts.ts
+++ b/lib/workers/repository/update/branch/artifacts.ts
@@ -16,7 +16,7 @@ export async function setArtifactErrorStatus(
     !is.nonEmptyString(config.statusCheckNames?.artifactError)
   ) {
     logger.debug(
-      'Status check is null or an empty string, skipping status check addition',
+      'Status check is null or an empty string, skipping status check addition.',
     );
     return;
   }

--- a/lib/workers/repository/update/branch/status-checks.spec.ts
+++ b/lib/workers/repository/update/branch/status-checks.spec.ts
@@ -59,7 +59,7 @@ describe('workers/repository/update/branch/status-checks', () => {
         },
       });
       expect(logger.debug).toHaveBeenCalledWith(
-        'Status check is null or an empty string, skipping status check addition',
+        'Status check is null or an empty string, skipping status check addition.',
       );
       expect(platform.setBranchStatus).not.toHaveBeenCalled();
     });
@@ -73,7 +73,7 @@ describe('workers/repository/update/branch/status-checks', () => {
         },
       });
       expect(logger.debug).toHaveBeenCalledWith(
-        'Status check is null or an empty string, skipping status check addition',
+        'Status check is null or an empty string, skipping status check addition.',
       );
       expect(platform.setBranchStatus).not.toHaveBeenCalled();
     });
@@ -85,7 +85,7 @@ describe('workers/repository/update/branch/status-checks', () => {
         statusCheckNames: undefined as never,
       });
       expect(logger.debug).toHaveBeenCalledWith(
-        'Status check is null or an empty string, skipping status check addition',
+        'Status check is null or an empty string, skipping status check addition.',
       );
       expect(platform.setBranchStatus).not.toHaveBeenCalled();
     });
@@ -143,7 +143,7 @@ describe('workers/repository/update/branch/status-checks', () => {
         },
       });
       expect(logger.debug).toHaveBeenCalledWith(
-        'Status check is null or an empty string, skipping status check addition',
+        'Status check is null or an empty string, skipping status check addition.',
       );
       expect(platform.setBranchStatus).not.toHaveBeenCalled();
     });
@@ -158,7 +158,7 @@ describe('workers/repository/update/branch/status-checks', () => {
         },
       });
       expect(logger.debug).toHaveBeenCalledWith(
-        'Status check is null or an empty string, skipping status check addition',
+        'Status check is null or an empty string, skipping status check addition.',
       );
       expect(platform.setBranchStatus).not.toHaveBeenCalled();
     });
@@ -171,7 +171,7 @@ describe('workers/repository/update/branch/status-checks', () => {
         statusCheckNames: undefined as never,
       });
       expect(logger.debug).toHaveBeenCalledWith(
-        'Status check is null or an empty string, skipping status check addition',
+        'Status check is null or an empty string, skipping status check addition.',
       );
       expect(platform.setBranchStatus).not.toHaveBeenCalled();
     });

--- a/lib/workers/repository/update/branch/status-checks.spec.ts
+++ b/lib/workers/repository/update/branch/status-checks.spec.ts
@@ -1,4 +1,5 @@
 import { partial, platform } from '../../../../../test/util';
+import { logger } from '../../../../logger';
 import {
   ConfidenceConfig,
   StabilityConfig,
@@ -48,6 +49,46 @@ describe('workers/repository/update/branch/status-checks', () => {
       expect(platform.getBranchStatusCheck).toHaveBeenCalledTimes(1);
       expect(platform.setBranchStatus).toHaveBeenCalledTimes(0);
     });
+
+    it('skips status if statusCheckNames.minimumReleaseAge is null', async () => {
+      config.stabilityStatus = 'green';
+      await setStability({
+        ...config,
+        statusCheckNames: {
+          minimumReleaseAge: null,
+        },
+      });
+      expect(logger.debug).toHaveBeenCalledWith(
+        'Status check is null or an empty string, skipping status check addition',
+      );
+      expect(platform.setBranchStatus).not.toHaveBeenCalled();
+    });
+
+    it('skips status if statusCheckNames.minimumReleaseAge is empty string', async () => {
+      config.stabilityStatus = 'green';
+      await setStability({
+        ...config,
+        statusCheckNames: {
+          minimumReleaseAge: '',
+        },
+      });
+      expect(logger.debug).toHaveBeenCalledWith(
+        'Status check is null or an empty string, skipping status check addition',
+      );
+      expect(platform.setBranchStatus).not.toHaveBeenCalled();
+    });
+
+    it('skips status if statusCheckNames is undefined', async () => {
+      config.stabilityStatus = 'green';
+      await setStability({
+        ...config,
+        statusCheckNames: undefined as never,
+      });
+      expect(logger.debug).toHaveBeenCalledWith(
+        'Status check is null or an empty string, skipping status check addition',
+      );
+      expect(platform.setBranchStatus).not.toHaveBeenCalled();
+    });
   });
 
   describe('setConfidence', () => {
@@ -90,6 +131,49 @@ describe('workers/repository/update/branch/status-checks', () => {
       await setConfidence(config);
       expect(platform.getBranchStatusCheck).toHaveBeenCalledTimes(1);
       expect(platform.setBranchStatus).toHaveBeenCalledTimes(0);
+    });
+
+    it('skips status if statusCheckNames.mergeConfidence is null', async () => {
+      config.minimumConfidence = 'high';
+      config.confidenceStatus = 'green';
+      await setConfidence({
+        ...config,
+        statusCheckNames: {
+          mergeConfidence: null,
+        },
+      });
+      expect(logger.debug).toHaveBeenCalledWith(
+        'Status check is null or an empty string, skipping status check addition',
+      );
+      expect(platform.setBranchStatus).not.toHaveBeenCalled();
+    });
+
+    it('skips status if statusCheckNames.mergeConfidence is empty string', async () => {
+      config.minimumConfidence = 'high';
+      config.confidenceStatus = 'green';
+      await setConfidence({
+        ...config,
+        statusCheckNames: {
+          mergeConfidence: '',
+        },
+      });
+      expect(logger.debug).toHaveBeenCalledWith(
+        'Status check is null or an empty string, skipping status check addition',
+      );
+      expect(platform.setBranchStatus).not.toHaveBeenCalled();
+    });
+
+    it('skips status if statusCheckNames is undefined', async () => {
+      config.minimumConfidence = 'high';
+      config.confidenceStatus = 'green';
+      await setConfidence({
+        ...config,
+        statusCheckNames: undefined as never,
+      });
+      expect(logger.debug).toHaveBeenCalledWith(
+        'Status check is null or an empty string, skipping status check addition',
+      );
+      expect(platform.setBranchStatus).not.toHaveBeenCalled();
     });
   });
 

--- a/lib/workers/repository/update/branch/status-checks.spec.ts
+++ b/lib/workers/repository/update/branch/status-checks.spec.ts
@@ -14,6 +14,9 @@ describe('workers/repository/update/branch/status-checks', () => {
     beforeEach(() => {
       config = partial<StabilityConfig>({
         branchName: 'renovate/some-branch',
+        statusCheckNames: {
+          minimumReleaseAge: 'renovate/stability-days',
+        },
       });
     });
 
@@ -53,6 +56,9 @@ describe('workers/repository/update/branch/status-checks', () => {
     beforeEach(() => {
       config = {
         branchName: 'renovate/some-branch',
+        statusCheckNames: {
+          mergeConfidence: 'renovate/merge-confidence',
+        },
       };
     });
 

--- a/lib/workers/repository/update/branch/status-checks.spec.ts
+++ b/lib/workers/repository/update/branch/status-checks.spec.ts
@@ -1,4 +1,4 @@
-import { partial, platform } from '../../../../../test/util';
+import { RenovateConfig, partial, platform } from '../../../../../test/util';
 import { logger } from '../../../../logger';
 import {
   ConfidenceConfig,
@@ -15,9 +15,9 @@ describe('workers/repository/update/branch/status-checks', () => {
     beforeEach(() => {
       config = partial<StabilityConfig>({
         branchName: 'renovate/some-branch',
-        statusCheckNames: {
+        statusCheckNames: partial<RenovateConfig['statusCheckNames']>({
           minimumReleaseAge: 'renovate/stability-days',
-        },
+        }),
       });
     });
 
@@ -54,9 +54,9 @@ describe('workers/repository/update/branch/status-checks', () => {
       config.stabilityStatus = 'green';
       await setStability({
         ...config,
-        statusCheckNames: {
+        statusCheckNames: partial<RenovateConfig['statusCheckNames']>({
           minimumReleaseAge: null,
-        },
+        }),
       });
       expect(logger.debug).toHaveBeenCalledWith(
         'Status check is null or an empty string, skipping status check addition.',
@@ -68,9 +68,9 @@ describe('workers/repository/update/branch/status-checks', () => {
       config.stabilityStatus = 'green';
       await setStability({
         ...config,
-        statusCheckNames: {
+        statusCheckNames: partial<RenovateConfig['statusCheckNames']>({
           minimumReleaseAge: '',
-        },
+        }),
       });
       expect(logger.debug).toHaveBeenCalledWith(
         'Status check is null or an empty string, skipping status check addition.',
@@ -97,9 +97,9 @@ describe('workers/repository/update/branch/status-checks', () => {
     beforeEach(() => {
       config = {
         branchName: 'renovate/some-branch',
-        statusCheckNames: {
+        statusCheckNames: partial<RenovateConfig['statusCheckNames']>({
           mergeConfidence: 'renovate/merge-confidence',
-        },
+        }),
       };
     });
 
@@ -138,9 +138,9 @@ describe('workers/repository/update/branch/status-checks', () => {
       config.confidenceStatus = 'green';
       await setConfidence({
         ...config,
-        statusCheckNames: {
+        statusCheckNames: partial<RenovateConfig['statusCheckNames']>({
           mergeConfidence: null,
-        },
+        }),
       });
       expect(logger.debug).toHaveBeenCalledWith(
         'Status check is null or an empty string, skipping status check addition.',
@@ -153,9 +153,9 @@ describe('workers/repository/update/branch/status-checks', () => {
       config.confidenceStatus = 'green';
       await setConfidence({
         ...config,
-        statusCheckNames: {
+        statusCheckNames: partial<RenovateConfig['statusCheckNames']>({
           mergeConfidence: '',
-        },
+        }),
       });
       expect(logger.debug).toHaveBeenCalledWith(
         'Status check is null or an empty string, skipping status check addition.',

--- a/lib/workers/repository/update/branch/status-checks.ts
+++ b/lib/workers/repository/update/branch/status-checks.ts
@@ -60,10 +60,7 @@ export interface StabilityConfig extends RenovateConfig {
 }
 
 export async function setStability(config: StabilityConfig): Promise<void> {
-  if (
-    !config.stabilityStatus ||
-    !is.nonEmptyString(config.statusCheckNames?.minimumReleaseAge)
-  ) {
+  if (!config.stabilityStatus) {
     return;
   }
   if (
@@ -71,7 +68,7 @@ export async function setStability(config: StabilityConfig): Promise<void> {
     !is.nonEmptyString(config.statusCheckNames?.minimumReleaseAge)
   ) {
     logger.debug(
-      'Status check is null or empty an string, skipping status check addition',
+      'Status check is null or an empty string, skipping status check addition',
     );
     return;
   }

--- a/lib/workers/repository/update/branch/status-checks.ts
+++ b/lib/workers/repository/update/branch/status-checks.ts
@@ -59,10 +59,11 @@ export interface StabilityConfig extends RenovateConfig {
 }
 
 export async function setStability(config: StabilityConfig): Promise<void> {
-  if (!config.stabilityStatus) {
+  if (!config.stabilityStatus || !config.statusCheckNames?.minimumReleaseAge) {
     return;
   }
-  const context = `renovate/stability-days`;
+
+  const context = config.statusCheckNames.minimumReleaseAge;
   const description =
     config.stabilityStatus === 'green'
       ? 'Updates have met minimum release age requirement'
@@ -85,12 +86,13 @@ export async function setConfidence(config: ConfidenceConfig): Promise<void> {
   if (
     !config.branchName ||
     !config.confidenceStatus ||
+    !config.statusCheckNames?.minimumConfidence ||
     (config.minimumConfidence &&
       !isActiveConfidenceLevel(config.minimumConfidence))
   ) {
     return;
   }
-  const context = `renovate/merge-confidence`;
+  const context = config.statusCheckNames.minimumConfidence;
   const description =
     config.confidenceStatus === 'green'
       ? 'Updates have met Merge Confidence requirement'

--- a/lib/workers/repository/update/branch/status-checks.ts
+++ b/lib/workers/repository/update/branch/status-checks.ts
@@ -60,11 +60,14 @@ export interface StabilityConfig extends RenovateConfig {
 }
 
 export async function setStability(config: StabilityConfig): Promise<void> {
-  if (!config.stabilityStatus || !config.statusCheckNames?.minimumReleaseAge) {
+  if (
+    !config.stabilityStatus ||
+    !is.nonEmptyString(config.statusCheckNames?.minimumReleaseAge)
+  ) {
     return;
   }
 
-  const context = config.statusCheckNames.minimumReleaseAge;
+  const context = config.statusCheckNames!.minimumReleaseAge;
   const description =
     config.stabilityStatus === 'green'
       ? 'Updates have met minimum release age requirement'

--- a/lib/workers/repository/update/branch/status-checks.ts
+++ b/lib/workers/repository/update/branch/status-checks.ts
@@ -68,7 +68,7 @@ export async function setStability(config: StabilityConfig): Promise<void> {
     !is.nonEmptyString(config.statusCheckNames?.minimumReleaseAge)
   ) {
     logger.debug(
-      'Status check is null or an empty string, skipping status check addition',
+      'Status check is null or an empty string, skipping status check addition.',
     );
     return;
   }
@@ -106,7 +106,7 @@ export async function setConfidence(config: ConfidenceConfig): Promise<void> {
     !is.nonEmptyString(config.statusCheckNames?.mergeConfidence)
   ) {
     logger.debug(
-      'Status check is null or an empty string, skipping status check addition',
+      'Status check is null or an empty string, skipping status check addition.',
     );
     return;
   }

--- a/lib/workers/repository/update/branch/status-checks.ts
+++ b/lib/workers/repository/update/branch/status-checks.ts
@@ -1,3 +1,4 @@
+import is from '@sindresorhus/is';
 import type { RenovateConfig } from '../../../../config/types';
 import { logger } from '../../../../logger';
 import { platform } from '../../../../modules/platform';
@@ -86,13 +87,13 @@ export async function setConfidence(config: ConfidenceConfig): Promise<void> {
   if (
     !config.branchName ||
     !config.confidenceStatus ||
-    !config.statusCheckNames?.minimumConfidence ||
+    !is.nonEmptyString(config.statusCheckNames?.mergeConfidence) ||
     (config.minimumConfidence &&
       !isActiveConfidenceLevel(config.minimumConfidence))
   ) {
     return;
   }
-  const context = config.statusCheckNames.minimumConfidence;
+  const context = config.statusCheckNames!.mergeConfidence;
   const description =
     config.confidenceStatus === 'green'
       ? 'Updates have met Merge Confidence requirement'

--- a/lib/workers/repository/update/branch/status-checks.ts
+++ b/lib/workers/repository/update/branch/status-checks.ts
@@ -1,4 +1,3 @@
-import is from '@sindresorhus/is';
 import type { RenovateConfig } from '../../../../config/types';
 import { logger } from '../../../../logger';
 import { platform } from '../../../../modules/platform';
@@ -63,17 +62,15 @@ export async function setStability(config: StabilityConfig): Promise<void> {
   if (!config.stabilityStatus) {
     return;
   }
-  if (
-    !config.statusCheckNames ||
-    !is.nonEmptyString(config.statusCheckNames?.minimumReleaseAge)
-  ) {
+
+  const context = config.statusCheckNames?.minimumReleaseAge;
+  if (!context) {
     logger.debug(
       'Status check is null or an empty string, skipping status check addition.',
     );
     return;
   }
 
-  const context = config.statusCheckNames.minimumReleaseAge;
   const description =
     config.stabilityStatus === 'green'
       ? 'Updates have met minimum release age requirement'
@@ -101,17 +98,14 @@ export async function setConfidence(config: ConfidenceConfig): Promise<void> {
   ) {
     return;
   }
-  if (
-    !config.statusCheckNames ||
-    !is.nonEmptyString(config.statusCheckNames?.mergeConfidence)
-  ) {
+  const context = config.statusCheckNames?.mergeConfidence;
+  if (!context) {
     logger.debug(
       'Status check is null or an empty string, skipping status check addition.',
     );
     return;
   }
 
-  const context = config.statusCheckNames.mergeConfidence;
   const description =
     config.confidenceStatus === 'green'
       ? 'Updates have met Merge Confidence requirement'

--- a/lib/workers/repository/update/branch/status-checks.ts
+++ b/lib/workers/repository/update/branch/status-checks.ts
@@ -66,8 +66,17 @@ export async function setStability(config: StabilityConfig): Promise<void> {
   ) {
     return;
   }
+  if (
+    !config.statusCheckNames ||
+    !is.nonEmptyString(config.statusCheckNames?.minimumReleaseAge)
+  ) {
+    logger.debug(
+      'Status check is null or empty an string, skipping status check addition',
+    );
+    return;
+  }
 
-  const context = config.statusCheckNames!.minimumReleaseAge;
+  const context = config.statusCheckNames.minimumReleaseAge;
   const description =
     config.stabilityStatus === 'green'
       ? 'Updates have met minimum release age requirement'
@@ -90,13 +99,22 @@ export async function setConfidence(config: ConfidenceConfig): Promise<void> {
   if (
     !config.branchName ||
     !config.confidenceStatus ||
-    !is.nonEmptyString(config.statusCheckNames?.mergeConfidence) ||
     (config.minimumConfidence &&
       !isActiveConfidenceLevel(config.minimumConfidence))
   ) {
     return;
   }
-  const context = config.statusCheckNames!.mergeConfidence;
+  if (
+    !config.statusCheckNames ||
+    !is.nonEmptyString(config.statusCheckNames?.mergeConfidence)
+  ) {
+    logger.debug(
+      'Status check is null or an empty string, skipping status check addition',
+    );
+    return;
+  }
+
+  const context = config.statusCheckNames.mergeConfidence;
   const description =
     config.confidenceStatus === 'green'
       ? 'Updates have met Merge Confidence requirement'


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Allow users to set custom status check strings.
- Added new config option `statusCheckNames`
- Add validation for the new option such that only the 4 existing status check strings can be modified and new ones cannot be added
<!-- Describe what behavior is changed by this PR. -->

## Context
Closes: https://github.com/renovatebot/renovate/issues/23530
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
