### PR TITLE
feat(workarounds): add node docker versioning template

### DIFF
--- a/lib/config/presets/internal/workarounds.ts
+++ b/lib/config/presets/internal/workarounds.ts
@@ -13,6 +13,7 @@ export const presets: Record<string, Preset> = {
       'workarounds:ignoreWeb3jCoreWithOldReleaseTimestamp',
       'workarounds:ignoreHttp4sDigestMilestones',
       'workarounds:typesNodeVersioning',
+      'workarounds:nodeDockerVersioning',
       'workarounds:reduceRepologyServerLoad',
       'workarounds:doNotUpgradeFromAlpineStableToEdge',
       'workarounds:supportRedHatImageVersion',
@@ -136,6 +137,13 @@ export const presets: Record<string, Preset> = {
         matchPackagePrefixes: ['commons-'],
       },
     ],
+  },
+  nodeDockerVersioning: {
+    description: 'Use node versioning for `node` docker images.',
+    matchDatasources: ['docker'],
+    matchPackageNames: ['node'],
+    versionCompatibility: '^(?<version>[^-]+)(?<compatibility>-.*)?$',
+    versioning: 'node',
   },
   reduceRepologyServerLoad: {
     description:


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds a new workaround preset that uses the node versioning strategy for node docker images.

<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

Fixes #13270

Originally, this snippet was added as an example in #24717. In the further discussion of #13270, it seemed most reasonable to add this as a workaround and not as a default behavior - which this MR aims to implement.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The repo is private unfortunately, but those are the diffs on the `chore(deps): update node.js to v20` PR:

With codenames:

```diff
default:
-  image: node:hydrogen-slim@sha256:caea82ddba051b3f8157bf6d12c732d6f232b56af0dcefd4b51d8d9f5196e9dd
+  image: node:iron-slim@sha256:363a50faa3a561618775c1bab18dae9b4d0910a28f249bf8b72c0251c83791ff
```

With numerical versions:

```diff
-FROM node:18-slim@sha256:caea82ddba051b3f8157bf6d12c732d6f232b56af0dcefd4b51d8d9f5196e9dd
+FROM node:20-slim@sha256:363a50faa3a561618775c1bab18dae9b4d0910a28f249bf8b72c0251c83791ff
```

The CI easily passes with those two changes.

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->

EDIT:
~~I created a test repo with the essential parts of the above-mentioned files to test the custom `packageRules`. This is the resulting PR: pwuersch/renovate-config-test#1~~

EDIT 2:
A new PR with more testing was created here: pwuersch/renovate-config-test#3
