### PR TITLE
feat(helmfile): support optional `.gotmpl` extension (#23176)

### DIFF
--- a/lib/modules/manager/helmfile/index.ts
+++ b/lib/modules/manager/helmfile/index.ts
@@ -11,7 +11,7 @@ export const defaultConfig = {
     stable: 'https://charts.helm.sh/stable',
   },
   commitMessageTopic: 'helm chart {{depName}}',
-  fileMatch: ['(^|/)helmfile\\.ya?ml$'],
+  fileMatch: ['(^|/)helmfile\\.ya?ml(?:\\.gotmpl)?$'],
 };
 
 export const categories: Category[] = ['cd', 'helm', 'kubernetes'];


### PR DESCRIPTION
## Changes

I adjusted the `fileMatch` attribute in the default config for the Helmfile manager to support optional `.gotmpl` extensions for Helmfile. I didn't create or modify any test cases because I didn't see any test cases related to the allowed file name variants.

## Context

Helmfiles are YAML files and usually have a `.yml` or `.yaml` extension. However, they can also be Go-templated and then need to have a `.yml.gotmpl` or `.yaml.gotmpl` extension. For Helmfile v1 it is even proposed to force users to use the `.gotmpl` extension. For more information have a look at the linked issue.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

(...from my perspective)

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

(I've tested the new regex by overriding the default config in my project.)