### PR TITLE
refactor(http): Separate search and apply of host rules

### DIFF
--- a/lib/util/http/github.ts
+++ b/lib/util/http/github.ts
@@ -14,7 +14,7 @@ import * as p from '../promises';
 import { range } from '../range';
 import { regEx } from '../regex';
 import { joinUrlParts, parseLinkHeader, resolveBaseUrl } from '../url';
-import { findMatchingRules } from './host-rules';
+import { findMatchingRule } from './host-rules';
 import type { GotLegacyError } from './legacy';
 import type {
   GraphqlOptions,
@@ -295,10 +295,9 @@ export class GithubHttp extends Http<GithubHttpOptions> {
         );
       }
 
-      const { token } = findMatchingRules(
-        { hostType: this.hostType },
-        authUrl.toString(),
-      );
+      const { token } = findMatchingRule(authUrl.toString(), {
+        hostType: this.hostType,
+      });
       opts.token = token;
     }
 

--- a/lib/util/http/host-rules.spec.ts
+++ b/lib/util/http/host-rules.spec.ts
@@ -53,75 +53,59 @@ describe('util/http/host-rules', () => {
   it('adds token', () => {
     const opts = { ...options };
     const hostRule = findMatchingRule(url, opts);
-    expect(hostRule).toMatchInlineSnapshot(`
-      {
-        "token": "token",
-      }
-    `);
-    expect(applyHostRule(url, opts, hostRule)).toMatchInlineSnapshot(`
-      {
-        "context": {
-          "authType": undefined,
-        },
-        "hostType": "github",
-        "token": "token",
-      }
-    `);
+    expect(hostRule).toEqual({
+      token: 'token',
+    });
+    expect(applyHostRule(url, opts, hostRule)).toEqual({
+      context: {
+        authType: undefined,
+      },
+      hostType: 'github',
+      token: 'token',
+    });
   });
 
   it('adds auth', () => {
     const opts = { hostType: 'gitea' };
     const hostRule = findMatchingRule(url, opts);
-    expect(hostRule).toMatchInlineSnapshot(`
-      {
-        "password": "password",
-      }
-    `);
-    expect(applyHostRule(url, opts, hostRule)).toMatchInlineSnapshot(`
-      {
-        "hostType": "gitea",
-        "password": "password",
-        "username": undefined,
-      }
-    `);
+    expect(hostRule).toEqual({
+      password: 'password',
+    });
+    expect(applyHostRule(url, opts, hostRule)).toEqual({
+      hostType: 'gitea',
+      password: 'password',
+      username: undefined,
+    });
   });
 
   it('adds custom auth', () => {
     const opts = { hostType: 'npm' };
     const hostRule = findMatchingRule(url, opts);
-    expect(hostRule).toMatchInlineSnapshot(`
-      {
-        "authType": "Basic",
-        "timeout": 5000,
-        "token": "XXX",
-      }
-    `);
-    expect(applyHostRule(url, opts, hostRule)).toMatchInlineSnapshot(`
-      {
-        "context": {
-          "authType": "Basic",
-        },
-        "hostType": "npm",
-        "timeout": 5000,
-        "token": "XXX",
-      }
-    `);
+    expect(hostRule).toEqual({
+      authType: 'Basic',
+      timeout: 5000,
+      token: 'XXX',
+    });
+    expect(applyHostRule(url, opts, hostRule)).toEqual({
+      context: {
+        authType: 'Basic',
+      },
+      hostType: 'npm',
+      timeout: 5000,
+      token: 'XXX',
+    });
   });
 
   it('skips', () => {
     const opts = { ...options, token: 'xxx' };
     const hostRule = findMatchingRule(url, opts);
-    expect(hostRule).toMatchInlineSnapshot(`
-      {
-        "token": "token",
-      }
-    `);
-    expect(applyHostRule(url, opts, hostRule)).toMatchInlineSnapshot(`
-      {
-        "hostType": "github",
-        "token": "xxx",
-      }
-    `);
+    expect(hostRule).toEqual({
+      token: 'token',
+    });
+    expect(applyHostRule(url, opts, hostRule)).toEqual({
+      hostType: 'github',
+      token: 'xxx',
+    });
   });
 
   it('uses http2', () => {
@@ -129,19 +113,15 @@ describe('util/http/host-rules', () => {
 
     const opts = { ...options, token: 'xxx' };
     const hostRule = findMatchingRule(url, opts);
-    expect(hostRule).toMatchInlineSnapshot(`
-      {
-        "enableHttp2": true,
-        "token": "token",
-      }
-    `);
-    expect(applyHostRule(url, opts, hostRule)).toMatchInlineSnapshot(`
-      {
-        "hostType": "github",
-        "http2": true,
-        "token": "xxx",
-      }
-    `);
+    expect(hostRule).toEqual({
+      enableHttp2: true,
+      token: 'token',
+    });
+    expect(applyHostRule(url, opts, hostRule)).toEqual({
+      hostType: 'github',
+      http2: true,
+      token: 'xxx',
+    });
   });
 
   it('uses dnsCache', () => {
@@ -149,12 +129,10 @@ describe('util/http/host-rules', () => {
 
     const opts = { ...options, token: 'xxx' };
     const hostRule = findMatchingRule(url, opts);
-    expect(hostRule).toMatchInlineSnapshot(`
-      {
-        "dnsCache": true,
-        "token": "token",
-      }
-    `);
+    expect(hostRule).toEqual({
+      dnsCache: true,
+      token: 'token',
+    });
     expect(applyHostRule(url, opts, hostRule)).toMatchObject({
       hostType: 'github',
       lookup: dnsLookup,
@@ -167,12 +145,10 @@ describe('util/http/host-rules', () => {
 
     const opts = { ...options, token: 'xxx' };
     const hostRule = findMatchingRule(url, opts);
-    expect(hostRule).toMatchInlineSnapshot(`
-      {
-        "keepAlive": true,
-        "token": "token",
-      }
-    `);
+    expect(hostRule).toEqual({
+      keepAlive: true,
+      token: 'token',
+    });
     expect(applyHostRule(url, opts, hostRule).agent).toBeDefined();
   });
 
@@ -183,34 +159,26 @@ describe('util/http/host-rules', () => {
 
     const opts = { ...options, token: 'xxx' };
     const hostRule = findMatchingRule(url, opts);
-    expect(hostRule).toMatchInlineSnapshot(`
-      {
-        "enableHttp2": true,
-        "token": "token",
-      }
-    `);
-    expect(applyHostRule(url, opts, hostRule)).toMatchInlineSnapshot(`
-      {
-        "hostType": "github",
-        "token": "xxx",
-      }
-    `);
+    expect(hostRule).toEqual({
+      enableHttp2: true,
+      token: 'token',
+    });
+    expect(applyHostRule(url, opts, hostRule)).toEqual({
+      hostType: 'github',
+      token: 'xxx',
+    });
   });
 
   it('noAuth', () => {
     const opts = { ...options, noAuth: true };
     const hostRule = findMatchingRule(url, opts);
-    expect(hostRule).toMatchInlineSnapshot(`
-      {
-        "token": "token",
-      }
-    `);
-    expect(applyHostRule(url, opts, hostRule)).toMatchInlineSnapshot(`
-      {
-        "hostType": "github",
-        "noAuth": true,
-      }
-    `);
+    expect(hostRule).toEqual({
+      token: 'token',
+    });
+    expect(applyHostRule(url, opts, hostRule)).toEqual({
+      hostType: 'github',
+      noAuth: true,
+    });
   });
 
   it('certificateAuthority', () => {
@@ -223,19 +191,15 @@ describe('util/http/host-rules', () => {
     const url = 'https://custom.datasource.ca/data/path';
     const opts = { ...options, hostType: 'maven' };
     const hostRule = findMatchingRule(url, opts);
-    expect(hostRule).toMatchInlineSnapshot(`
-      {
-        "httpsCertificateAuthority": "ca-cert",
-      }
-    `);
-    expect(applyHostRule(url, opts, hostRule)).toMatchInlineSnapshot(`
-      {
-        "hostType": "maven",
-        "https": {
-          "certificateAuthority": "ca-cert",
-        },
-      }
-    `);
+    expect(hostRule).toEqual({
+      httpsCertificateAuthority: 'ca-cert',
+    });
+    expect(applyHostRule(url, opts, hostRule)).toEqual({
+      hostType: 'maven',
+      https: {
+        certificateAuthority: 'ca-cert',
+      },
+    });
   });
 
   it('privateKey', () => {
@@ -248,19 +212,15 @@ describe('util/http/host-rules', () => {
     const url = 'https://custom.datasource.key/data/path';
     const opts = { ...options, hostType: 'maven' };
     const hostRule = findMatchingRule(url, opts);
-    expect(hostRule).toMatchInlineSnapshot(`
-      {
-        "httpsPrivateKey": "key",
-      }
-    `);
-    expect(applyHostRule(url, opts, hostRule)).toMatchInlineSnapshot(`
-      {
-        "hostType": "maven",
-        "https": {
-          "key": "key",
-        },
-      }
-    `);
+    expect(hostRule).toEqual({
+      httpsPrivateKey: 'key',
+    });
+    expect(applyHostRule(url, opts, hostRule)).toEqual({
+      hostType: 'maven',
+      https: {
+        key: 'key',
+      },
+    });
   });
 
   it('certificate', () => {
@@ -273,19 +233,15 @@ describe('util/http/host-rules', () => {
     const url = 'https://custom.datasource.cert/data/path';
     const opts = { ...options, hostType: 'maven' };
     const hostRule = findMatchingRule(url, opts);
-    expect(hostRule).toMatchInlineSnapshot(`
-      {
-        "httpsCertificate": "cert",
-      }
-    `);
-    expect(applyHostRule(url, opts, hostRule)).toMatchInlineSnapshot(`
-      {
-        "hostType": "maven",
-        "https": {
-          "certificate": "cert",
-        },
-      }
-    `);
+    expect(hostRule).toEqual({
+      httpsCertificate: 'cert',
+    });
+    expect(applyHostRule(url, opts, hostRule)).toEqual({
+      hostType: 'maven',
+      https: {
+        certificate: 'cert',
+      },
+    });
   });
 
   it('no fallback to github', () => {
@@ -313,12 +269,10 @@ describe('util/http/host-rules', () => {
 
     opts = { ...options, hostType: 'github-releases' };
     hostRule = findMatchingRule(url, opts);
-    expect(hostRule).toMatchInlineSnapshot(`
-      {
-        "password": "xxx",
-        "username": "some",
-      }
-    `);
+    expect(hostRule).toEqual({
+      password: 'xxx',
+      username: 'some',
+    });
     expect(applyHostRule(url, opts, hostRule)).toEqual({
       hostType: 'github-releases',
       username: 'some',
@@ -327,12 +281,10 @@ describe('util/http/host-rules', () => {
 
     opts = { ...options, hostType: 'github-tags' };
     hostRule = findMatchingRule(url, opts);
-    expect(hostRule).toMatchInlineSnapshot(`
-      {
-        "password": "xxx2",
-        "username": "some2",
-      }
-    `);
+    expect(hostRule).toEqual({
+      password: 'xxx2',
+      username: 'some2',
+    });
     expect(applyHostRule(url, opts, hostRule)).toEqual({
       hostType: 'github-tags',
       username: 'some2',
@@ -341,11 +293,9 @@ describe('util/http/host-rules', () => {
 
     opts = { ...options, hostType: 'pod' };
     hostRule = findMatchingRule(url, opts);
-    expect(hostRule).toMatchInlineSnapshot(`
-      {
-        "token": "pod-token",
-      }
-    `);
+    expect(hostRule).toEqual({
+      token: 'pod-token',
+    });
     expect(applyHostRule(url, opts, hostRule)).toEqual({
       context: {
         authType: undefined,
@@ -356,11 +306,9 @@ describe('util/http/host-rules', () => {
 
     opts = { ...options, hostType: 'github-changelog' };
     hostRule = findMatchingRule(url, opts);
-    expect(hostRule).toMatchInlineSnapshot(`
-      {
-        "token": "changelogtoken",
-      }
-    `);
+    expect(hostRule).toEqual({
+      token: 'changelogtoken',
+    });
     expect(applyHostRule(url, opts, hostRule)).toEqual({
       context: {
         authType: undefined,
@@ -376,11 +324,9 @@ describe('util/http/host-rules', () => {
 
     opts = { ...options, hostType: 'github-tags' };
     hostRule = findMatchingRule(url, opts);
-    expect(hostRule).toMatchInlineSnapshot(`
-      {
-        "token": "token",
-      }
-    `);
+    expect(hostRule).toEqual({
+      token: 'token',
+    });
     expect(applyHostRule(url, opts, hostRule)).toEqual({
       context: {
         authType: undefined,
@@ -391,11 +337,9 @@ describe('util/http/host-rules', () => {
 
     opts = { ...options, hostType: 'github-changelog' };
     hostRule = findMatchingRule(url, opts);
-    expect(hostRule).toMatchInlineSnapshot(`
-      {
-        "token": "token",
-      }
-    `);
+    expect(hostRule).toEqual({
+      token: 'token',
+    });
     expect(applyHostRule(url, opts, hostRule)).toEqual({
       context: {
         authType: undefined,
@@ -406,11 +350,9 @@ describe('util/http/host-rules', () => {
 
     opts = { ...options, hostType: 'pod' };
     hostRule = findMatchingRule(url, opts);
-    expect(hostRule).toMatchInlineSnapshot(`
-      {
-        "token": "token",
-      }
-    `);
+    expect(hostRule).toEqual({
+      token: 'token',
+    });
     expect(applyHostRule(url, opts, hostRule)).toEqual({
       context: {
         authType: undefined,
@@ -439,11 +381,9 @@ describe('util/http/host-rules', () => {
 
     opts = { ...options, hostType: 'gitlab-tags' };
     hostRule = findMatchingRule(url, opts);
-    expect(hostRule).toMatchInlineSnapshot(`
-      {
-        "token": "tags-token",
-      }
-    `);
+    expect(hostRule).toEqual({
+      token: 'tags-token',
+    });
     expect(applyHostRule(url, opts, hostRule)).toEqual({
       context: {
         authType: undefined,
@@ -454,11 +394,9 @@ describe('util/http/host-rules', () => {
 
     opts = { ...options, hostType: 'gitlab-releases' };
     hostRule = findMatchingRule(url, opts);
-    expect(hostRule).toMatchInlineSnapshot(`
-      {
-        "token": "release-token",
-      }
-    `);
+    expect(hostRule).toEqual({
+      token: 'release-token',
+    });
     expect(applyHostRule(url, opts, hostRule)).toEqual({
       context: {
         authType: undefined,
@@ -469,11 +407,9 @@ describe('util/http/host-rules', () => {
 
     opts = { ...options, hostType: 'gitlab-packages' };
     hostRule = findMatchingRule(url, opts);
-    expect(hostRule).toMatchInlineSnapshot(`
-      {
-        "token": "package-token",
-      }
-    `);
+    expect(hostRule).toEqual({
+      token: 'package-token',
+    });
     expect(applyHostRule(url, opts, hostRule)).toEqual({
       context: {
         authType: undefined,
@@ -489,11 +425,9 @@ describe('util/http/host-rules', () => {
 
     opts = { ...options, hostType: 'gitlab-tags' };
     hostRule = findMatchingRule(url, opts);
-    expect(hostRule).toMatchInlineSnapshot(`
-      {
-        "token": "abc",
-      }
-    `);
+    expect(hostRule).toEqual({
+      token: 'abc',
+    });
     expect(applyHostRule(url, opts, hostRule)).toEqual({
       context: {
         authType: undefined,
@@ -504,11 +438,9 @@ describe('util/http/host-rules', () => {
 
     opts = { ...options, hostType: 'gitlab-releases' };
     hostRule = findMatchingRule(url, opts);
-    expect(hostRule).toMatchInlineSnapshot(`
-      {
-        "token": "abc",
-      }
-    `);
+    expect(hostRule).toEqual({
+      token: 'abc',
+    });
     expect(applyHostRule(url, opts, hostRule)).toEqual({
       context: {
         authType: undefined,
@@ -519,11 +451,9 @@ describe('util/http/host-rules', () => {
 
     opts = { ...options, hostType: 'gitlab-packages' };
     hostRule = findMatchingRule(url, opts);
-    expect(hostRule).toMatchInlineSnapshot(`
-      {
-        "token": "abc",
-      }
-    `);
+    expect(hostRule).toEqual({
+      token: 'abc',
+    });
     expect(applyHostRule(url, opts, hostRule)).toEqual({
       context: {
         authType: undefined,
@@ -534,11 +464,9 @@ describe('util/http/host-rules', () => {
 
     opts = { ...options, hostType: 'gitlab-changelog' };
     hostRule = findMatchingRule(url, opts);
-    expect(hostRule).toMatchInlineSnapshot(`
-      {
-        "token": "abc",
-      }
-    `);
+    expect(hostRule).toEqual({
+      token: 'abc',
+    });
     expect(applyHostRule(url, opts, hostRule)).toEqual({
       context: {
         authType: undefined,
@@ -556,12 +484,10 @@ describe('util/http/host-rules', () => {
     });
     const opts = { ...options, hostType: 'bitbucket-tags' };
     const hostRule = findMatchingRule(url, opts);
-    expect(hostRule).toMatchInlineSnapshot(`
-      {
-        "password": "xxx",
-        "username": "some",
-      }
-    `);
+    expect(hostRule).toEqual({
+      password: 'xxx',
+      username: 'some',
+    });
     expect(applyHostRule(url, opts, hostRule)).toEqual({
       hostType: 'bitbucket-tags',
       username: 'some',
@@ -572,11 +498,9 @@ describe('util/http/host-rules', () => {
   it('fallback to bitbucket', () => {
     const opts = { ...options, hostType: 'bitbucket-tags' };
     const hostRule = findMatchingRule(url, opts);
-    expect(hostRule).toMatchInlineSnapshot(`
-      {
-        "token": "cdef",
-      }
-    `);
+    expect(hostRule).toEqual({
+      token: 'cdef',
+    });
     expect(applyHostRule(url, opts, hostRule)).toEqual({
       context: {
         authType: undefined,
@@ -594,11 +518,9 @@ describe('util/http/host-rules', () => {
 
     const opts = { ...options, hostType: 'gitea-tags' };
     const hostRule = findMatchingRule(url, opts);
-    expect(hostRule).toMatchInlineSnapshot(`
-      {
-        "token": "abc",
-      }
-    `);
+    expect(hostRule).toEqual({
+      token: 'abc',
+    });
     expect(applyHostRule(url, opts, hostRule)).toEqual({
       context: {
         authType: undefined,
@@ -611,11 +533,9 @@ describe('util/http/host-rules', () => {
   it('fallback to gitea', () => {
     const opts = { ...options, hostType: 'gitea-tags' };
     const hostRule = findMatchingRule(url, opts);
-    expect(hostRule).toMatchInlineSnapshot(`
-      {
-        "password": "password",
-      }
-    `);
+    expect(hostRule).toEqual({
+      password: 'password',
+    });
     expect(applyHostRule(url, opts, hostRule)).toEqual({
       hostType: 'gitea-tags',
       password: 'password',

--- a/lib/util/http/host-rules.ts
+++ b/lib/util/http/host-rules.ts
@@ -34,9 +34,9 @@ export type HostRulesGotOptions = Pick<
   | 'https'
 >;
 
-export function findMatchingRules<GotOptions extends HostRulesGotOptions>(
-  options: GotOptions,
+export function findMatchingRule<GotOptions extends HostRulesGotOptions>(
   url: string,
+  options: GotOptions,
 ): HostRule {
   const { hostType } = options;
   let res = hostRules.find({ hostType, url });
@@ -114,13 +114,12 @@ export function findMatchingRules<GotOptions extends HostRulesGotOptions>(
 }
 
 // Apply host rules to requests
-export function applyHostRules<GotOptions extends HostRulesGotOptions>(
+export function applyHostRule<GotOptions extends HostRulesGotOptions>(
   url: string,
-  inOptions: GotOptions,
+  options: GotOptions,
+  hostRule: HostRule,
 ): GotOptions {
-  const options: GotOptions = { ...inOptions };
-  const foundRules = findMatchingRules(options, url);
-  const { username, password, token, enabled, authType } = foundRules;
+  const { username, password, token, enabled, authType } = hostRule;
   const host = parseUrl(url)?.host;
   if (options.noAuth) {
     logger.trace({ url }, `Authorization disabled`);
@@ -147,48 +146,48 @@ export function applyHostRules<GotOptions extends HostRulesGotOptions>(
     logger.once.debug(`hostRules: no authentication for ${host}`);
   }
   // Apply optional params
-  if (foundRules.abortOnError) {
-    options.abortOnError = foundRules.abortOnError;
+  if (hostRule.abortOnError) {
+    options.abortOnError = hostRule.abortOnError;
   }
 
-  if (foundRules.abortIgnoreStatusCodes) {
-    options.abortIgnoreStatusCodes = foundRules.abortIgnoreStatusCodes;
+  if (hostRule.abortIgnoreStatusCodes) {
+    options.abortIgnoreStatusCodes = hostRule.abortIgnoreStatusCodes;
   }
 
-  if (foundRules.timeout) {
-    options.timeout = foundRules.timeout;
+  if (hostRule.timeout) {
+    options.timeout = hostRule.timeout;
   }
 
-  if (foundRules.dnsCache) {
+  if (hostRule.dnsCache) {
     options.lookup = dnsLookup;
   }
 
-  if (foundRules.keepAlive) {
+  if (hostRule.keepAlive) {
     options.agent = keepAliveAgents;
   }
 
-  if (!hasProxy() && foundRules.enableHttp2 === true) {
+  if (!hasProxy() && hostRule.enableHttp2 === true) {
     options.http2 = true;
   }
 
-  if (is.nonEmptyString(foundRules.httpsCertificateAuthority)) {
+  if (is.nonEmptyString(hostRule.httpsCertificateAuthority)) {
     options.https = {
       ...(options.https ?? {}),
-      certificateAuthority: foundRules.httpsCertificateAuthority,
+      certificateAuthority: hostRule.httpsCertificateAuthority,
     };
   }
 
-  if (is.nonEmptyString(foundRules.httpsPrivateKey)) {
+  if (is.nonEmptyString(hostRule.httpsPrivateKey)) {
     options.https = {
       ...(options.https ?? {}),
-      key: foundRules.httpsPrivateKey,
+      key: hostRule.httpsPrivateKey,
     };
   }
 
-  if (is.nonEmptyString(foundRules.httpsCertificate)) {
+  if (is.nonEmptyString(hostRule.httpsCertificate)) {
     options.https = {
       ...(options.https ?? {}),
-      certificate: foundRules.httpsCertificate,
+      certificate: hostRule.httpsCertificate,
     };
   }
 

--- a/lib/util/http/index.ts
+++ b/lib/util/http/index.ts
@@ -13,7 +13,7 @@ import { type AsyncResult, Result } from '../result';
 import { resolveBaseUrl } from '../url';
 import { applyAuthorization, removeAuthorization } from './auth';
 import { hooks } from './hooks';
-import { applyHostRules } from './host-rules';
+import { applyHostRule, findMatchingRule } from './host-rules';
 import { getQueue } from './queue';
 import { Throttle, getThrottle } from './throttle';
 import type {
@@ -176,7 +176,8 @@ export class Http<Opts extends HttpOptions = HttpOptions> {
 
     applyDefaultHeaders(options);
 
-    options = applyHostRules(url, options);
+    const hostRule = findMatchingRule(url, options);
+    options = applyHostRule(url, options, hostRule);
     if (options.enabled === false) {
       logger.debug(`Host is disabled - rejecting request. HostUrl: ${url}`);
       throw new Error(HOST_DISABLED);
@@ -486,7 +487,8 @@ export class Http<Opts extends HttpOptions = HttpOptions> {
     }
 
     applyDefaultHeaders(combinedOptions);
-    combinedOptions = applyHostRules(resolvedUrl, combinedOptions);
+    const hostRule = findMatchingRule(url, combinedOptions);
+    combinedOptions = applyHostRule(resolvedUrl, combinedOptions, hostRule);
     if (combinedOptions.enabled === false) {
       throw new Error(HOST_DISABLED);
     }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Rename `findMatchingRules` to `findMatchingRule`
- Rename `applyHostRules` to `applyHostRule`
- Move `findMatchingRule` call out of the `applyHostRule` body
- Refactor tests

## Context

- Ref: #25499
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
