### PR TITLE
fix(helmfile): make resolving deps in multi-doc files more stable

### DIFF
--- a/lib/modules/manager/helmfile/__fixtures__/multidoc.yaml
+++ b/lib/modules/manager/helmfile/__fixtures__/multidoc.yaml
@@ -26,6 +26,8 @@ repositories:
 - name: prometheus-community
   url: https://prometheus-community.github.io/helm-charts
 
+---
+
 templates:
   external-chart: &external-chart
     missingFileHandler: Debug

--- a/lib/modules/manager/helmfile/extract.spec.ts
+++ b/lib/modules/manager/helmfile/extract.spec.ts
@@ -14,6 +14,19 @@ describe('modules/manager/helmfile/extract', () => {
       GlobalConfig.set({ localDir });
     });
 
+    it('skip null YAML document', async () => {
+      const content = `
+      ~
+      `;
+      const fileName = 'helmfile.yaml';
+      const result = await extractPackageFile(content, fileName, {
+        registryAliases: {
+          stable: 'https://charts.helm.sh/stable',
+        },
+      });
+      expect(result).toBeNull();
+    });
+
     it('returns null if no releases', async () => {
       const content = `
       repositories:

--- a/lib/modules/manager/helmfile/extract.spec.ts
+++ b/lib/modules/manager/helmfile/extract.spec.ts
@@ -1,3 +1,4 @@
+import { codeBlock } from 'common-tags';
 import { Fixtures } from '../../../../test/fixtures';
 import { fs } from '../../../../test/util';
 import { GlobalConfig } from '../../../config/global';
@@ -15,9 +16,9 @@ describe('modules/manager/helmfile/extract', () => {
     });
 
     it('skip null YAML document', async () => {
-      const content = `
-      ~
-      `;
+      const content = codeBlock`
+        ~
+        `;
       const fileName = 'helmfile.yaml';
       const result = await extractPackageFile(content, fileName, {
         registryAliases: {

--- a/lib/modules/manager/helmfile/extract.ts
+++ b/lib/modules/manager/helmfile/extract.ts
@@ -46,7 +46,7 @@ export async function extractPackageFile(
     );
     return null;
   }
-  for (const [docIndex, doc] of docs.entries()) {
+  for (const doc of docs) {
     if (!doc) {
       continue;
     }
@@ -58,8 +58,8 @@ export async function extractPackageFile(
         registryAliases[doc.repositories[i].name] = doc.repositories[i].url;
       }
       logger.debug(
-        { registryAliases },
-        `repositories discovered in document ${docIndex + 1} in ${packageFile}`,
+        { registryAliases, packageFile },
+        `repositories discovered.`,
       );
     }
 

--- a/lib/modules/manager/helmfile/extract.ts
+++ b/lib/modules/manager/helmfile/extract.ts
@@ -42,7 +42,7 @@ export async function extractPackageFile(
   } catch (err) {
     logger.debug(
       { err, packageFile },
-      `Failed to parse helmfile ${packageFile}`,
+      'Failed to parse helmfile helmfile.yaml',
     );
     return null;
   }


### PR DESCRIPTION
## Changes

Renovate doesn't manage to resolve dependencies anymore when there is a YAML document separator between repositories and releases. This is achieved by not `continue`'ing anymore when the document doesn't contain a releases block. Repositories that have potentionally been discovered in a document before are overriden (same as YAML would do).

## Context

The Renovate dependency resolution breaks when a Helmfile contains a document separator between the repositories and the releases blocks. Using a document separator can be necessary when working with environments, as the following example Helmfile output shows:

```
$ helmfile -e qa template
Warning: environments and releases cannot be defined within the same YAML part. Use --- to extract the environments into a dedicated part
Warning: environments and releases cannot be defined within the same YAML part. Use --- to extract the environments into a dedicated part
...
```

Since these blocks are lists, they can not be extended in later documents. so e.g. a repositories list defined in the first document would completely be overridden by a repositories list in a later document (that's normal YAML behaviour). The Renovate manager should be adjusted to mimic this behaviour and properly support multi-document Helmfiles.

The following [simple example from the Helmfile documentation](https://helmfile.readthedocs.io/en/stable/#getting-started) can be used for reproducing the issue.

Before working:

```yaml
environments:
  qa:
  staging:
  prod:

## document separator to satisfy Helmfile:
---

repositories:
 - name: prometheus-community
   url: https://prometheus-community.github.io/helm-charts

releases:
- name: prom-norbac-ubuntu
  namespace: prometheus
  chart: prometheus-community/prometheus
  ## Add a version to the example
  version: 25.7.0
  set:
  - name: rbac.create
    value: false
```

Before not working:

```yaml
environments:
  qa:
  staging:
  prod:

repositories:
 - name: prometheus-community
   url: https://prometheus-community.github.io/helm-charts

## document separator to satisfy Helmfile:
---

releases:
- name: prom-norbac-ubuntu
  namespace: prometheus
  chart: prometheus-community/prometheus
  ## Add a version to the example
  version: 25.7.0
  set:
  - name: rbac.create
    value: false
```

With this PR, both variants are now working.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

Closes #26077