### PR TITLE
feat(manager/gradle-wrapper): change wrapper task to :wrapper

### DIFF
--- a/lib/modules/manager/gradle-wrapper/artifacts.spec.ts
+++ b/lib/modules/manager/gradle-wrapper/artifacts.spec.ts
@@ -112,7 +112,7 @@ describe('modules/manager/gradle-wrapper/artifacts', () => {
       );
       expect(execSnapshots).toMatchObject([
         {
-          cmd: './gradlew wrapper --gradle-distribution-url https://services.gradle.org/distributions/gradle-6.3-bin.zip',
+          cmd: './gradlew :wrapper --gradle-distribution-url https://services.gradle.org/distributions/gradle-6.3-bin.zip',
           options: {
             cwd: '/tmp/github/some/repo',
             encoding: 'utf-8',
@@ -162,7 +162,7 @@ describe('modules/manager/gradle-wrapper/artifacts', () => {
       expect(result).toBeEmptyArray();
       expect(execSnapshots).toMatchObject([
         {
-          cmd: './gradlew wrapper --gradle-version 5.6.4',
+          cmd: './gradlew :wrapper --gradle-version 5.6.4',
           options: { cwd: '/tmp/github/some/repo' },
         },
       ]);
@@ -219,7 +219,7 @@ describe('modules/manager/gradle-wrapper/artifacts', () => {
             ' bash -l -c "' +
             'install-tool java 11.0.1' +
             ' && ' +
-            './gradlew wrapper --gradle-distribution-url https://services.gradle.org/distributions/gradle-6.3-bin.zip --gradle-distribution-sha256-sum 038794feef1f4745c6347107b6726279d1c824f3fc634b60f86ace1e9fbd1768' +
+            './gradlew :wrapper --gradle-distribution-url https://services.gradle.org/distributions/gradle-6.3-bin.zip --gradle-distribution-sha256-sum 038794feef1f4745c6347107b6726279d1c824f3fc634b60f86ace1e9fbd1768' +
             '"',
           options: { cwd: '/tmp/github/some/repo' },
         },
@@ -261,7 +261,7 @@ describe('modules/manager/gradle-wrapper/artifacts', () => {
       expect(execSnapshots).toMatchObject([
         { cmd: 'install-tool java 11.0.1' },
         {
-          cmd: './gradlew wrapper --gradle-distribution-url https://services.gradle.org/distributions/gradle-6.3-bin.zip --gradle-distribution-sha256-sum 038794feef1f4745c6347107b6726279d1c824f3fc634b60f86ace1e9fbd1768',
+          cmd: './gradlew :wrapper --gradle-distribution-url https://services.gradle.org/distributions/gradle-6.3-bin.zip --gradle-distribution-sha256-sum 038794feef1f4745c6347107b6726279d1c824f3fc634b60f86ace1e9fbd1768',
           options: { cwd: '/tmp/github/some/repo' },
         },
       ]);
@@ -328,7 +328,7 @@ describe('modules/manager/gradle-wrapper/artifacts', () => {
       );
       expect(execSnapshots).toMatchObject([
         {
-          cmd: './gradlew wrapper --gradle-distribution-url https://services.gradle.org/distributions/gradle-6.3-bin.zip',
+          cmd: './gradlew :wrapper --gradle-distribution-url https://services.gradle.org/distributions/gradle-6.3-bin.zip',
           options: {
             cwd: '/tmp/github/some/repo/sub',
             encoding: 'utf-8',
@@ -458,7 +458,7 @@ describe('modules/manager/gradle-wrapper/artifacts', () => {
       expect(res).toStrictEqual(updatedArtifacts);
       expect(execSnapshots).toMatchObject([
         {
-          cmd: './gradlew wrapper --gradle-version 8.2',
+          cmd: './gradlew :wrapper --gradle-version 8.2',
         },
       ]);
     });

--- a/lib/modules/manager/gradle-wrapper/artifacts.ts
+++ b/lib/modules/manager/gradle-wrapper/artifacts.ts
@@ -146,7 +146,7 @@ export async function updateArtifacts({
       logger.info('No gradlew found - skipping Artifacts update');
       return null;
     }
-    cmd += ' wrapper';
+    cmd += ' :wrapper';
 
     let checksum: string | null = null;
     const distributionUrl = getDistributionUrl(newPackageFileContent);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Replaces the call to `gradlew wrapper` with `gradlew :wrapper`. This causes the `wrapper` task to run only on the root project and not sub-projects.

As a result, the runtime of `gradle-wrapper` updates should improve (depending on the project size) and also the likelihood that updates of `gradle-wrapper.jar` won't fail with error: `Error executing gradle wrapper update command. It can be not a critical one though.` (especially Android app builds that lack the Android SDK). 

A consequence of this change is that custom `wrapper` definitions in sub-projects are now ignored. In fact, they are highly uncommon anyway since sub-projects typically inherit `wrapper` properties from the root project. Still it should be noted that this behavior [differs from the official gradle documentation](https://docs.gradle.org/current/userguide/gradle_wrapper.html#sec:upgrading_wrapper) and may need to be reverted in case of yet unknown side effects.

<!-- Describe what behavior is changed by this PR. -->

## Context

- https://github.com/renovatebot/renovate/discussions/26050

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

Reproduction repo working now:
- https://github.com/renovate-demo/26050-renovate-gradle-wrapper-bug-reproducer/pull/1

Confirmed that result is unchanged using reproduction repos from previous `gradle-wrapper` PRs:
- gradle-wrapper update with version update in build.gradle
  - https://github.com/renovate-demo/26050-renovate-bot-gradle-build-minimal-repo/pull/2
  - ref: https://github.com/renovatebot/renovate/pull/17290:
- gradle-wrapper update with lockfile refresh
  - https://github.com/renovate-demo/26050-renovate-gradle-lockfile-test/pull/1
  - ref: https://github.com/renovatebot/renovate/pull/23081

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
