### PR TITLE
feat(config): add `.gitea/renovate.json` to valid config locations

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -16,6 +16,8 @@ You can store your Renovate configuration file in one of these locations:
 1. `.github/renovate.json5`
 1. `.gitlab/renovate.json`
 1. `.gitlab/renovate.json5`
+1. `.gitea/renovate.json`
+1. `.gitea/renovate.json5`
 1. `.renovaterc`
 1. `.renovaterc.json`
 1. `.renovaterc.json5`

--- a/docs/usage/getting-started/installing-onboarding.md
+++ b/docs/usage/getting-started/installing-onboarding.md
@@ -79,6 +79,8 @@ If you don't want a `renovate.json` file in your repository you can use one of t
 - `.github/renovate.json5`
 - `.gitlab/renovate.json`
 - `.gitlab/renovate.json5`
+- `.gitea/renovate.json`
+- `.gitea/renovate.json5`
 - `.renovaterc`
 - `.renovaterc.json`
 - `.renovaterc.json5`

--- a/lib/config/app-strings.ts
+++ b/lib/config/app-strings.ts
@@ -5,6 +5,8 @@ export const configFileNames = [
   '.github/renovate.json5',
   '.gitlab/renovate.json',
   '.gitlab/renovate.json5',
+  '.gitea/renovate.json',
+  '.gitea/renovate.json5',
   '.renovaterc',
   '.renovaterc.json',
   '.renovaterc.json5',

--- a/lib/workers/repository/init/merge.spec.ts
+++ b/lib/workers/repository/init/merge.spec.ts
@@ -229,6 +229,19 @@ describe('workers/repository/init/merge', () => {
       });
     });
 
+    it('finds .gitea/renovate.json', async () => {
+      scm.getFileList.mockResolvedValue([
+        'package.json',
+        '.gitea/renovate.json',
+      ]);
+      fs.readLocalFile.mockResolvedValue('{}');
+      expect(await detectRepoFileConfig()).toEqual({
+        configFileName: '.gitea/renovate.json',
+        configFileParsed: {},
+        configFileRaw: '{}',
+      });
+    });
+
     it('finds .renovaterc.json', async () => {
       scm.getFileList.mockResolvedValue(['package.json', '.renovaterc.json']);
       fs.readLocalFile.mockResolvedValue('{}');


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Accept `.gitea/renovate.json`  as a valid location for the repository configuration file.

## Context

Gitea supports actions simular and mostly compatible with github actions, the workflows are stored in `.gitea/workflows`, so i think it would be interesting to be possible to store the renovate configuration in the `.gitea` folder.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
