### PR TITLE
feat(presets): add russh monorepo

### DIFF
--- a/lib/config/presets/internal/monorepo.ts
+++ b/lib/config/presets/internal/monorepo.ts
@@ -512,6 +512,9 @@ const patternGroups = {
   fullcalendar: '^@fullcalendar/',
   hotchocolate: '^HotChocolate\\.',
   'prometheus-simpleclient': '^io.prometheus:simpleclient',
+  // Can't specify the russh repo (https://github.com/warp-tech/russh) in repoGroups because parts
+  // of it (e.g. russh-config) are released separately.
+  russh: ['^russh$', '^russh-keys$'],
   spfx: ['^@microsoft/sp-', '^@microsoft/eslint-.+-spfx$'],
   spock: '^org\\.spockframework:spock-',
   'syncfusion-dotnet': '^Syncfusion\\.',


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Add the Rust russh monorepo to presets.

As it currently stands, the Rust russh monorepo appears to consist of two crates that are released monolithically (russh and russh-keys) and one crate that isn't (russh-config). This means that we sadly can't just specify the russh monorepo via its URL.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository