### PR TITLE
fix(presets): update smithy-rs monorepo

### DIFF
--- a/lib/config/presets/internal/monorepo.ts
+++ b/lib/config/presets/internal/monorepo.ts
@@ -52,6 +52,7 @@ const repoGroups = {
   'aws-sdk-net': 'https://github.com/aws/aws-sdk-net',
   'aws-sdk-rust': [
     'https://github.com/smithy-lang/smithy-rs',
+    'https://github.com/awslabs/smithy-rs',
     'https://github.com/awslabs/aws-sdk-rust',
   ],
   awsappsync: 'https://github.com/awslabs/aws-mobile-appsync-sdk-js',

--- a/lib/config/presets/internal/monorepo.ts
+++ b/lib/config/presets/internal/monorepo.ts
@@ -51,7 +51,7 @@ const repoGroups = {
   'aws-sdk-js-v3': 'https://github.com/aws/aws-sdk-js-v3',
   'aws-sdk-net': 'https://github.com/aws/aws-sdk-net',
   'aws-sdk-rust': [
-    'https://github.com/awslabs/smithy-rs',
+    'https://github.com/smithy-lang/smithy-rs',
     'https://github.com/awslabs/aws-sdk-rust',
   ],
   awsappsync: 'https://github.com/awslabs/aws-mobile-appsync-sdk-js',


### PR DESCRIPTION
## Changes

It looks like the repository got move to another GitHub org...

## Context

see https://github.com/smithy-lang/smithy-rs

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
