### PR TITLE
feat: add gitlab openssf scorecards

### DIFF
--- a/lib/config/presets/internal/security.ts
+++ b/lib/config/presets/internal/security.ts
@@ -5,7 +5,7 @@ export const presets: Record<string, Preset> = {
     description: 'Show OpenSSF badge on pull requests.',
     packageRules: [
       {
-        matchSourceUrlPrefixes: ['https://github.com/','https://gitlab.com'],
+        matchSourceUrlPrefixes: ['https://github.com/', 'https://gitlab.com'],
         prBodyDefinitions: {
           OpenSSF:
             '[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/{{platform}}.com/{{sourceRepo}}/badge)](https://securityscorecards.dev/viewer/?uri={{platform}}.com/{{sourceRepo}})',

--- a/lib/config/presets/internal/security.ts
+++ b/lib/config/presets/internal/security.ts
@@ -5,10 +5,10 @@ export const presets: Record<string, Preset> = {
     description: 'Show OpenSSF badge on pull requests.',
     packageRules: [
       {
-        matchSourceUrlPrefixes: ['https://github.com/'],
+        matchSourceUrlPrefixes: ['https://github.com/','https://gitlab.com'],
         prBodyDefinitions: {
           OpenSSF:
-            '[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/{{sourceRepo}}/badge)](https://securityscorecards.dev/viewer/?uri=github.com/{{sourceRepo}})',
+            '[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/{{platform}}.com/{{sourceRepo}}/badge)](https://securityscorecards.dev/viewer/?uri={{platform}}.com/{{sourceRepo}})',
         },
         prBodyColumns: [
           'Package',

--- a/lib/config/presets/internal/security.ts
+++ b/lib/config/presets/internal/security.ts
@@ -8,7 +8,7 @@ export const presets: Record<string, Preset> = {
         matchSourceUrlPrefixes: ['https://github.com/', 'https://gitlab.com'],
         prBodyDefinitions: {
           OpenSSF:
-            '[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/{{platform}}.com/{{sourceRepo}}/badge)](https://securityscorecards.dev/viewer/?uri={{platform}}.com/{{sourceRepo}})',
+            "[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/{{{ replace '(^https?://)?' '' sourceUrl }}}/badge)](https://securityscorecards.dev/viewer/?uri={{{ replace '(^https?://)?' '' sourceUrl }}})",
         },
         prBodyColumns: [
           'Package',


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Adds OpenSSF scorecard reporting for GitLab.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

Adding following testing as part of https://github.com/renovatebot/renovate/discussions/25125#discussioncomment-7769281

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [X] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
