### PR TITLE
feat(templating): adds encodeBase64 handlebars helper

### DIFF
--- a/docs/usage/templates.md
+++ b/docs/usage/templates.md
@@ -59,6 +59,14 @@ In the example above `depName` is the string you want to decode.
 
 Read the [MDN Web Docs, decodeURIComponent()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/decodeURIComponent) to learn more.
 
+### encodeBase64
+
+If you want to convert a string to Base64, use the built-in function `encodeBase64` like this:
+
+`{{{encodeBase64 body}}}`
+
+In the example above `body` is the string you want to transform into a Base64-encoded value.
+
 ### replace
 
 The `replace` helper replaces _all_ found strings matching the given regex with the replacement string.

--- a/lib/util/template/index.spec.ts
+++ b/lib/util/template/index.spec.ts
@@ -219,6 +219,16 @@ describe('util/template/index', () => {
     });
   });
 
+  describe('base64 encoding', () => {
+    it('encodes values', () => {
+      const output = template.compile(
+        '{{{encodeBase64 "@fsouza/prettierd"}}}',
+        undefined as never,
+      );
+      expect(output).toBe('QGZzb3V6YS9wcmV0dGllcmQ=');
+    });
+  });
+
   describe('equals', () => {
     it('equals', () => {
       const output = template.compile(

--- a/lib/util/template/index.spec.ts
+++ b/lib/util/template/index.spec.ts
@@ -227,6 +227,20 @@ describe('util/template/index', () => {
       );
       expect(output).toBe('QGZzb3V6YS9wcmV0dGllcmQ=');
     });
+
+    it('handles null values gracefully', () => {
+      const output = template.compile('{{{encodeBase64 packageName}}}', {
+        packageName: null,
+      });
+      expect(output).toBe('');
+    });
+
+    it('handles undefined values gracefully', () => {
+      const output = template.compile('{{{encodeBase64 packageName}}}', {
+        packageName: undefined,
+      });
+      expect(output).toBe('');
+    });
   });
 
   describe('equals', () => {

--- a/lib/util/template/index.ts
+++ b/lib/util/template/index.ts
@@ -8,6 +8,10 @@ import { regEx } from '../regex';
 handlebars.registerHelper('encodeURIComponent', encodeURIComponent);
 handlebars.registerHelper('decodeURIComponent', decodeURIComponent);
 
+handlebars.registerHelper('encodeBase64', (str: string) =>
+  Buffer.from(str).toString('base64'),
+);
+
 handlebars.registerHelper('stringToPrettyJSON', (input: string): string =>
   JSON.stringify(JSON.parse(input), null, 2),
 );

--- a/lib/util/template/index.ts
+++ b/lib/util/template/index.ts
@@ -9,7 +9,7 @@ handlebars.registerHelper('encodeURIComponent', encodeURIComponent);
 handlebars.registerHelper('decodeURIComponent', decodeURIComponent);
 
 handlebars.registerHelper('encodeBase64', (str: string) =>
-  Buffer.from(str).toString('base64'),
+  Buffer.from(str ?? '').toString('base64'),
 );
 
 handlebars.registerHelper('stringToPrettyJSON', (input: string): string =>


### PR DESCRIPTION
## Changes

Adds a `encodeBase64` handlebars helper that encodes a string to Base64.

## Context

When using template variables with strings that may contain special characters, it makes it more
difficult to use with commands.

Consider this example:

```json
"postUpgradeTasks": [
  "echo \"{{body}}\" > file.md"
]
```

The value of the `body` variable contains the full changelog, which may contain _anything_.

Renovate will replace the variable, _before_ the command runs, and thus it will result in a command:

```sh
echo "This is a changelog" > file.md
```

But if the `body` variable contains a double quote, the command will fail:

```sh
echo "This is "a" changelog" > file.md
```

By encoding the values in Base64, we can avoid this issue:

```json
"postUpgradeTasks": [
  "echo \"{{encodeBase64 body}}\" | base64 -d > file.md"
]
```

Related discussion: <https://github.com/renovatebot/renovate/discussions/26175>

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
