### PR TITLE
fix(config): ignore GITHUB_COM_TOKEN when detectHostRulesFromEnv=true

### DIFF
--- a/lib/workers/global/config/parse/host-rules-from-env.spec.ts
+++ b/lib/workers/global/config/parse/host-rules-from-env.spec.ts
@@ -1,3 +1,4 @@
+import { logger } from '../../../../../test/util';
 import { hostRulesFromEnv } from './host-rules-from-env';
 
 describe('workers/global/config/parse/host-rules-from-env', () => {
@@ -91,6 +92,7 @@ describe('workers/global/config/parse/host-rules-from-env', () => {
 
   it('supports platform env token', () => {
     const envParam: NodeJS.ProcessEnv = {
+      GITHUB_COM_TOKEN: 'this-should-be-ignored-here',
       GITHUB_SOME_GITHUB__ENTERPRISE_HOST_TOKEN: 'some-token',
     };
     expect(hostRulesFromEnv(envParam)).toMatchObject([
@@ -100,6 +102,7 @@ describe('workers/global/config/parse/host-rules-from-env', () => {
         token: 'some-token',
       },
     ]);
+    expect(logger.logger.warn).not.toHaveBeenCalled();
   });
 
   it('rejects incomplete datasource env token', () => {

--- a/lib/workers/global/config/parse/host-rules-from-env.ts
+++ b/lib/workers/global/config/parse/host-rules-from-env.ts
@@ -61,6 +61,9 @@ export function hostRulesFromEnv(env: NodeJS.ProcessEnv): HostRule[] {
   const npmEnvPrefixes = ['npm_config_', 'npm_lifecycle_', 'npm_package_'];
 
   for (const envName of Object.keys(env).sort()) {
+    if (envName === 'GITHUB_COM_TOKEN') {
+      continue;
+    }
     if (npmEnvPrefixes.some((prefix) => envName.startsWith(prefix))) {
       logger.trace('Ignoring npm env: ' + envName);
       continue;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Ignore GITHUB_COM_TOKEN when parsing for detectHostRulesFromEnv

## Context

Fixes #26210

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
