### PR TITLE
fix(repo-cache): pass relative paths to fs layer

### DIFF
--- a/lib/util/cache/repository/impl/local.spec.ts
+++ b/lib/util/cache/repository/impl/local.spec.ts
@@ -188,7 +188,7 @@ describe('util/cache/repository/impl/local', () => {
       `Repository cache type not supported using type "local" instead`,
     );
     expect(fs.outputCacheFile).toHaveBeenCalledWith(
-      '/tmp/cache/renovate/repository/github/some/repo.json',
+      'renovate/repository/github/some/repo.json',
       JSON.stringify(newCacheRecord),
     );
   });

--- a/lib/util/cache/repository/impl/local.ts
+++ b/lib/util/cache/repository/impl/local.ts
@@ -1,5 +1,4 @@
 import upath from 'upath';
-import { GlobalConfig } from '../../../../config/global';
 import { logger } from '../../../../logger';
 import { cachePathExists, outputCacheFile, readCacheFile } from '../../../fs';
 import type { RepoCacheRecord } from '../schema';
@@ -30,10 +29,9 @@ export class RepoCacheLocal extends RepoCacheBase {
   }
 
   private getCacheFileName(): string {
-    const cacheDir = GlobalConfig.get('cacheDir');
-    const repoCachePath = '/renovate/repository/';
+    const repoCachePath = 'renovate/repository/';
     const platform = this.platform;
     const fileName = `${this.repository}.json`;
-    return upath.join(cacheDir, repoCachePath, platform, fileName);
+    return upath.join(repoCachePath, platform, fileName);
   }
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
fs layer will add the cache path for us
<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
