### PR TITLE
fix(dashboard): improve note

### DIFF
--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -1823,6 +1823,7 @@ export function massageMarkdown(input: string): string {
     )
     .replace(regEx(/]\(https:\/\/github\.com\//g), '](https://togithub.com/')
     .replace(regEx(/]: https:\/\/github\.com\//g), ']: https://togithub.com/')
+    .replace('> ℹ **Note**\n> \n', '> [!NOTE]\n')
     .replace('> ⚠ **Warning**\n> \n', '> [!WARNING]\n')
     .replace('> ❗ **Important**\n> \n', '> [!IMPORTANT]\n');
   return smartTruncate(massagedInput, GitHubMaxPrBodyLen);

--- a/lib/workers/repository/dependency-dashboard.spec.ts
+++ b/lib/workers/repository/dependency-dashboard.spec.ts
@@ -1036,7 +1036,7 @@ describe('workers/repository/dependency-dashboard', () => {
 
       describe('PackageFiles.getDashboardMarkdown()', () => {
         const note =
-          '> **Note**\n\n> Detected dependencies section has been truncated\n';
+          '> ℹ **Note**\n> \n> Detected dependencies section has been truncated\n\n';
         const title = `## Detected dependencies\n\n`;
 
         beforeEach(() => {

--- a/lib/workers/repository/package-files.ts
+++ b/lib/workers/repository/package-files.ts
@@ -33,7 +33,7 @@ export class PackageFiles {
    */
   static getDashboardMarkdown(maxLength: number, setHeader = true): string {
     const note =
-      '> **Note**\n\n> Detected dependencies section has been truncated\n';
+      '> ℹ **Note**\n> \n> Detected dependencies section has been truncated\n\n';
     const title = `## Detected dependencies\n\n`;
 
     // exclude header length from the available space


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

### non-GitHub platform

```md
> ℹ **Note**
> 
> Detected dependencies section has been truncated
```

> ℹ **Note**
> 
> Detected dependencies section has been truncated

### GitHub platform

```md
> [!NOTE]
> Detected dependencies section has been truncated
```

> [!NOTE]
> Detected dependencies section has been truncated

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

The current note has some newline issues and its format can be improved

```md
> **Note**

> Detected dependencies section has been truncated
```

> **Note**

> Detected dependencies section has been truncated

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
