### PR TITLE
fix(onboarding): fix semantic ignored onboarding PRs

### DIFF
--- a/lib/workers/repository/onboarding/branch/check.ts
+++ b/lib/workers/repository/onboarding/branch/check.ts
@@ -11,6 +11,7 @@ import { scm } from '../../../../modules/platform/scm';
 import { getCache } from '../../../../util/cache/repository';
 import { readLocalFile } from '../../../../util/fs';
 import { getBranchCommit } from '../../../../util/git';
+import { getSemanticCommitPrTitle } from '../common';
 
 async function findFile(fileName: string): Promise<boolean> {
   logger.debug(`findFile(${fileName})`);
@@ -41,13 +42,21 @@ async function packageJsonConfigExists(): Promise<boolean> {
   return false;
 }
 
-function closedPrExists(config: RenovateConfig): Promise<Pr | null> {
-  return platform.findPr({
-    branchName: config.onboardingBranch!,
-    prTitle: config.onboardingPrTitle,
-    state: '!open',
-    targetBranch: config.baseBranch,
-  });
+async function closedPrExists(config: RenovateConfig): Promise<Pr | null> {
+  return (
+    (await platform.findPr({
+      branchName: config.onboardingBranch!,
+      prTitle: config.onboardingPrTitle,
+      state: '!open',
+      targetBranch: config.baseBranch,
+    })) ??
+    (await platform.findPr({
+      branchName: config.onboardingBranch!,
+      prTitle: getSemanticCommitPrTitle(config),
+      state: '!open',
+      targetBranch: config.baseBranch,
+    }))
+  );
 }
 
 export async function isOnboarded(config: RenovateConfig): Promise<boolean> {

--- a/lib/workers/repository/onboarding/common.ts
+++ b/lib/workers/repository/onboarding/common.ts
@@ -3,6 +3,10 @@ import type { RenovateConfig } from '../../../config/types';
 import { logger } from '../../../logger';
 import * as memCache from '../../../util/cache/memory';
 
+export function getSemanticCommitPrTitle(config: RenovateConfig): string {
+  return `${config.semanticCommitType ?? 'chore'}: ${config.onboardingPrTitle}`;
+}
+
 export function defaultConfigFile(config: RenovateConfig): string {
   return configFileNames.includes(config.onboardingConfigFileName!)
     ? config.onboardingConfigFileName!

--- a/lib/workers/repository/onboarding/pr/index.ts
+++ b/lib/workers/repository/onboarding/pr/index.ts
@@ -21,7 +21,11 @@ import { getPlatformPrOptions } from '../../update/pr';
 import { prepareLabels } from '../../update/pr/labels';
 import { addParticipants } from '../../update/pr/participants';
 import { isOnboardingBranchConflicted } from '../branch/onboarding-branch-cache';
-import { OnboardingState, defaultConfigFile } from '../common';
+import {
+  OnboardingState,
+  defaultConfigFile,
+  getSemanticCommitPrTitle,
+} from '../common';
 import { getBaseBranchDesc } from './base-branch';
 import { getConfigDesc } from './config-description';
 import { getPrList } from './pr-list';
@@ -175,9 +179,7 @@ If you need any further assistance then you can also [request help here](${
       // TODO #22198
       const prTitle =
         config.semanticCommits === 'enabled'
-          ? `${config.semanticCommitType ?? 'chore'}: ${
-              config.onboardingPrTitle
-            }`
+          ? getSemanticCommitPrTitle(config)
           : config.onboardingPrTitle!;
       const pr = await platform.createPr({
         sourceBranch: config.onboardingBranch!,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds extra check for semantic commit onboarding PRs so that they can be closed ignored.

## Context

Fixes #26090

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
