### PR TITLE
fix(manager/git-submodules): Fix branch detection for special branch value `.`

### DIFF
--- a/lib/modules/manager/git-submodules/extract.ts
+++ b/lib/modules/manager/git-submodules/extract.ts
@@ -70,7 +70,7 @@ async function getBranch(
   ).trim();
 
   return branchFromConfig === '.'
-    ? (await git.branch(['--show-current'])).current.trim()
+    ? (await git.branch(['--list'])).current.trim()
     : branchFromConfig || (await getDefaultBranch(subModuleUrl)).trim();
 }
 


### PR DESCRIPTION
Fix branch detection due to GitSimple "--show-current" always returning empty values.

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Use "--list" option instead of "--show-current" to get the name of the current branch.

## Context

The current option was not working as expected, as it was always returning empty values :
`{"all":[],"branches":{},"current":"","detached":false}`
Due to this, the detected branch was always an empty string when using the special branch value `.`

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
