### PR TITLE
feat(bitbucket): Server-side filtering of PR list response

### DIFF
--- a/lib/modules/platform/bitbucket/index.spec.ts
+++ b/lib/modules/platform/bitbucket/index.spec.ts
@@ -3,6 +3,7 @@ import type { logger as _logger } from '../../../logger';
 import type * as _git from '../../../util/git';
 import { setBaseUrl } from '../../../util/http/bitbucket';
 import type { Platform, PlatformResult, RepoParams } from '../types';
+import { prFieldsFilter } from './utils';
 
 jest.mock('../../../util/git');
 jest.mock('../../../util/host-rules');
@@ -235,7 +236,7 @@ describe('modules/platform/bitbucket/index', () => {
       const scope = await initRepoMock();
       scope
         .get(
-          '/2.0/repositories/some/repo/pullrequests?state=OPEN&state=MERGED&state=DECLINED&state=SUPERSEDED&pagelen=50',
+          `/2.0/repositories/some/repo/pullrequests?state=OPEN&state=MERGED&state=DECLINED&state=SUPERSEDED&fields=${prFieldsFilter}&pagelen=50`,
         )
         .reply(200, { values: [pr] })
         .get('/2.0/repositories/some/repo/pullrequests/5')
@@ -248,7 +249,7 @@ describe('modules/platform/bitbucket/index', () => {
       const scope = await initRepoMock();
       scope
         .get(
-          '/2.0/repositories/some/repo/pullrequests?state=OPEN&state=MERGED&state=DECLINED&state=SUPERSEDED&pagelen=50',
+          `/2.0/repositories/some/repo/pullrequests?state=OPEN&state=MERGED&state=DECLINED&state=SUPERSEDED&fields=${prFieldsFilter}&pagelen=50`,
         )
         .reply(200, { values: [pr] });
 
@@ -753,7 +754,7 @@ describe('modules/platform/bitbucket/index', () => {
       await initRepoMock(undefined, null, scope);
       scope
         .get(
-          '/2.0/repositories/some/repo/pullrequests?state=OPEN&state=MERGED&state=DECLINED&state=SUPERSEDED&q=author.uuid="12345"&pagelen=50',
+          `/2.0/repositories/some/repo/pullrequests?state=OPEN&state=MERGED&state=DECLINED&state=SUPERSEDED&q=author.uuid="12345"&fields=${prFieldsFilter}&pagelen=50`,
         )
         .reply(200, {
           values: [
@@ -779,7 +780,7 @@ describe('modules/platform/bitbucket/index', () => {
       const scope = await initRepoMock();
       scope
         .get(
-          '/2.0/repositories/some/repo/pullrequests?state=OPEN&state=MERGED&state=DECLINED&state=SUPERSEDED&pagelen=50',
+          `/2.0/repositories/some/repo/pullrequests?state=OPEN&state=MERGED&state=DECLINED&state=SUPERSEDED&fields=${prFieldsFilter}&pagelen=50`,
         )
         .reply(200, { values: [pr] });
       expect(
@@ -805,7 +806,7 @@ describe('modules/platform/bitbucket/index', () => {
       const scope = await initRepoMock();
       scope
         .get(
-          '/2.0/repositories/some/repo/pullrequests?state=OPEN&state=MERGED&state=DECLINED&state=SUPERSEDED&pagelen=50',
+          `/2.0/repositories/some/repo/pullrequests?state=OPEN&state=MERGED&state=DECLINED&state=SUPERSEDED&fields=${prFieldsFilter}&pagelen=50`,
         )
         .reply(200, {
           values: [
@@ -843,7 +844,7 @@ describe('modules/platform/bitbucket/index', () => {
       const scope = await initRepoMock({}, { is_private: true });
       scope
         .get(
-          '/2.0/repositories/some/repo/pullrequests?state=OPEN&state=MERGED&state=DECLINED&state=SUPERSEDED&pagelen=50',
+          `/2.0/repositories/some/repo/pullrequests?state=OPEN&state=MERGED&state=DECLINED&state=SUPERSEDED&fields=${prFieldsFilter}&pagelen=50`,
         )
         .reply(200, {
           values: [
@@ -883,7 +884,7 @@ describe('modules/platform/bitbucket/index', () => {
       const scope = await initRepoMock({}, { is_private: false });
       scope
         .get(
-          '/2.0/repositories/some/repo/pullrequests?state=OPEN&state=MERGED&state=DECLINED&state=SUPERSEDED&pagelen=50',
+          `/2.0/repositories/some/repo/pullrequests?state=OPEN&state=MERGED&state=DECLINED&state=SUPERSEDED&fields=${prFieldsFilter}&pagelen=50`,
         )
         .reply(200, {
           values: [
@@ -927,7 +928,7 @@ describe('modules/platform/bitbucket/index', () => {
       const scope = await initRepoMock({}, { is_private: false });
       scope
         .get(
-          '/2.0/repositories/some/repo/pullrequests?state=OPEN&state=MERGED&state=DECLINED&state=SUPERSEDED&pagelen=50',
+          `/2.0/repositories/some/repo/pullrequests?state=OPEN&state=MERGED&state=DECLINED&state=SUPERSEDED&fields=${prFieldsFilter}&pagelen=50`,
         )
         .reply(200, {
           values: [

--- a/lib/modules/platform/bitbucket/index.ts
+++ b/lib/modules/platform/bitbucket/index.ts
@@ -44,7 +44,7 @@ import type {
   RepoInfoBody,
 } from './types';
 import * as utils from './utils';
-import { mergeBodyTransformer } from './utils';
+import { mergeBodyTransformer, prFieldsFilter } from './utils';
 
 export const id = 'bitbucket';
 
@@ -282,6 +282,7 @@ export async function getPrList(): Promise<Pr[]> {
     if (renovateUserUuid && !config.ignorePrAuthor) {
       querySearchParams.append('q', `author.uuid="${renovateUserUuid}"`);
     }
+    querySearchParams.append('fields', prFieldsFilter);
     const query = querySearchParams.toString();
     const url = `/2.0/repositories/${config.repository}/pullrequests?${query}`;
     const prs = (

--- a/lib/modules/platform/bitbucket/types.ts
+++ b/lib/modules/platform/bitbucket/types.ts
@@ -89,7 +89,7 @@ export interface PrResponse {
       name: string;
     };
   };
-  reviewers: Array<Account>;
+  reviewers: Account[];
   created_on: string;
 }
 

--- a/lib/modules/platform/bitbucket/utils.ts
+++ b/lib/modules/platform/bitbucket/utils.ts
@@ -72,3 +72,18 @@ export function prInfo(pr: PrResponse): Pr {
     createdAt: pr.created_on,
   };
 }
+
+export const prFieldsFilter = [
+  'values.id',
+  'values.title',
+  'values.state',
+  'values.links.commits.href',
+  'values.summary.raw',
+  'values.source.branch.name',
+  'values.destination.branch.name',
+  'values.reviewers.display_name',
+  'values.reviewers.uuid',
+  'values.reviewers.nickname',
+  'values.reviewers.account_status',
+  'values.created_on',
+].join(',');


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Stop receiving irrelevant PR fields

## Context

- Ref: #26278
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
