### PR TITLE
feat(manager/poetry): add support for explicit sources

### DIFF
--- a/lib/modules/manager/poetry/__snapshots__/extract.spec.ts.snap
+++ b/lib/modules/manager/poetry/__snapshots__/extract.spec.ts.snap
@@ -358,6 +358,7 @@ exports[`modules/manager/poetry/extract extractPackageFile() extracts multiple d
       "depType": "dependencies",
       "managerData": {
         "nestedVersion": true,
+        "sourceName": undefined,
       },
       "versioning": "poetry",
     },
@@ -368,6 +369,7 @@ exports[`modules/manager/poetry/extract extractPackageFile() extracts multiple d
       "depType": "dependencies",
       "managerData": {
         "nestedVersion": true,
+        "sourceName": undefined,
       },
       "versioning": "poetry",
     },
@@ -539,14 +541,6 @@ exports[`modules/manager/poetry/extract extractPackageFile() extracts multiple d
     "packageName": "extra-dep3",
     "versioning": "poetry",
   },
-]
-`;
-
-exports[`modules/manager/poetry/extract extractPackageFile() extracts registries 1`] = `
-[
-  "https://foo.bar/simple/",
-  "https://bar.baz/+simple/",
-  "https://pypi.org/pypi/",
 ]
 `;
 

--- a/lib/modules/manager/poetry/schema.spec.ts
+++ b/lib/modules/manager/poetry/schema.spec.ts
@@ -1,0 +1,360 @@
+import { PoetrySources } from './schema';
+
+describe('modules/manager/poetry/schema', () => {
+  describe('PoetrySources', () => {
+    it('parses default values', () => {
+      expect(PoetrySources.parse([])).toBeEmptyArray();
+      expect(PoetrySources.parse([null])).toBeEmptyArray();
+    });
+
+    it('parses unordered sources', () => {
+      expect(
+        PoetrySources.parse([
+          { name: 'missing-url' },
+          { name: 'missing-priority', url: 'https://some-source.com' },
+          {
+            name: 'foo-Secondary',
+            priority: 'secondary',
+            url: 'https://some-vcs.com/secondary',
+          },
+          { name: 'PyPI', priority: 'primary' },
+          {
+            name: 'foo-Primary',
+            priority: 'primary',
+            url: 'https://some-vcs.com/primary',
+          },
+          {
+            name: 'foo-Default',
+            priority: 'default',
+            url: 'https://some-vcs.com/default',
+          },
+          {
+            name: 'foo-Explicit',
+            priority: 'explicit',
+            url: 'https://some-vcs.com/explicit',
+          },
+          {
+            name: 'foo-Supplemental',
+            priority: 'supplemental',
+            url: 'https://some-vcs.com/supplemental',
+          },
+        ]),
+      ).toEqual([
+        {
+          name: 'foo-default',
+          priority: 'default',
+          url: 'https://some-vcs.com/default',
+        },
+        {
+          name: 'missing-priority',
+          priority: 'primary',
+          url: 'https://some-source.com',
+        },
+        {
+          name: 'pypi',
+          priority: 'primary',
+          url: 'https://pypi.org/pypi/',
+        },
+        {
+          name: 'foo-primary',
+          priority: 'primary',
+          url: 'https://some-vcs.com/primary',
+        },
+        {
+          name: 'foo-secondary',
+          priority: 'secondary',
+          url: 'https://some-vcs.com/secondary',
+        },
+        {
+          name: 'foo-supplemental',
+          priority: 'supplemental',
+          url: 'https://some-vcs.com/supplemental',
+        },
+        {
+          name: 'foo-explicit',
+          priority: 'explicit',
+          url: 'https://some-vcs.com/explicit',
+        },
+      ]);
+    });
+
+    it('implicit use of PyPI source', () => {
+      expect(
+        PoetrySources.parse([
+          {
+            name: 'foo-Supplemental',
+            priority: 'supplemental',
+            url: 'https://some-vcs.com/supplemental',
+          },
+        ]),
+      ).toEqual([
+        {
+          name: 'pypi',
+          priority: 'default',
+          url: 'https://pypi.org/pypi/',
+        },
+        {
+          name: 'foo-supplemental',
+          priority: 'supplemental',
+          url: 'https://some-vcs.com/supplemental',
+        },
+      ]);
+
+      expect(
+        PoetrySources.parse([
+          {
+            name: 'foo-Primary',
+            priority: 'primary',
+            url: 'https://some-vcs.com/primary',
+          },
+        ]),
+      ).toEqual([
+        {
+          name: 'foo-primary',
+          priority: 'primary',
+          url: 'https://some-vcs.com/primary',
+        },
+        {
+          name: 'pypi',
+          priority: 'secondary',
+          url: 'https://pypi.org/pypi/',
+        },
+      ]);
+    });
+
+    it('source with priority="default"', () => {
+      expect(
+        PoetrySources.parse([
+          {
+            name: 'foo',
+            priority: 'default',
+            url: 'https://foo.bar/simple/',
+          },
+        ]),
+      ).toEqual([
+        {
+          name: 'foo',
+          priority: 'default',
+          url: 'https://foo.bar/simple/',
+        },
+      ]);
+    });
+
+    it('PyPI source with priority="default"', () => {
+      expect(
+        PoetrySources.parse([
+          {
+            name: 'PyPI',
+            priority: 'default',
+          },
+        ]),
+      ).toEqual([
+        {
+          name: 'pypi',
+          priority: 'default',
+          url: 'https://pypi.org/pypi/',
+        },
+      ]);
+    });
+
+    it('source with priority="primary"', () => {
+      expect(
+        PoetrySources.parse([
+          {
+            name: 'foo',
+            priority: 'primary',
+            url: 'https://foo.bar/simple/',
+          },
+        ]),
+      ).toEqual([
+        {
+          name: 'foo',
+          priority: 'primary',
+          url: 'https://foo.bar/simple/',
+        },
+        {
+          name: 'pypi',
+          priority: 'secondary',
+          url: 'https://pypi.org/pypi/',
+        },
+      ]);
+    });
+
+    it('source with implicit priority="primary"', () => {
+      expect(
+        PoetrySources.parse([
+          {
+            name: 'foo',
+            url: 'https://foo.bar/simple/',
+          },
+        ]),
+      ).toEqual([
+        {
+          name: 'foo',
+          priority: 'primary',
+          url: 'https://foo.bar/simple/',
+        },
+        {
+          name: 'pypi',
+          priority: 'secondary',
+          url: 'https://pypi.org/pypi/',
+        },
+      ]);
+    });
+
+    it('sources with priority="secondary"', () => {
+      expect(
+        PoetrySources.parse([
+          {
+            name: 'foo',
+            priority: 'secondary',
+            url: 'https://foo.bar/simple/',
+          },
+          {
+            name: 'bar',
+            priority: 'secondary',
+            url: 'https://bar.baz/simple/',
+          },
+        ]),
+      ).toEqual([
+        {
+          name: 'pypi',
+          priority: 'default',
+          url: 'https://pypi.org/pypi/',
+        },
+        {
+          name: 'foo',
+          priority: 'secondary',
+          url: 'https://foo.bar/simple/',
+        },
+        {
+          name: 'bar',
+          priority: 'secondary',
+          url: 'https://bar.baz/simple/',
+        },
+      ]);
+    });
+
+    it('unordered sources and implicit PyPI priority="primary"', () => {
+      expect(
+        PoetrySources.parse([
+          {
+            name: 'foo',
+            priority: 'secondary',
+            url: 'https://foo.bar/simple/',
+          },
+          {
+            name: 'bar',
+            url: 'https://bar.baz/simple/',
+          },
+          {
+            name: 'PyPI',
+          },
+          {
+            name: 'baz',
+            url: 'https://baz.bar/simple/',
+          },
+        ]),
+      ).toEqual([
+        {
+          name: 'bar',
+          priority: 'primary',
+          url: 'https://bar.baz/simple/',
+        },
+        {
+          name: 'pypi',
+          priority: 'primary',
+          url: 'https://pypi.org/pypi/',
+        },
+        {
+          name: 'baz',
+          priority: 'primary',
+          url: 'https://baz.bar/simple/',
+        },
+        {
+          name: 'foo',
+          priority: 'secondary',
+          url: 'https://foo.bar/simple/',
+        },
+      ]);
+    });
+
+    it('unordered sources with implicit PyPI priority="secondary"', () => {
+      expect(
+        PoetrySources.parse([
+          {
+            name: 'foo',
+            priority: 'secondary',
+            url: 'https://foo.bar/simple/',
+          },
+          {
+            name: 'bar',
+            url: 'https://bar.baz/simple/',
+          },
+        ]),
+      ).toEqual([
+        {
+          name: 'bar',
+          priority: 'primary',
+          url: 'https://bar.baz/simple/',
+        },
+        {
+          name: 'foo',
+          priority: 'secondary',
+          url: 'https://foo.bar/simple/',
+        },
+        {
+          name: 'pypi',
+          priority: 'secondary',
+          url: 'https://pypi.org/pypi/',
+        },
+      ]);
+    });
+
+    it('source with priority="supplemental"', () => {
+      expect(
+        PoetrySources.parse([
+          {
+            name: 'supplemental',
+            priority: 'supplemental',
+            url: 'https://supplemental.com/simple/',
+          },
+        ]),
+      ).toEqual([
+        {
+          name: 'pypi',
+          priority: 'default',
+          url: 'https://pypi.org/pypi/',
+        },
+        {
+          name: 'supplemental',
+          priority: 'supplemental',
+          url: 'https://supplemental.com/simple/',
+        },
+      ]);
+    });
+
+    it('source with priority="explicit"', () => {
+      expect(
+        PoetrySources.parse([
+          {
+            name: 'explicit',
+            priority: 'explicit',
+            url: 'https://explicit.com/simple/',
+          },
+        ]),
+      ).toEqual([
+        {
+          name: 'pypi',
+          priority: 'default',
+          url: 'https://pypi.org/pypi/',
+        },
+        {
+          name: 'explicit',
+          priority: 'explicit',
+          url: 'https://explicit.com/simple/',
+        },
+      ]);
+    });
+  });
+});

--- a/lib/modules/manager/poetry/schema.ts
+++ b/lib/modules/manager/poetry/schema.ts
@@ -1,4 +1,5 @@
 import { ZodEffects, ZodType, ZodTypeDef, z } from 'zod';
+import { logger } from '../../../logger';
 import { parseGitUrl } from '../../../util/git/url';
 import { regEx } from '../../../util/regex';
 import { LooseArray, LooseRecord, Toml } from '../../../util/schema-utils';
@@ -71,15 +72,15 @@ const PoetryGitDependency = z
 
 const PoetryPypiDependency = z.union([
   z
-    .object({ version: z.string().optional() })
-    .transform(({ version: currentValue }): PackageDependency => {
+    .object({ version: z.string().optional(), source: z.string().optional() })
+    .transform(({ version: currentValue, source }): PackageDependency => {
       if (!currentValue) {
         return { datasource: PypiDatasource.id };
       }
 
       return {
         datasource: PypiDatasource.id,
-        managerData: { nestedVersion: true },
+        managerData: { nestedVersion: true, sourceName: source?.toLowerCase() },
         currentValue,
       };
     }),
@@ -178,6 +179,70 @@ export const PoetryGroupDependencies = LooseRecord(
   return deps;
 });
 
+const PoetrySourceOrder = [
+  'default',
+  'primary',
+  'secondary',
+  'supplemental',
+  'explicit',
+] as const;
+
+export const PoetrySource = z.object({
+  name: z.string().toLowerCase(),
+  url: z.string().optional(),
+  priority: z.enum(PoetrySourceOrder).default('primary'),
+});
+export type PoetrySource = z.infer<typeof PoetrySource>;
+
+export const PoetrySources = LooseArray(PoetrySource, {
+  onError: ({ error: err }) => {
+    logger.debug({ err }, 'Poetry: error parsing sources array');
+  },
+})
+  .transform((sources) => {
+    const pypiUrl = process.env.PIP_INDEX_URL ?? 'https://pypi.org/pypi/';
+    const result: PoetrySource[] = [];
+
+    let overridesPyPi = false;
+    let hasDefaultSource = false;
+    let hasPrimarySource = false;
+    for (const source of sources) {
+      if (source.name === 'pypi') {
+        source.url = pypiUrl;
+        overridesPyPi = true;
+      }
+
+      if (!source.url) {
+        continue;
+      }
+
+      if (source.priority === 'default') {
+        hasDefaultSource = true;
+      } else if (source.priority === 'primary') {
+        hasPrimarySource = true;
+      }
+
+      result.push(source);
+    }
+
+    if (sources.length && !hasDefaultSource && !overridesPyPi) {
+      result.push({
+        name: 'pypi',
+        priority: hasPrimarySource ? 'secondary' : 'default',
+        url: pypiUrl,
+      });
+    }
+
+    result.sort(
+      (a, b) =>
+        PoetrySourceOrder.indexOf(a.priority) -
+        PoetrySourceOrder.indexOf(b.priority),
+    );
+
+    return result;
+  })
+  .catch([]);
+
 export const PoetrySectionSchema = z
   .object({
     dependencies: withDepType(PoetryDependencies, 'dependencies').optional(),
@@ -187,21 +252,7 @@ export const PoetrySectionSchema = z
     ).optional(),
     extras: withDepType(PoetryDependencies, 'extras').optional(),
     group: PoetryGroupDependencies.optional(),
-    source: LooseArray(
-      z
-        .object({
-          url: z.string(),
-        })
-        .transform(({ url }) => url),
-    )
-      .refine((urls) => urls.length > 0)
-      .transform((urls) => [
-        ...urls,
-        process.env.PIP_INDEX_URL ?? 'https://pypi.org/pypi/',
-      ])
-      .transform((urls) => uniq(urls))
-      .optional()
-      .catch(undefined),
+    source: PoetrySources,
   })
   .transform(
     ({
@@ -209,7 +260,7 @@ export const PoetrySectionSchema = z
       'dev-dependencies': devDependencies = [],
       extras: extraDependencies = [],
       group: groupDependencies = [],
-      source: registryUrls,
+      source: sourceUrls,
     }) => {
       const deps: PackageDependency[] = [
         ...dependencies,
@@ -220,8 +271,22 @@ export const PoetrySectionSchema = z
 
       const res: PackageFileContent = { deps };
 
-      if (registryUrls) {
-        res.registryUrls = registryUrls;
+      if (sourceUrls.length) {
+        for (const dep of res.deps) {
+          if (dep.managerData?.sourceName) {
+            const sourceUrl = sourceUrls.find(
+              ({ name }) => name === dep.managerData?.sourceName,
+            );
+            if (sourceUrl?.url) {
+              dep.registryUrls = [sourceUrl.url];
+            }
+          }
+        }
+
+        const sourceUrlsFiltered = sourceUrls.filter(
+          ({ priority }) => priority !== 'explicit',
+        );
+        res.registryUrls = uniq(sourceUrlsFiltered.map(({ url }) => url!));
       }
 
       return res;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

* Extends parsing of Poetry package sources by `name` and `priority`
  * Extracted registry URLs are ordered in the way poetry visits them (see [docs](https://python-poetry.org/docs/repositories/))
* Adds support for packages with [explicit sources](https://python-poetry.org/docs/repositories/#explicit-package-sources).

Newly added tests cover the same scenarios that are also covered by poetry-internal tests (see [here](https://github.com/python-poetry/poetry/blob/81e76c2f3684dbadd69ec7372602ee15df20ca55/tests/test_factory.py)).

<!-- Describe what behavior is changed by this PR. -->

## Context

- Closes https://github.com/renovatebot/renovate/issues/12003
- Closes https://github.com/renovatebot/renovate/discussions/23714

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

Test repo: https://github.com/renovate-demo/12003-poetry-source/pull/2

<details>
  <summary>Logs with only https://christopherfrieler.github.io/renovate-issue-12003/ in registryUrls but no PyPI</summary>
  
```json
DEBUG: packageFiles with updates (repository=renovate-demo/12003-poetry-source, baseBranch=master)
"config": {
  "poetry": [
   {
     "deps": [
       {
         "datasource": "pypi",
         "managerData": {
           "nestedVersion": true,
           "sourceName": "my-package-index"
         },
         "currentValue": "1.0.0",
         "versioning": "pep440",
         "depName": "some_dependency",
         "packageName": "some-dependency",
         "depType": "dependencies",
         "registryUrls": [
           "https://christopherfrieler.github.io/renovate-issue-12003/"
         ],
         "lockedVersion": "1.0.0",
         "updates": [
           {
             "bucket": "non-major",
             "newVersion": "1.1.0",
             "newValue": "1.1.0",
             "newMajor": 1,
             "newMinor": 1,
             "updateType": "minor",
             "branchName": "renovate/some_dependency-1.x"
           }
         ],
         "warnings": [],
         "registryUrl": "https://christopherfrieler.github.io/renovate-issue-12003",
         "currentVersion": "1.0.0",
         "isSingleVersion": true,
         "fixedVersion": "1.0.0"
       }
     ],
     "registryUrls": [
       "https://christopherfrieler.github.io/renovate-issue-12003/",
       "https://pypi.org/pypi/"
     ],
     "extractedConstraints": {"python": "~3.8"},
     "lockFiles": ["poetry.lock"],
     "packageFile": "pyproject.toml"
   }
  ]
}
```

</details>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
