### PR TITLE
fix(versioning/loose): sort numeric parts numerically

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,7 +9,7 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "[md]": {
-    "editor.wordBasedSuggestions": false
+    "editor.wordBasedSuggestions": "off"
   },
   "files.associations": {
     "Dockerfile.*": "dockerfile",
@@ -21,6 +21,6 @@
   "npm.packageManager": "pnpm",
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,7 +9,7 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "[md]": {
-    "editor.wordBasedSuggestions": "off"
+    "editor.wordBasedSuggestions": false
   },
   "files.associations": {
     "Dockerfile.*": "dockerfile",
@@ -21,6 +21,6 @@
   "npm.packageManager": "pnpm",
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": "explicit"
+    "source.fixAll.eslint": true
   }
 }

--- a/lib/modules/versioning/loose/index.spec.ts
+++ b/lib/modules/versioning/loose/index.spec.ts
@@ -53,6 +53,7 @@ describe('modules/versioning/loose/index', () => {
     a                               | b                               | expected
     ${'2.4.0'}                      | ${'2.4'}                        | ${true}
     ${'2.4.2'}                      | ${'2.4.1'}                      | ${true}
+    ${'2.4.100'}                    | ${'2.4.99'}                     | ${true}
     ${'2.4.beta'}                   | ${'2.4.alpha'}                  | ${true}
     ${'1.9'}                        | ${'2'}                          | ${false}
     ${'1.9'}                        | ${'1.9.1'}                      | ${false}
@@ -63,6 +64,7 @@ describe('modules/versioning/loose/index', () => {
     ${'2024-07-21T11-33-05.abc123'} | ${'2023-06-21T11-33-05.abc123'} | ${true}
     ${'2023-07-21T11-33-05.abc123'} | ${'2023-07-21T11-33-04.abc123'} | ${true}
     ${'2023-07-21-113305-abc123'}   | ${'2023-07-21-113304-abc123'}   | ${true}
+    ${'1.1.5-100'}                  | ${'1.1.5-99'}                   | ${true}
   `('isGreaterThan("$a", "$b") === $expected', ({ a, b, expected }) => {
     expect(loose.isGreaterThan(a, b)).toBe(expected);
   });

--- a/lib/modules/versioning/loose/index.ts
+++ b/lib/modules/versioning/loose/index.ts
@@ -52,7 +52,9 @@ class LooseVersioningApi extends GenericVersioningApi {
     }
 
     if (parsed1.suffix && parsed2.suffix) {
-      return parsed1.suffix.localeCompare(parsed2.suffix);
+      return parsed1.suffix.localeCompare(parsed2.suffix, undefined, {
+        numeric: true,
+      });
     }
 
     if (parsed1.suffix) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Enabled the `numeric` option in `String.localCompare` method which comapres the suffix of the versions
<!-- Describe what behavior is changed by this PR. -->

## Context
Closes: https://github.com/renovatebot/renovate/issues/26136
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
