### PR TITLE
feat(manager/pep621): add support for `bumpVersion` option

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -410,7 +410,7 @@ This is an advance field and it's recommend you seek a config review before appl
 
 ## bumpVersion
 
-Currently this setting supports `helmv3`, `npm`, `nuget`, `maven` and `sbt` only, so raise a feature request if you have a use for it with other package managers.
+Currently this setting supports `helmv3`, `npm`, `nuget`, `maven`, `pep621` and `sbt` only, so raise a feature request if you have a use for it with other package managers.
 Its purpose is if you want Renovate to update the `version` field within your package file any time it updates dependencies within.
 Usually this is for automatic release purposes, so that you don't need to add another step after Renovate before you can release a new version.
 

--- a/lib/modules/manager/pep621/extract.spec.ts
+++ b/lib/modules/manager/pep621/extract.spec.ts
@@ -311,5 +311,17 @@ describe('modules/manager/pep621/extract', () => {
         },
       ]);
     });
+
+    it('should extract project version', () => {
+      const content = codeBlock`
+        [project]
+        name = "test"
+        version = "0.0.2"
+        dependencies = [ "requests==2.30.0" ]
+      `;
+
+      const res = extractPackageFile(content, 'pyproject.toml');
+      expect(res?.packageFileVersion).toBe('0.0.2');
+    });
   });
 });

--- a/lib/modules/manager/pep621/extract.ts
+++ b/lib/modules/manager/pep621/extract.ts
@@ -26,6 +26,8 @@ export function extractPackageFile(
   if (is.nullOrUndefined(def)) {
     return null;
   }
+
+  const packageFileVersion = def.project?.version;
   const pythonConstraint = def.project?.['requires-python'];
   const extractedConstraints = is.nonEmptyString(pythonConstraint)
     ? { extractedConstraints: { python: pythonConstraint } }
@@ -49,6 +51,6 @@ export function extractPackageFile(
   }
 
   return processedDeps.length
-    ? { ...extractedConstraints, deps: processedDeps }
+    ? { ...extractedConstraints, deps: processedDeps, packageFileVersion }
     : null;
 }

--- a/lib/modules/manager/pep621/index.ts
+++ b/lib/modules/manager/pep621/index.ts
@@ -1,5 +1,6 @@
 import type { Category } from '../../../constants';
 import { PypiDatasource } from '../../datasource/pypi';
+export { bumpPackageVersion } from './update';
 export { extractPackageFile } from './extract';
 export { updateArtifacts } from './artifacts';
 

--- a/lib/modules/manager/pep621/schema.ts
+++ b/lib/modules/manager/pep621/schema.ts
@@ -10,6 +10,7 @@ const DependencyRecordSchema = z
 export const PyProjectSchema = z.object({
   project: z
     .object({
+      version: z.string().optional().catch(undefined),
       'requires-python': z.string().optional(),
       dependencies: DependencyListSchema,
       'optional-dependencies': DependencyRecordSchema,

--- a/lib/modules/manager/pep621/update.spec.ts
+++ b/lib/modules/manager/pep621/update.spec.ts
@@ -1,0 +1,51 @@
+import { codeBlock } from 'common-tags';
+import * as projectUpdater from '.';
+
+describe('modules/manager/pep621/update', () => {
+  describe('bumpPackageVersion()', () => {
+    const content = codeBlock`
+      [project]
+      name = "test"
+      version = "0.0.2"
+      description = "test"
+    `;
+
+    it('increments', () => {
+      const { bumpedContent } = projectUpdater.bumpPackageVersion(
+        content,
+        '0.0.2',
+        'patch',
+      );
+      const expected = content.replace('0.0.2', '0.0.3');
+      expect(bumpedContent).toEqual(expected);
+    });
+
+    it('no ops', () => {
+      const { bumpedContent } = projectUpdater.bumpPackageVersion(
+        content,
+        '0.0.1',
+        'patch',
+      );
+      expect(bumpedContent).toEqual(content);
+    });
+
+    it('updates', () => {
+      const { bumpedContent } = projectUpdater.bumpPackageVersion(
+        content,
+        '0.0.1',
+        'minor',
+      );
+      const expected = content.replace('0.0.2', '0.1.0');
+      expect(bumpedContent).toEqual(expected);
+    });
+
+    it('returns content if bumping errors', () => {
+      const { bumpedContent } = projectUpdater.bumpPackageVersion(
+        content,
+        '0.0.2',
+        true as any,
+      );
+      expect(bumpedContent).toEqual(content);
+    });
+  });
+});

--- a/lib/modules/manager/pep621/update.ts
+++ b/lib/modules/manager/pep621/update.ts
@@ -38,6 +38,7 @@ export function bumpPackageVersion(
         content,
         currentValue,
         bumpVersion,
+        manager: 'pep621',
       },
       'Failed to bumpVersion',
     );

--- a/lib/modules/manager/pep621/update.ts
+++ b/lib/modules/manager/pep621/update.ts
@@ -1,0 +1,47 @@
+import { inc } from '@renovatebot/pep440';
+import type { ReleaseType } from 'semver';
+import { logger } from '../../../logger';
+import { regEx } from '../../../util/regex';
+import type { BumpPackageVersionResult } from '../types';
+
+export function bumpPackageVersion(
+  content: string,
+  currentValue: string,
+  bumpVersion: ReleaseType,
+): BumpPackageVersionResult {
+  logger.debug(
+    { bumpVersion, currentValue },
+    'Checking if we should bump pyproject.toml version',
+  );
+
+  let bumpedContent = content;
+  try {
+    const newProjectVersion = inc(currentValue, bumpVersion);
+    if (!newProjectVersion) {
+      throw new Error('pep440 inc failed');
+    }
+
+    logger.debug(`newProjectVersion: ${newProjectVersion}`);
+    bumpedContent = content.replace(
+      regEx(`^(?<version>version[ \\t]*=[ \\t]*['"])[^'"]*`, 'm'),
+      `$<version>${newProjectVersion}`,
+    );
+
+    if (bumpedContent === content) {
+      logger.debug('Version was already bumped');
+    } else {
+      logger.debug('Bumped pyproject.toml version');
+    }
+  } catch (err) {
+    logger.warn(
+      {
+        content,
+        currentValue,
+        bumpVersion,
+      },
+      'Failed to bumpVersion',
+    );
+  }
+
+  return { bumpedContent };
+}


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Introduces `bumpVersion` support for the pep621 manager.

_Note_: `bumpPackageVersion()` implementation and tests were taken almost verbatim from the helmv3 manager.

<!-- Describe what behavior is changed by this PR. -->

## Context

- https://github.com/renovatebot/renovate/issues/16704
  -> `bumpPackageVersion()` from pep621 can be reused for poetry manager. Follow-up PR is ready.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

Test repo: https://github.com/renovate-demo/pep621-bumpversion/pull/1

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
