### PR TITLE
feat(manager/poetry): add support for `bumpVersion` option

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -411,6 +411,7 @@ This is an advance field and it's recommend you seek a config review before appl
 ## bumpVersion
 
 Currently this setting supports `helmv3`, `npm`, `nuget`, `maven`, `pep621` and `sbt` only, so raise a feature request if you have a use for it with other package managers.
+Currently this setting supports `helmv3`, `npm`, `nuget`, `maven`, `pep621`, `poetry` and `sbt` only, so raise a feature request if you have a use for it with other package managers.
 Its purpose is if you want Renovate to update the `version` field within your package file any time it updates dependencies within.
 Usually this is for automatic release purposes, so that you don't need to add another step after Renovate before you can release a new version.
 

--- a/lib/modules/manager/poetry/__snapshots__/extract.spec.ts.snap
+++ b/lib/modules/manager/poetry/__snapshots__/extract.spec.ts.snap
@@ -345,6 +345,7 @@ exports[`modules/manager/poetry/extract extractPackageFile() extracts mixed vers
     },
   ],
   "extractedConstraints": {},
+  "packageFileVersion": "0.1.0",
 }
 `;
 
@@ -427,6 +428,7 @@ exports[`modules/manager/poetry/extract extractPackageFile() extracts multiple d
     },
   ],
   "extractedConstraints": {},
+  "packageFileVersion": "0.1.0",
 }
 `;
 
@@ -555,6 +557,7 @@ exports[`modules/manager/poetry/extract extractPackageFile() handles multiple co
     },
   ],
   "extractedConstraints": {},
+  "packageFileVersion": "0.1.0",
 }
 `;
 
@@ -589,5 +592,6 @@ exports[`modules/manager/poetry/extract extractPackageFile() resolves lockedVers
   "extractedConstraints": {
     "python": "^3.9",
   },
+  "packageFileVersion": undefined,
 }
 `;

--- a/lib/modules/manager/poetry/index.ts
+++ b/lib/modules/manager/poetry/index.ts
@@ -3,6 +3,7 @@ import { GithubReleasesDatasource } from '../../datasource/github-releases';
 import { GithubTagsDatasource } from '../../datasource/github-tags';
 import { PypiDatasource } from '../../datasource/pypi';
 
+export { bumpPackageVersion } from '../pep621/update';
 export { extractPackageFile } from './extract';
 export { updateArtifacts } from './artifacts';
 export { updateLockedDependency } from './update-locked';

--- a/lib/modules/manager/poetry/schema.spec.ts
+++ b/lib/modules/manager/poetry/schema.spec.ts
@@ -1,6 +1,17 @@
-import { PoetrySources } from './schema';
+import { PoetrySectionSchema, PoetrySources } from './schema';
 
 describe('modules/manager/poetry/schema', () => {
+  it('parses project version', () => {
+    expect(
+      PoetrySectionSchema.parse({ version: '1.2.3' }).packageFileVersion,
+    ).toBe('1.2.3');
+
+    expect(
+      PoetrySectionSchema.parse({ version: { some: 'value' } })
+        .packageFileVersion,
+    ).toBeUndefined();
+  });
+
   describe('PoetrySources', () => {
     it('parses default values', () => {
       expect(PoetrySources.parse([])).toBeEmptyArray();

--- a/lib/modules/manager/poetry/schema.ts
+++ b/lib/modules/manager/poetry/schema.ts
@@ -271,8 +271,7 @@ export const PoetrySectionSchema = z
         ...groupDependencies,
       ];
 
-      const res: PackageFileContent = { deps };
-      res.packageFileVersion = version;
+      const res: PackageFileContent = { deps, packageFileVersion: version };
 
       if (sourceUrls.length) {
         for (const dep of res.deps) {

--- a/lib/modules/manager/poetry/schema.ts
+++ b/lib/modules/manager/poetry/schema.ts
@@ -245,6 +245,7 @@ export const PoetrySources = LooseArray(PoetrySource, {
 
 export const PoetrySectionSchema = z
   .object({
+    version: z.string().optional().catch(undefined),
     dependencies: withDepType(PoetryDependencies, 'dependencies').optional(),
     'dev-dependencies': withDepType(
       PoetryDependencies,
@@ -256,6 +257,7 @@ export const PoetrySectionSchema = z
   })
   .transform(
     ({
+      version,
       dependencies = [],
       'dev-dependencies': devDependencies = [],
       extras: extraDependencies = [],
@@ -270,6 +272,7 @@ export const PoetrySectionSchema = z
       ];
 
       const res: PackageFileContent = { deps };
+      res.packageFileVersion = version;
 
       if (sourceUrls.length) {
         for (const dep of res.deps) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Introduces `bumpVersion` support for the poetry manager.

<!-- Describe what behavior is changed by this PR. -->

## Context

- Closes https://github.com/renovatebot/renovate/issues/16704

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

Test repo: https://github.com/renovate-demo/renovate-issue-16704/pull/1

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
