### PR TITLE
fix(pypi): fallback to simple lookup on 403

### DIFF
--- a/lib/modules/datasource/pypi/__snapshots__/index.spec.ts.snap
+++ b/lib/modules/datasource/pypi/__snapshots__/index.spec.ts.snap
@@ -42,6 +42,48 @@ exports[`modules/datasource/pypi/index getReleases fall back from json and proce
 }
 `;
 
+exports[`modules/datasource/pypi/index getReleases fall back from json and process data from simple endpoint 2`] = `
+{
+  "registryUrl": "https://custom.pypi.net/foo",
+  "releases": [
+    {
+      "version": "0.1.2",
+    },
+    {
+      "version": "0.1.3",
+    },
+    {
+      "version": "0.1.4",
+    },
+    {
+      "version": "0.2.0",
+    },
+    {
+      "version": "0.2.1",
+    },
+    {
+      "version": "0.2.2",
+    },
+    {
+      "version": "0.3.0",
+    },
+    {
+      "version": "0.4.0",
+    },
+    {
+      "version": "0.4.1",
+    },
+    {
+      "version": "0.4.2",
+    },
+    {
+      "isDeprecated": true,
+      "version": "0.5.0",
+    },
+  ],
+}
+`;
+
 exports[`modules/datasource/pypi/index getReleases parses data-requires-python and respects constraints from simple endpoint 1`] = `
 {
   "registryUrl": "https://some.registry.org/simple",

--- a/lib/modules/datasource/pypi/index.spec.ts
+++ b/lib/modules/datasource/pypi/index.spec.ts
@@ -484,25 +484,28 @@ describe('modules/datasource/pypi/index', () => {
       ).toBeNull();
     });
 
-    it('fall back from json and process data from simple endpoint', async () => {
-      httpMock
-        .scope('https://custom.pypi.net/foo')
-        .get('/dj-database-url/json')
-        .reply(404);
-      httpMock
-        .scope('https://custom.pypi.net/foo')
-        .get('/dj-database-url/')
-        .reply(200, htmlResponse);
-      const config = {
-        registryUrls: ['https://custom.pypi.net/foo'],
-      };
-      const result = await getPkgReleases({
-        datasource,
-        ...config,
-        packageName: 'dj-database-url',
-      });
-      expect(result).toMatchSnapshot();
-    });
+    it.each([404, 403])(
+      'fall back from json and process data from simple endpoint',
+      async (code: number) => {
+        httpMock
+          .scope('https://custom.pypi.net/foo')
+          .get('/dj-database-url/json')
+          .reply(code);
+        httpMock
+          .scope('https://custom.pypi.net/foo')
+          .get('/dj-database-url/')
+          .reply(200, htmlResponse);
+        const config = {
+          registryUrls: ['https://custom.pypi.net/foo'],
+        };
+        const result = await getPkgReleases({
+          datasource,
+          ...config,
+          packageName: 'dj-database-url',
+        });
+        expect(result).toMatchSnapshot();
+      },
+    );
 
     it('parses data-requires-python and respects constraints from simple endpoint', async () => {
       httpMock

--- a/lib/modules/datasource/pypi/index.ts
+++ b/lib/modules/datasource/pypi/index.ts
@@ -54,10 +54,10 @@ export class PypiDatasource extends Datasource {
     } else {
       logger.trace({ packageName, hostUrl }, 'Looking up pypi api dependency');
       try {
-        // we need to resolve early here so we can catch any 404s and fallback to a simple lookup
+        // we need to resolve early here so we can catch any 404 or 403s and fallback to a simple lookup
         dependency = await this.getDependency(normalizedLookupName, hostUrl);
       } catch (err) {
-        if (err.statusCode !== 404) {
+        if (err.statusCode !== 404 && err.statusCode !== 403) {
           throw err;
         }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This adds 403 to the simple index fallback check, so that pytorch index urls are correctly resolved by renovate.

## Context

See #26383 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
