### PR TITLE
fix(matchConfidence): align supported datasources list with internal preset

### DIFF
--- a/docs/usage/merge-confidence.md
+++ b/docs/usage/merge-confidence.md
@@ -28,7 +28,8 @@ Merge Confidence badges for pull requests are available on any supported platfor
 Renovate will show Merge Confidence badges for these languages:
 
 | Language   | Datasource  |
-| ---------- | ----------- |
+|------------|-------------|
+| Golang     | `go`        |
 | JavaScript | `npm`       |
 | Java       | `maven`     |
 | Python     | `pypi`      |

--- a/docs/usage/merge-confidence.md
+++ b/docs/usage/merge-confidence.md
@@ -28,7 +28,7 @@ Merge Confidence badges for pull requests are available on any supported platfor
 Renovate will show Merge Confidence badges for these languages:
 
 | Language   | Datasource  |
-|------------|-------------|
+| ---------- | ----------- |
 | Golang     | `go`        |
 | JavaScript | `npm`       |
 | Java       | `maven`     |

--- a/docs/usage/self-hosted-experimental.md
+++ b/docs/usage/self-hosted-experimental.md
@@ -126,6 +126,11 @@ Skip initializing `RE2` for regular expressions and instead use Node-native `Reg
 If set, Renovate will query this API for Merge Confidence data.
 This feature is in private beta.
 
+## `RENOVATE_X_MERGE_CONFIDENCE_SUPPORTED_DATASOURCES`
+
+If set, Renovate will query the merge-confidence JSON API only for datasources that are part of this list.
+The expected value for this environment variable is a JSON array of strings.
+
 ## `RENOVATE_X_PLATFORM_VERSION`
 
 If set, Renovate will use this string as GitLab server version instead of checking via the GitLab API.

--- a/lib/config/presets/internal/merge-confidence.ts
+++ b/lib/config/presets/internal/merge-confidence.ts
@@ -1,19 +1,21 @@
 import type { Preset } from '../types';
 
+export const supportedDatasources = [
+  'go',
+  'maven',
+  'npm',
+  'nuget',
+  'packagist',
+  'pypi',
+  'rubygems',
+];
+
 export const presets: Record<string, Preset> = {
   'all-badges': {
     description: 'Show all Merge Confidence badges for pull requests.',
     packageRules: [
       {
-        matchDatasources: [
-          'maven',
-          'npm',
-          'nuget',
-          'packagist',
-          'pypi',
-          'rubygems',
-          'go',
-        ],
+        matchDatasources: supportedDatasources,
         matchUpdateTypes: ['patch', 'minor', 'major'],
         prBodyColumns: [
           'Package',
@@ -31,15 +33,7 @@ export const presets: Record<string, Preset> = {
       'Show only the Age and Confidence Merge Confidence badges for pull requests.',
     packageRules: [
       {
-        matchDatasources: [
-          'maven',
-          'npm',
-          'nuget',
-          'packagist',
-          'pypi',
-          'rubygems',
-          'go',
-        ],
+        matchDatasources: supportedDatasources,
         matchUpdateTypes: ['patch', 'minor', 'major'],
         prBodyColumns: ['Package', 'Change', 'Age', 'Confidence'],
       },

--- a/lib/util/merge-confidence/index.spec.ts
+++ b/lib/util/merge-confidence/index.spec.ts
@@ -406,11 +406,21 @@ describe('util/merge-confidence/index', () => {
       });
 
       describe('parseSupportedDatasourceList()', () => {
+        let envOrg: NodeJS.ProcessEnv;
+
         type ParseSupportedDatasourceTestCase = {
           name: string;
           datasourceListString: string | undefined;
           expected: string[] | undefined;
         };
+
+        beforeEach(() => {
+          envOrg = process.env;
+        });
+
+        afterEach(() => {
+          process.env = envOrg;
+        });
 
         it.each([
           {
@@ -444,9 +454,10 @@ describe('util/merge-confidence/index', () => {
             datasourceListString,
             expected,
           }: ParseSupportedDatasourceTestCase) => {
-            expect(
-              parseSupportedDatasourceString(datasourceListString),
-            ).toStrictEqual(expected);
+            process.env.RENOVATE_X_MERGE_CONFIDENCE_SUPPORTED_DATASOURCES =
+              datasourceListString;
+
+            expect(parseSupportedDatasourceString()).toStrictEqual(expected);
           },
         );
       });

--- a/lib/util/merge-confidence/index.spec.ts
+++ b/lib/util/merge-confidence/index.spec.ts
@@ -308,12 +308,22 @@ describe('util/merge-confidence/index', () => {
           .get(`/api/mc/availability`)
           .reply(200);
 
-        await expect(initMergeConfidence('["go"]')).toResolve();
+        await expect(initMergeConfidence()).toResolve();
         expect(logger.trace).toHaveBeenCalledWith(
           'using default merge confidence API base URL',
         );
         expect(logger.debug).toHaveBeenCalledWith(
-          { supportedDatasources: ['go'] },
+          {
+            supportedDatasources: [
+              'go',
+              'maven',
+              'npm',
+              'nuget',
+              'packagist',
+              'pypi',
+              'rubygems',
+            ],
+          },
           'merge confidence API - successfully authenticated',
         );
       });
@@ -332,17 +342,7 @@ describe('util/merge-confidence/index', () => {
           'invalid merge confidence API base URL found in environment variables - using default value instead',
         );
         expect(logger.debug).toHaveBeenCalledWith(
-          {
-            supportedDatasources: [
-              'go',
-              'maven',
-              'npm',
-              'nuget',
-              'packagist',
-              'pypi',
-              'rubygems',
-            ],
-          },
+          expect.anything(),
           'merge confidence API - successfully authenticated',
         );
       });

--- a/lib/util/merge-confidence/index.spec.ts
+++ b/lib/util/merge-confidence/index.spec.ts
@@ -406,20 +406,14 @@ describe('util/merge-confidence/index', () => {
       });
 
       describe('parseSupportedDatasourceList()', () => {
-        let envOrg: NodeJS.ProcessEnv;
-
         type ParseSupportedDatasourceTestCase = {
           name: string;
           datasourceListString: string | undefined;
           expected: string[] | undefined;
         };
 
-        beforeEach(() => {
-          envOrg = process.env;
-        });
-
         afterEach(() => {
-          process.env = envOrg;
+          delete process.env.RENOVATE_X_MERGE_CONFIDENCE_SUPPORTED_DATASOURCES;
         });
 
         it.each([

--- a/lib/util/merge-confidence/index.spec.ts
+++ b/lib/util/merge-confidence/index.spec.ts
@@ -9,6 +9,7 @@ import {
   initConfig,
   initMergeConfidence,
   isActiveConfidenceLevel,
+  parseSupportedDatasourceString,
   resetConfig,
   satisfiesConfidenceLevel,
 } from '.';
@@ -296,25 +297,28 @@ describe('util/merge-confidence/index', () => {
     });
 
     describe('initMergeConfidence()', () => {
-      it('using default base url if none is set', async () => {
+      beforeEach(() => {
         resetConfig();
+      });
+
+      it('using default base url if none is set', async () => {
         delete process.env.RENOVATE_X_MERGE_CONFIDENCE_API_BASE_URL;
         httpMock
           .scope(defaultApiBaseUrl)
           .get(`/api/mc/availability`)
           .reply(200);
 
-        await expect(initMergeConfidence()).toResolve();
+        await expect(initMergeConfidence('["go"]')).toResolve();
         expect(logger.trace).toHaveBeenCalledWith(
           'using default merge confidence API base URL',
         );
         expect(logger.debug).toHaveBeenCalledWith(
+          { supportedDatasources: ['go'] },
           'merge confidence API - successfully authenticated',
         );
       });
 
       it('warns and then resolves if base url is invalid', async () => {
-        resetConfig();
         process.env.RENOVATE_X_MERGE_CONFIDENCE_API_BASE_URL =
           'invalid-url.com';
         httpMock
@@ -328,12 +332,22 @@ describe('util/merge-confidence/index', () => {
           'invalid merge confidence API base URL found in environment variables - using default value instead',
         );
         expect(logger.debug).toHaveBeenCalledWith(
+          {
+            supportedDatasources: [
+              'go',
+              'maven',
+              'npm',
+              'nuget',
+              'packagist',
+              'pypi',
+              'rubygems',
+            ],
+          },
           'merge confidence API - successfully authenticated',
         );
       });
 
       it('resolves if no token', async () => {
-        resetConfig();
         hostRules.clear();
 
         await expect(initMergeConfidence()).toResolve();
@@ -347,6 +361,7 @@ describe('util/merge-confidence/index', () => {
 
         await expect(initMergeConfidence()).toResolve();
         expect(logger.debug).toHaveBeenCalledWith(
+          expect.anything(),
           'merge confidence API - successfully authenticated',
         );
       });
@@ -387,6 +402,52 @@ describe('util/merge-confidence/index', () => {
         expect(logger.error).toHaveBeenCalledWith(
           expect.anything(),
           'merge confidence API request failed - aborting run',
+        );
+      });
+
+      describe('parseSupportedDatasourceList()', () => {
+        type ParseSupportedDatasourceTestCase = {
+          name: string;
+          datasourceListString: string | undefined;
+          expected: string[] | undefined;
+        };
+
+        it.each([
+          {
+            name: 'it should do nothing when the input is undefined',
+            datasourceListString: undefined,
+            expected: undefined,
+          },
+          {
+            name: 'it should successfully parse the given datasource list',
+            datasourceListString: `["go","npm"]`,
+            expected: ['go', 'npm'],
+          },
+          {
+            name: 'it should gracefully handle invalid json',
+            datasourceListString: `{`,
+            expected: undefined,
+          },
+          {
+            name: 'it should discard non-array JSON input',
+            datasourceListString: `{}`,
+            expected: undefined,
+          },
+          {
+            name: 'it should discard non-string array JSON input',
+            datasourceListString: `[1,2]`,
+            expected: undefined,
+          },
+        ])(
+          `$name`,
+          ({
+            datasourceListString,
+            expected,
+          }: ParseSupportedDatasourceTestCase) => {
+            expect(
+              parseSupportedDatasourceString(datasourceListString),
+            ).toStrictEqual(expected);
+          },
         );
       });
     });

--- a/lib/util/merge-confidence/index.ts
+++ b/lib/util/merge-confidence/index.ts
@@ -25,7 +25,9 @@ export const confidenceLevels: Record<MergeConfidence, number> = {
 export function initConfig(): void {
   apiBaseUrl = getApiBaseUrl();
   token = getApiToken();
-  supportedDatasources = [...presetSupportedDatasources];
+  supportedDatasources = parseSupportedDatasourceString() ?? [
+    ...presetSupportedDatasources,
+  ];
 
   if (!is.nullOrUndefined(token)) {
     logger.debug(`Merge confidence token found for ${apiBaseUrl}`);
@@ -33,9 +35,12 @@ export function initConfig(): void {
 }
 
 export function parseSupportedDatasourceString(
-  supportedDatasourceString: string | undefined = process.env
-    .RENOVATE_X_MERGE_CONFIDENCE_SUPPORTED_DATASOURCES,
+  supportedDatasourceRawString?: string,
 ): string[] | undefined {
+  const supportedDatasourceString =
+    process.env.RENOVATE_X_MERGE_CONFIDENCE_SUPPORTED_DATASOURCES ??
+    supportedDatasourceRawString;
+
   if (!is.string(supportedDatasourceString)) {
     return;
   }
@@ -209,15 +214,8 @@ async function queryApi(
  * authenticate with the API. If either the base URL or token is not defined, it will immediately return
  * without making a request.
  */
-export async function initMergeConfidence(
-  supportedDatasourcesString?: string,
-): Promise<void> {
+export async function initMergeConfidence(): Promise<void> {
   initConfig();
-
-  const p = parseSupportedDatasourceString(supportedDatasourcesString);
-  if (!is.undefined(p)) {
-    supportedDatasources = p;
-  }
 
   if (is.nullOrUndefined(apiBaseUrl) || is.nullOrUndefined(token)) {
     logger.trace('merge confidence API usage is disabled');

--- a/lib/util/merge-confidence/index.ts
+++ b/lib/util/merge-confidence/index.ts
@@ -4,6 +4,7 @@ import type { UpdateType } from '../../config/types';
 import { logger } from '../../logger';
 import { ExternalHostError } from '../../types/errors/external-host-error';
 import * as packageCache from '../cache/package';
+import { parseJson } from '../common';
 import * as hostRules from '../host-rules';
 import { Http } from '../http';
 import { MERGE_CONFIDENCE } from './common';
@@ -41,9 +42,9 @@ export function parseSupportedDatasourceString(): string[] | undefined {
     return undefined;
   }
 
-  let parsedDatasourceList: string[] | undefined;
+  let parsedDatasourceList: unknown;
   try {
-    parsedDatasourceList = JSON.parse(supportedDatasourceString);
+    parsedDatasourceList = parseJson(supportedDatasourceString, '.json5');
   } catch (err) {
     logger.error(
       { supportedDatasourceString, err },

--- a/lib/util/merge-confidence/index.ts
+++ b/lib/util/merge-confidence/index.ts
@@ -33,7 +33,8 @@ export function initConfig(): void {
 }
 
 export function parseSupportedDatasourceString(
-  supportedDatasourceString: string | undefined,
+  supportedDatasourceString: string | undefined = process.env
+    .RENOVATE_X_MERGE_CONFIDENCE_SUPPORTED_DATASOURCES,
 ): string[] | undefined {
   if (!is.string(supportedDatasourceString)) {
     return;

--- a/lib/util/merge-confidence/index.ts
+++ b/lib/util/merge-confidence/index.ts
@@ -37,7 +37,7 @@ export function parseSupportedDatasourceString(
     .RENOVATE_X_MERGE_CONFIDENCE_SUPPORTED_DATASOURCES,
 ): string[] | undefined {
   if (!is.string(supportedDatasourceString)) {
-    return;
+    return undefined;
   }
 
   let parsedDatasourceList: string[] | undefined;
@@ -55,7 +55,7 @@ export function parseSupportedDatasourceString(
       { parsedDatasourceList },
       `Expected a string array but got ${typeof parsedDatasourceList}`,
     );
-    return;
+    return undefined;
   }
 
   return parsedDatasourceList;

--- a/lib/util/merge-confidence/index.ts
+++ b/lib/util/merge-confidence/index.ts
@@ -25,21 +25,17 @@ export const confidenceLevels: Record<MergeConfidence, number> = {
 export function initConfig(): void {
   apiBaseUrl = getApiBaseUrl();
   token = getApiToken();
-  supportedDatasources = parseSupportedDatasourceString() ?? [
-    ...presetSupportedDatasources,
-  ];
+  supportedDatasources =
+    parseSupportedDatasourceString() ?? presetSupportedDatasources;
 
   if (!is.nullOrUndefined(token)) {
     logger.debug(`Merge confidence token found for ${apiBaseUrl}`);
   }
 }
 
-export function parseSupportedDatasourceString(
-  supportedDatasourceRawString?: string,
-): string[] | undefined {
+export function parseSupportedDatasourceString(): string[] | undefined {
   const supportedDatasourceString =
-    process.env.RENOVATE_X_MERGE_CONFIDENCE_SUPPORTED_DATASOURCES ??
-    supportedDatasourceRawString;
+    process.env.RENOVATE_X_MERGE_CONFIDENCE_SUPPORTED_DATASOURCES;
 
   if (!is.string(supportedDatasourceString)) {
     return undefined;
@@ -202,8 +198,6 @@ async function queryApi(
 
 /**
  * Checks the health of the Merge Confidence API by attempting to authenticate with it.
- *
- * @param supportedDatasourcesString an optional JSON string array consisting of supported datasources
  *
  * @returns Resolves when the API health check is completed successfully.
  *

--- a/lib/workers/global/initialize.ts
+++ b/lib/workers/global/initialize.ts
@@ -76,9 +76,7 @@ export async function globalInitialize(
   limitCommitsPerRun(config);
   setEmojiConfig(config);
   setGlobalHostRules(config);
-  await initMergeConfidence(
-    process.env.RENOVATE_X_MERGE_CONFIDENCE_SUPPORTED_DATASOURCES,
-  );
+  await initMergeConfidence();
   return config;
 }
 

--- a/lib/workers/global/initialize.ts
+++ b/lib/workers/global/initialize.ts
@@ -76,7 +76,9 @@ export async function globalInitialize(
   limitCommitsPerRun(config);
   setEmojiConfig(config);
   setGlobalHostRules(config);
-  await initMergeConfidence();
+  await initMergeConfidence(
+    process.env.RENOVATE_X_MERGE_CONFIDENCE_SUPPORTED_DATASOURCES,
+  );
   return config;
 }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
The current implementation of the `getConfidenceLevel` function uses a hardcoded list of supported datasources. This list is used to filter requests to the backend, ensuring that only supported datasources result in an actual API call. 
However, the current list is out of sync with the internal badges preset. In this PR, these two lists are combined into a single source of truth.

Additionally, an experimental feature flag has been added for internal use, allowing the overriding of the list for the `getConfidenceLeve` function.

<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
