### PR TITLE
fix(onboarding): add `commitBody` to commitMessage

### DIFF
--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -208,6 +208,7 @@ export interface RenovateConfig
     Record<string, unknown> {
   depName?: string;
   baseBranches?: string[];
+  commitBody?: string;
   useBaseBranchConfig?: UseBaseBranchConfigType;
   baseBranch?: string;
   defaultBranch?: string;

--- a/lib/workers/repository/onboarding/branch/create.spec.ts
+++ b/lib/workers/repository/onboarding/branch/create.spec.ts
@@ -58,12 +58,11 @@ describe('workers/repository/onboarding/branch/create', () => {
     });
 
     describe('applies the commitBody value', () => {
+      const commitBody = 'Signed Off: {{gitAuthor}}';
+      const gitAuthor = 'Bot bot@botland.com';
+
       it('to the default commit message', async () => {
-        await createOnboardingBranch({
-          ...config,
-          commitBody: 'Signed Off: {{gitAuthor}}',
-          gitAuthor: 'Bot bot@botland.com',
-        });
+        await createOnboardingBranch({ ...config, commitBody, gitAuthor });
         expect(scm.commitAndPush).toHaveBeenCalledWith({
           branchName: 'renovate/configure',
           files: [
@@ -85,11 +84,7 @@ describe('workers/repository/onboarding/branch/create', () => {
 
         config.onboardingCommitMessage = message;
 
-        await createOnboardingBranch({
-          ...config,
-          commitBody: 'Signed Off: {{gitAuthor}}',
-          gitAuthor: 'Bot bot@botland.com',
-        });
+        await createOnboardingBranch({ ...config, commitBody, gitAuthor });
         expect(scm.commitAndPush).toHaveBeenCalledWith({
           branchName: 'renovate/configure',
           files: [

--- a/lib/workers/repository/onboarding/branch/create.spec.ts
+++ b/lib/workers/repository/onboarding/branch/create.spec.ts
@@ -34,7 +34,7 @@ describe('workers/repository/onboarding/branch/create', () => {
       });
     });
 
-    it('applies the supplied commit message', async () => {
+    it('applies supplied commit message', async () => {
       const message =
         'We can Renovate if we want to, we can leave PRs in decline';
 

--- a/lib/workers/repository/onboarding/branch/create.spec.ts
+++ b/lib/workers/repository/onboarding/branch/create.spec.ts
@@ -34,7 +34,7 @@ describe('workers/repository/onboarding/branch/create', () => {
       });
     });
 
-    it('applies supplied commit message', async () => {
+    it('applies the supplied commit message', async () => {
       const message =
         'We can Renovate if we want to, we can leave PRs in decline';
 
@@ -54,6 +54,55 @@ describe('workers/repository/onboarding/branch/create', () => {
         force: true,
         message,
         platformCommit: false,
+      });
+    });
+
+    describe('applies the commitBody value', () => {
+      it('to the default commit message', async () => {
+        await createOnboardingBranch({
+          ...config,
+          commitBody: 'Signed Off: {{gitAuthor}}',
+          gitAuthor: 'Bot bot@botland.com',
+        });
+        expect(scm.commitAndPush).toHaveBeenCalledWith({
+          branchName: 'renovate/configure',
+          files: [
+            {
+              type: 'addition',
+              path: 'renovate.json',
+              contents: '{"foo":"bar"}',
+            },
+          ],
+          force: true,
+          message: `Add renovate.json\n\nSigned Off: Bot bot@botland.com`,
+          platformCommit: false,
+        });
+      });
+
+      it('to the supplied commit message', async () => {
+        const message =
+          'We can Renovate if we want to, we can leave PRs in decline';
+
+        config.onboardingCommitMessage = message;
+
+        await createOnboardingBranch({
+          ...config,
+          commitBody: 'Signed Off: {{gitAuthor}}',
+          gitAuthor: 'Bot bot@botland.com',
+        });
+        expect(scm.commitAndPush).toHaveBeenCalledWith({
+          branchName: 'renovate/configure',
+          files: [
+            {
+              type: 'addition',
+              path: 'renovate.json',
+              contents: '{"foo":"bar"}',
+            },
+          ],
+          force: true,
+          message: `We can Renovate if we want to, we can leave PRs in decline\n\nSigned Off: Bot bot@botland.com`,
+          platformCommit: false,
+        });
       });
     });
 

--- a/lib/workers/repository/onboarding/branch/create.spec.ts
+++ b/lib/workers/repository/onboarding/branch/create.spec.ts
@@ -58,11 +58,11 @@ describe('workers/repository/onboarding/branch/create', () => {
     });
 
     describe('applies the commitBody value', () => {
-      const commitBody = 'Signed Off: {{gitAuthor}}';
-      const gitAuthor = 'Bot bot@botland.com';
-
       it('to the default commit message', async () => {
-        await createOnboardingBranch({ ...config, commitBody, gitAuthor });
+        await createOnboardingBranch({
+          ...config,
+          commitBody: 'some commit body',
+        });
         expect(scm.commitAndPush).toHaveBeenCalledWith({
           branchName: 'renovate/configure',
           files: [
@@ -73,7 +73,7 @@ describe('workers/repository/onboarding/branch/create', () => {
             },
           ],
           force: true,
-          message: `Add renovate.json\n\nSigned Off: Bot bot@botland.com`,
+          message: `Add renovate.json\n\nsome commit body`,
           platformCommit: false,
         });
       });
@@ -84,7 +84,11 @@ describe('workers/repository/onboarding/branch/create', () => {
 
         config.onboardingCommitMessage = message;
 
-        await createOnboardingBranch({ ...config, commitBody, gitAuthor });
+        await createOnboardingBranch({
+          ...config,
+          commitBody: 'Signed Off: {{{gitAuthor}}}',
+          gitAuthor: '<Bot bot@botland.com>',
+        });
         expect(scm.commitAndPush).toHaveBeenCalledWith({
           branchName: 'renovate/configure',
           files: [
@@ -95,7 +99,7 @@ describe('workers/repository/onboarding/branch/create', () => {
             },
           ],
           force: true,
-          message: `We can Renovate if we want to, we can leave PRs in decline\n\nSigned Off: Bot bot@botland.com`,
+          message: `We can Renovate if we want to, we can leave PRs in decline\n\nSigned Off: <Bot bot@botland.com>`,
           platformCommit: false,
         });
       });

--- a/lib/workers/repository/onboarding/branch/create.ts
+++ b/lib/workers/repository/onboarding/branch/create.ts
@@ -54,7 +54,7 @@ export async function createOnboardingBranch(
         contents,
       },
     ],
-    message: commitMessage.toString(),
+    message: commitMessage,
     platformCommit: !!config.platformCommit,
     force: true,
   });

--- a/lib/workers/repository/onboarding/branch/create.ts
+++ b/lib/workers/repository/onboarding/branch/create.ts
@@ -3,6 +3,7 @@ import { GlobalConfig } from '../../../../config/global';
 import type { RenovateConfig } from '../../../../config/types';
 import { logger } from '../../../../logger';
 import { scm } from '../../../../modules/platform/scm';
+import * as template from '../../../../util/template';
 import { OnboardingCommitMessageFactory } from './commit-message';
 import { getOnboardingConfigContents } from './config';
 
@@ -25,7 +26,16 @@ export async function createOnboardingBranch(
     config,
     configFile!,
   );
-  const commitMessage = commitMessageFactory.create();
+  let commitMessage = commitMessageFactory.create().toString();
+
+  if (config.commitBody) {
+    commitMessage = `${commitMessage}\n\n${template.compile(
+      config.commitBody,
+      config,
+    )}`;
+
+    logger.trace(`commitMessage: ` + JSON.stringify(commitMessage));
+  }
 
   // istanbul ignore if
   if (GlobalConfig.get('dryRun')) {

--- a/lib/workers/repository/onboarding/branch/create.ts
+++ b/lib/workers/repository/onboarding/branch/create.ts
@@ -3,7 +3,7 @@ import { GlobalConfig } from '../../../../config/global';
 import type { RenovateConfig } from '../../../../config/types';
 import { logger } from '../../../../logger';
 import { scm } from '../../../../modules/platform/scm';
-import * as template from '../../../../util/template';
+import { compile } from '../../../../util/template';
 import { OnboardingCommitMessageFactory } from './commit-message';
 import { getOnboardingConfigContents } from './config';
 
@@ -29,12 +29,13 @@ export async function createOnboardingBranch(
   let commitMessage = commitMessageFactory.create().toString();
 
   if (config.commitBody) {
-    commitMessage = `${commitMessage}\n\n${template.compile(
+    commitMessage = `${commitMessage}\n\n${compile(
       config.commitBody,
-      config,
+      // only allow gitAuthor template value in the commitBody
+      { gitAuthor: config.gitAuthor },
     )}`;
 
-    logger.trace(`commitMessage: ` + JSON.stringify(commitMessage));
+    logger.trace(`commitMessage: ${commitMessage}`);
   }
 
   // istanbul ignore if


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
If `commitBody` is not null, append it to the commitMessage. Using template compile since the `commitBody` can have templates inside it. 
<!-- Describe what behavior is changed by this PR. -->

## Context
Closes: https://github.com/renovatebot/renovate/issues/25943
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
