### PR TITLE
feat(manager/pep621): Add support for python build-system dependencies

### DIFF
--- a/lib/modules/manager/pep621/extract.spec.ts
+++ b/lib/modules/manager/pep621/extract.spec.ts
@@ -346,6 +346,13 @@ describe('modules/manager/pep621/extract', () => {
 
       expect(result?.deps).toEqual([
         {
+          currentValue: '==2.30.0',
+          datasource: 'pypi',
+          depName: 'requests',
+          depType: 'project.dependencies',
+          packageName: 'requests',
+        },
+        {
           currentValue: '==1.18.0',
           datasource: 'pypi',
           depName: 'hatchling',

--- a/lib/modules/manager/pep621/extract.spec.ts
+++ b/lib/modules/manager/pep621/extract.spec.ts
@@ -282,6 +282,13 @@ describe('modules/manager/pep621/extract', () => {
           packageName: 'requests',
         },
         {
+          datasource: 'pypi',
+          depName: 'hatchling',
+          depType: 'build-system.requires',
+          packageName: 'hatchling',
+          skipReason: 'unspecified-version',
+        },
+        {
           currentValue: '==6.5',
           datasource: 'pypi',
           depName: 'coverage',
@@ -322,6 +329,37 @@ describe('modules/manager/pep621/extract', () => {
 
       const res = extractPackageFile(content, 'pyproject.toml');
       expect(res?.packageFileVersion).toBe('0.0.2');
+    });
+
+    it('should extract dependencies from build-system.requires', function () {
+      const content = codeBlock`
+        [build-system]
+        requires = ["hatchling==1.18.0", "setuptools==69.0.3"]
+        build-backend = "hatchling.build"
+
+        [project]
+        name = "test"
+        version = "0.0.2"
+        dependencies = [ "requests==2.30.0" ]
+      `;
+      const result = extractPackageFile(content, 'pyproject.toml');
+
+      expect(result?.deps).toEqual([
+        {
+          currentValue: '==1.18.0',
+          datasource: 'pypi',
+          depName: 'hatchling',
+          depType: 'build-system.requires',
+          packageName: 'hatchling',
+        },
+        {
+          currentValue: '==69.0.3',
+          datasource: 'pypi',
+          depName: 'setuptools',
+          depType: 'build-system.requires',
+          packageName: 'setuptools',
+        },
+      ]);
     });
   });
 });

--- a/lib/modules/manager/pep621/extract.ts
+++ b/lib/modules/manager/pep621/extract.ts
@@ -43,6 +43,12 @@ export function extractPackageFile(
       def.project?.['optional-dependencies'],
     ),
   );
+  deps.push(
+    ...parseDependencyList(
+      depTypes.buildSystemRequires,
+      def['build-system']?.requires,
+    ),
+  );
 
   // process specific tool sets
   let processedDeps = deps;

--- a/lib/modules/manager/pep621/readme.md
+++ b/lib/modules/manager/pep621/readme.md
@@ -9,5 +9,6 @@ Available `depType`s:
 
 - `project.dependencies`
 - `project.optional-dependencies`
+- `build-system.requires`
 - `tool.pdm.dev-dependencies`
 - `tool.hatch.envs.<env-name>`

--- a/lib/modules/manager/pep621/schema.ts
+++ b/lib/modules/manager/pep621/schema.ts
@@ -16,6 +16,11 @@ export const PyProjectSchema = z.object({
       'optional-dependencies': DependencyRecordSchema,
     })
     .optional(),
+  'build-system': z
+    .object({
+      requires: DependencyListSchema,
+    })
+    .optional(),
   tool: z
     .object({
       pdm: z

--- a/lib/modules/manager/pep621/utils.ts
+++ b/lib/modules/manager/pep621/utils.ts
@@ -15,6 +15,7 @@ export const depTypes = {
   dependencies: 'project.dependencies',
   optionalDependencies: 'project.optional-dependencies',
   pdmDevDependencies: 'tool.pdm.dev-dependencies',
+  buildSystemRequires: 'build-system.requires',
 };
 
 export function parsePEP508(


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Update the Python `pep621` manager to be able to find dependencies in the `build-system` table of `pyproject.toml`.

## Context

[Initial discussion](https://github.com/renovatebot/renovate/discussions/26431)

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
