### PR TITLE
fix(terraform): Escape literal . in Bitbucket module ref regex

### DIFF
--- a/lib/modules/manager/terraform/extractors/others/modules.spec.ts
+++ b/lib/modules/manager/terraform/extractors/others/modules.spec.ts
@@ -148,6 +148,9 @@ describe('modules/manager/terraform/extractors/others/modules', () => {
       const subfolderWithDoubleSlash = bitbucketRefMatchRegex.exec(
         'bitbucket.org/hashicorp/example.git//terraform?ref=v1.0.0',
       )?.groups;
+      const subfolderWithGitInName = bitbucketRefMatchRegex.exec(
+        'bitbucket.org/hashicorp/example.git//terraform-git?ref=v1.0.0',
+      )?.groups;
       const depth = bitbucketRefMatchRegex.exec(
         'git::https://git@bitbucket.org/hashicorp/example.git?depth=1&ref=v1.0.0',
       )?.groups;
@@ -176,6 +179,11 @@ describe('modules/manager/terraform/extractors/others/modules', () => {
         tag: 'v1.0.0',
       });
       expect(subfolderWithDoubleSlash).toMatchObject({
+        workspace: 'hashicorp',
+        project: 'example',
+        tag: 'v1.0.0',
+      });
+      expect(subfolderWithGitInName).toMatchObject({
         workspace: 'hashicorp',
         project: 'example',
         tag: 'v1.0.0',

--- a/lib/modules/manager/terraform/extractors/others/modules.ts
+++ b/lib/modules/manager/terraform/extractors/others/modules.ts
@@ -13,7 +13,7 @@ export const githubRefMatchRegex = regEx(
   /github\.com([/:])(?<project>[^/]+\/[a-z0-9-_.]+).*\?(depth=\d+&)?ref=(?<tag>.*?)(&depth=\d+)?$/i,
 );
 export const bitbucketRefMatchRegex = regEx(
-  /(?:git::)?(?<url>(?:http|https|ssh)?(?::\/\/)?(?:.*@)?(?<path>bitbucket\.org\/(?<workspace>.*)\/(?<project>.*).git\/?(?<subfolder>.*)))\?(depth=\d+&)?ref=(?<tag>.*?)(&depth=\d+)?$/,
+  /(?:git::)?(?<url>(?:http|https|ssh)?(?::\/\/)?(?:.*@)?(?<path>bitbucket\.org\/(?<workspace>.*)\/(?<project>.*)\.git\/?(?<subfolder>.*)))\?(depth=\d+&)?ref=(?<tag>.*?)(&depth=\d+)?$/,
 );
 export const gitTagsRefMatchRegex = regEx(
   /(?:git::)?(?<url>(?:(?:http|https|ssh):\/\/)?(?:.*@)?(?<path>.*\/(?<project>.*\/.*)))\?(depth=\d+&)?ref=(?<tag>.*?)(&depth=\d+)?$/,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
Escapes a `.` in Terraform manager's Bitbucket Ref regex. The `.git` sequence should be interpreted literally instead of as `<any_character>git`.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

Currently Renovate's Terraform manager is failing to properly parse the package name in Bitbucket Git module sources when the URI path contains the word `git`.

Example:
```terraform
module "example" {
  source = "git::ssh://git@bitbucket.org/workspace/repo.git//path_with_git?depth=1&ref=v2.0.0"
}
```

The regex currently parses
* Group `workspace` as `workspace/repo.git/`. Expected: `workspace`
* Group `project` as `path_with`. Expected: `repo`
* Group `subfolder` as empty string. Expected: `/path_with_git`

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
