### PR TITLE
fix(platform/gerrit): Check for comment size limit

### DIFF
--- a/lib/modules/platform/gerrit/client.spec.ts
+++ b/lib/modules/platform/gerrit/client.spec.ts
@@ -256,6 +256,18 @@ describe('modules/platform/gerrit/client', () => {
         .reply(200, gerritRestResponse([]), jsonResultHeader);
       await expect(client.addMessage(123456, 'message')).toResolve();
     });
+
+    it('add too big message', async () => {
+      const okMessage = 'a'.repeat(0x4000);
+      const tooBigMessage = okMessage + 'b';
+      httpMock
+        .scope(gerritEndpointUrl)
+        .post('/a/changes/123456/revisions/current/review', {
+          message: okMessage,
+        })
+        .reply(200, gerritRestResponse([]), jsonResultHeader);
+      await expect(client.addMessage(123456, tooBigMessage)).toResolve();
+    });
   });
 
   describe('checkForExistingMessage()', () => {

--- a/lib/modules/platform/gerrit/client.ts
+++ b/lib/modules/platform/gerrit/client.ts
@@ -215,10 +215,8 @@ class GerritClient {
   }
 
   normalizeMessage(message: string): string {
-    const trimmedMessage = message.trim(); //the last \n was removed from gerrit after the comment was added...
-    return trimmedMessage.length > 0x4000
-      ? trimmedMessage.slice(0, 0x4000)
-      : trimmedMessage;
+    //the last \n was removed from gerrit after the comment was added...
+    return message.substring(0, 0x4000).trim();
   }
 
   private static buildSearchFilters(


### PR DESCRIPTION
If generated message too big request to gerrit will fail with:

     One or more comments were rejected in validation: Comment size exceeds limit (16437 > 16384)

Avoid this by truncating messages before posting them.

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Fix minor issue with gerrit integration.

## Context

While testing new gerrit integration I found in some cases (long changelog) it might fail to create changeset. It is the fix for the issue.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
