### PR TITLE
feat(autodiscover): restore INFO logging of number of found repos

### DIFF
--- a/lib/workers/global/autodiscover.ts
+++ b/lib/workers/global/autodiscover.ts
@@ -61,14 +61,11 @@ export async function autodiscoverRepositories(
       logger.debug('None of the discovered repositories matched the filter');
       return config;
     }
-    logger.debug(
-      `Autodiscovered ${discovered.length} repositories after filter`,
-    );
   }
 
   logger.info(
     { length: discovered.length, repositories: discovered },
-    `Autodiscovered repositories`
+    `Autodiscovered repositories`,
   );
 
   // istanbul ignore if

--- a/lib/workers/global/autodiscover.ts
+++ b/lib/workers/global/autodiscover.ts
@@ -66,7 +66,10 @@ export async function autodiscoverRepositories(
     );
   }
 
-  logger.info({ repositories: discovered }, `Autodiscovered repositories`);
+  logger.info(
+    { length: discovered.length, repositories: discovered },
+    `Autodiscovered repositories`
+  );
 
   // istanbul ignore if
   if (config.repositories?.length) {


### PR DESCRIPTION
## Changes

Restore INFO logging for number of autodiscovered repositories.

## Context

Can be useful, as discussed in https://github.com/renovatebot/renovate/discussions/26444.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
