### PR TITLE
fix(manager/nuget): Add autoReplaceStringTemplate

### DIFF
--- a/lib/modules/manager/nuget/extract.spec.ts
+++ b/lib/modules/manager/nuget/extract.spec.ts
@@ -86,6 +86,7 @@ describe('modules/manager/nuget/extract', () => {
             depType: 'docker',
             datasource: 'docker',
             currentValue: '7.0.10',
+            replaceString: 'mcr.microsoft.com/dotnet/runtime:7.0.10',
           },
         ],
         packageFileVersion: '0.1.0',
@@ -112,6 +113,8 @@ describe('modules/manager/nuget/extract', () => {
             currentValue: '7.0.10',
             currentDigest:
               'sha256:181067029e094856691ee1ce3782ea3bd3fda01bb5b6d19411d0f673cab1ab19',
+            replaceString:
+              'mcr.microsoft.com/dotnet/runtime:7.0.10@sha256:181067029e094856691ee1ce3782ea3bd3fda01bb5b6d19411d0f673cab1ab19',
           },
         ],
         packageFileVersion: '0.1.0',

--- a/lib/modules/manager/nuget/extract.spec.ts
+++ b/lib/modules/manager/nuget/extract.spec.ts
@@ -82,8 +82,8 @@ describe('modules/manager/nuget/extract', () => {
           {
             autoReplaceStringTemplate:
               '{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}',
+            currentDigest: undefined,
             depName: 'mcr.microsoft.com/dotnet/runtime',
-            depType: 'docker',
             datasource: 'docker',
             currentValue: '7.0.10',
             replaceString: 'mcr.microsoft.com/dotnet/runtime:7.0.10',
@@ -108,7 +108,6 @@ describe('modules/manager/nuget/extract', () => {
             autoReplaceStringTemplate:
               '{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}',
             depName: 'mcr.microsoft.com/dotnet/runtime',
-            depType: 'docker',
             datasource: 'docker',
             currentValue: '7.0.10',
             currentDigest:

--- a/lib/modules/manager/nuget/extract.spec.ts
+++ b/lib/modules/manager/nuget/extract.spec.ts
@@ -80,6 +80,8 @@ describe('modules/manager/nuget/extract', () => {
       expect(await extractPackageFile(contents, contents, config)).toEqual({
         deps: [
           {
+            autoReplaceStringTemplate:
+              '{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}',
             depName: 'mcr.microsoft.com/dotnet/runtime',
             depType: 'docker',
             datasource: 'docker',
@@ -102,6 +104,8 @@ describe('modules/manager/nuget/extract', () => {
       expect(await extractPackageFile(contents, contents, config)).toEqual({
         deps: [
           {
+            autoReplaceStringTemplate:
+              '{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}',
             depName: 'mcr.microsoft.com/dotnet/runtime',
             depType: 'docker',
             datasource: 'docker',

--- a/lib/modules/manager/nuget/extract.spec.ts
+++ b/lib/modules/manager/nuget/extract.spec.ts
@@ -84,6 +84,7 @@ describe('modules/manager/nuget/extract', () => {
               '{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}',
             currentDigest: undefined,
             depName: 'mcr.microsoft.com/dotnet/runtime',
+            depType: 'docker',
             datasource: 'docker',
             currentValue: '7.0.10',
             replaceString: 'mcr.microsoft.com/dotnet/runtime:7.0.10',
@@ -108,6 +109,7 @@ describe('modules/manager/nuget/extract', () => {
             autoReplaceStringTemplate:
               '{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}',
             depName: 'mcr.microsoft.com/dotnet/runtime',
+            depType: 'docker',
             datasource: 'docker',
             currentValue: '7.0.10',
             currentDigest:

--- a/lib/modules/manager/nuget/extract.spec.ts
+++ b/lib/modules/manager/nuget/extract.spec.ts
@@ -82,7 +82,6 @@ describe('modules/manager/nuget/extract', () => {
           {
             autoReplaceStringTemplate:
               '{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}',
-            currentDigest: undefined,
             depName: 'mcr.microsoft.com/dotnet/runtime',
             depType: 'docker',
             datasource: 'docker',

--- a/lib/modules/manager/nuget/extract.ts
+++ b/lib/modules/manager/nuget/extract.ts
@@ -51,7 +51,7 @@ function extractDepsFromXml(xmlNode: XmlDocument): NugetPackageDependency[] {
       const dep = getDep(child.val, true);
 
       if (is.nonEmptyStringAndNotWhitespace(dep.depName)) {
-        results.push(dep);
+        results.push({ ...dep, depType: 'docker' });
       }
     }
 

--- a/lib/modules/manager/nuget/extract.ts
+++ b/lib/modules/manager/nuget/extract.ts
@@ -53,14 +53,13 @@ function extractDepsFromXml(xmlNode: XmlDocument): NugetPackageDependency[] {
 
       if (is.nonEmptyStringAndNotWhitespace(dep.depName)) {
         results.push({
-          autoReplaceStringTemplate:
-            '{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}',
+          autoReplaceStringTemplate: dep.autoReplaceStringTemplate,
           datasource: DockerDatasource.id,
           depType: 'docker',
           depName: dep.depName,
           currentValue: dep.currentValue,
           currentDigest: dep.currentDigest,
-          replaceString: child.val,
+          replaceString: dep.replaceString,
         });
       }
     }

--- a/lib/modules/manager/nuget/extract.ts
+++ b/lib/modules/manager/nuget/extract.ts
@@ -48,9 +48,9 @@ function extractDepsFromXml(xmlNode: XmlDocument): NugetPackageDependency[] {
     const { name, attr } = child;
 
     if (name === 'ContainerBaseImage') {
-      const dep = getDep(child.val, true);
+      const { depName, ...dep } = getDep(child.val, true);
 
-      if (is.nonEmptyStringAndNotWhitespace(dep.depName)) {
+      if (is.nonEmptyStringAndNotWhitespace(depName)) {
         results.push({ ...dep, depName: dep.depName, depType: 'docker' });
       }
     }

--- a/lib/modules/manager/nuget/extract.ts
+++ b/lib/modules/manager/nuget/extract.ts
@@ -60,6 +60,7 @@ function extractDepsFromXml(xmlNode: XmlDocument): NugetPackageDependency[] {
           depName: dep.depName,
           currentValue: dep.currentValue,
           currentDigest: dep.currentDigest,
+          replaceString: child.val,
         });
       }
     }

--- a/lib/modules/manager/nuget/extract.ts
+++ b/lib/modules/manager/nuget/extract.ts
@@ -53,6 +53,8 @@ function extractDepsFromXml(xmlNode: XmlDocument): NugetPackageDependency[] {
 
       if (is.nonEmptyStringAndNotWhitespace(dep.depName)) {
         results.push({
+          autoReplaceStringTemplate:
+            '{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}',
           datasource: DockerDatasource.id,
           depType: 'docker',
           depName: dep.depName,

--- a/lib/modules/manager/nuget/extract.ts
+++ b/lib/modules/manager/nuget/extract.ts
@@ -51,7 +51,7 @@ function extractDepsFromXml(xmlNode: XmlDocument): NugetPackageDependency[] {
       const { depName, ...dep } = getDep(child.val, true);
 
       if (is.nonEmptyStringAndNotWhitespace(depName)) {
-        results.push({ ...dep, depName: dep.depName, depType: 'docker' });
+        results.push({ ...dep, depName, depType: 'docker' });
       }
     }
 

--- a/lib/modules/manager/nuget/extract.ts
+++ b/lib/modules/manager/nuget/extract.ts
@@ -52,15 +52,7 @@ function extractDepsFromXml(xmlNode: XmlDocument): NugetPackageDependency[] {
       const dep = getDep(child.val, true);
 
       if (is.nonEmptyStringAndNotWhitespace(dep.depName)) {
-        results.push({
-          autoReplaceStringTemplate: dep.autoReplaceStringTemplate,
-          datasource: DockerDatasource.id,
-          depType: 'docker',
-          depName: dep.depName,
-          currentValue: dep.currentValue,
-          currentDigest: dep.currentDigest,
-          replaceString: dep.replaceString,
-        });
+        results.push(dep);
       }
     }
 

--- a/lib/modules/manager/nuget/extract.ts
+++ b/lib/modules/manager/nuget/extract.ts
@@ -4,7 +4,6 @@ import { logger } from '../../../logger';
 import { getSiblingFileName, localPathExists } from '../../../util/fs';
 import { hasKey } from '../../../util/object';
 import { regEx } from '../../../util/regex';
-import { DockerDatasource } from '../../datasource/docker';
 import { NugetDatasource } from '../../datasource/nuget';
 import { getDep } from '../dockerfile/extract';
 import type {

--- a/lib/modules/manager/nuget/extract.ts
+++ b/lib/modules/manager/nuget/extract.ts
@@ -51,7 +51,7 @@ function extractDepsFromXml(xmlNode: XmlDocument): NugetPackageDependency[] {
       const dep = getDep(child.val, true);
 
       if (is.nonEmptyStringAndNotWhitespace(dep.depName)) {
-        results.push({ ...dep, depName: dep.depName!, depType: 'docker' });
+        results.push({ ...dep, depName: dep.depName, depType: 'docker' });
       }
     }
 

--- a/lib/modules/manager/nuget/extract.ts
+++ b/lib/modules/manager/nuget/extract.ts
@@ -51,7 +51,7 @@ function extractDepsFromXml(xmlNode: XmlDocument): NugetPackageDependency[] {
       const dep = getDep(child.val, true);
 
       if (is.nonEmptyStringAndNotWhitespace(dep.depName)) {
-        results.push({ ...dep, depType: 'docker' });
+        results.push({ ...dep, depName: dep.depName!, depType: 'docker' });
       }
     }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Support updating docker image digests for `ContainerBaseImage` property.

<!-- Describe what behavior is changed by this PR. -->

## Context

- Fixes #26502 
Feature implemented in #26400, but pinning digest is not working, I think it is linked to the missing `autoReplaceStringTemplate` property.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
