### PR TITLE
fix(helmv3): add --force-update when adding a repo

### DIFF
--- a/lib/modules/manager/helmv3/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/modules/manager/helmv3/__snapshots__/artifacts.spec.ts.snap
@@ -74,7 +74,7 @@ exports[`modules/manager/helmv3/artifacts do not add registryAliases to reposito
     },
   },
   {
-    "cmd": "helm repo add nginx https://kubernetes.github.io/ingress-nginx --force-update --force-update",
+    "cmd": "helm repo add nginx https://kubernetes.github.io/ingress-nginx --force-update",
     "options": {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",

--- a/lib/modules/manager/helmv3/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/modules/manager/helmv3/__snapshots__/artifacts.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`modules/manager/helmv3/artifacts alias name is picked, when repository is as alias and dependency defined 1`] = `
 [
   {
-    "cmd": "helm repo add repo1 https://gitlab.com/api/v4/projects/xxxxxxx/packages/helm/stable --username basicUser --password secret",
+    "cmd": "helm repo add repo1 https://gitlab.com/api/v4/projects/xxxxxxx/packages/helm/stable --force-update --username basicUser --password secret",
     "options": {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -52,7 +52,7 @@ exports[`modules/manager/helmv3/artifacts alias name is picked, when repository 
 exports[`modules/manager/helmv3/artifacts do not add registryAliases to repository list 1`] = `
 [
   {
-    "cmd": "helm repo add jetstack https://charts.jetstack.io",
+    "cmd": "helm repo add jetstack https://charts.jetstack.io --force-update",
     "options": {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -74,7 +74,7 @@ exports[`modules/manager/helmv3/artifacts do not add registryAliases to reposito
     },
   },
   {
-    "cmd": "helm repo add nginx https://kubernetes.github.io/ingress-nginx",
+    "cmd": "helm repo add nginx https://kubernetes.github.io/ingress-nginx --force-update --force-update",
     "options": {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -145,7 +145,7 @@ exports[`modules/manager/helmv3/artifacts log into private registries and reposi
     },
   },
   {
-    "cmd": "helm repo add repo-test https://gitlab.com/api/v4/projects/xxxxxxx/packages/helm/stable --username basicUser --password secret",
+    "cmd": "helm repo add repo-test https://gitlab.com/api/v4/projects/xxxxxxx/packages/helm/stable --force-update --username basicUser --password secret",
     "options": {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -216,7 +216,7 @@ exports[`modules/manager/helmv3/artifacts log into private registries and reposi
     },
   },
   {
-    "cmd": "helm repo add stable the_stable_url",
+    "cmd": "helm repo add stable the_stable_url --force-update",
     "options": {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -238,7 +238,7 @@ exports[`modules/manager/helmv3/artifacts log into private registries and reposi
     },
   },
   {
-    "cmd": "helm repo add repo1 https://the_repo1_url --username basicUser --password secret",
+    "cmd": "helm repo add repo1 https://the_repo1_url --force-update --username basicUser --password secret",
     "options": {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -260,7 +260,7 @@ exports[`modules/manager/helmv3/artifacts log into private registries and reposi
     },
   },
   {
-    "cmd": "helm repo add repo-test https://gitlab.com/api/v4/projects/xxxxxxx/packages/helm/stable",
+    "cmd": "helm repo add repo-test https://gitlab.com/api/v4/projects/xxxxxxx/packages/helm/stable --force-update",
     "options": {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -309,7 +309,7 @@ exports[`modules/manager/helmv3/artifacts log into private registries and reposi
 exports[`modules/manager/helmv3/artifacts returns null if unchanged 1`] = `
 [
   {
-    "cmd": "helm repo add repo-test https://gitlab.com/api/v4/projects/xxxxxxx/packages/helm/stable",
+    "cmd": "helm repo add repo-test https://gitlab.com/api/v4/projects/xxxxxxx/packages/helm/stable --force-update",
     "options": {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -358,7 +358,7 @@ exports[`modules/manager/helmv3/artifacts returns null if unchanged 1`] = `
 exports[`modules/manager/helmv3/artifacts returns updated Chart.lock 1`] = `
 [
   {
-    "cmd": "helm repo add repo-test https://gitlab.com/api/v4/projects/xxxxxxx/packages/helm/stable",
+    "cmd": "helm repo add repo-test https://gitlab.com/api/v4/projects/xxxxxxx/packages/helm/stable --force-update",
     "options": {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -407,7 +407,7 @@ exports[`modules/manager/helmv3/artifacts returns updated Chart.lock 1`] = `
 exports[`modules/manager/helmv3/artifacts returns updated Chart.lock for lockfile maintenance 1`] = `
 [
   {
-    "cmd": "helm repo add repo-test https://gitlab.com/api/v4/projects/xxxxxxx/packages/helm/stable",
+    "cmd": "helm repo add repo-test https://gitlab.com/api/v4/projects/xxxxxxx/packages/helm/stable --force-update",
     "options": {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -468,7 +468,7 @@ exports[`modules/manager/helmv3/artifacts returns updated Chart.lock with docker
     },
   },
   {
-    "cmd": "docker run --rm --name=renovate_sidecar --label=renovate_child -v "/tmp/github/some/repo":"/tmp/github/some/repo" -v "/tmp/renovate/cache":"/tmp/renovate/cache" -e HELM_EXPERIMENTAL_OCI -e HELM_REGISTRY_CONFIG -e HELM_REPOSITORY_CONFIG -e HELM_REPOSITORY_CACHE -e CONTAINERBASE_CACHE_DIR -w "/tmp/github/some/repo" ghcr.io/containerbase/sidecar bash -l -c "install-tool helm v3.7.2 && helm repo add repo-test https://gitlab.com/api/v4/projects/xxxxxxx/packages/helm/stable && helm dependency update ''"",
+    "cmd": "docker run --rm --name=renovate_sidecar --label=renovate_child -v "/tmp/github/some/repo":"/tmp/github/some/repo" -v "/tmp/renovate/cache":"/tmp/renovate/cache" -e HELM_EXPERIMENTAL_OCI -e HELM_REGISTRY_CONFIG -e HELM_REPOSITORY_CONFIG -e HELM_REPOSITORY_CACHE -e CONTAINERBASE_CACHE_DIR -w "/tmp/github/some/repo" ghcr.io/containerbase/sidecar bash -l -c "install-tool helm v3.7.2 && helm repo add repo-test https://gitlab.com/api/v4/projects/xxxxxxx/packages/helm/stable --force-update && helm dependency update ''"",
     "options": {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -496,7 +496,7 @@ exports[`modules/manager/helmv3/artifacts returns updated Chart.lock with docker
 exports[`modules/manager/helmv3/artifacts sets repositories from registryAliases 1`] = `
 [
   {
-    "cmd": "helm repo add stable the_stable_url",
+    "cmd": "helm repo add stable the_stable_url --force-update",
     "options": {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -518,7 +518,7 @@ exports[`modules/manager/helmv3/artifacts sets repositories from registryAliases
     },
   },
   {
-    "cmd": "helm repo add repo1 the_repo1_url",
+    "cmd": "helm repo add repo1 the_repo1_url --force-update",
     "options": {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -540,7 +540,7 @@ exports[`modules/manager/helmv3/artifacts sets repositories from registryAliases
     },
   },
   {
-    "cmd": "helm repo add repo-test https://gitlab.com/api/v4/projects/xxxxxxx/packages/helm/stable",
+    "cmd": "helm repo add repo-test https://gitlab.com/api/v4/projects/xxxxxxx/packages/helm/stable --force-update",
     "options": {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -601,7 +601,7 @@ exports[`modules/manager/helmv3/artifacts sets repositories from registryAliases
     },
   },
   {
-    "cmd": "docker run --rm --name=renovate_sidecar --label=renovate_child -v "/tmp/github/some/repo":"/tmp/github/some/repo" -v "/tmp/renovate/cache":"/tmp/renovate/cache" -e HELM_EXPERIMENTAL_OCI -e HELM_REGISTRY_CONFIG -e HELM_REPOSITORY_CONFIG -e HELM_REPOSITORY_CACHE -e CONTAINERBASE_CACHE_DIR -w "/tmp/github/some/repo" ghcr.io/containerbase/sidecar bash -l -c "install-tool helm v3.7.2 && helm repo add stable the_stable_url && helm repo add repo1 the_repo1_url && helm repo add repo-test https://gitlab.com/api/v4/projects/xxxxxxx/packages/helm/stable && helm dependency update ''"",
+    "cmd": "docker run --rm --name=renovate_sidecar --label=renovate_child -v "/tmp/github/some/repo":"/tmp/github/some/repo" -v "/tmp/renovate/cache":"/tmp/renovate/cache" -e HELM_EXPERIMENTAL_OCI -e HELM_REGISTRY_CONFIG -e HELM_REPOSITORY_CONFIG -e HELM_REPOSITORY_CACHE -e CONTAINERBASE_CACHE_DIR -w "/tmp/github/some/repo" ghcr.io/containerbase/sidecar bash -l -c "install-tool helm v3.7.2 && helm repo add stable the_stable_url --force-update && helm repo add repo1 the_repo1_url --force-update && helm repo add repo-test https://gitlab.com/api/v4/projects/xxxxxxx/packages/helm/stable --force-update && helm dependency update ''"",
     "options": {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",

--- a/lib/modules/manager/helmv3/artifacts.spec.ts
+++ b/lib/modules/manager/helmv3/artifacts.spec.ts
@@ -290,7 +290,7 @@ describe('modules/manager/helmv3/artifacts', () => {
     ]);
     expect(execSnapshots).toMatchObject([
       {
-        cmd: 'helm repo add repo-test https://gitlab.com/api/v4/projects/xxxxxxx/packages/helm/stable',
+        cmd: 'helm repo add repo-test https://gitlab.com/api/v4/projects/xxxxxxx/packages/helm/stable --force-update',
       },
       {
         cmd: "helm dependency update ''",
@@ -343,7 +343,7 @@ describe('modules/manager/helmv3/artifacts', () => {
     ]);
     expect(execSnapshots).toMatchObject([
       {
-        cmd: 'helm repo add repo-test https://gitlab.com/api/v4/projects/xxxxxxx/packages/helm/stable',
+        cmd: 'helm repo add repo-test https://gitlab.com/api/v4/projects/xxxxxxx/packages/helm/stable --force-update',
         options: {
           env: {
             HELM_EXPERIMENTAL_OCI: '1',
@@ -411,7 +411,7 @@ describe('modules/manager/helmv3/artifacts', () => {
     ]);
     expect(execSnapshots).toMatchObject([
       {
-        cmd: 'helm repo add repo-test https://gitlab.com/api/v4/projects/xxxxxxx/packages/helm/stable',
+        cmd: 'helm repo add repo-test https://gitlab.com/api/v4/projects/xxxxxxx/packages/helm/stable --force-update',
         options: {
           env: {
             HELM_EXPERIMENTAL_OCI: '1',
@@ -486,7 +486,7 @@ describe('modules/manager/helmv3/artifacts', () => {
     ]);
     expect(execSnapshots).toMatchObject([
       {
-        cmd: 'helm repo add repo-test https://gitlab.com/api/v4/projects/xxxxxxx/packages/helm/stable',
+        cmd: 'helm repo add repo-test https://gitlab.com/api/v4/projects/xxxxxxx/packages/helm/stable --force-update',
         options: {
           env: {
             HELM_EXPERIMENTAL_OCI: '1',
@@ -546,7 +546,7 @@ describe('modules/manager/helmv3/artifacts', () => {
     ).toBeNull();
     expect(execSnapshots).toMatchObject([
       {
-        cmd: 'helm repo add repo-test https://gitlab.com/api/v4/projects/xxxxxxx/packages/helm/stable',
+        cmd: 'helm repo add repo-test https://gitlab.com/api/v4/projects/xxxxxxx/packages/helm/stable --force-update',
         options: {
           env: {
             HELM_EXPERIMENTAL_OCI: '1',

--- a/lib/modules/manager/helmv3/artifacts.ts
+++ b/lib/modules/manager/helmv3/artifacts.ts
@@ -70,7 +70,7 @@ async function helmCommands(
   // add helm repos if an alias or credentials for the url are defined
   classicRepositories.forEach((value) => {
     const { username, password } = value.hostRule;
-    const parameters = [`${value.repository}`];
+    const parameters = [`${value.repository}`, `--force-update`];
     const isPrivateRepo = username && password;
     if (isPrivateRepo) {
       parameters.push(`--username ${quote(username)}`);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

We add [`--force-update`](https://helm.sh/docs/helm/helm_repo_add/) to overwrite any existing repo with the same name.

## Context

When using renovate to update helm lock files in a monorepo, we encounter the following error when a helm chart is present in multiple Chart.yaml : 

```
The artifact failure details are included below:

Command failed: helm repo add <name> <url>
Error: repository name (<name>) already exists, please specify a different name
```

Using [`--force-update`](https://helm.sh/docs/helm/helm_repo_add/) works around this behaviour by overwriting any existing repo with the same name.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [X] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
