### PR TITLE
feat(config-migration): support editorconfig `max_line_length`

### DIFF
--- a/lib/util/json-writer/__fixtures__/.global_editorconfig
+++ b/lib/util/json-writer/__fixtures__/.global_editorconfig
@@ -1,3 +1,4 @@
 [*]
 indent_style = space
 indent_size = 6
+max_line_length = 160

--- a/lib/util/json-writer/__fixtures__/.json_editorconfig
+++ b/lib/util/json-writer/__fixtures__/.json_editorconfig
@@ -1,2 +1,5 @@
+[*]
+max_line_length = off
+
 [*.json]
 indent_style = tab

--- a/lib/util/json-writer/code-format.ts
+++ b/lib/util/json-writer/code-format.ts
@@ -3,4 +3,5 @@ import type { IndentationType } from './indentation-type';
 export interface CodeFormat {
   indentationSize?: number;
   indentationType?: IndentationType;
+  maxLineLength?: number | 'off';
 }

--- a/lib/util/json-writer/editor-config.spec.ts
+++ b/lib/util/json-writer/editor-config.spec.ts
@@ -33,7 +33,6 @@ describe('util/json-writer/editor-config', () => {
   });
 
   it('should handle empty .editorconfig file', async () => {
-    expect.assertions(2);
     Fixtures.mock({
       '.editorconfig': '',
     });
@@ -41,20 +40,20 @@ describe('util/json-writer/editor-config', () => {
 
     expect(format.indentationSize).toBeUndefined();
     expect(format.indentationType).toBeUndefined();
+    expect(format.maxLineLength).toBeUndefined();
   });
 
   it('should handle global config from .editorconfig', async () => {
-    expect.assertions(2);
     Fixtures.mock({
       '.editorconfig': Fixtures.get('.global_editorconfig'),
     });
     const format = await EditorConfig.getCodeFormat(defaultConfigFile);
     expect(format.indentationSize).toBe(6);
     expect(format.indentationType).toBe('space');
+    expect(format.maxLineLength).toBe(160);
   });
 
   it('should return undefined in case of exception', async () => {
-    expect.assertions(2);
     Fixtures.mock({
       '.editorconfig': Fixtures.get('.global_editorconfig'),
     });
@@ -70,7 +69,6 @@ describe('util/json-writer/editor-config', () => {
   });
 
   it('should not handle non json config from .editorconfig', async () => {
-    expect.assertions(2);
     Fixtures.mock({
       '.editorconfig': Fixtures.get('.non_json_editorconfig'),
     });
@@ -81,12 +79,12 @@ describe('util/json-writer/editor-config', () => {
   });
 
   it('should handle json config from .editorconfig', async () => {
-    expect.assertions(1);
     Fixtures.mock({
       '.editorconfig': Fixtures.get('.json_editorconfig'),
     });
     const format = await EditorConfig.getCodeFormat(defaultConfigFile);
 
     expect(format.indentationType).toBe('tab');
+    expect(format.maxLineLength).toBe('off');
   });
 });

--- a/lib/util/json-writer/editor-config.ts
+++ b/lib/util/json-writer/editor-config.ts
@@ -13,6 +13,7 @@ export class EditorConfig {
       return {
         indentationSize: EditorConfig.getIndentationSize(knownProps),
         indentationType: EditorConfig.getIndentationType(knownProps),
+        maxLineLength: knownProps.max_line_length as number | 'off' | undefined,
       };
     } catch (err) {
       logger.warn({ err }, 'Failed to parse editor config');

--- a/lib/workers/repository/config-migration/branch/migrated-data.ts
+++ b/lib/workers/repository/config-migration/branch/migrated-data.ts
@@ -51,7 +51,9 @@ export async function applyPrettierFormatting(
       prettierConfigFilenames.has(file),
     );
 
-    const editroconfExists = fileList.some((file) => file === '.editorconfig');
+    const editorconfigExists = fileList.some(
+      (file) => file === '.editorconfig',
+    );
 
     if (!prettierExists) {
       try {
@@ -75,7 +77,7 @@ export async function applyPrettierFormatting(
       useTabs: indent?.type === 'tab',
     };
 
-    if (editroconfExists) {
+    if (editorconfigExists) {
       const editorconf = await EditorConfig.getCodeFormat(filename);
 
       // https://github.com/prettier/prettier/blob/bab892242a1f9d8fcae50514b9304bf03f2e25ab/src/config/editorconfig/editorconfig-to-prettier.js#L47


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
<!-- Describe what behavior is changed by this PR. -->

Read editorconfig when a `.editorconfig` file exits in repo and use `max_line_length` when configured.
Helps to reduces config migration changes.

- broken: https://github.com/visualon/docker-images/pull/2212
- better: https://github.com/renovate-reproductions/prettier-formating/pull/1

## Context
- #16359
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
