### PR TITLE
fix(containerbase): support ranges in flutter and dart sdks

### DIFF
--- a/lib/util/exec/containerbase.spec.ts
+++ b/lib/util/exec/containerbase.spec.ts
@@ -209,6 +209,7 @@ describe('util/exec/containerbase', () => {
       ${'>2.19.0'}         | ${'2.19.0-81.0.dev'}
       ${'<=2.17.5'}        | ${'2.17.5'}
       ${'<2.17.5'}         | ${'2.19.0-81.0.dev'}
+      ${'<2.17.6'}         | ${'2.17.5'}
     `(
       'supports dart ranges "$version" => "$expected"',
       async ({ version: constraint, expected }) => {

--- a/lib/util/exec/containerbase.spec.ts
+++ b/lib/util/exec/containerbase.spec.ts
@@ -172,6 +172,67 @@ describe('util/exec/containerbase', () => {
         }),
       ).toBe('2020.8.13');
     });
+
+    it.each`
+      version                             | expected
+      ${'>=2.5.0 <2.6.0'}                 | ${'2.5.1'}
+      ${'>=2.6.0-0.0.pre <2.7.0-0.0.pre'} | ${'2.6.0-0.0.pre'}
+      ${'>=2.8.0'}                        | ${'2.8.1'}
+      ${'<2.9.0-0.1.pre'}                 | ${'2.8.1'}
+      ${'2.10.0-0.2.pre'}                 | ${'2.10.0-0.2.pre'}
+      ${'>=2.11.0-0.1.pre'}               | ${'2.12.0-4.1.pre'}
+      ${'<=2.10.0'}                       | ${'2.8.1'}
+    `(
+      'supports flutter ranges "$version" => "$expected"',
+      async ({ version: constraint, expected }) => {
+        datasource.getPkgReleases.mockResolvedValueOnce({
+          releases: [
+            { version: '2.5.0-1.0.pre', isStable: false },
+            { version: '2.5.0', isStable: true },
+            { version: '2.5.1', isStable: true },
+            { version: '2.6.0-0.0.pre', isStable: false },
+            { version: '2.8.0', isStable: true },
+            { version: '2.8.1', isStable: true },
+            { version: '2.9.0-0.1.pre', isStable: false },
+            { version: '2.12.0-4.1.pre', isStable: false },
+          ],
+        });
+        expect(
+          await resolveConstraint({ toolName: 'flutter', constraint }),
+        ).toBe(expected);
+      },
+    );
+
+    it.each`
+      version              | expected
+      ${'>2.17.0 <2.17.8'} | ${'2.17.7'}
+      ${'>2.19.0'}         | ${'2.19.0-81.0.dev'}
+      ${'<=2.17.5'}        | ${'2.17.5'}
+      ${'<2.17.5'}         | ${'2.19.0-81.0.dev'}
+    `(
+      'supports dart ranges "$version" => "$expected"',
+      async ({ version: constraint, expected }) => {
+        datasource.getPkgReleases.mockResolvedValueOnce({
+          releases: [
+            { version: '2.17.0-69.2.beta', isStable: false },
+            { version: '2.17.0-7.0.dev', isStable: false },
+            { version: '2.17.5', isStable: true },
+            { version: '2.17.6', isStable: true },
+            { version: '2.17.7', isStable: true },
+            { version: '2.18.0', isStable: true },
+            { version: '2.18.0-44.1.beta', isStable: false },
+            { version: '2.18.0-99.0.dev', isStable: false },
+            { version: '2.18.4', isStable: true },
+            { version: '2.18.5', isStable: true },
+            { version: '2.19.0-255.2.beta', isStable: false },
+            { version: '2.19.0-81.0.dev', isStable: false },
+          ],
+        });
+        expect(await resolveConstraint({ toolName: 'dart', constraint })).toBe(
+          expected,
+        );
+      },
+    );
   });
 
   describe('generateInstallCommands()', () => {

--- a/lib/util/exec/containerbase.ts
+++ b/lib/util/exec/containerbase.ts
@@ -189,12 +189,12 @@ const allToolConfig: Record<string, ToolConfig> = {
   dart: {
     datasource: 'dart-version',
     packageName: 'dart',
-    versioning: semverVersioningId,
+    versioning: npmVersioningId,
   },
   flutter: {
     datasource: 'flutter-version',
     packageName: 'flutter',
-    versioning: semverVersioningId,
+    versioning: npmVersioningId,
   },
 };
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Swtich from semver to npm versioning for the flutter and dart tools, to enable ranges support.
<!-- Describe what behavior is changed by this PR. -->

## Context
Closes: https://github.com/renovatebot/renovate/issues/26349
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
