### PR TITLE
docs(gerrit): use list in known problem section

### DIFF
--- a/lib/modules/platform/gerrit/readme.md
+++ b/lib/modules/platform/gerrit/readme.md
@@ -64,7 +64,7 @@ For example, if you want to use the [Merge Confidence](https://docs.renovatebot.
 Sometimes the PR title passed to the Gerrit platform code is different from the first line of the commit message.
 For example:
 
-Commit-Message=`Update keycloak.version to v21` \
-Pull-Request-Title=`Update keycloak.version to v21 (major)`
+- Commit-Message=`Update keycloak.version to v21`
+- Pull-Request-Title=`Update keycloak.version to v21 (major)`
 
 In this case the Gerrit-Platform implementation tries to detect this and change the commit-message in a second patch-set.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Use a list so the final output renders properly in Material for MkDocs

## Context

See the PR changes for the full context. Here's the current "bad" Material for MkDocs output. I guess the `\` in the source file messes things up somehow. I think forcing the layout with a list is better.

![renovate-gerrit-platform-docs-rendering](https://github.com/renovatebot/renovate/assets/34918129/e42ad39a-22e7-42d9-bb6f-b2bba9e586fb)

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
