### PR TITLE
fix(datasource/docker): add cache decorator to `getDockerHubTags`

### DIFF
--- a/lib/modules/datasource/docker/index.ts
+++ b/lib/modules/datasource/docker/index.ts
@@ -176,7 +176,7 @@ export class DockerDatasource extends Datasource {
     ) => `${registryHost}:${dockerRepository}@${configDigest}`,
     ttlMinutes: 1440 * 28,
   })
-  public async getImageConfig(
+  async getImageConfig(
     registryHost: string,
     dockerRepository: string,
     configDigest: string,
@@ -221,7 +221,7 @@ export class DockerDatasource extends Datasource {
     ) => `${registryHost}:${dockerRepository}@${configDigest}`,
     ttlMinutes: 1440 * 28,
   })
-  public async getHelmConfig(
+  async getHelmConfig(
     registryHost: string,
     dockerRepository: string,
     configDigest: string,
@@ -336,7 +336,7 @@ export class DockerDatasource extends Datasource {
     ) => `${registryHost}:${dockerRepository}@${currentDigest}`,
     ttlMinutes: 1440 * 28,
   })
-  public async getImageArchitecture(
+  async getImageArchitecture(
     registryHost: string,
     dockerRepository: string,
     currentDigest: string,
@@ -434,7 +434,7 @@ export class DockerDatasource extends Datasource {
       `${registryHost}:${dockerRepository}:${tag}`,
     ttlMinutes: 24 * 60,
   })
-  public async getLabels(
+  async getLabels(
     registryHost: string,
     dockerRepository: string,
     tag: string,
@@ -687,7 +687,7 @@ export class DockerDatasource extends Datasource {
     key: (registryHost: string, dockerRepository: string) =>
       `${registryHost}:${dockerRepository}`,
   })
-  public async getTags(
+  async getTags(
     registryHost: string,
     dockerRepository: string,
   ): Promise<string[] | null> {
@@ -913,6 +913,11 @@ export class DockerDatasource extends Datasource {
     return digest;
   }
 
+  @cache({
+    namespace: 'datasource-docker-hub-tags',
+    key: (registryHost: string, dockerRepository: string) =>
+      `${registryHost}:${dockerRepository}`,
+  })
   async getDockerHubTags(dockerRepository: string): Promise<Release[] | null> {
     const result: Release[] = [];
     let url: null | string =

--- a/lib/modules/datasource/docker/index.ts
+++ b/lib/modules/datasource/docker/index.ts
@@ -915,8 +915,7 @@ export class DockerDatasource extends Datasource {
 
   @cache({
     namespace: 'datasource-docker-hub-tags',
-    key: (registryHost: string, dockerRepository: string) =>
-      `${registryHost}:${dockerRepository}`,
+    key: (dockerRepository: string) => `${dockerRepository}`,
   })
   async getDockerHubTags(dockerRepository: string): Promise<Release[] | null> {
     const result: Release[] = [];


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Add cache decorator to `getDockerHubTags`
<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
