### PR TITLE
fix: Renovate JSON schema allows invalid package rules #26484

### DIFF
--- a/tools/docs/schema.ts
+++ b/tools/docs/schema.ts
@@ -85,18 +85,14 @@ function addChildrenArrayInParents(): void {
   for (const option of options) {
     if (option.parent) {
       properties[option.parent].items = {
-        allOf: [
-          {
-            type: 'object',
-            properties: {
-              description: {
-                type: 'string',
-                description:
-                  'A custom description for this configuration object',
-              },
-            },
+        type: 'object',
+        properties: {
+          description: {
+            type: 'string',
+            description: 'A custom description for this configuration object',
           },
-        ],
+        },
+        additionalProperties: false,
       };
     }
   }
@@ -105,7 +101,7 @@ function addChildrenArrayInParents(): void {
 function createSchemaForChildConfigs(): void {
   for (const option of options) {
     if (option.parent) {
-      properties[option.parent].items.allOf[0].properties[option.name] =
+      properties[option.parent].items.properties[option.name] =
         createSingleConfig(option);
     }
   }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

JSON schema generated by `tools/docs/schema.ts` will now have additional `additionalProperties: false` for arrays items which will prevent arbitrary configuration objects like `{"foo": "bar"}`.

## Context

This change is a follow-up to discussion in https://github.com/renovatebot/renovate/discussions/26484

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

Neither of those. I ran `pnpm release:prepare` and used the generated JSON schema from `tmp/docs/renovate-schema.json` in JSON schema validator. I took most of the examples from [Renovate configuration](https://docs.renovatebot.com/configuration-options/) page and made sure the JSON examples are still valid.