### PR TITLE
docs(github): improve example endpoint

### DIFF
--- a/lib/modules/platform/github/readme.md
+++ b/lib/modules/platform/github/readme.md
@@ -13,7 +13,7 @@ Let Renovate use your PAT by doing _one_ of the following:
 
 Remember to set `platform=github` somewhere in your Renovate config file.
 
-If you use GitHub Enterprise Server then `endpoint` must point to `https://github.enterprise.com/api/v3/`.
+If you use GitHub Enterprise Server then `endpoint` must point to `https://github-enterprise.example.com/api/v3/`.
 You can choose where you want to set `endpoint`:
 
 - In your `config.js` file


### PR DESCRIPTION
Readers might miss the clue that they should change the URL for their on-premises or in-cloud instance of GHE

--> CLA signed, contributing guide read.

## Changes

clearer documentation

## Context

enterprise.com isn't a domain is classically used in snippets of example code. example.com is.

## Documentation (please check one with an [x])

- [✓] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
- [✓] No code was changed
 