### PR TITLE
fix(datasource/docker): map `registry-1.docker.io` to `index.docker.io`

### DIFF
--- a/lib/modules/datasource/docker/common.spec.ts
+++ b/lib/modules/datasource/docker/common.spec.ts
@@ -102,6 +102,14 @@ describe('modules/datasource/docker/common', () => {
           registryHost: 'https://index.docker.io',
         },
       },
+      {
+        name: 'registry-1.docker.io/bitnamicharts/cert-manager',
+        url: 'https://index.docker.io',
+        res: {
+          dockerRepository: 'bitnamicharts/cert-manager',
+          registryHost: 'https://index.docker.io',
+        },
+      },
     ])('($name, $url)', ({ name, url, res }) => {
       expect(getRegistryRepository(name, url)).toStrictEqual(res);
     });

--- a/lib/modules/datasource/docker/common.ts
+++ b/lib/modules/datasource/docker/common.ts
@@ -299,10 +299,9 @@ export function getRegistryRepository(
     dockerRepository = `${trimTrailingSlash(path)}/${dockerRepository}`;
   }
 
-  registryHost = registryHost.replace(
-    'https://docker.io',
-    'https://index.docker.io',
-  );
+  registryHost = registryHost
+    .replace('https://docker.io', 'https://index.docker.io')
+    .replace('https://registry-1.docker.io', 'https://index.docker.io');
 
   const opts = hostRules.find({
     hostType: dockerDatasourceId,

--- a/lib/modules/datasource/docker/index.spec.ts
+++ b/lib/modules/datasource/docker/index.spec.ts
@@ -1787,6 +1787,47 @@ describe('modules/datasource/docker/index', () => {
       });
     });
 
+    it('Uses Docker Hub tags for registry-1.docker.io', async () => {
+      process.env.RENOVATE_X_DOCKER_HUB_TAGS = 'true';
+      httpMock
+        .scope(dockerHubUrl)
+        .get('/library/node/tags?page_size=1000')
+        .reply(200, {
+          next: `${dockerHubUrl}/library/node/tags?page=2&page_size=1000`,
+          results: [
+            {
+              name: '1.0.0',
+              tag_last_pushed: '2021-01-01T00:00:00.000Z',
+              digest: 'aaa',
+            },
+          ],
+        })
+        .get('/library/node/tags?page=2&page_size=1000')
+        .reply(200, {
+          results: [
+            {
+              name: '0.9.0',
+              tag_last_pushed: '2020-01-01T00:00:00.000Z',
+              digest: 'bbb',
+            },
+          ],
+        });
+      const res = await getPkgReleases({
+        datasource: DockerDatasource.id,
+        packageName: 'registry-1.docker.io/library/node',
+      });
+      expect(res?.releases).toMatchObject([
+        {
+          version: '0.9.0',
+          releaseTimestamp: '2020-01-01T00:00:00.000Z',
+        },
+        {
+          version: '1.0.0',
+          releaseTimestamp: '2021-01-01T00:00:00.000Z',
+        },
+      ]);
+    });
+
     it('adds library/ prefix for Docker Hub (implicit)', async () => {
       process.env.RENOVATE_X_DOCKER_HUB_TAGS = 'true';
       const tags = ['1.0.0'];


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Map `registry-1.docker.io` to `index.docker.io`.
<!-- Describe what behavior is changed by this PR. -->

## Context

`registry-1.docker.io` is shown on docker hub and recommend for helm oci charts.
So we should map this to `index.docker.io`, so we use the docker hub api.
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
