### PR TITLE
fix(conan): Allow include_prerelease without argument

### DIFF
--- a/lib/modules/manager/conan/__fixtures__/conanfile.py
+++ b/lib/modules/manager/conan/__fixtures__/conanfile.py
@@ -12,6 +12,7 @@ class Pkg(ConanFile):
    requires = (("req_c/1.0@user/stable", "private"), )
    requires = ("req_f/1.0@user/stable", ("req_h/3.0@other/beta", "override"))
    requires = "req_g/[>1.0 <1.8]@user/stable"
+   requires = "req_z/[>1.0 <1.8, include_prerelease]@user/stable"
 #  requires = "commentedout/[>1.0 <1.8]@user/stable"
    #  requires = "commentedout2/[>1.0 <1.8]@user/stable"
    requires = (("req_l/1.0@user/stable#bc592346b33fd19c1fbffce25d1e4236", "private"), )

--- a/lib/modules/manager/conan/extract.spec.ts
+++ b/lib/modules/manager/conan/extract.spec.ts
@@ -202,6 +202,13 @@ describe('modules/manager/conan/extract', () => {
           replaceString: 'req_g/[>1.0 <1.8]@user/stable',
         },
         {
+          currentValue: '[>1.0 <1.8, include_prerelease]',
+          depName: 'req_z',
+          depType: 'requires',
+          packageName: 'req_z/[>1.0 <1.8, include_prerelease]@user/stable',
+          replaceString: 'req_z/[>1.0 <1.8, include_prerelease]@user/stable',
+        },
+        {
           autoReplaceStringTemplate:
             '{{depName}}/{{newValue}}@user/stable{{#if newDigest}}#{{newDigest}}{{/if}}',
           currentDigest: 'bc592346b33fd19c1fbffce25d1e4236',

--- a/lib/modules/versioning/conan/common.ts
+++ b/lib/modules/versioning/conan/common.ts
@@ -30,7 +30,12 @@ export function makeVersion(
 export function cleanVersion(version: string): string {
   if (version) {
     return version
-      .replace(regEx(/,|\[|\]|"|include_prerelease=|loose=|True|False/g), '')
+      .replace(
+        regEx(
+          /,|\[|\]|"|include_prerelease=|include_prerelease|loose=|True|False/g,
+        ),
+        '',
+      )
       .trim();
   }
   return version;
@@ -44,7 +49,7 @@ export function getOptions(input: string): {
   let loose = true;
   if (input) {
     includePrerelease =
-      input.includes('include_prerelease=True') &&
+      input.includes('include_prerelease') &&
       !input.includes('include_prerelease=False');
     loose = input.includes('loose=True') || !input.includes('loose=False');
   }


### PR DESCRIPTION
## Changes

In Conan 2.x the option `include_prerelease` does not have an argument anymore. See https://docs.conan.io/2/tutorial/versioning/version_ranges.html?highlight=include_prerelease.

With this fix it is possible to use `include_prerelease` without arguments.

## Context

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [X] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
