### PR TITLE
docs(validator): Recommend npx to run validator

### DIFF
--- a/docs/usage/config-validation.md
+++ b/docs/usage/config-validation.md
@@ -18,9 +18,7 @@ When you run `renovate-config-validator` with no arguments it will check:
 For example:
 
 ```console
-$ npm install --global renovate
-added 750 packages, and audited 751 packages in 51s
-$ renovate-config-validator
+$ npx --yes --package renovate -- renovate-config-validator
  INFO: Validating renovate.json
  INFO: Config validated successfully
 ```
@@ -28,7 +26,20 @@ $ renovate-config-validator
 ### Strict mode
 
 By default, the validator program fails with a non-zero exit code if there are any validation warnings or errors.
-You can pass the `--strict` flag to make it fail if a scanned config needs migration.
+You can pass the `--strict` flag to make it fail if a scanned config needs migration:
+```console
+$ npx --yes --package renovate -- renovate-config-validator --strict
+ INFO: Validating renovate.json
+ WARN: Config migration necessary
+       "oldConfig": {
+         "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+         "extends": [ "config:base" ]
+       },
+       "newConfig": {
+         "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+         "extends": [ "config:recommended" ]
+       },
+```
 
 ### Pass file to check as CLI arguments
 
@@ -37,9 +48,7 @@ This can be handy to check a config file with a non-default name, like when you'
 For example:
 
 ```console
-$ npm install --global renovate
-added 750 packages, and audited 751 packages in 51s
-$ renovate-config-validator first_config.json
+$ npx --yes --package renovate -- renovate-config-validator first_config.json
  INFO: Validating first_config_.json
  INFO: Config validated successfully
 ```

--- a/docs/usage/config-validation.md
+++ b/docs/usage/config-validation.md
@@ -27,6 +27,7 @@ $ npx --yes --package renovate -- renovate-config-validator
 
 By default, the validator program fails with a non-zero exit code if there are any validation warnings or errors.
 You can pass the `--strict` flag to make it fail if a scanned config needs migration:
+
 ```console
 $ npx --yes --package renovate -- renovate-config-validator --strict
  INFO: Validating renovate.json

--- a/docs/usage/config-validation.md
+++ b/docs/usage/config-validation.md
@@ -28,7 +28,7 @@ $ npx --yes --package renovate -- renovate-config-validator
 By default, the validator program fails with a non-zero exit code if there are any validation warnings or errors.
 You can pass the `--strict` flag to make it fail if a scanned config needs migration:
 
-```console
+```console title="Strict mode validation"
 $ npx --yes --package renovate -- renovate-config-validator --strict
  INFO: Validating renovate.json
  WARN: Config migration necessary


### PR DESCRIPTION
## Changes

Using `npx` has all the same benefits as `--global` (e.g. caching), except it does not pollute the global namespace and installed dependencies.

This also works better on CI, shared environments, and for aliasing, because it's a simple one-liner.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
