### PR TITLE
fix(cache): Store memory cache in `global`

### DIFF
--- a/lib/util/cache/memory/index.ts
+++ b/lib/util/cache/memory/index.ts
@@ -1,19 +1,23 @@
-let repoCache: Record<string, any> | undefined;
+declare const global: {
+  renovateMemCache: Record<string, any> | undefined;
+};
+
+global.renovateMemCache = undefined;
 
 export function init(): void {
-  repoCache = {};
+  global.renovateMemCache = {};
 }
 
 export function reset(): void {
-  repoCache = undefined;
+  global.renovateMemCache = undefined;
 }
 
 export function get<T = any>(key: string): T {
-  return repoCache?.[key];
+  return global.renovateMemCache?.[key];
 }
 
 export function set(key: string, value: unknown): void {
-  if (repoCache) {
-    repoCache[key] = value;
+  if (global.renovateMemCache) {
+    global.renovateMemCache[key] = value;
   }
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

There is annoying behavior of module-level variables being reset during testing.

Sometimes, proper testing requires manipulating memory cache, so we need to initialize and use it, but then we may realize it's always `undefined` no matter what (probably due to some Jest behavior).

This PR moves the variable to the `global` level, which seems to fix the problem.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->
- Ref: #26451

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
