### PR TITLE
fix: Override Brotli compress default options

### DIFF
--- a/lib/util/compress.ts
+++ b/lib/util/compress.ts
@@ -1,11 +1,16 @@
 import { promisify } from 'node:util';
-import zlib from 'node:zlib';
+import zlib, { constants } from 'node:zlib';
 
 const brotliCompress = promisify(zlib.brotliCompress);
 const brotliDecompress = promisify(zlib.brotliDecompress);
 
 export async function compress(input: string): Promise<string> {
-  const buf = await brotliCompress(input);
+  const buf = await brotliCompress(input, {
+    params: {
+      [constants.BROTLI_PARAM_MODE]: constants.BROTLI_MODE_TEXT,
+      [constants.BROTLI_PARAM_QUALITY]: 8,
+    },
+  });
   return buf.toString('base64');
 }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- `BROTLI_PARAM_QUALITY` could be a number from `0` to `11`. By default, it's `11`, and it's slow. I've found `8` is an optimal value which does decent compression and performs well enough.
- According to docs `BROTLI_MODE_TEXT` is adjusted for UTF-8 text, so let's set it as well.

These changes will significantly speed up the compressing phase, while decompressing speed remains the same.

## Context

- Ref: #26608

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
