### PR TITLE
feat(replacements): rename semantic-release-replace-plugin to unscoped

### DIFF
--- a/lib/config/presets/internal/replacements.ts
+++ b/lib/config/presets/internal/replacements.ts
@@ -752,7 +752,8 @@ export const presets: Record<string, Preset> = {
     ],
   },
   'semantic-release-replace-plugin-to-unscoped': {
-    description: '`semantic-release-replace-plugin` was moved out of the `google` organization.',
+    description:
+      '`semantic-release-replace-plugin` was moved out of the `google` organization.',
     packageRules: [
       {
         matchDatasources: ['npm'],

--- a/lib/config/presets/internal/replacements.ts
+++ b/lib/config/presets/internal/replacements.ts
@@ -751,6 +751,17 @@ export const presets: Record<string, Preset> = {
       },
     ],
   },
+  'semantic-release-replace-plugin-to-unscoped': {
+    description: '`semantic-release-replace-plugin` was moved out of the `google` organization.',
+    packageRules: [
+      {
+        matchDatasources: ['npm'],
+        matchPackageNames: ['@google/semantic-release-replace-plugin'],
+        replacementName: 'semantic-release-replace-plugin',
+        replacementVersion: '1.2.1',
+      },
+    ],
+  },
   'spectre-cli-to-spectre-console-cli': {
     description:
       'The `Spectre.Cli` package was renamed to `Spectre.Console.Cli`.',


### PR DESCRIPTION
## Changes

semantic-release-replace-plugin was moved out of the google organization

## Context

There is a notice of deprecation/name change on the npmjs project page at https://www.npmjs.com/package/@google/semantic-release-replace-plugin.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository