### PR TITLE
fix: add semantic-release-replace-plugin-to-unscoped to replacements:all

### DIFF
--- a/lib/config/presets/internal/replacements.ts
+++ b/lib/config/presets/internal/replacements.ts
@@ -30,6 +30,7 @@ export const presets: Record<string, Preset> = {
       'replacements:rollup-babel-to-scoped',
       'replacements:rollup-node-resolve-to-scoped',
       'replacements:rome-to-biome',
+      'replacements:semantic-release-replace-plugin-to-unscoped',
       'replacements:vso-task-lib-to-azure-pipelines-task-lib',
       'replacements:vsts-task-lib-to-azure-pipelines-task-lib',
       'replacements:xmldom-to-scoped',

--- a/lib/config/presets/internal/replacements.ts
+++ b/lib/config/presets/internal/replacements.ts
@@ -752,7 +752,8 @@ export const presets: Record<string, Preset> = {
     ],
   },
   'semantic-release-replace-plugin-to-unscoped': {
-    description: '`semantic-release-replace-plugin` was moved out of the `google` organization.',
+    description:
+      '`semantic-release-replace-plugin` was moved out of the `google` organization.',
     packageRules: [
       {
         matchDatasources: ['npm'],

--- a/lib/config/presets/internal/replacements.ts
+++ b/lib/config/presets/internal/replacements.ts
@@ -751,6 +751,17 @@ export const presets: Record<string, Preset> = {
       },
     ],
   },
+  'semantic-release-replace-plugin-to-unscoped': {
+    description: '`semantic-release-replace-plugin` was moved out of the `google` organization.',
+    packageRules: [
+      {
+        matchDatasources: ['npm'],
+        matchPackageNames: ['@google/semantic-release-replace-plugin'],
+        replacementName: 'semantic-release-replace-plugin',
+        replacementVersion: '1.2.1',
+      },
+    ],
+  },
   'spectre-cli-to-spectre-console-cli': {
     description:
       'The `Spectre.Cli` package was renamed to `Spectre.Console.Cli`.',


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Update for #26656 adding the new replacement to `replacements:all`.  I missed that in the previous PR.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
