### PR TITLE
feat(utils/yaml): Remove jinja2 block delimiters from YAML

### DIFF
--- a/lib/util/yaml.spec.ts
+++ b/lib/util/yaml.spec.ts
@@ -112,6 +112,9 @@ describe('util/yaml', () => {
       ).toEqual({
         myObject: {
           aString: null,
+          myNestedObject: {
+            aNestedString: null
+          }
         },
       });
     });

--- a/lib/util/yaml.spec.ts
+++ b/lib/util/yaml.spec.ts
@@ -102,6 +102,10 @@ describe('util/yaml', () => {
           codeBlock`
       myObject:
         aString: {{value}}
+        {% if test.enabled %}
+        myNestedObject:
+          aNestedString: {{value}}
+        {% endif %}
       `,
           { removeTemplates: true },
         ),

--- a/lib/util/yaml.spec.ts
+++ b/lib/util/yaml.spec.ts
@@ -113,8 +113,8 @@ describe('util/yaml', () => {
         myObject: {
           aString: null,
           myNestedObject: {
-            aNestedString: null
-          }
+            aNestedString: null,
+          },
         },
       });
     });

--- a/lib/util/yaml.ts
+++ b/lib/util/yaml.ts
@@ -37,8 +37,8 @@ function massageContent(content: string, options?: YamlOptions): string {
   if (options?.removeTemplates) {
     return content
       .replace(regEx(/{{`.+?`}}/gs), '')
-      .replace(regEx(/{{.+?}}/g), '').
-      .replace(regEx(/{%`.+?`%}/gs), '').
+      .replace(regEx(/{{.+?}}/g), '')
+      .replace(regEx(/{%`.+?`%}/gs), '')
       .replace(regEx(/{%.+?%}/g), '');
   }
 

--- a/lib/util/yaml.ts
+++ b/lib/util/yaml.ts
@@ -38,7 +38,7 @@ function massageContent(content: string, options?: YamlOptions): string {
     return content
       .replace(regEx(/{{`.+?`}}/gs), '')
       .replace(regEx(/{{.+?}}/g), '').
-      .replace(regEx(/{%`.+?`%}/gs), '')
+      .replace(regEx(/{%`.+?`%}/gs), '').
       .replace(regEx(/{%.+?%}/g), '');
   }
 

--- a/lib/util/yaml.ts
+++ b/lib/util/yaml.ts
@@ -37,7 +37,9 @@ function massageContent(content: string, options?: YamlOptions): string {
   if (options?.removeTemplates) {
     return content
       .replace(regEx(/{{`.+?`}}/gs), '')
-      .replace(regEx(/{{.+?}}/g), '');
+      .replace(regEx(/{{.+?}}/g), '').
+      .replace(regEx(/{%`.+?`%}/gs), '')
+      .replace(regEx(/{%.+?%}/g), '');
   }
 
   return content;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

The default jinja2 block delimiter is `{% ... %}`. This change strips them out of the YAML files.

## Context

https://github.com/renovatebot/renovate/discussions/18470

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
