### PR TITLE
fix(conan): correct regex for packages without @user/channel but with revisions

### DIFF
--- a/lib/modules/manager/conan/__fixtures__/conanfile.txt
+++ b/lib/modules/manager/conan/__fixtures__/conanfile.txt
@@ -1,16 +1,17 @@
 [requires]
 poco/1.9.4
-zlib/[~1.2.3, loose=False]  
+zlib/[~1.2.3, loose=False]
 fake/8.62.134@test/dev
+cairo/1.17.2#aff2d03608351db075ec1348a3afc9ff
 cairo/1.17.2@_/_#aff2d03608351db075ec1348a3afc9ff
 
 [build_requires]
 7zip/[>1.1 <2.1, include_prerelease=True]
 curl/[~1.2.3, loose=False, include_prerelease=True]@test/dev
 boost/[>1.1 <2.1]
-catch2/[2.8]     
+catch2/[2.8]
 openssl/[~=3.0]@test/prod
-cmake/[>1.1 || 0.8] 
+cmake/[>1.1 || 0.8]
 cryptopp/[1.2.7 || >=1.2.9 <2.0.0]@test/local
 #commentedout/1.2
 # commentedout/3.4

--- a/lib/modules/manager/conan/extract.spec.ts
+++ b/lib/modules/manager/conan/extract.spec.ts
@@ -43,6 +43,16 @@ describe('modules/manager/conan/extract', () => {
           depName: 'cairo',
           depType: 'requires',
           packageName: 'cairo/1.17.2@_/_',
+          replaceString: 'cairo/1.17.2#aff2d03608351db075ec1348a3afc9ff',
+        },
+        {
+          autoReplaceStringTemplate:
+            '{{depName}}/{{newValue}}@_/_{{#if newDigest}}#{{newDigest}}{{/if}}',
+          currentDigest: 'aff2d03608351db075ec1348a3afc9ff',
+          currentValue: '1.17.2',
+          depName: 'cairo',
+          depType: 'requires',
+          packageName: 'cairo/1.17.2@_/_',
           replaceString: 'cairo/1.17.2@_/_#aff2d03608351db075ec1348a3afc9ff',
         },
         {

--- a/lib/modules/manager/conan/extract.ts
+++ b/lib/modules/manager/conan/extract.ts
@@ -4,7 +4,7 @@ import type { PackageDependency, PackageFileContent } from '../types';
 import { isComment } from './common';
 
 const regex = regEx(
-  `(?<name>[-_a-z0-9]+)/(?<version>[^@\n{*"']+)(?<userChannel>@[-_a-zA-Z0-9]+(?:/[^#\n.{*"' ]+|))?#?(?<revision>[-_a-f0-9]+[^\n{*"'])?`,
+  `(?<name>[-_a-z0-9]+)/(?<version>[^@#\n{*"']+)(?<userChannel>@[-_a-zA-Z0-9]+(?:/[^#\n.{*"' ]+|))?#?(?<revision>[-_a-f0-9]+[^\n{*"'])?`,
 );
 
 function setDepType(content: string, originalType: string): string {


### PR DESCRIPTION
## Changes

Fixes the problem with Conan packages that have no @user/channel but a revision set.

## Context

see https://github.com/renovatebot/renovate/discussions/26673

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
