### PR TITLE
refactor: Deprecate compression with `base64` encoding

### DIFF
--- a/lib/util/cache/package/file.ts
+++ b/lib/util/cache/package/file.ts
@@ -2,7 +2,7 @@ import cacache from 'cacache';
 import { DateTime } from 'luxon';
 import upath from 'upath';
 import { logger } from '../../../logger';
-import { compress, decompress } from '../../compress';
+import { compressToBase64, decompressFromBase64 } from '../../compress';
 
 function getKey(namespace: string, key: string): string {
   return `${namespace}-${key}`;
@@ -32,7 +32,7 @@ export async function get<T = never>(
         if (!cachedValue.compress) {
           return cachedValue.value;
         }
-        const res = await decompress(cachedValue.value);
+        const res = await decompressFromBase64(cachedValue.value);
         return JSON.parse(res);
       }
       await rm(namespace, key);
@@ -58,7 +58,7 @@ export async function set(
     getKey(namespace, key),
     JSON.stringify({
       compress: true,
-      value: await compress(JSON.stringify(value)),
+      value: await compressToBase64(value),
       expiry: DateTime.local().plus({ minutes: ttlMinutes }),
     }),
   );

--- a/lib/util/cache/package/redis.ts
+++ b/lib/util/cache/package/redis.ts
@@ -2,7 +2,7 @@
 import { DateTime } from 'luxon';
 import { createClient } from 'redis';
 import { logger } from '../../../logger';
-import { compress, decompress } from '../../compress';
+import { compressToBase64, decompressFromBase64 } from '../../compress';
 
 let client: ReturnType<typeof createClient> | undefined;
 let rprefix: string | undefined;
@@ -43,7 +43,7 @@ export async function get<T = never>(
         if (!cachedValue.compress) {
           return cachedValue.value;
         }
-        const res = await decompress(cachedValue.value);
+        const res = await decompressFromBase64(cachedValue.value);
         return JSON.parse(res);
       }
       // istanbul ignore next
@@ -71,7 +71,7 @@ export async function set(
       getKey(namespace, key),
       JSON.stringify({
         compress: true,
-        value: await compress(JSON.stringify(value)),
+        value: await compressToBase64(value),
         expiry: DateTime.local().plus({ minutes: ttlMinutes }),
       }),
       { EX: redisTTL },

--- a/lib/util/cache/repository/impl/base.ts
+++ b/lib/util/cache/repository/impl/base.ts
@@ -1,7 +1,7 @@
 import is from '@sindresorhus/is';
 import { GlobalConfig } from '../../../../config/global';
 import { logger } from '../../../../logger';
-import { compress, decompress } from '../../../compress';
+import { compressToBase64, decompressFromBase64 } from '../../../compress';
 import { hash } from '../../../hash';
 import { safeStringify } from '../../../stringify';
 import { CACHE_REVISION } from '../common';
@@ -41,7 +41,7 @@ export abstract class RepoCacheBase implements RepoCache {
       logger.debug('Repository cache fingerprint is invalid');
       return;
     }
-    const jsonStr = await decompress(oldCache.payload);
+    const jsonStr = await decompressFromBase64(oldCache.payload);
     this.data = RepoCacheBase.parseData(jsonStr);
     this.oldHash = oldCache.hash;
   }
@@ -80,7 +80,7 @@ export abstract class RepoCacheBase implements RepoCache {
     const repository = this.repository;
     const fingerprint = this.fingerprint;
 
-    const payload = await compress(jsonStr);
+    const payload = await compressToBase64(jsonStr);
 
     await this.write({
       revision,

--- a/lib/util/cache/repository/impl/local.spec.ts
+++ b/lib/util/cache/repository/impl/local.spec.ts
@@ -1,7 +1,7 @@
 import { fs } from '../../../../../test/util';
 import { GlobalConfig } from '../../../../config/global';
 import { logger } from '../../../../logger';
-import { compress } from '../../../compress';
+import { compressToBase64 } from '../../../compress';
 import { hash } from '../../../hash';
 import { CACHE_REVISION } from '../common';
 import type { RepoCacheRecord } from '../schema';
@@ -21,7 +21,7 @@ async function createCacheRecord(
 
   const jsonStr = JSON.stringify(data);
   const hashedJsonStr = hash(jsonStr);
-  const payload = await compress(jsonStr);
+  const payload = await compressToBase64(jsonStr);
 
   return {
     revision,

--- a/lib/util/compress.spec.ts
+++ b/lib/util/compress.spec.ts
@@ -1,13 +1,23 @@
-import { compress, decompress } from './compress';
+import { compressToBase64, decompressFromBase64 } from './compress';
 
 describe('util/compress', () => {
-  it('works', async () => {
+  it('compresses strings', async () => {
     const input = 'foobar';
 
-    const compressed = await compress(input);
+    const compressed = await compressToBase64(input);
     expect(compressed).toBe('iwKAZm9vYmFyAw==');
 
-    const decompressed = await decompress(compressed);
+    const decompressed = await decompressFromBase64(compressed);
     expect(decompressed).toBe(input);
+  });
+
+  it('compresses objects', async () => {
+    const input = { foo: 'bar' };
+
+    const compressed = await compressToBase64(input);
+    expect(compressed).toBe('CwaAeyJmb28iOiJiYXIifQM=');
+
+    const decompressed = await decompressFromBase64(compressed);
+    expect(JSON.parse(decompressed)).toEqual(input);
   });
 });

--- a/lib/util/compress.ts
+++ b/lib/util/compress.ts
@@ -1,11 +1,16 @@
 import { promisify } from 'node:util';
 import zlib, { constants } from 'node:zlib';
+import is from '@sindresorhus/is';
 
 const brotliCompress = promisify(zlib.brotliCompress);
 const brotliDecompress = promisify(zlib.brotliDecompress);
 
-export async function compress(input: string): Promise<string> {
-  const buf = await brotliCompress(input, {
+/**
+ * @deprecated
+ */
+export async function compressToBase64(input: unknown): Promise<string> {
+  const jsonStr = is.string(input) ? input : JSON.stringify(input);
+  const buf = await brotliCompress(jsonStr, {
     params: {
       [constants.BROTLI_PARAM_MODE]: constants.BROTLI_MODE_TEXT,
       [constants.BROTLI_PARAM_QUALITY]: 8,
@@ -14,7 +19,10 @@ export async function compress(input: string): Promise<string> {
   return buf.toString('base64');
 }
 
-export async function decompress(input: string): Promise<string> {
+/**
+ * @deprecated
+ */
+export async function decompressFromBase64(input: string): Promise<string> {
   const buf = Buffer.from(input, 'base64');
   const str = await brotliDecompress(buf);
   return str.toString('utf8');


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Rename `compress` to `compressToBase64`
- Rename `decompress` to `decompressFromBase64`

## Context

- Ref: #26699

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
