### PR TITLE
fix(cake): fix explicit registryUrl

### DIFF
--- a/lib/modules/manager/cake/__fixtures__/build.cake
+++ b/lib/modules/manager/cake/__fixtures__/build.cake
@@ -1,7 +1,9 @@
 foo
 #addin nuget:?package=Foo.Foo
 #addin "nuget:?package=Bim.Bim&version=6.6.6"
-#tool nuget:https://example.com/feed/v3?package=Bar.Bar&version=2.2.2
+#tool nuget:https://example.com?package=Bar.Bar&version=2.2.2
+#tool nuget:https://example.com/feed/v3/?package=Cake.Git&version=2.2.3
+#tool nuget:https://example.com/feed/v3/index.json?package=Cake.MinVer&version=2.2.4
 #module nuget:file:///tmp/?package=Baz.Baz&version=3.3.3
 #load nuget:?package=Cake.7zip&version=1.0.3
 #l nuget:?package=Cake.asciidoctorj&version=1.0.0

--- a/lib/modules/manager/cake/__fixtures__/build.cake
+++ b/lib/modules/manager/cake/__fixtures__/build.cake
@@ -1,7 +1,7 @@
 foo
 #addin nuget:?package=Foo.Foo
 #addin "nuget:?package=Bim.Bim&version=6.6.6"
-#tool nuget:https://example.com?package=Bar.Bar&version=2.2.2
+#tool nuget:https://example.com/feed/v3?package=Bar.Bar&version=2.2.2
 #module nuget:file:///tmp/?package=Baz.Baz&version=3.3.3
 #load nuget:?package=Cake.7zip&version=1.0.3
 #l nuget:?package=Cake.asciidoctorj&version=1.0.0

--- a/lib/modules/manager/cake/index.spec.ts
+++ b/lib/modules/manager/cake/index.spec.ts
@@ -7,7 +7,12 @@ describe('modules/manager/cake/index', () => {
       deps: [
         { depName: 'Foo.Foo', currentValue: undefined },
         { depName: 'Bim.Bim', currentValue: '6.6.6' },
-        { depName: 'Bar.Bar', registryUrls: ['https://example.com/feed/v3'] },
+        { depName: 'Bar.Bar', registryUrls: ['https://example.com/'] },
+        { depName: 'Cake.Git', registryUrls: ['https://example.com/feed/v3/'] },
+        {
+          depName: 'Cake.MinVer',
+          registryUrls: ['https://example.com/feed/v3/index.json'],
+        },
         { depName: 'Baz.Baz', skipReason: 'unsupported-url' },
         { depName: 'Cake.7zip', currentValue: '1.0.3' },
         { depName: 'Cake.asciidoctorj', currentValue: '1.0.0' },

--- a/lib/modules/manager/cake/index.spec.ts
+++ b/lib/modules/manager/cake/index.spec.ts
@@ -7,7 +7,7 @@ describe('modules/manager/cake/index', () => {
       deps: [
         { depName: 'Foo.Foo', currentValue: undefined },
         { depName: 'Bim.Bim', currentValue: '6.6.6' },
-        { depName: 'Bar.Bar', registryUrls: ['https://example.com'] },
+        { depName: 'Bar.Bar', registryUrls: ['https://example.com/feed/v3'] },
         { depName: 'Baz.Baz', skipReason: 'unsupported-url' },
         { depName: 'Cake.7zip', currentValue: '1.0.3' },
         { depName: 'Cake.asciidoctorj', currentValue: '1.0.0' },

--- a/lib/modules/manager/cake/index.ts
+++ b/lib/modules/manager/cake/index.ts
@@ -32,7 +32,7 @@ function parseDependencyLine(line: string): PackageDependency | null {
     url = isEmptyHost ? `http://localhost/${url}` : url;
 
     const { origin, pathname, protocol, searchParams } = new URL(url);
-    const registryUrl = `${origin}${pathname}`
+    const registryUrl = `${origin}${pathname}`;
 
     const depName = searchParams.get('package')!;
     const currentValue = searchParams.get('version') ?? undefined;

--- a/lib/modules/manager/cake/index.ts
+++ b/lib/modules/manager/cake/index.ts
@@ -31,7 +31,8 @@ function parseDependencyLine(line: string): PackageDependency | null {
     const isEmptyHost = url.startsWith('?');
     url = isEmptyHost ? `http://localhost/${url}` : url;
 
-    const { origin: registryUrl, protocol, searchParams } = new URL(url);
+    const { origin, pathname, protocol, searchParams } = new URL(url);
+    const registryUrl = `${origin}${pathname}`
 
     const depName = searchParams.get('package')!;
     const currentValue = searchParams.get('version') ?? undefined;


### PR DESCRIPTION
The full registryUrl is the combination of origin and pathname

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

The `registryUrl` that is parsed from the cake directives is changed from parsing it as the `origin` to a combination of `origin` and `pathname`.

I consulted [the `URL` documentation](https://nodejs.org/api/url.html#url-strings-and-url-objects) to extract that this was the required properties.

The fixture and expectations were modified accordingly.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

This is the fix for the problem described at https://github.com/renovatebot/renovate/discussions/26684.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
