### PR TITLE
fix(npm): use lockfileVersion from npm-shrinkwrap

### DIFF
--- a/lib/modules/manager/npm/post-update/npm.ts
+++ b/lib/modules/manager/npm/post-update/npm.ts
@@ -32,8 +32,9 @@ import { getPackageManagerVersion, lazyLoadPackageJson } from './utils';
 
 async function getNpmConstraintFromPackageLock(
   lockFileDir: string,
+  filename: string,
 ): Promise<string | null> {
-  const packageLockFileName = upath.join(lockFileDir, 'package-lock.json');
+  const packageLockFileName = upath.join(lockFileDir, filename);
   const packageLockContents = await readLocalFile(packageLockFileName, 'utf8');
   const packageLockJson = Result.parse(
     packageLockContents,
@@ -79,7 +80,7 @@ export async function generateLockFile(
       constraint:
         config.constraints?.npm ??
         getPackageManagerVersion('npm', await lazyPkgJson.getValue()) ??
-        (await getNpmConstraintFromPackageLock(lockFileDir)) ??
+        (await getNpmConstraintFromPackageLock(lockFileDir, filename)) ??
         null,
     };
     const supportsPreferDedupeFlag =


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Read `lockfileVersion` from `npm-shrinkwrap.json` file in case of `package-lock.json` missing.

## Context

In case of `npm-shrinkwrap.json` file is used and Node.js engine set in `package.json` (with the version like `>= 10.x`) where `npm` version may be different than the one detected vs used to create `npm-shrinkwrap.json`, check the `lockfileVersion` and use proper `npm` version.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
