### PR TITLE
fix(bazelisk): Switch to GithubTagsDatasource

### DIFF
--- a/lib/modules/manager/bazelisk/extract.spec.ts
+++ b/lib/modules/manager/bazelisk/extract.spec.ts
@@ -7,7 +7,7 @@ describe('modules/manager/bazelisk/extract', () => {
       expect(res.deps).toEqual([
         {
           currentValue: '5.2.0',
-          datasource: 'github-releases',
+          datasource: 'github-tags',
           depName: 'bazel',
           packageName: 'bazelbuild/bazel',
         },
@@ -19,7 +19,7 @@ describe('modules/manager/bazelisk/extract', () => {
       expect(res.deps).toEqual([
         {
           currentValue: '5.2',
-          datasource: 'github-releases',
+          datasource: 'github-tags',
           depName: 'bazel',
           packageName: 'bazelbuild/bazel',
         },
@@ -31,7 +31,7 @@ describe('modules/manager/bazelisk/extract', () => {
       expect(res.deps).toEqual([
         {
           currentValue: 'latestn',
-          datasource: 'github-releases',
+          datasource: 'github-tags',
           depName: 'bazel',
           packageName: 'bazelbuild/bazel',
         },
@@ -43,7 +43,7 @@ describe('modules/manager/bazelisk/extract', () => {
       expect(res.deps).toEqual([
         {
           currentValue: '5.2.0',
-          datasource: 'github-releases',
+          datasource: 'github-tags',
           depName: 'bazel',
           packageName: 'bazelbuild/bazel',
         },

--- a/lib/modules/manager/bazelisk/extract.ts
+++ b/lib/modules/manager/bazelisk/extract.ts
@@ -1,11 +1,11 @@
-import { GithubReleasesDatasource } from '../../datasource/github-releases';
+import { GithubTagsDatasource } from '../../datasource/github-tags';
 import type { PackageDependency, PackageFileContent } from '../types';
 
 export function extractPackageFile(content: string): PackageFileContent {
   const dep: PackageDependency = {
     depName: 'bazel',
     currentValue: content.split('\n', 2)[0].trim(),
-    datasource: GithubReleasesDatasource.id,
+    datasource: GithubTagsDatasource.id,
     packageName: 'bazelbuild/bazel',
   };
   return { deps: [dep] };

--- a/lib/modules/manager/bazelisk/index.ts
+++ b/lib/modules/manager/bazelisk/index.ts
@@ -1,5 +1,5 @@
 import type { Category } from '../../../constants';
-import { GithubReleasesDatasource } from '../../datasource/github-releases';
+import { GithubTagsDatasource } from '../../datasource/github-tags';
 import * as semverVersioning from '../../versioning/semver';
 
 export { extractPackageFile } from './extract';
@@ -12,4 +12,4 @@ export const defaultConfig = {
 
 export const categories: Category[] = ['bazel'];
 
-export const supportedDatasources = [GithubReleasesDatasource.id];
+export const supportedDatasources = [GithubTagsDatasource.id];


### PR DESCRIPTION
Hi Rhys and wonderful Renovate team,

Bazel moved over to only adding tags for their rolling releases, not GitHub releases, which unfortunately means that things stopped auto updating.

I happened to notice, and figured I'd put up a quick PR switching from using the releases datasource to tags, with the goal or restoring the behavior of correctly updating Bazel rolling users. 

I'm filing this as a PR rather than a discussion, figuring that this change would likely work and be submitted for automated testing; I haven't yet tested separately, but it seems high likelihood and like this was was the overall most efficient path to discussion around a fix.

Cheers,
Chris