### PR TITLE
refactor(util/yaml): allow to set failure behavior when parsing multidoc yamls

### DIFF
--- a/lib/util/yaml.spec.ts
+++ b/lib/util/yaml.spec.ts
@@ -122,6 +122,56 @@ describe('util/yaml', () => {
       ).toThrow();
     });
 
+    it('should throw if schema does not match and failureBehaviour "throw"', () => {
+      expect(() =>
+        parseYaml(
+          codeBlock`
+      myObject:
+        aString: foo
+      ---
+      aString: bar
+      `,
+          null,
+          {
+            customSchema: z.object({
+              myObject: z.object({
+                aString: z.string(),
+              }),
+            }),
+            failureBehaviour: 'throw',
+          },
+        ),
+      ).toThrow();
+    });
+
+    it('should still return valid elements if schema does not match with "filter" behaviour', () => {
+      expect(
+        parseYaml(
+          codeBlock`
+      myObject:
+        aString: foo
+      ---
+      aString: bar
+      `,
+          null,
+          {
+            customSchema: z.object({
+              myObject: z.object({
+                aString: z.string(),
+              }),
+            }),
+            failureBehaviour: 'filter',
+          },
+        ),
+      ).toEqual([
+        {
+          myObject: {
+            aString: 'foo',
+          },
+        },
+      ]);
+    });
+
     it('should parse content with templates', () => {
       expect(
         parseYaml(

--- a/lib/util/yaml.ts
+++ b/lib/util/yaml.ts
@@ -40,18 +40,19 @@ export function parseYaml<ResT = unknown>(
 
   const parsed: ResT[] = [];
   for (const element of rawDocuments) {
-    try {
-      const singleParsed = schema.parse(element);
-      parsed.push(singleParsed);
-    } catch (error) {
-      if (options?.failureBehaviour !== 'filter') {
-        throw new Error('Failed to parse YAML file', { cause: error.cause });
-      }
-      logger.debug(
-        { error, document: element },
-        'Failed to parse schema for YAML',
-      );
+    const result = schema.safeParse(element);
+    if (result.success) {
+      parsed.push(result.data);
+      continue;
     }
+
+    if (options?.failureBehaviour !== 'filter') {
+      throw new Error('Failed to parse YAML file', { cause: result.error });
+    }
+    logger.debug(
+      { error: result.error, document: element },
+      'Failed to parse schema for YAML',
+    );
   }
   return parsed;
 }

--- a/lib/util/yaml.ts
+++ b/lib/util/yaml.ts
@@ -45,7 +45,7 @@ export function parseYaml<ResT = unknown>(
       parsed.push(singleParsed);
     } catch (error) {
       if (options?.failureBehaviour !== 'filter') {
-        throw new Error('Failed to parse YAML file', { cause: error });
+        throw new Error('Failed to parse YAML file', { cause: error.cause });
       }
       logger.debug(
         { error, document: element },


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Adds a YAML option to define what should happen if a document in the file fails schema parsing


<!-- Describe what behavior is changed by this PR. -->

## Context
This is as preperation for https://github.com/renovatebot/renovate/pull/26762
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
