### PR TITLE
fix(workers/pr): improve deduplication in updates-table

### DIFF
--- a/lib/workers/repository/update/pr/body/updates-table.spec.ts
+++ b/lib/workers/repository/update/pr/body/updates-table.spec.ts
@@ -162,6 +162,29 @@ describe('workers/repository/update/pr/body/updates-table', () => {
         Update: '{{{updateType}}}',
         'Current value': '{{{currentValue}}}',
         'New value': '{{{newValue}}}',
+        Change: '`{{{displayFrom}}}` -> `{{{displayTo}}}`',
+      },
+      updateType: 'pin',
+      depNameLinked:
+        '[mocha](https://mochajs.org/) ([source](https://github.com/mochajs/mocha))',
+      depType: 'devDependencies',
+      depName: 'mocha',
+      currentValue: '^6.2.3',
+      newValue: '6.2.3',
+      displayFrom: '^6.2.3',
+      displayTo: '6.2.3',
+    });
+
+    // duplicate of upgrade1
+    const upgrade2 = partial<BranchUpgradeConfig>({
+      manager: 'some-manager',
+      branchName: 'some-branch',
+      prBodyDefinitions: {
+        Package: '{{{depNameLinked}}}',
+        Type: '{{{depType}}}',
+        Update: '{{{updateType}}}',
+        'Current value': '{{{currentValue}}}',
+        'New value': '{{{newValue}}}',
         Change:
           "[{{#if displayFrom}}`{{{displayFrom}}}` -> {{else}}{{#if currentValue}}`{{{currentValue}}}` -> {{/if}}{{/if}}{{#if displayTo}}`{{{displayTo}}}`{{else}}`{{{newValue}}}`{{/if}}]({{#if depName}}https://renovatebot.com/diffs/npm/{{replace '/' '%2f' depName}}/{{{currentVersion}}}/{{{newVersion}}}{{/if}})",
       },
@@ -179,19 +202,13 @@ describe('workers/repository/update/pr/body/updates-table', () => {
     });
 
     // duplicate of upgrade1
-    const upgrade2 = partial<BranchUpgradeConfig>({
+    const upgrade3 = partial<BranchUpgradeConfig>({
       manager: 'some-manager',
       branchName: 'some-branch',
+      updateType: 'pin',
       prBodyDefinitions: {
-        Package: '{{{depNameLinked}}}',
-        Type: '{{{depType}}}',
-        Update: '{{{updateType}}}',
-        'Current value': '{{{currentValue}}}',
-        'New value': '{{{newValue}}}',
-        Change: '`{{{displayFrom}}}` -> `{{{displayTo}}}`',
         Pending: '{{{displayPending}}}',
       },
-      updateType: 'pin',
       depNameLinked:
         '[mocha](https://mochajs.org/) ([source](https://github.com/mochajs/mocha))',
       depType: 'devDependencies',
@@ -201,21 +218,6 @@ describe('workers/repository/update/pr/body/updates-table', () => {
       displayFrom: '^6.2.3',
       displayTo: '6.2.3',
       displayPending: 'some-string',
-    });
-
-    // duplicate of upgrade1
-    const upgrade3 = partial<BranchUpgradeConfig>({
-      manager: 'some-manager',
-      branchName: 'some-branch',
-      updateType: 'pin',
-      depNameLinked:
-        '[mocha](https://mochajs.org/) ([source](https://github.com/mochajs/mocha))',
-      depType: 'devDependencies',
-      depName: 'mocha',
-      currentValue: '^6.2.3',
-      newValue: '6.2.3',
-      displayFrom: '^6.2.3',
-      displayTo: '6.2.3',
     });
 
     const configObj: BranchConfig = {

--- a/lib/workers/repository/update/pr/body/updates-table.spec.ts
+++ b/lib/workers/repository/update/pr/body/updates-table.spec.ts
@@ -190,7 +190,6 @@ describe('workers/repository/update/pr/body/updates-table', () => {
         'New value': '{{{newValue}}}',
         Change: '`{{{displayFrom}}}` -> `{{{displayTo}}}`',
         Pending: '{{{displayPending}}}',
-        displayPending: 'some-string',
       },
       updateType: 'pin',
       depNameLinked:
@@ -201,6 +200,7 @@ describe('workers/repository/update/pr/body/updates-table', () => {
       newValue: '6.2.3',
       displayFrom: '^6.2.3',
       displayTo: '6.2.3',
+      displayPending: 'some-string',
     });
 
     // duplicate of upgrade1

--- a/lib/workers/repository/update/pr/body/updates-table.spec.ts
+++ b/lib/workers/repository/update/pr/body/updates-table.spec.ts
@@ -190,6 +190,7 @@ describe('workers/repository/update/pr/body/updates-table', () => {
         'New value': '{{{newValue}}}',
         Change: '`{{{displayFrom}}}` -> `{{{displayTo}}}`',
         Pending: '{{{displayPending}}}',
+        displayPending: 'some-string',
       },
       updateType: 'pin',
       depNameLinked:

--- a/lib/workers/repository/update/pr/body/updates-table.spec.ts
+++ b/lib/workers/repository/update/pr/body/updates-table.spec.ts
@@ -87,13 +87,40 @@ describe('workers/repository/update/pr/body/updates-table', () => {
       displayFrom: '^6.2.3',
       displayTo: '6.2.3',
     });
+
+    const upgrade4 = partial<BranchUpgradeConfig>({
+      manager: 'some-manager',
+      branchName: 'some-branch',
+      prBodyDefinitions: {
+        Package: '{{{depNameLinked}}}',
+        Type: '{{{depType}}}',
+        Update: '{{{updateType}}}',
+        'Current value': '{{{currentValue}}}',
+        'New value': '{{{newValue}}}',
+        Change: '`{{{displayFrom}}}` -> `{{{displayTo}}}`',
+        Pending: '{{{displayPending}}}',
+        References: '{{{references}}}',
+        'Package file': '{{{packageFile}}}',
+      },
+      updateType: 'pin',
+      depNameLinked:
+        '[mocha](https://mochajs.org/) ([source](https://github.com/mochajs/mocha))',
+      depType: 'devDependencies',
+      depName: 'mocha',
+      currentValue: '^6.2.3',
+      newValue: '6.2.3',
+      currentVersion: '6.2.3',
+      newVersion: '6.2.3',
+      displayFrom: '^6.2.3',
+      displayTo: '6.2.3',
+    });
     // TODO #22198 allow or filter undefined
     const upgrade3 = undefined as never;
     const configObj: BranchConfig = {
       manager: 'some-manager',
       branchName: 'some-branch',
       baseBranch: 'base',
-      upgrades: [upgrade0, upgrade1, upgrade2, upgrade3],
+      upgrades: [upgrade0, upgrade1, upgrade2, upgrade3, upgrade4],
       prBodyColumns: ['Package', 'Type', 'Update', 'Change', 'Pending'],
       prBodyDefinitions: {
         Package: '{{{depNameLinked}}}',

--- a/lib/workers/repository/update/pr/body/updates-table.spec.ts
+++ b/lib/workers/repository/update/pr/body/updates-table.spec.ts
@@ -88,6 +88,10 @@ describe('workers/repository/update/pr/body/updates-table', () => {
       displayTo: '6.2.3',
     });
 
+    // TODO #22198 allow or filter undefined
+    const upgrade3 = undefined as never;
+
+    // duplicate of upgrade2
     const upgrade4 = partial<BranchUpgradeConfig>({
       manager: 'some-manager',
       branchName: 'some-branch',
@@ -114,8 +118,6 @@ describe('workers/repository/update/pr/body/updates-table', () => {
       displayFrom: '^6.2.3',
       displayTo: '6.2.3',
     });
-    // TODO #22198 allow or filter undefined
-    const upgrade3 = undefined as never;
     const configObj: BranchConfig = {
       manager: 'some-manager',
       branchName: 'some-branch',

--- a/lib/workers/repository/update/pr/body/updates-table.ts
+++ b/lib/workers/repository/update/pr/body/updates-table.ts
@@ -104,7 +104,7 @@ function filterDuplicateUpgrades(
       const key = `${upgrade.depName ?? ''}_${upgrade.depType ?? ''}_${
         upgrade.newValue ?? upgrade.newValue ?? ''
       }_${upgrade.currentValue ?? upgrade.currentVersion ?? ''}_${
-        upgrade.updateType ?? ''
+        upgrade.updateType
       }`;
 
       // Check if the key already exists

--- a/lib/workers/repository/update/pr/body/updates-table.ts
+++ b/lib/workers/repository/update/pr/body/updates-table.ts
@@ -46,8 +46,7 @@ export function getPrUpdatesTable(config: BranchConfig): string {
   }
 
   // filter duplicate upgrades
-  const uniqueUpgrades = filterDuplicateUpgrades(config.upgrades);
-  const tableValues = uniqueUpgrades
+  const tableValues = filterDuplicateUpgrades(config.upgrades)
     .filter((upgrade) => upgrade !== undefined)
     .map((upgrade) => {
       const res: Record<string, string> = {};

--- a/lib/workers/repository/update/pr/body/updates-table.ts
+++ b/lib/workers/repository/update/pr/body/updates-table.ts
@@ -44,7 +44,9 @@ export function getPrUpdatesTable(config: BranchConfig): string {
     logger.warn('getPrUpdatesTable - prBodyColumns is undefined');
     return '';
   }
-  const tableValues = config.upgrades
+
+  const uniqueUpgrades = filterDuplicateUpgrades(config.upgrades);
+  const tableValues = uniqueUpgrades
     .filter((upgrade) => upgrade !== undefined)
     .map((upgrade) => {
       const res: Record<string, string> = {};
@@ -88,4 +90,31 @@ export function getPrUpdatesTable(config: BranchConfig): string {
   res += uniqueRows.join('');
   res += '\n\n';
   return res;
+}
+
+function filterDuplicateUpgrades(
+  upgrades: BranchUpgradeConfig[],
+): BranchUpgradeConfig[] {
+  // Create an empty object to track unique combinations of properties
+  const uniqueObjects: Record<string, boolean> = {};
+
+  // Filter the array to remove duplicates
+  const resultArray = upgrades
+    .filter((upgrade) => upgrade !== undefined)
+    .filter((obj) => {
+      // Create a key based on the specified properties
+      const key = `${obj.depName}_${obj.depType}_${obj.newValue}_${obj.currentValue}`;
+
+      // Check if the key already exists in the uniqueObjects
+      // If it doesn't exist, add the key and return true (keep the object)
+      if (!uniqueObjects[key]) {
+        uniqueObjects[key] = true;
+        return true;
+      }
+
+      // If the key already exists, return false (filter out the duplicate object)
+      return false;
+    });
+
+  return resultArray;
 }

--- a/lib/workers/repository/update/pr/body/updates-table.ts
+++ b/lib/workers/repository/update/pr/body/updates-table.ts
@@ -45,6 +45,7 @@ export function getPrUpdatesTable(config: BranchConfig): string {
     return '';
   }
 
+  // filter duplicate upgrades
   const uniqueUpgrades = filterDuplicateUpgrades(config.upgrades);
   const tableValues = uniqueUpgrades
     .filter((upgrade) => upgrade !== undefined)
@@ -95,26 +96,26 @@ export function getPrUpdatesTable(config: BranchConfig): string {
 function filterDuplicateUpgrades(
   upgrades: BranchUpgradeConfig[],
 ): BranchUpgradeConfig[] {
-  // Create an empty object to track unique combinations of properties
-  const uniqueObjects: Record<string, boolean> = {};
+  const uniqueUpgradeKeys = new Set();
 
-  // Filter the array to remove duplicates
-  const resultArray = upgrades
+  const uniqueUpgrades = upgrades
     .filter((upgrade) => upgrade !== undefined)
-    .filter((obj) => {
-      // Create a key based on the specified properties
-      const key = `${obj.depName}_${obj.depType}_${obj.newValue}_${obj.currentValue}`;
+    .filter((upgrade) => {
+      // Create a key based on the properties which are significant in the updates table
+      const key = `${upgrade.depName ?? ''}_${upgrade.depType ?? ''}_${
+        upgrade.newValue ?? upgrade.newValue ?? ''
+      }_${upgrade.currentValue ?? upgrade.currentVersion ?? ''}_${
+        upgrade.updateType ?? ''
+      }`;
 
-      // Check if the key already exists in the uniqueObjects
-      // If it doesn't exist, add the key and return true (keep the object)
-      if (!uniqueObjects[key]) {
-        uniqueObjects[key] = true;
+      // Check if the key already exists
+      if (!uniqueUpgradeKeys.has(key)) {
+        uniqueUpgradeKeys.add(key);
         return true;
       }
 
-      // If the key already exists, return false (filter out the duplicate object)
       return false;
     });
 
-  return resultArray;
+  return uniqueUpgrades;
 }

--- a/lib/workers/repository/update/pr/body/updates-table.ts
+++ b/lib/workers/repository/update/pr/body/updates-table.ts
@@ -50,7 +50,7 @@ export function getPrUpdatesTable(config: BranchConfig): string {
     if (upgrade) {
       // Create a key based on the properties which are significant in the updates table
       const key = `${upgrade.depName ?? ''}_${upgrade.depType ?? ''}_${
-        upgrade.newValue ?? upgrade.newValue ?? ''
+        upgrade.newValue ?? upgrade.newVersion ?? ''
       }_${upgrade.currentValue ?? upgrade.currentVersion ?? ''}_${
         upgrade.updateType
       }`;
@@ -121,12 +121,12 @@ function compareTableValues(
   let score = 0;
 
   for (const header of prBodyColumns) {
-    if (!a[header]) {
-      score++;
-      continue;
-    }
     if (!b[header]) {
       score--;
+      continue;
+    }
+    if (!a[header]) {
+      score++;
       continue;
     }
 

--- a/lib/workers/repository/update/pr/body/updates-table.ts
+++ b/lib/workers/repository/update/pr/body/updates-table.ts
@@ -121,6 +121,9 @@ function compareTableValues(
   let score = 0;
 
   for (const header of prBodyColumns) {
+    if (!b[header] && !a[header]) {
+      continue;
+    }
     if (!b[header]) {
       score--;
       continue;
@@ -130,8 +133,9 @@ function compareTableValues(
       continue;
     }
 
-    a[header].length < b[header].length ? score++ : score--;
+    if (a[header] !== b[header]) {
+      a[header].length < b[header].length ? score++ : score--;
+    }
   }
-
   return score > 0 ? b : a;
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Improved the de-duplication among rows of the update pr table by only using the necessary properties to compare the upgrades rather than comparing the entire row (which is a string)
The properties used for comparison are: `depName`, `depType`, `updateType`, `currentVersion/Value` and `newVersion/Value`
<!-- Describe what behavior is changed by this PR. -->

## Context
- Closes: #26073
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
