### PR TITLE
fix(dependency-dashboard): skip unnecessary cache bust when unchanged

### DIFF
--- a/lib/workers/repository/dependency-dashboard.spec.ts
+++ b/lib/workers/repository/dependency-dashboard.spec.ts
@@ -841,6 +841,10 @@ describe('workers/repository/dependency-dashboard', () => {
       config.dependencyDashboardIssue = 1;
       mockedFunction(platform.getIssue).mockResolvedValueOnce({
         title: 'Dependency Dashboard',
+        body: '',
+      });
+      mockedFunction(platform.getIssue).mockResolvedValueOnce({
+        title: 'Dependency Dashboard',
         body: `This issue contains a list of Renovate updates and their statuses.
 
         ## Pending Approval
@@ -861,6 +865,31 @@ describe('workers/repository/dependency-dashboard', () => {
       });
       await dependencyDashboard.ensureDependencyDashboard(config, branches);
       expect(platform.ensureIssue.mock.calls[0][0].body).toMatchSnapshot();
+    });
+
+    it('skips fetching issue if content unchanged', async () => {
+      const branches: BranchConfig[] = [];
+      config.dependencyDashboard = true;
+      config.dependencyDashboardChecks = {};
+      config.dependencyDashboardIssue = 1;
+      mockedFunction(platform.getIssue).mockResolvedValueOnce({
+        title: 'Dependency Dashboard',
+        body: `This issue lists Renovate updates and detected dependencies. Read the [Dependency Dashboard](https://docs.renovatebot.com/key-concepts/dashboard/) docs to learn more.
+
+This repository currently has no open or pending branches.
+
+## Detected dependencies
+
+None detected
+
+`,
+      });
+      mockedFunction(platform.getIssue).mockResolvedValueOnce({
+        title: 'Dependency Dashboard',
+        body: '',
+      });
+      await dependencyDashboard.ensureDependencyDashboard(config, branches);
+      expect(platform.ensureIssue.mock.calls).toBeEmpty();
     });
 
     it('forwards configured labels to the ensure issue call', async () => {

--- a/lib/workers/repository/dependency-dashboard.spec.ts
+++ b/lib/workers/repository/dependency-dashboard.spec.ts
@@ -889,7 +889,7 @@ None detected
         body: '',
       });
       await dependencyDashboard.ensureDependencyDashboard(config, branches);
-      expect(platform.ensureIssue.mock.calls).toBeEmpty();
+      expect(platform.ensureIssue).not.toHaveBeenCalled();
     });
 
     it('forwards configured labels to the ensure issue call', async () => {

--- a/lib/workers/repository/dependency-dashboard.ts
+++ b/lib/workers/repository/dependency-dashboard.ts
@@ -423,6 +423,18 @@ export async function ensureDependencyDashboard(
   issueBody += footer;
 
   if (config.dependencyDashboardIssue) {
+    // If we're not changing the dashboard issue then we can skip checking if the user changed it
+    // The cached issue we get back here will reflect its state at the _start_ of our run
+    const cachedIssue = await platform.getIssue?.(
+      config.dependencyDashboardIssue,
+    );
+    if (cachedIssue?.body === issueBody) {
+      logger.debug('No changes to dependency dashboard issue needed');
+      return;
+    }
+
+    // Skip cache when getting the issue to ensure we get the latest body,
+    // including any updates the user made after we started the run
     const updatedIssue = await platform.getIssue?.(
       config.dependencyDashboardIssue,
       false,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Enhances dashboard logic to only cache bust get dashboard issue if we need to _change_ anything.

## Context

Performance - saves an API call

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
