### PR TITLE
feat(manager/pip-compile): add full support for lock files

### DIFF
--- a/lib/modules/manager/pip-compile/artifacts.ts
+++ b/lib/modules/manager/pip-compile/artifacts.ts
@@ -33,6 +33,7 @@ function getPythonConstraint(
   return undefined;
 }
 
+// TODO(not7cd): rename to getPipToolsVersionConstraint, as constraints have their meaning in pip
 function getPipToolsConstraint(config: UpdateArtifactsConfig): string {
   const { constraints = {} } = config;
   const { pipTools } = constraints;
@@ -51,7 +52,7 @@ const constraintLineRegex = regEx(
 const allowedPipArguments = [
   '--allow-unsafe',
   '--generate-hashes',
-  '--no-emit-index-url',
+  '--no-emit-index-url', // handle this!!!
   '--strip-extras',
 ];
 
@@ -61,12 +62,13 @@ export function constructPipCompileCmd(
   outputFileName: string,
 ): string {
   const headers = constraintLineRegex.exec(content);
-  const args = ['pip-compile'];
+  const args = ['./pip-compile-wrapped'];
   if (headers?.groups) {
     logger.debug(`Found pip-compile header: ${headers[0]}`);
     for (const argument of split(headers.groups.arguments)) {
       if (allowedPipArguments.includes(argument)) {
         args.push(argument);
+        // TODO(not7cd) -o arg
       } else if (argument.startsWith('--output-file=')) {
         const file = upath.parse(outputFileName).base;
         if (argument !== `--output-file=${file}`) {
@@ -88,6 +90,7 @@ export function constructPipCompileCmd(
           'pip-compile argument is not (yet) supported',
         );
       } else {
+        // TODO(not7cd): get position arguments and infer original files
         // ignore position argument (.in file)
       }
     }

--- a/lib/modules/manager/pip-compile/common.ts
+++ b/lib/modules/manager/pip-compile/common.ts
@@ -76,6 +76,7 @@ interface PipCompileArgs {
   fullCommand: string; // parsed and reconstructed
 }
 
+// TODO(not7cd): test on all correct headers, even with CUSTOM_COMPILE_COMMAND
 export function extractHeaderCommand(
   content: string,
   outputFileName: string,
@@ -97,7 +98,7 @@ export function extractHeaderCommand(
         if (value) {
           const file = upath.parse(outputFileName).base;
           if (value !== file) {
-            // we don't trust the user-supplied output-file argument; use our value here
+            // we don't trust the user-supplied output-file argument; TODO(not7cd): use our value here
             logger.warn(
               { argument },
               'pip-compile was previously executed with an unexpected `--output-file` filename',
@@ -121,4 +122,5 @@ export function extractHeaderCommand(
   }
   // args.push(upath.parse(inputFileName).base);
   logger.trace({ compileCommand }, 'Failed to parse command');
+  return pipCompileArgs;
 }

--- a/lib/modules/manager/pip-compile/common.ts
+++ b/lib/modules/manager/pip-compile/common.ts
@@ -1,7 +1,10 @@
 import is from '@sindresorhus/is';
+import { split } from 'shlex';
+import upath from 'upath';
 import { logger } from '../../../logger';
 import type { ExecOptions } from '../../../util/exec/types';
 import { ensureCacheDir } from '../../../util/fs';
+import { regEx } from '../../../util/regex';
 import type { UpdateArtifactsConfig } from '../types';
 
 export function getPipToolsConstraint(config: UpdateArtifactsConfig): string {
@@ -52,4 +55,70 @@ export async function getExecOptions(
     },
   };
   return execOptions;
-} // TODO(not7cd): rename to getPipToolsVersionConstraint, as constraints have their meaning in pip
+} // TODO(not7cd): rename to getPipToolsVersionConstraint, as constraints have their meaning in pipexport function extractHeaderCommand(content: string): string {
+
+export const constraintLineRegex = regEx(
+  /^(#.*?\r?\n)+# {4}(?<command>\S*)(?<arguments> .*?)\r?\n/,
+);
+export const allowedPipArguments = [
+  '--allow-unsafe',
+  '--generate-hashes',
+  '--no-emit-index-url', // handle this!!!
+  '--strip-extras',
+];
+
+interface PipCompileArgs {
+  command: string;
+  output?: string;
+  extra?: string[];
+  constraint?: string[];
+  sourceFiles: string[]; // positional arguments
+  fullCommand: string; // parsed and reconstructed
+}
+
+export function extractHeaderCommand(
+  content: string,
+  outputFileName: string,
+): PipCompileArgs {
+  const compileCommand = constraintLineRegex.exec(content);
+  const _fullCommand = [];
+  const pipCompileArgs: PipCompileArgs = {
+    fullCommand: '',
+    command: '',
+    sourceFiles: [],
+  };
+  if (compileCommand?.groups) {
+    const command = compileCommand.groups.command;
+    _fullCommand.push(command);
+    logger.debug(`Found pip-compile header: ${compileCommand[0]}`);
+    for (const argument of split(compileCommand.groups.arguments)) {
+      if (argument.startsWith('--output-file=') || argument.startsWith('-o=')) {
+        const value = argument.split('=')[1];
+        if (value) {
+          const file = upath.parse(outputFileName).base;
+          if (value !== file) {
+            // we don't trust the user-supplied output-file argument; use our value here
+            logger.warn(
+              { argument },
+              'pip-compile was previously executed with an unexpected `--output-file` filename',
+            );
+          }
+          pipCompileArgs.output = value;
+        }
+      } else if (argument.startsWith('--')) {
+        logger.trace(
+          { argument },
+          'pip-compile argument is not (yet) supported',
+        );
+      } else {
+        // TODO(not7cd): get position arguments and infer original files
+        pipCompileArgs.sourceFiles.push(argument);
+      }
+      _fullCommand.push(argument);
+    }
+    pipCompileArgs.fullCommand = _fullCommand.join(' ');
+    return pipCompileArgs;
+  }
+  // args.push(upath.parse(inputFileName).base);
+  logger.trace({ compileCommand }, 'Failed to parse command');
+}

--- a/lib/modules/manager/pip-compile/common.ts
+++ b/lib/modules/manager/pip-compile/common.ts
@@ -1,0 +1,55 @@
+import is from '@sindresorhus/is';
+import { logger } from '../../../logger';
+import type { ExecOptions } from '../../../util/exec/types';
+import { ensureCacheDir } from '../../../util/fs';
+import type { UpdateArtifactsConfig } from '../types';
+
+export function getPipToolsConstraint(config: UpdateArtifactsConfig): string {
+  const { constraints = {} } = config;
+  const { pipTools } = constraints;
+
+  if (is.string(pipTools)) {
+    logger.debug('Using pipTools constraint from config');
+    return pipTools;
+  }
+
+  return '';
+}
+export function getPythonConstraint(
+  config: UpdateArtifactsConfig,
+): string | undefined | null {
+  const { constraints = {} } = config;
+  const { python } = constraints;
+
+  if (python) {
+    logger.debug('Using python constraint from config');
+    return python;
+  }
+
+  return undefined;
+}
+export async function getExecOptions(
+  config: UpdateArtifactsConfig,
+  inputFileName: string,
+): Promise<ExecOptions> {
+  const constraint = getPythonConstraint(config);
+  const pipToolsConstraint = getPipToolsConstraint(config);
+  const execOptions: ExecOptions = {
+    cwdFile: inputFileName,
+    docker: {},
+    toolConstraints: [
+      {
+        toolName: 'python',
+        constraint,
+      },
+      {
+        toolName: 'pip-tools',
+        constraint: pipToolsConstraint,
+      },
+    ],
+    extraEnv: {
+      PIP_CACHE_DIR: await ensureCacheDir('pip'),
+    },
+  };
+  return execOptions;
+} // TODO(not7cd): rename to getPipToolsVersionConstraint, as constraints have their meaning in pip

--- a/lib/modules/manager/pip-compile/extract.ts
+++ b/lib/modules/manager/pip-compile/extract.ts
@@ -15,27 +15,35 @@ export async function extractAllPackageFiles(
   config: ExtractConfig, // NOTE(not7cd): ignore, useless in this use-case
   packageFiles: string[],
 ): Promise<PackageFile[]> {
-  const pipReqFiles: PackageFile[] = [];
-  for (const packageFile of packageFiles) {
-    logger.debug({ packageFile }, 'READING FILE');
-    const content = await readLocalFile(packageFile, 'utf8');
+  const result: PackageFile[] = [];
+  for (const lockFile of packageFiles) {
+    logger.debug({ packageFile: lockFile }, 'READING FILE');
+    const content = await readLocalFile(lockFile, 'utf8');
     // istanbul ignore else
     if (content) {
       // TODO(not7cd): extract based on manager: setup.py, pep621, pip_requirements
-      const pipCompileArgs = extractHeaderCommand(content, packageFile);
-      const deps = extractRequirementsFile(content);
-      if (deps) {
-        pipReqFiles.push({
-          ...deps,
-          packageFile,
-        });
+      const pipCompileArgs = extractHeaderCommand(content, lockFile);
+      const lockedDeps = extractRequirementsFile(content);
+      for (const sourceFile of pipCompileArgs.sourceFiles) {
+        // TODO(not7cd): if sourceFile ends with .txt
+        const content = await readLocalFile(sourceFile, 'utf8');
+        if (content) {
+          const deps = extractRequirementsFile(content);
+          if (deps) {
+            result.push({
+              ...deps,
+              lockFiles: [lockFile],
+              packageFile: sourceFile,
+            });
+          }
+        }
       }
     } else {
-      logger.debug({ packageFile }, `No content found`);
+      logger.debug({ packageFile: lockFile }, `No content found`);
     }
   }
 
   // TODO(not7cd): in post extract there is mono repo detection and "get locked versions"
   // await postExtract(pipReqFiles);
-  return pipReqFiles;
+  return result;
 }

--- a/lib/modules/manager/pip-compile/extract.ts
+++ b/lib/modules/manager/pip-compile/extract.ts
@@ -1,0 +1,36 @@
+import { RANGE_PATTERN } from '@renovatebot/pep440';
+import is from '@sindresorhus/is';
+import { GlobalConfig } from '../../../config/global';
+import { logger } from '../../../logger';
+import { readLocalFile } from '../../../util/fs';
+import { isSkipComment } from '../../../util/ignore';
+import { newlineRegex, regEx } from '../../../util/regex';
+import { GitTagsDatasource } from '../../datasource/git-tags';
+import { PypiDatasource } from '../../datasource/pypi';
+import { extractPackageFile as extractRequirementsFile } from '../pip_requirements/extract';
+import type { PackageDependency, PackageFileContent } from '../types';
+
+export async function extractAllPackageFiles(
+  config: ExtractConfig,
+  packageFiles: string[],
+): Promise<PackageFile<NpmManagerData>[]> {
+  const pipReqFiles: PackageFile<NpmManagerData>[] = [];
+  for (const packageFile of packageFiles) {
+    const content = await readLocalFile(packageFile, 'utf8');
+    // istanbul ignore else
+    if (content) {
+      const deps = await extractRequirementsFile(content, packageFile, config);
+      if (deps) {
+        pipReqFiles.push({
+          ...deps,
+          packageFile,
+        });
+      }
+    } else {
+      logger.debug({ packageFile }, `No content found`);
+    }
+  }
+
+  await postExtract(pipReqFiles);
+  return pipReqFiles;
+}

--- a/lib/modules/manager/pip-compile/index.ts
+++ b/lib/modules/manager/pip-compile/index.ts
@@ -2,8 +2,11 @@ import type { Category } from '../../../constants';
 import { GitTagsDatasource } from '../../datasource/git-tags';
 import { PypiDatasource } from '../../datasource/pypi';
 
-export { extractPackageFile } from '../pip_requirements/extract';
+// TODO(not7cd): unsure if both extract* exports can exist in a single manager
+// export { extractPackageFile } from '../pip_requirements/extract';
+export { extractAllPackageFiles } from './extract';
 export { updateArtifacts } from './artifacts';
+export { updateLockedDependency } from './update-locked';
 
 export const supportsLockFileMaintenance = true;
 

--- a/lib/modules/manager/pip-compile/readme.md
+++ b/lib/modules/manager/pip-compile/readme.md
@@ -17,6 +17,10 @@ You can "activate" the manager by specifying a `fileMatch` pattern such as:
 }
 ```
 
+### Assumption of header with a command
+
+TODO
+
 ### Assumption of `.in`/`.txt`
 
 If Renovate matches/extracts a file, it assumes that the corresponding output file is found by swapping the `.in` for `.txt`.
@@ -49,3 +53,7 @@ Renovate reads the `requirements.txt` file and extracts these `pip-compile` argu
 - `--no-emit-index-url`
 - `--strip-extras`
 - `--resolver`
+
+#### `CUSTOM_COMPILE_COMMAND`
+
+If a wrapper is used, it should not obstruct these arguments.

--- a/lib/modules/manager/pip-compile/update-locked.ts
+++ b/lib/modules/manager/pip-compile/update-locked.ts
@@ -1,0 +1,24 @@
+import { logger } from '../../../logger';
+import type { UpdateLockedConfig, UpdateLockedResult } from '../types';
+import { extractLockFileEntries } from './locked-version';
+
+export function updateLockedDependency(
+  config: UpdateLockedConfig,
+): UpdateLockedResult {
+  const { depName, currentVersion, newVersion, lockFile, lockFileContent } =
+    config;
+  logger.debug(
+    `pip-compile.updateLockedDependency: ${depName}@${currentVersion} -> ${newVersion} [${lockFile}]`,
+  );
+  try {
+    const locked = extractLockFileEntries(lockFileContent ?? '');
+    if (locked.get(depName ?? '') === newVersion) {
+      return { status: 'already-updated' };
+    }
+    // exec pip-compile --upgrade-package ${depName}==${newVersion}
+    return { status: 'unsupported' };
+  } catch (err) {
+    logger.debug({ err }, 'bundler.updateLockedDependency() error');
+    return { status: 'update-failed' };
+  }
+}


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

As this is a draft PR, the list below is a planned scope.

- [ ] Extract dependencies from lock files, as only `requirements.in` is handled at the moment.
- [ ] Run `pip-compile --upgrade-package` for indirect dependencies that exist only in `requirements.txt`.
  - [ ] Bundle updates to lock file and run a single command if grouped.
- [ ] Better command extraction handling. Allow for `CUSTOM_COMPILE_COMMAND` if it doesn't obstruct original arguments. See https://github.com/renovatebot/renovate/discussions/24725#discussioncomment-8066769
- [ ] Handle other `pip-compile` arguments, pass them without change as to not change command in the header.

<!-- Describe what behavior is changed by this PR. -->

## Context

Support for `pip-compile` is partial. It doesn't parse lock files like other implemented managers do. In turn it will ignore updates for dependencies in the lock file. It also "eats" arguments extracted from header in the lock file, for example when `--no-emit-index-url` is dropped, this is very undesirable as `PIP_INDEX_URL` can contain secrets like HTTP passwords. Lastly hard-coded `pip-compile` command doesn't allow for `CUSTOM_COMPILE_COMMAND`, and will not allow for setups that require docker containers that have system depenencies pre-installed.

Discussion 2018-2022: https://github.com/renovatebot/renovate/discussions/24725

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
