### PR TITLE
feat: allow `i` flag in regex patterns

### DIFF
--- a/lib/config/validation.spec.ts
+++ b/lib/config/validation.spec.ts
@@ -89,6 +89,10 @@ describe('config/validation', () => {
             matchPackageNames: ['quack'],
             allowedVersions: '!/***$}{]][/',
           },
+          {
+            matchPackageNames: ['quack'],
+            allowedVersions: '/quaCk/i',
+          },
         ],
       };
       const { errors } = await configValidation.validateConfig(false, config);
@@ -112,6 +116,11 @@ describe('config/validation', () => {
           {
             matchPackageNames: ['quack'],
             matchCurrentValue: '<1.0.0',
+            enabled: true,
+          },
+          {
+            matchPackageNames: ['foo'],
+            matchCurrentValue: '/^2/i',
             enabled: true,
           },
         ],
@@ -141,6 +150,11 @@ describe('config/validation', () => {
           {
             matchPackageNames: ['quack'],
             matchCurrentVersion: '!/***$}{]][/',
+            enabled: true,
+          },
+          {
+            matchPackageNames: ['foo'],
+            matchCurrentVersion: '/^2/i',
             enabled: true,
           },
         ],
@@ -218,7 +232,7 @@ describe('config/validation', () => {
 
     it('catches invalid baseBranches regex', async () => {
       const config = {
-        baseBranches: ['/***$}{]][/'],
+        baseBranches: ['/***$}{]][/', '/branch/i'],
       };
       const { errors } = await configValidation.validateConfig(false, config);
       expect(errors).toEqual([

--- a/lib/util/package-rules/current-value.spec.ts
+++ b/lib/util/package-rules/current-value.spec.ts
@@ -28,6 +28,18 @@ describe('util/package-rules/current-value', () => {
       expect(result).toBeFalse();
     });
 
+    it('case insensitive match', () => {
+      const result = matcher.matches(
+        {
+          currentValue: '"V1.1.0"',
+        },
+        {
+          matchCurrentValue: '/^"v/i',
+        },
+      );
+      expect(result).toBeTrue();
+    });
+
     it('return true for regex version match', () => {
       const result = matcher.matches(
         {

--- a/lib/util/package-rules/current-version.spec.ts
+++ b/lib/util/package-rules/current-version.spec.ts
@@ -50,6 +50,19 @@ describe('util/package-rules/current-version', () => {
       expect(result).toBeFalse();
     });
 
+    it('case insensitive match', () => {
+      const result = matcher.matches(
+        {
+          versioning: 'pep440',
+          currentValue: 'bbbbbb',
+        },
+        {
+          matchCurrentVersion: '/BBB.*/i',
+        },
+      );
+      expect(result).toBeTrue();
+    });
+
     it('return false for regex version non match', () => {
       const result = matcher.matches(
         {

--- a/lib/util/regex.spec.ts
+++ b/lib/util/regex.spec.ts
@@ -1,6 +1,6 @@
 import RE2 from 're2';
 import { CONFIG_VALIDATION } from '../constants/error-messages';
-import { isUUID, regEx } from './regex';
+import { configRegexPredicate, isUUID, regEx } from './regex';
 
 describe('util/regex', () => {
   beforeEach(() => {
@@ -43,6 +43,28 @@ describe('util/regex', () => {
       expect(isUUID('{90b6646d-1724-4a64-9fd9-539515fe94e9}')).toBe(true);
       expect(isUUID('{90B6646D-1724-4A64-9FD9-539515FE94E9}')).toBe(true);
       expect(isUUID('not-a-uuid')).toBe(false);
+    });
+  });
+
+  describe('configRegexPredicate', () => {
+    it('allows valid regex pattern', () => {
+      expect(configRegexPredicate('/hello/')).not.toBeNull();
+    });
+
+    it('invalidates invalid regex pattern', () => {
+      expect(configRegexPredicate('/^test\\d+$/m')).toBeNull();
+    });
+
+    it('allows the i flag in regex pattern', () => {
+      expect(configRegexPredicate('/^test\\d+$/i')).not.toBeNull();
+    });
+
+    it('allows negative regex pattern', () => {
+      expect(configRegexPredicate('!/^test\\d+$/i')).not.toBeNull();
+    });
+
+    it('does not allow non-regex input', () => {
+      expect(configRegexPredicate('hello')).toBeNull();
     });
   });
 });

--- a/lib/util/regex.ts
+++ b/lib/util/regex.ts
@@ -65,7 +65,7 @@ export function escapeRegExp(input: string): string {
 export const newlineRegex = regEx(/\r?\n/);
 
 const configValStart = regEx(/^!?\//);
-const configValEnd = regEx(/\/$/);
+const configValEnd = regEx(/\/i?$/);
 
 export function isConfigRegex(input: unknown): input is string {
   return (
@@ -78,7 +78,8 @@ function parseConfigRegex(input: string): RegExp | null {
     const regexString = input
       .replace(configValStart, '')
       .replace(configValEnd, '');
-    return regEx(regexString);
+    const isCaseSensitive = input.endsWith('i');
+    return isCaseSensitive ? regEx(regexString, 'i') : regEx(regexString);
   } catch (err) {
     // no-op
   }

--- a/lib/util/regex.ts
+++ b/lib/util/regex.ts
@@ -78,8 +78,8 @@ function parseConfigRegex(input: string): RegExp | null {
     const regexString = input
       .replace(configValStart, '')
       .replace(configValEnd, '');
-    const isCaseSensitive = input.endsWith('i');
-    return isCaseSensitive ? regEx(regexString, 'i') : regEx(regexString);
+    const isCaseSensitive = !input.endsWith('i');
+    return isCaseSensitive ? regEx(regexString) : regEx(regexString, 'i');
   } catch (err) {
     // no-op
   }

--- a/lib/util/regex.ts
+++ b/lib/util/regex.ts
@@ -78,8 +78,7 @@ function parseConfigRegex(input: string): RegExp | null {
     const regexString = input
       .replace(configValStart, '')
       .replace(configValEnd, '');
-    const isCaseSensitive = !input.endsWith('i');
-    return isCaseSensitive ? regEx(regexString) : regEx(regexString, 'i');
+    return input.endsWith('i') ? regEx(regexString, 'i') : regEx(regexString));
   } catch (err) {
     // no-op
   }

--- a/lib/util/regex.ts
+++ b/lib/util/regex.ts
@@ -78,7 +78,7 @@ function parseConfigRegex(input: string): RegExp | null {
     const regexString = input
       .replace(configValStart, '')
       .replace(configValEnd, '');
-    return input.endsWith('i') ? regEx(regexString, 'i') : regEx(regexString));
+    return input.endsWith('i') ? regEx(regexString, 'i') : regEx(regexString);
   } catch (err) {
     // no-op
   }

--- a/lib/workers/global/autodiscover.spec.ts
+++ b/lib/workers/global/autodiscover.spec.ts
@@ -107,7 +107,7 @@ describe('workers/global/autodiscover', () => {
 
   it('filters autodiscovered github repos with regex', async () => {
     config.autodiscover = true;
-    config.autodiscoverFilter = ['/project/re*./'];
+    config.autodiscoverFilter = ['/project/RE*./i'];
     config.platform = 'github';
     hostRules.find = jest.fn(() => ({
       token: 'abc',


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
After this change the regex patterns of the options `allowedVersions`, `baseBranches`, `matchBaseBranches`, `matcCurrentValue` , `matchCurrentVersion` and the `autodiscoverFilter` will allow the `i` flag

Logic changes have been made to the `configRegexPredicate` function, and new tests have been added to all affected functions.
<!-- Describe what behavior is changed by this PR. -->

## Context
https://github.com/renovatebot/renovate/issues/21286#issuecomment-1902550512
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
