### PR TITLE
feat(pipenv): set a cache dir location for WORKON_HOME (virtualenvs)

### DIFF
--- a/lib/modules/manager/pipenv/artifacts.spec.ts
+++ b/lib/modules/manager/pipenv/artifacts.spec.ts
@@ -50,6 +50,7 @@ const config: UpdateArtifactsConfig = {};
 const lockMaintenanceConfig = { ...config, isLockFileMaintenance: true };
 const pipenvCacheDir = '/tmp/renovate/cache/others/pipenv';
 const pipCacheDir = '/tmp/renovate/cache/others/pip';
+const virtualenvsCacheDir = '/tmp/renovate/cache/others/virtualenvs';
 
 describe('modules/manager/pipenv/artifacts', () => {
   let pipFileLock: PipfileLockSchema;
@@ -103,6 +104,7 @@ describe('modules/manager/pipenv/artifacts', () => {
   it('returns null if unchanged', async () => {
     pipFileLock._meta!.requires!.python_full_version = '3.7.6';
     fs.ensureCacheDir.mockResolvedValueOnce(pipenvCacheDir);
+    fs.ensureCacheDir.mockResolvedValueOnce(virtualenvsCacheDir);
     fs.readLocalFile.mockResolvedValueOnce(JSON.stringify(pipFileLock));
     const execSnapshots = mockExecAll();
     fs.readLocalFile.mockResolvedValueOnce(JSON.stringify(pipFileLock));
@@ -131,6 +133,8 @@ describe('modules/manager/pipenv/artifacts', () => {
 
   it('handles no constraint', async () => {
     fs.ensureCacheDir.mockResolvedValueOnce(pipenvCacheDir);
+    fs.ensureCacheDir.mockResolvedValueOnce(pipCacheDir);
+    fs.ensureCacheDir.mockResolvedValueOnce(virtualenvsCacheDir);
     fs.readLocalFile.mockResolvedValueOnce('unparseable pipfile lock');
     const execSnapshots = mockExecAll();
     fs.readLocalFile.mockResolvedValueOnce('unparseable pipfile lock');
@@ -151,6 +155,8 @@ describe('modules/manager/pipenv/artifacts', () => {
           cwd: '/tmp/github/some/repo',
           env: {
             PIPENV_CACHE_DIR: pipenvCacheDir,
+            PIP_CACHE_DIR: pipCacheDir,
+            WORKON_HOME: virtualenvsCacheDir,
           },
         },
       },
@@ -159,6 +165,8 @@ describe('modules/manager/pipenv/artifacts', () => {
 
   it('returns updated Pipfile.lock', async () => {
     fs.ensureCacheDir.mockResolvedValueOnce(pipenvCacheDir);
+    fs.ensureCacheDir.mockResolvedValueOnce(pipCacheDir);
+    fs.ensureCacheDir.mockResolvedValueOnce(virtualenvsCacheDir);
     fs.readLocalFile.mockResolvedValueOnce('current pipfile.lock');
     const execSnapshots = mockExecAll();
     git.getRepoStatus.mockResolvedValue(
@@ -184,6 +192,8 @@ describe('modules/manager/pipenv/artifacts', () => {
           cwd: '/tmp/github/some/repo',
           env: {
             PIPENV_CACHE_DIR: pipenvCacheDir,
+            PIP_CACHE_DIR: pipCacheDir,
+            WORKON_HOME: virtualenvsCacheDir,
           },
         },
       },
@@ -195,6 +205,7 @@ describe('modules/manager/pipenv/artifacts', () => {
     pipFileLock._meta!.requires!.python_version = '3.7';
     fs.ensureCacheDir.mockResolvedValueOnce(pipenvCacheDir);
     fs.ensureCacheDir.mockResolvedValueOnce(pipCacheDir);
+    fs.ensureCacheDir.mockResolvedValueOnce(virtualenvsCacheDir);
     fs.readLocalFile.mockResolvedValueOnce(JSON.stringify(pipFileLock));
     // pipenv
     datasource.getPkgReleases.mockResolvedValueOnce({
@@ -227,6 +238,7 @@ describe('modules/manager/pipenv/artifacts', () => {
           '-v "/tmp/renovate/cache":"/tmp/renovate/cache" ' +
           '-e PIPENV_CACHE_DIR ' +
           '-e PIP_CACHE_DIR ' +
+          '-e WORKON_HOME ' +
           '-e CONTAINERBASE_CACHE_DIR ' +
           '-w "/tmp/github/some/repo" ' +
           'ghcr.io/containerbase/sidecar' +
@@ -242,6 +254,7 @@ describe('modules/manager/pipenv/artifacts', () => {
           env: {
             PIPENV_CACHE_DIR: pipenvCacheDir,
             PIP_CACHE_DIR: pipCacheDir,
+            WORKON_HOME: virtualenvsCacheDir,
           },
         },
       },
@@ -253,6 +266,7 @@ describe('modules/manager/pipenv/artifacts', () => {
     pipFileLock._meta!.requires!.python_full_version = '3.7.6';
     fs.ensureCacheDir.mockResolvedValueOnce(pipenvCacheDir);
     fs.ensureCacheDir.mockResolvedValueOnce(pipCacheDir);
+    fs.ensureCacheDir.mockResolvedValueOnce(virtualenvsCacheDir);
     fs.readLocalFile.mockResolvedValueOnce(JSON.stringify(pipFileLock));
     // pipenv
     datasource.getPkgReleases.mockResolvedValueOnce({
@@ -285,6 +299,7 @@ describe('modules/manager/pipenv/artifacts', () => {
           env: {
             PIPENV_CACHE_DIR: pipenvCacheDir,
             PIP_CACHE_DIR: pipCacheDir,
+            WORKON_HOME: virtualenvsCacheDir,
           },
         },
       },
@@ -293,6 +308,8 @@ describe('modules/manager/pipenv/artifacts', () => {
 
   it('catches errors', async () => {
     fs.ensureCacheDir.mockResolvedValueOnce(pipenvCacheDir);
+    fs.ensureCacheDir.mockResolvedValueOnce(pipCacheDir);
+    fs.ensureCacheDir.mockResolvedValueOnce(virtualenvsCacheDir);
     fs.readLocalFile.mockResolvedValueOnce('Current Pipfile.lock');
     fs.writeLocalFile.mockImplementationOnce(() => {
       throw new Error('not found');
@@ -312,6 +329,8 @@ describe('modules/manager/pipenv/artifacts', () => {
 
   it('returns updated Pipenv.lock when doing lockfile maintenance', async () => {
     fs.ensureCacheDir.mockResolvedValueOnce(pipenvCacheDir);
+    fs.ensureCacheDir.mockResolvedValueOnce(pipCacheDir);
+    fs.ensureCacheDir.mockResolvedValueOnce(virtualenvsCacheDir);
     fs.readLocalFile.mockResolvedValueOnce('Current Pipfile.lock');
     const execSnapshots = mockExecAll();
     git.getRepoStatus.mockResolvedValue(
@@ -337,6 +356,8 @@ describe('modules/manager/pipenv/artifacts', () => {
           cwd: '/tmp/github/some/repo',
           env: {
             PIPENV_CACHE_DIR: pipenvCacheDir,
+            PIP_CACHE_DIR: pipCacheDir,
+            WORKON_HOME: virtualenvsCacheDir,
           },
         },
       },
@@ -345,6 +366,8 @@ describe('modules/manager/pipenv/artifacts', () => {
 
   it('uses pipenv version from Pipfile', async () => {
     fs.ensureCacheDir.mockResolvedValueOnce(pipenvCacheDir);
+    fs.ensureCacheDir.mockResolvedValueOnce(pipCacheDir);
+    fs.ensureCacheDir.mockResolvedValueOnce(virtualenvsCacheDir);
     GlobalConfig.set(dockerAdminConfig);
     pipFileLock.default!['pipenv'].version = '==2020.8.13';
     fs.readLocalFile.mockResolvedValueOnce(JSON.stringify(pipFileLock));
@@ -374,6 +397,8 @@ describe('modules/manager/pipenv/artifacts', () => {
           '-v "/tmp/github/some/repo":"/tmp/github/some/repo" ' +
           '-v "/tmp/renovate/cache":"/tmp/renovate/cache" ' +
           '-e PIPENV_CACHE_DIR ' +
+          '-e PIP_CACHE_DIR ' +
+          '-e WORKON_HOME ' +
           '-e CONTAINERBASE_CACHE_DIR ' +
           '-w "/tmp/github/some/repo" ' +
           'ghcr.io/containerbase/sidecar' +
@@ -388,6 +413,7 @@ describe('modules/manager/pipenv/artifacts', () => {
           cwd: '/tmp/github/some/repo',
           env: {
             PIPENV_CACHE_DIR: pipenvCacheDir,
+            WORKON_HOME: virtualenvsCacheDir,
           },
         },
       },
@@ -398,6 +424,8 @@ describe('modules/manager/pipenv/artifacts', () => {
     GlobalConfig.set(dockerAdminConfig);
     pipFileLock.develop!['pipenv'].version = '==2020.8.13';
     fs.ensureCacheDir.mockResolvedValueOnce(pipenvCacheDir);
+    fs.ensureCacheDir.mockResolvedValueOnce(pipCacheDir);
+    fs.ensureCacheDir.mockResolvedValueOnce(virtualenvsCacheDir);
     fs.readLocalFile.mockResolvedValueOnce(JSON.stringify(pipFileLock));
     const execSnapshots = mockExecAll();
     git.getRepoStatus.mockResolvedValue(
@@ -425,6 +453,8 @@ describe('modules/manager/pipenv/artifacts', () => {
           '-v "/tmp/github/some/repo":"/tmp/github/some/repo" ' +
           '-v "/tmp/renovate/cache":"/tmp/renovate/cache" ' +
           '-e PIPENV_CACHE_DIR ' +
+          '-e PIP_CACHE_DIR ' +
+          '-e WORKON_HOME ' +
           '-e CONTAINERBASE_CACHE_DIR ' +
           '-w "/tmp/github/some/repo" ' +
           'ghcr.io/containerbase/sidecar' +
@@ -439,6 +469,7 @@ describe('modules/manager/pipenv/artifacts', () => {
           cwd: '/tmp/github/some/repo',
           env: {
             PIPENV_CACHE_DIR: pipenvCacheDir,
+            WORKON_HOME: virtualenvsCacheDir,
           },
         },
       },
@@ -449,6 +480,8 @@ describe('modules/manager/pipenv/artifacts', () => {
     GlobalConfig.set(dockerAdminConfig);
     pipFileLock.default!['pipenv'].version = '==2020.8.13';
     fs.ensureCacheDir.mockResolvedValueOnce(pipenvCacheDir);
+    fs.ensureCacheDir.mockResolvedValueOnce(pipCacheDir);
+    fs.ensureCacheDir.mockResolvedValueOnce(virtualenvsCacheDir);
     fs.readLocalFile.mockResolvedValueOnce(JSON.stringify(pipFileLock));
     const execSnapshots = mockExecAll();
     git.getRepoStatus.mockResolvedValue(
@@ -476,6 +509,8 @@ describe('modules/manager/pipenv/artifacts', () => {
           '-v "/tmp/github/some/repo":"/tmp/github/some/repo" ' +
           '-v "/tmp/renovate/cache":"/tmp/renovate/cache" ' +
           '-e PIPENV_CACHE_DIR ' +
+          '-e PIP_CACHE_DIR ' +
+          '-e WORKON_HOME ' +
           '-e CONTAINERBASE_CACHE_DIR ' +
           '-w "/tmp/github/some/repo" ' +
           'ghcr.io/containerbase/sidecar' +
@@ -490,6 +525,7 @@ describe('modules/manager/pipenv/artifacts', () => {
           cwd: '/tmp/github/some/repo',
           env: {
             PIPENV_CACHE_DIR: pipenvCacheDir,
+            WORKON_HOME: virtualenvsCacheDir,
           },
         },
       },
@@ -498,6 +534,8 @@ describe('modules/manager/pipenv/artifacts', () => {
 
   it('passes private credential environment vars', async () => {
     fs.ensureCacheDir.mockResolvedValueOnce(pipenvCacheDir);
+    fs.ensureCacheDir.mockResolvedValueOnce(pipCacheDir);
+    fs.ensureCacheDir.mockResolvedValueOnce(virtualenvsCacheDir);
     fs.readLocalFile.mockResolvedValueOnce('current pipfile.lock');
     const execSnapshots = mockExecAll();
     git.getRepoStatus.mockResolvedValue(
@@ -536,6 +574,7 @@ describe('modules/manager/pipenv/artifacts', () => {
           cwd: '/tmp/github/some/repo',
           env: {
             PIPENV_CACHE_DIR: pipenvCacheDir,
+            WORKON_HOME: virtualenvsCacheDir,
             USERNAME: 'usernameOne',
             PASSWORD: 'passwordTwo',
           },
@@ -546,6 +585,8 @@ describe('modules/manager/pipenv/artifacts', () => {
 
   it('does not pass private credential environment vars if variable names differ from allowed', async () => {
     fs.ensureCacheDir.mockResolvedValueOnce(pipenvCacheDir);
+    fs.ensureCacheDir.mockResolvedValueOnce(pipCacheDir);
+    fs.ensureCacheDir.mockResolvedValueOnce(virtualenvsCacheDir);
     fs.readLocalFile.mockResolvedValueOnce('current pipfile.lock');
     const execSnapshots = mockExecAll();
     git.getRepoStatus.mockResolvedValue(
@@ -579,6 +620,7 @@ describe('modules/manager/pipenv/artifacts', () => {
           cwd: '/tmp/github/some/repo',
           env: {
             PIPENV_CACHE_DIR: pipenvCacheDir,
+            WORKON_HOME: virtualenvsCacheDir,
           },
         },
       },

--- a/lib/modules/manager/pipenv/artifacts.ts
+++ b/lib/modules/manager/pipenv/artifacts.ts
@@ -140,6 +140,7 @@ export async function updateArtifacts({
     const extraEnv: Opt<ExtraEnv> = {
       PIPENV_CACHE_DIR: await ensureCacheDir('pipenv'),
       PIP_CACHE_DIR: await ensureCacheDir('pip'),
+      WORKON_HOME: await ensureCacheDir('virtualenvs'),
     };
     const execOptions: ExecOptions = {
       cwdFile: pipfileName,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
Related to #26806, handle a cache location for virtualenvs files with WORKON_HOME env variable and do not use home directory (which may be non writable in some conditions). Dedicated cache will be reused for the next runs.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
