### PR TITLE
feat(gitea) autodiscover repositories by namespace

### DIFF
--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -852,7 +852,7 @@ const options: RenovateOptions[] = [
     subType: 'string',
     default: null,
     globalOnly: true,
-    supportedPlatforms: ['gitlab'],
+    supportedPlatforms: ['gitea', 'gitlab'],
   },
   {
     name: 'autodiscoverTopics',

--- a/lib/modules/platform/gitea/gitea-helper.spec.ts
+++ b/lib/modules/platform/gitea/gitea-helper.spec.ts
@@ -22,6 +22,7 @@ import {
   getRepoLabels,
   getVersion,
   mergePR,
+  orgListRepos,
   requestPrReviewers,
   searchIssues,
   searchRepos,
@@ -247,6 +248,15 @@ describe('modules/platform/gitea/gitea-helper', () => {
       });
 
       await expect(searchRepos({})).rejects.toThrow();
+    });
+  });
+
+  describe('orgListRepos', () => {
+    it('should call /api/v1/orgs/[organization]/repos endpoint', async () => {
+      httpMock.scope(baseUrl).get('/orgs/some/repos').reply(200, mockRepo);
+
+      const res = await orgListRepos('some');
+      expect(res).toEqual(mockRepo);
     });
   });
 

--- a/lib/modules/platform/gitea/gitea-helper.ts
+++ b/lib/modules/platform/gitea/gitea-helper.ts
@@ -75,7 +75,7 @@ export async function searchRepos(
 }
 
 export async function orgListRepos(
-  organization?: string,
+  organization: string,
   options?: GiteaHttpOptions,
 ): Promise<Repo[]> {
   const url = `${API_PATH}/orgs/${organization}/repos`;

--- a/lib/modules/platform/gitea/gitea-helper.ts
+++ b/lib/modules/platform/gitea/gitea-helper.ts
@@ -65,7 +65,6 @@ export async function searchRepos(
     ...options,
     paginate: true,
   });
-
   if (!res.body.ok) {
     throw new Error(
       'Unable to search for repositories, ok flag has not been set',
@@ -73,6 +72,19 @@ export async function searchRepos(
   }
 
   return res.body.data;
+}
+
+export async function orgListRepos(
+  organization?: string,
+  options?: GiteaHttpOptions,
+): Promise<Repo[]> {
+  const url = `${API_PATH}/orgs/${organization}/repos`;
+  const res = await giteaHttp.getJson<Repo[]>(url, {
+    ...options,
+    paginate: true,
+  });
+
+  return res.body;
 }
 
 export async function getRepo(

--- a/lib/modules/platform/gitea/index.spec.ts
+++ b/lib/modules/platform/gitea/index.spec.ts
@@ -72,6 +72,12 @@ describe('modules/platform/gitea/index', () => {
 
   const mockTopicRepos: Repo[] = [partial<Repo>({ full_name: 'a/b' })];
 
+  const mockNamespaceRepos: Repo[] = [
+    partial<Repo>({ full_name: 'org1/repo' }),
+    partial<Repo>({ full_name: 'org2/repo' }),
+    partial<Repo>({ full_name: 'org2/repo2', archived: true }),
+  ];
+
   const mockPRs: MockPr[] = [
     partial<MockPr>({
       number: 1,
@@ -388,6 +394,20 @@ describe('modules/platform/gitea/index', () => {
         topics: ['renovate', 'renovatebot'],
       });
       expect(repos).toEqual(['a/b']);
+    });
+
+    it('should query the organization endpoint for each namespace', async () => {
+      const scope = httpMock.scope('https://gitea.com/api/v1');
+
+      scope.get('/orgs/org1/repos').reply(200, mockNamespaceRepos);
+      scope.get('/orgs/org2/repos').reply(200, mockNamespaceRepos);
+
+      await initFakePlatform(scope);
+
+      const repos = await gitea.getRepos({
+        namespaces: ['org1', 'org2'],
+      });
+      expect(repos).toEqual(['org1/repo', 'org2/repo']);
     });
 
     it('Sorts repos', async () => {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds Gitea support for the configuration option autodiscoverNamespaces to run Renovate against all repositories in a namespace (Gitea organization).

## Context

Closes https://github.com/renovatebot/renovate/discussions/26792

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
