### PR TITLE
feat(azure): Log if we cannot find a reviewer

### DIFF
--- a/lib/modules/platform/azure/index.spec.ts
+++ b/lib/modules/platform/azure/index.spec.ts
@@ -1530,7 +1530,7 @@ describe('modules/platform/azure/index', () => {
       );
       await azure.addReviewers(123, ['test@bonjour.fr', 'jyc', 'required:def']);
       expect(azureApi.gitApi).toHaveBeenCalledTimes(3);
-      expect(logger.warn).toHaveBeenCalledTimes(1);
+      expect(logger.once.info).toHaveBeenCalledTimes(1);
     });
 
     it('addReviewers all valid', async () => {
@@ -1556,7 +1556,7 @@ describe('modules/platform/azure/index', () => {
       );
       await azure.addReviewers(123, ['required:jyc']);
       expect(azureApi.gitApi).toHaveBeenCalledTimes(3);
-      expect(logger.warn).toHaveBeenCalledTimes(0);
+      expect(logger.once.info).toHaveBeenCalledTimes(0);
     });
   });
 

--- a/lib/modules/platform/azure/index.spec.ts
+++ b/lib/modules/platform/azure/index.spec.ts
@@ -1507,7 +1507,7 @@ describe('modules/platform/azure/index', () => {
   });
 
   describe('Reviewers', () => {
-    it('addReviewers', async () => {
+    it('addReviewers one valid', async () => {
       await initRepo({ repository: 'some/repo' });
       azureApi.gitApi.mockImplementation(
         () =>
@@ -1530,6 +1530,33 @@ describe('modules/platform/azure/index', () => {
       );
       await azure.addReviewers(123, ['test@bonjour.fr', 'jyc', 'required:def']);
       expect(azureApi.gitApi).toHaveBeenCalledTimes(3);
+      expect(logger.warn).toHaveBeenCalledTimes(1);
+    });
+
+    it('addReviewers all valid', async () => {
+      await initRepo({ repository: 'some/repo' });
+      azureApi.gitApi.mockImplementation(
+        () =>
+          ({
+            getRepositories: jest.fn(() => [{ id: '1', project: { id: 2 } }]),
+            createPullRequestReviewer: jest.fn(),
+          }) as any,
+      );
+      azureApi.coreApi.mockImplementation(
+        () =>
+          ({
+            getTeams: jest.fn(() => [
+              { id: 3, name: 'abc' },
+              { id: 4, name: 'def' },
+            ]),
+            getTeamMembersWithExtendedProperties: jest.fn(() => [
+              { identity: { displayName: 'jyc', uniqueName: 'jyc', id: 123 } },
+            ]),
+          }) as any,
+      );
+      await azure.addReviewers(123, ['required:jyc']);
+      expect(azureApi.gitApi).toHaveBeenCalledTimes(3);
+      expect(logger.warn).toHaveBeenCalledTimes(0);
     });
   });
 

--- a/lib/modules/platform/azure/index.ts
+++ b/lib/modules/platform/azure/index.ts
@@ -921,9 +921,11 @@ async function getUserIds(users: string[]): Promise<User[]> {
   for (const u of users) {
     const reviewer = u.replace(requiredReviewerPrefix, '');
     if (!validReviewers.has(reviewer)) {
-      logger.once.info(`${reviewer} is neither an Azure DevOps Team nor a user associated with a Team`);
+      logger.once.info(
+        `${reviewer} is neither an Azure DevOps Team nor a user associated with a Team`,
+      );
     }
-  };
+  }
 
   return ids;
 }

--- a/lib/modules/platform/azure/index.ts
+++ b/lib/modules/platform/azure/index.ts
@@ -855,6 +855,7 @@ async function getUserIds(users: string[]): Promise<User[]> {
   const repos = await azureApiGit.getRepositories();
   const repo = repos.filter((c) => c.id === config.repoId)[0];
   const requiredReviewerPrefix = 'required:';
+  const validReviewers: string[] = [];
 
   // TODO #22198
   const teams = await azureApiCore.getTeams(repo.project!.id!);
@@ -890,6 +891,8 @@ async function getUserIds(users: string[]): Promise<User[]> {
               name: reviewer,
               isRequired,
             });
+
+            validReviewers.push(reviewer);
           }
         }
       });
@@ -908,9 +911,18 @@ async function getUserIds(users: string[]): Promise<User[]> {
         if (ids.filter((c) => c.id === t.id).length === 0) {
           // TODO #22198
           ids.push({ id: t.id!, name: reviewer, isRequired });
+
+          validReviewers.push(reviewer);
         }
       }
     });
+  });
+
+  users.forEach((u) => {
+    let reviewer = u;
+    if (validReviewers.indexOf(reviewer) == -1) {
+      logger.warn(`${reviewer} is neither an Azure DevOps Team nor a user associated with a Team`);
+    }
   });
 
   return ids;

--- a/lib/modules/platform/azure/index.ts
+++ b/lib/modules/platform/azure/index.ts
@@ -919,7 +919,7 @@ async function getUserIds(users: string[]): Promise<User[]> {
   });
 
   users.forEach((u) => {
-    let reviewer = u;
+    let reviewer = u.replace(requiredReviewerPrefix, '');
     if (validReviewers.indexOf(reviewer) == -1) {
       logger.warn(`${reviewer} is neither an Azure DevOps Team nor a user associated with a Team`);
     }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Log a warning for any configured reviewers that cannot be found in Azure DevOps.

## Context

Closes #26735 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
