### PR TITLE
feat(config): mergeable `repositoryAliases` global option

### DIFF
--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -976,6 +976,7 @@ const options: RenovateOptions[] = [
   {
     name: 'registryAliases',
     description: 'Aliases for registries.',
+    mergeable: true,
     type: 'object',
     default: {},
     additionalProperties: {

--- a/lib/workers/repository/extract/extract-fingerprint-config.spec.ts
+++ b/lib/workers/repository/extract/extract-fingerprint-config.spec.ts
@@ -7,7 +7,7 @@ describe('workers/repository/extract/extract-fingerprint-config', () => {
   it('filter with enabledManagers', () => {
     const config = mergeChildConfig(getConfig(), {
       registryAliases: {
-        stable: 'http://some.link'
+        stable: 'http://some.link',
       },
       ignorePaths: ['ignore-path-1'],
       includePaths: ['include-path-1'],
@@ -47,7 +47,7 @@ describe('workers/repository/extract/extract-fingerprint-config', () => {
       npmrcMerge: false,
       registryAliases: {
         notStable: 'http://some.link.2',
-        stable: 'http://some.link'
+        stable: 'http://some.link',
       },
       skipInstalls: null,
     });

--- a/lib/workers/repository/extract/extract-fingerprint-config.spec.ts
+++ b/lib/workers/repository/extract/extract-fingerprint-config.spec.ts
@@ -7,7 +7,7 @@ describe('workers/repository/extract/extract-fingerprint-config', () => {
   it('filter with enabledManagers', () => {
     const config = mergeChildConfig(getConfig(), {
       registryAliases: {
-        stable: 'http://some.link', // intentionally placing the field incorrectly
+        stable: 'http://some.link'
       },
       ignorePaths: ['ignore-path-1'],
       includePaths: ['include-path-1'],
@@ -47,6 +47,7 @@ describe('workers/repository/extract/extract-fingerprint-config', () => {
       npmrcMerge: false,
       registryAliases: {
         notStable: 'http://some.link.2',
+        stable: 'http://some.link'
       },
       skipInstalls: null,
     });


### PR DESCRIPTION
## Changes

This should fix the repositoryAliases that are being defined in renovate.js or via the env var RENOVATE_REPOSITORY_ALIASES not actually being picked up as mentioned int he discussion.

## Context
https://github.com/renovatebot/renovate/discussions/26756

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
