### PR TITLE
fix(terraform): Replace correct currentValue match in constraint with new value

### DIFF
--- a/lib/modules/manager/terraform/lockfile/index.spec.ts
+++ b/lib/modules/manager/terraform/lockfile/index.spec.ts
@@ -1118,6 +1118,19 @@ describe('modules/manager/terraform/lockfile/index', () => {
       ).toBe('>= 2.36.0, 2.46.0');
     });
 
+    it('update constraint with multiple element ranges', () => {
+      expect(
+        getNewConstraint(
+          {
+            currentValue: '2.41.0',
+            newValue: '2.46.0',
+            newVersion: '2.46.0',
+          },
+          '>= 2.41.0, 2.41.0',
+        ),
+      ).toBe('>= 2.46.0, 2.46.0');
+    });
+
     it('create constraint with full version', () => {
       expect(
         getNewConstraint(

--- a/lib/modules/manager/terraform/lockfile/index.spec.ts
+++ b/lib/modules/manager/terraform/lockfile/index.spec.ts
@@ -1118,7 +1118,7 @@ describe('modules/manager/terraform/lockfile/index', () => {
       ).toBe('>= 2.36.0, 2.46.0');
     });
 
-    it('update constraint with multiple element ranges', () => {
+    it('update constraint when current version is matched multiple times', () => {
       expect(
         getNewConstraint(
           {
@@ -1128,7 +1128,7 @@ describe('modules/manager/terraform/lockfile/index', () => {
           },
           '>= 2.41.0, 2.41.0',
         ),
-      ).toBe('>= 2.46.0, 2.46.0');
+      ).toBe('>= 2.41.0, 2.46.0');
     });
 
     it('create constraint with full version', () => {

--- a/lib/modules/manager/terraform/lockfile/index.spec.ts
+++ b/lib/modules/manager/terraform/lockfile/index.spec.ts
@@ -1131,6 +1131,19 @@ describe('modules/manager/terraform/lockfile/index', () => {
       ).toBe('>= 2.41.0, 2.46.0');
     });
 
+    it('update constraint when current version is in a complicated constraint', () => {
+      expect(
+        getNewConstraint(
+          {
+            currentValue: '<= 2.41.0',
+            newValue: '<= 2.46.0',
+            newVersion: '2.46.0',
+          },
+          '>= 2.41.0, <= 2.41.0, >= 2',
+        ),
+      ).toBe('>= 2.41.0, <= 2.46.0, >= 2');
+    });
+
     it('create constraint with full version', () => {
       expect(
         getNewConstraint(

--- a/lib/modules/manager/terraform/lockfile/index.spec.ts
+++ b/lib/modules/manager/terraform/lockfile/index.spec.ts
@@ -1139,9 +1139,9 @@ describe('modules/manager/terraform/lockfile/index', () => {
             newValue: '<= 2.46.0',
             newVersion: '2.46.0',
           },
-          '>= 2.41.0, <= 2.41.0, >= 2',
+          '>= 2.41.0, <= 2.41.0, >= 2.0.0',
         ),
-      ).toBe('>= 2.41.0, <= 2.46.0, >= 2');
+      ).toBe('>= 2.41.0, <= 2.46.0, >= 2.0.0');
     });
 
     it('create constraint with full version', () => {

--- a/lib/modules/manager/terraform/lockfile/index.ts
+++ b/lib/modules/manager/terraform/lockfile/index.ts
@@ -98,7 +98,7 @@ export function getNewConstraint(
       `Updating constraint "${oldConstraint}" to replace "${currentValue}" with "${newValue}" for "${packageName}"`,
     );
     //remove surplus .0 version
-    return oldConstraint.replace(
+    return oldConstraint.replaceAll(
       regEx(`${escapeRegExp(currentValue)}(\\.0)*`),
       newValue,
     );
@@ -113,7 +113,7 @@ export function getNewConstraint(
     logger.debug(
       `Updating constraint "${oldConstraint}" to replace "${currentVersion}" with "${newVersion}" for "${packageName}"`,
     );
-    return oldConstraint.replace(currentVersion, newVersion);
+    return oldConstraint.replaceAll(currentVersion, newVersion);
   }
 
   if (isPinnedVersion(newValue)) {

--- a/lib/modules/manager/terraform/lockfile/index.ts
+++ b/lib/modules/manager/terraform/lockfile/index.ts
@@ -98,9 +98,9 @@ export function getNewConstraint(
       `Updating constraint "${oldConstraint}" to replace "${currentValue}" with "${newValue}" for "${packageName}"`,
     );
     //remove surplus .0 version
-    return oldConstraint.replaceAll(
-      regEx(`${escapeRegExp(currentValue)}(\\.0)*`, 'g'),
-      newValue,
+    return oldConstraint.replace(
+      regEx(`(,\\s|^)${escapeRegExp(currentValue)}(\\.0)*`),
+      `$1${newValue}`,
     );
   }
 
@@ -113,7 +113,7 @@ export function getNewConstraint(
     logger.debug(
       `Updating constraint "${oldConstraint}" to replace "${currentVersion}" with "${newVersion}" for "${packageName}"`,
     );
-    return oldConstraint.replaceAll(currentVersion, newVersion);
+    return oldConstraint.replace(currentVersion, newVersion);
   }
 
   if (isPinnedVersion(newValue)) {

--- a/lib/modules/manager/terraform/lockfile/index.ts
+++ b/lib/modules/manager/terraform/lockfile/index.ts
@@ -99,7 +99,7 @@ export function getNewConstraint(
     );
     //remove surplus .0 version
     return oldConstraint.replaceAll(
-      regEx(`${escapeRegExp(currentValue)}(\\.0)*`),
+      regEx(`${escapeRegExp(currentValue)}(\\.0)*`, 'g'),
       newValue,
     );
   }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
Terraform constraints has the `currentVersion` multiple times in the string. However only the `required_provider` currentValue should be updated, instead of the first occurrence of `currentValue`

eg. Terraform hashicorp/aws provider update didn't update the last occurrence of `5.31.0`

```diff
provider "registry.opentofu.org/hashicorp/aws" {
-   version     = "5.31.0"
-   constraints = ">= 2.49.0, >= 3.29.0, >= 3.75.0, >= 4.0.0, >= 4.9.0, >= 4.40.0, >= 4.42.0, >= 4.66.1, >= 5.26.0, >= 5.31.0, 5.31.0"
+   version     = "5.34.0"
+   constraints = ">= 2.49.0, >= 3.29.0, >= 3.75.0, >= 4.0.0, >= 4.9.0, >= 4.40.0, >= 4.42.0, >= 4.66.1, >= 5.26.0, >= 5.34.0, 5.31.0"
```

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
