### PR TITLE
fix(helmv3): disable digest pinning for OCI charts

### DIFF
--- a/lib/modules/manager/helmv3/__snapshots__/extract.spec.ts.snap
+++ b/lib/modules/manager/helmv3/__snapshots__/extract.spec.ts.snap
@@ -9,6 +9,7 @@ exports[`modules/manager/helmv3/extract extractPackageFile() extract correctly o
       "datasource": "docker",
       "depName": "library",
       "packageName": "ghcr.io/ankitabhopatkar13/library",
+      "pinDigests": false,
     },
     {
       "currentValue": "0.8.1",
@@ -68,6 +69,7 @@ exports[`modules/manager/helmv3/extract extractPackageFile() resolves aliased re
       "datasource": "docker",
       "depName": "oci-example",
       "packageName": "quay.example.com/organization/oci-example",
+      "pinDigests": false,
     },
   ],
   "packageFileVersion": "0.1.0",

--- a/lib/modules/manager/helmv3/utils.ts
+++ b/lib/modules/manager/helmv3/utils.ts
@@ -17,6 +17,9 @@ export function parseRepository(
       case 'oci:':
         res.datasource = DockerDatasource.id;
         res.packageName = `${repositoryURL.replace('oci://', '')}/${depName}`;
+        // https://github.com/helm/helm/issues/10312
+        // https://github.com/helm/helm/issues/10678
+        res.pinDigests = false;
         break;
       case 'file:':
         res.skipReason = 'local-dependency';


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

As in title

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->


OCI-based Helm charts do not support pulling by digest at the moment

Similar to #24942

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
