### PR TITLE
refactor(package-rules): delete all matchers from config 

### DIFF
--- a/lib/util/package-rules/index.spec.ts
+++ b/lib/util/package-rules/index.spec.ts
@@ -43,6 +43,7 @@ describe('util/package-rules/index', () => {
       depName: 'a',
       isBump: true,
       currentValue: '1.0.0',
+      labels: ['bump'],
       packageRules: [
         {
           matchPackagePatterns: ['*'],
@@ -69,7 +70,7 @@ describe('util/package-rules/index', () => {
     };
     expect(applyPackageRules(config)).toEqual({
       ...config,
-      matchUpdateTypes: ['bump'],
+      labels: ['bump'],
     });
   });
 

--- a/lib/util/package-rules/index.spec.ts
+++ b/lib/util/package-rules/index.spec.ts
@@ -43,7 +43,6 @@ describe('util/package-rules/index', () => {
       depName: 'a',
       isBump: true,
       currentValue: '1.0.0',
-      labels: ['bump'],
       packageRules: [
         {
           matchPackagePatterns: ['*'],
@@ -58,6 +57,7 @@ describe('util/package-rules/index', () => {
         },
         {
           matchUpdateTypes: ['bump'],
+          labels: ['bump'],
         },
         {
           excludePackageNames: ['a'],

--- a/lib/util/package-rules/index.ts
+++ b/lib/util/package-rules/index.ts
@@ -73,7 +73,7 @@ export function applyPackageRules<T extends PackageRuleInputConfig>(
     // This rule is considered matched if there was at least one positive match and no negative matches
     if (matchesRule(config, packageRule)) {
       // Package rule config overrides any existing config
-      const toApply = { ...packageRule };
+      const toApply = removeMatchers({ ...packageRule });
       if (config.groupSlug && packageRule.groupName && !packageRule.groupSlug) {
         // Need to apply groupSlug otherwise the existing one will take precedence
         toApply.groupSlug = slugify(packageRule.groupName, {
@@ -81,32 +81,20 @@ export function applyPackageRules<T extends PackageRuleInputConfig>(
         });
       }
       config = mergeChildConfig(config, toApply);
-      delete config.matchPackageNames;
-      delete config.matchPackagePatterns;
-      delete config.matchPackagePrefixes;
-      delete config.excludePackageNames;
-      delete config.excludePackagePatterns;
-      delete config.excludePackagePrefixes;
-      delete config.matchDepTypes;
-      delete config.matchCurrentValue;
-      delete config.matchCurrentVersion;
-      delete config.matchCurrentAge;
-      delete config.excludeDepNames;
-      delete config.excludeDepPatterns;
-      delete config.excludeRepositories;
-      delete config.matchCategories;
-      delete config.matchRepositories;
-      delete config.matchBaseBranches;
-      delete config.matchManagers;
-      delete config.matchDatasources;
-      delete config.matchFileNames;
-      delete config.matchDepNames;
-      delete config.matchDepPatterns;
-      delete config.matchSourceUrlPrefixes;
-      delete config.matchSourceUrls;
-      delete config.matchUpdateTypes;
-      delete config.matchConfidence;
     }
   }
   return config;
+}
+
+function removeMatchers(
+  packageRule: PackageRule & PackageRuleInputConfig,
+): Record<string, unknown> {
+  const toApply: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(packageRule)) {
+    if (!key.includes('match') && !key.includes('exclude')) {
+      toApply[key] = value;
+    }
+  }
+
+  return toApply;
 }

--- a/lib/util/package-rules/index.ts
+++ b/lib/util/package-rules/index.ts
@@ -89,12 +89,11 @@ export function applyPackageRules<T extends PackageRuleInputConfig>(
 function removeMatchers(
   packageRule: PackageRule & PackageRuleInputConfig,
 ): Record<string, unknown> {
-  const toApply: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(packageRule)) {
-    if (!key.includes('match') && !key.includes('exclude')) {
-      toApply[key] = value;
+  for (const key of Object.keys(packageRule)) {
+    if (key.includes('match') || key.includes('exclude')) {
+      delete packageRule[key];
     }
   }
 
-  return toApply;
+  return packageRule;
 }

--- a/lib/util/package-rules/index.ts
+++ b/lib/util/package-rules/index.ts
@@ -91,6 +91,21 @@ export function applyPackageRules<T extends PackageRuleInputConfig>(
       delete config.matchCurrentValue;
       delete config.matchCurrentVersion;
       delete config.matchCurrentAge;
+      delete config.excludeDepNames;
+      delete config.excludeDepPatterns;
+      delete config.excludeRepositories;
+      delete config.matchCategories;
+      delete config.matchRepositories;
+      delete config.matchBaseBranches;
+      delete config.matchManagers;
+      delete config.matchDatasources;
+      delete config.matchFileNames;
+      delete config.matchDepNames;
+      delete config.matchDepPatterns;
+      delete config.matchSourceUrlPrefixes;
+      delete config.matchSourceUrls;
+      delete config.matchUpdateTypes;
+      delete config.matchConfidence;
     }
   }
   return config;

--- a/lib/util/package-rules/index.ts
+++ b/lib/util/package-rules/index.ts
@@ -90,7 +90,7 @@ function removeMatchers(
   packageRule: PackageRule & PackageRuleInputConfig,
 ): Record<string, unknown> {
   for (const key of Object.keys(packageRule)) {
-    if (key.includes('match') || key.includes('exclude')) {
+    if (key.startsWith('match') || key.startsWith('exclude')) {
       delete packageRule[key];
     }
   }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Remove all macther/excluders from the config after tha package rule has been merged in it.
<!-- Describe what behavior is changed by this PR. -->

## Context
These matchers should have been deleted as per the logic but it seems we missed them.
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
