### PR TITLE
feat(manager/cargo): add support for `bumpVersion` option

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -412,6 +412,7 @@ This is an advanced field, and it's recommend you seek a config review before ap
 
 Currently, this config option only works with these managers:
 
+- `cargo`
 - `helmv3`
 - `npm`
 - `nuget`

--- a/lib/modules/manager/cargo/extract.spec.ts
+++ b/lib/modules/manager/cargo/extract.spec.ts
@@ -585,5 +585,19 @@ replace-with = "mcorbin"
         expect.not.objectContaining({ lockedVersion: expect.anything() }),
       ]);
     });
+
+    it('should extract project version', async () => {
+      const cargotoml = codeBlock`
+        [package]
+        name = "test"
+        version = "0.1.0"
+        edition = "2021"
+        [dependencies]
+        syn = "2.0"
+        `;
+
+      const res = await extractPackageFile(cargotoml, 'Cargo.toml', config);
+      expect(res?.packageFileVersion).toBe('0.1.0');
+    });
   });
 });

--- a/lib/modules/manager/cargo/extract.ts
+++ b/lib/modules/manager/cargo/extract.ts
@@ -224,6 +224,7 @@ export async function extractPackageFile(
   }
   /*
     There are the following sections in Cargo.toml:
+    [package]
     [dependencies]
     [dev-dependencies]
     [build-dependencies]
@@ -284,11 +285,18 @@ export async function extractPackageFile(
   if (!deps.length) {
     return null;
   }
+
+  const packageSection = cargoManifest.package;
+  let version: string | undefined = undefined;
+  if (packageSection) {
+    version = packageSection.version;
+  }
+
   const lockFileName = await findLocalSiblingOrParent(
     packageFile,
     'Cargo.lock',
   );
-  const res: PackageFileContent = { deps };
+  const res: PackageFileContent = { deps, packageFileVersion: version };
   if (lockFileName) {
     logger.debug(
       `Found lock file ${lockFileName} for packageFile: ${packageFile}`,

--- a/lib/modules/manager/cargo/index.ts
+++ b/lib/modules/manager/cargo/index.ts
@@ -3,6 +3,7 @@ import { CrateDatasource } from '../../datasource/crate';
 import * as cargoVersioning from '../../versioning/cargo';
 import { updateArtifacts } from './artifacts';
 import { extractPackageFile } from './extract';
+export { bumpPackageVersion  } from './update';
 export { getRangeStrategy } from './range';
 export { updateLockedDependency } from './update-locked';
 

--- a/lib/modules/manager/cargo/index.ts
+++ b/lib/modules/manager/cargo/index.ts
@@ -3,7 +3,7 @@ import { CrateDatasource } from '../../datasource/crate';
 import * as cargoVersioning from '../../versioning/cargo';
 import { updateArtifacts } from './artifacts';
 import { extractPackageFile } from './extract';
-export { bumpPackageVersion  } from './update';
+export { bumpPackageVersion } from './update';
 export { getRangeStrategy } from './range';
 export { updateLockedDependency } from './update-locked';
 

--- a/lib/modules/manager/cargo/types.ts
+++ b/lib/modules/manager/cargo/types.ts
@@ -1,5 +1,10 @@
 import type { DEFAULT_REGISTRY_URL } from './utils';
 
+export interface CargoPackage {
+  /** Semver version */
+  version: string
+}
+
 export interface CargoDep {
   /** Path on disk to the crate sources */
   path?: string;
@@ -26,6 +31,7 @@ export interface CargoSection {
 export interface CargoManifest extends CargoSection {
   target?: Record<string, CargoSection>;
   workspace?: CargoSection;
+  package?: CargoPackage
 }
 
 export interface CargoConfig {

--- a/lib/modules/manager/cargo/types.ts
+++ b/lib/modules/manager/cargo/types.ts
@@ -2,7 +2,7 @@ import type { DEFAULT_REGISTRY_URL } from './utils';
 
 export interface CargoPackage {
   /** Semver version */
-  version: string
+  version: string;
 }
 
 export interface CargoDep {
@@ -31,7 +31,7 @@ export interface CargoSection {
 export interface CargoManifest extends CargoSection {
   target?: Record<string, CargoSection>;
   workspace?: CargoSection;
-  package?: CargoPackage
+  package?: CargoPackage;
 }
 
 export interface CargoConfig {

--- a/lib/modules/manager/cargo/update.spec.ts
+++ b/lib/modules/manager/cargo/update.spec.ts
@@ -1,0 +1,50 @@
+import { codeBlock } from 'common-tags';
+import * as projectUpdater from '.';
+
+describe('modules/manager/cargo/update', () => {
+  describe('bumpPackageVersion()', () => {
+    const content = codeBlock`
+      [package]
+      name = "test"
+      version = "0.0.2"
+    `;
+
+    it('increments', () => {
+      const { bumpedContent } = projectUpdater.bumpPackageVersion(
+        content,
+        '0.0.2',
+        'patch',
+      );
+      const expected = content.replace('0.0.2', '0.0.3');
+      expect(bumpedContent).toEqual(expected);
+    });
+
+    it('no ops', () => {
+      const { bumpedContent } = projectUpdater.bumpPackageVersion(
+        content,
+        '0.0.1',
+        'patch',
+      );
+      expect(bumpedContent).toEqual(content);
+    });
+
+    it('updates', () => {
+      const { bumpedContent } = projectUpdater.bumpPackageVersion(
+        content,
+        '0.0.1',
+        'minor',
+      );
+      const expected = content.replace('0.0.2', '0.1.0');
+      expect(bumpedContent).toEqual(expected);
+    });
+
+    it('returns content if bumping errors', () => {
+      const { bumpedContent } = projectUpdater.bumpPackageVersion(
+        content,
+        '0.0.2',
+        true as any,
+      );
+      expect(bumpedContent).toEqual(content);
+    });
+  });
+});

--- a/lib/modules/manager/cargo/update.spec.ts
+++ b/lib/modules/manager/cargo/update.spec.ts
@@ -46,5 +46,14 @@ describe('modules/manager/cargo/update', () => {
       );
       expect(bumpedContent).toEqual(content);
     });
+
+    it('does not bump version if version is not a semantic version', () => {
+      const { bumpedContent } = projectUpdater.bumpPackageVersion(
+        content,
+        '1',
+        'patch',
+      );
+      expect(bumpedContent).toEqual(content);
+    });
   });
 });

--- a/lib/modules/manager/cargo/update.ts
+++ b/lib/modules/manager/cargo/update.ts
@@ -53,4 +53,3 @@ export function bumpPackageVersion(
 
   return { bumpedContent };
 }
-

--- a/lib/modules/manager/cargo/update.ts
+++ b/lib/modules/manager/cargo/update.ts
@@ -1,0 +1,56 @@
+import semver, { ReleaseType } from 'semver';
+import { logger } from '../../../logger';
+import { regEx } from '../../../util/regex';
+import type { BumpPackageVersionResult } from '../types';
+
+export function bumpPackageVersion(
+  content: string,
+  currentValue: string,
+  bumpVersion: ReleaseType,
+): BumpPackageVersionResult {
+  logger.debug(
+    { bumpVersion, currentValue },
+    'Checking if we should bump Cargo.toml version',
+  );
+  let bumpedContent = content;
+
+  if (!semver.valid(currentValue)) {
+    logger.warn(
+      { currentValue },
+      'Unable to bump Cargo.toml version, not a valid semver',
+    );
+    return { bumpedContent };
+  }
+
+  try {
+    const newCrateVersion = semver.inc(currentValue, bumpVersion);
+    if (!newCrateVersion) {
+      throw new Error('semver inc failed');
+    }
+
+    logger.debug({ newCrateVersion });
+
+    bumpedContent = content.replace(
+      regEx(`^(?<version>version[ \\t]*=[ \\t]*['"])[^'"]*`, 'm'),
+      `$<version>${newCrateVersion}`,
+    );
+
+    if (bumpedContent === content) {
+      logger.debug('Version was already bumped');
+    } else {
+      logger.debug('Bumped Cargo.toml version');
+    }
+  } catch (err) {
+    logger.warn(
+      {
+        content,
+        currentValue,
+        bumpVersion,
+      },
+      'Failed to bumpVersion',
+    );
+  }
+
+  return { bumpedContent };
+}
+


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Introduces `bumpVersion` support for the Cargo manager.

## Context

I made this feature request in #26776, but didn't get a response, so I made a PR directly.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
