### PR TITLE
fix(pnpm): better log warning for updateLockFile()

### DIFF
--- a/lib/modules/manager/npm/update/locked-dependency/index.spec.ts
+++ b/lib/modules/manager/npm/update/locked-dependency/index.spec.ts
@@ -245,5 +245,11 @@ describe('modules/manager/npm/update/locked-dependency/index', () => {
       const res = await updateLockedDependency(config);
       expect(res.status).toBe('update-failed');
     });
+
+    it('fails if pnpm', async () => {
+      config.lockFile = 'pnpm-lock.yaml';
+      const res = await updateLockedDependency(config);
+      expect(res.status).toBe('update-failed');
+    });
   });
 });

--- a/lib/modules/manager/npm/update/locked-dependency/index.ts
+++ b/lib/modules/manager/npm/update/locked-dependency/index.ts
@@ -19,6 +19,14 @@ export async function updateLockedDependency(
   if (lockFile.endsWith('yarn.lock')) {
     return yarnLock.updateLockedDependency(config);
   }
-  logger.debug(`Unsupported lock file: ${lockFile}`);
+  if (lockFile.endsWith('pnpm-lock.yaml')) {
+    logger.debug(
+      'updateLockedDependency(): pnpm is not supported yet. See https://github.com/renovatebot/renovate/issues/21438',
+    );
+  } else {
+    logger.debug(
+      `updateLockedDependency(): unsupported lock file: ${lockFile}`,
+    );
+  }
   return { status: 'update-failed' };
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Better log message when pnpm updateLockedDependency() does not work

## Context

https://github.com/renovatebot/renovate/issues/21438

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
