### PR TITLE
fix(npm): don't set default versioning

### DIFF
--- a/lib/modules/manager/bun/index.ts
+++ b/lib/modules/manager/bun/index.ts
@@ -1,7 +1,6 @@
 import type { Category } from '../../../constants';
 import { GithubTagsDatasource } from '../../datasource/github-tags';
 import { NpmDatasource } from '../../datasource/npm';
-import * as npmVersioning from '../../versioning/npm';
 
 export { updateArtifacts } from './artifacts';
 export { extractAllPackageFiles } from './extract';
@@ -12,7 +11,6 @@ export const supportsLockFileMaintenance = true;
 
 export const defaultConfig = {
   fileMatch: ['(^|/)bun\\.lockb$'],
-  versioning: npmVersioning.id,
   digest: {
     prBodyDefinitions: {
       Change:

--- a/lib/modules/manager/npm/extract/__snapshots__/index.spec.ts.snap
+++ b/lib/modules/manager/npm/extract/__snapshots__/index.spec.ts.snap
@@ -119,6 +119,7 @@ exports[`modules/manager/npm/extract/index .extractPackageFile() extracts engine
       "depType": "engines",
       "packageName": "microsoft/vscode",
       "prettyDepType": "engine",
+      "versioning": "npm",
     },
   ],
   "extractedConstraints": {
@@ -170,6 +171,7 @@ exports[`modules/manager/npm/extract/index .extractPackageFile() extracts non-np
       "pinDigests": false,
       "prettyDepType": "dependency",
       "sourceUrl": "https://github.com/owner/c",
+      "versioning": "npm",
     },
     {
       "currentValue": "github:owner/d#a7g3eaf",
@@ -189,6 +191,7 @@ exports[`modules/manager/npm/extract/index .extractPackageFile() extracts non-np
       "packageName": "owner/e",
       "prettyDepType": "dependency",
       "sourceUrl": "https://github.com/owner/e",
+      "versioning": "npm",
     },
     {
       "currentRawValue": "owner/f#v2.0.0",
@@ -201,6 +204,7 @@ exports[`modules/manager/npm/extract/index .extractPackageFile() extracts non-np
       "pinDigests": false,
       "prettyDepType": "dependency",
       "sourceUrl": "https://github.com/owner/f",
+      "versioning": "npm",
     },
     {
       "currentValue": "gitlab:owner/g#v1.0.0",
@@ -241,6 +245,7 @@ exports[`modules/manager/npm/extract/index .extractPackageFile() extracts non-np
       "packageName": "owner/k",
       "prettyDepType": "dependency",
       "sourceUrl": "https://github.com/owner/k",
+      "versioning": "npm",
     },
     {
       "currentDigest": "abcdef0",
@@ -253,6 +258,7 @@ exports[`modules/manager/npm/extract/index .extractPackageFile() extracts non-np
       "packageName": "owner/l",
       "prettyDepType": "dependency",
       "sourceUrl": "https://github.com/owner/l",
+      "versioning": "npm",
     },
     {
       "currentRawValue": "https://github.com/owner/m.git#v1.0.0",
@@ -265,6 +271,7 @@ exports[`modules/manager/npm/extract/index .extractPackageFile() extracts non-np
       "pinDigests": false,
       "prettyDepType": "dependency",
       "sourceUrl": "https://github.com/owner/m",
+      "versioning": "npm",
     },
     {
       "currentRawValue": "git+https://github.com/owner/n#v2.0.0",
@@ -277,6 +284,7 @@ exports[`modules/manager/npm/extract/index .extractPackageFile() extracts non-np
       "pinDigests": false,
       "prettyDepType": "dependency",
       "sourceUrl": "https://github.com/owner/n",
+      "versioning": "npm",
     },
     {
       "currentRawValue": "git@github.com:owner/o.git#v2.0.0",
@@ -289,6 +297,7 @@ exports[`modules/manager/npm/extract/index .extractPackageFile() extracts non-np
       "pinDigests": false,
       "prettyDepType": "dependency",
       "sourceUrl": "https://github.com/owner/o",
+      "versioning": "npm",
     },
     {
       "currentRawValue": "Owner/P.git#v2.0.0",
@@ -301,6 +310,7 @@ exports[`modules/manager/npm/extract/index .extractPackageFile() extracts non-np
       "pinDigests": false,
       "prettyDepType": "dependency",
       "sourceUrl": "https://github.com/Owner/P",
+      "versioning": "npm",
     },
   ],
   "extractedConstraints": {},

--- a/lib/modules/manager/npm/extract/common/dependency.ts
+++ b/lib/modules/manager/npm/extract/common/dependency.ts
@@ -5,7 +5,12 @@ import { regEx } from '../../../../../util/regex';
 import { GithubTagsDatasource } from '../../../../datasource/github-tags';
 import { NodeVersionDatasource } from '../../../../datasource/node-version';
 import { NpmDatasource } from '../../../../datasource/npm';
-import { api, isValid, isVersion } from '../../../../versioning/npm';
+import {
+  api,
+  isValid,
+  isVersion,
+  id as npmVersioningId,
+} from '../../../../versioning/npm';
 import type { PackageDependency } from '../../../types';
 
 const RE_REPOSITORY_GITHUB_SSH_FORMAT = regEx(
@@ -56,6 +61,7 @@ export function extractDependency(
     } else if (depName === 'vscode') {
       dep.datasource = GithubTagsDatasource.id;
       dep.packageName = 'microsoft/vscode';
+      dep.versioning = npmVersioningId;
     } else {
       dep.skipReason = 'unknown-engines';
     }
@@ -161,6 +167,7 @@ export function extractDependency(
     dep.currentRawValue = dep.currentValue;
     dep.currentValue = depRefPart;
     dep.datasource = GithubTagsDatasource.id;
+    dep.versioning = npmVersioningId;
     dep.packageName = githubOwnerRepo;
     dep.pinDigests = false;
   } else if (
@@ -171,6 +178,7 @@ export function extractDependency(
     dep.currentValue = null;
     dep.currentDigest = depRefPart;
     dep.datasource = GithubTagsDatasource.id;
+    dep.versioning = npmVersioningId;
     dep.packageName = githubOwnerRepo;
   } else {
     dep.skipReason = 'unversioned-reference';

--- a/lib/modules/manager/npm/index.ts
+++ b/lib/modules/manager/npm/index.ts
@@ -2,7 +2,6 @@ import type { Category } from '../../../constants';
 import { GithubTagsDatasource } from '../../datasource/github-tags';
 import { NodeVersionDatasource } from '../../datasource/node-version';
 import { NpmDatasource } from '../../datasource/npm';
-import * as npmVersioning from '../../versioning/npm';
 
 export { detectGlobalConfig } from './detect';
 export { extractAllPackageFiles } from './extract';
@@ -17,7 +16,6 @@ export const supportsLockFileMaintenance = true;
 
 export const defaultConfig = {
   fileMatch: ['(^|/)package\\.json$'],
-  versioning: npmVersioning.id,
   digest: {
     prBodyDefinitions: {
       Change:


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
The `npm` manager shouldn't set a default versioniong, it should be the datasource which decides the versioning.
I've added explicit npm versioning to git sources to not cause a behavior change there.
<!-- Describe what behavior is changed by this PR. -->

## Context
- #26918
- #26926
- renovate-reproductions/26926-node-versioning#6
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
