### PR TITLE
fix(update/pr): improve de-duplication of table rows

### DIFF
--- a/lib/workers/repository/update/pr/body/updates-table.spec.ts
+++ b/lib/workers/repository/update/pr/body/updates-table.spec.ts
@@ -171,6 +171,8 @@ describe('workers/repository/update/pr/body/updates-table', () => {
       depName: 'mocha',
       currentValue: '^6.2.3',
       newValue: '6.2.3',
+      currentVersion: '6.2.3',
+      newVersion: '6.2.3',
       displayFrom: '^6.2.3',
       displayTo: '6.2.3',
     });
@@ -215,6 +217,8 @@ describe('workers/repository/update/pr/body/updates-table', () => {
       depName: 'mocha',
       currentValue: '^6.2.3',
       newValue: '6.2.3',
+      currentVersion: '6.2.3',
+      newVersion: '6.2.3',
       displayFrom: '^6.2.3',
       displayTo: '6.2.3',
       displayPending: 'some-string',

--- a/lib/workers/repository/update/pr/body/updates-table.ts
+++ b/lib/workers/repository/update/pr/body/updates-table.ts
@@ -49,11 +49,7 @@ export function getPrUpdatesTable(config: BranchConfig): string {
   for (const upgrade of config.upgrades) {
     if (upgrade) {
       // Create a key based on the properties which are significant in the updates table
-      const key = `${upgrade.depName ?? ''}_${upgrade.depType ?? ''}_${
-        upgrade.newValue ?? upgrade.newVersion ?? ''
-      }_${upgrade.currentValue ?? upgrade.currentVersion ?? ''}_${
-        upgrade.updateType
-      }`;
+      const key = `${upgrade.depName ?? ''}_${upgrade.depType ?? ''}_${upgrade.newValue ?? ''}_${upgrade.newVersion ?? ''}_${upgrade.currentValue ?? ''}_${upgrade.currentVersion ?? ''}_${upgrade.updateType}`;
 
       const res: Record<string, string> = {};
       const rowDefinition = getRowDefinition(config.prBodyColumns, upgrade);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Use `current/newVersion` and `current/newValue` separately in the row key rather than use them in-place of each other
<!-- Describe what behavior is changed by this PR. -->

## Context
Fixes: https://github.com/renovatebot/renovate/discussions/26964
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
