### PR TITLE
refactor(regex): Inverse dependency on logger util

### DIFF
--- a/lib/util/regex.ts
+++ b/lib/util/regex.ts
@@ -14,6 +14,7 @@ type RegExpEngineStatus =
 
 let status: RegExpEngineStatus;
 let RegEx: RegExpConstructor = RegExp;
+// istanbul ignore next
 if (process.env.RENOVATE_X_IGNORE_RE2) {
   status = { type: 'ignored' };
 } else {

--- a/lib/util/regex.ts
+++ b/lib/util/regex.ts
@@ -2,24 +2,33 @@ import is from '@sindresorhus/is';
 import { CONFIG_VALIDATION } from '../constants/error-messages';
 import { re2 } from '../expose.cjs';
 
-import { logger } from '../logger';
-
-let RegEx: RegExpConstructor;
-
 const cache = new Map<string, RegExp>();
 
-if (!process.env.RENOVATE_X_IGNORE_RE2) {
+type RegExpEngineStatus =
+  | { type: 'available' }
+  | {
+      type: 'unavailable';
+      err: Error;
+    }
+  | { type: 'ignored' };
+
+let status: RegExpEngineStatus;
+let RegEx: RegExpConstructor = RegExp;
+if (process.env.RENOVATE_X_IGNORE_RE2) {
+  status = { type: 'ignored' };
+} else {
   try {
     const RE2 = re2();
     // Test if native is working
     new RE2('.*').exec('test');
-    logger.debug('Using RE2 as regex engine');
     RegEx = RE2;
+    status = { type: 'available' };
   } catch (err) {
-    logger.warn({ err }, 'RE2 not usable, falling back to RegExp');
+    status = { type: 'unavailable', err };
   }
 }
-RegEx ??= RegExp;
+
+export const regexEngineStatus = status;
 
 export function regEx(
   pattern: string | RegExp,
@@ -49,7 +58,6 @@ export function regEx(
     }
     return instance;
   } catch (err) {
-    logger.trace({ err }, 'RegEx constructor error');
     const error = new Error(CONFIG_VALIDATION);
     error.validationMessage = err.message;
     error.validationSource = pattern.toString();


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Regex utility uses logger to print the diagnostic message during init
- With introduction of #26951, logger will depend on regex

This PR makes the regex diagnostic messages to be logged externally.

It sacrifices the `trace` log messages when constructor has failed, but since it re-throws with `CONFIG_VALIDATION`, hopefully it remains salient enough. Maybe, in future steps we also need to refactor out the `CONFIG_VALIDATION` error, it's not always could be a config problem.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
