### PR TITLE
fix(pypi): trim simple repo markup with extra whitespaces and new lines

### DIFF
--- a/lib/modules/datasource/pypi/__fixtures__/versions-html-with-whitespaces.html
+++ b/lib/modules/datasource/pypi/__fixtures__/versions-html-with-whitespaces.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html><head>
+<meta http-equiv="content-type" content="text/html; charset=UTF-8">
+    <title>   Links for package with extra whitespaces   </title>
+  </head>
+  <body>
+    <h1>   Links for package with extra whitespaces   </h1>
+    <a href="">
+      package_with_whitespaces-2.0.0.tar.gz
+      </a><br>
+    <a href="">      package_with_whitespaces-2.0.1-py3-none-any.whl </a><br>
+    <a href="">   package_with_whitespaces-2.0.2-py3-none-any.whl</a><br>
+    <a href="">package_with_whitespaces-2.0.2.tar.gz   </a><br>
+</body></html>

--- a/lib/modules/datasource/pypi/index.spec.ts
+++ b/lib/modules/datasource/pypi/index.spec.ts
@@ -14,6 +14,9 @@ const dataRequiresPythonResponse = Fixtures.get(
 const mixedHyphensResponse = Fixtures.get('versions-html-mixed-hyphens.html');
 const mixedCaseResponse = Fixtures.get('versions-html-mixed-case.html');
 const withPeriodsResponse = Fixtures.get('versions-html-with-periods.html');
+const withWhitespacesResponse = Fixtures.get(
+  'versions-html-with-whitespaces.html',
+);
 const hyphensResponse = Fixtures.get('versions-html-hyphens.html');
 
 const baseUrl = 'https://pypi.org/pypi';
@@ -422,6 +425,26 @@ describe('modules/datasource/pypi/index', () => {
         datasource,
         ...config,
         packageName: 'package.with.periods',
+      });
+      expect(res?.releases).toMatchObject([
+        { version: '2.0.0' },
+        { version: '2.0.1' },
+        { version: '2.0.2' },
+      ]);
+    });
+
+    it('process data from simple endpoint with extra whitespaces in html', async () => {
+      httpMock
+        .scope('https://some.registry.org/simple/')
+        .get('/package-with-whitespaces/')
+        .reply(200, withWhitespacesResponse);
+      const config = {
+        registryUrls: ['https://some.registry.org/simple/'],
+      };
+      const res = await getPkgReleases({
+        datasource,
+        ...config,
+        packageName: 'package-with-whitespaces',
       });
       expect(res?.releases).toMatchObject([
         { version: '2.0.0' },

--- a/lib/modules/datasource/pypi/index.ts
+++ b/lib/modules/datasource/pypi/index.ts
@@ -246,7 +246,7 @@ export class PypiDatasource extends Datasource {
     const releases: Releases = {};
     for (const link of Array.from(links)) {
       const version = PypiDatasource.extractVersionFromLinkText(
-        link.text,
+        link.text.trim(),
         packageName,
       );
       if (version) {

--- a/lib/modules/datasource/pypi/index.ts
+++ b/lib/modules/datasource/pypi/index.ts
@@ -246,7 +246,7 @@ export class PypiDatasource extends Datasource {
     const releases: Releases = {};
     for (const link of Array.from(links)) {
       const version = PypiDatasource.extractVersionFromLinkText(
-        link.text.trim(),
+        link.text?.trim(),
         packageName,
       );
       if (version) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Fixes issue with `pypi simple` repositories where markup contains extra spaces and new line characters in HTML `<a>` node's `text`:
```html
<a
             href="https://buf.build/gen/python/connectrpc-eliza-grpc-python/connectrpc_eliza_grpc_python-1.60.0.1.20230913231627&#43;233fca715f49-py3-none-any.whl"
             data-requires-python="&gt;=3.7"
             >
             connectrpc_eliza_grpc_python-1.60.0.1.20230913231627&#43;233fca715f49-py3-none-any.whl
           </a>
```

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

Related to discussion https://github.com/renovatebot/renovate/discussions/26967

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
