### PR TITLE
fix: redis cache deserialization does not work on strings

### DIFF
--- a/lib/util/cache/package/redis.ts
+++ b/lib/util/cache/package/redis.ts
@@ -71,7 +71,7 @@ export async function set(
       getKey(namespace, key),
       JSON.stringify({
         compress: true,
-        value: await compressToBase64(value),
+        value: await compressToBase64(JSON.stringify(value)),
         expiry: DateTime.local().plus({ minutes: ttlMinutes }),
       }),
       { EX: redisTTL },


### PR DESCRIPTION
Always stringify values when sending them to cache for Redis. Deserialization always goes through `JSON.parse` and it won't work for non-json content

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

As started here : https://github.com/renovatebot/renovate/discussions/27019 and following changes in https://github.com/renovatebot/renovate/pull/26711 there seems to be an issue with Redis caching.

But I found that the changes introduced in `redis.ts` have a bug : https://github.com/renovatebot/renovate/pull/26711/files#diff-610d51991db61d09b161be1f555e73365ed418997f1b291538102ccfe5493da3

Before: 
* `redis.ts` serialization: passes the value through `JSON.stringify()` before calling `compress`
* `redis.ts` deserialization: always run `JSON.parse()` after `decompress`

After:
* `redis.ts` serialization: `JSON.stringify` is delegated to `compressToBase64` which does it __only if it is not a string__
* `redis.ts` deserialization: always run `JSON.parse()` after `decompress`

The problem:
* `JSON.stringify("String")` -> `'"String"'`
* `JSON.parse('"String"')` -> `"String"`
* `JSON.parse("String")` -> `JSON.parse: unexpected character at line 1 column 1 of the JSON data`

This means that when a string is cached it always fails deserialization

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

Discussion: https://github.com/renovatebot/renovate/discussions/27019

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
