### PR TITLE
refactor: Tidy arguments for `matchRegexOrMinimatch`

### DIFF
--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -706,7 +706,7 @@ export async function validateConfig(
     }
 
     if (key === 'hostRules' && is.array(val)) {
-      const allowedHeaders = GlobalConfig.get('allowedHeaders');
+      const allowedHeaders = GlobalConfig.get('allowedHeaders', []);
       for (const rule of val as HostRule[]) {
         if (!rule.headers) {
           continue;
@@ -718,7 +718,7 @@ export async function validateConfig(
               message: `Invalid hostRules headers value configuration: header must be a string.`,
             });
           }
-          if (!anyMatchRegexOrMinimatch(allowedHeaders, header)) {
+          if (!anyMatchRegexOrMinimatch(header, allowedHeaders)) {
             errors.push({
               topic: 'Configuration Error',
               message: `hostRules header \`${header}\` is not allowed by this bot's \`allowedHeaders\`.`,

--- a/lib/util/http/host-rules.ts
+++ b/lib/util/http/host-rules.ts
@@ -165,11 +165,11 @@ export function applyHostRule<GotOptions extends HostRulesGotOptions>(
   }
 
   if (hostRule.headers) {
-    const allowedHeaders = GlobalConfig.get('allowedHeaders');
+    const allowedHeaders = GlobalConfig.get('allowedHeaders', []);
     const filteredHeaders: Record<string, string> = {};
 
     for (const [header, value] of Object.entries(hostRule.headers)) {
-      if (anyMatchRegexOrMinimatch(allowedHeaders, header)) {
+      if (anyMatchRegexOrMinimatch(header, allowedHeaders)) {
         filteredHeaders[header] = value;
       } else {
         logger.once.error(

--- a/lib/util/package-rules/match.ts
+++ b/lib/util/package-rules/match.ts
@@ -1,9 +1,8 @@
-import is from '@sindresorhus/is';
 import { logger } from '../../logger';
 import { minimatch } from '../minimatch';
 import { regEx } from '../regex';
 
-export function matchRegexOrMinimatch(pattern: string, input: string): boolean {
+export function matchRegexOrMinimatch(input: string, pattern: string): boolean {
   if (pattern.length > 2 && pattern.startsWith('/') && pattern.endsWith('/')) {
     try {
       const regex = regEx(pattern.slice(1, -1));
@@ -18,14 +17,8 @@ export function matchRegexOrMinimatch(pattern: string, input: string): boolean {
 }
 
 export function anyMatchRegexOrMinimatch(
-  patterns: string[] | undefined,
-  input: string | undefined,
+  input: string,
+  patterns: string[],
 ): boolean | null {
-  if (is.undefined(patterns)) {
-    return null;
-  }
-  if (is.undefined(input)) {
-    return false;
-  }
-  return patterns.some((pattern) => matchRegexOrMinimatch(pattern, input));
+  return patterns.some((pattern) => matchRegexOrMinimatch(input, pattern));
 }

--- a/lib/util/package-rules/repositories.ts
+++ b/lib/util/package-rules/repositories.ts
@@ -1,3 +1,4 @@
+import is from '@sindresorhus/is';
 import type { PackageRule, PackageRuleInputConfig } from '../../config/types';
 import { Matcher } from './base';
 import { anyMatchRegexOrMinimatch } from './match';
@@ -7,13 +8,29 @@ export class RepositoriesMatcher extends Matcher {
     { repository }: PackageRuleInputConfig,
     { matchRepositories }: PackageRule,
   ): boolean | null {
-    return anyMatchRegexOrMinimatch(matchRepositories, repository);
+    if (is.undefined(repository)) {
+      return false;
+    }
+
+    if (is.undefined(matchRepositories)) {
+      return null;
+    }
+
+    return anyMatchRegexOrMinimatch(repository, matchRepositories);
   }
 
   override excludes(
     { repository }: PackageRuleInputConfig,
     { excludeRepositories }: PackageRule,
   ): boolean | null {
-    return anyMatchRegexOrMinimatch(excludeRepositories, repository);
+    if (is.undefined(repository)) {
+      return false;
+    }
+
+    if (is.undefined(excludeRepositories)) {
+      return null;
+    }
+
+    return anyMatchRegexOrMinimatch(repository, excludeRepositories);
   }
 }

--- a/lib/util/package-rules/repositories.ts
+++ b/lib/util/package-rules/repositories.ts
@@ -8,12 +8,12 @@ export class RepositoriesMatcher extends Matcher {
     { repository }: PackageRuleInputConfig,
     { matchRepositories }: PackageRule,
   ): boolean | null {
-    if (is.undefined(repository)) {
-      return false;
-    }
-
     if (is.undefined(matchRepositories)) {
       return null;
+    }
+
+    if (is.undefined(repository)) {
+      return false;
     }
 
     return anyMatchRegexOrMinimatch(repository, matchRepositories);
@@ -23,12 +23,12 @@ export class RepositoriesMatcher extends Matcher {
     { repository }: PackageRuleInputConfig,
     { excludeRepositories }: PackageRule,
   ): boolean | null {
-    if (is.undefined(repository)) {
-      return false;
-    }
-
     if (is.undefined(excludeRepositories)) {
       return null;
+    }
+
+    if (is.undefined(repository)) {
+      return false;
     }
 
     return anyMatchRegexOrMinimatch(repository, excludeRepositories);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Change `input` and `pattern` argument order
- Restrict them to be strings only

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
