### PR TITLE
feat(datasource/custom): add `currentValue` to template metadata 

### DIFF
--- a/lib/modules/datasource/custom/readme.md
+++ b/lib/modules/datasource/custom/readme.md
@@ -16,6 +16,7 @@ Options:
 Available template variables:
 
 - `packageName`
+- `currentValue`
 
 ```json
 {

--- a/lib/modules/datasource/custom/utils.ts
+++ b/lib/modules/datasource/custom/utils.ts
@@ -9,6 +9,7 @@ export function massageCustomDatasourceConfig(
   {
     customDatasources,
     packageName,
+    currentValue,
     registryUrl: defaultRegistryUrl,
   }: GetReleasesConfig,
 ): Required<CustomDatasourceConfig> | null {
@@ -19,7 +20,7 @@ export function massageCustomDatasourceConfig(
     );
     return null;
   }
-  const templateInput = { packageName };
+  const templateInput = { packageName, currentValue };
 
   const registryUrlTemplate =
     defaultRegistryUrl ?? customDatasource.defaultRegistryUrlTemplate;

--- a/lib/modules/datasource/types.ts
+++ b/lib/modules/datasource/types.ts
@@ -27,6 +27,7 @@ export interface GetReleasesConfig {
   datasource?: string;
   packageName: string;
   registryUrl?: string;
+  currentValue?: string;
 }
 
 export interface GetPkgReleasesConfig {
@@ -37,6 +38,7 @@ export interface GetPkgReleasesConfig {
   additionalRegistryUrls?: string[];
   datasource: string;
   packageName: string;
+  currentValue?: string;
   versioning?: string;
   extractVersion?: string;
   versionCompatibility?: string;


### PR DESCRIPTION
## Changes

- add `currentValue` property to `GetReleasesConfig` and `GetPkgReleasesConfig`
- this makes it accessible within `massageCustomDatasourceConfig` function and allows us to make it templatable

## Context

In our scenario, we are using a custom data source which talks to a proxy web server to derive Azure AKS versions. With AKS versions, you are only able to upgrade from certain versions to certain versions. The Azure CLI will give you a list of versions you can upgrade to for every AKS version.

Being able to template the current version into the registry URL allows us to only return releases for renovate which we are allowed to upgrade to. This way the repo's maintainer does need to know or care about these update restrictions. Also I could imagine users might have other use cases for this as well.

## Documentation (please check one with an [x]) 

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
