### PR TITLE
refactor: Move `isUUID()` to string utils

### DIFF
--- a/lib/modules/platform/bitbucket/index.ts
+++ b/lib/modules/platform/bitbucket/index.ts
@@ -8,8 +8,9 @@ import * as git from '../../../util/git';
 import * as hostRules from '../../../util/host-rules';
 import { BitbucketHttp, setBaseUrl } from '../../../util/http/bitbucket';
 import type { HttpOptions } from '../../../util/http/types';
-import { isUUID, regEx } from '../../../util/regex';
+import { regEx } from '../../../util/regex';
 import { sanitize } from '../../../util/sanitize';
+import { isUUID } from '../../../util/string';
 import type {
   BranchStatusConfig,
   CreatePRConfig,

--- a/lib/util/regex.spec.ts
+++ b/lib/util/regex.spec.ts
@@ -1,6 +1,6 @@
 import RE2 from 're2';
 import { CONFIG_VALIDATION } from '../constants/error-messages';
-import { configRegexPredicate, isUUID, regEx } from './regex';
+import { configRegexPredicate, regEx } from './regex';
 
 describe('util/regex', () => {
   beforeEach(() => {
@@ -36,14 +36,6 @@ describe('util/regex', () => {
 
     const regex = await import('./regex');
     expect(regex.regEx('foo')).toBeInstanceOf(RegExp);
-  });
-
-  describe('isUUID', () => {
-    it('proper checks valid and invalid UUID strings', () => {
-      expect(isUUID('{90b6646d-1724-4a64-9fd9-539515fe94e9}')).toBe(true);
-      expect(isUUID('{90B6646D-1724-4A64-9FD9-539515FE94E9}')).toBe(true);
-      expect(isUUID('not-a-uuid')).toBe(false);
-    });
   });
 
   describe('configRegexPredicate', () => {

--- a/lib/util/regex.ts
+++ b/lib/util/regex.ts
@@ -111,11 +111,3 @@ export function configRegexPredicate(
   }
   return null;
 }
-
-const UUIDRegex = regEx(
-  /^\{[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\}$/i,
-);
-
-export function isUUID(input: string): boolean {
-  return UUIDRegex.test(input);
-}

--- a/lib/util/string.spec.ts
+++ b/lib/util/string.spec.ts
@@ -1,4 +1,4 @@
-import { coerceString, looseEquals, replaceAt } from './string';
+import { coerceString, isUUID, looseEquals, replaceAt } from './string';
 
 describe('util/string', () => {
   describe('replaceAt', () => {
@@ -39,5 +39,13 @@ describe('util/string', () => {
     expect(coerceString(undefined)).toBe('');
     expect(coerceString(null)).toBe('');
     expect(coerceString(null, 'foo')).toBe('foo');
+  });
+
+  describe('isUUID', () => {
+    it('proper checks valid and invalid UUID strings', () => {
+      expect(isUUID('{90b6646d-1724-4a64-9fd9-539515fe94e9}')).toBe(true);
+      expect(isUUID('{90B6646D-1724-4A64-9FD9-539515FE94E9}')).toBe(true);
+      expect(isUUID('not-a-uuid')).toBe(false);
+    });
   });
 });

--- a/lib/util/string.ts
+++ b/lib/util/string.ts
@@ -117,3 +117,11 @@ export function anyMatchRegexOrMinimatch(
 ): boolean | null {
   return patterns.some((pattern) => matchRegexOrMinimatch(input, pattern));
 }
+
+const UUIDRegex = regEx(
+  /^\{[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\}$/i,
+);
+
+export function isUUID(input: string): boolean {
+  return UUIDRegex.test(input);
+}


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- `isUUID()` is the string-related utility, while regex is an implementation detail

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
