### PR TITLE
feat(cache): cache http response for files in same org

### DIFF
--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -319,9 +319,10 @@ export async function getRawFile(
   branchOrTag?: string,
 ): Promise<string | null> {
   const repo = repoName ?? config.repository;
+  const isSameOrg = repo?.split('/')[0] === config.repositoryOwner;
   const httpOptions: InternalHttpOptions = {
-    // Only cache response if it's from the same repo
-    repoCache: repo === config.repository,
+    // Only cache response if it's from the same org
+    repoCache: isSameOrg,
   };
   let url = `repos/${repo}/contents/${fileName}`;
   if (branchOrTag) {

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -319,7 +319,7 @@ export async function getRawFile(
   branchOrTag?: string,
 ): Promise<string | null> {
   const repo = repoName ?? config.repository;
-  const isSameOrg = repo?.split('/')[0] === config.repositoryOwner;
+  const isSameOrg = repo?.split('/')?.[0] === config.repositoryOwner;
   const httpOptions: InternalHttpOptions = {
     // Only cache response if it's from the same org
     repoCache: isSameOrg,


### PR DESCRIPTION



<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Cache http responses for file fetches in same org. Goal: cache shared org presets which don’t change often.

## Context

Closes #27033


<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
