### PR TITLE
fix(packageRules/package-patterns): consider depName for exclude

### DIFF
--- a/lib/util/package-rules/package-patterns.spec.ts
+++ b/lib/util/package-rules/package-patterns.spec.ts
@@ -42,4 +42,19 @@ describe('util/package-rules/package-patterns', () => {
       expect(result).toBeTrue();
     });
   });
+
+  describe('exclude', () => {
+    it('should exclude packageName', () => {
+      const result = packageNameMatcher.excludes(
+        {
+          depName: 'abc',
+          packageName: 'def',
+        },
+        {
+          excludePackagePatterns: ['def'],
+        },
+      );
+      expect(result).toBeTrue();
+    });
+  });
 });

--- a/lib/util/package-rules/package-patterns.ts
+++ b/lib/util/package-rules/package-patterns.ts
@@ -50,9 +50,10 @@ export class PackagePatternsMatcher extends Matcher {
   }
 
   override excludes(
-    { depName }: PackageRuleInputConfig,
-    { excludePackagePatterns }: PackageRule,
+    { depName, packageName }: PackageRuleInputConfig,
+    packageRule: PackageRule,
   ): boolean | null {
+    const { excludePackagePatterns } = packageRule;
     // ignore lockFileMaintenance for backwards compatibility
     if (is.undefined(excludePackagePatterns)) {
       return null;
@@ -61,15 +62,22 @@ export class PackagePatternsMatcher extends Matcher {
       return false;
     }
 
-    let isMatch = false;
-    for (const pattern of excludePackagePatterns) {
-      const packageRegex = regEx(massagePattern(pattern));
-      if (packageRegex.test(depName)) {
-        logger.trace(`${depName} matches against ${String(packageRegex)}`);
-        isMatch = true;
-      }
+    if (
+      is.string(packageName) &&
+      matchPatternsAgainstName(excludePackagePatterns, packageName)
+    ) {
+      return true;
     }
-    return isMatch;
+
+    if (matchPatternsAgainstName(excludePackagePatterns, depName)) {
+      logger.once.info(
+        { packageRule, packageName, depName },
+        'Use excludeDepPatterns instead of excludePackagePatterns',
+      );
+      return true;
+    }
+
+    return false;
   }
 }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Consider `depName` for exclude package patterns rules.
<!-- Describe what behavior is changed by this PR. -->

## Context
https://github.com/renovatebot/renovate/discussions/27024

matchPackagePatterns implementation https://github.com/renovatebot/renovate/pull/22703
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
