### PR TITLE
fix(packageRules/package*): consider packageNames for package* excludes

### DIFF
--- a/lib/util/package-rules/package-names.spec.ts
+++ b/lib/util/package-rules/package-names.spec.ts
@@ -56,4 +56,17 @@ describe('util/package-rules/package-names', () => {
       expect(result).toBeFalse();
     });
   });
+
+  it('should excludePackageName', () => {
+    const result = packageNameMatcher.excludes(
+      {
+        depName: 'abc',
+        packageName: 'def',
+      },
+      {
+        excludePackageNames: ['def'],
+      },
+    );
+    expect(result).toBeTrue();
+  });
 });

--- a/lib/util/package-rules/package-names.ts
+++ b/lib/util/package-rules/package-names.ts
@@ -32,15 +32,29 @@ export class PackageNameMatcher extends Matcher {
   }
 
   override excludes(
-    { depName }: PackageRuleInputConfig,
-    { excludePackageNames }: PackageRule,
+    { depName, packageName }: PackageRuleInputConfig,
+    packageRule: PackageRule,
   ): boolean | null {
+    const { excludePackageNames } = packageRule;
     if (is.undefined(excludePackageNames)) {
       return null;
     }
     if (is.undefined(depName)) {
       return false;
     }
-    return excludePackageNames.includes(depName);
+
+    if (is.string(packageName) && excludePackageNames.includes(packageName)) {
+      return true;
+    }
+
+    if (excludePackageNames.includes(depName)) {
+      logger.once.info(
+        { packageRule, packageName, depName },
+        'Use excludeDepNames instead of excludePackageNames',
+      );
+      return true;
+    }
+
+    return false;
   }
 }

--- a/lib/util/package-rules/package-prefixes.spec.ts
+++ b/lib/util/package-rules/package-prefixes.spec.ts
@@ -55,5 +55,18 @@ describe('util/package-rules/package-prefixes', () => {
       );
       expect(result).toBeFalse();
     });
+
+    it('should return true if packageName matched', () => {
+      const result = packagePrefixesMatcher.excludes(
+        {
+          depName: 'abc1',
+          packageName: 'def1',
+        },
+        {
+          excludePackagePrefixes: ['def'],
+        },
+      );
+      expect(result).toBeTrue();
+    });
   });
 });

--- a/lib/util/package-rules/package-prefixes.ts
+++ b/lib/util/package-rules/package-prefixes.ts
@@ -34,9 +34,10 @@ export class PackagePrefixesMatcher extends Matcher {
   }
 
   override excludes(
-    { depName }: PackageRuleInputConfig,
-    { excludePackagePrefixes }: PackageRule,
+    { depName, packageName }: PackageRuleInputConfig,
+    packageRule: PackageRule,
   ): boolean | null {
+    const { excludePackagePrefixes } = packageRule;
     if (is.undefined(excludePackagePrefixes)) {
       return null;
     }
@@ -44,6 +45,20 @@ export class PackagePrefixesMatcher extends Matcher {
       return false;
     }
 
-    return excludePackagePrefixes.some((prefix) => depName.startsWith(prefix));
+    if (
+      is.string(packageName) &&
+      excludePackagePrefixes.some((prefix) => packageName.startsWith(prefix))
+    ) {
+      return true;
+    }
+    if (excludePackagePrefixes.some((prefix) => depName.startsWith(prefix))) {
+      logger.once.info(
+        { packageName, depName },
+        'Use excludeDepPatterns instead of excludePackagePrefixes',
+      );
+      return true;
+    }
+
+    return false;
   }
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Add packageName awareness for other package* matchers. 

<!-- Describe what behavior is changed by this PR. -->

## Context
This is a follow up to https://github.com/renovatebot/renovate/pull/27046
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
