### PR TITLE
fix(config-migration): fetch raw file from platform, not fs

### DIFF
--- a/lib/workers/repository/config-migration/branch/migrated-data.ts
+++ b/lib/workers/repository/config-migration/branch/migrated-data.ts
@@ -6,6 +6,7 @@ import upath from 'upath';
 import { migrateConfig } from '../../../../config/migration';
 import { prettier } from '../../../../expose.cjs';
 import { logger } from '../../../../logger';
+import { platform } from '../../../../modules/platform';
 import { scm } from '../../../../modules/platform/scm';
 import { readLocalFile } from '../../../../util/fs';
 import { EditorConfig } from '../../../../util/json-writer';
@@ -142,10 +143,10 @@ export class MigratedDataFactory {
       delete migratedConfig.errors;
       delete migratedConfig.warnings;
 
-      // indent defaults to 2 spaces
       // TODO #22198
-      const raw = await readLocalFile(configFileName!, 'utf8');
+      const raw = await platform.getRawFile(configFileName!);
       const indent = detectIndent(raw!);
+      // indent defaults to 2 spaces
       const indentSpace = indent.indent ?? '  ';
       const filename = configFileName!;
       let content: string;

--- a/lib/workers/repository/config-migration/branch/migrated-data.ts
+++ b/lib/workers/repository/config-migration/branch/migrated-data.ts
@@ -145,7 +145,7 @@ export class MigratedDataFactory {
 
       // TODO #22198
       const raw = await platform.getRawFile(configFileName!);
-      const indent = detectIndent(raw!);
+      const indent = detectIndent(raw ?? '');
       // indent defaults to 2 spaces
       const indentSpace = indent.indent ?? '  ';
       const filename = configFileName!;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Fetch raw config file from platform, not fs. fs may not be initialized.

## Context

This was a mistake during refactoring. Note: we mock detectIntent() so this was not caught/is not tested here, but this fix needs prioritization.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
