### PR TITLE
feat(manager/pep621): set currentVersion field for exact dependency versions

### DIFF
--- a/lib/modules/manager/pep621/extract.spec.ts
+++ b/lib/modules/manager/pep621/extract.spec.ts
@@ -62,6 +62,7 @@ describe('modules/manager/pep621/extract', () => {
           datasource: 'pypi',
           depType: 'project.dependencies',
           currentValue: '==20.0.0',
+          currentVersion: '20.0.0',
         },
         {
           packageName: 'pyproject-hooks',
@@ -276,6 +277,7 @@ describe('modules/manager/pep621/extract', () => {
       expect(result?.deps).toEqual([
         {
           currentValue: '==2.30.0',
+          currentVersion: '2.30.0',
           datasource: 'pypi',
           depName: 'requests',
           depType: 'project.dependencies',
@@ -290,6 +292,7 @@ describe('modules/manager/pep621/extract', () => {
         },
         {
           currentValue: '==6.5',
+          currentVersion: '6.5',
           datasource: 'pypi',
           depName: 'coverage',
           depType: 'tool.hatch.envs.default',
@@ -347,6 +350,7 @@ describe('modules/manager/pep621/extract', () => {
       expect(result?.deps).toEqual([
         {
           currentValue: '==2.30.0',
+          currentVersion: '2.30.0',
           datasource: 'pypi',
           depName: 'requests',
           depType: 'project.dependencies',
@@ -354,6 +358,7 @@ describe('modules/manager/pep621/extract', () => {
         },
         {
           currentValue: '==1.18.0',
+          currentVersion: '1.18.0',
           datasource: 'pypi',
           depName: 'hatchling',
           depType: 'build-system.requires',
@@ -361,6 +366,7 @@ describe('modules/manager/pep621/extract', () => {
         },
         {
           currentValue: '==69.0.3',
+          currentVersion: '69.0.3',
           datasource: 'pypi',
           depName: 'setuptools',
           depType: 'build-system.requires',

--- a/lib/modules/manager/pep621/utils.ts
+++ b/lib/modules/manager/pep621/utils.ts
@@ -70,6 +70,10 @@ export function pep508ToPackageDependency(
     dep.skipReason = 'unspecified-version';
   } else {
     dep.currentValue = parsed.currentValue;
+
+    if (parsed.currentValue.startsWith('==')) {
+      dep.currentVersion = parsed.currentValue.replace(regEx(/^==\s*/), '');
+    }
   }
   return dep;
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds `currentVersion` values to extracted dependencies that are specified with an exact version requirement. This change enables vulnerability fix PRs for dependencies located in a `pyproject.toml` file that is compliant with PEP-621.

<!-- Describe what behavior is changed by this PR. -->

## Context

After #26769, I noticed that vulnerability fix PRs are also not working for PEP-621 managed projects.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

Test repo: https://github.com/renovate-demo/renovate-osv-pypi/pull/4

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
