### PR TITLE
docs(github): change GitHub App token Action suggested to GitHub official

### DIFF
--- a/lib/modules/platform/github/readme.md
+++ b/lib/modules/platform/github/readme.md
@@ -65,7 +65,7 @@ Any tokens that do not start with `ghs_` (for example tokens from GitHub Enterpr
 
 <!-- prettier-ignore -->
 !!! tip "Third-party tools to regenerate installation tokens"
-    If you're self-hosting Renovate within a GitHub Actions workflow, then you can use the [`jnwng/github-app-installation-token-action`](https://github.com/jnwng/github-app-installation-token-action) or [`tibdex/github-app-token`](https://github.com/tibdex/github-app-token) actions.
+    If you're self-hosting Renovate within a GitHub Actions workflow, then you can use the [`actions/create-github-app-token`](https://github.com/actions/create-github-app-token) action.
     If you use Node.js/CLI, then you can use the [`github-app-installation-token`](https://github.com/gagoar/github-app-installation-token) package.
     If you use Docker, then you can use the [`mshekow/github-app-installation-token`](https://github.com/MShekow/github-app-installation-token) image.
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Changing the suggested GitHub Actions to get a token with a GitHub App, to use the GitHub official Action for this purpose.

I have also opened https://github.com/renovatebot/github-action/pull/815

## Context

Handling these authentication flow is quite security sensitive, so GitHub's official action should be safer to use.

## Documentation (please check one with an [x])

- [X] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
