### PR TITLE
feat(manager/github-actions): support full qualified actions

### DIFF
--- a/lib/modules/manager/github-actions/extract.ts
+++ b/lib/modules/manager/github-actions/extract.ts
@@ -71,7 +71,7 @@ function extractWithRegex(content: string): PackageDependency[] {
         path = '',
         tag,
         replaceString,
-        registryUrl,
+        registryUrl = '',
       } = tagMatch.groups;
       let quotes = '';
       if (replaceString.indexOf("'") >= 0) {
@@ -87,7 +87,7 @@ function extractWithRegex(content: string): PackageDependency[] {
         versioning: dockerVersioning.id,
         depType: 'action',
         replaceString,
-        autoReplaceStringTemplate: `${quotes}${registryUrl ?? ''}{{depName}}${path}@{{#if newDigest}}{{newDigest}}${quotes}{{#if newValue}} # {{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}${quotes}{{/unless}}`,
+        autoReplaceStringTemplate: `${quotes}${registryUrl}{{depName}}${path}@{{#if newDigest}}{{newDigest}}${quotes}{{#if newValue}} # {{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}${quotes}{{/unless}}`,
         ...(registryUrl
           ? detectDatasource(registryUrl)
           : customRegistryUrlsPackageDependency),

--- a/lib/modules/manager/github-actions/extract.ts
+++ b/lib/modules/manager/github-actions/extract.ts
@@ -2,8 +2,10 @@ import is from '@sindresorhus/is';
 import { GlobalConfig } from '../../../config/global';
 import { logger } from '../../../logger';
 import { isNotNullOrUndefined } from '../../../util/array';
+import { detectPlatform } from '../../../util/common';
 import { newlineRegex, regEx } from '../../../util/regex';
 import { parseSingleYaml } from '../../../util/yaml';
+import { GiteaTagsDatasource } from '../../datasource/gitea-tags';
 import { GithubRunnersDatasource } from '../../datasource/github-runners';
 import { GithubTagsDatasource } from '../../datasource/github-tags';
 import * as dockerVersioning from '../../versioning/docker';
@@ -13,7 +15,7 @@ import type { Workflow } from './types';
 
 const dockerActionRe = regEx(/^\s+uses: ['"]?docker:\/\/([^'"]+)\s*$/);
 const actionRe = regEx(
-  /^\s+-?\s+?uses: (?<replaceString>['"]?(?<depName>[\w-]+\/[.\w-]+)(?<path>\/.*)?@(?<currentValue>[^\s'"]+)['"]?(?:\s+#\s*(?:renovate\s*:\s*)?(?:pin\s+|tag\s*=\s*)?@?(?<tag>v?\d+(?:\.\d+(?:\.\d+)?)?))?)/,
+  /^\s+-?\s+?uses: (?<replaceString>['"]?(?<registryUrl>https:\/\/[.\w-]+\/)?(?<depName>[\w-]+\/[.\w-]+)(?<path>\/.*)?@(?<currentValue>[^\s'"]+)['"]?(?:\s+#\s*(?:renovate\s*:\s*)?(?:pin\s+|tag\s*=\s*)?@?(?<tag>v?\d+(?:\.\d+(?:\.\d+)?)?))?)/,
 );
 
 // SHA1 or SHA256, see https://github.blog/2020-10-19-git-2-29-released/
@@ -69,6 +71,7 @@ function extractWithRegex(content: string): PackageDependency[] {
         path = '',
         tag,
         replaceString,
+        registryUrl,
       } = tagMatch.groups;
       let quotes = '';
       if (replaceString.indexOf("'") >= 0) {
@@ -84,8 +87,10 @@ function extractWithRegex(content: string): PackageDependency[] {
         versioning: dockerVersioning.id,
         depType: 'action',
         replaceString,
-        autoReplaceStringTemplate: `${quotes}{{depName}}${path}@{{#if newDigest}}{{newDigest}}${quotes}{{#if newValue}} # {{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}${quotes}{{/unless}}`,
-        ...customRegistryUrlsPackageDependency,
+        autoReplaceStringTemplate: `${quotes}${registryUrl ?? ''}{{depName}}${path}@{{#if newDigest}}{{newDigest}}${quotes}{{#if newValue}} # {{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}${quotes}{{/unless}}`,
+        ...(registryUrl
+          ? detectDatasource(registryUrl)
+          : customRegistryUrlsPackageDependency),
       };
       if (shaRe.test(currentValue)) {
         dep.currentValue = tag;
@@ -103,6 +108,24 @@ function extractWithRegex(content: string): PackageDependency[] {
     }
   }
   return deps;
+}
+
+function detectDatasource(registryUrl: string): PackageDependency {
+  const platform = detectPlatform(registryUrl);
+
+  switch (platform) {
+    case 'github':
+      return { registryUrls: [registryUrl] };
+    case 'gitea':
+      return {
+        registryUrls: [registryUrl],
+        datasource: GiteaTagsDatasource.id,
+      };
+  }
+
+  return {
+    skipReason: 'unsupported-url',
+  };
 }
 
 function extractContainer(container: unknown): PackageDependency | undefined {

--- a/lib/modules/manager/github-actions/index.ts
+++ b/lib/modules/manager/github-actions/index.ts
@@ -1,4 +1,5 @@
 import type { Category } from '../../../constants';
+import { GiteaTagsDatasource } from '../../datasource/gitea-tags';
 import { GithubRunnersDatasource } from '../../datasource/github-runners';
 import { GithubTagsDatasource } from '../../datasource/github-tags';
 export { extractPackageFile } from './extract';
@@ -13,6 +14,7 @@ export const defaultConfig = {
 export const categories: Category[] = ['ci'];
 
 export const supportedDatasources = [
+  GiteaTagsDatasource.id,
   GithubTagsDatasource.id,
   GithubRunnersDatasource.id,
 ];


### PR DESCRIPTION
They will be used by Forgejo and Gitea.

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Allow full qualified actions which are used on Forgejo and Gitea to reference actions from other systems without mirroring.

<!-- Describe what behavior is changed by this PR. -->

## Context
- https://codeberg.org/forgejo-contrib/forgejo-helm/src/branch/main/.forgejo/workflows/build.yml#L118

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
