### PR TITLE
ci(release): add mutex to serialize npm and docker releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,8 +34,23 @@ permissions:
   id-token: write
 
 jobs:
+  mutex:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write # pushes a branch
+
+    steps:
+      - name: Set up mutex
+        uses: ben-z/gh-action-mutex@v1.0-alpha-8
+        with:
+          branch: mutex-rel
+
   release-npm:
     runs-on: ubuntu-latest
+    needs:
+      - mutex
+
     steps:
       - name: Prepare env
         run: |

--- a/renovate.json
+++ b/renovate.json
@@ -39,6 +39,12 @@
       "matchDepNames": ["ghcr.io/renovatebot/base-image"],
       "matchUpdateTypes": ["major", "minor"],
       "semanticCommitType": "feat"
+    },
+    {
+      "description": "fix versioning for ben-z/gh-action-mutex, eg v1.0-alpha-8",
+      "matchDepNames": ["ben-z/gh-action-mutex"],
+      "matchManagers": ["github-actions"],
+      "versioning": "regex:^v(?<major>\\d+)\\.(?<minor>\\d+)(?:\\.(?<patch>\\d+))?(?<prerelease>\\-.+)?$"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Serialize npm and docker publish, so we have a fixed order.
Currently we can have overlappings when jobs are running in parallel.
Sadly not possible with native concurrency, we would loose pending releases.
<!-- Describe what behavior is changed by this PR. -->

## Context
- https://github.com/orgs/community/discussions/5435
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
