### PR TITLE
feat(manager/pip-compile): Create wrapper for pip extractPackageFile

### DIFF
--- a/lib/modules/manager/pip-compile/extract.spec.ts
+++ b/lib/modules/manager/pip-compile/extract.spec.ts
@@ -1,0 +1,30 @@
+import { Fixtures } from '../../../../test/fixtures';
+import { extractPackageFile } from './extract';
+
+jest.mock('../../../util/fs');
+
+describe('modules/manager/pip-compile/extract', () => {
+  describe('extractPackageFile()', () => {
+    it('returns object for requirements.in', () => {
+      const packageFile = extractPackageFile(
+        Fixtures.get('requirementsWithHashes.txt'),
+        'requirements.in',
+        {},
+      );
+      expect(packageFile).toHaveProperty('deps');
+      expect(packageFile?.deps[0]).toHaveProperty('depName', 'attrs');
+    });
+
+    it.each([
+      'random.py',
+      'app.cfg',
+      'already_locked.txt',
+      // TODO(not7cd)
+      'pyproject.toml',
+      'setup.py',
+      'setup.cfg',
+    ])('returns null on not supported package files', (file: string) => {
+      expect(extractPackageFile('some content', file, {})).toBeNull();
+    });
+  });
+});

--- a/lib/modules/manager/pip-compile/extract.spec.ts
+++ b/lib/modules/manager/pip-compile/extract.spec.ts
@@ -1,5 +1,5 @@
 import { Fixtures } from '../../../../test/fixtures';
-import { extractPackageFile } from './extract';
+import { extractPackageFile } from '.';
 
 jest.mock('../../../util/fs');
 

--- a/lib/modules/manager/pip-compile/extract.ts
+++ b/lib/modules/manager/pip-compile/extract.ts
@@ -1,0 +1,55 @@
+import { logger } from '../../../logger';
+import { extractPackageFile as extractRequirementsFile } from '../pip_requirements/extract';
+// TODO(not7cd): enable in the next PR, when this can be properly tested
+// import { extractPackageFile as extractSetupPyFile } from '../pip_setup';
+// import { extractPackageFile as extractSetupCfgFile } from '../setup-cfg';
+import type { ExtractConfig, PackageFileContent } from '../types';
+import type { SupportedManagers } from './types';
+
+function matchManager(filename: string): SupportedManagers | 'unknown' {
+  if (filename.endsWith('setup.py')) {
+    return 'pip_setup';
+  }
+  if (filename.endsWith('setup.cfg')) {
+    return 'setup-cfg';
+  }
+  if (filename.endsWith('pyproject.toml')) {
+    return 'pep621';
+  }
+  // naive, could be improved, maybe use pip_requirements.fileMatch
+  if (filename.endsWith('.in')) {
+    return 'pip_requirements';
+  }
+  return 'unknown';
+}
+
+export function extractPackageFile(
+  content: string,
+  packageFile: string,
+  _config: ExtractConfig,
+): PackageFileContent | null {
+  logger.trace('pip-compile.extractPackageFile()');
+  const manager = matchManager(packageFile);
+  // TODO(not7cd): extract based on manager: pep621, setuptools, identify other missing source types
+  switch (manager) {
+    // TODO(not7cd): enable in the next PR, when this can be properly tested
+    // case 'pip_setup':
+    //   return extractSetupPyFile(content, _packageFile, _config);
+    // case 'setup-cfg':
+    //   return await extractSetupCfgFile(content);
+    case 'pip_requirements':
+      return extractRequirementsFile(content);
+    case 'unknown':
+      logger.warn(
+        { packageFile },
+        `pip-compile: could not determine manager for source file`,
+      );
+      return null;
+    default:
+      logger.warn(
+        { packageFile, manager },
+        `pip-compile: support for manager is not yet implemented`,
+      );
+      return null;
+  }
+}

--- a/lib/modules/manager/pip-compile/extract.ts
+++ b/lib/modules/manager/pip-compile/extract.ts
@@ -42,9 +42,9 @@ export function extractPackageFile(
     case 'unknown':
       logger.warn(
         { packageFile },
-        `pip-compile: could not determine manager for source file`,
+        `pip-compile: could not determine manager for source file, fallback to pip_requirements`,
       );
-      return null;
+      return extractRequirementsFile(content);
     default:
       logger.warn(
         { packageFile, manager },

--- a/lib/modules/manager/pip-compile/index.ts
+++ b/lib/modules/manager/pip-compile/index.ts
@@ -2,7 +2,7 @@ import type { Category } from '../../../constants';
 import { GitTagsDatasource } from '../../datasource/git-tags';
 import { PypiDatasource } from '../../datasource/pypi';
 
-export { extractPackageFile } from '../pip_requirements/extract';
+export { extractPackageFile } from './extract';
 export { updateArtifacts } from './artifacts';
 
 export const supportsLockFileMaintenance = true;

--- a/lib/modules/manager/pip-compile/types.ts
+++ b/lib/modules/manager/pip-compile/types.ts
@@ -1,0 +1,6 @@
+// managers supported by pip-tools Python package
+export type SupportedManagers =
+  | 'pip_requirements'
+  | 'pip_setup'
+  | 'setup-cfg'
+  | 'pep621';


### PR DESCRIPTION
This is in preparation for #26858. 
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

`pip-compile` lock files can be built from multiple sources, and not only from `requirements.in`. Original `pip_requirements.extractPackageFile()` has been wrapped with switch case statements that check if source file could be handled by `setuptools` managers or `pep621`.

This change shouldn't be breaking, as it will have no direct effect in current constraints. Namely, `.in-.txt` pairing between files. 
<!-- Describe what behavior is changed by this PR. -->

## Context

#26858 too big
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
