### PR TITLE
fix(platform/bitbucket-server): retry add reviewer

### DIFF
--- a/lib/modules/platform/bitbucket-server/index.spec.ts
+++ b/lib/modules/platform/bitbucket-server/index.spec.ts
@@ -674,16 +674,57 @@ describe('modules/platform/bitbucket-server/index', () => {
           );
         });
 
-        it('throws repository-changed', async () => {
+        it('does not throws repository-changed after 1 try', async () => {
           const scope = await initRepo();
           scope
             .get(
               `${urlPath}/rest/api/1.0/projects/SOME/repos/repo/pull-requests/5`,
             )
+            .thrice()
             .reply(200, prMock(url, 'SOME', 'repo'))
             .put(
               `${urlPath}/rest/api/1.0/projects/SOME/repos/repo/pull-requests/5`,
             )
+            .reply(409)
+            .put(
+              `${urlPath}/rest/api/1.0/projects/SOME/repos/repo/pull-requests/5`,
+            )
+            .reply(200, prMock(url, 'SOME', 'repo'));
+          await expect(bitbucket.addReviewers(5, ['name'])).toResolve();
+        });
+
+        it('does not throws repository-changed after 2 tries', async () => {
+          const scope = await initRepo();
+          scope
+            .get(
+              `${urlPath}/rest/api/1.0/projects/SOME/repos/repo/pull-requests/5`,
+            )
+            .times(4)
+            .reply(200, prMock(url, 'SOME', 'repo'))
+            .put(
+              `${urlPath}/rest/api/1.0/projects/SOME/repos/repo/pull-requests/5`,
+            )
+            .twice()
+            .reply(409)
+            .put(
+              `${urlPath}/rest/api/1.0/projects/SOME/repos/repo/pull-requests/5`,
+            )
+            .reply(200, prMock(url, 'SOME', 'repo'));
+          await expect(bitbucket.addReviewers(5, ['name'])).toResolve();
+        });
+
+        it('throws repository-changed after 3 tries', async () => {
+          const scope = await initRepo();
+          scope
+            .get(
+              `${urlPath}/rest/api/1.0/projects/SOME/repos/repo/pull-requests/5`,
+            )
+            .thrice()
+            .reply(200, prMock(url, 'SOME', 'repo'))
+            .put(
+              `${urlPath}/rest/api/1.0/projects/SOME/repos/repo/pull-requests/5`,
+            )
+            .thrice()
             .reply(409);
           await expect(bitbucket.addReviewers(5, ['name'])).rejects.toThrow(
             REPOSITORY_CHANGED,

--- a/lib/modules/platform/bitbucket-server/index.ts
+++ b/lib/modules/platform/bitbucket-server/index.ts
@@ -637,7 +637,7 @@ async function retry<T extends (...arg0: any[]) => any>(
   fn: T,
   args: Parameters<T>,
   maxTries: number,
-  retryErrorMessages: string[] = [],
+  retryErrorMessages: string[],
 ): Promise<Awaited<ReturnType<T>>> {
   const maxAttempts = Math.max(maxTries, 1);
   let lastError: Error | null = null;

--- a/lib/modules/platform/bitbucket-server/index.ts
+++ b/lib/modules/platform/bitbucket-server/index.ts
@@ -646,7 +646,7 @@ async function retry<T extends (...arg0: any[]) => any>(
   } catch (e) {
     if (
       retryErrorMessages.length === 0 ||
-      retryErrorMessages.indexOf(e.message) !== -1
+      retryErrorMessages.includes(e.message)
     ) {
       if (retryCount === maxTries - 1) {
         logger.debug(`All ${maxTries} retry attempts exhausted`);

--- a/lib/modules/platform/bitbucket-server/index.ts
+++ b/lib/modules/platform/bitbucket-server/index.ts
@@ -633,7 +633,7 @@ async function updatePRAndAddReviewers(
   }
 }
 
-async function retry<T extends (...arg0: any[]) => any>(
+async function retry<T extends (...arg0: any[]) => Promise<any>>(
   fn: T,
   args: Parameters<T>,
   maxTries: number,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Retries to add reviewers to a PR on Bitbucket Server when Bitbucket responses with 409 because the repository/PR has changed in the meantime. The maximum tries are limited to three.

## Context

We have a plugin for our Bitbucket Server that automatically adds reviewers if the PR has none set. This leads to a race condition with Renovate when reviewers are defined in the `renovate.json` file and it can therefor not add the correct reviewers.

The flow of the race condition is as follow:

1. Renovate creates a PR - the PR has version 0
2. Then it wants to update the PR to add the defined reviewers from the `renovate.json` file. It does this by first fetching the current PR version form Bitbucket which is version 0. 
4. In the meantime our plugin adds the reviewers and hence the PR gets a new version - version 1.
5. Renovate fails to add the reviewers because the PR version 0 it wants to update is already outdated.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
