### PR TITLE
fix(poetry): Provide better feedback for negation in the ranges

### DIFF
--- a/lib/modules/versioning/poetry/index.spec.ts
+++ b/lib/modules/versioning/poetry/index.spec.ts
@@ -83,6 +83,8 @@ describe('modules/versioning/poetry/index', () => {
 
   it.each`
     version                                          | expected
+    ${null}                                          | ${false}
+    ${undefined}                                     | ${false}
     ${'17.04.00'}                                    | ${true}
     ${'17.b4.0'}                                     | ${false}
     ${'1.2.3'}                                       | ${true}
@@ -101,6 +103,7 @@ describe('modules/versioning/poetry/index', () => {
     ${'renovatebot/renovate'}                        | ${false}
     ${'renovatebot/renovate#master'}                 | ${false}
     ${'https://github.com/renovatebot/renovate.git'} | ${false}
+    ${'>=2.6, !=3.0.*, !=3.1.*, !=3.2.*, <4'}        | ${false}
   `('isValid("$version") === $expected', ({ version, expected }) => {
     expect(!!versioning.isValid(version)).toBe(expected);
   });

--- a/lib/modules/versioning/poetry/index.ts
+++ b/lib/modules/versioning/poetry/index.ts
@@ -64,7 +64,19 @@ function isLessThanRange(version: string, range: string): boolean {
 }
 
 export function isValid(input: string): boolean {
-  return npm.isValid(poetry2npm(input));
+  if (!input) {
+    return false;
+  }
+
+  try {
+    return npm.isValid(poetry2npm(input, true));
+  } catch (err) {
+    logger.once.debug(
+      { version: input },
+      'Poetry version or range is not supported by current implementation',
+    );
+    return false;
+  }
 }
 
 function isStable(version: string): boolean {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- `poetry2npm` and `npm2poetry` don't provide 1:1 match, because `npm` isn't expressive enough: it doesn't have negations

This PR provides some basic error handling for such cases.

## Context

- Closes: #26908
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
