### PR TITLE
fix(datasource/github-runners): wrong macos labels

### DIFF
--- a/lib/modules/datasource/github-runners/index.ts
+++ b/lib/modules/datasource/github-runners/index.ts
@@ -12,9 +12,9 @@ export class GithubRunnersDatasource extends Datasource {
     ubuntu: [{ version: '22.04' }, { version: '20.04' }, { version: '18.04' }],
     macos: [
       { version: '13' },
-      { version: '13-xl' },
+      { version: '13-xlarge' },
       { version: '12' },
-      { version: '12-xl' },
+      { version: '12-large' },
       { version: '11' },
       { version: '10.15' },
     ],

--- a/lib/modules/manager/github-actions/extract.spec.ts
+++ b/lib/modules/manager/github-actions/extract.spec.ts
@@ -11,7 +11,7 @@ jobs:
     runs-on:
       ubuntu-22.04
   test3:
-    runs-on: "macos-12-xl"
+    runs-on: "macos-12-large"
   test4:
     runs-on: 'macos-latest'
   test5:
@@ -454,8 +454,8 @@ describe('modules/manager/github-actions/extract', () => {
         },
         {
           depName: 'macos',
-          currentValue: '12-xl',
-          replaceString: 'macos-12-xl',
+          currentValue: '12-large',
+          replaceString: 'macos-12-large',
           depType: 'github-runner',
           datasource: 'github-runners',
           autoReplaceStringTemplate: '{{depName}}-{{newValue}}',


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- fix the label names
- `macos-12-xl` doesn't exist only `macos-12-large`
- `macos-13-xl` doesn't exist, only `macos-13-large` and `macos-13-xlarge`
<!-- Describe what behavior is changed by this PR. -->

## Context
- #27228
- #27229
- https://github.com/actions/runner-images?tab=readme-ov-file#available-images
- https://docs.github.com/en/actions/using-github-hosted-runners/about-larger-runners/about-larger-runners
- https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
