### PR TITLE
fix(schema): Correct schema for descriptions

### DIFF
--- a/tools/docs/schema.ts
+++ b/tools/docs/schema.ts
@@ -91,9 +91,21 @@ function addChildrenArrayInParents(): void {
               type: 'object',
               properties: {
                 description: {
-                  type: 'string',
-                  description:
-                    'A custom description for this configuration object',
+                  oneOf: [
+                    {
+                      type: 'array',
+                      items: {
+                        type: 'string',
+                        description:
+                          'A custom description for this configuration object',
+                      },
+                    },
+                    {
+                      type: 'string',
+                      description:
+                        'A custom description for this configuration object',
+                    },
+                  ],
                 },
               },
             },


### PR DESCRIPTION
The documentation (https://docs.renovatebot.com/configuration-options/#description) and Renovate config validation enforces that descriptions must be arrays of strings. The schema insists on plain strings.

This breaks the tie by allowing both in the schema.