### PR TITLE
feat(manager/gomod): Added support for the gomod toolchain directive

### DIFF
--- a/lib/modules/manager/gomod/extract.spec.ts
+++ b/lib/modules/manager/gomod/extract.spec.ts
@@ -146,7 +146,7 @@ replace golang.org/x/foo => github.com/pravesht/gocql v0.0.0`;
               lineNumber: 3,
             },
             depName: 'go',
-            depType: 'golang',
+            depType: 'golangtoolchain',
             currentValue: '1.21.7',
             datasource: 'golang-version',
           },

--- a/lib/modules/manager/gomod/extract.spec.ts
+++ b/lib/modules/manager/gomod/extract.spec.ts
@@ -146,7 +146,7 @@ replace golang.org/x/foo => github.com/pravesht/gocql v0.0.0`;
               lineNumber: 3,
             },
             depName: 'go',
-            depType: 'golangtoolchain',
+            depType: 'toolchain',
             currentValue: '1.21.7',
             datasource: 'golang-version',
           },

--- a/lib/modules/manager/gomod/extract.spec.ts
+++ b/lib/modules/manager/gomod/extract.spec.ts
@@ -121,5 +121,46 @@ replace (
         ],
       });
     });
+
+    it('extracts the toolchain directive', () => {
+      const goMod = `
+module github.com/renovate-tests/gomod
+go 1.21
+toolchain go1.21.7
+replace golang.org/x/foo => github.com/pravesht/gocql v0.0.0`;
+      const res = extractPackageFile(goMod);
+      expect(res).toEqual({
+        deps: [
+          {
+            managerData: {
+              lineNumber: 2,
+            },
+            depName: 'go',
+            depType: 'golang',
+            currentValue: '1.21',
+            datasource: 'golang-version',
+            versioning: 'go-mod-directive',
+          },
+          {
+            managerData: {
+              lineNumber: 3,
+            },
+            depName: 'go',
+            depType: 'golang',
+            currentValue: '1.21.7',
+            datasource: 'golang-version',
+          },
+          {
+            managerData: {
+              lineNumber: 4,
+            },
+            depName: 'github.com/pravesht/gocql',
+            depType: 'replace',
+            currentValue: 'v0.0.0',
+            datasource: 'go',
+          },
+        ],
+      });
+    });
   });
 });

--- a/lib/modules/manager/gomod/extract.ts
+++ b/lib/modules/manager/gomod/extract.ts
@@ -75,12 +75,7 @@ export function extractPackageFile(
         ? line.replace('toolchain go', '')
         : null;
       if (goToolVer && semver.valid(goToolVer)) {
-        const dep = getGoDep(
-          lineNumber,
-          goToolVer,
-          undefined,
-          'golangtoolchain',
-        );
+        const dep = getGoDep(lineNumber, goToolVer, undefined, 'toolchain');
         deps.push(dep);
         continue;
       }

--- a/lib/modules/manager/gomod/extract.ts
+++ b/lib/modules/manager/gomod/extract.ts
@@ -41,6 +41,7 @@ function getGoDep(
   lineNumber: number,
   goVer: string,
   versioning: string | undefined = undefined,
+  depType: string = 'golang',
 ): PackageDependency {
   return {
     managerData: {
@@ -74,7 +75,12 @@ export function extractPackageFile(
         ? line.replace('toolchain go', '')
         : null;
       if (goToolVer && semver.valid(goToolVer)) {
-        const dep = getGoDep(lineNumber, goToolVer);
+        const dep = getGoDep(
+          lineNumber,
+          goToolVer,
+          undefined,
+          'golangtoolchain',
+        );
         deps.push(dep);
         continue;
       }

--- a/lib/modules/manager/gomod/extract.ts
+++ b/lib/modules/manager/gomod/extract.ts
@@ -48,7 +48,7 @@ function getGoDep(
       lineNumber,
     },
     depName: 'go',
-    depType: 'golang',
+    depType,
     currentValue: goVer,
     datasource: GolangVersionDatasource.id,
     ...(versioning && { versioning }),

--- a/lib/modules/manager/gomod/extract.ts
+++ b/lib/modules/manager/gomod/extract.ts
@@ -37,7 +37,11 @@ function getDep(
   return dep;
 }
 
-function getGoDep(lineNumber: number, goVer: string): PackageDependency {
+function getGoDep(
+  lineNumber: number,
+  goVer: string,
+  versioning: string | undefined = undefined,
+): PackageDependency {
   return {
     managerData: {
       lineNumber,
@@ -46,7 +50,7 @@ function getGoDep(lineNumber: number, goVer: string): PackageDependency {
     depType: 'golang',
     currentValue: goVer,
     datasource: GolangVersionDatasource.id,
-    versioning: 'go-mod-directive',
+    versioning,
   };
 }
 
@@ -62,7 +66,14 @@ export function extractPackageFile(
       const line = lines[lineNumber];
       const goVer = line.startsWith('go ') ? line.replace('go ', '') : null;
       if (goVer && semver.validRange(goVer)) {
-        const dep = getGoDep(lineNumber, goVer);
+        const dep = getGoDep(lineNumber, goVer, 'go-mod-directive');
+        deps.push(dep);
+      }
+      const goToolVer = line.startsWith('toolchain go')
+        ? line.replace('toolchain go', '')
+        : null;
+      if (goToolVer && semver.valid(goToolVer)) {
+        const dep = getGoDep(lineNumber, goToolVer);
         deps.push(dep);
       }
       const replaceMatch = regEx(

--- a/lib/modules/manager/gomod/extract.ts
+++ b/lib/modules/manager/gomod/extract.ts
@@ -50,7 +50,7 @@ function getGoDep(
     depType: 'golang',
     currentValue: goVer,
     datasource: GolangVersionDatasource.id,
-    ...(versioning && {versioning}),
+    ...(versioning && { versioning }),
   };
 }
 

--- a/lib/modules/manager/gomod/extract.ts
+++ b/lib/modules/manager/gomod/extract.ts
@@ -68,6 +68,7 @@ export function extractPackageFile(
       if (goVer && semver.validRange(goVer)) {
         const dep = getGoDep(lineNumber, goVer, 'go-mod-directive');
         deps.push(dep);
+        continue;
       }
       const goToolVer = line.startsWith('toolchain go')
         ? line.replace('toolchain go', '')
@@ -75,6 +76,7 @@ export function extractPackageFile(
       if (goToolVer && semver.valid(goToolVer)) {
         const dep = getGoDep(lineNumber, goToolVer);
         deps.push(dep);
+        continue;
       }
       const replaceMatch = regEx(
         /^replace\s+[^\s]+[\s]+[=][>]\s+([^\s]+)\s+([^\s]+)/,

--- a/lib/modules/manager/gomod/extract.ts
+++ b/lib/modules/manager/gomod/extract.ts
@@ -50,7 +50,7 @@ function getGoDep(
     depType: 'golang',
     currentValue: goVer,
     datasource: GolangVersionDatasource.id,
-    versioning,
+    ...(versioning && {versioning}),
   };
 }
 

--- a/lib/modules/manager/gomod/update.ts
+++ b/lib/modules/manager/gomod/update.ts
@@ -48,7 +48,7 @@ export function updateDependency({
 
     if (depType === 'golang') {
       updateLineExp = regEx(
-        /(?<depPart>(toolchain )??go)(?<divider>\s*)([^\s]+|[\w]+)/,
+        /(?<depPart>(?:toolchain )?go)(?<divider>\s*)([^\s]+|[\w]+)/,
       );
     }
     if (depType === 'replace') {

--- a/lib/modules/manager/gomod/update.ts
+++ b/lib/modules/manager/gomod/update.ts
@@ -47,7 +47,9 @@ export function updateDependency({
     let updateLineExp: RegExp | undefined;
 
     if (depType === 'golang') {
-      updateLineExp = regEx(/(?<depPart>go)(?<divider>\s+)[^\s]+/);
+      updateLineExp = regEx(
+        /(?<depPart>(toolchain )??go)(?<divider>\s*)([^\s]+|[\w]+)/,
+      );
     }
     if (depType === 'replace') {
       if (upgrade.managerData.multiLine) {
@@ -69,7 +71,7 @@ export function updateDependency({
       }
     }
     if (updateLineExp && !updateLineExp.test(lineToChange)) {
-      logger.debug('No image line found');
+      logger.debug('No line found to update');
       return null;
     }
     let newLine: string;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Added support for the go.mod toolchain directive to the gomod manager.
<!-- Describe what behavior is changed by this PR. -->

## Context
Go 1.21 introduced the `toolchain` directive. This directive, contrary to the `go` directive, should be updated by Renovate, see #24427 and #16715. Closes #24427
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository: https://github.com/kvanzuijlen/renovate-reproduction-gomod-toolchain/pull/2

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
