### PR TITLE
fix(github-runners): add deprecation flag

### DIFF
--- a/lib/modules/datasource/github-runners/index.spec.ts
+++ b/lib/modules/datasource/github-runners/index.spec.ts
@@ -11,7 +11,7 @@ describe('modules/datasource/github-runners/index', () => {
 
       expect(res).toMatchObject({
         releases: [
-          { version: '18.04' },
+          { version: '18.04', isDeprecated: true },
           { version: '20.04' },
           { version: '22.04' },
         ],

--- a/lib/modules/datasource/github-runners/index.spec.ts
+++ b/lib/modules/datasource/github-runners/index.spec.ts
@@ -11,6 +11,7 @@ describe('modules/datasource/github-runners/index', () => {
 
       expect(res).toMatchObject({
         releases: [
+          { version: '16.04', isDeprecated: true },
           { version: '18.04', isDeprecated: true },
           { version: '20.04' },
           { version: '22.04' },

--- a/lib/modules/datasource/github-runners/index.ts
+++ b/lib/modules/datasource/github-runners/index.ts
@@ -9,17 +9,25 @@ export class GithubRunnersDatasource extends Datasource {
    * Only add stable runners to the datasource. See datasource readme for details.
    */
   private static readonly releases: Record<string, Release[] | undefined> = {
-    ubuntu: [{ version: '22.04' }, { version: '20.04' }, { version: '18.04' }],
+    ubuntu: [
+      { version: '22.04' },
+      { version: '20.04' },
+      { version: '18.04', isDeprecated: true },
+    ],
     macos: [
       { version: '13' },
       { version: '13-large' },
       { version: '13-xlarge' },
       { version: '12' },
       { version: '12-large' },
-      { version: '11' },
-      { version: '10.15' },
+      { version: '11', isDeprecated: true },
+      { version: '10.15', isDeprecated: true },
     ],
-    windows: [{ version: '2022' }, { version: '2019' }],
+    windows: [
+      { version: '2022' },
+      { version: '2019' },
+      { version: '2016', isDeprecated: true },
+    ],
   };
 
   public static isValidRunner(

--- a/lib/modules/datasource/github-runners/index.ts
+++ b/lib/modules/datasource/github-runners/index.ts
@@ -13,6 +13,7 @@ export class GithubRunnersDatasource extends Datasource {
       { version: '22.04' },
       { version: '20.04' },
       { version: '18.04', isDeprecated: true },
+      { version: '16.04', isDeprecated: true },
     ],
     macos: [
       { version: '13' },


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- mark know runners as deprecated
<!-- Describe what behavior is changed by this PR. -->

## Context
- closes #27290
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
