### PR TITLE
fix(versioning): strip leading v from getNewValue

### DIFF
--- a/lib/modules/versioning/bazel-module/index.spec.ts
+++ b/lib/modules/versioning/bazel-module/index.spec.ts
@@ -104,5 +104,12 @@ describe('modules/versioning/bazel-module/index', () => {
       newVersion: '1.0.1',
     };
     expect(bzlmod.getNewValue(config)).toBe('1.0.1');
+    const vConfig: NewValueConfig = {
+      currentValue: '1.0.0',
+      currentVersion: 'v1.0.0',
+      rangeStrategy: 'auto',
+      newVersion: 'v1.0.1',
+    };
+    expect(bzlmod.getNewValue(vConfig)).toBe('1.0.1');
   });
 });

--- a/lib/modules/versioning/bazel-module/index.ts
+++ b/lib/modules/versioning/bazel-module/index.ts
@@ -84,7 +84,14 @@ function minSatisfyingVersion(
  * Calculate a new version constraint based on the current constraint, the
  * `rangeStrategy` option, and the current and new version.
  */
-function getNewValue({ newVersion }: NewValueConfig): string {
+function getNewValue({
+  currentValue,
+  currentVersion,
+  newVersion,
+}: NewValueConfig): string {
+  if (currentVersion === `v${currentValue}`) {
+    return newVersion.replace(/^v/, '');
+  }
   return newVersion;
 }
 

--- a/lib/modules/versioning/generic.spec.ts
+++ b/lib/modules/versioning/generic.spec.ts
@@ -107,6 +107,15 @@ describe('modules/versioning/generic', () => {
         }),
       ).toBe('3.2.1');
 
+      expect(
+        api.getNewValue({
+          currentValue: '1.2.3',
+          rangeStrategy: 'auto',
+          currentVersion: 'v1.2.3',
+          newVersion: 'v3.2.1',
+        }),
+      ).toBe('3.2.1');
+
       expect(api.getNewValue(partial<NewValueConfig>({}))).toBeNull();
     });
 

--- a/lib/modules/versioning/generic.ts
+++ b/lib/modules/versioning/generic.ts
@@ -129,7 +129,14 @@ export abstract class GenericVersioningApi<
     return result ?? null;
   }
 
-  getNewValue({ newVersion }: NewValueConfig): string | null {
+  getNewValue({
+    currentValue,
+    currentVersion,
+    newVersion,
+  }: NewValueConfig): string | null {
+    if (currentVersion === `v${currentValue}`) {
+      return newVersion.replace(/^v/, '');
+    }
     return newVersion ?? null;
   }
 

--- a/lib/modules/versioning/semver-coerced/index.spec.ts
+++ b/lib/modules/versioning/semver-coerced/index.spec.ts
@@ -267,6 +267,14 @@ describe('modules/versioning/semver-coerced/index', () => {
           newVersion: 'v1.1.0',
         }),
       ).toBe('1.1.0');
+      expect(
+        semverCoerced.getNewValue({
+          currentValue: '1.0.0',
+          rangeStrategy: 'auto',
+          currentVersion: 'v1.0.0',
+          newVersion: '1.1.0',
+        }),
+      ).toBe('1.1.0');
     });
   });
 

--- a/lib/modules/versioning/semver-coerced/index.spec.ts
+++ b/lib/modules/versioning/semver-coerced/index.spec.ts
@@ -259,6 +259,14 @@ describe('modules/versioning/semver-coerced/index', () => {
           newVersion: '1.1.0',
         }),
       ).toBe('1.1.0');
+      expect(
+        semverCoerced.getNewValue({
+          currentValue: '1.0.0',
+          rangeStrategy: 'auto',
+          currentVersion: 'v1.0.0',
+          newVersion: 'v1.1.0',
+        }),
+      ).toBe('1.1.0');
     });
   });
 

--- a/lib/modules/versioning/semver-coerced/index.ts
+++ b/lib/modules/versioning/semver-coerced/index.ts
@@ -119,7 +119,14 @@ export const isVersion = (input: string): boolean => isValid(input);
 
 export { isVersion as isValid, getSatisfyingVersion };
 
-function getNewValue({ newVersion }: NewValueConfig): string {
+function getNewValue({
+  currentValue,
+  currentVersion,
+  newVersion,
+}: NewValueConfig): string {
+  if (currentVersion === `v${currentValue}`) {
+    return newVersion.replace(/^v/, '');
+  }
   return newVersion;
 }
 

--- a/lib/modules/versioning/semver/index.spec.ts
+++ b/lib/modules/versioning/semver/index.spec.ts
@@ -29,8 +29,9 @@ describe('modules/versioning/semver/index', () => {
   });
 
   it.each`
-    currentValue | rangeStrategy | currentVersion | newVersion | expected
-    ${'=1.0.0'}  | ${'bump'}     | ${'1.0.0'}     | ${'1.1.0'} | ${'1.1.0'}
+    currentValue | rangeStrategy | currentVersion | newVersion  | expected
+    ${'=1.0.0'}  | ${'bump'}     | ${'1.0.0'}     | ${'1.1.0'}  | ${'1.1.0'}
+    ${'1.0.0'}   | ${'auto'}     | ${'v1.0.0'}    | ${'v2.0.0'} | ${'2.0.0'}
   `(
     'getNewValue("$currentValue", "$rangeStrategy", "$currentVersion", "$newVersion") === "$expected"',
     ({ currentValue, rangeStrategy, currentVersion, newVersion, expected }) => {

--- a/lib/modules/versioning/semver/index.ts
+++ b/lib/modules/versioning/semver/index.ts
@@ -28,7 +28,14 @@ export const isVersion = (input: string): boolean => !!valid(input);
 
 export { isVersion as isValid, getSatisfyingVersion };
 
-function getNewValue({ newVersion }: NewValueConfig): string {
+function getNewValue({
+  currentValue,
+  currentVersion,
+  newVersion,
+}: NewValueConfig): string {
+  if (currentVersion === `v${currentValue}`) {
+    return newVersion.replace(/^v/, '');
+  }
   return newVersion;
 }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Fixes some versioning schemes which would return a v prefix for newValue unnecessarily.

## Context

Part of a bigger fix for the v prefix problem

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
