### PR TITLE
chore(logs): mention debug logging on exit if info level set

### DIFF
--- a/lib/workers/global/index.spec.ts
+++ b/lib/workers/global/index.spec.ts
@@ -159,6 +159,7 @@ describe('workers/global/index', () => {
   });
 
   it('exits with zero when warnings are logged', async () => {
+    delete process.env.LOG_LEVEL;
     parseConfigs.mockResolvedValueOnce({
       baseDir: '/tmp/base',
       cacheDir: '/tmp/cache',

--- a/lib/workers/global/index.ts
+++ b/lib/workers/global/index.ts
@@ -220,7 +220,12 @@ export async function start(): Promise<number> {
     }
   } finally {
     await globalFinalize(config!);
-    logger.debug(`Renovate exiting`);
+    const logLevel = process.env.LOG_LEVEL || 'info';
+    if (logLevel === 'info') {
+      logger.info(
+        `Renovate was run at log level "${logLevel}". Set LOG_LEVEL=debug in environment variables to see extended debug logs.`,
+      );
+    }
   }
   const loggerErrors = getProblems().filter((p) => p.level >= ERROR);
   if (loggerErrors.length) {

--- a/lib/workers/global/index.ts
+++ b/lib/workers/global/index.ts
@@ -220,7 +220,7 @@ export async function start(): Promise<number> {
     }
   } finally {
     await globalFinalize(config!);
-    const logLevel = process.env.LOG_LEVEL || 'info';
+    const logLevel = process.env.LOG_LEVEL ?? 'info';
     if (logLevel === 'info') {
       logger.info(
         `Renovate was run at log level "${logLevel}". Set LOG_LEVEL=debug in environment variables to see extended debug logs.`,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds a log message on how to enable debug logging if running at info log level.

## Context

This might help some users who only see INFO/WARN and want to understand more

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
