### PR TITLE
fix(vulnerabilities): describe last_affected version as ecosystem-specific version constraint

### DIFF
--- a/lib/workers/repository/process/vulnerabilities.ts
+++ b/lib/workers/repository/process/vulnerabilities.ts
@@ -263,7 +263,7 @@ export class Vulnerabilities {
     const versionsCleaned: Record<string, string> = {};
     for (const rule of packageRules) {
       const version = rule.allowedVersions as string;
-      versionsCleaned[version] = version.replace(regEx(/[=> ]+/g), '');
+      versionsCleaned[version] = version.replace(regEx(/[(),=> ]+/g), '');
     }
     packageRules.sort((a, b) =>
       versioningApi.sortVersions(
@@ -417,10 +417,22 @@ export class Vulnerabilities {
       this.isVersionGtOrEq(version, depVersion, versioningApi),
     );
     if (lastAffected) {
-      return `> ${lastAffected}`;
+      return this.getLastAffectedByEcosystem(lastAffected, ecosystem);
     }
 
     return null;
+  }
+
+  private getLastAffectedByEcosystem(
+    lastAffected: string,
+    ecosystem: Ecosystem,
+  ): string {
+    if (ecosystem === 'Maven') {
+      return `(${lastAffected},)`;
+    }
+
+    // crates.io, Go, Hex, npm, RubyGems, PyPI
+    return `> ${lastAffected}`;
   }
 
   private isVersionGt(


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Ensures that Maven version ranges are used in `allowedVersions` constraints when OSV vulnerabilities specify an ecosystem-specific `last_affected` version. This prevents an `Aggregate error` exception that was thrown when advisories specify non-semver compatible versions, such as `1.2.1.2-jre17` (see discussion).

Of the OSV-supported ecosystems, this change is only required for `maven` and `nuget`. Support for `nuget` is missing for now as it depends on support for nuget version ranges being available.

<!-- Describe what behavior is changed by this PR. -->

## Context

- https://github.com/renovatebot/renovate/discussions/27221
- https://github.com/renovatebot/renovate/pull/26150

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

Test repo: https://github.com/renovate-demo/renovate-osv-ecosystem-lastaffected/pull/1

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
