### PR TITLE
refactor: Use "Result" wrapper for "fetchDepUpdates" function

### DIFF
--- a/lib/workers/repository/process/fetch.spec.ts
+++ b/lib/workers/repository/process/fetch.spec.ts
@@ -3,6 +3,7 @@ import { getConfig } from '../../../config/defaults';
 import { MavenDatasource } from '../../../modules/datasource/maven';
 import type { PackageFile } from '../../../modules/manager/types';
 import { ExternalHostError } from '../../../types/errors/external-host-error';
+import { Result } from '../../../util/result';
 import { fetchUpdates } from './fetch';
 import * as lookup from './lookup';
 
@@ -155,7 +156,7 @@ describe('workers/repository/process/fetch', () => {
           },
         ],
       };
-      lookupUpdates.mockRejectedValueOnce(new Error('some error'));
+      lookupUpdates.mockResolvedValueOnce(Result.err(new Error('some error')));
 
       await expect(
         fetchUpdates({ ...config, repoIsOnboarded: true }, packageFiles),
@@ -172,7 +173,7 @@ describe('workers/repository/process/fetch', () => {
           },
         ],
       };
-      lookupUpdates.mockRejectedValueOnce(new Error('some error'));
+      lookupUpdates.mockResolvedValueOnce(Result.err(new Error('some error')));
 
       await expect(
         fetchUpdates({ ...config, repoIsOnboarded: true }, packageFiles),

--- a/lib/workers/repository/process/fetch.ts
+++ b/lib/workers/repository/process/fetch.ts
@@ -69,10 +69,10 @@ async function fetchDepUpdates(
     dep.skipReason = 'disabled';
   } else {
     if (depConfig.datasource) {
-      const { val: updateResult, err } = await withLookupStats(depConfig.datasource, () =>
-        Result.wrap(
-          lookupUpdates(depConfig as LookupUpdateConfig),
-        ).unwrap(),
+      const { val: updateResult, err } = await withLookupStats(
+        depConfig.datasource,
+        () =>
+          Result.wrap(lookupUpdates(depConfig as LookupUpdateConfig)).unwrap(),
       );
 
       if (updateResult) {
@@ -114,11 +114,10 @@ async function fetchManagerPackagerFileUpdates(
   }
   const { manager } = packageFileConfig;
   const queue = pFile.deps.map(
-    (dep) => async (): Promise<PackageDependency> =>
-      {
-        const updates = await fetchDepUpdates(packageFileConfig, dep);
-        return updates.unwrapOrThrow();
-      },
+    (dep) => async (): Promise<PackageDependency> => {
+      const updates = await fetchDepUpdates(packageFileConfig, dep);
+      return updates.unwrapOrThrow();
+    },
   );
   logger.trace(
     { manager, packageFile, queueLength: queue.length },

--- a/lib/workers/repository/process/fetch.ts
+++ b/lib/workers/repository/process/fetch.ts
@@ -36,7 +36,7 @@ async function withLookupStats<T>(
 async function fetchDepUpdates(
   packageFileConfig: RenovateConfig & PackageFile,
   indep: PackageDependency,
-): Promise<PackageDependency> {
+): Promise<Result<PackageDependency, Error>> {
   const dep = clone(indep);
   dep.updates = [];
   if (is.string(dep.depName)) {
@@ -50,7 +50,7 @@ async function fetchDepUpdates(
     dep.skipReason = 'internal-package';
   }
   if (dep.skipReason) {
-    return dep;
+    return Result.ok(dep);
   }
   const { depName } = dep;
   // TODO: fix types
@@ -69,19 +69,20 @@ async function fetchDepUpdates(
     dep.skipReason = 'disabled';
   } else {
     if (depConfig.datasource) {
-      try {
-        const updateResult = await withLookupStats(depConfig.datasource, () =>
-          Result.wrap(
-            lookupUpdates(depConfig as LookupUpdateConfig),
-          ).unwrapOrThrow(),
-        );
+      const { val: updateResult, err } = await withLookupStats(depConfig.datasource, () =>
+        Result.wrap(
+          lookupUpdates(depConfig as LookupUpdateConfig),
+        ).unwrap(),
+      );
+
+      if (updateResult) {
         Object.assign(dep, updateResult);
-      } catch (err) {
+      } else {
         if (
           packageFileConfig.repoIsOnboarded === true ||
           !(err instanceof ExternalHostError)
         ) {
-          throw err;
+          return Result.err(err);
         }
 
         const cause = err.err;
@@ -95,7 +96,7 @@ async function fetchDepUpdates(
     }
     dep.updates ??= [];
   }
-  return dep;
+  return Result.ok(dep);
 }
 
 async function fetchManagerPackagerFileUpdates(
@@ -113,8 +114,11 @@ async function fetchManagerPackagerFileUpdates(
   }
   const { manager } = packageFileConfig;
   const queue = pFile.deps.map(
-    (dep) => (): Promise<PackageDependency> =>
-      fetchDepUpdates(packageFileConfig, dep),
+    (dep) => async (): Promise<PackageDependency> =>
+      {
+        const updates = await fetchDepUpdates(packageFileConfig, dep);
+        return updates.unwrapOrThrow();
+      },
   );
   logger.trace(
     { manager, packageFile, queueLength: queue.length },


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Make the `Result` value unwrap one level higher.

After series of small refactoring PRs, we'll end up having flat queue of lookup tasks.

## Context

- Ref: #6575
- Ref: #21757
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
