### PR TITLE
refactor(workers/repository): Wrapper for get(manager, 'updateArtifacts')

### DIFF
--- a/lib/workers/repository/update/branch/get-updated.ts
+++ b/lib/workers/repository/update/branch/get-updated.ts
@@ -6,7 +6,9 @@ import { get } from '../../../../modules/manager';
 import type {
   ArtifactError,
   PackageDependency,
+  UpdateArtifact,
   UpdateArtifactsResult,
+  Upgrade,
 } from '../../../../modules/manager/types';
 import { getFile } from '../../../../util/git';
 import type { FileAddition, FileChange } from '../../../../util/git/types';
@@ -291,21 +293,14 @@ export async function getUpdatedPackageFiles(
     const managers = packageFileManagers[packageFile.path];
     if (is.nonEmptySet(managers)) {
       for (const manager of managers) {
-        const updateArtifacts = get(manager, 'updateArtifacts');
-        if (updateArtifacts) {
-          const results = await updateArtifacts({
-            packageFileName: packageFile.path,
-            updatedDeps,
-            // TODO #22198
-            newPackageFileContent: packageFile.contents!.toString(),
-            config,
-          });
-          processUpdateArtifactResults(
-            results,
-            updatedArtifacts,
-            artifactErrors,
-          );
-        }
+        const results = await managerUpdateArtifacts(manager, {
+          packageFileName: packageFile.path,
+          updatedDeps,
+          // TODO #22198
+          newPackageFileContent: packageFile.contents!.toString(),
+          config,
+        });
+        processUpdateArtifactResults(results, updatedArtifacts, artifactErrors);
       }
     }
   }
@@ -321,13 +316,33 @@ export async function getUpdatedPackageFiles(
     const managers = packageFileManagers[packageFile.path];
     if (is.nonEmptySet(managers)) {
       for (const manager of managers) {
-        const updateArtifacts = get(manager, 'updateArtifacts');
-        if (updateArtifacts) {
-          const results = await updateArtifacts({
-            packageFileName: packageFile.path,
-            updatedDeps,
-            // TODO #22198
-            newPackageFileContent: packageFile.contents!.toString(),
+        const results = await managerUpdateArtifacts(manager, {
+          packageFileName: packageFile.path,
+          updatedDeps,
+          // TODO #22198
+          newPackageFileContent: packageFile.contents!.toString(),
+          config,
+        });
+        processUpdateArtifactResults(results, updatedArtifacts, artifactErrors);
+        if (is.nonEmptyArray(results)) {
+          updatedPackageFiles.push(packageFile);
+        }
+      }
+    }
+  }
+  if (!reuseExistingBranch) {
+    // Only perform lock file maintenance if it's a fresh commit
+    for (const packageFileName of lockFileMaintenanceFiles) {
+      const managers = packageFileManagers[packageFileName];
+      if (is.nonEmptySet(managers)) {
+        for (const manager of managers) {
+          const contents =
+            updatedFileContents[packageFileName] ||
+            (await getFile(packageFileName, config.baseBranch));
+          const results = await managerUpdateArtifacts(manager, {
+            packageFileName,
+            updatedDeps: [],
+            newPackageFileContent: contents!,
             config,
           });
           processUpdateArtifactResults(
@@ -335,36 +350,6 @@ export async function getUpdatedPackageFiles(
             updatedArtifacts,
             artifactErrors,
           );
-          if (is.nonEmptyArray(results)) {
-            updatedPackageFiles.push(packageFile);
-          }
-        }
-      }
-    }
-  }
-  if (!reuseExistingBranch) {
-    // Only perform lock file maintenance if it's a fresh commit
-    for (const packageFile of lockFileMaintenanceFiles) {
-      const managers = packageFileManagers[packageFile];
-      if (is.nonEmptySet(managers)) {
-        for (const manager of managers) {
-          const updateArtifacts = get(manager, 'updateArtifacts');
-          if (updateArtifacts) {
-            const packageFileContents =
-              updatedFileContents[packageFile] ||
-              (await getFile(packageFile, config.baseBranch));
-            const results = await updateArtifacts({
-              packageFileName: packageFile,
-              updatedDeps: [],
-              newPackageFileContent: packageFileContents!,
-              config,
-            });
-            processUpdateArtifactResults(
-              results,
-              updatedArtifacts,
-              artifactErrors,
-            );
-          }
         }
       }
     }
@@ -375,6 +360,17 @@ export async function getUpdatedPackageFiles(
     updatedArtifacts,
     artifactErrors,
   };
+}
+
+async function managerUpdateArtifacts(
+  manager: string,
+  updateArtifact: UpdateArtifact,
+): Promise<UpdateArtifactsResult[] | null> {
+  const updateArtifacts = get(manager, 'updateArtifacts');
+  if (updateArtifacts) {
+    return await updateArtifacts(updateArtifact);
+  }
+  return null;
 }
 
 function processUpdateArtifactResults(

--- a/lib/workers/repository/update/branch/get-updated.ts
+++ b/lib/workers/repository/update/branch/get-updated.ts
@@ -8,7 +8,6 @@ import type {
   PackageDependency,
   UpdateArtifact,
   UpdateArtifactsResult,
-  Upgrade,
 } from '../../../../modules/manager/types';
 import { getFile } from '../../../../util/git';
 import type { FileAddition, FileChange } from '../../../../util/git/types';


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Improve readability in updateArtifacts section of get-updated

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
