### PR TITLE
chore(azure): increase logging when determining merge method

### DIFF
--- a/lib/modules/platform/azure/azure-helper.ts
+++ b/lib/modules/platform/azure/azure-helper.ts
@@ -119,6 +119,9 @@ export async function getMergeMethod(
   branchRef?: string | null,
   defaultBranch?: string,
 ): Promise<GitPullRequestMergeStrategy> {
+  logger.debug(
+    `getMergeMethod(branchRef=${branchRef}, defaultBranch=${defaultBranch})`,
+  );
   type Scope = {
     repositoryId: string;
     refName?: string;
@@ -152,9 +155,9 @@ export async function getMergeMethod(
     .filter((p) => p.settings.scope.some(isRelevantScope))
     .map((p) => p.settings)[0];
 
-  logger.trace(
+  logger.debug(
     // TODO: types (#22198)
-    `getMergeMethod(${repoId}, ${project}, ${branchRef!}) determining mergeMethod from matched policy:\n${JSON.stringify(
+    `getMergeMethod(branchRef=${branchRef!}) determining mergeMethod from matched policy:\n${JSON.stringify(
       policyConfigurations,
       null,
       4,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds extra debug logging to azure merge method determiniation

## Context

Gather extra data for #27330

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
