### PR TITLE
fix(semver-coerced): only coerce if not a valid semver version

### DIFF
--- a/lib/modules/versioning/semver-coerced/index.spec.ts
+++ b/lib/modules/versioning/semver-coerced/index.spec.ts
@@ -231,7 +231,7 @@ describe('modules/versioning/semver-coerced/index', () => {
     it('should support coercion', () => {
       expect(
         semverCoerced.getSatisfyingVersion(['v1.0', '1.0.4-foo'], '^1.0'),
-      ).toBe('1.0.4');
+      ).toBe('1.0.0');
     });
   });
 

--- a/lib/modules/versioning/semver-coerced/index.ts
+++ b/lib/modules/versioning/semver-coerced/index.ts
@@ -71,7 +71,9 @@ function getSatisfyingVersion(
   range: string,
 ): string | null {
   const coercedVersions = versions
-    .map((version) => semver.coerce(version)?.version)
+    .map((version) =>
+      semver.valid(version) ? version : semver.coerce(version)?.version,
+    )
     .filter(is.string);
 
   return semver.maxSatisfying(coercedVersions, range);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Only coerces versions if they are invalid semver.

## Context

Part of #27317

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
