### PR TITLE
refactor: minimatch -> glob renaming

### DIFF
--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -10,7 +10,7 @@ import type { CustomManager } from '../modules/manager/custom/types';
 import type { HostRule } from '../types/host-rules';
 import { regEx } from '../util/regex';
 import {
-  anyMatchRegexOrMinimatch,
+  anyMatchRegexOrGlob,
   configRegexPredicate,
   isConfigRegex,
 } from '../util/string-match';
@@ -724,7 +724,7 @@ export async function validateConfig(
               message: `Invalid hostRules headers value configuration: header must be a string.`,
             });
           }
-          if (!anyMatchRegexOrMinimatch(header, allowedHeaders)) {
+          if (!anyMatchRegexOrGlob(header, allowedHeaders)) {
             errors.push({
               topic: 'Configuration Error',
               message: `hostRules header \`${header}\` is not allowed by this bot's \`allowedHeaders\`.`,

--- a/lib/logger/remap.ts
+++ b/lib/logger/remap.ts
@@ -1,7 +1,7 @@
 import type { LogLevelString } from 'bunyan';
 import {
   StringMatchPredicate,
-  makeRegexOrMinimatchPredicate,
+  makeRegexOrGlobPredicate,
 } from '../util/string-match';
 import type { LogLevelRemap } from './types';
 
@@ -14,7 +14,7 @@ function match(remap: LogLevelRemap, input: string): boolean {
   const { matchMessage: pattern } = remap;
   let matchFn = matcherCache.get(remap);
   if (!matchFn) {
-    matchFn = makeRegexOrMinimatchPredicate(pattern) ?? (() => false);
+    matchFn = makeRegexOrGlobPredicate(pattern) ?? (() => false);
     matcherCache.set(remap, matchFn);
   }
 

--- a/lib/util/http/host-rules.ts
+++ b/lib/util/http/host-rules.ts
@@ -10,7 +10,7 @@ import { logger } from '../../logger';
 import { hasProxy } from '../../proxy';
 import type { HostRule } from '../../types';
 import * as hostRules from '../host-rules';
-import { anyMatchRegexOrMinimatch } from '../string-match';
+import { anyMatchRegexOrGlob } from '../string-match';
 import { parseUrl } from '../url';
 import { dnsLookup } from './dns';
 import { keepAliveAgents } from './keep-alive';
@@ -169,7 +169,7 @@ export function applyHostRule<GotOptions extends HostRulesGotOptions>(
     const filteredHeaders: Record<string, string> = {};
 
     for (const [header, value] of Object.entries(hostRule.headers)) {
-      if (anyMatchRegexOrMinimatch(header, allowedHeaders)) {
+      if (anyMatchRegexOrGlob(header, allowedHeaders)) {
         filteredHeaders[header] = value;
       } else {
         logger.once.error(

--- a/lib/util/package-rules/repositories.ts
+++ b/lib/util/package-rules/repositories.ts
@@ -1,6 +1,6 @@
 import is from '@sindresorhus/is';
 import type { PackageRule, PackageRuleInputConfig } from '../../config/types';
-import { anyMatchRegexOrMinimatch } from '../string-match';
+import { anyMatchRegexOrGlob } from '../string-match';
 import { Matcher } from './base';
 
 export class RepositoriesMatcher extends Matcher {
@@ -16,7 +16,7 @@ export class RepositoriesMatcher extends Matcher {
       return false;
     }
 
-    return anyMatchRegexOrMinimatch(repository, matchRepositories);
+    return anyMatchRegexOrGlob(repository, matchRepositories);
   }
 
   override excludes(
@@ -31,6 +31,6 @@ export class RepositoriesMatcher extends Matcher {
       return false;
     }
 
-    return anyMatchRegexOrMinimatch(repository, excludeRepositories);
+    return anyMatchRegexOrGlob(repository, excludeRepositories);
   }
 }

--- a/lib/util/string-match.ts
+++ b/lib/util/string-match.ts
@@ -8,7 +8,7 @@ export function isDockerDigest(input: string): boolean {
   return /^sha256:[a-f0-9]{64}$/i.test(input);
 }
 
-export function makeRegexOrMinimatchPredicate(
+export function makeRegexOrGlobPredicate(
   pattern: string,
 ): StringMatchPredicate | null {
   if (pattern.length > 2 && pattern.startsWith('/') && pattern.endsWith('/')) {
@@ -24,16 +24,16 @@ export function makeRegexOrMinimatchPredicate(
   return (x: string): boolean => mm.match(x);
 }
 
-export function matchRegexOrMinimatch(input: string, pattern: string): boolean {
-  const predicate = makeRegexOrMinimatchPredicate(pattern);
+export function matchRegexOrGlob(input: string, pattern: string): boolean {
+  const predicate = makeRegexOrGlobPredicate(pattern);
   return predicate ? predicate(input) : false;
 }
 
-export function anyMatchRegexOrMinimatch(
+export function anyMatchRegexOrGlob(
   input: string,
   patterns: string[],
 ): boolean | null {
-  return patterns.some((pattern) => matchRegexOrMinimatch(input, pattern));
+  return patterns.some((pattern) => matchRegexOrGlob(input, pattern));
 }
 
 export const UUIDRegex = regEx(


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Internal renaming to take focus off minimatch and replace with glob.

## Context

Minimatch is an implementation detail, like re2 - should not be part of function names.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
