### PR TITLE
fix(manager/terraform): skip lockfile update when version is pinned

### DIFF
--- a/lib/modules/manager/terraform/lockfile/index.spec.ts
+++ b/lib/modules/manager/terraform/lockfile/index.spec.ts
@@ -188,6 +188,86 @@ describe('modules/manager/terraform/lockfile/index', () => {
     ]);
   });
 
+  it('does not update dependency with exact constraint during lockfile update', async () => {
+    fs.readLocalFile.mockResolvedValueOnce(codeBlock`
+      provider "registry.terraform.io/hashicorp/aws" {
+        version     = "3.0.0"
+        constraints = "3.0.0"
+        hashes = [
+          "aaa",
+          "bbb",
+          "ccc",
+        ]
+      }
+    `);
+    fs.findLocalSiblingOrParent.mockResolvedValueOnce('.terraform.lock.hcl');
+
+    mockHash.mockResolvedValueOnce([
+      'h1:lDsKRxDRXPEzA4AxkK4t+lJd3IQIP2UoaplJGjQSp2s=',
+      'h1:6zB2hX7YIOW26OrKsLJn0uLMnjqbPNxcz9RhlWEuuSY=',
+    ]);
+
+    const result = await updateArtifacts({
+      packageFileName: 'main.tf',
+      updatedDeps: [
+        {
+          depName: 'hashicorp/aws',
+          packageName: 'hashicorp/aws',
+          depType: 'required_provider',
+          currentVersion: '3.0.0',
+          currentValue: '3.0.0',
+          newVersion: '3.36.0',
+          newValue: '3.36.0',
+          isLockfileUpdate: true,
+        },
+      ],
+      newPackageFileContent: '',
+      config,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('does not update dependency with exact constraint within multiple during lockfile update', async () => {
+    fs.readLocalFile.mockResolvedValueOnce(codeBlock`
+      provider "registry.terraform.io/hashicorp/aws" {
+        version     = "3.0.0"
+        constraints = "~> 3.0, 3.0.0"
+        hashes = [
+          "aaa",
+          "bbb",
+          "ccc",
+        ]
+      }
+    `);
+    fs.findLocalSiblingOrParent.mockResolvedValueOnce('.terraform.lock.hcl');
+
+    mockHash.mockResolvedValueOnce([
+      'h1:lDsKRxDRXPEzA4AxkK4t+lJd3IQIP2UoaplJGjQSp2s=',
+      'h1:6zB2hX7YIOW26OrKsLJn0uLMnjqbPNxcz9RhlWEuuSY=',
+    ]);
+
+    const result = await updateArtifacts({
+      packageFileName: 'main.tf',
+      updatedDeps: [
+        {
+          depName: 'hashicorp/aws',
+          packageName: 'hashicorp/aws',
+          depType: 'required_provider',
+          currentVersion: '3.0.0',
+          currentValue: '3.0.0',
+          newVersion: '3.36.0',
+          newValue: '3.36.0',
+          isLockfileUpdate: true,
+        },
+      ],
+      newPackageFileContent: '',
+      config,
+    });
+
+    expect(result).toBeNull();
+  });
+
   it('do not update dependency with depType module', async () => {
     const result = await updateArtifacts({
       packageFileName: 'main.tf',

--- a/lib/modules/manager/terraform/lockfile/index.ts
+++ b/lib/modules/manager/terraform/lockfile/index.ts
@@ -177,6 +177,18 @@ export async function updateArtifacts({
         if (!updateLock) {
           continue;
         }
+        if (dep.isLockfileUpdate) {
+          const versioning = getVersioning(dep.versioning);
+          const satisfyingVersion = versioning.getSatisfyingVersion(
+            [dep.newVersion!],
+            updateLock.constraints,
+          );
+
+          // skip lockfile update if new version does not satisfy constraints
+          if (!satisfyingVersion) {
+            continue;
+          }
+        }
         const newConstraint = getNewConstraint(dep, updateLock.constraints);
         const update: ProviderLockUpdate = {
           // TODO #22198

--- a/lib/modules/manager/terraform/lockfile/index.ts
+++ b/lib/modules/manager/terraform/lockfile/index.ts
@@ -184,8 +184,10 @@ export async function updateArtifacts({
             updateLock.constraints,
           );
 
-          // skip lockfile update if new version does not satisfy constraints
           if (!satisfyingVersion) {
+            logger.debug(
+              `Skipping. Lockfile update with "${newVersion}" does not statisfy constraints "${updateLock.constraints}" for "${packageName}"`,
+            );
             continue;
           }
         }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Skip any changes for lockfile update when version is pinned 

I think this improves the current situation, but it is not perfect as it happens while generating, rather than a decision made on the extracted package, so the update still shows in the dashboard for example.

A deeper refactor might be needed to get the right solution, since the decision needs to be base on the `currentValue`s of all the sibling and parent modules, or the lockfile's `constraints` since this is what it aggregates, but it is not currently extracted with the package. Maybe `constraints` should be the `currentValue`, but it likely has other implications

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

- #27222

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
