### PR TITLE
fix(manager/pub): prioritise SDK version constraint from `pubspec.yaml` over `pubspec.lock`

### DIFF
--- a/lib/modules/manager/pub/artifacts.ts
+++ b/lib/modules/manager/pub/artifacts.ts
@@ -10,7 +10,7 @@ import {
   writeLocalFile,
 } from '../../../util/fs';
 import type { UpdateArtifact, UpdateArtifactsResult, Upgrade } from '../types';
-import { parsePubspecLock } from './utils';
+import { parsePubspec, parsePubspecLock } from './utils';
 
 const SDK_NAMES = ['dart', 'flutter'];
 const PUB_GET_COMMAND = 'pub get --no-precompile';
@@ -45,8 +45,14 @@ export async function updateArtifacts({
 
     let constraint = config.constraints?.[toolName];
     if (!constraint) {
-      const pubspecLock = parsePubspecLock(lockFileName, oldLockFileContent);
-      constraint = pubspecLock?.sdks[toolName];
+      const pubspec = parsePubspec(packageFileName, newPackageFileContent);
+      const pubspecToolName = isFlutter ? 'flutter' : 'sdk';
+      constraint = pubspec?.environment[pubspecToolName];
+
+      if (!constraint) {
+        const pubspecLock = parsePubspecLock(lockFileName, oldLockFileContent);
+        constraint = pubspecLock?.sdks[toolName];
+      }
     }
 
     const execOptions: ExecOptions = {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

For the `pub` manager artifacts update, prioritise to use the SDK version from `pubspec.yaml` over `pubspec.lock` as the tool version constraint to update the artifacts.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

If you define a specific SDK version, e.g. `flutter: 3.16.9` in [pubspec.yaml](https://github.com/zeshuaro/appainter/blob/main/pubspec.yaml#L9), the resulted [pubspec.lock](https://github.com/zeshuaro/appainter/blob/main/pubspec.lock#L1420) would still generate a ranged version `flutter: ">=3.16.9"`.

Right now, Renovate uses the version from the lock file to determine the tool/SDK version constraint, which might not be accurate to what's defined in `pubspec.yaml`. And causing the wrong version to be used to update the artifacts. For example, the current latest Flutter version is 3.19.0 which would conflict to what's defined in `pubspec.yaml` and may fail to update artifacts.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
