### PR TITLE
feat(presets): add group for storybook

### DIFF
--- a/lib/config/presets/internal/group.ts
+++ b/lib/config/presets/internal/group.ts
@@ -742,6 +742,17 @@ const staticGroups = {
       },
     ],
   },
+  storybook: {
+    description: 'Group Storybook packages together.',
+    packageRules: [
+      {
+        groupName: 'storybook packages',
+        groupSlug: 'storybook',
+        matchDatasources: ['npm'],
+        matchPackagePatterns: ['^storybook$', '^@storybook/'],
+      }
+    ],
+  },
   symfony: {
     description: 'Group PHP Symfony packages together.',
     packageRules: [

--- a/lib/config/presets/internal/group.ts
+++ b/lib/config/presets/internal/group.ts
@@ -468,6 +468,7 @@ const staticGroups = {
       'group:springStatemachine',
       'group:springWebflow',
       'group:springWs',
+      'group:storybook',
       'group:symfony',
     ],
     ignoreDeps: [], // Hack to improve onboarding PR description


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

This adds a group for the widely used ["Storybook"](https://storybook.js.org/) package.

There is a global `storybook` package on npmjs.com, and a `@storybook/` group.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

This removes the need for people to maintain their own config for this, which I am guessing is not uncommon.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
