### PR TITLE
fix(manager/bundler): Update Gemfile.lock when only Ruby upgraded

### DIFF
--- a/lib/modules/manager/bundler/artifacts.spec.ts
+++ b/lib/modules/manager/bundler/artifacts.spec.ts
@@ -946,6 +946,27 @@ describe('modules/manager/bundler/artifacts', () => {
           { cmd: 'bundler lock --minor --conservative --update foo' },
         ]);
       });
+
+      it('updates the Gemfile.lock when ruby upgraded', async () => {
+        // See https://github.com/renovatebot/renovate/issues/15114
+        fs.readLocalFile.mockResolvedValue('Current Gemfile.lock');
+        const execSnapshots = mockExecSequence([{ stdout: '', stderr: '' }]);
+        git.getRepoStatus.mockResolvedValueOnce(
+          partial<StatusResult>({
+            modified: ['Gemfile.lock'],
+          }),
+        );
+
+        const res = await updateArtifacts({
+          packageFileName: 'Gemfile',
+          updatedDeps: [{ depName: 'ruby', updateType: 'patch' }],
+          newPackageFileContent: '{}',
+          config,
+        });
+
+        expect(res).toMatchObject([{ file: { path: 'Gemfile.lock' } }]);
+        expect(execSnapshots).toMatchObject([{ cmd: 'bundler lock' }]);
+      });
     });
   });
 });

--- a/lib/modules/manager/bundler/artifacts.ts
+++ b/lib/modules/manager/bundler/artifacts.ts
@@ -121,6 +121,13 @@ export async function updateArtifacts(
           commands.push(cmd);
         }
       }
+
+      const rubyUpgraded = updatedDeps
+        .map((dep) => dep.depName)
+        .includes('ruby');
+      if (rubyUpgraded) {
+        commands.push('bundler lock');
+      }
     }
 
     const bundlerHostRules = findAllAuthenticatable({


### PR DESCRIPTION
## Changes

Updates Gemfile.lock even if the only version changed is Ruby.

## Context

Fixes #15114 again which was broken by 77e106841cd4490353ca23205227ee57fdefef28.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository