### PR TITLE
fix(versionCompatibility): support datasources without digests

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -3868,6 +3868,19 @@ This feature _can_ be used in combination with `extractVersion` although that's 
 When combined, `extractVersion` is applied to datasource results first, and then `versionCompatibility`.
 `extractVersion` should be used when the raw version string returned by the `datasource` contains extra details (such as a `v` prefix) when compared to the value/version used within the repository.
 
+During the lookup phase, Renovate evaluates the `versionCompatibility` regex against the `currentValue` string.
+If there is a match, the version part is stored internally temporarily as `compareValue` and the compatibility part stored as `currentCompatibility`.
+Storing `currentCompatibility` allows Renovate to reuse this value later to filter for new versions with the same compatibility.
+Renovate applies this compatibility check to datasource lookup results by passing both the `versionCompatibility` and `currentCompatibility` strings to a filter.
+
+For a new version to be allowed, it must:
+
+- Satisfy the `versionCompatibility` regex, and
+- Have the same `compatibility` part as the `currentValue`
+
+At this point, Renovate's core lookup logic is comparing versions to versions, and ignoring compatibility strings like `-jre8`.
+Finally, once updates are decided, Renovate restores the compatibility part to the `newValue` result.
+
 ## versioning
 
 Usually, each language or package manager has a specific type of "versioning":

--- a/lib/workers/repository/process/lookup/index.spec.ts
+++ b/lib/workers/repository/process/lookup/index.spec.ts
@@ -9,6 +9,7 @@ import { DockerDatasource } from '../../../../modules/datasource/docker';
 import { GitRefsDatasource } from '../../../../modules/datasource/git-refs';
 import { GithubReleasesDatasource } from '../../../../modules/datasource/github-releases';
 import { GithubTagsDatasource } from '../../../../modules/datasource/github-tags';
+import { MavenDatasource } from '../../../../modules/datasource/maven';
 import { NpmDatasource } from '../../../../modules/datasource/npm';
 import { PackagistDatasource } from '../../../../modules/datasource/packagist';
 import { PypiDatasource } from '../../../../modules/datasource/pypi';
@@ -16,6 +17,7 @@ import { id as composerVersioningId } from '../../../../modules/versioning/compo
 import { id as debianVersioningId } from '../../../../modules/versioning/debian';
 import { id as dockerVersioningId } from '../../../../modules/versioning/docker';
 import { id as gitVersioningId } from '../../../../modules/versioning/git';
+import { id as mavenVersioningId } from '../../../../modules/versioning/maven';
 import { id as nodeVersioningId } from '../../../../modules/versioning/node';
 import { id as npmVersioningId } from '../../../../modules/versioning/npm';
 import { id as pep440VersioningId } from '../../../../modules/versioning/pep440';
@@ -57,6 +59,8 @@ describe('workers/repository/process/lookup/index', () => {
     DockerDatasource.prototype,
     'getReleases',
   );
+
+  const getMavenReleases = jest.spyOn(MavenDatasource.prototype, 'getReleases');
 
   const getDockerDigest = jest.spyOn(DockerDatasource.prototype, 'getDigest');
 
@@ -3508,6 +3512,42 @@ describe('workers/repository/process/lookup/index', () => {
           },
         ],
         versioning: 'node',
+        warnings: [],
+      });
+    });
+
+    it('applies versionCompatibility for maven', async () => {
+      config.currentValue = '12.4.2.jre8';
+      config.packageName = 'com.microsoft.sqlserver:mssql-jdbc';
+      config.versioning = mavenVersioningId;
+      config.versionCompatibility =
+        '^(?<version>.*)(?<compatibility>\\.jre.*)$';
+      config.datasource = MavenDatasource.id;
+      getMavenReleases.mockResolvedValueOnce({
+        releases: [
+          { version: '12.4.2.jre8' },
+          { version: '12.5.0.jre11' },
+          { version: '12.6.1.jre8' },
+          { version: '12.6.1.jre11' },
+          { version: '12.6.2.jre11' },
+        ],
+      });
+
+      const res = await Result.wrap(
+        lookup.lookupUpdates(config),
+      ).unwrapOrThrow();
+
+      expect(res).toMatchObject({
+        currentVersion: '12.4.2',
+        updates: [
+          {
+            bucket: 'non-major',
+            newValue: '12.6.1.jre8',
+            newVersion: '12.6.1',
+            updateType: 'minor',
+          },
+        ],
+        versioning: 'maven',
         warnings: [],
       });
     });

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -475,23 +475,6 @@ export async function lookupUpdates(
         config.registryUrls = [res.registryUrl];
       }
 
-      // massage versionCompatibility
-      if (
-        is.string(config.currentValue) &&
-        is.string(compareValue) &&
-        is.string(config.versionCompatibility)
-      ) {
-        for (const update of res.updates) {
-          logger.debug({ update });
-          if (is.string(config.currentValue) && is.string(update.newValue)) {
-            update.newValue = config.currentValue.replace(
-              compareValue,
-              update.newValue,
-            );
-          }
-        }
-      }
-
       // update digest for all
       for (const update of res.updates) {
         if (config.pinDigests === true || config.currentDigest) {
@@ -536,6 +519,24 @@ export async function lookupUpdates(
         }
       }
     }
+
+    // massage versionCompatibility
+    if (
+      is.string(config.currentValue) &&
+      is.string(compareValue) &&
+      is.string(config.versionCompatibility)
+    ) {
+      for (const update of res.updates) {
+        logger.debug({ update });
+        if (is.string(config.currentValue) && is.string(update.newValue)) {
+          update.newValue = config.currentValue.replace(
+            compareValue,
+            update.newValue,
+          );
+        }
+      }
+    }
+
     if (res.updates.length) {
       delete res.skipReason;
     }


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Some essential logic was mistakenly nested inside an "if (datasource.supportsDigests)" branch

## Context

Fixes #27489

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
