### PR TITLE
docs(automerge): warn when using automergeSchedule and platformAutomerge

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -238,7 +238,7 @@ To configure this option refer to [`schedule`](#schedule) as the syntax is the s
 <!-- prettier-ignore -->
 !!! warning
     When `platformAutomerge` is enabled, Renovate enqueues the platform PR automerge at time of creation, so the schedule specified in `automergeSchedule` cannot be followed.
-    As a workaround, set `platformAutomerge: false`, configure `schedule` to control PR creation, and enforce successful pipelines before merging on your platform.
+    If it's essential that automerging only happens within the specific `automergeSchedule` time window, then you need to set `platformAutomerge` to `false` and instead rely on Renovate's automerge instead of the platform one.
 
 ## automergeStrategy
 

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -237,7 +237,7 @@ To configure this option refer to [`schedule`](#schedule) as the syntax is the s
 
 <!-- prettier-ignore -->
 !!! warning
-    When `platformAutomerge` is enabled, the schedule specified in `automergeSchedule` will not be followed.
+    When `platformAutomerge` is enabled, Renovate enqueues the platform PR automerge at time of creation, so the schedule specified in `automergeSchedule` cannot be followed.
     As a workaround, set `platformAutomerge: false`, configure `schedule` to control PR creation, and enforce successful pipelines before merging on your platform.
 
 ## automergeStrategy

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -235,6 +235,11 @@ Use the `automergeSchedule` option to define times of week or month during which
 The default value for `automergeSchedule` is "at any time", which functions the same as setting a `null` schedule.
 To configure this option refer to [`schedule`](#schedule) as the syntax is the same.
 
+<!-- prettier-ignore -->
+!!! warning
+    When `platformAutomerge` is enabled, the schedule specified in `automergeSchedule` will not be followed.
+    As a workaround, set `platformAutomerge: false`, configure `schedule` to control PR creation, and enforce successful pipelines before merging on your platform.
+
 ## automergeStrategy
 
 The automerge strategy defaults to `auto`, so Renovate decides how to merge pull requests as best it can.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Multiple people have reported in https://github.com/renovatebot/renovate/issues/21436 that they have not understood that `platformAutomerge` disables `automergeSchedule`, and have called for this to be in the documentation.

## Context

See https://github.com/renovatebot/renovate/issues/21436

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
