### PR TITLE
feat(replacements): replace cpx with maintenance fork cpx2

### DIFF
--- a/lib/config/presets/internal/replacements.ts
+++ b/lib/config/presets/internal/replacements.ts
@@ -13,6 +13,7 @@ export const presets: Record<string, Preset> = {
       'replacements:apollo-server-to-scoped',
       'replacements:babel-eslint-to-eslint-parser',
       'replacements:containerbase',
+      'replacements:cpx-to-maintenance-fork',
       'replacements:cucumber-to-scoped',
       'replacements:fakerjs-to-scoped',
       'replacements:fastify-to-scoped',
@@ -168,6 +169,17 @@ export const presets: Record<string, Preset> = {
         matchDatasources: ['docker'],
         matchPackageNames: ['ghcr.io/renovatebot/renovate'],
         matchPackagePatterns: ['^(?:docker\\.io/)?renovate/renovate$'],
+      },
+    ],
+  },
+  'cpx-to-maintenance-fork': {
+    description: 'Maintenance fork of `cpx`',
+    packageRules: [
+      {
+        matchDatasources: ['npm'],
+        matchPackageNames: ['cpx'],
+        replacementName: 'cpx2',
+        replacementVersion: '2.0.0',
       },
     ],
   },


### PR DESCRIPTION
## Changes

Add a replacements preset to replace [cpx](https://www.npmjs.com/package/cpx) with the maintenance fork, [cpx2](https://www.npmjs.com/package/cpx2).

## Context

Renovate already includes a preset for a maintenance fork, [npm-run-all2](https://www.npmjs.com/package/npm-run-all2), from the same author. Replacing the unmaintained package with the maintenance fork helps reduce manual work for project maintainers and moves them to a maintained version of the dependency.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

