### PR TITLE
feat(asdf): Add tuist to the list of upgradeable tools

### DIFF
--- a/lib/modules/manager/asdf/upgradeable-tooling.ts
+++ b/lib/modules/manager/asdf/upgradeable-tooling.ts
@@ -661,6 +661,13 @@ export const upgradeableTooling: Record<string, ToolingDefinition> = {
       extractVersion: '^v(?<version>\\S+)',
     },
   },
+  tuist: {
+    asdfPluginUrl: 'https://github.com/asdf-community/asdf-tuist',
+    config: {
+      datasource: GithubTagsDatasource.id,
+      packageName: 'tuist/tuist',
+    },
+  },
   typos: {
     asdfPluginUrl: 'https://github.com/aschiavon91/asdf-typos',
     config: {


### PR DESCRIPTION
Related: https://github.com/asdf-community/asdf-tuist/issues/15

## Changes
I'm adding [tuist](https://github.com/asdf-community/asdf-tuist) to the list of upgradeable tools for asdf.

## Context
I'm a maintainer of Tuist. A user reported that renovatebot doesn't update Tuist because it's not listed in this repository. This PR extends the list to include Tuist so that users can use Renovatebot.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository