### PR TITLE
fix(versioning/regex): don't use semver for compare

### DIFF
--- a/lib/modules/versioning/regex/index.spec.ts
+++ b/lib/modules/versioning/regex/index.spec.ts
@@ -356,6 +356,12 @@ describe('modules/versioning/regex/index', () => {
       'regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(:?-(?<compatibility>.+)(?<build>\\d+)-r(?<revision>\\d+))?$',
     );
 
+    const versions = [
+      '12.7.0-debian-10-r69',
+      '12.7.0-debian-10-r100',
+      '12.7.0-debian-10-r101',
+    ];
+
     it.each`
       version                    | expected
       ${'12.7.0-debian-10-r69'}  | ${true}
@@ -385,13 +391,31 @@ describe('modules/versioning/regex/index', () => {
 
     it.each`
       version                  | range                     | expected
-      ${'12.7.0-debian-9-r69'} | ${'12.7.0-debian-10-r69'} | ${true}
-      ${'12.7.0-debian-9-r69'} | ${'12.7.0-debian-10-r68'} | ${true}
+      ${'12.7.0-debian-9-r69'} | ${'12.7.0-debian-9-r69'}  | ${true}
+      ${'12.7.0-debian-9-r69'} | ${'12.7.0-debian-10-r68'} | ${false}
     `(
       'matches("$version", "$range") === $expected',
       ({ version, range, expected }) => {
         expect(re.matches(version, range)).toBe(expected);
       },
     );
+
+    it('getSatisfyingVersion', () => {
+      expect(re.getSatisfyingVersion(versions, '12.7.0-debian-10-r100')).toBe(
+        '12.7.0-debian-10-r100',
+      );
+      expect(
+        re.getSatisfyingVersion(versions, '12.7.0-debian-12-r100'),
+      ).toBeNull();
+    });
+
+    it('minSatisfyingVersion', () => {
+      expect(re.minSatisfyingVersion(versions, '12.7.0-debian-10-r100')).toBe(
+        '12.7.0-debian-10-r100',
+      );
+      expect(
+        re.minSatisfyingVersion(versions, '12.7.0-debian-12-r100'),
+      ).toBeNull();
+    });
   });
 });

--- a/lib/modules/versioning/regex/index.ts
+++ b/lib/modules/versioning/regex/index.ts
@@ -1,5 +1,3 @@
-import is from '@sindresorhus/is';
-import semver from 'semver';
 import { CONFIG_VALIDATION } from '../../../constants/error-messages';
 import { regEx } from '../../../util/regex';
 import { GenericVersion, GenericVersioningApi } from '../generic';
@@ -16,15 +14,6 @@ export interface RegExpVersion extends GenericVersion {
    * never try to update to a version with a different compatibility.
    */
   compatibility: string;
-}
-
-// convenience method for passing a Version object into any semver.* method.
-function asSemver(version: RegExpVersion): string {
-  let vstring = `${version.release[0]}.${version.release[1]}.${version.release[2]}`;
-  if (is.nonEmptyString(version.prerelease)) {
-    vstring += `-${version.prerelease}`;
-  }
-  return vstring;
 }
 
 export class RegExpVersioningApi extends GenericVersioningApi<RegExpVersion> {
@@ -100,58 +89,6 @@ export class RegExpVersioningApi extends GenericVersioningApi<RegExpVersion> {
       parsedVersion &&
       parsedCurrent &&
       parsedVersion.compatibility === parsedCurrent.compatibility
-    );
-  }
-
-  override isLessThanRange(version: string, range: string): boolean {
-    const parsedVersion = this._parse(version);
-    const parsedRange = this._parse(range);
-    return !!(
-      parsedVersion &&
-      parsedRange &&
-      semver.ltr(asSemver(parsedVersion), asSemver(parsedRange))
-    );
-  }
-
-  override getSatisfyingVersion(
-    versions: string[],
-    range: string,
-  ): string | null {
-    const parsedRange = this._parse(range);
-    return parsedRange
-      ? semver.maxSatisfying(
-          versions
-            .map((v) => this._parse(v))
-            .filter(is.truthy)
-            .map(asSemver),
-          asSemver(parsedRange),
-        )
-      : null;
-  }
-
-  override minSatisfyingVersion(
-    versions: string[],
-    range: string,
-  ): string | null {
-    const parsedRange = this._parse(range);
-    return parsedRange
-      ? semver.minSatisfying(
-          versions
-            .map((v) => this._parse(v))
-            .filter(is.truthy)
-            .map(asSemver),
-          asSemver(parsedRange),
-        )
-      : null;
-  }
-
-  override matches(version: string, range: string): boolean {
-    const parsedVersion = this._parse(version);
-    const parsedRange = this._parse(range);
-    return !!(
-      parsedVersion &&
-      parsedRange &&
-      semver.satisfies(asSemver(parsedVersion), asSemver(parsedRange))
     );
   }
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
No longer coerce any regex version to semver, we don't support ranges anyways.
<!-- Describe what behavior is changed by this PR. -->

## Context
- fix #27510 (this is only a partial fix)
- https://github.com/renovate-reproductions/27510-multipart-regex-versioning/pull/4
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
