### PR TITLE
fix(merge-confidence): ensure URL path has trailing slashes

### DIFF
--- a/lib/util/merge-confidence/index.spec.ts
+++ b/lib/util/merge-confidence/index.spec.ts
@@ -350,10 +350,10 @@ describe('util/merge-confidence/index', () => {
       it('uses a custom base url containing path', async () => {
         const renovateApi = 'https://domain.com/proxy/renovate-api';
         process.env.RENOVATE_X_MERGE_CONFIDENCE_API_BASE_URL = renovateApi;
-
         httpMock.scope(renovateApi).get(`/api/mc/availability`).reply(200);
 
         await expect(initMergeConfidence()).toResolve();
+
         expect(logger.trace).toHaveBeenCalledWith(
           expect.anything(),
           'using merge confidence API base found in environment variables',

--- a/lib/util/merge-confidence/index.spec.ts
+++ b/lib/util/merge-confidence/index.spec.ts
@@ -349,13 +349,9 @@ describe('util/merge-confidence/index', () => {
 
       it('uses a custom base url containing path', async () => {
         const renovateApi = 'https://domain.com/proxy/renovate-api';
-        process.env.RENOVATE_X_MERGE_CONFIDENCE_API_BASE_URL =
-          renovateApi;
+        process.env.RENOVATE_X_MERGE_CONFIDENCE_API_BASE_URL = renovateApi;
 
-        httpMock
-          .scope(renovateApi)
-          .get(`/api/mc/availability`)
-          .reply(200);
+        httpMock.scope(renovateApi).get(`/api/mc/availability`).reply(200);
 
         await expect(initMergeConfidence()).toResolve();
         expect(logger.trace).toHaveBeenCalledWith(

--- a/lib/util/merge-confidence/index.spec.ts
+++ b/lib/util/merge-confidence/index.spec.ts
@@ -347,6 +347,27 @@ describe('util/merge-confidence/index', () => {
         );
       });
 
+      it('uses a custom base url containing path', async () => {
+        const renovateApi = 'https://domain.com/proxy/renovate-api';
+        process.env.RENOVATE_X_MERGE_CONFIDENCE_API_BASE_URL =
+          renovateApi;
+
+        httpMock
+          .scope(renovateApi)
+          .get(`/api/mc/availability`)
+          .reply(200);
+
+        await expect(initMergeConfidence()).toResolve();
+        expect(logger.trace).toHaveBeenCalledWith(
+          expect.anything(),
+          'using merge confidence API base found in environment variables',
+        );
+        expect(logger.debug).toHaveBeenCalledWith(
+          expect.anything(),
+          'merge confidence API - successfully authenticated',
+        );
+      });
+
       it('resolves if no token', async () => {
         hostRules.clear();
 

--- a/lib/util/merge-confidence/index.ts
+++ b/lib/util/merge-confidence/index.ts
@@ -166,7 +166,14 @@ async function queryApi(
   }
 
   const escapedPackageName = packageName.replace('/', '%2f');
-  const url = joinPaths(apiBaseUrl, 'api/mc/json', datasource, escapedPackageName, currentVersion, newVersion);
+  const url = joinPaths(
+    apiBaseUrl,
+    'api/mc/json',
+    datasource,
+    escapedPackageName,
+    currentVersion,
+    newVersion,
+  );
   const cacheKey = `${token}:${url}`;
   const cachedResult = await packageCache.get(hostType, cacheKey);
 

--- a/lib/util/merge-confidence/index.ts
+++ b/lib/util/merge-confidence/index.ts
@@ -1,5 +1,4 @@
 import is from '@sindresorhus/is';
-import upath from 'upath';
 import { supportedDatasources as presetSupportedDatasources } from '../../config/presets/internal/merge-confidence';
 import type { UpdateType } from '../../config/types';
 import { logger } from '../../logger';
@@ -8,7 +7,7 @@ import * as packageCache from '../cache/package';
 import { parseJson } from '../common';
 import * as hostRules from '../host-rules';
 import { Http } from '../http';
-import { ensureTrailingSlash } from '../url';
+import { ensureTrailingSlash, joinUrlParts } from '../url';
 import { MERGE_CONFIDENCE } from './common';
 import type { MergeConfidence } from './types';
 
@@ -166,7 +165,7 @@ async function queryApi(
   }
 
   const escapedPackageName = packageName.replace('/', '%2f');
-  const url = joinPaths(
+  const url = joinUrlParts(
     apiBaseUrl,
     'api/mc/json',
     datasource,
@@ -226,7 +225,7 @@ export async function initMergeConfidence(): Promise<void> {
     return;
   }
 
-  const url = joinPaths(apiBaseUrl, 'api/mc/availability');
+  const url = joinUrlParts(apiBaseUrl, 'api/mc/availability');
   try {
     await http.get(url);
   } catch (err) {
@@ -295,8 +294,4 @@ function apiErrorHandler(err: any): void {
   }
 
   logger.warn({ err }, 'error fetching merge confidence data');
-}
-
-function joinPaths(...paths: string[]): string {
-  return upath.posix.join(...paths);
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Use ~~`upath.posix.join`~~ `joinUrlParts` to join url paths.
Although redundant (because above), ensure `baseUrl` trailing slash.

<!-- Describe what behavior is changed by this PR. -->

## Context
- https://github.com/mend/renovate-ce-ee/discussions/442#discussioncomment-8455069
- URL constructor does not add trailing slashes for url paths
![image](https://github.com/renovatebot/renovate/assets/97394622/ae00f051-9fcd-4278-b89a-9d85c5ef3a2d)

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
