### PR TITLE
fix(datasource/go): Remove .git/v2 in go package name to retrieve it correctly

### DIFF
--- a/lib/modules/datasource/go/base.spec.ts
+++ b/lib/modules/datasource/go/base.spec.ts
@@ -260,7 +260,7 @@ describe('modules/datasource/go/base', () => {
         hostRules.hostType.mockReturnValue('gitlab');
         httpMock
           .scope('https://my.custom.domain')
-          .get('/golang/subgroup/myrepo.git/v2?go-get=1')
+          .get('/golang/subgroup/myrepo?go-get=1')
           .reply(200, Fixtures.get('go-get-gitlab-ee-private-subgroup.html'));
 
         const res = await BaseGoDatasource.getDatasource(

--- a/lib/modules/datasource/go/base.ts
+++ b/lib/modules/datasource/go/base.ts
@@ -77,12 +77,13 @@ export class BaseGoDatasource {
   private static async goGetDatasource(
     goModule: string,
   ): Promise<DataSource | null> {
-    const pkgUrl = `https://${goModule}?go-get=1`;
+    const goModuleUrl = goModule.replace(/\.git\/v2$/, '');
+    const pkgUrl = `https://${goModuleUrl}?go-get=1`;
     // GitHub Enterprise only returns a go-import meta
     const res = (await BaseGoDatasource.http.get(pkgUrl)).body;
     return (
-      BaseGoDatasource.goSourceHeader(res, goModule) ??
-      BaseGoDatasource.goImportHeader(res, goModule)
+      BaseGoDatasource.goSourceHeader(res, goModuleUrl) ??
+      BaseGoDatasource.goImportHeader(res, goModuleUrl)
     );
   }
 

--- a/lib/modules/datasource/go/base.ts
+++ b/lib/modules/datasource/go/base.ts
@@ -82,8 +82,8 @@ export class BaseGoDatasource {
     // GitHub Enterprise only returns a go-import meta
     const res = (await BaseGoDatasource.http.get(pkgUrl)).body;
     return (
-      BaseGoDatasource.goSourceHeader(res, goModuleUrl) ??
-      BaseGoDatasource.goImportHeader(res, goModuleUrl)
+      BaseGoDatasource.goSourceHeader(res, goModule) ??
+      BaseGoDatasource.goImportHeader(res, goModule)
     );
   }
 


### PR DESCRIPTION
## Changes

Remove .git/v2 from go module package names to find the correct repository.

## Context

A typical way of releasing a go package in the version 2 is adding v2 at the end of the repository e.g.:

v1: https://gitlab.example.com/project.git
v2: https://gitlab.example.com/project.git/v2

https://go.dev/blog/v2-go-modules

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [X] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
