### PR TITLE
fix: add replacementName support for hermit

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2995,7 +2995,6 @@ Managers which do not support replacement:
 - `git-submodules`
 - `gomod`
 - `gradle`
-- `hermit`
 - `homebrew`
 - `maven`
 - `regex`

--- a/lib/modules/manager/hermit/artifacts.ts
+++ b/lib/modules/manager/hermit/artifacts.ts
@@ -177,6 +177,8 @@ async function updateHermitPackage(update: UpdateArtifact): Promise<void> {
 
   const toInstall = [];
   const from = [];
+  // storing the old package for replacement
+  const toUninstall = [];
 
   for (const pkg of update.updatedDeps) {
     if (!pkg.depName || !pkg.currentVersion || !pkg.newValue) {
@@ -197,12 +199,18 @@ async function updateHermitPackage(update: UpdateArtifact): Promise<void> {
     }
 
     const depName = pkg.depName;
+    const newName = pkg.newName;
     const currentVersion = pkg.currentVersion;
     const newValue = pkg.newValue;
     const fromPackage = getHermitPackage(depName, currentVersion);
-    const toPackage = getHermitPackage(depName, newValue);
+    // newName will be available for replacement
+    const toPackage = getHermitPackage(newName ?? depName, newValue);
     toInstall.push(toPackage);
     from.push(fromPackage);
+    // skips uninstall for version only replacement
+    if (pkg.updateType === 'replacement' && newName !== depName) {
+      toUninstall.push(depName);
+    }
   }
 
   const execOptions: ExecOptions = {
@@ -211,8 +219,31 @@ async function updateHermitPackage(update: UpdateArtifact): Promise<void> {
     cwdFile: update.packageFileName,
   };
 
-  const packagesToInstall = toInstall.join(' ');
   const fromPackages = from.map(quote).join(' ');
+
+  // when a name replacement happens, need to uninstall the old package
+  if (toUninstall.length > 0) {
+    const packagesToUninstall = toUninstall.join(' ');
+    const uninstallCommands = `./hermit uninstall ${packagesToUninstall}`;
+
+    try {
+      const result = await exec(uninstallCommands, execOptions);
+      logger.trace(
+        { stdout: result.stdout },
+        `hermit uninstall command stdout`,
+      );
+    } catch (e) {
+      logger.warn({ err: e }, `error uninstall hermit package for replacement`);
+      throw new UpdateHermitError(
+        fromPackages,
+        packagesToUninstall,
+        e.stderr,
+        e.stdout,
+      );
+    }
+  }
+
+  const packagesToInstall = toInstall.join(' ');
 
   const execCommands = `./hermit install ${packagesToInstall}`;
   logger.debug(


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Hermit manager now supports replacementName configuration. When replacementName supplied is different to the current package name. `hermit uninstall` will be called for the replaced package.

## Context

https://github.com/renovatebot/renovate/discussions/24883#discussioncomment-8601465

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [X] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [X] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
