### PR TITLE
docs(manager/pip-compile): Explicitly describe output file matching

### DIFF
--- a/lib/modules/manager/pip-compile/readme.md
+++ b/lib/modules/manager/pip-compile/readme.md
@@ -16,6 +16,7 @@ You can "activate" the manager by specifying a `fileMatch` pattern such as:
   }
 }
 ```
+
 `pip-compile` reads the output files to extract the arguments passed to the original command, as such the `fileMatch` must be configured for `*.txt` files and not `*.in`.
 
 ### Assumption of header with a command

--- a/lib/modules/manager/pip-compile/readme.md
+++ b/lib/modules/manager/pip-compile/readme.md
@@ -27,8 +27,14 @@ Because of that `pip-compile` manager poses restrictions on how this file is gen
 - Use default header generation, don't use `--no-header` option.
 - Pass all source files explicitly.
 
-In turn `pip-compile` manager will find all source files and parse them as package files.
-Currently only `*.txt` files associated with `pip_requirements` manager and `setup.py` files associated with `pip_setup` manager are handled.
+In turn `pip-compile` manager will find all source files and parse them as package files using their respective managers.
+
+The following files are currently supported:
+
+| Source filename  |            Manager |
+| ---------------: | ------------------ |
+|       `setup.py` |        `pip_setup` |
+|           `*.in` | `pip_requirements` |
 
 Example header:
 

--- a/lib/modules/manager/pip-compile/readme.md
+++ b/lib/modules/manager/pip-compile/readme.md
@@ -31,10 +31,10 @@ In turn `pip-compile` manager will find all source files and parse them as packa
 
 The following files are currently supported:
 
-| Source filename  |            Manager |
-| ---------------: | ------------------ |
-|       `setup.py` |        `pip_setup` |
-|           `*.in` | `pip_requirements` |
+| Source filename | Manager            |
+| --------------: | ------------------ |
+|      `setup.py` | `pip_setup`        |
+|          `*.in` | `pip_requirements` |
 
 Example header:
 

--- a/lib/modules/manager/pip-compile/readme.md
+++ b/lib/modules/manager/pip-compile/readme.md
@@ -16,16 +16,19 @@ You can "activate" the manager by specifying a `fileMatch` pattern such as:
   }
 }
 ```
+`pip-compile` reads the output files to extract the arguments passed to the original command, as such the `fileMatch` must be configured for
+`*.txt` files and not `*.in`.
 
 ### Assumption of header with a command
 
-If Renovate matches a `pip-compile` output file it will extract original command that was used to create it from header in this file. Because of that `pip-compile` manager poses restrictions on how this file is generated:
+As Renovate matches a `pip-compile` output file it will extract original command that was used to create it from header in this file.
+Because of that `pip-compile` manager poses restrictions on how this file is generated:
 
 - Use default header generation, don't use `--no-header` option.
 - Pass all source files explicitly.
 
 In turn `pip-compile` manager will find all source files and parse them as package files.
-Currently only `*.in` files associated with `pip_requirements` manager and `setup.py` files associated with `pip_setup` manager are handled.
+Currently only `*.txt` files associated with `pip_requirements` manager and `setup.py` files associated with `pip_setup` manager are handled.
 
 Example header:
 

--- a/lib/modules/manager/pip-compile/readme.md
+++ b/lib/modules/manager/pip-compile/readme.md
@@ -16,8 +16,7 @@ You can "activate" the manager by specifying a `fileMatch` pattern such as:
   }
 }
 ```
-`pip-compile` reads the output files to extract the arguments passed to the original command, as such the `fileMatch` must be configured for
-`*.txt` files and not `*.in`.
+`pip-compile` reads the output files to extract the arguments passed to the original command, as such the `fileMatch` must be configured for `*.txt` files and not `*.in`.
 
 ### Assumption of header with a command
 


### PR DESCRIPTION


## Changes

Updates the docs for the pip-compile manager, explicitly mentioning output file matching

- Remove references to `*.in` files
- Add sentence explicitly mentioning output file matching in fileMatch section


## Context

Output file matching was introdocued in #26858 but the documention still mentioned `*.in` files, and the automatic config migration lead to me opening #27559 

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
