### PR TITLE
fix(lookup): use newValue for digest lookup, not compareValue

### DIFF
--- a/lib/workers/repository/process/lookup/index.spec.ts
+++ b/lib/workers/repository/process/lookup/index.spec.ts
@@ -3489,6 +3489,27 @@ describe('workers/repository/process/lookup/index', () => {
         lookup.lookupUpdates(config),
       ).unwrapOrThrow();
 
+      expect(getDockerDigest.mock.calls).toEqual([
+        [
+          {
+            currentDigest: 'aaa111',
+            currentValue: '18.10.0-alpine',
+            packageName: 'node',
+            registryUrl: 'https://index.docker.io',
+          },
+          '18.19.0-alpine',
+        ],
+        [
+          {
+            currentDigest: 'aaa111',
+            currentValue: '18.10.0-alpine',
+            packageName: 'node',
+            registryUrl: 'https://index.docker.io',
+          },
+          '18.10.0-alpine',
+        ],
+      ]);
+
       expect(res).toEqual({
         currentVersion: '18.10.0',
         fixedVersion: '18.10.0',

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -442,6 +442,24 @@ export async function lookupUpdates(
     } else if (compareValue && versioning.isSingleVersion(compareValue)) {
       res.fixedVersion = compareValue.replace(regEx(/^=+/), '');
     }
+
+    // massage versionCompatibility
+    if (
+      is.string(config.currentValue) &&
+      is.string(compareValue) &&
+      is.string(config.versionCompatibility)
+    ) {
+      for (const update of res.updates) {
+        logger.debug({ update });
+        if (is.string(config.currentValue) && is.string(update.newValue)) {
+          update.newValue = config.currentValue.replace(
+            compareValue,
+            update.newValue,
+          );
+        }
+      }
+    }
+
     // Add digests if necessary
     if (supportsDigests(config.datasource)) {
       if (config.currentDigest) {
@@ -449,7 +467,7 @@ export async function lookupUpdates(
           // digest update
           res.updates.push({
             updateType: 'digest',
-            newValue: compareValue,
+            newValue: config.currentValue,
           });
         }
       } else if (config.pinDigests) {
@@ -459,7 +477,7 @@ export async function lookupUpdates(
           res.updates.push({
             isPinDigest: true,
             updateType: 'pinDigest',
-            newValue: compareValue,
+            newValue: config.currentValue,
           });
         }
       }
@@ -516,23 +534,6 @@ export async function lookupUpdates(
           if (registryUrl && registryUrl !== res.registryUrl) {
             update.registryUrl = registryUrl;
           }
-        }
-      }
-    }
-
-    // massage versionCompatibility
-    if (
-      is.string(config.currentValue) &&
-      is.string(compareValue) &&
-      is.string(config.versionCompatibility)
-    ) {
-      for (const update of res.updates) {
-        logger.debug({ update });
-        if (is.string(config.currentValue) && is.string(update.newValue)) {
-          update.newValue = config.currentValue.replace(
-            compareValue,
-            update.newValue,
-          );
         }
       }
     }


### PR DESCRIPTION



<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Fixes a regression error where digest updates for images with versionCompatibility would be incorrect, e.g. using the digest for node:20.11.1 instead of node:20.11.1-alpine

## Context

Fixes #27584


## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
