### PR TITLE
fix(config-validator): allow default `null` val for `globalOptions`

### DIFF
--- a/lib/config/validation.spec.ts
+++ b/lib/config/validation.spec.ts
@@ -1222,6 +1222,39 @@ describe('config/validation', () => {
         },
       ]);
     });
+
+    it('validates options with different type but defaultValue=null', async () => {
+      const config = {
+        minimumReleaseAge: null,
+        groupName: null,
+        groupSlug: null,
+        dependencyDashboardLabels: null,
+        defaultRegistryUrls: null,
+        registryUrls: null,
+        hostRules: [
+          {
+            artifactAuth: null,
+            concurrentRequestLimit: null,
+            httpsCertificate: null,
+            httpsPrivateKey: null,
+            httpsCertificateAuthority: null,
+          },
+        ],
+        encrypted: null,
+        milestone: null,
+        branchConcurrentLimit: null,
+        hashedBranchLength: null,
+        assigneesSampleSize: null,
+        reviewersSampleSize: null,
+      };
+      const { warnings, errors } = await configValidation.validateConfig(
+        false,
+        // @ts-expect-error: contains invalid values
+        config,
+      );
+      expect(warnings).toHaveLength(0);
+      expect(errors).toHaveLength(0);
+    });
   });
 
   describe('validate globalOptions()', () => {
@@ -1506,6 +1539,26 @@ describe('config/validation', () => {
       };
       const { warnings, errors } = await configValidation.validateConfig(
         true,
+        config,
+      );
+      expect(warnings).toHaveLength(0);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('validates options with different type but defaultValue=null', async () => {
+      const config = {
+        onboardingCommitMessage: null,
+        dryRun: null,
+        logContext: null,
+        endpoint: null,
+        skipInstalls: null,
+        autodiscoverFilter: null,
+        autodiscoverNamespaces: null,
+        autodiscoverTopics: null,
+      };
+      const { warnings, errors } = await configValidation.validateConfig(
+        true,
+        // @ts-expect-error: contains invalid values
         config,
       );
       expect(warnings).toHaveLength(0);

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -818,139 +818,141 @@ async function validateGlobalConfig(
   warnings: ValidationMessage[],
   currentPath: string | undefined,
 ): Promise<void> {
-  if (type === 'string') {
-    if (is.string(val)) {
-      if (
-        key === 'onboardingConfigFileName' &&
-        !configFileNames.includes(val)
-      ) {
+  if (val !== null) {
+    if (type === 'string') {
+      if (is.string(val)) {
+        if (
+          key === 'onboardingConfigFileName' &&
+          !configFileNames.includes(val)
+        ) {
+          warnings.push({
+            topic: 'Configuration Error',
+            message: `Invalid value \`${val}\` for \`${currentPath}\`. The allowed values are ${configFileNames.join(', ')}.`,
+          });
+        } else if (
+          key === 'repositoryCache' &&
+          !['enabled', 'disabled', 'reset'].includes(val)
+        ) {
+          warnings.push({
+            topic: 'Configuration Error',
+            message: `Invalid value \`${val}\` for \`${currentPath}\`. The allowed values are ${['enabled', 'disabled', 'reset'].join(', ')}.`,
+          });
+        } else if (
+          key === 'dryRun' &&
+          !['extract', 'lookup', 'full'].includes(val)
+        ) {
+          warnings.push({
+            topic: 'Configuration Error',
+            message: `Invalid value \`${val}\` for \`${currentPath}\`. The allowed values are ${['extract', 'lookup', 'full'].join(', ')}.`,
+          });
+        } else if (
+          key === 'binarySource' &&
+          !['docker', 'global', 'install', 'hermit'].includes(val)
+        ) {
+          warnings.push({
+            topic: 'Configuration Error',
+            message: `Invalid value \`${val}\` for \`${currentPath}\`. The allowed values are ${['docker', 'global', 'install', 'hermit'].join(', ')}.`,
+          });
+        } else if (
+          key === 'requireConfig' &&
+          !['required', 'optional', 'ignored'].includes(val)
+        ) {
+          warnings.push({
+            topic: 'Configuration Error',
+            message: `Invalid value \`${val}\` for \`${currentPath}\`. The allowed values are ${['required', 'optional', 'ignored'].join(', ')}.`,
+          });
+        } else if (
+          key === 'gitUrl' &&
+          !['default', 'ssh', 'endpoint'].includes(val)
+        ) {
+          warnings.push({
+            topic: 'Configuration Error',
+            message: `Invalid value \`${val}\` for \`${currentPath}\`. The allowed values are ${['default', 'ssh', 'endpoint'].join(', ')}.`,
+          });
+        }
+      } else {
         warnings.push({
           topic: 'Configuration Error',
-          message: `Invalid value \`${val}\` for \`${currentPath}\`. The allowed values are ${configFileNames.join(', ')}.`,
-        });
-      } else if (
-        key === 'repositoryCache' &&
-        !['enabled', 'disabled', 'reset'].includes(val)
-      ) {
-        warnings.push({
-          topic: 'Configuration Error',
-          message: `Invalid value \`${val}\` for \`${currentPath}\`. The allowed values are ${['enabled', 'disabled', 'reset'].join(', ')}.`,
-        });
-      } else if (
-        key === 'dryRun' &&
-        !['extract', 'lookup', 'full'].includes(val)
-      ) {
-        warnings.push({
-          topic: 'Configuration Error',
-          message: `Invalid value \`${val}\` for \`${currentPath}\`. The allowed values are ${['extract', 'lookup', 'full'].join(', ')}.`,
-        });
-      } else if (
-        key === 'binarySource' &&
-        !['docker', 'global', 'install', 'hermit'].includes(val)
-      ) {
-        warnings.push({
-          topic: 'Configuration Error',
-          message: `Invalid value \`${val}\` for \`${currentPath}\`. The allowed values are ${['docker', 'global', 'install', 'hermit'].join(', ')}.`,
-        });
-      } else if (
-        key === 'requireConfig' &&
-        !['required', 'optional', 'ignored'].includes(val)
-      ) {
-        warnings.push({
-          topic: 'Configuration Error',
-          message: `Invalid value \`${val}\` for \`${currentPath}\`. The allowed values are ${['required', 'optional', 'ignored'].join(', ')}.`,
-        });
-      } else if (
-        key === 'gitUrl' &&
-        !['default', 'ssh', 'endpoint'].includes(val)
-      ) {
-        warnings.push({
-          topic: 'Configuration Error',
-          message: `Invalid value \`${val}\` for \`${currentPath}\`. The allowed values are ${['default', 'ssh', 'endpoint'].join(', ')}.`,
+          message: `Configuration option \`${currentPath}\` should be a string.`,
         });
       }
-    } else {
-      warnings.push({
-        topic: 'Configuration Error',
-        message: `Configuration option \`${currentPath}\` should be a string.`,
-      });
-    }
-  } else if (type === 'integer') {
-    if (!is.number(val)) {
-      warnings.push({
-        topic: 'Configuration Error',
-        message: `Configuration option \`${currentPath}\` should be an integer. Found: ${JSON.stringify(
-          val,
-        )} (${typeof val}).`,
-      });
-    }
-  } else if (type === 'boolean') {
-    if (val !== true && val !== false) {
-      warnings.push({
-        topic: 'Configuration Error',
-        message: `Configuration option \`${currentPath}\` should be a boolean. Found: ${JSON.stringify(
-          val,
-        )} (${typeof val}).`,
-      });
-    }
-  } else if (type === 'array') {
-    if (is.array(val)) {
-      if (key === 'gitNoVerify') {
-        const allowedValues = ['commit', 'push'];
-        for (const value of val as string[]) {
-          if (!allowedValues.includes(value)) {
-            warnings.push({
-              topic: 'Configuration Error',
-              message: `Invalid value for \`${currentPath}\`. The allowed values are ${allowedValues.join(', ')}.`,
-            });
+    } else if (type === 'integer') {
+      if (!is.number(val)) {
+        warnings.push({
+          topic: 'Configuration Error',
+          message: `Configuration option \`${currentPath}\` should be an integer. Found: ${JSON.stringify(
+            val,
+          )} (${typeof val}).`,
+        });
+      }
+    } else if (type === 'boolean') {
+      if (val !== true && val !== false) {
+        warnings.push({
+          topic: 'Configuration Error',
+          message: `Configuration option \`${currentPath}\` should be a boolean. Found: ${JSON.stringify(
+            val,
+          )} (${typeof val}).`,
+        });
+      }
+    } else if (type === 'array') {
+      if (is.array(val)) {
+        if (key === 'gitNoVerify') {
+          const allowedValues = ['commit', 'push'];
+          for (const value of val as string[]) {
+            if (!allowedValues.includes(value)) {
+              warnings.push({
+                topic: 'Configuration Error',
+                message: `Invalid value for \`${currentPath}\`. The allowed values are ${allowedValues.join(', ')}.`,
+              });
+            }
           }
         }
+      } else {
+        warnings.push({
+          topic: 'Configuration Error',
+          message: `Configuration option \`${currentPath}\` should be a list (Array).`,
+        });
       }
-    } else {
-      warnings.push({
-        topic: 'Configuration Error',
-        message: `Configuration option \`${currentPath}\` should be a list (Array).`,
-      });
-    }
-  } else if (type === 'object') {
-    if (is.plainObject(val)) {
-      if (key === 'onboardingConfig') {
-        const subValidation = await validateConfig(false, val);
-        for (const warning of subValidation.warnings.concat(
-          subValidation.errors,
-        )) {
-          warnings.push(warning);
-        }
-      } else if (key === 'force') {
-        const subValidation = await validateConfig(true, val);
-        for (const warning of subValidation.warnings.concat(
-          subValidation.errors,
-        )) {
-          warnings.push(warning);
-        }
-      } else if (key === 'cacheTtlOverride') {
-        for (const [subKey, subValue] of Object.entries(val)) {
-          if (!is.number(subValue)) {
+    } else if (type === 'object') {
+      if (is.plainObject(val)) {
+        if (key === 'onboardingConfig') {
+          const subValidation = await validateConfig(false, val);
+          for (const warning of subValidation.warnings.concat(
+            subValidation.errors,
+          )) {
+            warnings.push(warning);
+          }
+        } else if (key === 'force') {
+          const subValidation = await validateConfig(true, val);
+          for (const warning of subValidation.warnings.concat(
+            subValidation.errors,
+          )) {
+            warnings.push(warning);
+          }
+        } else if (key === 'cacheTtlOverride') {
+          for (const [subKey, subValue] of Object.entries(val)) {
+            if (!is.number(subValue)) {
+              warnings.push({
+                topic: 'Configuration Error',
+                message: `Invalid \`${currentPath}.${subKey}\` configuration: value must be an integer.`,
+              });
+            }
+          }
+        } else {
+          const res = validatePlainObject(val);
+          if (res !== true) {
             warnings.push({
               topic: 'Configuration Error',
-              message: `Invalid \`${currentPath}.${subKey}\` configuration: value must be an integer.`,
+              message: `Invalid \`${currentPath}.${res}\` configuration: value must be a string.`,
             });
           }
         }
       } else {
-        const res = validatePlainObject(val);
-        if (res !== true) {
-          warnings.push({
-            topic: 'Configuration Error',
-            message: `Invalid \`${currentPath}.${res}\` configuration: value must be a string.`,
-          });
-        }
+        warnings.push({
+          topic: 'Configuration Error',
+          message: `Configuration option \`${currentPath}\` should be a JSON object.`,
+        });
       }
-    } else {
-      warnings.push({
-        topic: 'Configuration Error',
-        message: `Configuration option \`${currentPath}\` should be a JSON object.`,
-      });
     }
   }
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Allowed default `null` value.
 I have used similar logic to one present for repo config options
 https://github.com/renovatebot/renovate/blob/9f2394680e6f15d16c16a1571b0a9945ff07368e/lib/config/validation.ts#L305
<!-- Describe what behavior is changed by this PR. -->

## Context
Closes: https://github.com/renovatebot/renovate/issues/27615

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
