### PR TITLE
fix(datasource/go):  don't strip `api/` from `packageName` on gitlab

### DIFF
--- a/lib/modules/datasource/go/__fixtures__/go-get-gitlab-ee-private-subgroup-api.html
+++ b/lib/modules/datasource/go/__fixtures__/go-get-gitlab-ee-private-subgroup-api.html
@@ -1,0 +1,12 @@
+<html>
+
+<head>
+  <meta name="go-import"
+    content="my.custom.domain/group/subgroup-api/myrepo git https://my.custom.domain/group/subgroup-api/myrepo.git" />
+  <meta name="go-source"
+    content="my.custom.domain/group/subgroup-api/myrepo https://my.custom.domain/group/subgroup-api/myrepo https://my.custom.domain/group/subgroup-api/myrepo/-/tree/master{/dir} https://my.custom.domain/group/subgroup-api/myrepo/-/blob/master{/dir}/{file}#L{line}" />
+</head>
+
+<body>go get https://my.custom.domain/group/subgroup-api/myrepo</body>
+
+</html>

--- a/lib/modules/datasource/go/base.spec.ts
+++ b/lib/modules/datasource/go/base.spec.ts
@@ -238,6 +238,29 @@ describe('modules/datasource/go/base', () => {
         });
       });
 
+      it('supports GitLab EE deps in private subgroup with api/ as part of packageName and api/v4 as part of endpoint', async () => {
+        GlobalConfig.set({ endpoint: 'https://my.custom.domain/api/v4' });
+
+        hostRules.hostType.mockReturnValue('gitlab');
+        httpMock
+          .scope('https://my.custom.domain')
+          .get('/group/subgroup-api/myrepo?go-get=1')
+          .reply(
+            200,
+            Fixtures.get('go-get-gitlab-ee-private-subgroup-api.html'),
+          );
+
+        const res = await BaseGoDatasource.getDatasource(
+          'my.custom.domain/group/subgroup-api/myrepo',
+        );
+
+        expect(res).toEqual({
+          datasource: GitlabTagsDatasource.id,
+          packageName: 'group/subgroup-api/myrepo',
+          registryUrl: 'https://my.custom.domain/',
+        });
+      });
+
       it('supports GitLab EE deps in subgroup with version', async () => {
         hostRules.hostType.mockReturnValue('gitlab');
         httpMock

--- a/lib/modules/datasource/go/base.ts
+++ b/lib/modules/datasource/go/base.ts
@@ -164,7 +164,7 @@ export class BaseGoDatasource {
         endpoint,
       );
 
-      if (endpointPrefix) {
+      if (endpointPrefix && endpointPrefix[1] !== 'api/') {
         packageName = packageName.replace(endpointPrefix[1], '');
       }
 


### PR DESCRIPTION
## Changes

Added 'api/' to condition

Discussion is here: https://github.com/renovatebot/renovate/discussions/27595#discussioncomment-8621614
 
## Context

A bug was introduced by an earlier pull requests

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [X] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository