### PR TITLE
fix(datasource/docker): fix getDigest when lookupName different from packageName

### DIFF
--- a/lib/modules/datasource/docker/index.spec.ts
+++ b/lib/modules/datasource/docker/index.spec.ts
@@ -1457,6 +1457,7 @@ describe('modules/datasource/docker/index', () => {
           packageName: '123456789.dkr.ecr.us-east-1.amazonaws.com/node',
         }),
       ).toEqual({
+        lookupName: 'node',
         registryUrl: 'https://123456789.dkr.ecr.us-east-1.amazonaws.com',
         releases: [],
       });
@@ -1509,6 +1510,7 @@ describe('modules/datasource/docker/index', () => {
           packageName: 'public.ecr.aws/amazonlinux/amazonlinux',
         }),
       ).toEqual({
+        lookupName: 'amazonlinux/amazonlinux',
         registryUrl: 'https://public.ecr.aws',
         releases: [],
       });
@@ -1567,6 +1569,7 @@ describe('modules/datasource/docker/index', () => {
             packageName: 'ecr-proxy.company.com/node',
           }),
         ).toEqual({
+          lookupName: 'node',
           registryUrl: 'https://ecr-proxy.company.com',
           releases: [],
           sourceUrl: 'https://github.com/renovatebot/renovate',
@@ -2026,6 +2029,7 @@ describe('modules/datasource/docker/index', () => {
         packageName: 'registry.company.com/node',
       });
       expect(res).toEqual({
+        lookupName: 'node',
         registryUrl: 'https://registry.company.com',
         releases: [
           {
@@ -2081,6 +2085,7 @@ describe('modules/datasource/docker/index', () => {
         packageName: 'registry.company.com/node',
       });
       expect(res).toEqual({
+        lookupName: 'node',
         registryUrl: 'https://registry.company.com',
         releases: [
           {
@@ -2144,6 +2149,7 @@ describe('modules/datasource/docker/index', () => {
         packageName: 'registry.company.com/node',
       });
       expect(res).toEqual({
+        lookupName: 'node',
         registryUrl: 'https://registry.company.com',
         releases: [],
         sourceUrl: 'https://github.com/renovatebot/renovate',
@@ -2171,6 +2177,7 @@ describe('modules/datasource/docker/index', () => {
         packageName: 'registry.company.com/node',
       });
       expect(res).toEqual({
+        lookupName: 'node',
         registryUrl: 'https://registry.company.com',
         releases: [],
       });
@@ -2195,6 +2202,7 @@ describe('modules/datasource/docker/index', () => {
         packageName: 'registry.company.com/node',
       });
       expect(res).toEqual({
+        lookupName: 'node',
         registryUrl: 'https://registry.company.com',
         releases: [],
       });
@@ -2216,6 +2224,7 @@ describe('modules/datasource/docker/index', () => {
         packageName: 'registry.company.com/node',
       });
       expect(res).toEqual({
+        lookupName: 'node',
         registryUrl: 'https://registry.company.com',
         releases: [],
       });
@@ -2266,6 +2275,7 @@ describe('modules/datasource/docker/index', () => {
         packageName: 'registry.company.com/node',
       });
       expect(res).toEqual({
+        lookupName: 'node',
         registryUrl: 'https://registry.company.com',
         releases: [
           {
@@ -2320,6 +2330,7 @@ describe('modules/datasource/docker/index', () => {
         packageName: 'registry.company.com/node',
       });
       expect(res).toEqual({
+        lookupName: 'node',
         registryUrl: 'https://registry.company.com',
         releases: [
           {
@@ -2350,6 +2361,7 @@ describe('modules/datasource/docker/index', () => {
         packageName: 'registry.company.com/node',
       });
       expect(res).toEqual({
+        lookupName: 'node',
         registryUrl: 'https://registry.company.com',
         releases: [],
       });
@@ -2404,6 +2416,7 @@ describe('modules/datasource/docker/index', () => {
         packageName: 'registry.company.com/node',
       });
       expect(res).toEqual({
+        lookupName: 'node',
         registryUrl: 'https://registry.company.com',
         releases: [],
       });
@@ -2463,6 +2476,7 @@ describe('modules/datasource/docker/index', () => {
         packageName: 'ghcr.io/visualon/drone-git',
       });
       expect(res).toEqual({
+        lookupName: 'visualon/drone-git',
         registryUrl: 'https://ghcr.io',
         sourceUrl: 'https://github.com/visualon/drone-git',
         releases: [{ version: '1.0.0' }],

--- a/lib/modules/datasource/docker/index.ts
+++ b/lib/modules/datasource/docker/index.ts
@@ -1006,6 +1006,10 @@ export class DockerDatasource extends Datasource {
       registryUrl: registryHost,
       releases,
     };
+    if (dockerRepository !== packageName) {
+      // This will be reused later if a getDigest() call is made
+      ret.lookupName = dockerRepository;
+    }
 
     const tags = releases.map((release) => release.version);
     const latestTag = tags.includes('latest')

--- a/lib/modules/datasource/types.ts
+++ b/lib/modules/datasource/types.ts
@@ -83,6 +83,7 @@ export interface ReleaseResult {
   registryUrl?: string;
   replacementName?: string;
   replacementVersion?: string;
+  lookupName?: string;
 }
 
 export type RegistryStrategy = 'first' | 'hunt' | 'merge';

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -4,6 +4,7 @@ import type { ValidationMessage } from '../../../../config/types';
 import { CONFIG_VALIDATION } from '../../../../constants/error-messages';
 import { logger } from '../../../../logger';
 import {
+  GetDigestInputConfig,
   Release,
   ReleaseResult,
   applyDatasourceFilters,
@@ -157,6 +158,7 @@ export async function lookupUpdates(
         'homepage',
         'changelogUrl',
         'dependencyUrl',
+        'lookupName',
       ]);
 
       const latestVersion = dependency.tags?.latest;
@@ -496,10 +498,15 @@ export async function lookupUpdates(
       // update digest for all
       for (const update of res.updates) {
         if (config.pinDigests === true || config.currentDigest) {
+          const getDigestConfig: GetDigestInputConfig = {
+            ...config,
+            packageName: res.lookupName ?? config.packageName,
+          };
           // TODO #22198
           update.newDigest ??=
             dependency?.releases.find((r) => r.version === update.newValue)
-              ?.newDigest ?? (await getDigest(config, update.newValue))!;
+              ?.newDigest ??
+            (await getDigest(getDigestConfig, update.newValue))!;
 
           // If the digest could not be determined, report this as otherwise the
           // update will be omitted later on without notice.

--- a/lib/workers/repository/process/lookup/types.ts
+++ b/lib/workers/repository/process/lookup/types.ts
@@ -59,6 +59,7 @@ export interface UpdateResult {
   sourceUrl?: string | null;
   currentVersion?: string;
   isSingleVersion?: boolean;
+  lookupName?: string;
   skipReason?: SkipReason;
   registryUrl?: string;
   fixedVersion?: string;


### PR DESCRIPTION


<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Store both registryUrl (already) and lookupName (new, this PR) after getReleases() call and use them for the getDigest() call.

## Context

Fixes #26161

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
