### PR TITLE
fix(sbt): initialize registry urls for sbt version

### DIFF
--- a/lib/modules/manager/sbt/extract.spec.ts
+++ b/lib/modules/manager/sbt/extract.spec.ts
@@ -556,5 +556,31 @@ describe('modules/manager/sbt/extract', () => {
       const packages = await extractAllPackageFiles({}, ['build.sbt']);
       expect(packages).toBeEmpty();
     });
+
+    it('extracts build properties correctly', async () => {
+      const buildProps = codeBlock`
+      sbt.version=1.6.0
+    `;
+      fs.readLocalFile.mockResolvedValueOnce(buildProps);
+      const packages = await extractAllPackageFiles({}, [
+        'project/build.properties',
+      ]);
+      expect(packages).toMatchObject([
+        {
+          deps: [
+            {
+              datasource: 'github-releases',
+              packageName: 'sbt/sbt',
+              depName: 'sbt/sbt',
+              currentValue: '1.6.0',
+              replaceString: 'sbt.version=1.6.0',
+              versioning: 'semver',
+              extractVersion: '^v(?<version>\\S+)',
+              registryUrls: ['https://repo1.maven.org/maven2'],
+            },
+          ],
+        },
+      ]);
+    });
   });
 });

--- a/lib/modules/manager/sbt/extract.ts
+++ b/lib/modules/manager/sbt/extract.ts
@@ -334,6 +334,7 @@ export function extractPackageFile(
         currentValue: sbtVersion,
         replaceString: matchString,
         extractVersion: '^v(?<version>\\S+)',
+        registryUrls: [],
       };
 
       return {
@@ -394,13 +395,12 @@ export async function extractAllPackageFiles(
   }
   for (const pkg of packages) {
     for (const dep of pkg.deps) {
-      dep.registryUrls ??= [];
       if (proxyUrls.length > 0) {
-        dep.registryUrls.unshift(...proxyUrls);
+        dep.registryUrls!.unshift(...proxyUrls);
       } else if (dep.depType === 'plugin') {
-        dep.registryUrls.unshift(SBT_PLUGINS_REPO, SBT_MVN_REPO);
+        dep.registryUrls!.unshift(SBT_PLUGINS_REPO, SBT_MVN_REPO);
       } else {
-        dep.registryUrls.unshift(SBT_MVN_REPO);
+        dep.registryUrls!.unshift(SBT_MVN_REPO);
       }
     }
   }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

The PR https://github.com/renovatebot/renovate/pull/27276 caused a bug since the registry urls were not initialized when fetching sbt version from build.properties. This fixes the bug by initializing the array. Added a test to cover this scenario as well.

## Context

Closes issue https://github.com/renovatebot/renovate/issues/27653

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
