### PR TITLE
fix(manager/pip-compile): Decrease log level for ignored args

### DIFF
--- a/lib/modules/manager/pip-compile/common.spec.ts
+++ b/lib/modules/manager/pip-compile/common.spec.ts
@@ -1,5 +1,6 @@
 import { mockDeep } from 'jest-mock-extended';
 import { hostRules } from '../../../../test/util';
+import { logger } from '../../../logger';
 import {
   allowedPipOptions,
   extractHeaderCommand,
@@ -24,7 +25,10 @@ describe('modules/manager/pip-compile/common', () => {
     it.each([
       '-v',
       '--all-extras',
+      `--allow-unsafe`,
       '--generate-hashes',
+      `--no-emit-index-url`,
+      `--strip-extras`,
       '--resolver=backtracking',
       '--resolver=legacy',
       '--output-file=reqs.txt',
@@ -36,6 +40,7 @@ describe('modules/manager/pip-compile/common', () => {
           'reqs.txt',
         ),
       ).toBeObject();
+      expect(logger.warn).toHaveBeenCalledTimes(0);
     });
 
     it.each(['--resolver', '--output-file reqs.txt', '--extra = jupyter'])(

--- a/lib/modules/manager/pip-compile/common.ts
+++ b/lib/modules/manager/pip-compile/common.ts
@@ -160,7 +160,7 @@ export function extractHeaderCommand(
         result.indexUrl = value;
         // TODO: add to secrets? next PR
       } else {
-        logger.warn(`pip-compile: option ${arg} not handled`);
+        logger.debug({ option }, `pip-compile: option not handled`);
       }
       continue;
     }
@@ -177,7 +177,7 @@ export function extractHeaderCommand(
       continue;
     }
 
-    logger.warn(`pip-compile: option ${arg} not handled`);
+    logger.debug({ option: arg }, `pip-compile: option not handled`);
   }
   logger.trace(
     {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Improved tests. Decreased warning logs to debug.
<!-- Describe what behavior is changed by this PR. -->

## Context

Some of the args are not handled by this manager but only passed over to `pip-compile` exec. They previously raised warnings that gave false alarm that something is wrong.  
https://github.com/renovatebot/renovate/discussions/27699
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
