### PR TITLE
fix(datasource/docker): better reuse of lookupName for getDigest

### DIFF
--- a/lib/modules/datasource/docker/index.spec.ts
+++ b/lib/modules/datasource/docker/index.spec.ts
@@ -491,14 +491,16 @@ describe('modules/datasource/docker/index', () => {
         .scope(gcrUrl)
         .get('/')
         .reply(200)
-        .head('/some-project/some-package/manifests/some-tag')
+        .head('/google.com/some-project/some-package/manifests/some-tag')
         .reply(200, '', { 'docker-content-digest': 'some-digest' });
 
       hostRules.find.mockReturnValue({});
       const res = await getDigest(
         {
           datasource: 'docker',
-          packageName: 'eu.gcr.io/some-project/some-package',
+          registryUrl: 'https://eu.gcr.io',
+          lookupName: 'google.com/some-project/some-package',
+          packageName: 'eu.gcr.io/google.com/some-project/some-package',
         },
         'some-tag',
       );
@@ -1234,6 +1236,8 @@ describe('modules/datasource/docker/index', () => {
 
       expect(res).toBe(newDigest);
     });
+
+    it('prefers lookupName', async () => {});
   });
 
   describe('getReleases', () => {

--- a/lib/modules/datasource/docker/index.spec.ts
+++ b/lib/modules/datasource/docker/index.spec.ts
@@ -1236,8 +1236,6 @@ describe('modules/datasource/docker/index', () => {
 
       expect(res).toBe(newDigest);
     });
-
-    it('prefers lookupName', async () => {});
   });
 
   describe('getReleases', () => {

--- a/lib/modules/datasource/docker/index.ts
+++ b/lib/modules/datasource/docker/index.ts
@@ -788,13 +788,22 @@ export class DockerDatasource extends Datasource {
     },
   })
   override async getDigest(
-    { registryUrl, packageName, currentDigest }: DigestConfig,
+    { registryUrl, lookupName, packageName, currentDigest }: DigestConfig,
     newValue?: string,
   ): Promise<string | null> {
-    const { registryHost, dockerRepository } = getRegistryRepository(
-      packageName,
-      registryUrl!,
-    );
+    let registryHost: string;
+    let dockerRepository: string;
+    if (registryUrl && lookupName) {
+      // Reuse the resolved values from getReleases()
+      registryHost = registryUrl;
+      dockerRepository = lookupName;
+    } else {
+      // Resolve values independently
+      ({ registryHost, dockerRepository } = getRegistryRepository(
+        packageName,
+        registryUrl!,
+      ));
+    }
     logger.debug(
       // TODO: types (#22198)
       `getDigest(${registryHost}, ${dockerRepository}, ${newValue})`,

--- a/lib/modules/datasource/index.ts
+++ b/lib/modules/datasource/index.ts
@@ -398,15 +398,18 @@ function getDigestConfig(
   datasource: DatasourceApi,
   config: GetDigestInputConfig,
 ): DigestConfig {
-  const { currentValue, currentDigest } = config;
+  const { lookupName, currentValue, currentDigest } = config;
   const packageName = config.replacementName ?? config.packageName;
-  const [registryUrl] = resolveRegistryUrls(
-    datasource,
-    config.defaultRegistryUrls,
-    config.registryUrls,
-    config.additionalRegistryUrls,
-  );
-  return { packageName, registryUrl, currentValue, currentDigest };
+  // Prefer registryUrl from getReleases() lookup if it has been passed
+  const registryUrl =
+    config.registryUrl ??
+    resolveRegistryUrls(
+      datasource,
+      config.defaultRegistryUrls,
+      config.registryUrls,
+      config.additionalRegistryUrls,
+    )[0];
+  return { lookupName, packageName, registryUrl, currentValue, currentDigest };
 }
 
 export function getDigest(

--- a/lib/modules/datasource/types.ts
+++ b/lib/modules/datasource/types.ts
@@ -9,6 +9,8 @@ export interface GetDigestInputConfig {
   packageName: string;
   defaultRegistryUrls?: string[];
   registryUrls?: string[] | null;
+  registryUrl?: string;
+  lookupName?: string;
   additionalRegistryUrls?: string[];
   currentValue?: string;
   currentDigest?: string;
@@ -17,6 +19,7 @@ export interface GetDigestInputConfig {
 
 export interface DigestConfig {
   packageName: string;
+  lookupName?: string;
   registryUrl?: string;
   currentValue?: string;
   currentDigest?: string;

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -500,7 +500,8 @@ export async function lookupUpdates(
         if (config.pinDigests === true || config.currentDigest) {
           const getDigestConfig: GetDigestInputConfig = {
             ...config,
-            packageName: res.lookupName ?? config.packageName,
+            registryUrl: update.registryUrl ?? res.registryUrl,
+            lookupName: res.lookupName,
           };
           // TODO #22198
           update.newDigest ??=


### PR DESCRIPTION


<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds lookupName to getDigest params instead of overloading packageName.

## Context

Fixes #27723

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
