### PR TITLE
fix(lookup/get-digest): add new variable `lookupRegistryUrl`

### DIFF
--- a/lib/modules/datasource/index.ts
+++ b/lib/modules/datasource/index.ts
@@ -400,12 +400,18 @@ function getDigestConfig(
 ): DigestConfig {
   const { currentValue, currentDigest } = config;
   const packageName = config.replacementName ?? config.packageName;
-  const [registryUrl] = resolveRegistryUrls(
-    datasource,
-    config.defaultRegistryUrls,
-    config.registryUrls,
-    config.additionalRegistryUrls,
-  );
+  let registryUrl: string;
+  // if regsitryUrl from package lookup is present use it
+  if (config.lookupRegistryUrl) {
+    registryUrl = config.lookupRegistryUrl;
+  } else {
+    [registryUrl] = resolveRegistryUrls(
+      datasource,
+      config.defaultRegistryUrls,
+      config.registryUrls,
+      config.additionalRegistryUrls,
+    );
+  }
   return { packageName, registryUrl, currentValue, currentDigest };
 }
 

--- a/lib/modules/datasource/types.ts
+++ b/lib/modules/datasource/types.ts
@@ -7,6 +7,7 @@ import type { ModuleApi } from '../../types';
 export interface GetDigestInputConfig {
   datasource: string;
   packageName: string;
+  lookupRegistryUrl?: string;
   defaultRegistryUrls?: string[];
   registryUrls?: string[] | null;
   additionalRegistryUrls?: string[];

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -492,7 +492,7 @@ export async function lookupUpdates(
         }
       }
       if (res.registryUrl) {
-        config.registryUrls = [res.registryUrl];
+        config.lookupRegistryUrl = res.registryUrl;
       }
 
       // update digest for all

--- a/lib/workers/repository/process/lookup/types.ts
+++ b/lib/workers/repository/process/lookup/types.ts
@@ -48,6 +48,7 @@ export interface LookupUpdateConfig
   replacementNameTemplate?: string;
   replacementVersion?: string;
   extractVersion?: string;
+  lookupRegistryUrl?: string;
 }
 
 export interface UpdateResult {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Add new variable `lookupRegistryUrl` which will be used to pass the url from the package lookup response to perform digest lookups.
<!-- Describe what behavior is changed by this PR. -->

## Context
Closes: https://github.com/renovatebot/renovate/issues/27576
I am not sure if this is best approach, but I would like to have a different variable because reusing url from the package looup response is a new and separate logic and it shouldn't be mixed up with the existing registryUrl logic. It also made it harder to debug issues as the logic were mixed. Now it should be more clear. 
Open to suggestions on this.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
