### PR TITLE
fix(circleci): correctly get a Orb name when a line has an inline comment

### DIFF
--- a/lib/modules/manager/circleci/__fixtures__/config2.yml
+++ b/lib/modules/manager/circleci/__fixtures__/config2.yml
@@ -5,11 +5,11 @@ orbs:
   release-workflows: hutson/library-release-workflows@4.1.0
   # Comments help me understand my work.
   # The next line is intentionally just whitespace!
-  
+
   no-version: abc/def
 
   # Comments help me understand my work.
-  volatile: zzz/zzz@volatile
+  volatile: zzz/zzz@volatile # Comments help me understand my work.
 
 test_plan: &test_plan
   steps:

--- a/lib/modules/manager/circleci/extract.ts
+++ b/lib/modules/manager/circleci/extract.ts
@@ -29,7 +29,7 @@ export function extractPackageFile(
             lineNumber += 1;
             continue;
           }
-          const orbMatch = regEx(/^\s+([^:]+):\s(.+)$/).exec(orbLine);
+          const orbMatch = regEx(/^\s+([^:]+):\s(.+?)(?:\s*#.*)?$/).exec(orbLine);
           if (orbMatch) {
             logger.trace('orbMatch');
             foundOrbOrNoop = true;

--- a/lib/modules/manager/circleci/extract.ts
+++ b/lib/modules/manager/circleci/extract.ts
@@ -29,7 +29,9 @@ export function extractPackageFile(
             lineNumber += 1;
             continue;
           }
-          const orbMatch = regEx(/^\s+([^:]+):\s(.+?)(?:\s*#.*)?$/).exec(orbLine);
+          const orbMatch = regEx(/^\s+([^:]+):\s(.+?)(?:\s*#.*)?$/).exec(
+            orbLine,
+          );
           if (orbMatch) {
             logger.trace('orbMatch');
             foundOrbOrNoop = true;


### PR DESCRIPTION
## Changes

Correctly get an Orb name when a line has an inline comment.

## Context

YAML allows us to write an inline comment like the following.

```yml
awsecr: circleci/aws-ecr   # https://circleci.com/developer/orbs/orb/circleci/aws-ecr
```

But Renovate can't parse this line now. Renovate treats an inline comment as a part of an Orb name.  This PR fixes that and removes a comment from an Orb name.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->
