### PR TITLE
docs: improve description of two config options

### DIFF
--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -2416,7 +2416,7 @@ const options: RenovateOptions[] = [
   },
   {
     name: 'concurrentRequestLimit',
-    description: 'Limit concurrent requests per host. Set to 0 for no limit.',
+    description: 'Limit concurrent requests per host. Set to `0` for no limit.',
     type: 'integer',
     default: 5,
     stage: 'repository',
@@ -2426,7 +2426,7 @@ const options: RenovateOptions[] = [
   },
   {
     name: 'maxRequestsPerSecond',
-    description: 'Limit requests rate per host. Set to 0 for no limit.',
+    description: 'Limit requests rate per host. Set to `0` for no limit.',
     type: 'integer',
     default: 5,
     stage: 'repository',


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Improve `description` for two config options:
  - `concurrentRequestLimit`
  - `maxRequestsPerSecond`

## Context

Follow up after PR:

- #27621

Use the code styling for values like `0`.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
