### PR TITLE
feat: add support for go-templates in argocd yaml files

### DIFF
--- a/lib/modules/manager/argocd/__fixtures__/validApplication.yml
+++ b/lib/modules/manager/argocd/__fixtures__/validApplication.yml
@@ -128,4 +128,13 @@ spec:
       helm:
         valueFiles:
           - $foo/values.yaml
-
+---
+{{- if .Values.enabled }}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+spec:
+  source:
+    chart: somechart
+    repoURL: https://git.example.com/foo/bar.git
+    targetRevision: 3.2.1
+{{- end }}

--- a/lib/modules/manager/argocd/extract.spec.ts
+++ b/lib/modules/manager/argocd/extract.spec.ts
@@ -165,6 +165,12 @@ spec:
             depName: 'somechart',
             registryUrls: ['https://foo.io/repo'],
           },
+          {
+            currentValue: '3.2.1',
+            datasource: 'helm',
+            depName: 'somechart',
+            registryUrls: ['https://git.example.com/foo/bar.git'],
+          },
         ],
       });
     });

--- a/lib/modules/manager/argocd/extract.ts
+++ b/lib/modules/manager/argocd/extract.ts
@@ -36,6 +36,7 @@ export function extractPackageFile(
     definitions = parseYaml(content, null, {
       customSchema: ApplicationDefinition,
       failureBehaviour: 'filter',
+      removeTemplates: true,
     });
   } catch (err) {
     logger.debug({ err, packageFile }, 'Failed to parse ArgoCD definition.');


### PR DESCRIPTION
## Changes

Hi everyone,
we recently discovered that Renovate silently skips Argo CD yaml-files, that are wrapped in go-templates like in the following example:

```yaml
{{- if .Values.enabled }}
apiVersion: argoproj.io/v1alpha1
kind: Application
spec:
  source:
    chart: kube-state-metrics
    repoURL: https://prometheus-community.github.io/helm-charts
    targetRevision: 2.4.1
{{- end }}
```

## Context

Closes https://github.com/renovatebot/renovate/discussions/27762

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
