### PR TITLE
fix(workers/repository): Verbose logging for updateArtifacts

### DIFF
--- a/lib/workers/repository/update/branch/get-updated.ts
+++ b/lib/workers/repository/update/branch/get-updated.ts
@@ -288,6 +288,10 @@ export async function getUpdatedPackageFiles(
   }));
   const updatedArtifacts: FileChange[] = [];
   const artifactErrors: ArtifactError[] = [];
+  // istanbul ignore if
+  if (is.nonEmptyArray(updatedPackageFiles)) {
+    logger.debug('updateArtifacts for updatedPackageFiles');
+  }
   for (const packageFile of updatedPackageFiles) {
     const updatedDeps = packageFileUpdatedDeps[packageFile.path];
     const managers = packageFileManagers[packageFile.path];
@@ -311,6 +315,10 @@ export async function getUpdatedPackageFiles(
     path: name,
     contents: nonUpdatedFileContents[name],
   }));
+  // istanbul ignore if
+  if (is.nonEmptyArray(nonUpdatedPackageFiles)) {
+    logger.debug('updateArtifacts for nonUpdatedPackageFiles');
+  }
   for (const packageFile of nonUpdatedPackageFiles) {
     const updatedDeps = packageFileUpdatedDeps[packageFile.path];
     const managers = packageFileManagers[packageFile.path];
@@ -332,6 +340,10 @@ export async function getUpdatedPackageFiles(
   }
   if (!reuseExistingBranch) {
     // Only perform lock file maintenance if it's a fresh commit
+    // istanbul ignore if
+    if (is.nonEmptyArray(lockFileMaintenanceFiles)) {
+      logger.debug('updateArtifacts for lockFileMaintenanceFiles');
+    }
     for (const packageFileName of lockFileMaintenanceFiles) {
       const managers = packageFileManagers[packageFileName];
       if (is.nonEmptySet(managers)) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Added logging to differentiate which branch was taken
<!-- Describe what behavior is changed by this PR. -->

## Context

To help debug problems like #27761
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
