### PR TITLE
feat(github): Use ETag for PR caching

### DIFF
--- a/lib/modules/platform/github/api-cache.ts
+++ b/lib/modules/platform/github/api-cache.ts
@@ -14,6 +14,14 @@ export class ApiCache<T extends ApiPageItem> {
     return this.cache.items[number] ?? null;
   }
 
+  getEtag(): string | undefined {
+    return this.cache.etag;
+  }
+
+  setEtag(etag: string | undefined): void {
+    this.cache.etag = etag;
+  }
+
   /**
    * It intentionally doesn't alter `lastModified` cache field.
    *

--- a/lib/modules/platform/github/types.ts
+++ b/lib/modules/platform/github/types.ts
@@ -152,4 +152,5 @@ export interface ApiPageItem {
 export interface ApiPageCache<T extends ApiPageItem = ApiPageItem> {
   items: Record<number, T>;
   lastModified?: string;
+  etag?: string;
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Support for ETag caching of Pull Request results. 

During tests, I wasn't able to reproduce 304 status using `If-Modified-Since` header, while ETag worked pretty well. So let's start with ETag and see if we need any further changes.

## Context

- Ref: #27641
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
