### PR TITLE
fix(versioning/swift): restore exact version support

### DIFF
--- a/lib/modules/versioning/swift/index.spec.ts
+++ b/lib/modules/versioning/swift/index.spec.ts
@@ -98,6 +98,7 @@ describe('modules/versioning/swift/index', () => {
 
   it.each`
     version     | range           | expected
+    ${'1.2.3'}  | ${'1.2.3'}      | ${true}
     ${'1.2.4'}  | ${'..."1.2.4"'} | ${true}
     ${'v1.2.4'} | ${'..."1.2.4"'} | ${true}
     ${'1.2.4'}  | ${'..."1.2.3"'} | ${false}

--- a/lib/modules/versioning/swift/index.ts
+++ b/lib/modules/versioning/swift/index.ts
@@ -62,6 +62,10 @@ function isLessThanRange(version: string, range: string): boolean {
 }
 
 function matches(version: string, range: string): boolean {
+  // Check if both are an exact version
+  if (valid(range) && version === range) {
+    return true;
+  }
   const semverRange = toSemverRange(range);
   return semverRange ? satisfies(version, semverRange) : false;
 }


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Fixes `matches()` for exact match versions in Swift versioning

## Context

Fixes #27788

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
