### PR TITLE
feat(yarn): set http proxy config from environment variables

### DIFF
--- a/lib/modules/manager/npm/post-update/yarn.ts
+++ b/lib/modules/manager/npm/post-update/yarn.ts
@@ -210,6 +210,17 @@ export async function generateLockFile(
       commands.push(`yarn set version ${quote(yarnUpdate.newValue!)}`);
     }
 
+    if (process.env.HTTP_PROXY && !isYarn1) {
+      commands.push(
+        `yarn config set --home httpProxy ${quote(process.env.HTTP_PROXY)}`,
+      );
+    }
+    if (process.env.HTTPS_PROXY && !isYarn1) {
+      commands.push(
+        `yarn config set --home httpsProxy ${quote(process.env.HTTPS_PROXY)}`,
+      );
+    }
+
     // This command updates the lock file based on package.json
     commands.push(`yarn install${cmdOptions}`);
 

--- a/lib/modules/manager/npm/readme.md
+++ b/lib/modules/manager/npm/readme.md
@@ -7,3 +7,15 @@ The following `depTypes` are currently supported by the npm manager :
 - `engines` : Renovate will update any `node`, `npm` and `yarn` version specified under `engines`.
 - `volta` : Renovate will update any `node`, `npm`, `pnpm` and `yarn` version specified under `volta`.
 - `packageManager`
+
+## Yarn
+
+### Version Selection / Installation
+
+If Renovate detects a `packageManager` setting for Yarn in `package.json` then it will use Corepack to install Yarn.
+
+### HTTP Proxy Support
+
+Yarn itself does not natively recognize/support the `HTTP_PROXY` and `HTTPS_PROXY` environment variables.
+If Renovate detects Yarn 2+, and one or both of those variables are present, then it will run commands like `yarn config set --home httpProxy http://proxy` prior to executing `yarn install`.
+This will result in the `~/.yarnrc.yml` file being created or modified with these settings, and the settings are not removed afterwards.

--- a/lib/modules/manager/npm/readme.md
+++ b/lib/modules/manager/npm/readme.md
@@ -8,13 +8,13 @@ The following `depTypes` are currently supported by the npm manager :
 - `volta` : Renovate will update any `node`, `npm`, `pnpm` and `yarn` version specified under `volta`.
 - `packageManager`
 
-## Yarn
+### Yarn
 
-### Version Selection / Installation
+#### Version Selection / Installation
 
 If Renovate detects a `packageManager` setting for Yarn in `package.json` then it will use Corepack to install Yarn.
 
-### HTTP Proxy Support
+#### HTTP Proxy Support
 
 Yarn itself does not natively recognize/support the `HTTP_PROXY` and `HTTPS_PROXY` environment variables.
 If Renovate detects Yarn 2+, and one or both of those variables are present, then it will run commands like `yarn config set --home httpProxy http://proxy` prior to executing `yarn install`.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Runs yarn global config commands to set http(s) proxy if the environment variables are set.

## Context

Yarn does not recognize the environment variables natively

## Documentation (please check one with an [x])

- [=x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
