### PR TITLE
feat(circleci): target all YAML files in `.circleci` directory

### DIFF
--- a/lib/modules/manager/circleci/index.spec.ts
+++ b/lib/modules/manager/circleci/index.spec.ts
@@ -1,0 +1,24 @@
+import { regexMatches } from '../../../../test/util';
+import { defaultConfig } from '.';
+
+describe('modules/manager/circleci/index', () => {
+  describe('file names match fileMatch', () => {
+    it.each`
+      path                           | expected
+      ${'.circleci/config.yml'}      | ${true}
+      ${'.circleci/config.yaml'}     | ${true}
+      ${'.circleci/foo.yaml'}        | ${true}
+      ${'.circleci/foo.yml'}         | ${true}
+      ${'.circleci/foo/config.yaml'} | ${true}
+      ${'.circleci/foo/bar.yml'}     | ${true}
+      ${'foo/.circleci/bar.yaml'}    | ${true}
+      ${'foo.yml'}                   | ${false}
+      ${'circleci/foo.yml'}          | ${false}
+      ${'circleci/foo.yml'}          | ${false}
+      ${'.circleci_foo/bar.yml'}     | ${false}
+      ${'.circleci/foo.toml'}        | ${false}
+    `('regexMatches("$path") === $expected', ({ path, expected }) => {
+      expect(regexMatches(path, defaultConfig.fileMatch)).toBe(expected);
+    });
+  });
+});

--- a/lib/modules/manager/circleci/index.ts
+++ b/lib/modules/manager/circleci/index.ts
@@ -10,7 +10,7 @@ export const displayName = 'CircleCI';
 export const url = 'https://circleci.com/docs/configuration-reference';
 
 export const defaultConfig = {
-  fileMatch: ['(^|/)\\.circleci/config\\.ya?ml$'],
+  fileMatch: ['(^|/)\\.circleci/.+\\.ya?ml$'],
 };
 
 export const categories: Category[] = ['ci'];


### PR DESCRIPTION
## Changes

Update the default `fileMatch` regex in CircleCI manager to target all YAML files under `.circleci` directory.

Note that there were no tests on this, and it looks like most other managers do not have ones. I took the liberty to add some but if you feel like this is overkill, I can remove them.

## Context

Discussed in https://github.com/renovatebot/renovate/discussions/27807. Per https://circleci.com/docs/using-dynamic-configuration/, CircleCI supports dynamic configuration to spread configuration across multiple files, where each of them could contain dependencies (e.g. orbs).

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository