### PR TITLE
chore(ci): add issue labeling reporter 

### DIFF
--- a/.github/workflows/check-unlabeled-issues.yml
+++ b/.github/workflows/check-unlabeled-issues.yml
@@ -1,0 +1,60 @@
+name: 'Check unlabeled issues'
+on:
+  schedule:
+    # Run every sunday at midnight
+    - cron: '0 0 * * 0'
+
+jobs:
+  check-unlabeled-issues:
+    runs-on: ubuntu-latest
+
+    env:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
+
+    steps:
+      - name: Check for unlabeled issues
+        run: |
+          # If any updates are made to the the labels (i.e dropped a label, added a label, etc), just add/remove the label from the lists below.
+          # For instance, if added a "to-do" status label, just add "-label:status:to-do" to the STATUS_LABELS_FILTER.
+          STATUS_LABELS_FILTER='-label:status:requirements -label:status:in-progress -label:status:blocked -label:status:waiting-on-response'
+
+          TYPE_LABELS_FILTER='-label:type:bug -label:type:feature -label:type:docs -label:type:refactor -label:type:help'
+
+          PRIORITY_LABELS_FILTER='label:priority-1-critical -label:priority-2-high -label:priority-3-medium -label:priority-4-low'
+
+          HAS_ISSUES_MISSING_LABELS=false
+
+          ISSUE_BODY="# Label check action\n"
+
+          for FILTER in "$STATUS_LABELS_FILTER" "$TYPE_LABELS_FILTER" "$PRIORITY_LABELS_FILTER"; do
+            # Extract the label type from the filter
+            LABEL_TYPE=$(echo "$FILTER" | cut -d ':' -f 2 | cut -d '-' -f 1)
+
+            # Fetch issues filtered by the label type
+            ISSUES_MISSING_LABEL=$(gh issue list --repo 'renovatebot/renovate' -s open -S "$FILTER" --json number) || { echo "Failed to fetch issues without $LABEL_TYPE labels"; exit 1; }
+
+            if [ "$ISSUES_MISSING_LABEL" != "[]" ]; then
+              HAS_ISSUES_MISSING_LABELS=true
+
+              # Format the output to be a list of issues numbers
+              FORMATTED_OUTPUT=$(echo "$ISSUES_MISSING_LABEL" | jq -r '.[].number' | sed 's/^/- #/')
+          
+              # Count the number of issues to determine if it's singular or plural
+              ISSUE_COUNT=$(echo "$ISSUES_MISSING_LABEL" | jq '. | length')
+              ISSUE_SINGULAR_PLURAL=$(if [ "$ISSUE_COUNT" -eq 1 ]; then echo "issue"; else echo "issues"; fi)
+
+              # Append the list of issues to the new issue body
+              ISSUE_BODY="$ISSUE_BODY## Found $ISSUE_COUNT $ISSUE_SINGULAR_PLURAL missing \`$LABEL_TYPE:\` labels:\n$FORMATTED_OUTPUT\n"
+            fi
+          done
+
+          if [ "$HAS_ISSUES_MISSING_LABELS" ]; then
+            # Create a new issue with the list of issues
+            gh issue create --repo 'renovatebot/renovate' --title "Label check action" --body "$(echo -e "$ISSUE_BODY")" || { echo "Failed to create issue"; exit 1; }
+          
+            # Provide an output in the action itself
+            echo -e "$ISSUE_BODY"
+
+            # Fail the action to indicate that there are issues missing labels
+            exit 1
+          fi

--- a/.github/workflows/check-unlabeled-issues.yml
+++ b/.github/workflows/check-unlabeled-issues.yml
@@ -1,60 +1,21 @@
 name: 'Check unlabeled issues'
 on:
   schedule:
-    # Run every sunday at midnight
+    # Run every Sunday at midnight
     - cron: '0 0 * * 0'
+
+permissions:
+  issues: write
 
 jobs:
   check-unlabeled-issues:
     runs-on: ubuntu-latest
 
     env:
-      GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      GH_TOKEN: ${{ github.token }}
 
     steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
       - name: Check for unlabeled issues
-        run: |
-          # If any updates are made to the the labels (i.e dropped a label, added a label, etc), just add/remove the label from the lists below.
-          # For instance, if added a "to-do" status label, just add "-label:status:to-do" to the STATUS_LABELS_FILTER.
-          STATUS_LABELS_FILTER='-label:status:requirements -label:status:in-progress -label:status:blocked -label:status:waiting-on-response'
-
-          TYPE_LABELS_FILTER='-label:type:bug -label:type:feature -label:type:docs -label:type:refactor -label:type:help'
-
-          PRIORITY_LABELS_FILTER='label:priority-1-critical -label:priority-2-high -label:priority-3-medium -label:priority-4-low'
-
-          HAS_ISSUES_MISSING_LABELS=false
-
-          ISSUE_BODY="# Label check action\n"
-
-          for FILTER in "$STATUS_LABELS_FILTER" "$TYPE_LABELS_FILTER" "$PRIORITY_LABELS_FILTER"; do
-            # Extract the label type from the filter
-            LABEL_TYPE=$(echo "$FILTER" | cut -d ':' -f 2 | cut -d '-' -f 1)
-
-            # Fetch issues filtered by the label type
-            ISSUES_MISSING_LABEL=$(gh issue list --repo 'renovatebot/renovate' -s open -S "$FILTER" --json number) || { echo "Failed to fetch issues without $LABEL_TYPE labels"; exit 1; }
-
-            if [ "$ISSUES_MISSING_LABEL" != "[]" ]; then
-              HAS_ISSUES_MISSING_LABELS=true
-
-              # Format the output to be a list of issues numbers
-              FORMATTED_OUTPUT=$(echo "$ISSUES_MISSING_LABEL" | jq -r '.[].number' | sed 's/^/- #/')
-          
-              # Count the number of issues to determine if it's singular or plural
-              ISSUE_COUNT=$(echo "$ISSUES_MISSING_LABEL" | jq '. | length')
-              ISSUE_SINGULAR_PLURAL=$(if [ "$ISSUE_COUNT" -eq 1 ]; then echo "issue"; else echo "issues"; fi)
-
-              # Append the list of issues to the new issue body
-              ISSUE_BODY="$ISSUE_BODY## Found $ISSUE_COUNT $ISSUE_SINGULAR_PLURAL missing \`$LABEL_TYPE:\` labels:\n$FORMATTED_OUTPUT\n"
-            fi
-          done
-
-          if [ "$HAS_ISSUES_MISSING_LABELS" ]; then
-            # Create a new issue with the list of issues
-            gh issue create --repo 'renovatebot/renovate' --title "Label check action" --body "$(echo -e "$ISSUE_BODY")" || { echo "Failed to create issue"; exit 1; }
-          
-            # Provide an output in the action itself
-            echo -e "$ISSUE_BODY"
-
-            # Fail the action to indicate that there are issues missing labels
-            exit 1
-          fi
+        run: sh ./tools/check-unlabeled-issues.sh

--- a/.github/workflows/label-actions.yml
+++ b/.github/workflows/label-actions.yml
@@ -21,3 +21,4 @@ jobs:
       - uses: dessant/label-actions@102faf474a544be75fbaf4df54e73d3c515a0e65 # v4.0.1
         with:
           github-token: ${{ github.token }}
+          exclude-any-issue-labels: ['action-label-check']

--- a/docs/development/issue-labeling.md
+++ b/docs/development/issue-labeling.md
@@ -226,7 +226,7 @@ Apply the `self-hosted` label when an issue is applicable only to users who self
 
 We have a GitHub Action that checks if we're using the correct labels on our issues.
 
-The action runs once in a week and checks for issues without the proper labels.
+The action runs once a week and checks for issues without the proper labels.
 
 If the action finds any issues missing labels, it creates a new issue with the missing labels and details the issues found so any collaborator can label them accordingly.
 

--- a/docs/development/issue-labeling.md
+++ b/docs/development/issue-labeling.md
@@ -224,7 +224,9 @@ Apply the `self-hosted` label when an issue is applicable only to users who self
 
 ## Automated label report
 
-There is a GitHub Action to automate the labeling process of issues, the job runs once in a week and checks for issues without the proper labels.
+We have a GitHub Action that checks if we're using the correct labels on our issues.
 
-If it finds any issues missing labels, it creates a new issue with the missing labels and details the issues found so any collaborator can label them accordingly.
+The action runs once in a week and checks for issues without the proper labels.
+
+If the action finds any issues missing labels, it creates a new issue with the missing labels and details the issues found so any collaborator can label them accordingly.
 

--- a/docs/development/issue-labeling.md
+++ b/docs/development/issue-labeling.md
@@ -221,3 +221,10 @@ Add a label `auto:retry-latest` to any Discussion where the user should retry th
 </details>
 
 Apply the `self-hosted` label when an issue is applicable only to users who self-administer their own bot.
+
+## Automated label report
+
+There is a GitHub Action to automate the labeling process of issues, the job runs once in a week and checks for issues without the proper labels.
+
+If it finds any issues missing labels, it creates a new issue with the missing labels and details the issues found so any collaborator can label them accordingly.
+

--- a/tools/check-unlabeled-issues.sh
+++ b/tools/check-unlabeled-issues.sh
@@ -2,7 +2,7 @@
 
 # When the repository labels are changed (i.e dropped a label, added a label, etc), you should make the same change to the lists below.
 # For example, if the repository added a "to-do" status label, then add "-label:status:to-do" to the STATUS_LABELS_FILTER.
-STATUS_LABELS_FILTER='-label:status:requirements -label:status:in-progress -label:status:blocked -label:status:waiting-on-response'
+STATUS_LABELS_FILTER='-label:status:requirements -label:status:in-progress -label:status:blocked'
 
 TYPE_LABELS_FILTER='-label:type:bug -label:type:feature -label:type:docs -label:type:refactor -label:type:help'
 

--- a/tools/check-unlabeled-issues.sh
+++ b/tools/check-unlabeled-issues.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# When the repository labels are changed (i.e dropped a label, added a label, etc), you should make the same change to the lists below.
+# For example, if the repository added a "to-do" status label, then add "-label:status:to-do" to the STATUS_LABELS_FILTER.
+STATUS_LABELS_FILTER='-label:status:requirements -label:status:in-progress -label:status:blocked -label:status:waiting-on-response'
+
+TYPE_LABELS_FILTER='-label:type:bug -label:type:feature -label:type:docs -label:type:refactor -label:type:help'
+
+PRIORITY_LABELS_FILTER='label:priority-1-critical -label:priority-2-high -label:priority-3-medium -label:priority-4-low'
+
+HAS_ISSUES_MISSING_LABELS=false
+
+ISSUE_BODY="# Label check action\n"
+
+for FILTER in "$STATUS_LABELS_FILTER" "$TYPE_LABELS_FILTER" "$PRIORITY_LABELS_FILTER"; do
+  # Extract the label type from the filter
+  LABEL_TYPE=$(echo "$FILTER" | cut -d ':' -f 2 | cut -d '-' -f 1)
+
+  # Fetch issues filtered by the label type
+  ISSUES_MISSING_LABEL=$(gh issue list --repo 'renovatebot/renovate' -s open -S "$FILTER" --json number) || { echo "Failed to fetch issues without $LABEL_TYPE labels"; exit 1; }
+
+  if [ "$ISSUES_MISSING_LABEL" != "[]" ]; then
+    HAS_ISSUES_MISSING_LABELS=true
+
+    # Format the output to be a list of issue numbers
+    FORMATTED_OUTPUT=$(echo "$ISSUES_MISSING_LABEL" | jq -r '.[].number' | sed 's/^/- #/')
+
+    # Count the number of issues to determine if it's singular or plural
+    ISSUE_COUNT=$(echo "$ISSUES_MISSING_LABEL" | jq '. | length')
+    ISSUE_SINGULAR_PLURAL=$(if [ "$ISSUE_COUNT" -eq 1 ]; then echo "issue"; else echo "issues"; fi)
+
+    # Append the list of issues to the new issue body
+    ISSUE_BODY="$ISSUE_BODY## Found $ISSUE_COUNT $ISSUE_SINGULAR_PLURAL missing \`$LABEL_TYPE:\` labels:\n$FORMATTED_OUTPUT\n"
+  fi
+done
+
+if [ "$HAS_ISSUES_MISSING_LABELS" ]; then
+  # Create a new issue with the list of issues
+  gh issue create --repo 'renovatebot/renovate' --title "Label check action" --body "$(echo -e "$ISSUE_BODY")" || { echo "Failed to create issue"; exit 1; }
+
+  # Provide an output in the action itself
+  echo -e "$ISSUE_BODY"
+
+  # Fail the action if there are issues missing the correct labels
+  exit 1
+fi

--- a/tools/check-unlabeled-issues.sh
+++ b/tools/check-unlabeled-issues.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 
 # When the repository labels are changed (i.e dropped a label, added a label, etc), you should make the same change to the lists below.
-# For example, if the repository added a "to-do" status label, then add "-label:status:to-do" to the STATUS_LABELS_FILTER.
-STATUS_LABELS_FILTER='-label:status:requirements -label:status:in-progress -label:status:blocked'
-
+# For example, if the repository added a "type:task" type label, then add "-label:type:task" to the TYPE_LABELS_FILTER.
 TYPE_LABELS_FILTER='-label:type:bug -label:type:feature -label:type:docs -label:type:refactor -label:type:help'
 
 PRIORITY_LABELS_FILTER='label:priority-1-critical -label:priority-2-high -label:priority-3-medium -label:priority-4-low'


### PR DESCRIPTION
## Changes

This PR will create a new workflow that once in a week will check all open issues and search if any of them are not labeled correctly. If all of them are labeled as expected, it'll cleanly complete the job, otherwise, a new issue reporting the unlabeled issues will be created.

Currently the new issue does not have an label, though. I don't know if we should create a particular label just for that kind of issue or if the action should ignore them.

## Context

Explained at #16273 

## Related issues

- Closes #16273

## Documentation

- [x] I have updated the documentation.

## How I've tested my work

- [x] Tested the new actions in a real repository and using [act](https://github.com/nektos/act).
