### PR TITLE
feat(platform/bitbucket): autodiscoverProjects

### DIFF
--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -216,6 +216,7 @@ For example:
 ## autodiscoverProjects
 
 You can use this option to filter the list of autodiscovered repositories by project names.
+This feature is useful for users who want Renovate to only work on repositories within specific projects or exclude certain repositories from being processed.
 
 ```json title="Example for Bitbucket"
 {

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -217,16 +217,14 @@ For example:
 
 You can use this option to filter the list of autodiscovered repositories by project names.
 
-For example:
-
-```json
+```json title="Example for Bitbucket"
 {
   "platform": "bitbucket",
   "autodiscoverProjects": ["a-group", "!another-group/some-subgroup"]
 }
 ```
 
-The `autodiscoverProjects` config option takes an array of minimatch-compatible globs or re2-compatible regex strings.
+The `autodiscoverProjects` config option takes an array of minimatch-compatible globs or RE2-compatible regex strings.
 For more details on this syntax see Renovate's [string pattern matching documentation](./string-pattern-matching.md).
 
 ## autodiscoverTopics

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -213,6 +213,22 @@ For example:
 }
 ```
 
+## autodiscoverProjects
+
+You can use this option to filter the list of autodiscovered repositories by project names.
+
+For example:
+
+```json
+{
+  "platform": "bitbucket",
+  "autodiscoverProjects": ["a-group", "!another-group/some-subgroup"]
+}
+```
+
+The `autodiscoverProjects` config option takes an array of minimatch-compatible globs or re2-compatible regex strings.
+For more details on this syntax see Renovate's [string pattern matching documentation](./string-pattern-matching.md).
+
 ## autodiscoverTopics
 
 Some platforms allow you to add tags, or topics, to repositories and retrieve repository lists by specifying those

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -885,7 +885,7 @@ const options: RenovateOptions[] = [
     supportedPlatforms: ['gitlab'],
   },
   {
-    name: 'autodiscoverNamespaces',
+    name: 'autodiscoverProjects',
     description:
       'Filter the list of autodiscovered repositories by project names.',
     stage: 'global',

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -885,6 +885,17 @@ const options: RenovateOptions[] = [
     supportedPlatforms: ['gitlab'],
   },
   {
+    name: 'autodiscoverNamespaces',
+    description:
+      'Filter the list of autodiscovered repositories by project names.',
+    stage: 'global',
+    type: 'array',
+    subType: 'string',
+    default: null,
+    globalOnly: true,
+    supportedPlatforms: ['bitbucket'],
+  },
+  {
     name: 'autodiscoverTopics',
     description: 'Filter the list of autodiscovered repositories by topics.',
     stage: 'global',

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -100,6 +100,7 @@ export interface GlobalOnlyConfig {
   autodiscover?: boolean;
   autodiscoverFilter?: string[] | string;
   autodiscoverNamespaces?: string[];
+  autodiscoverProjects?: string[];
   autodiscoverTopics?: string[];
   baseDir?: string;
   cacheDir?: string;

--- a/lib/modules/platform/bitbucket/index.spec.ts
+++ b/lib/modules/platform/bitbucket/index.spec.ts
@@ -133,7 +133,7 @@ describe('modules/platform/bitbucket/index', () => {
         .reply(200, {
           values: [{ full_name: 'foo/bar' }, { full_name: 'some/repo' }],
         });
-      const res = await bitbucket.getRepos();
+      const res = await bitbucket.getRepos({});
       expect(res).toEqual(['foo/bar', 'some/repo']);
     });
 

--- a/lib/modules/platform/bitbucket/index.spec.ts
+++ b/lib/modules/platform/bitbucket/index.spec.ts
@@ -136,6 +136,34 @@ describe('modules/platform/bitbucket/index', () => {
       const res = await bitbucket.getRepos();
       expect(res).toEqual(['foo/bar', 'some/repo']);
     });
+
+    it('filters repos based on autodiscoverProjects patterns', async () => {
+      httpMock
+        .scope(baseUrl)
+        .get('/2.0/repositories?role=contributor&pagelen=100')
+        .reply(200, {
+          values: [
+            { full_name: 'foo/bar', project: { name: 'ignore' } },
+            { full_name: 'some/repo', project: { name: 'allow' } },
+          ],
+        });
+      const res = await bitbucket.getRepos({ projects: ['allow'] });
+      expect(res).toEqual(['some/repo']);
+    });
+
+    it('filters repos based on autodiscoverProjects patterns with negation', async () => {
+      httpMock
+        .scope(baseUrl)
+        .get('/2.0/repositories?role=contributor&pagelen=100')
+        .reply(200, {
+          values: [
+            { full_name: 'foo/bar', project: { name: 'ignore' } },
+            { full_name: 'some/repo', project: { name: 'allow' } },
+          ],
+        });
+      const res = await bitbucket.getRepos({ projects: ['!ignore'] });
+      expect(res).toEqual(['some/repo']);
+    });
   });
 
   describe('initRepo()', () => {

--- a/lib/modules/platform/bitbucket/index.ts
+++ b/lib/modules/platform/bitbucket/index.ts
@@ -128,13 +128,14 @@ export async function getRepos(config: AutodiscoverConfig): Promise<string[]> {
 
     // if autodiscoverProjects is configured
     // filter the repos list
-    if (config.projects?.length) {
+    const autodiscoverProjects = config.projects;
+    if (is.nonEmptyArray(autodiscoverProjects)) {
       logger.debug(
-        { autodiscoverProjects: config?.projects },
+        { autodiscoverProjects: config.projects },
         'Applying autodiscoverProjects filter',
       );
       repos = repos.filter((repo) =>
-        matchRegexOrGlobList(repo.project.name, config.projects!),
+        matchRegexOrGlobList(repo.project.name, autodiscoverProjects),
       );
     }
 

--- a/lib/modules/platform/bitbucket/index.ts
+++ b/lib/modules/platform/bitbucket/index.ts
@@ -114,7 +114,7 @@ export async function initPlatform({
 }
 
 // Get all repositories that the user has access to
-export async function getRepos(config?: AutodiscoverConfig): Promise<string[]> {
+export async function getRepos(config: AutodiscoverConfig): Promise<string[]> {
   logger.debug('Autodiscovering Bitbucket Cloud repositories');
   try {
     let repos = (
@@ -128,7 +128,7 @@ export async function getRepos(config?: AutodiscoverConfig): Promise<string[]> {
 
     // if autodiscoverProjects is configured
     // filter the repos list
-    if (config?.projects?.length) {
+    if (config.projects?.length) {
       logger.debug(
         { autodiscoverProjects: config?.projects },
         'Applying autodiscoverProjects filter',

--- a/lib/modules/platform/bitbucket/types.ts
+++ b/lib/modules/platform/bitbucket/types.ts
@@ -66,6 +66,9 @@ export interface RepoInfoBody {
   uuid: string;
   full_name: string;
   is_private: boolean;
+  project: {
+    name: string;
+  };
 }
 
 export interface PrResponse {

--- a/lib/modules/platform/types.ts
+++ b/lib/modules/platform/types.ts
@@ -178,6 +178,7 @@ export interface AutodiscoverConfig {
   topics?: string[];
   includeMirrors?: boolean;
   namespaces?: string[];
+  projects?: string[];
 }
 
 export interface Platform {

--- a/lib/workers/global/autodiscover.ts
+++ b/lib/workers/global/autodiscover.ts
@@ -40,6 +40,7 @@ export async function autodiscoverRepositories(
     topics: config.autodiscoverTopics,
     includeMirrors: config.includeMirrors,
     namespaces: config.autodiscoverNamespaces,
+    projects: config.autodiscoverProjects,
   });
   if (!discovered?.length) {
     // Soft fail (no error thrown) if no accessible repositories


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- Add new config option `autodiscoverProjects` for the bitbucket platform which will filter the list of autodiscovered repositories 
- It can be used to both include/exclude projects 
<!-- Describe what behavior is changed by this PR. -->

## Context
Closes: https://github.com/renovatebot/renovate/issues/27661
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository (tested locally)

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
