### PR TITLE
refactor: config file parsing

### DIFF
--- a/lib/config/parse.ts
+++ b/lib/config/parse.ts
@@ -1,0 +1,75 @@
+import jsonValidator from 'json-dup-key-validator';
+import JSON5 from 'json5';
+import upath from 'upath';
+import { logger } from '../logger';
+import { parseJson } from '../util/common';
+
+export function parseFileConfig(
+  fileName: string,
+  fileContents: string,
+):
+  | { success: true; parsedContents: unknown }
+  | { success: false; validationError: string; validationMessage: string } {
+  const fileType = upath.extname(fileName);
+
+  if (fileType === '.json5') {
+    try {
+      return { success: true, parsedContents: JSON5.parse(fileContents) };
+    } catch (err) /* istanbul ignore next */ {
+      logger.debug({ fileName, fileContents }, 'Error parsing JSON5 file');
+      const validationError = 'Invalid JSON5 (parsing failed)';
+      const validationMessage = `JSON5.parse error: \`${err.message.replaceAll(
+        '`',
+        "'",
+      )}\``;
+      return {
+        success: false,
+        validationError,
+        validationMessage,
+      };
+    }
+  } else {
+    let allowDuplicateKeys = true;
+    let jsonValidationError = jsonValidator.validate(
+      fileContents,
+      allowDuplicateKeys,
+    );
+    if (jsonValidationError) {
+      const validationError = 'Invalid JSON (parsing failed)';
+      const validationMessage = jsonValidationError;
+      return {
+        success: false,
+        validationError,
+        validationMessage,
+      };
+    }
+    allowDuplicateKeys = false;
+    jsonValidationError = jsonValidator.validate(
+      fileContents,
+      allowDuplicateKeys,
+    );
+    if (jsonValidationError) {
+      const validationError = 'Duplicate keys in JSON';
+      const validationMessage = JSON.stringify(jsonValidationError);
+      return {
+        success: false,
+        validationError,
+        validationMessage,
+      };
+    }
+    try {
+      return {
+        success: true,
+        parsedContents: parseJson(fileContents, fileName),
+      };
+    } catch (err) /* istanbul ignore next */ {
+      logger.debug({ fileContents }, 'Error parsing renovate config');
+      const validationError = 'Invalid JSON (parsing failed)';
+      const validationMessage = `JSON.parse error:  \`${err.message.replaceAll(
+        '`',
+        "'",
+      )}\``;
+      return { success: false, validationError, validationMessage };
+    }
+  }
+}

--- a/lib/workers/repository/init/merge.ts
+++ b/lib/workers/repository/init/merge.ts
@@ -1,12 +1,10 @@
 import is from '@sindresorhus/is';
-import jsonValidator from 'json-dup-key-validator';
-import JSON5 from 'json5';
-import upath from 'upath';
 import { mergeChildConfig } from '../../../config';
 import { configFileNames } from '../../../config/app-strings';
 import { decryptConfig } from '../../../config/decrypt';
 import { migrateAndValidate } from '../../../config/migrate-validate';
 import { migrateConfig } from '../../../config/migration';
+import { parseFileConfig } from '../../../config/parse';
 import * as presets from '../../../config/presets';
 import { applySecretsToConfig } from '../../../config/secrets';
 import type { RenovateConfig } from '../../../config/types';
@@ -131,71 +129,18 @@ export async function detectRepoFileConfig(): Promise<RepoFileConfig> {
       configFileRaw = '{}';
     }
 
-    const fileType = upath.extname(configFileName);
+    const parseResult = parseFileConfig(configFileName, configFileRaw);
 
-    if (fileType === '.json5') {
-      try {
-        configFileParsed = JSON5.parse(configFileRaw);
-      } catch (err) /* istanbul ignore next */ {
-        logger.debug(
-          { renovateConfig: configFileRaw },
-          'Error parsing renovate config renovate.json5',
-        );
-        const validationError = 'Invalid JSON5 (parsing failed)';
-        const validationMessage = `JSON5.parse error: \`${err.message.replaceAll(
-          '`',
-          "'",
-        )}\``;
-        return {
-          configFileName,
-          configFileParseError: { validationError, validationMessage },
-        };
-      }
-    } else {
-      let allowDuplicateKeys = true;
-      let jsonValidationError = jsonValidator.validate(
-        configFileRaw,
-        allowDuplicateKeys,
-      );
-      if (jsonValidationError) {
-        const validationError = 'Invalid JSON (parsing failed)';
-        const validationMessage = jsonValidationError;
-        return {
-          configFileName,
-          configFileParseError: { validationError, validationMessage },
-        };
-      }
-      allowDuplicateKeys = false;
-      jsonValidationError = jsonValidator.validate(
-        configFileRaw,
-        allowDuplicateKeys,
-      );
-      if (jsonValidationError) {
-        const validationError = 'Duplicate keys in JSON';
-        const validationMessage = JSON.stringify(jsonValidationError);
-        return {
-          configFileName,
-          configFileParseError: { validationError, validationMessage },
-        };
-      }
-      try {
-        configFileParsed = parseJson(configFileRaw, configFileName);
-      } catch (err) /* istanbul ignore next */ {
-        logger.debug(
-          { renovateConfig: configFileRaw },
-          'Error parsing renovate config',
-        );
-        const validationError = 'Invalid JSON (parsing failed)';
-        const validationMessage = `JSON.parse error:  \`${err.message.replaceAll(
-          '`',
-          "'",
-        )}\``;
-        return {
-          configFileName,
-          configFileParseError: { validationError, validationMessage },
-        };
-      }
+    if (!parseResult.success) {
+      return {
+        configFileName,
+        configFileParseError: {
+          validationError: parseResult.validationError,
+          validationMessage: parseResult.validationMessage,
+        },
+      };
     }
+    configFileParsed = parseResult.parsedContents;
     logger.debug(
       { fileName: configFileName, config: configFileParsed },
       'Repository config',


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Refactors config file parsing into a separate file.

## Context

Preparation for inherited config support

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
