### PR TITLE
feat(manager/gradle): add support for new header used by gradle-consistent-versions plugin

### DIFF
--- a/lib/modules/manager/gradle/extract/consistent-versions-plugin.spec.ts
+++ b/lib/modules/manager/gradle/extract/consistent-versions-plugin.spec.ts
@@ -20,6 +20,18 @@ describe('modules/manager/gradle/extract/consistent-versions-plugin', () => {
     expect(usesGcv('othersub/versions.props', fsMock)).toBeFalse();
   });
 
+  it('detects lock file header introduced with gradle-consistent-versions version 2.20.0', () => {
+    const fsMock = {
+      'build.gradle.kts': `(this file contains) 'com.palantir.consistent-versions'`,
+      'versions.props': `org.apache.lucene:* = 1.2.3`,
+      'versions.lock': stripIndent`
+        # Run ./gradlew writeVersionsLock to regenerate this file
+        org.apache.lucene:lucene-core:1.2.3`,
+    };
+
+    expect(usesGcv('versions.props', fsMock)).toBeTrue();
+  });
+
   it('gradle-consistent-versions plugin correct position for CRLF and LF', () => {
     const crlfProps = parsePropsFile(`a.b:c.d=1\r\na.b:c.e=2`);
     expect(crlfProps).toBeArrayOfSize(2);
@@ -47,7 +59,6 @@ describe('modules/manager/gradle/extract/consistent-versions-plugin', () => {
     expect(parsedProps[0]).toMatchObject({ size: 1 }); // no 7 is valid exact dep
     expect(parsedProps[1]).toMatchObject({ size: 1 }); // no 8 is valid glob dep
 
-    // lockfile
     const parsedLock = parseLockFile(stripIndent`
       # comment:foo.bar:1 (10 constraints: 95be0c15)
       123.foo:bar:2 (10 constraints: 95be0c15)

--- a/lib/modules/manager/gradle/extract/consistent-versions-plugin.ts
+++ b/lib/modules/manager/gradle/extract/consistent-versions-plugin.ts
@@ -8,8 +8,9 @@ import { isDependencyString, versionLikeSubstring } from '../utils';
 
 export const VERSIONS_PROPS = 'versions.props';
 export const VERSIONS_LOCK = 'versions.lock';
-const LOCKFILE_HEADER_TEXT =
-  '# Run ./gradlew --write-locks to regenerate this file';
+export const LOCKFIlE_HEADER_TEXT = regEx(
+  /^# Run \.\/gradlew (--write-locks|writeVersionsLock) to regenerate this file/,
+);
 
 /**
  * Determines if Palantir gradle-consistent-versions is in use, https://github.com/palantir/gradle-consistent-versions.
@@ -26,9 +27,8 @@ export function usesGcv(
     versionsPropsFilename,
     VERSIONS_LOCK,
   );
-  return (
-    fileContents[versionsLockFile]?.startsWith(LOCKFILE_HEADER_TEXT) ?? false
-  );
+
+  return !!fileContents[versionsLockFile]?.match(LOCKFIlE_HEADER_TEXT);
 }
 
 /**

--- a/lib/modules/manager/gradle/extract/consistent-versions-plugin.ts
+++ b/lib/modules/manager/gradle/extract/consistent-versions-plugin.ts
@@ -9,7 +9,7 @@ import { isDependencyString, versionLikeSubstring } from '../utils';
 export const VERSIONS_PROPS = 'versions.props';
 export const VERSIONS_LOCK = 'versions.lock';
 export const LOCKFIlE_HEADER_TEXT = regEx(
-  /^# Run \.\/gradlew (--write-locks|writeVersionsLock) to regenerate this file/,
+  /^# Run \.\/gradlew (?:--write-locks|writeVersionsLock) to regenerate this file/,
 );
 
 /**


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds functionality to detect the new header line used by the [gradle-consistent-versions](https://github.com/palantir/gradle-consistent-versions) plugin since version 2.20.0: 
`# Run ./gradlew writeVersionsLock to regenerate this file`

<!-- Describe what behavior is changed by this PR. -->

## Context

- Closes https://github.com/renovatebot/renovate/discussions/27230

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<details>
  <summary>Output when ran on https://github.com/bduisenov/renovate-27230</summary>

 ```json
 INFO: Extracted dependencies (repository=bduisenov/renovate-27230)
 "packageFiles": {
   "gradle": [
     {"packageFile": "settings.gradle.kts", "datasource": "maven", "deps": []},
     {"packageFile": "versions.lock", "datasource": "maven", "deps": []},
     {
       "packageFile": "versions.props",
       "datasource": "maven",
       "deps": [
         {
           "managerData": {
             "packageFile": "versions.props",
             "fileReplacePosition": 29
           },
           "depName": "org.springframework.boot:spring-boot",
           "currentValue": "3.2.3",
           "lockedVersion": "3.2.3",
           "depType": "dependencies",
           "groupName": "org.springframework.boot:*",
           "fileReplacePosition": 29,
           "datasource": "maven",
           "registryUrls": ["https://repo.maven.apache.org/maven2"]
         },
         {
           "managerData": {
             "packageFile": "versions.props",
             "fileReplacePosition": 29
           },
           "depName": "org.springframework.boot:spring-boot-autoconfigure",
           "currentValue": "3.2.3",
           "lockedVersion": "3.2.3",
           "depType": "dependencies",
           "groupName": "org.springframework.boot:*",
           "fileReplacePosition": 29,
           "datasource": "maven",
           "registryUrls": ["https://repo.maven.apache.org/maven2"]
         },
         {
           "managerData": {
             "packageFile": "versions.props",
             "fileReplacePosition": 29
           },
           "depName": "org.springframework.boot:spring-boot-starter",
           "currentValue": "3.2.3",
           "lockedVersion": "3.2.3",
           "depType": "dependencies",
           "groupName": "org.springframework.boot:*",
           "fileReplacePosition": 29,
           "datasource": "maven",
           "registryUrls": ["https://repo.maven.apache.org/maven2"]
         },
         {
           "managerData": {
             "packageFile": "versions.props",
             "fileReplacePosition": 29
           },
           "depName": "org.springframework.boot:spring-boot-starter-json",
           "currentValue": "3.2.3",
           "lockedVersion": "3.2.3",
           "depType": "dependencies",
           "groupName": "org.springframework.boot:*",
           "fileReplacePosition": 29,
           "datasource": "maven",
           "registryUrls": ["https://repo.maven.apache.org/maven2"]
         },
         {
           "managerData": {
             "packageFile": "versions.props",
             "fileReplacePosition": 29
           },
           "depName": "org.springframework.boot:spring-boot-starter-logging",
           "currentValue": "3.2.3",
           "lockedVersion": "3.2.3",
           "depType": "dependencies",
           "groupName": "org.springframework.boot:*",
           "fileReplacePosition": 29,
           "datasource": "maven",
           "registryUrls": ["https://repo.maven.apache.org/maven2"]
         },
         {
           "managerData": {
             "packageFile": "versions.props",
             "fileReplacePosition": 29
           },
           "depName": "org.springframework.boot:spring-boot-starter-tomcat",
           "currentValue": "3.2.3",
           "lockedVersion": "3.2.3",
           "depType": "dependencies",
           "groupName": "org.springframework.boot:*",
           "fileReplacePosition": 29,
           "datasource": "maven",
           "registryUrls": ["https://repo.maven.apache.org/maven2"]
         },
         {
           "managerData": {
             "packageFile": "versions.props",
             "fileReplacePosition": 29
           },
           "depName": "org.springframework.boot:spring-boot-starter-web",
           "currentValue": "3.2.3",
           "lockedVersion": "3.2.3",
           "depType": "dependencies",
           "groupName": "org.springframework.boot:*",
           "fileReplacePosition": 29,
           "datasource": "maven",
           "registryUrls": ["https://repo.maven.apache.org/maven2"]
         },
         {
           "managerData": {
             "packageFile": "versions.props",
             "fileReplacePosition": 29
           },
           "depName": "org.springframework.boot:spring-boot-starter-test",
           "currentValue": "3.2.3",
           "lockedVersion": "3.2.3",
           "depType": "test",
           "groupName": "org.springframework.boot:*",
           "fileReplacePosition": 29,
           "datasource": "maven",
           "registryUrls": ["https://repo.maven.apache.org/maven2"]
         },
         {
           "managerData": {
             "packageFile": "versions.props",
             "fileReplacePosition": 29
           },
           "depName": "org.springframework.boot:spring-boot-test",
           "currentValue": "3.2.3",
           "lockedVersion": "3.2.3",
           "depType": "test",
           "groupName": "org.springframework.boot:*",
           "fileReplacePosition": 29,
           "datasource": "maven",
           "registryUrls": ["https://repo.maven.apache.org/maven2"]
         },
         {
           "managerData": {
             "packageFile": "versions.props",
             "fileReplacePosition": 29
           },
           "depName": "org.springframework.boot:spring-boot-test-autoconfigure",
           "currentValue": "3.2.3",
           "lockedVersion": "3.2.3",
           "depType": "test",
           "groupName": "org.springframework.boot:*",
           "fileReplacePosition": 29,
           "datasource": "maven",
           "registryUrls": ["https://repo.maven.apache.org/maven2"]
         }
       ]
     },
     {
       "packageFile": "build.gradle.kts",
       "datasource": "maven",
       "deps": [
         {
           "depType": "plugin",
           "depName": "com.palantir.consistent-versions",
           "packageName": "com.palantir.consistent-versions:com.palantir.consistent-versions.gradle.plugin",
           "commitMessageTopic": "plugin com.palantir.consistent-versions",
           "currentValue": "2.21.0",
           "managerData": {
             "fileReplacePosition": 65,
             "packageFile": "build.gradle.kts"
           },
           "fileReplacePosition": 65,
           "datasource": "maven",
           "registryUrls": ["https://plugins.gradle.org/m2/"]
         }
       ]
     }
   ]
 }

```

</details>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
