### PR TITLE
fix(workers/repository): Pass correct lock files when updating a dependency in multiple input files

### DIFF
--- a/lib/workers/repository/update/branch/get-updated.spec.ts
+++ b/lib/workers/repository/update/branch/get-updated.spec.ts
@@ -205,6 +205,81 @@ describe('workers/repository/update/branch/get-updated', () => {
       });
     });
 
+    it('for updatedArtifacts passes proper lockFiles', async () => {
+      config.upgrades.push({
+        packageFile: 'composer.json',
+        manager: 'composer',
+        branchName: '',
+      });
+      config.lockFiles = ['different.lock'];
+      config.packageFiles = {
+        composer: [
+          {
+            packageFile: 'composer.json',
+            lockFiles: ['composer.lock'],
+            deps: [],
+          },
+        ] satisfies PackageFile[],
+      };
+      autoReplace.doAutoReplace.mockResolvedValueOnce('some new content');
+      composer.updateArtifacts.mockResolvedValueOnce([
+        {
+          file: {
+            type: 'addition',
+            path: 'composer.lock',
+            contents: 'some contents',
+          },
+        },
+      ]);
+      await getUpdatedPackageFiles(config);
+      expect(composer.updateArtifacts).toHaveBeenCalledWith(
+        expect.objectContaining({
+          config: expect.objectContaining({
+            lockFiles: ['composer.lock'],
+          }),
+        }),
+      );
+    });
+
+    it('for nonUpdatedArtifacts passes proper lockFiles', async () => {
+      config.upgrades.push({
+        packageFile: 'composer.json',
+        manager: 'composer',
+        branchName: '',
+        isLockfileUpdate: true,
+      });
+      composer.updateLockedDependency.mockReturnValueOnce({
+        status: 'unsupported',
+      });
+      config.lockFiles = ['different.lock'];
+      config.packageFiles = {
+        composer: [
+          {
+            packageFile: 'composer.json',
+            lockFiles: ['composer.lock'],
+            deps: [],
+          },
+        ] satisfies PackageFile[],
+      };
+      composer.updateArtifacts.mockResolvedValueOnce([
+        {
+          file: {
+            type: 'addition',
+            path: 'composer.lock',
+            contents: 'some contents',
+          },
+        },
+      ]);
+      await getUpdatedPackageFiles(config);
+      expect(composer.updateArtifacts).toHaveBeenCalledWith(
+        expect.objectContaining({
+          config: expect.objectContaining({
+            lockFiles: ['composer.lock'],
+          }),
+        }),
+      );
+    });
+
     it('for lockFileMaintenance passes proper lockFiles', async () => {
       config.upgrades.push({
         manager: 'composer',

--- a/lib/workers/repository/update/branch/get-updated.ts
+++ b/lib/workers/repository/update/branch/get-updated.ts
@@ -302,7 +302,11 @@ export async function getUpdatedPackageFiles(
           updatedDeps,
           // TODO #22198
           newPackageFileContent: packageFile.contents!.toString(),
-          config,
+          config: patchConfigForArtifactsUpdate(
+            config,
+            manager,
+            packageFile.path,
+          ),
         });
         processUpdateArtifactResults(results, updatedArtifacts, artifactErrors);
       }
@@ -329,7 +333,11 @@ export async function getUpdatedPackageFiles(
           updatedDeps,
           // TODO #22198
           newPackageFileContent: packageFile.contents!.toString(),
-          config,
+          config: patchConfigForArtifactsUpdate(
+            config,
+            manager,
+            packageFile.path,
+          ),
         });
         processUpdateArtifactResults(results, updatedArtifacts, artifactErrors);
         if (is.nonEmptyArray(results)) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This applies the fix from #27319 to non-lockFileMaintanence updates so that the correct `lockFiles` attribute gets passed to the manager's `updateArtifacts` function when updating single dependencies.  Without this change, the same `lockFiles` attribute gets passed along with every `packageFileName`, which causes the pip-compile manager to update the same lock file multiple times when a dependency is updated in multiple input files.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->
Discussion of the impact of this bug on the pip-compile manager: #27761 
Original PR that applied this workaround to lockFileMaintanence: #27319 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
