### PR TITLE
fix(cache): Revert "refactor: Initialize caches before repository init"

### DIFF
--- a/lib/workers/repository/init/index.ts
+++ b/lib/workers/repository/init/index.ts
@@ -48,8 +48,8 @@ export async function initRepo(
   let config: RenovateConfig = initializeConfig(config_);
   await resetCaches();
   logger.once.reset();
-  await initializeCaches(config as WorkerPlatformConfig);
   config = await initApis(config);
+  await initializeCaches(config as WorkerPlatformConfig);
   config = await getRepoConfig(config);
   setRepositoryLogLevelRemaps(config.logLevelRemap);
   checkIfConfigured(config);


### PR DESCRIPTION
Reverts renovatebot/renovate#27897

> The refactor of init meant that the repo fingerprint wasn't available, which meant it wasn't written to the cache.
> Then on the second run on the new/bad version it failed to parse the cache with zod due to the missing fingerprint
