### PR TITLE
fix(azure): Support exact branch merge policies.

### DIFF
--- a/lib/modules/platform/azure/azure-helper.spec.ts
+++ b/lib/modules/platform/azure/azure-helper.spec.ts
@@ -244,7 +244,8 @@ describe('modules/platform/azure/azure-helper', () => {
       const refMock = 'refs/heads/ding';
 
       azureApi.policyApi.mockResolvedValueOnce({
-          getPolicyConfigurations: jest.fn(() => Promise.resolve([
+        getPolicyConfigurations: jest.fn(() =>
+          Promise.resolve([
             partial<PolicyConfiguration>({
               settings: {
                 allowSquash: true,
@@ -256,11 +257,11 @@ describe('modules/platform/azure/azure-helper', () => {
                     refName: refMock,
                   },
                 ],
-              }
+              },
             }),
-          ]))
-        }
-      );
+          ]),
+        ),
+      });
       expect(await azureHelper.getMergeMethod('', '', refMock)).toEqual(
         GitPullRequestMergeStrategy.Squash,
       );

--- a/lib/modules/platform/azure/azure-helper.spec.ts
+++ b/lib/modules/platform/azure/azure-helper.spec.ts
@@ -238,6 +238,33 @@ describe('modules/platform/azure/azure-helper', () => {
       );
     });
 
+    it('should return Squash when Project wide exact branch policy exists', async () => {
+      azureApi.policyApi.mockImplementationOnce(
+        () =>
+          ({
+            getPolicyConfigurations: jest.fn(() => [
+              {
+                settings: {
+                  allowSquash: true,
+                  scope: [
+                    {
+                      // null here means project wide
+                      repositoryId: null,
+                    },
+                  ],
+                },
+                type: {
+                  id: 'fa4e907d-c16b-4a4c-9dfa-4916e5d171ab',
+                },
+              },
+            ]),
+          }) as any,
+      );
+      expect(await azureHelper.getMergeMethod('', '')).toEqual(
+        GitPullRequestMergeStrategy.Squash,
+      );
+    });
+
     it('should return default branch policy', async () => {
       azureApi.policyApi.mockImplementationOnce(
         () =>

--- a/lib/modules/platform/azure/azure-helper.spec.ts
+++ b/lib/modules/platform/azure/azure-helper.spec.ts
@@ -1,7 +1,8 @@
 import { Readable } from 'node:stream';
-import { GitPullRequestMergeStrategy } from 'azure-devops-node-api/interfaces/GitInterfaces.js';
-import { partial } from '../../../../test/util';
+import type { IPolicyApi } from 'azure-devops-node-api/PolicyApi';
+import { GitPullRequestMergeStrategy } from 'azure-devops-node-api/interfaces/GitInterfaces';
 import type { PolicyConfiguration } from 'azure-devops-node-api/interfaces/PolicyInterfaces';
+import { partial } from '../../../../test/util';
 
 jest.mock('./azure-got-wrapper');
 
@@ -243,25 +244,27 @@ describe('modules/platform/azure/azure-helper', () => {
     it('should return Squash when Project wide exact branch policy exists', async () => {
       const refMock = 'refs/heads/ding';
 
-      azureApi.policyApi.mockResolvedValueOnce({
-        getPolicyConfigurations: jest.fn(() =>
-          Promise.resolve([
-            partial<PolicyConfiguration>({
-              settings: {
-                allowSquash: true,
-                scope: [
-                  {
-                    // null here means project wide
-                    repositoryId: null,
-                    matchKind: 'Exact',
-                    refName: refMock,
-                  },
-                ],
-              },
-            }),
-          ]),
-        ),
-      });
+      azureApi.policyApi.mockResolvedValueOnce(
+        partial<IPolicyApi>({
+          getPolicyConfigurations: jest.fn(() =>
+            Promise.resolve([
+              partial<PolicyConfiguration>({
+                settings: {
+                  allowSquash: true,
+                  scope: [
+                    {
+                      // null here means project wide
+                      repositoryId: null,
+                      matchKind: 'Exact',
+                      refName: refMock,
+                    },
+                  ],
+                },
+              }),
+            ]),
+          ),
+        }),
+      );
       expect(await azureHelper.getMergeMethod('', '', refMock)).toEqual(
         GitPullRequestMergeStrategy.Squash,
       );

--- a/lib/modules/platform/azure/azure-helper.spec.ts
+++ b/lib/modules/platform/azure/azure-helper.spec.ts
@@ -1,8 +1,6 @@
 import { Readable } from 'node:stream';
 import { GitPullRequestMergeStrategy } from 'azure-devops-node-api/interfaces/GitInterfaces.js';
 import { partial } from '../../../../test/util';
-import type { IPolicyApi } from 'azure-devops-node-api/PolicyApi';
-import type { PagedList }from 'azure-devops-node-api/interfaces/common/VSSInterfaces';
 import type { PolicyConfiguration } from 'azure-devops-node-api/interfaces/PolicyInterfaces';
 
 jest.mock('./azure-got-wrapper');

--- a/lib/modules/platform/azure/azure-helper.ts
+++ b/lib/modules/platform/azure/azure-helper.ts
@@ -135,7 +135,7 @@ export async function getMergeMethod(
     ) {
       return true;
     }
-    if (scope.repositoryId !== repoId) {
+    if (scope.repositoryId !== repoId && scope.repositoryId !== null) {
       return false;
     }
     if (!branchRef) {


### PR DESCRIPTION
## Changes

Renovate will now honor merge strategy policies targeting a branch  when one exists at the Azure DevOps Project level. 

## Context

This resolves the issue in this discussion: #27330

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
