### PR TITLE
feat: allow packageScope in template compilation and add packageScope in maven datasource

### DIFF
--- a/lib/modules/datasource/clojure/__snapshots__/index.spec.ts.snap
+++ b/lib/modules/datasource/clojure/__snapshots__/index.spec.ts.snap
@@ -6,6 +6,7 @@ exports[`modules/datasource/clojure/index falls back to next registry url 1`] = 
   "group": "org.example",
   "homepage": "https://package.example.org/about",
   "name": "package",
+  "packageScope": "org.example",
   "registryUrl": "https://clojars.org/repo",
   "releases": [
     {
@@ -53,6 +54,7 @@ exports[`modules/datasource/clojure/index returns releases from custom repositor
   "group": "org.example",
   "homepage": "https://package.example.org/about",
   "name": "package",
+  "packageScope": "org.example",
   "registryUrl": "https://custom.registry.renovatebot.com",
   "releases": [
     {
@@ -80,6 +82,7 @@ exports[`modules/datasource/clojure/index skips registry with invalid XML 1`] = 
   "group": "org.example",
   "homepage": "https://package.example.org/about",
   "name": "package",
+  "packageScope": "org.example",
   "registryUrl": "https://clojars.org/repo",
   "releases": [
     {
@@ -107,6 +110,7 @@ exports[`modules/datasource/clojure/index skips registry with invalid metadata s
   "group": "org.example",
   "homepage": "https://package.example.org/about",
   "name": "package",
+  "packageScope": "org.example",
   "registryUrl": "https://clojars.org/repo",
   "releases": [
     {

--- a/lib/modules/datasource/maven/__snapshots__/index.spec.ts.snap
+++ b/lib/modules/datasource/maven/__snapshots__/index.spec.ts.snap
@@ -6,6 +6,7 @@ exports[`modules/datasource/maven/index falls back to next registry url 1`] = `
   "group": "org.example",
   "homepage": "https://package.example.org/about",
   "name": "package",
+  "packageScope": "org.example",
   "registryUrl": "https://repo.maven.apache.org/maven2",
   "releases": [
     {
@@ -53,6 +54,7 @@ exports[`modules/datasource/maven/index removes authentication header after redi
   "group": "org.example",
   "homepage": "https://package.example.org/about",
   "name": "package",
+  "packageScope": "org.example",
   "registryUrl": "https://frontend_for_private_s3_repository/maven2",
   "releases": [
     {
@@ -89,6 +91,7 @@ exports[`modules/datasource/maven/index returns releases 1`] = `
   "group": "org.example",
   "homepage": "https://package.example.org/about",
   "name": "package",
+  "packageScope": "org.example",
   "registryUrl": "https://repo.maven.apache.org/maven2",
   "releases": [
     {
@@ -116,6 +119,7 @@ exports[`modules/datasource/maven/index returns releases from custom repository 
   "group": "org.example",
   "homepage": "https://package.example.org/about",
   "name": "package",
+  "packageScope": "org.example",
   "registryUrl": "https://custom.registry.renovatebot.com",
   "releases": [
     {
@@ -143,6 +147,7 @@ exports[`modules/datasource/maven/index skips registry with invalid XML 1`] = `
   "group": "org.example",
   "homepage": "https://package.example.org/about",
   "name": "package",
+  "packageScope": "org.example",
   "registryUrl": "https://repo.maven.apache.org/maven2",
   "releases": [
     {
@@ -170,6 +175,7 @@ exports[`modules/datasource/maven/index skips registry with invalid metadata str
   "group": "org.example",
   "homepage": "https://package.example.org/about",
   "name": "package",
+  "packageScope": "org.example",
   "registryUrl": "https://repo.maven.apache.org/maven2",
   "releases": [
     {

--- a/lib/modules/datasource/maven/index.spec.ts
+++ b/lib/modules/datasource/maven/index.spec.ts
@@ -240,6 +240,7 @@ describe('modules/datasource/maven/index', () => {
       group: 'org.example',
       homepage: 'https://package.example.org/about',
       name: 'package',
+      packageScope: 'org.example',
       registryUrl: 'https://repo.maven.apache.org/maven2',
       releases: [
         {
@@ -268,6 +269,7 @@ describe('modules/datasource/maven/index', () => {
       group: 'org.example',
       homepage: 'https://package.example.org/about',
       name: 'package',
+      packageScope: 'org.example',
       registryUrl: 'https://repo.maven.apache.org/maven2',
       releases: [
         { version: '1.0.0', releaseTimestamp: '2021-02-22T14:43:00.000Z' },
@@ -484,6 +486,7 @@ describe('modules/datasource/maven/index', () => {
       group: 'org.example',
       homepage: 'https://package.example.org/about',
       name: 'package',
+      packageScope: 'org.example',
       registryUrl:
         'artifactregistry://maven.pkg.dev/some-project/some-repository',
       releases: [
@@ -535,6 +538,7 @@ describe('modules/datasource/maven/index', () => {
       group: 'org.example',
       homepage: 'https://package.example.org/about',
       name: 'package',
+      packageScope: 'org.example',
       registryUrl:
         'artifactregistry://maven.pkg.dev/some-project/some-repository',
       releases: [

--- a/lib/modules/datasource/maven/util.ts
+++ b/lib/modules/datasource/maven/util.ts
@@ -449,6 +449,11 @@ export async function getDependencyInfo(
     }
   }
 
+  const groupId = pomContent.valueWithPath('groupId');
+  if (groupId) {
+    result.packageScope = groupId;
+  }
+
   const parent = pomContent.childNamed('parent');
   if (recursionLimit > 0 && parent && (!result.sourceUrl || !result.homepage)) {
     // if we found a parent and are missing some information

--- a/lib/modules/datasource/types.ts
+++ b/lib/modules/datasource/types.ts
@@ -87,6 +87,7 @@ export interface ReleaseResult {
   replacementName?: string;
   replacementVersion?: string;
   lookupName?: string;
+  packageScope?: string;
 }
 
 export type RegistryStrategy = 'first' | 'hunt' | 'merge';

--- a/lib/util/template/index.ts
+++ b/lib/util/template/index.ts
@@ -123,6 +123,7 @@ export const allowedFields = {
   packageFileDir:
     'The directory with full path where the packageFile was found',
   packageName: 'The full name that was used to look up the dependency',
+  packageScope: 'The scope of the package name',
   parentDir:
     'The name of the directory that the dependency was found in, without full path',
   platform: 'VCS platform in use, e.g. "github", "gitlab", etc.',

--- a/lib/util/template/index.ts
+++ b/lib/util/template/index.ts
@@ -123,7 +123,7 @@ export const allowedFields = {
   packageFileDir:
     'The directory with full path where the packageFile was found',
   packageName: 'The full name that was used to look up the dependency',
-  packageScope: 'The scope of the package name',
+  packageScope: 'The scope of the package name. Supports Maven group ID only',
   parentDir:
     'The name of the directory that the dependency was found in, without full path',
   platform: 'VCS platform in use, e.g. "github", "gitlab", etc.',

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -165,6 +165,7 @@ export async function lookupUpdates(
         'changelogUrl',
         'dependencyUrl',
         'lookupName',
+        'packageScope',
       ]);
 
       const latestVersion = dependency.tags?.latest;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
This PR allows `packageScope` to be compiled in template module and adds packageScope in `maven` datasource.

This feature makes `maven` datasource to be able to pickup artifact `groupId` as the `packageScope` and allows the `packageScope` to be used in `groupName` so that we could group maven artifact update by its group name. 

example configuration

```json5
{
  packageRules: [
    {
       matchManagers: [
          'gradle'
       ],
       groupName: "{{packageScope}}"
    }
  ]
}
```

<!-- Describe what behavior is changed by this PR. -->

## Context

https://github.com/renovatebot/renovate/discussions/27721

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [X] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
