### PR TITLE
fix(templates): compile groupSlug

### DIFF
--- a/lib/workers/repository/updates/branch-name.spec.ts
+++ b/lib/workers/repository/updates/branch-name.spec.ts
@@ -31,14 +31,15 @@ describe('workers/repository/updates/branch-name', () => {
     it('uses groupSlug if defined', () => {
       const upgrade: RenovateConfig = {
         groupName: 'some group name',
-        groupSlug: 'some group slug',
+        groupSlug: 'some group {{parentDir}}',
+        parentDir: 'abc',
         group: {
           branchName: '{{groupSlug}}-{{branchTopic}}',
           branchTopic: 'grouptopic',
         },
       };
       generateBranchName(upgrade);
-      expect(upgrade.branchName).toBe('some-group-slug-grouptopic');
+      expect(upgrade.branchName).toBe('some-group-abc-grouptopic');
     });
 
     it('separates major with groups', () => {

--- a/lib/workers/repository/updates/branch-name.ts
+++ b/lib/workers/repository/updates/branch-name.ts
@@ -54,7 +54,12 @@ export function generateBranchName(update: RenovateConfig): void {
     logger.trace(
       `Dependency ${update.depName!} is part of group ${update.groupName}`,
     );
-    update.groupSlug = slugify(update.groupSlug ?? update.groupName, {
+    if (update.groupSlug) {
+      update.groupSlug = template.compile(update.groupSlug, update);
+    } else {
+      update.groupSlug = update.groupName;
+    }
+    update.groupSlug = slugify(update.groupSlug, {
       lower: true,
     });
     if (update.updateType === 'major' && update.separateMajorMinor) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Compile groupSlug if set

## Context

groupName was already compiled but not grouSlug

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
