### PR TITLE
docs(nuget): add hint for protocol version in NuGet.config

### DIFF
--- a/docs/usage/nuget.md
+++ b/docs/usage/nuget.md
@@ -78,15 +78,26 @@ So Renovate behaves like the official NuGet client.
 
 #### v3 feed URL not ending with index.json
 
-If a `v3` feed URL does not end with `index.json`, you must append `#protocolVersion=3` to the registry URL:
+If a `v3` feed URL does not end with `index.json`, you must specify the version explicitely.
 
-```json
-{
-  "nuget": {
-    "registryUrls": ["http://myV3feed#protocolVersion=3"]
+- If the feed is defined in a `NuGet.config` file set the `protocolVersion` attribute to `3`:
+
+  ```xml
+  <packageSources>
+     <clear />
+     <add key="myV3feed" value="http://myV3feed" protocolVersion="3" />
+  </packageSources>
+  ```
+
+- If the feed is defined via Renovate configuration append `#protocolVersion=3` to the registry URL:
+
+  ```json
+  {
+    "nuget": {
+      "registryUrls": ["http://myV3feed#protocolVersion=3"]
+    }
   }
-}
-```
+  ```
 
 You may need this workaround when you use the JFrog Artifactory.
 

--- a/docs/usage/nuget.md
+++ b/docs/usage/nuget.md
@@ -78,7 +78,7 @@ So Renovate behaves like the official NuGet client.
 
 #### v3 feed URL not ending with index.json
 
-If a `v3` feed URL does not end with `index.json`, you must specify the version explicitely.
+If a `v3` feed URL does not end with `index.json`, you must specify the version explicitly.
 
 - If the feed is defined in a `NuGet.config` file set the `protocolVersion` attribute to `3`:
 


### PR DESCRIPTION
## Changes

Update NuGet docs to mention how to define the protocol version for feeds in `NuGet.config` files. 

## Context

I forgot to update this documentation in https://github.com/renovatebot/renovate/pull/5757. Funnily this was nearly four years ago and nobody noticed :) 

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

:hammer_and_pick: with :heart: by [Siemens](https://opensource.siemens.com/) 
