### PR TITLE
feat(manager/github-actions): extract complex github tags

### DIFF
--- a/lib/modules/manager/github-actions/__snapshots__/extract.spec.ts.snap
+++ b/lib/modules/manager/github-actions/__snapshots__/extract.spec.ts.snap
@@ -10,7 +10,6 @@ exports[`modules/manager/github-actions/extract extractPackageFile() extracts mu
     "depName": "actions/bin",
     "depType": "action",
     "replaceString": "actions/bin/shellcheck@master",
-    "skipReason": "invalid-version",
     "versioning": "docker",
   },
   {
@@ -127,7 +126,6 @@ exports[`modules/manager/github-actions/extract extractPackageFile() extracts mu
     "depName": "actions/bin",
     "depType": "action",
     "replaceString": "actions/bin/shellcheck@master",
-    "skipReason": "invalid-version",
     "versioning": "docker",
   },
   {
@@ -147,7 +145,6 @@ exports[`modules/manager/github-actions/extract extractPackageFile() extracts mu
     "depName": "actions/docker",
     "depType": "action",
     "replaceString": "actions/docker/cli@master",
-    "skipReason": "invalid-version",
     "versioning": "docker",
   },
   {

--- a/lib/modules/manager/github-actions/extract.spec.ts
+++ b/lib/modules/manager/github-actions/extract.spec.ts
@@ -371,7 +371,6 @@ describe('modules/manager/github-actions/extract', () => {
         {
           currentValue: '01aecc#v2.1.0',
           replaceString: 'actions/checkout@01aecc#v2.1.0',
-          skipReason: 'invalid-version',
         },
         {
           currentDigest: '689fcce700ae7ffc576f2b029b51b2ffb66d3abd',
@@ -404,6 +403,8 @@ describe('modules/manager/github-actions/extract', () => {
             'actions-runner-controller/execute-assert-arc-e2e@f1d7c52253b89f0beae60141f8465d9495cdc2cf # actions-runner-controller-0.23.5',
         },
       ]);
+
+      expect(res!.deps[14]).not.toHaveProperty('skipReason');
     });
 
     it('extracts actions with fqdn', () => {

--- a/lib/modules/manager/github-actions/extract.ts
+++ b/lib/modules/manager/github-actions/extract.ts
@@ -100,9 +100,6 @@ function extractWithRegex(content: string): PackageDependency[] {
         dep.currentDigestShort = currentValue;
       } else {
         dep.currentValue = currentValue;
-        if (!dockerVersioning.api.isValid(currentValue)) {
-          dep.skipReason = 'invalid-version';
-        }
       }
       deps.push(dep);
     }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
### Github Action manager
Removing version control from the extractor allows more tuning with `packageRules`
It should be the responsibility of the versioning updater to check the version's validity.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

Github Action extractor skipped entries when we tried to use tags with a prefix like: 
```
uses: monorepo/actions/workflows/deployment.yaml@deployment-v1
uses: monorepo/actions/workflows/tests.yaml@test-v1.2
```

I want Renovate to be allowed to upgrade to version `deployment-v2` with this kind of package rule: 
```
packageRules: [
    {
      matchDatasources: ["github-tags"],
      matchPackageNames: ["monorepo/actions"],
      versioning: "docker",
      versionCompatibility: "^(?<compatibility>.*)-v(?<version>.*)$",
    },
  ]
```

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
