### PR TITLE
feat: expose branch depTypes for templating

### DIFF
--- a/lib/util/template/index.ts
+++ b/lib/util/template/index.ts
@@ -88,6 +88,8 @@ export const allowedFields = {
   depNameSanitized:
     'The depName field sanitized for use in branches after removing spaces and special characters',
   depType: 'The dependency type (if extracted - manager-dependent)',
+  depTypes:
+    'A deduplicated array of dependency types (if extracted - manager-dependent) in a branch',
   displayFrom: 'The current value, formatted for display',
   displayPending: 'Latest pending update, if internalChecksFilter is in use',
   displayTo: 'The to value, formatted for display',

--- a/lib/workers/repository/updates/generate.spec.ts
+++ b/lib/workers/repository/updates/generate.spec.ts
@@ -1443,5 +1443,30 @@ describe('workers/repository/updates/generate', () => {
       const res = generateBranchConfig(upgrades);
       expect(res.additionalReviewers).toEqual(['foo', 'bar']);
     });
+
+    it('merges depTypes', () => {
+      const upgrades = [
+        {
+          ...requiredDefaultOptions,
+          branchName: 'some-branch',
+          manager: 'some-manager',
+          depType: 'devDependencies',
+        },
+        {
+          ...requiredDefaultOptions,
+          branchName: 'some-branch',
+          manager: 'some-manager',
+          depType: 'dependencies',
+        },
+        {
+          ...requiredDefaultOptions,
+          branchName: 'some-branch',
+          manager: 'some-manager',
+          depType: 'devDependencies',
+        },
+      ] satisfies BranchUpgradeConfig[];
+      const res = generateBranchConfig(upgrades);
+      expect(res.depTypes).toEqual(['dependencies', 'devDependencies']);
+    });
   });
 });

--- a/lib/workers/repository/updates/generate.ts
+++ b/lib/workers/repository/updates/generate.ts
@@ -83,6 +83,7 @@ export function generateBranchConfig(
   const newValue: string[] = [];
   const toVersions: string[] = [];
   const toValues = new Set<string>();
+  const depTypes = new Set<string>();
   for (const upg of branchUpgrades) {
     upg.recreateClosed = upg.recreateWhen === 'always';
 
@@ -119,6 +120,9 @@ export function generateBranchConfig(
       toVersions.push(upg.newVersion!);
     }
     toValues.add(upg.newValue!);
+    if (upg.depType) {
+      depTypes.add(upg.depType);
+    }
     // prettify newVersion and newMajor for printing
     if (upg.newVersion) {
       upg.prettyNewVersion = prettifyVersion(upg.newVersion);
@@ -424,6 +428,9 @@ export function generateBranchConfig(
   );
   if (additionalReviewers.length > 0) {
     config.additionalReviewers = additionalReviewers;
+  }
+  if (depTypes.size) {
+    config.depTypes = Array.from(depTypes).sort();
   }
   return config;
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Collects `depTypes` for branches and exposes it for templating

## Context

Requested in #27818, may be useful elsewhere.

Note: matchDepTypes already has a capability to match against `depTypes` although it seems it wasn't possible to trigger before now.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
