### PR TITLE
fix(gitlab): Don't delete approval rules (report_approver, code_owner…

### DIFF
--- a/lib/modules/platform/gitlab/index.spec.ts
+++ b/lib/modules/platform/gitlab/index.spec.ts
@@ -2320,6 +2320,85 @@ describe('modules/platform/gitlab/index', () => {
       });
     });
 
+
+    it('does not try to remove "report_approver" and "code_owner" approval rules', async () => {
+      await initPlatform('13.3.6-ee');
+      httpMock
+        .scope(gitlabApiHost)
+        .post('/api/v4/projects/undefined/merge_requests')
+        .reply(200, {
+          id: 1,
+          iid: 12345,
+          title: 'some title',
+        })
+        .get('/api/v4/projects/undefined/merge_requests/12345')
+        .reply(200)
+        .get('/api/v4/projects/undefined/merge_requests/12345')
+        .reply(200, {
+          merge_status: 'can_be_merged',
+          pipeline: {
+            id: 29626725,
+            sha: '2be7ddb704c7b6b83732fdd5b9f09d5a397b5f8f',
+            ref: 'patch-28',
+            status: 'success',
+          },
+        })
+        .put('/api/v4/projects/undefined/merge_requests/12345/merge')
+        .reply(200)
+        .get('/api/v4/projects/undefined/merge_requests/12345/approval_rules')
+        .reply(200, [
+          {
+            name: 'RegularApproverRule',
+            rule_type: 'regular',
+            id: 50006,
+          },
+          {
+            name: 'AnotherRegularApproverRule',
+            rule_type: 'regular',
+            id: 50007,
+          },
+          {
+            name: 'Coverage-Check',
+            rule_type: 'report_approver',
+            id: 50008,
+          },
+          {
+            name: 'path/to/folder',
+            rule_type: 'code_owner',
+            id: 50009,
+          },
+        ])
+        .delete(
+          '/api/v4/projects/undefined/merge_requests/12345/approval_rules/50006',
+        )
+        .reply(200)
+        .delete(
+          '/api/v4/projects/undefined/merge_requests/12345/approval_rules/50007',
+        )
+        .reply(200)
+        .post('/api/v4/projects/undefined/merge_requests/12345/approval_rules')
+        .reply(200);
+      expect(
+        await gitlab.createPr({
+          sourceBranch: 'some-branch',
+          targetBranch: 'master',
+          prTitle: 'some-title',
+          prBody: 'the-body',
+          labels: [],
+          platformOptions: {
+            usePlatformAutomerge: true,
+            gitLabIgnoreApprovals: true,
+          },
+        }),
+      ).toStrictEqual({
+        id: 1,
+        iid: 12345,
+        number: 12345,
+        sourceBranch: 'some-branch',
+        title: 'some title',
+      });
+    });
+
     it('does not try to create already existing approval rule', async () => {
       await initPlatform('13.3.6-ee');
       httpMock

--- a/lib/modules/platform/gitlab/index.ts
+++ b/lib/modules/platform/gitlab/index.ts
@@ -608,7 +608,7 @@ async function ignoreApprovals(pr: number): Promise<void> {
     );
     const existingRegularApproverRules = rules?.filter(
       ({ rule_type, name }) =>
-        rule_type !== 'any_approver' && name !== ruleName,
+        rule_type !== 'any_approver' && name !== ruleName && rule_type!== 'report_approver' && rule_type!== 'code_owner',
     );
 
     if (existingRegularApproverRules?.length) {


### PR DESCRIPTION
## Changes

This is a fix for gitlab users. Renovate tries to delete approval rules that can't be deleted. The Gitlab API returns a 403 for 2 kind of rules: `report_approver` and `code_owner`. I just updated the filter of the approval rules that will be deleted from this:

```typescript
    const existingRegularApproverRules = rules?.filter(
      ({ rule_type, name }) =>
        rule_type !== 'any_approver' && name !== ruleName
    );
```

to this:
```typescript
    const existingRegularApproverRules = rules?.filter(
      ({ rule_type, name }) =>
        rule_type !== 'any_approver' && name !== ruleName && rule_type!== 'report_approver' && rule_type!== 'code_owner',
    );
```


## Context

See #27950 

![CleanShot 2024-03-16 at 16 39 49](https://github.com/renovatebot/renovate/assets/375867/ea8e8565-7aab-4bb7-84aa-5e3142a8c03f)

## Documentation (please check one with an [x])

- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
