### PR TITLE
docs(manager/gitlabci): Add hint about environment variables

### DIFF
--- a/lib/modules/manager/gitlabci/readme.md
+++ b/lib/modules/manager/gitlabci/readme.md
@@ -16,3 +16,11 @@ If you use the predefined `CI_REGISTRY` variable make sure to configure its valu
   }
 }
 ```
+
+GitLab CI Components that are included are also supported, but should not reference environment variables.
+
+```yaml
+include:
+  - component: $CI_SERVER_FQDN/my-organization/my-components/specific-component@0.1.0 # This will not work
+  - component: gitlab.example.biz/my-organization/my-components/specific-component@0.1.0 # This will work
+```


### PR DESCRIPTION
## Changes

Update the docs for the gitlabci manager, mentioning that CI components are supported, but shouldn't reference environment variables

## Context

Helps debugging issues if the CI compoent can't be resolved, as described in #27964 

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
