### PR TITLE
feat(config): expose topLevelOrg, templateOrg to templates

### DIFF
--- a/lib/util/template/index.ts
+++ b/lib/util/template/index.ts
@@ -128,6 +128,7 @@ export const allowedFields = {
   packageScope: 'The scope of the package name. Supports Maven group ID only',
   parentDir:
     'The name of the directory that the dependency was found in, without full path',
+  parentOrg: 'The name of the parent organization for the current repository',
   platform: 'VCS platform in use, e.g. "github", "gitlab", etc.',
   prettyDepType: 'Massaged depType',
   prettyNewMajor: 'The new major value with v prepended to it.',
@@ -144,6 +145,8 @@ export const allowedFields = {
   sourceRepoOrg: 'The repository organization in the sourceUrl, if present',
   sourceRepoSlug: 'The slugified pathname of the sourceUrl, if present',
   sourceUrl: 'The source URL for the package',
+  topLevelOrg:
+    'The name of the top-level organization for the current repository',
   updateType:
     'One of digest, pin, rollback, patch, minor, major, replacement, pinDigest',
   upgrades: 'An array of upgrade objects in the branch',

--- a/lib/workers/global/index.spec.ts
+++ b/lib/workers/global/index.spec.ts
@@ -1,6 +1,7 @@
 import { ERROR, WARN } from 'bunyan';
 import fs from 'fs-extra';
-import { logger, mocked } from '../../../test/util';
+import { RenovateConfig, logger, mocked } from '../../../test/util';
+import { GlobalConfig } from '../../config/global';
 import * as _presets from '../../config/presets';
 import { CONFIG_PRESETS_INVALID } from '../../constants/error-messages';
 import { DockerDatasource } from '../../modules/datasource/docker';
@@ -44,6 +45,34 @@ describe('workers/global/index', () => {
     initPlatform.mockImplementation((input) => Promise.resolve(input));
     delete process.env.AWS_SECRET_ACCESS_KEY;
     delete process.env.AWS_SESSION_TOKEN;
+  });
+
+  describe('getRepositoryConfig', () => {
+    const globalConfig: RenovateConfig = { baseDir: '/tmp/base' };
+
+    GlobalConfig.set({ platform: 'gitlab' });
+
+    it('should generate correct topLevelOrg/parentOrg with multiple levels', async () => {
+      const repository = 'a/b/c/d';
+      const repoConfig = await globalWorker.getRepositoryConfig(
+        globalConfig,
+        repository,
+      );
+      expect(repoConfig.topLevelOrg).toBe('a');
+      expect(repoConfig.parentOrg).toBe('a/b/c');
+      expect(repoConfig.repository).toBe('a/b/c/d');
+    });
+
+    it('should generate correct topLevelOrg/parentOrg with two levels', async () => {
+      const repository = 'a/b';
+      const repoConfig = await globalWorker.getRepositoryConfig(
+        globalConfig,
+        repository,
+      );
+      expect(repoConfig.topLevelOrg).toBe('a');
+      expect(repoConfig.parentOrg).toBe('a');
+      expect(repoConfig.repository).toBe('a/b');
+    });
   });
 
   it('handles config warnings and errors', async () => {

--- a/lib/workers/global/index.ts
+++ b/lib/workers/global/index.ts
@@ -38,6 +38,10 @@ export async function getRepositoryConfig(
     globalConfig,
     is.string(repository) ? { repository } : repository,
   );
+  const repoParts = repoConfig.repository.split('/');
+  repoParts.pop();
+  repoConfig.parentOrg = repoParts.join('/');
+  repoConfig.topLevelOrg = repoParts.shift();
   // TODO: types (#22198)
   const platform = GlobalConfig.get('platform')!;
   repoConfig.localDir =


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds topLevelOrg and parentOrg fields to templates

## Context

Spun out of inheritConfig work

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
