### PR TITLE
feat(config): Add @babel/eslint-parser to ESLint packages Presets

### DIFF
--- a/lib/config/presets/__snapshots__/index.spec.ts.snap
+++ b/lib/config/presets/__snapshots__/index.spec.ts.snap
@@ -119,6 +119,7 @@ exports[`config/presets/index resolvePreset resolves eslint 1`] = `
   "matchPackageNames": [
     "@types/eslint",
     "babel-eslint",
+    "@babel/eslint-parser",
   ],
   "matchPackagePrefixes": [
     "@typescript-eslint/",
@@ -135,6 +136,7 @@ exports[`config/presets/index resolvePreset resolves linters 1`] = `
   "matchPackageNames": [
     "@types/eslint",
     "babel-eslint",
+    "@babel/eslint-parser",
     "friendsofphp/php-cs-fixer",
     "squizlabs/php_codesniffer",
     "symplify/easy-coding-standard",
@@ -169,6 +171,7 @@ exports[`config/presets/index resolvePreset resolves nested groups 1`] = `
       "matchPackageNames": [
         "@types/eslint",
         "babel-eslint",
+        "@babel/eslint-parser",
         "friendsofphp/php-cs-fixer",
         "squizlabs/php_codesniffer",
         "symplify/easy-coding-standard",

--- a/lib/config/presets/index.spec.ts
+++ b/lib/config/presets/index.spec.ts
@@ -233,7 +233,11 @@ describe('config/presets/index', () => {
       config.extends = ['packages:eslint', 'packages:stylelint'];
       const res = await presets.resolveConfigPresets(config);
       expect(res).toEqual({
-        matchPackageNames: ['@types/eslint', 'babel-eslint'],
+        matchPackageNames: [
+          '@types/eslint',
+          'babel-eslint',
+          '@babel/eslint-parser',
+        ],
         matchPackagePrefixes: ['@typescript-eslint/', 'eslint', 'stylelint'],
       });
     });
@@ -250,7 +254,11 @@ describe('config/presets/index', () => {
         packageRules: [
           {
             groupName: 'eslint',
-            matchPackageNames: ['@types/eslint', 'babel-eslint'],
+            matchPackageNames: [
+              '@types/eslint',
+              'babel-eslint',
+              '@babel/eslint-parser',
+            ],
             matchPackagePrefixes: ['@typescript-eslint/', 'eslint'],
           },
         ],
@@ -268,7 +276,7 @@ describe('config/presets/index', () => {
       config.extends = ['packages:linters'];
       const res = await presets.resolveConfigPresets(config);
       expect(res).toMatchSnapshot();
-      expect(res.matchPackageNames).toHaveLength(9);
+      expect(res.matchPackageNames).toHaveLength(10);
       expect(res.matchPackagePatterns).toHaveLength(1);
       expect(res.matchPackagePrefixes).toHaveLength(4);
     });
@@ -279,7 +287,7 @@ describe('config/presets/index', () => {
       expect(res).toMatchSnapshot();
       const rule = res.packageRules![0];
       expect(rule.automerge).toBeTrue();
-      expect(rule.matchPackageNames).toHaveLength(9);
+      expect(rule.matchPackageNames).toHaveLength(10);
       expect(rule.matchPackagePatterns).toHaveLength(1);
       expect(rule.matchPackagePrefixes).toHaveLength(4);
     });

--- a/lib/config/presets/internal/packages.ts
+++ b/lib/config/presets/internal/packages.ts
@@ -22,7 +22,11 @@ export const presets: Record<string, Preset> = {
   },
   eslint: {
     description: 'All ESLint packages.',
-    matchPackageNames: ['@types/eslint', 'babel-eslint'],
+    matchPackageNames: [
+      '@types/eslint',
+      'babel-eslint',
+      '@babel/eslint-parser',
+    ],
     matchPackagePrefixes: ['@typescript-eslint/', 'eslint'],
   },
   gatsby: {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Added @babel/eslint-parser to ESLint packages Presets

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

@babel/eslint-parser is added because it's the successor library to the currently included babel-eslint.
Also, babel-eslint has been retained in the preset to ensure it continues to be grouped.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
