### PR TITLE
fix(manager/pipenv): better artifacts handling of deprecated python

### DIFF
--- a/lib/modules/manager/pipenv/artifacts.ts
+++ b/lib/modules/manager/pipenv/artifacts.ts
@@ -41,6 +41,7 @@ export function getPythonConstraint(
       return undefined;
     }
     // Exact python version has been included since 2022.10.9. It is more specific than the major.minor version
+    // https://github.com/pypa/pipenv/blob/main/CHANGELOG.md#2022109-2022-10-09
     if (result.data._meta?.requires?.python_full_version) {
       const pythonFullVersion = result.data._meta.requires.python_full_version;
       return `== ${pythonFullVersion}`;
@@ -84,7 +85,10 @@ export function getPipenvConstraint(
     const pythonFullVersion = result.data._meta?.requires?.python_full_version;
     if (is.string(pythonFullVersion) && semver.valid(pythonFullVersion)) {
       // python_full_version was added after 3.6 was already deprecated, so it should be impossible to have a 3.6 version
+      // https://github.com/pypa/pipenv/blob/main/CHANGELOG.md#2022109-2022-10-09
       if (semver.satisfies(pythonFullVersion, '3.7.*')) {
+        // Python 3.7 support was dropped in pipenv 2023.10.20
+        // https://github.com/pypa/pipenv/blob/main/CHANGELOG.md#20231020-2023-10-20
         return '< 2023.10.20';
       }
       // Future deprecations will go here
@@ -94,10 +98,12 @@ export function getPipenvConstraint(
     if (pythonVersion) {
       if (pythonVersion === '3.6') {
         // Python 3.6 was deprecated in 2022.4.20
+        // https://github.com/pypa/pipenv/blob/main/CHANGELOG.md#2022420-2022-04-20
         return '< 2022.4.20';
       }
       if (pythonVersion === '3.7') {
         // Python 3.7 was deprecated in 2023.10.20 but we shouldn't reach here unless we are < 2022.10.9
+        // https://github.com/pypa/pipenv/blob/main/CHANGELOG.md#20231020-2023-10-20
         return '< 2022.10.9';
       }
     }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Improves pipenv containerbase version selection for deprecated python versions

## Context

If you pick the latest pipenv with python 3.6 and 3.7 then installation will fail.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
