### PR TITLE
feat(bitbucket): Enable HTTP cache for PR list and json fetch

### DIFF
--- a/lib/modules/platform/bitbucket/index.ts
+++ b/lib/modules/platform/bitbucket/index.ts
@@ -7,6 +7,7 @@ import { parseJson } from '../../../util/common';
 import * as git from '../../../util/git';
 import * as hostRules from '../../../util/host-rules';
 import { BitbucketHttp, setBaseUrl } from '../../../util/http/bitbucket';
+import { repoCacheProvider } from '../../../util/http/cache/repository-http-cache-provider';
 import type { HttpOptions } from '../../../util/http/types';
 import { regEx } from '../../../util/regex';
 import { sanitize } from '../../../util/sanitize';
@@ -163,7 +164,10 @@ export async function getRawFile(
     `/2.0/repositories/${repo}/src/` +
     (finalBranchOrTag ?? `HEAD`) +
     `/${path}`;
-  const res = await bitbucketHttp.get(url);
+  const res = await bitbucketHttp.get(url, {
+    cacheProvider: repoCacheProvider,
+    memCache: true,
+  });
   return res.body;
 }
 

--- a/lib/modules/platform/bitbucket/pr-cache.spec.ts
+++ b/lib/modules/platform/bitbucket/pr-cache.spec.ts
@@ -74,6 +74,7 @@ describe('modules/platform/bitbucket/pr-cache', () => {
       },
     ]);
     expect(cache).toEqual({
+      httpCache: {},
       platform: {
         bitbucket: {
           pullRequestsCache: {
@@ -120,6 +121,7 @@ describe('modules/platform/bitbucket/pr-cache', () => {
       { number: 2, title: 'title' },
     ]);
     expect(cache).toEqual({
+      httpCache: {},
       platform: {
         bitbucket: {
           pullRequestsCache: {

--- a/lib/modules/platform/bitbucket/pr-cache.ts
+++ b/lib/modules/platform/bitbucket/pr-cache.ts
@@ -4,6 +4,7 @@ import { logger } from '../../../logger';
 import * as memCache from '../../../util/cache/memory';
 import { getCache } from '../../../util/cache/repository';
 import type { BitbucketHttp } from '../../../util/http/bitbucket';
+import { repoCacheProvider } from '../../../util/http/cache/repository-http-cache-provider';
 import type { Pr } from '../types';
 import type { BitbucketPrCacheData, PagedResult, PrResponse } from './types';
 import { prFieldsFilter, prInfo, prStates } from './utils';
@@ -128,7 +129,11 @@ export class BitbucketPrCache {
   private async sync(http: BitbucketHttp): Promise<BitbucketPrCache> {
     logger.debug('Syncing PR list');
     const url = this.getUrl();
-    const opts = { paginate: true, pagelen: 50 };
+    const opts = {
+      paginate: true,
+      pagelen: 50,
+      cacheProvider: repoCacheProvider,
+    };
     const res = await http.getJson<PagedResult<PrResponse>>(url, opts);
     this.reconcile(res.body.values);
     return this;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Use repository cache for `renovate.json` fetch http requests
- Use repository cache for cached Pr http requests

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
