### PR TITLE
feat(manager/pip-compile): Support -r dependencies between files

### DIFF
--- a/lib/modules/manager/pip-compile/extract.spec.ts
+++ b/lib/modules/manager/pip-compile/extract.spec.ts
@@ -391,7 +391,7 @@ describe('modules/manager/pip-compile/extract', () => {
     const lockFiles = ['4.txt', '2.txt'];
     const packageFiles = await extractAllPackageFiles({}, lockFiles);
     expect(packageFiles).toBeDefined();
-    expect(packageFiles?.map((p) => p.lockFiles!)).toEqual([
+    expect(packageFiles?.map((p) => p.lockFiles)).toEqual([
       ['2.txt', '4.txt'],
       ['4.txt'],
     ]);

--- a/lib/modules/manager/pip-compile/extract.spec.ts
+++ b/lib/modules/manager/pip-compile/extract.spec.ts
@@ -246,26 +246,35 @@ describe('modules/manager/pip-compile/extract', () => {
   });
 
   it('return sorted package files', async () => {
-    fs.readLocalFile.mockResolvedValueOnce(
-      getSimpleRequirementsFile('pip-compile --output-file=4.txt 3.in', [
-        'foo==1.0.1',
-      ]),
-    );
-    fs.readLocalFile.mockResolvedValueOnce('-r 2.txt\nfoo');
-    fs.readLocalFile.mockResolvedValueOnce(
-      getSimpleRequirementsFile('pip-compile --output-file=2.txt 1.in', [
-        'foo==1.0.1',
-      ]),
-    );
-    fs.readLocalFile.mockResolvedValueOnce('foo');
+    jest
+      .spyOn(fs, 'readLocalFile')
+      // eslint-disable-next-line require-await,@typescript-eslint/require-await
+      .mockImplementation(async (name, _encoding) => {
+        if (name === '1.in') {
+          return 'foo';
+        } else if (name === '2.txt') {
+          return getSimpleRequirementsFile(
+            'pip-compile --output-file=2.txt 1.in',
+            ['foo==1.0.1'],
+          );
+        } else if (name === '3.in') {
+          return '-r 2.txt\nfoo';
+        } else if (name === '4.txt') {
+          return getSimpleRequirementsFile(
+            'pip-compile --output-file=4.txt 3.in',
+            ['foo==1.0.1'],
+          );
+        }
+        return null;
+      });
 
     const lockFiles = ['4.txt', '2.txt'];
     const packageFiles = await extractAllPackageFiles({}, lockFiles);
     expect(packageFiles).toBeDefined();
     expect(packageFiles?.map((p) => p.packageFile)).toEqual(['1.in', '3.in']);
-    expect(packageFiles?.map((p) => p.lockFiles!.pop())).toEqual([
-      '2.txt',
-      '4.txt',
+    expect(packageFiles?.map((p) => p.lockFiles!)).toEqual([
+      ['2.txt', '4.txt'],
+      ['4.txt'],
     ]);
   });
 
@@ -357,6 +366,90 @@ describe('modules/manager/pip-compile/extract', () => {
     expect(logger.warn).toHaveBeenCalledWith(
       { depName: 'bar', lockFile: 'requirements.txt' },
       'pip-compile: dependency not found in lock file',
+    );
+  });
+
+  it('handles -r reference to another input file', async () => {
+    jest
+      .spyOn(fs, 'readLocalFile')
+      // eslint-disable-next-line require-await,@typescript-eslint/require-await
+      .mockImplementation(async (name, _encoding) => {
+        if (name === '1.in') {
+          return 'foo';
+        } else if (name === '2.txt') {
+          return getSimpleRequirementsFile(
+            'pip-compile --output-file=2.txt 1.in',
+            ['foo==1.0.1'],
+          );
+        } else if (name === '3.in') {
+          return '-r 1.in\nfoo';
+        } else if (name === '4.txt') {
+          return getSimpleRequirementsFile(
+            'pip-compile --output-file=4.txt 3.in',
+            ['foo==1.0.1'],
+          );
+        }
+        return null;
+      });
+
+    const lockFiles = ['4.txt', '2.txt'];
+    const packageFiles = await extractAllPackageFiles({}, lockFiles);
+    expect(packageFiles).toBeDefined();
+    expect(packageFiles?.map((p) => p.lockFiles!)).toEqual([
+      ['2.txt', '4.txt'],
+      ['4.txt'],
+    ]);
+  });
+
+  it('warns on -r reference to failed file', async () => {
+    jest
+      .spyOn(fs, 'readLocalFile')
+      // eslint-disable-next-line require-await,@typescript-eslint/require-await
+      .mockImplementation(async (name, _encoding) => {
+        if (name === 'reqs-no-headers.txt') {
+          return Fixtures.get('requirementsNoHeaders.txt');
+        } else if (name === '1.in') {
+          return '-r reqs-no-headers.txt\nfoo';
+        } else if (name === '2.txt') {
+          return getSimpleRequirementsFile(
+            'pip-compile --output-file=2.txt 1.in',
+            ['foo==1.0.1'],
+          );
+        }
+        return null;
+      });
+
+    const lockFiles = ['reqs-no-headers.txt', '2.txt'];
+    const packageFiles = await extractAllPackageFiles({}, lockFiles);
+    expect(packageFiles).toBeDefined();
+    expect(packageFiles?.map((p) => p.lockFiles!)).toEqual([['2.txt']]);
+    expect(logger.warn).toHaveBeenCalledWith(
+      'pip-compile: 1.in references reqs-no-headers.txt which does not appear to be a requirements file managed by pip-compile',
+    );
+  });
+
+  it('warns on -r reference to requirements file not managed by pip-compile', async () => {
+    jest
+      .spyOn(fs, 'readLocalFile')
+      // eslint-disable-next-line require-await,@typescript-eslint/require-await
+      .mockImplementation(async (name, _encoding) => {
+        if (name === '1.in') {
+          return '-r unmanaged-file.txt\nfoo';
+        } else if (name === '2.txt') {
+          return getSimpleRequirementsFile(
+            'pip-compile --output-file=2.txt 1.in',
+            ['foo==1.0.1'],
+          );
+        }
+        return null;
+      });
+
+    const lockFiles = ['2.txt'];
+    const packageFiles = await extractAllPackageFiles({}, lockFiles);
+    expect(packageFiles).toBeDefined();
+    expect(packageFiles?.map((p) => p.lockFiles!)).toEqual([['2.txt']]);
+    expect(logger.warn).toHaveBeenCalledWith(
+      'pip-compile: references to requirements files not managed by pip-compile are not currently fully supported',
     );
   });
 });

--- a/lib/modules/manager/pip-compile/extract.spec.ts
+++ b/lib/modules/manager/pip-compile/extract.spec.ts
@@ -270,7 +270,7 @@ describe('modules/manager/pip-compile/extract', () => {
     const packageFiles = await extractAllPackageFiles({}, lockFiles);
     expect(packageFiles).toBeDefined();
     expect(packageFiles?.map((p) => p.packageFile)).toEqual(['1.in', '3.in']);
-    expect(packageFiles?.map((p) => p.lockFiles!)).toEqual([
+    expect(packageFiles?.map((p) => p.lockFiles)).toEqual([
       ['2.txt', '4.txt'],
       ['4.txt'],
     ]);

--- a/lib/modules/manager/pip-compile/extract.spec.ts
+++ b/lib/modules/manager/pip-compile/extract.spec.ts
@@ -246,8 +246,7 @@ describe('modules/manager/pip-compile/extract', () => {
   });
 
   it('return sorted package files', async () => {
-    // eslint-disable-next-line require-await,@typescript-eslint/require-await
-    fs.readLocalFile.mockImplementation(async (name): Promise<any> => {
+    fs.readLocalFile.mockImplementation((name): any => {
       if (name === '1.in') {
         return 'foo';
       } else if (name === '2.txt') {
@@ -368,8 +367,7 @@ describe('modules/manager/pip-compile/extract', () => {
   });
 
   it('handles -r reference to another input file', async () => {
-    // eslint-disable-next-line require-await,@typescript-eslint/require-await
-    fs.readLocalFile.mockImplementation(async (name): Promise<any> => {
+    fs.readLocalFile.mockImplementation((name): any => {
       if (name === '1.in') {
         return 'foo';
       } else if (name === '2.txt') {
@@ -390,7 +388,6 @@ describe('modules/manager/pip-compile/extract', () => {
 
     const lockFiles = ['4.txt', '2.txt'];
     const packageFiles = await extractAllPackageFiles({}, lockFiles);
-    expect(packageFiles).toBeDefined();
     expect(packageFiles?.map((p) => p.lockFiles)).toEqual([
       ['2.txt', '4.txt'],
       ['4.txt'],
@@ -398,8 +395,7 @@ describe('modules/manager/pip-compile/extract', () => {
   });
 
   it('handles transitive -r references', async () => {
-    // eslint-disable-next-line require-await,@typescript-eslint/require-await
-    fs.readLocalFile.mockImplementation(async (name): Promise<any> => {
+    fs.readLocalFile.mockImplementation((name): any => {
       if (name === '1.in') {
         return 'foo';
       } else if (name === '2.txt') {
@@ -427,8 +423,7 @@ describe('modules/manager/pip-compile/extract', () => {
 
     const lockFiles = ['4.txt', '2.txt', '6.txt'];
     const packageFiles = await extractAllPackageFiles({}, lockFiles);
-    expect(packageFiles).toBeDefined();
-    expect(packageFiles?.map((p) => p.lockFiles!)).toEqual([
+    expect(packageFiles?.map((p) => p.lockFiles)).toEqual([
       ['2.txt', '4.txt', '6.txt'],
       ['4.txt', '6.txt'],
       ['6.txt'],
@@ -436,8 +431,7 @@ describe('modules/manager/pip-compile/extract', () => {
   });
 
   it('warns on -r reference to failed file', async () => {
-    // eslint-disable-next-line require-await,@typescript-eslint/require-await
-    fs.readLocalFile.mockImplementation(async (name): Promise<any> => {
+    fs.readLocalFile.mockImplementation((name): any => {
       if (name === 'reqs-no-headers.txt') {
         return Fixtures.get('requirementsNoHeaders.txt');
       } else if (name === '1.in') {
@@ -453,16 +447,14 @@ describe('modules/manager/pip-compile/extract', () => {
 
     const lockFiles = ['reqs-no-headers.txt', '2.txt'];
     const packageFiles = await extractAllPackageFiles({}, lockFiles);
-    expect(packageFiles).toBeDefined();
-    expect(packageFiles?.map((p) => p.lockFiles!)).toEqual([['2.txt']]);
+    expect(packageFiles?.map((p) => p.lockFiles)).toEqual([['2.txt']]);
     expect(logger.warn).toHaveBeenCalledWith(
       'pip-compile: 1.in references reqs-no-headers.txt which does not appear to be a requirements file managed by pip-compile',
     );
   });
 
   it('warns on -r reference to requirements file not managed by pip-compile', async () => {
-    // eslint-disable-next-line require-await,@typescript-eslint/require-await
-    fs.readLocalFile.mockImplementation(async (name): Promise<any> => {
+    fs.readLocalFile.mockImplementation((name): any => {
       if (name === '1.in') {
         return '-r unmanaged-file.txt\nfoo';
       } else if (name === '2.txt') {
@@ -476,8 +468,7 @@ describe('modules/manager/pip-compile/extract', () => {
 
     const lockFiles = ['2.txt'];
     const packageFiles = await extractAllPackageFiles({}, lockFiles);
-    expect(packageFiles).toBeDefined();
-    expect(packageFiles?.map((p) => p.lockFiles!)).toEqual([['2.txt']]);
+    expect(packageFiles?.map((p) => p.lockFiles)).toEqual([['2.txt']]);
     expect(logger.warn).toHaveBeenCalledWith(
       'pip-compile: 1.in references unmanaged-file.txt which does not appear to be a requirements file managed by pip-compile',
     );

--- a/lib/modules/manager/pip-compile/extract.spec.ts
+++ b/lib/modules/manager/pip-compile/extract.spec.ts
@@ -449,7 +449,7 @@ describe('modules/manager/pip-compile/extract', () => {
     expect(packageFiles).toBeDefined();
     expect(packageFiles?.map((p) => p.lockFiles!)).toEqual([['2.txt']]);
     expect(logger.warn).toHaveBeenCalledWith(
-      'pip-compile: references to requirements files not managed by pip-compile are not currently fully supported',
+      'pip-compile: 1.in references unmanaged-file.txt which does not appear to be a requirements file managed by pip-compile',
     );
   });
 });

--- a/lib/modules/manager/pip-compile/extract.ts
+++ b/lib/modules/manager/pip-compile/extract.ts
@@ -200,12 +200,19 @@ export async function extractAllPackageFiles(
     depsBetweenFiles,
     packageFiles,
   );
+
+  const lockFileSources = new Map<string, PackageFile>();
+  for (const packageFile of result) {
+    for (const lockFile of packageFile.lockFiles!) {
+      if (!lockFileSources.has(lockFile)) {
+        lockFileSources.set(lockFile, packageFile);
+      }
+    }
+  }
   for (const packageFile of result) {
     for (const reqFile of packageFile.managerData?.requirementsFiles ?? []) {
       if (fileMatches.includes(reqFile)) {
-        const sourceFile = result.find((packageFile) =>
-          packageFile.lockFiles?.includes(reqFile),
-        );
+        const sourceFile = lockFileSources.get(reqFile);
         if (!sourceFile) {
           logger.warn(
             `pip-compile: ${packageFile.packageFile} references ${reqFile} which does not appear to be a requirements file managed by pip-compile`,

--- a/lib/modules/manager/pip-compile/extract.ts
+++ b/lib/modules/manager/pip-compile/extract.ts
@@ -221,10 +221,7 @@ export async function extractAllPackageFiles(
         );
         continue;
       }
-      sourceFile.lockFiles = [
-        ...sourceFile.lockFiles!,
-        ...packageFile.lockFiles!,
-      ];
+      sourceFile.lockFiles!.push(...packageFile.lockFiles!);
     }
   }
   logger.debug(

--- a/lib/modules/manager/pip-compile/extract.ts
+++ b/lib/modules/manager/pip-compile/extract.ts
@@ -207,7 +207,7 @@ export async function extractAllPackageFiles(
   );
 
   // This needs to go in reverse order to handle transitive dependencies
-  for (const packageFile of result.slice().reverse()) {
+  for (const packageFile of [...result].reverse()) {
     for (const reqFile of packageFile.managerData?.requirementsFiles ?? []) {
       let sourceFile: PackageFile | undefined = undefined;
       if (fileMatches.includes(reqFile)) {

--- a/lib/modules/manager/pip-compile/extract.ts
+++ b/lib/modules/manager/pip-compile/extract.ts
@@ -211,29 +211,22 @@ export async function extractAllPackageFiles(
   }
   for (const packageFile of result) {
     for (const reqFile of packageFile.managerData?.requirementsFiles ?? []) {
+      let sourceFile: PackageFile | undefined = undefined;
       if (fileMatches.includes(reqFile)) {
-        const sourceFile = lockFileSources.get(reqFile);
-        if (!sourceFile) {
-          logger.warn(
-            `pip-compile: ${packageFile.packageFile} references ${reqFile} which does not appear to be a requirements file managed by pip-compile`,
-          );
-          continue;
-        }
-        sourceFile.lockFiles = [
-          ...sourceFile.lockFiles!,
-          ...packageFile.lockFiles!,
-        ];
+        sourceFile = lockFileSources.get(reqFile);
       } else if (packageFiles.has(reqFile)) {
-        const sourceFile = packageFiles.get(reqFile)!;
-        sourceFile.lockFiles = [
-          ...sourceFile.lockFiles!,
-          ...packageFile.lockFiles!,
-        ];
-      } else {
-        logger.warn(
-          'pip-compile: references to requirements files not managed by pip-compile are not currently fully supported',
-        );
+        sourceFile = packageFiles.get(reqFile);
       }
+      if (!sourceFile) {
+        logger.warn(
+          `pip-compile: ${packageFile.packageFile} references ${reqFile} which does not appear to be a requirements file managed by pip-compile`,
+        );
+        continue;
+      }
+      sourceFile.lockFiles = [
+        ...sourceFile.lockFiles!,
+        ...packageFile.lockFiles!,
+      ];
     }
   }
   logger.debug(

--- a/lib/modules/manager/pip-compile/extract.ts
+++ b/lib/modules/manager/pip-compile/extract.ts
@@ -204,9 +204,7 @@ export async function extractAllPackageFiles(
   const lockFileSources = new Map<string, PackageFile>();
   for (const packageFile of result) {
     for (const lockFile of packageFile.lockFiles!) {
-      if (!lockFileSources.has(lockFile)) {
-        lockFileSources.set(lockFile, packageFile);
-      }
+      lockFileSources.set(lockFile, packageFile);
     }
   }
   for (const packageFile of result) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Pip-compile supports including other requirements files via the `-r` flag. The pip_requirements manager already extracts those flags, but this adds logic to the pip-compile manager to make sure dependent files' lock files get updated when a package is updated in a file that is included via a `-r` directive.

Note that this does not support including requirements files that aren't managed by pip-compile via `-r` directives.  While doing so won't break anything, the lock files won't get updated when the pip_requirements manager updates a dependency.  They will get updated later as part of the next lock file maintenance.

## Context

#28050 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
