### PR TITLE
fix(manager/helmv3): add helmv3 detection even if chart.name and char…

### DIFF
--- a/lib/modules/manager/helmv3/extract.ts
+++ b/lib/modules/manager/helmv3/extract.ts
@@ -24,7 +24,7 @@ export async function extractPackageFile(
   try {
     // TODO: use schema (#9610)
     chart = parseSingleYaml(content, { json: true });
-    if (!(chart?.apiVersion && chart.name && chart.version)) {
+    if (!(chart?.apiVersion && chart?.name && chart?.version)) {
       logger.debug(
         { packageFile },
         'Failed to find required fields in Chart.yaml',


### PR DESCRIPTION
# fix(manager/helmv3): add helmv3 detection even if chart.name and chart.version are not defined

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

It should detect helmv3 Charts  even if chart.version and chart.name are not defined

## Context

When Helm chart "Chart.yaml" files included YTT templates, Renovate does not recognize the file format and does not propose updates for dependencies because it not recognize the Chart.yaml file. 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
