### PR TITLE
feat: Make memory cache available before repo init

### DIFF
--- a/lib/workers/repository/init/cache.ts
+++ b/lib/workers/repository/init/cache.ts
@@ -1,11 +1,13 @@
 import fs from 'fs-extra';
 import * as npmApi from '../../../modules/datasource/npm';
+import * as memCache from '../../../util/cache/memory';
 import * as repositoryCache from '../../../util/cache/repository';
 import { initRepoCache } from '../../../util/cache/repository/init';
 import { privateCacheDir } from '../../../util/fs';
 import type { WorkerPlatformConfig } from './apis';
 
 export async function resetCaches(): Promise<void> {
+  memCache.reset();
   repositoryCache.resetCache();
   await fs.remove(privateCacheDir());
 }

--- a/lib/workers/repository/init/cache.ts
+++ b/lib/workers/repository/init/cache.ts
@@ -1,13 +1,11 @@
 import fs from 'fs-extra';
 import * as npmApi from '../../../modules/datasource/npm';
-import * as memCache from '../../../util/cache/memory';
 import * as repositoryCache from '../../../util/cache/repository';
 import { initRepoCache } from '../../../util/cache/repository/init';
 import { privateCacheDir } from '../../../util/fs';
 import type { WorkerPlatformConfig } from './apis';
 
 export async function resetCaches(): Promise<void> {
-  memCache.reset();
   repositoryCache.resetCache();
   await fs.remove(privateCacheDir());
 }
@@ -15,7 +13,6 @@ export async function resetCaches(): Promise<void> {
 export async function initializeCaches(
   config: WorkerPlatformConfig,
 ): Promise<void> {
-  memCache.init();
   await initRepoCache(config);
   await fs.ensureDir(privateCacheDir());
   npmApi.setNpmrc();

--- a/lib/workers/repository/init/index.ts
+++ b/lib/workers/repository/init/index.ts
@@ -4,6 +4,7 @@ import type { RenovateConfig } from '../../../config/types';
 import { logger } from '../../../logger';
 import { setRepositoryLogLevelRemaps } from '../../../logger/remap';
 import { platform } from '../../../modules/platform';
+import * as memCache from '../../../util/cache/memory';
 import { clone } from '../../../util/clone';
 import { cloneSubmodules, setUserRepoConfig } from '../../../util/git';
 import { getAll } from '../../../util/host-rules';
@@ -48,6 +49,7 @@ export async function initRepo(
   let config: RenovateConfig = initializeConfig(config_);
   await resetCaches();
   logger.once.reset();
+  memCache.init();
   config = await initApis(config);
   await initializeCaches(config as WorkerPlatformConfig);
   config = await getRepoConfig(config);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

We could not easily use repository cache before repo init.
Let's make at least memory cache available, it also helps a little bit.

## Context

- Ref: #27785
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
