### PR TITLE
refactor(datasource/nuget): move v2/v3 API logic to classes

### DIFF
--- a/lib/modules/datasource/nuget/common.spec.ts
+++ b/lib/modules/datasource/nuget/common.spec.ts
@@ -1,6 +1,6 @@
-import { sortNugetVersions } from './v3';
+import { sortNugetVersions } from './common';
 
-describe('modules/datasource/nuget/v3', () => {
+describe('modules/datasource/nuget/common', () => {
   it.each<{ version: string; other: string; result: number }>`
     version         | other           | result
     ${'invalid1'}   | ${'invalid2'}   | ${0}

--- a/lib/modules/datasource/nuget/common.ts
+++ b/lib/modules/datasource/nuget/common.ts
@@ -1,6 +1,7 @@
 import { logger } from '../../../logger';
 import { regEx } from '../../../util/regex';
 import { parseUrl } from '../../../util/url';
+import { api as versioning } from '../../versioning/nuget';
 import type { ParsedRegistryUrl } from './types';
 
 const buildMetaRe = regEx(/\+.+$/g);
@@ -46,4 +47,24 @@ export function parseRegistryUrl(registryUrl: string): ParsedRegistryUrl {
 
   const feedUrl = parsedUrl.href;
   return { feedUrl, protocolVersion };
+}
+
+/**
+ * Compare two versions. Return:
+ * - `1` if `a > b` or `b` is invalid
+ * - `-1` if `a < b` or `a` is invalid
+ * - `0` if `a == b` or both `a` and `b` are invalid
+ */
+export function sortNugetVersions(a: string, b: string): number {
+  if (versioning.isValid(a)) {
+    if (versioning.isValid(b)) {
+      return versioning.sortVersions(a, b);
+    } else {
+      return 1;
+    }
+  } else if (versioning.isValid(b)) {
+    return -1;
+  } else {
+    return 0;
+  }
 }

--- a/lib/modules/datasource/nuget/v2.ts
+++ b/lib/modules/datasource/nuget/v2.ts
@@ -6,65 +6,71 @@ import { regEx } from '../../../util/regex';
 import type { ReleaseResult } from '../types';
 import { massageUrl, removeBuildMeta } from './common';
 
-function getPkgProp(pkgInfo: XmlElement, propName: string): string | undefined {
-  return pkgInfo.childNamed('m:properties')?.childNamed(`d:${propName}`)?.val;
-}
+export class NugetV2Api {
+  getPkgProp(pkgInfo: XmlElement, propName: string): string | undefined {
+    return pkgInfo.childNamed('m:properties')?.childNamed(`d:${propName}`)?.val;
+  }
 
-export async function getReleases(
-  http: Http,
-  feedUrl: string,
-  pkgName: string,
-): Promise<ReleaseResult | null> {
-  const dep: ReleaseResult = {
-    releases: [],
-  };
-  let pkgUrlList: string | null = `${feedUrl.replace(
-    regEx(/\/+$/),
-    '',
-  )}/FindPackagesById()?id=%27${pkgName}%27&$select=Version,IsLatestVersion,ProjectUrl,Published`;
-  while (pkgUrlList !== null) {
-    // typescript issue
-    const pkgVersionsListRaw: HttpResponse<string> = await http.get(pkgUrlList);
-    const pkgVersionsListDoc = new XmlDocument(pkgVersionsListRaw.body);
+  async getReleases(
+    http: Http,
+    feedUrl: string,
+    pkgName: string,
+  ): Promise<ReleaseResult | null> {
+    const dep: ReleaseResult = {
+      releases: [],
+    };
+    let pkgUrlList: string | null = `${feedUrl.replace(
+      regEx(/\/+$/),
+      '',
+    )}/FindPackagesById()?id=%27${pkgName}%27&$select=Version,IsLatestVersion,ProjectUrl,Published`;
+    while (pkgUrlList !== null) {
+      // typescript issue
+      const pkgVersionsListRaw: HttpResponse<string> =
+        await http.get(pkgUrlList);
+      const pkgVersionsListDoc = new XmlDocument(pkgVersionsListRaw.body);
 
-    const pkgInfoList = pkgVersionsListDoc.childrenNamed('entry');
+      const pkgInfoList = pkgVersionsListDoc.childrenNamed('entry');
 
-    for (const pkgInfo of pkgInfoList) {
-      const version = getPkgProp(pkgInfo, 'Version');
-      const releaseTimestamp = getPkgProp(pkgInfo, 'Published');
-      dep.releases.push({
-        // TODO: types (#22198)
-        version: removeBuildMeta(`${version}`),
-        releaseTimestamp,
-      });
-      try {
-        const pkgIsLatestVersion = getPkgProp(pkgInfo, 'IsLatestVersion');
-        if (pkgIsLatestVersion === 'true') {
-          dep['tags'] = { latest: removeBuildMeta(`${version}`) };
-          const projectUrl = getPkgProp(pkgInfo, 'ProjectUrl');
-          if (projectUrl) {
-            dep.sourceUrl = massageUrl(projectUrl);
+      for (const pkgInfo of pkgInfoList) {
+        const version = this.getPkgProp(pkgInfo, 'Version');
+        const releaseTimestamp = this.getPkgProp(pkgInfo, 'Published');
+        dep.releases.push({
+          // TODO: types (#22198)
+          version: removeBuildMeta(`${version}`),
+          releaseTimestamp,
+        });
+        try {
+          const pkgIsLatestVersion = this.getPkgProp(
+            pkgInfo,
+            'IsLatestVersion',
+          );
+          if (pkgIsLatestVersion === 'true') {
+            dep['tags'] = { latest: removeBuildMeta(`${version}`) };
+            const projectUrl = this.getPkgProp(pkgInfo, 'ProjectUrl');
+            if (projectUrl) {
+              dep.sourceUrl = massageUrl(projectUrl);
+            }
           }
+        } catch (err) /* istanbul ignore next */ {
+          logger.debug(
+            { err, pkgName, feedUrl },
+            `nuget registry failure: can't parse pkg info for project url`,
+          );
         }
-      } catch (err) /* istanbul ignore next */ {
-        logger.debug(
-          { err, pkgName, feedUrl },
-          `nuget registry failure: can't parse pkg info for project url`,
-        );
       }
+
+      const nextPkgUrlListLink = pkgVersionsListDoc
+        .childrenNamed('link')
+        .find((node) => node.attr.rel === 'next');
+
+      pkgUrlList = nextPkgUrlListLink ? nextPkgUrlListLink.attr.href : null;
     }
 
-    const nextPkgUrlListLink = pkgVersionsListDoc
-      .childrenNamed('link')
-      .find((node) => node.attr.rel === 'next');
+    // dep not found if no release, so we can try next registry
+    if (dep.releases.length === 0) {
+      return null;
+    }
 
-    pkgUrlList = nextPkgUrlListLink ? nextPkgUrlListLink.attr.href : null;
+    return dep;
   }
-
-  // dep not found if no release, so we can try next registry
-  if (dep.releases.length === 0) {
-    return null;
-  }
-
-  return dep;
 }

--- a/lib/modules/datasource/nuget/v2.ts
+++ b/lib/modules/datasource/nuget/v2.ts
@@ -1,7 +1,6 @@
 import { XmlDocument, XmlElement } from 'xmldoc';
 import { logger } from '../../../logger';
 import type { Http } from '../../../util/http';
-import type { HttpResponse } from '../../../util/http/types';
 import { regEx } from '../../../util/regex';
 import type { ReleaseResult } from '../types';
 import { massageUrl, removeBuildMeta } from './common';
@@ -25,8 +24,7 @@ export class NugetV2Api {
     )}/FindPackagesById()?id=%27${pkgName}%27&$select=Version,IsLatestVersion,ProjectUrl,Published`;
     while (pkgUrlList !== null) {
       // typescript issue
-      const pkgVersionsListRaw: HttpResponse<string> =
-        await http.get(pkgUrlList);
+      const pkgVersionsListRaw = await http.get(pkgUrlList);
       const pkgVersionsListDoc = new XmlDocument(pkgVersionsListRaw.body);
 
       const pkgInfoList = pkgVersionsListDoc.childrenNamed('entry');

--- a/lib/modules/datasource/nuget/v3.ts
+++ b/lib/modules/datasource/nuget/v3.ts
@@ -10,7 +10,7 @@ import { regEx } from '../../../util/regex';
 import { ensureTrailingSlash } from '../../../util/url';
 import { api as versioning } from '../../versioning/nuget';
 import type { Release, ReleaseResult } from '../types';
-import { massageUrl, removeBuildMeta } from './common';
+import { massageUrl, removeBuildMeta, sortNugetVersions } from './common';
 import type {
   CatalogEntry,
   CatalogPage,
@@ -18,227 +18,219 @@ import type {
   ServicesIndexRaw,
 } from './types';
 
-const cacheNamespace = 'datasource-nuget';
+export class NugetV3Api {
+  static readonly cacheNamespace = 'datasource-nuget';
 
-export async function getResourceUrl(
-  http: Http,
-  url: string,
-  resourceType = 'RegistrationsBaseUrl',
-): Promise<string | null> {
-  // https://docs.microsoft.com/en-us/nuget/api/service-index
-  const resultCacheKey = `${url}:${resourceType}`;
-  const cachedResult = await packageCache.get<string>(
-    cacheNamespace,
-    resultCacheKey,
-  );
-
-  // istanbul ignore if
-  if (cachedResult) {
-    return cachedResult;
-  }
-  let servicesIndexRaw: ServicesIndexRaw | undefined;
-  try {
-    const responseCacheKey = url;
-    servicesIndexRaw = await packageCache.get<ServicesIndexRaw>(
-      cacheNamespace,
-      responseCacheKey,
+  async getResourceUrl(
+    http: Http,
+    url: string,
+    resourceType = 'RegistrationsBaseUrl',
+  ): Promise<string | null> {
+    // https://docs.microsoft.com/en-us/nuget/api/service-index
+    const resultCacheKey = `${url}:${resourceType}`;
+    const cachedResult = await packageCache.get<string>(
+      NugetV3Api.cacheNamespace,
+      resultCacheKey,
     );
-    // istanbul ignore else: currently not testable
-    if (!servicesIndexRaw) {
-      servicesIndexRaw = (await http.getJson<ServicesIndexRaw>(url)).body;
-      await packageCache.set(
-        cacheNamespace,
-        responseCacheKey,
-        servicesIndexRaw,
-        3 * 24 * 60,
-      );
+
+    // istanbul ignore if
+    if (cachedResult) {
+      return cachedResult;
     }
-
-    const services = servicesIndexRaw.resources
-      .map(({ '@id': serviceId, '@type': t }) => ({
-        serviceId,
-        type: t?.split('/')?.shift(),
-        version: t?.split('/')?.pop(),
-      }))
-      .filter(
-        ({ type, version }) => type === resourceType && semver.valid(version),
-      )
-      .sort((x, y) =>
-        x.version && y.version
-          ? semver.compare(x.version, y.version)
-          : /* istanbul ignore next: hard to test */ 0,
+    let servicesIndexRaw: ServicesIndexRaw | undefined;
+    try {
+      const responseCacheKey = url;
+      servicesIndexRaw = await packageCache.get<ServicesIndexRaw>(
+        NugetV3Api.cacheNamespace,
+        responseCacheKey,
       );
+      // istanbul ignore else: currently not testable
+      if (!servicesIndexRaw) {
+        servicesIndexRaw = (await http.getJson<ServicesIndexRaw>(url)).body;
+        await packageCache.set(
+          NugetV3Api.cacheNamespace,
+          responseCacheKey,
+          servicesIndexRaw,
+          3 * 24 * 60,
+        );
+      }
 
-    if (services.length === 0) {
-      await packageCache.set(cacheNamespace, resultCacheKey, null, 60);
+      const services = servicesIndexRaw.resources
+        .map(({ '@id': serviceId, '@type': t }) => ({
+          serviceId,
+          type: t?.split('/')?.shift(),
+          version: t?.split('/')?.pop(),
+        }))
+        .filter(
+          ({ type, version }) => type === resourceType && semver.valid(version),
+        )
+        .sort((x, y) =>
+          x.version && y.version
+            ? semver.compare(x.version, y.version)
+            : /* istanbul ignore next: hard to test */ 0,
+        );
+
+      if (services.length === 0) {
+        await packageCache.set(
+          NugetV3Api.cacheNamespace,
+          resultCacheKey,
+          null,
+          60,
+        );
+        logger.debug(
+          { url, servicesIndexRaw },
+          `no ${resourceType} services found`,
+        );
+        return null;
+      }
+
+      const { serviceId, version } = services.pop()!;
+
+      // istanbul ignore if
+      if (
+        resourceType === 'RegistrationsBaseUrl' &&
+        version &&
+        !version.startsWith('3.0.0-') &&
+        !semver.satisfies(version, '^3.0.0')
+      ) {
+        logger.warn(
+          { url, version },
+          `Nuget: Unknown version returned. Only v3 is supported`,
+        );
+      }
+
+      await packageCache.set(
+        NugetV3Api.cacheNamespace,
+        resultCacheKey,
+        serviceId,
+        60,
+      );
+      return serviceId;
+    } catch (err) {
+      // istanbul ignore if: not easy testable with nock
+      if (err instanceof ExternalHostError) {
+        throw err;
+      }
       logger.debug(
-        { url, servicesIndexRaw },
-        `no ${resourceType} services found`,
+        { err, url, servicesIndexRaw },
+        `nuget registry failure: can't get ${resourceType}`,
       );
       return null;
     }
+  }
 
-    const { serviceId, version } = services.pop()!;
+  async getCatalogEntry(
+    http: Http,
+    catalogPage: CatalogPage,
+  ): Promise<CatalogEntry[]> {
+    let items = catalogPage.items;
+    if (!items) {
+      const url = catalogPage['@id'];
+      const catalogPageFull = await http.getJson<CatalogPage>(url);
+      items = catalogPageFull.body.items;
+    }
+    return items.map(({ catalogEntry }) => catalogEntry);
+  }
 
-    // istanbul ignore if
-    if (
-      resourceType === 'RegistrationsBaseUrl' &&
-      version &&
-      !version.startsWith('3.0.0-') &&
-      !semver.satisfies(version, '^3.0.0')
-    ) {
-      logger.warn(
-        { url, version },
-        `Nuget: Unknown version returned. Only v3 is supported`,
+  async getReleases(
+    http: Http,
+    registryUrl: string,
+    feedUrl: string,
+    pkgName: string,
+  ): Promise<ReleaseResult | null> {
+    const baseUrl = feedUrl.replace(regEx(/\/*$/), '');
+    const url = `${baseUrl}/${pkgName.toLowerCase()}/index.json`;
+    const packageRegistration = await http.getJson<PackageRegistration>(url);
+    const catalogPages = packageRegistration.body.items || [];
+    const catalogPagesQueue = catalogPages.map(
+      (page) => (): Promise<CatalogEntry[]> => this.getCatalogEntry(http, page),
+    );
+    const catalogEntries = (await p.all(catalogPagesQueue))
+      .flat()
+      .sort((a, b) => sortNugetVersions(a.version, b.version));
+
+    let homepage: string | null = null;
+    let latestStable: string | null = null;
+    const releases = catalogEntries.map(
+      ({ version, published: releaseTimestamp, projectUrl, listed }) => {
+        const release: Release = { version: removeBuildMeta(version) };
+        if (releaseTimestamp) {
+          release.releaseTimestamp = releaseTimestamp;
+        }
+        if (versioning.isValid(version) && versioning.isStable(version)) {
+          latestStable = removeBuildMeta(version);
+          homepage = projectUrl ? massageUrl(projectUrl) : homepage;
+        }
+        if (listed === false) {
+          release.isDeprecated = true;
+        }
+        return release;
+      },
+    );
+
+    if (!releases.length) {
+      return null;
+    }
+
+    // istanbul ignore next: only happens when no stable version exists
+    if (latestStable === null && catalogPages.length) {
+      const last = catalogEntries.pop()!;
+      latestStable = removeBuildMeta(last.version);
+      homepage ??= last.projectUrl ?? null;
+    }
+
+    const dep: ReleaseResult = {
+      releases,
+    };
+
+    try {
+      const packageBaseAddress = await this.getResourceUrl(
+        http,
+        registryUrl,
+        'PackageBaseAddress',
       );
-    }
-
-    await packageCache.set(cacheNamespace, resultCacheKey, serviceId, 60);
-    return serviceId;
-  } catch (err) {
-    // istanbul ignore if: not easy testable with nock
-    if (err instanceof ExternalHostError) {
-      throw err;
-    }
-    logger.debug(
-      { err, url, servicesIndexRaw },
-      `nuget registry failure: can't get ${resourceType}`,
-    );
-    return null;
-  }
-}
-
-async function getCatalogEntry(
-  http: Http,
-  catalogPage: CatalogPage,
-): Promise<CatalogEntry[]> {
-  let items = catalogPage.items;
-  if (!items) {
-    const url = catalogPage['@id'];
-    const catalogPageFull = await http.getJson<CatalogPage>(url);
-    items = catalogPageFull.body.items;
-  }
-  return items.map(({ catalogEntry }) => catalogEntry);
-}
-
-/**
- * Compare two versions. Return:
- * - `1` if `a > b` or `b` is invalid
- * - `-1` if `a < b` or `a` is invalid
- * - `0` if `a == b` or both `a` and `b` are invalid
- */
-export function sortNugetVersions(a: string, b: string): number {
-  if (versioning.isValid(a)) {
-    if (versioning.isValid(b)) {
-      return versioning.sortVersions(a, b);
-    } else {
-      return 1;
-    }
-  } else if (versioning.isValid(b)) {
-    return -1;
-  } else {
-    return 0;
-  }
-}
-
-export async function getReleases(
-  http: Http,
-  registryUrl: string,
-  feedUrl: string,
-  pkgName: string,
-): Promise<ReleaseResult | null> {
-  const baseUrl = feedUrl.replace(regEx(/\/*$/), '');
-  const url = `${baseUrl}/${pkgName.toLowerCase()}/index.json`;
-  const packageRegistration = await http.getJson<PackageRegistration>(url);
-  const catalogPages = packageRegistration.body.items || [];
-  const catalogPagesQueue = catalogPages.map(
-    (page) => (): Promise<CatalogEntry[]> => getCatalogEntry(http, page),
-  );
-  const catalogEntries = (await p.all(catalogPagesQueue))
-    .flat()
-    .sort((a, b) => sortNugetVersions(a.version, b.version));
-
-  let homepage: string | null = null;
-  let latestStable: string | null = null;
-  const releases = catalogEntries.map(
-    ({ version, published: releaseTimestamp, projectUrl, listed }) => {
-      const release: Release = { version: removeBuildMeta(version) };
-      if (releaseTimestamp) {
-        release.releaseTimestamp = releaseTimestamp;
+      // istanbul ignore else: this is a required v3 api
+      if (is.nonEmptyString(packageBaseAddress)) {
+        const nuspecUrl = `${ensureTrailingSlash(
+          packageBaseAddress,
+        )}${pkgName.toLowerCase()}/${
+          // TODO: types (#22198)
+          latestStable
+        }/${pkgName.toLowerCase()}.nuspec`;
+        const metaresult = await http.get(nuspecUrl);
+        const nuspec = new XmlDocument(metaresult.body);
+        const sourceUrl = nuspec.valueWithPath('metadata.repository@url');
+        if (sourceUrl) {
+          dep.sourceUrl = massageUrl(sourceUrl);
+        }
       }
-      if (versioning.isValid(version) && versioning.isStable(version)) {
-        latestStable = removeBuildMeta(version);
-        homepage = projectUrl ? massageUrl(projectUrl) : homepage;
+    } catch (err) {
+      // istanbul ignore if: not easy testable with nock
+      if (err instanceof ExternalHostError) {
+        throw err;
       }
-      if (listed === false) {
-        release.isDeprecated = true;
+      // ignore / silence 404. Seen on proget, if remote connector is used and package is not yet cached
+      if (err instanceof HttpError && err.response?.statusCode === 404) {
+        logger.debug(
+          { registryUrl, pkgName, pkgVersion: latestStable },
+          `package manifest (.nuspec) not found`,
+        );
+        return dep;
       }
-      return release;
-    },
-  );
-
-  if (!releases.length) {
-    return null;
-  }
-
-  // istanbul ignore next: only happens when no stable version exists
-  if (latestStable === null && catalogPages.length) {
-    const last = catalogEntries.pop()!;
-    latestStable = removeBuildMeta(last.version);
-    homepage ??= last.projectUrl ?? null;
-  }
-
-  const dep: ReleaseResult = {
-    releases,
-  };
-
-  try {
-    const packageBaseAddress = await getResourceUrl(
-      http,
-      registryUrl,
-      'PackageBaseAddress',
-    );
-    // istanbul ignore else: this is a required v3 api
-    if (is.nonEmptyString(packageBaseAddress)) {
-      const nuspecUrl = `${ensureTrailingSlash(
-        packageBaseAddress,
-      )}${pkgName.toLowerCase()}/${
-        // TODO: types (#22198)
-        latestStable
-      }/${pkgName.toLowerCase()}.nuspec`;
-      const metaresult = await http.get(nuspecUrl);
-      const nuspec = new XmlDocument(metaresult.body);
-      const sourceUrl = nuspec.valueWithPath('metadata.repository@url');
-      if (sourceUrl) {
-        dep.sourceUrl = massageUrl(sourceUrl);
-      }
-    }
-  } catch (err) {
-    // istanbul ignore if: not easy testable with nock
-    if (err instanceof ExternalHostError) {
-      throw err;
-    }
-    // ignore / silence 404. Seen on proget, if remote connector is used and package is not yet cached
-    if (err instanceof HttpError && err.response?.statusCode === 404) {
       logger.debug(
-        { registryUrl, pkgName, pkgVersion: latestStable },
-        `package manifest (.nuspec) not found`,
+        { err, registryUrl, pkgName, pkgVersion: latestStable },
+        `Cannot obtain sourceUrl`,
       );
       return dep;
     }
-    logger.debug(
-      { err, registryUrl, pkgName, pkgVersion: latestStable },
-      `Cannot obtain sourceUrl`,
-    );
+
+    // istanbul ignore else: not easy testable
+    if (homepage) {
+      // only assign if not assigned
+      dep.sourceUrl ??= homepage;
+      dep.homepage ??= homepage;
+    }
+
     return dep;
   }
-
-  // istanbul ignore else: not easy testable
-  if (homepage) {
-    // only assign if not assigned
-    dep.sourceUrl ??= homepage;
-    dep.homepage ??= homepage;
-  }
-
-  return dep;
 }


### PR DESCRIPTION
## Changes

This is a preparation step for being able to use cache decorators more easily

## Context

See https://github.com/renovatebot/renovate/pull/28071#discussion_r1536813935

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
