### PR TITLE
fix: globalExtends merge default

### DIFF
--- a/docs/usage/self-hosted-experimental.md
+++ b/docs/usage/self-hosted-experimental.md
@@ -93,10 +93,6 @@ If set to any value, Renovate will use the Docker Hub API (`https://hub.docker.c
 If set to an integer, Renovate will use this as max page number for docker tags lookup on docker registries, instead of the default 20 pages.
 This is useful for registries which ignores the `n` parameter in the query string and only return 50 tags per page.
 
-## `RENOVATE_X_EAGER_GLOBAL_EXTENDS`
-
-Resolve and merge `globalExtends` presets before other global config, instead of after.
-
 ## `RENOVATE_X_EXEC_GPID_HANDLE`
 
 If set, Renovate will terminate the whole process group of a terminated child process spawned by Renovate.

--- a/lib/workers/global/index.spec.ts
+++ b/lib/workers/global/index.spec.ts
@@ -45,7 +45,6 @@ describe('workers/global/index', () => {
     initPlatform.mockImplementation((input) => Promise.resolve(input));
     delete process.env.AWS_SECRET_ACCESS_KEY;
     delete process.env.AWS_SESSION_TOKEN;
-    delete process.env.RENOVATE_X_EAGER_GLOBAL_EXTENDS;
   });
 
   describe('getRepositoryConfig', () => {
@@ -86,21 +85,6 @@ describe('workers/global/index', () => {
     process.env.AWS_SESSION_TOKEN = 'token';
     await expect(globalWorker.start()).resolves.toBe(0);
     expect(addSecretForSanitizing).toHaveBeenCalledTimes(2);
-  });
-
-  it('resolves global presets first', async () => {
-    process.env.RENOVATE_X_EAGER_GLOBAL_EXTENDS = 'true';
-    parseConfigs.mockResolvedValueOnce({
-      repositories: [],
-      globalExtends: [':pinVersions'],
-      hostRules: [{ matchHost: 'github.com', token: 'abc123' }],
-    });
-    presets.resolveConfigPresets.mockResolvedValueOnce({});
-    await expect(globalWorker.start()).resolves.toBe(0);
-    expect(presets.resolveConfigPresets).toHaveBeenCalledWith({
-      extends: [':pinVersions'],
-    });
-    expect(parseConfigs).toHaveBeenCalledTimes(1);
   });
 
   it('resolves global presets immediately', async () => {

--- a/lib/workers/global/index.ts
+++ b/lib/workers/global/index.ts
@@ -144,17 +144,10 @@ export async function start(): Promise<number> {
       config = await getGlobalConfig();
       if (config?.globalExtends) {
         // resolve global presets immediately
-        if (process.env.RENOVATE_X_EAGER_GLOBAL_EXTENDS) {
-          config = mergeChildConfig(
-            await resolveGlobalExtends(config.globalExtends),
-            config,
-          );
-        } else {
-          config = mergeChildConfig(
-            config,
-            await resolveGlobalExtends(config.globalExtends),
-          );
-        }
+        config = mergeChildConfig(
+          await resolveGlobalExtends(config.globalExtends),
+          config,
+        );
       }
       // initialize all submodules
       config = await globalInitialize(config);


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Fixes default globalExtends merge behavior so that presets in globalExtends are merged before other global config.

## Context

Closes #28131 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
