### PR TITLE
feat: adding includes helper for templating

### DIFF
--- a/docs/usage/templates.md
+++ b/docs/usage/templates.md
@@ -110,6 +110,12 @@ Returns `true` if at least one expression is `true`.
 
 `{{#if (or isPatch isSingleVersion}}Small update, safer to merge and release.{{else}}Check out the changelog for all versions before merging!{{/if}}`
 
+### includes
+
+Returns `true` if the value is included on the list given.
+
+`{{#if (includes depTypes "dependencies")}}production{{else}}notProduction{{/if}}`
+
 ## Environment variables
 
 By default, you can only access a handful of basic environment variables like `HOME` or `PATH`.

--- a/docs/usage/templates.md
+++ b/docs/usage/templates.md
@@ -114,7 +114,7 @@ Returns `true` if at least one expression is `true`.
 
 Returns `true` if the value is included on the list given.
 
-`{{#if (includes depTypes "dependencies")}}production{{else}}notProduction{{/if}}`
+`{{#if (includes labels 'dependencies')}}Production Dependencies{{else}}Not Production Dependencies{{/if}}`
 
 ## Environment variables
 

--- a/lib/util/template/index.spec.ts
+++ b/lib/util/template/index.spec.ts
@@ -276,4 +276,50 @@ describe('util/template/index', () => {
       expect(output).toBe('not equals');
     });
   });
+
+  describe('includes', () => {
+    it('includes is true', () => {
+      const output = template.compile(
+        '{{#if (includes depTypes "dependencies")}}production{{else}}notProduction{{/if}}',
+        {
+          depTypes: ['dependencies'],
+        },
+      );
+
+      expect(output).toBe('production');
+    });
+
+    it('includes is false', () => {
+      const output = template.compile(
+        '{{#if (includes depTypes "dependencies")}}production{{else}}notProduction{{/if}}',
+        {
+          depTypes: ['devDependencies'],
+        },
+      );
+
+      expect(output).toBe('notProduction');
+    });
+
+    it('includes with incorrect type first argument', () => {
+      const output = template.compile(
+        '{{#if (includes depTypes "dependencies")}}production{{else}}notProduction{{/if}}',
+        {
+          depTypes: 'devDependencies',
+        },
+      );
+
+      expect(output).toBe('notProduction');
+    });
+
+    it('includes with incorrect type second argument', () => {
+      const output = template.compile(
+        '{{#if (includes depTypes 555)}}production{{else}}notProduction{{/if}}',
+        {
+          depTypes: ['devDependencies'],
+        },
+      );
+
+      expect(output).toBe('notProduction');
+    });
+  });
 });

--- a/lib/util/template/index.spec.ts
+++ b/lib/util/template/index.spec.ts
@@ -280,9 +280,9 @@ describe('util/template/index', () => {
   describe('includes', () => {
     it('includes is true', () => {
       const output = template.compile(
-        '{{#if (includes depTypes "dependencies")}}production{{else}}notProduction{{/if}}',
+        '{{#if (includes labels "dependencies")}}production{{else}}notProduction{{/if}}',
         {
-          depTypes: ['dependencies'],
+          labels: ['dependencies'],
         },
       );
 
@@ -291,9 +291,9 @@ describe('util/template/index', () => {
 
     it('includes is false', () => {
       const output = template.compile(
-        '{{#if (includes depTypes "dependencies")}}production{{else}}notProduction{{/if}}',
+        '{{#if (includes labels "dependencies")}}production{{else}}notProduction{{/if}}',
         {
-          depTypes: ['devDependencies'],
+          labels: ['devDependencies'],
         },
       );
 
@@ -302,9 +302,9 @@ describe('util/template/index', () => {
 
     it('includes with incorrect type first argument', () => {
       const output = template.compile(
-        '{{#if (includes depTypes "dependencies")}}production{{else}}notProduction{{/if}}',
+        '{{#if (includes labels "dependencies")}}production{{else}}notProduction{{/if}}',
         {
-          depTypes: 'devDependencies',
+          labels: 'devDependencies',
         },
       );
 
@@ -313,9 +313,9 @@ describe('util/template/index', () => {
 
     it('includes with incorrect type second argument', () => {
       const output = template.compile(
-        '{{#if (includes depTypes 555)}}production{{else}}notProduction{{/if}}',
+        '{{#if (includes labels 555)}}production{{else}}notProduction{{/if}}',
         {
-          depTypes: ['devDependencies'],
+          labels: ['devDependencies'],
         },
       );
 

--- a/lib/util/template/index.ts
+++ b/lib/util/template/index.ts
@@ -28,6 +28,14 @@ handlebars.registerHelper('containsString', (str, subStr) =>
 
 handlebars.registerHelper('equals', (arg1, arg2) => arg1 === arg2);
 
+handlebars.registerHelper('includes', (arg1: string[], arg2: string) => {
+  if (is.array(arg1, is.string) && is.string(arg2)) {
+    return arg1.includes(arg2);
+  }
+
+  return false;
+});
+
 handlebars.registerHelper({
   and(...args) {
     // Need to remove the 'options', as last parameter


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Adding a custom helper for handlebars as `includes` that will check if a list of strings will be valid for a template configuration.

- [x] Add `includes` handlebars

## Context

#27818

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

All tests are passing locally with 100% code coverage

This has been tested also on a PR with a public project https://github.com/juancarlosjr97/renovate-test-27818/pull/13

Commit updated by template: https://github.com/juancarlosjr97/renovate-test-27818/pull/13/commits/791e2ae8a8a6bbd03aeb6da5fa52d905a9c3f603

```bash
chore(deps): update all dependencies
Jest Dependency
```

```json
{
  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
  "extends": ["config:base", "group:all"],
  "packageRules": [
    {
      "matchDepTypes": ["*"],
      "addLabels": ["jest"]
    },
    {
      "matchPackagePatterns": ["*"],
      "labels": ["jest"],
      "commitBody": "{{#if (includes labels 'jest')}}Jest Dependency{{else}}Other Libraries{{/if}}"
    }
  ],
  "fetchChangeLogs": "off"
}
```

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
