### PR TITLE
feat(manager/pip-compile): Handle some edge-cases with -r dependencies

### DIFF
--- a/lib/modules/manager/pip-compile/extract.spec.ts
+++ b/lib/modules/manager/pip-compile/extract.spec.ts
@@ -496,4 +496,110 @@ describe('modules/manager/pip-compile/extract', () => {
       'pip-compile: 1.in references unmanaged-file.txt which does not appear to be a requirements file managed by pip-compile',
     );
   });
+
+  it('handles duplicate -r dependencies', async () => {
+    fs.readLocalFile.mockImplementation((name): any => {
+      if (name === '1.in') {
+        return 'foo';
+      } else if (name === '1.txt') {
+        return getSimpleRequirementsFile(
+          'pip-compile --output-file=1.txt 1.in',
+          ['foo==1.0.1'],
+        );
+      } else if (name === '2.in') {
+        return '-r 1.txt\nbar';
+      } else if (name === '2.txt') {
+        return getSimpleRequirementsFile(
+          'pip-compile --output-file=2.txt 2.in',
+          ['foo==1.0.1', 'bar==2.0.0'],
+        );
+      } else if (name === '3.in') {
+        return '-r 1.txt\nbaz';
+      } else if (name === '3.txt') {
+        return getSimpleRequirementsFile(
+          'pip-compile --output-file=3.txt 3.in',
+          ['foo==1.0.1', 'baz==2.0.0'],
+        );
+      } else if (name === '4.in') {
+        return '-r 2.txt\n-r 3.txt\nqux';
+      } else if (name === '4.txt') {
+        return getSimpleRequirementsFile(
+          'pip-compile --output-file=4.txt 4.in',
+          ['foo==1.0.1', 'bar==2.0.0', 'baz==2.0.0', 'qux==1.2.3'],
+        );
+      }
+      return null;
+    });
+
+    const lockFiles = ['1.txt', '2.txt', '3.txt', '4.txt'];
+    const packageFiles = await extractAllPackageFiles({}, lockFiles);
+    expect(packageFiles?.map((p) => p.lockFiles)).toEqual([
+      ['1.txt', '2.txt', '3.txt', '4.txt'],
+      ['3.txt', '4.txt'],
+      ['2.txt', '4.txt'],
+      ['4.txt'],
+    ]);
+  });
+
+  it('handles -r dependency on lock file with multiple input files', async () => {
+    fs.readLocalFile.mockImplementation((name): any => {
+      if (name === '1.in') {
+        return 'foo';
+      } else if (name === '2.in') {
+        return 'bar';
+      } else if (name === 'multi_input.txt') {
+        return getSimpleRequirementsFile(
+          'pip-compile --output-file=multi_input.txt 1.in 2.in',
+          ['foo==1.0.1', 'bar==2.0.0'],
+        );
+      } else if (name === '3.in') {
+        return '-r multi_input.txt\nbaz';
+      } else if (name === 'dash_r.txt') {
+        return getSimpleRequirementsFile(
+          'pip-compile --output-file=dash_r.txt 3.in',
+          ['foo==1.0.1', 'bar==2.0.0', 'baz==2.0.0'],
+        );
+      }
+      return null;
+    });
+
+    const lockFiles = ['multi_input.txt', 'dash_r.txt'];
+    const packageFiles = await extractAllPackageFiles({}, lockFiles);
+    expect(packageFiles?.map((p) => p.lockFiles)).toEqual([
+      ['multi_input.txt', 'dash_r.txt'],
+      ['multi_input.txt', 'dash_r.txt'],
+      ['dash_r.txt'],
+    ]);
+  });
+
+  it('handles -r dependency on input file that is also used to generate lock file with multiple inputs', async () => {
+    fs.readLocalFile.mockImplementation((name): any => {
+      if (name === '1.in') {
+        return 'foo';
+      } else if (name === '2.in') {
+        return 'bar';
+      } else if (name === 'multi_input.txt') {
+        return getSimpleRequirementsFile(
+          'pip-compile --output-file=multi_input.txt 1.in 2.in',
+          ['foo==1.0.1', 'bar==2.0.0'],
+        );
+      } else if (name === '3.in') {
+        return '-r 1.in\nbaz';
+      } else if (name === 'dash_r.txt') {
+        return getSimpleRequirementsFile(
+          'pip-compile --output-file=dash_r.txt 3.in',
+          ['foo==1.0.1', 'baz==2.0.0'],
+        );
+      }
+      return null;
+    });
+
+    const lockFiles = ['multi_input.txt', 'dash_r.txt'];
+    const packageFiles = await extractAllPackageFiles({}, lockFiles);
+    expect(packageFiles?.map((p) => p.lockFiles)).toEqual([
+      ['multi_input.txt'],
+      ['multi_input.txt', 'dash_r.txt'],
+      ['dash_r.txt'],
+    ]);
+  });
 });

--- a/lib/modules/manager/pip-compile/extract.ts
+++ b/lib/modules/manager/pip-compile/extract.ts
@@ -232,11 +232,11 @@ export async function extractAllPackageFiles(
         );
         continue;
       }
+      // These get reversed before merging so that we keep the last instance of any common
+      // lock files, since a file that -r includes multiple lock files needs to be updated after
+      // all of the lock files it includes
       const files = new Set([...packageFile.lockFiles!].reverse());
       for (const sourceFile of sourceFiles) {
-        // These get reversed before merging so that we keep the last instance of any common
-        // lock files, since a file that -r includes multiple lock files needs to be updated after
-        // all of the lock files it includes
         const merged = new Set(files);
         for (const lockFile of [...sourceFile.lockFiles!].reverse()) {
           merged.add(lockFile);

--- a/lib/modules/manager/pip-compile/extract.ts
+++ b/lib/modules/manager/pip-compile/extract.ts
@@ -232,11 +232,12 @@ export async function extractAllPackageFiles(
         );
         continue;
       }
+      const files = new Set([...packageFile.lockFiles!].reverse());
       for (const sourceFile of sourceFiles) {
         // These get reversed before merging so that we keep the last instance of any common
         // lock files, since a file that -r includes multiple lock files needs to be updated after
         // all of the lock files it includes
-        const merged = new Set<string>([...packageFile.lockFiles!].reverse());
+        const merged = new Set(files);
         for (const lockFile of [...sourceFile.lockFiles!].reverse()) {
           merged.add(lockFile);
         }

--- a/lib/modules/manager/pip-compile/extract.ts
+++ b/lib/modules/manager/pip-compile/extract.ts
@@ -75,7 +75,7 @@ export async function extractAllPackageFiles(
   const lockFileArgs = new Map<string, PipCompileArgs>();
   const depsBetweenFiles: DependencyBetweenFiles[] = [];
   const packageFiles = new Map<string, PackageFile>();
-  const lockFileSources = new Map<string, PackageFile>();
+  const lockFileSources = new Map<string, PackageFile[]>();
   for (const fileMatch of fileMatches) {
     const fileContent = await readLocalFile(fileMatch, 'utf8');
     if (!fileContent) {
@@ -141,7 +141,9 @@ export async function extractAllPackageFiles(
         const existingPackageFile = packageFiles.get(packageFile)!;
         existingPackageFile.lockFiles!.push(fileMatch);
         extendWithIndirectDeps(existingPackageFile, lockedDeps);
-        lockFileSources.set(fileMatch, existingPackageFile);
+        const source = lockFileSources.get(fileMatch) ?? [];
+        source.push(existingPackageFile);
+        lockFileSources.set(fileMatch, source);
         continue;
       }
       const content = await readLocalFile(packageFile, 'utf8');
@@ -196,7 +198,9 @@ export async function extractAllPackageFiles(
           packageFile,
         };
         packageFiles.set(packageFile, newPackageFile);
-        lockFileSources.set(fileMatch, newPackageFile);
+        const source = lockFileSources.get(fileMatch) ?? [];
+        source.push(newPackageFile);
+        lockFileSources.set(fileMatch, source);
       } else {
         logger.warn(
           { packageFile },
@@ -216,19 +220,27 @@ export async function extractAllPackageFiles(
   // This needs to go in reverse order to handle transitive dependencies
   for (const packageFile of [...result].reverse()) {
     for (const reqFile of packageFile.managerData?.requirementsFiles ?? []) {
-      let sourceFile: PackageFile | undefined = undefined;
+      let sourceFiles: PackageFile[] | undefined = undefined;
       if (fileMatches.includes(reqFile)) {
-        sourceFile = lockFileSources.get(reqFile);
+        sourceFiles = lockFileSources.get(reqFile);
       } else if (packageFiles.has(reqFile)) {
-        sourceFile = packageFiles.get(reqFile);
+        sourceFiles = [packageFiles.get(reqFile)!];
       }
-      if (!sourceFile) {
+      if (!sourceFiles) {
         logger.warn(
           `pip-compile: ${packageFile.packageFile} references ${reqFile} which does not appear to be a requirements file managed by pip-compile`,
         );
         continue;
       }
-      sourceFile.lockFiles!.push(...packageFile.lockFiles!);
+      for (const sourceFile of sourceFiles) {
+        let merged = [...packageFile.lockFiles!];
+        for (const lockFile of [...sourceFile.lockFiles!].reverse()) {
+          if (!merged.includes(lockFile)) {
+            merged = [lockFile, ...merged];
+          }
+        }
+        sourceFile.lockFiles = merged;
+      }
     }
   }
   logger.debug(

--- a/lib/modules/manager/pip-compile/extract.ts
+++ b/lib/modules/manager/pip-compile/extract.ts
@@ -233,13 +233,14 @@ export async function extractAllPackageFiles(
         continue;
       }
       for (const sourceFile of sourceFiles) {
-        let merged = [...packageFile.lockFiles!];
+        // These get reversed before merging so that we keep the last instance of any common
+        // lock files, since a file that -r includes multiple lock files needs to be updated after
+        // all of the lock files it includes
+        const merged = new Set<string>([...packageFile.lockFiles!].reverse());
         for (const lockFile of [...sourceFile.lockFiles!].reverse()) {
-          if (!merged.includes(lockFile)) {
-            merged = [lockFile, ...merged];
-          }
+          merged.add(lockFile);
         }
-        sourceFile.lockFiles = merged;
+        sourceFile.lockFiles = Array.from(merged).reverse();
       }
     }
   }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This adds handling for two edge-cases I missed in #28052:

1. A -r dependency on a multi-input lock file; i.e.
```mermaid
graph LR
common.txt[[common.txt]]
final.txt[[final.txt]]
1.in --> common.txt
2.in --> common.txt
common.txt --> 3.in
3.in --> final.txt
```
2. An input file with multiple transitive -r dependencies on the same file, i.e.
``` mermaid
graph LR
common.in --> mid1.in
common.in --> mid2.in
mid1.in --> final.in
mid2.in --> final.in
```

CC @not7cd 

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->
#28050
#28052 (specifically https://github.com/renovatebot/renovate/pull/28052#discussion_r1544913745)

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
