### PR TITLE
fix(worker/repository): add normalized match for pip alertPackageRules

### DIFF
--- a/lib/workers/repository/init/vulnerability.spec.ts
+++ b/lib/workers/repository/init/vulnerability.spec.ts
@@ -368,6 +368,41 @@ describe('workers/repository/init/vulnerability', () => {
       expect(res.packageRules).toHaveLength(1);
     });
 
+    it('returns pip alerts with normalized name', async () => {
+      // TODO #22198
+      delete config.vulnerabilityAlerts!.enabled;
+      platform.getVulnerabilityAlerts.mockResolvedValue([
+        {
+          dismissReason: null,
+          vulnerableManifestFilename: 'requirements.txt',
+          vulnerableManifestPath: 'requirements.txt',
+          vulnerableRequirements: '= 1.6.7',
+          securityAdvisory: {
+            description: 'Description',
+            identifiers: [
+              { type: 'GHSA', value: 'GHSA-m956-frf4-m2wr' },
+              { type: 'CVE', value: 'CVE-2016-2137' },
+            ],
+            references: [
+              { url: 'https://nvd.nist.gov/vuln/detail/CVE-2016-9587' },
+            ],
+            severity: 'MODERATE',
+          },
+          securityVulnerability: {
+            package: { name: 'Pillow', ecosystem: 'PIP' },
+            firstPatchedVersion: { identifier: '2.1.4' },
+            vulnerableVersionRange: '< 2.1.4',
+          },
+        },
+      ]);
+      const res = await detectVulnerabilityAlerts(config);
+      expect(res.packageRules).toHaveLength(1);
+      expect(res.packageRules![0].matchPackageNames).toEqual([
+        'Pillow',
+        'pillow',
+      ]);
+    });
+
     it('returns remediations', async () => {
       config.transitiveRemediation = true;
       // TODO #22198

--- a/lib/workers/repository/init/vulnerability.ts
+++ b/lib/workers/repository/init/vulnerability.ts
@@ -9,6 +9,7 @@ import { NpmDatasource } from '../../../modules/datasource/npm';
 import { NugetDatasource } from '../../../modules/datasource/nuget';
 import { PackagistDatasource } from '../../../modules/datasource/packagist';
 import { PypiDatasource } from '../../../modules/datasource/pypi';
+import { normalizeDepName } from '../../../modules/datasource/pypi/common';
 import { RubyGemsDatasource } from '../../../modules/datasource/rubygems';
 import { platform } from '../../../modules/platform';
 import * as allVersioning from '../../../modules/versioning';
@@ -218,6 +219,12 @@ export async function detectVulnerabilityAlerts(
             matchCurrentVersion,
             matchFileNames,
           };
+          if (
+            datasource === PypiDatasource.id &&
+            normalizeDepName(depName) !== depName
+          ) {
+            matchRule.matchPackageNames?.push(normalizeDepName(depName));
+          }
           const supportedRemediationFileTypes = ['package-lock.json'];
           if (
             config.transitiveRemediation &&


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds additional normalized name in matchPackageName for alerts coming from vulnerability alerts. This should catch dependencies in managers using pep621 standards, poetry, and pip-compile lock files. 
<!-- Describe what behavior is changed by this PR. -->

## Context

Workaround for #27069, may be superseded by #27733.
There is an inconsistency how Renovate handles Python package names. When it comes to vulnerability alerts coming from GitHub dependabot, they are taken as is in their canonical form (ex.: Pillow). If a normalized name (pillow) is used in a file, the update will be ignored and not created.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
