### PR TITLE
ci: do not require codecov reports to be successful

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -462,19 +462,6 @@ jobs:
           needs.test.result == 'skipped'
         run: exit 1
 
-      - name: Fail for failed or cancelled codecov
-        if: |
-          needs.codecov.result == 'failure' ||
-          needs.codecov.result == 'cancelled'
-        run: exit 1
-
-      - name: Fail for skipped codecov when PR is ready for review
-        if: |
-          github.event_name == 'pull_request' &&
-          github.event.pull_request.draft != true &&
-          needs.codecov.result == 'skipped'
-        run: exit 1
-
       - name: Fail for failed or cancelled coverage-threshold
         if: |
           needs.coverage-threshold.result == 'failure' ||


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Removes the check if codecov is successful

That way we still see the codecov annotations if they are not ratelimited, but allow to merge anyway. 
<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
