### PR TITLE
fix(http): honor authType first

### DIFF
--- a/lib/util/http/auth.spec.ts
+++ b/lib/util/http/auth.spec.ts
@@ -189,6 +189,30 @@ describe('util/http/auth', () => {
         token: 'test',
       });
     });
+
+    it(`honors authType`, () => {
+      const opts: GotOptions = {
+        headers: {},
+        token: 'test',
+        context: {
+          authType: 'Bearer',
+        },
+        hostType: 'custom',
+      };
+
+      applyAuthorization(opts);
+
+      expect(opts).toEqual({
+        context: {
+          authType: 'Bearer',
+        },
+        headers: {
+          authorization: 'Bearer test',
+        },
+        hostType: 'custom',
+        token: 'test',
+      });
+    });
   });
 
   describe('removeAuthorization', () => {

--- a/lib/util/http/auth.ts
+++ b/lib/util/http/auth.ts
@@ -29,7 +29,14 @@ export function applyAuthorization<GotOptions extends AuthGotOptions>(
 
   options.headers ??= {};
   if (options.token) {
-    if (
+    const authType = options.context?.authType;
+    if (authType) {
+      if (authType === 'Token-Only') {
+        options.headers.authorization = options.token;
+      } else {
+        options.headers.authorization = `${authType} ${options.token}`;
+      }
+    } else if (
       options.hostType &&
       GITEA_API_USING_HOST_TYPES.includes(options.hostType)
     ) {
@@ -61,14 +68,7 @@ export function applyAuthorization<GotOptions extends AuthGotOptions>(
         options.headers.authorization = `Bearer ${options.token}`;
       }
     } else {
-      // Custom Auth type, eg `Basic XXXX_TOKEN`
-      const type = options.context?.authType ?? 'Bearer';
-
-      if (type === 'Token-Only') {
-        options.headers.authorization = options.token;
-      } else {
-        options.headers.authorization = `${type} ${options.token}`;
-      }
+      options.headers.authorization = `Bearer ${options.token}`;
     }
     delete options.token;
   } else if (options.password !== undefined) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Changes auth logic order so that if authType is explicitly configured then it will be evaluated first.

## Context

Semi-fix, semi-workaround for #28303

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
