### PR TITLE
feat(config): Add @eslint/* to ESLint packages preset

### DIFF
--- a/lib/config/presets/__snapshots__/index.spec.ts.snap
+++ b/lib/config/presets/__snapshots__/index.spec.ts.snap
@@ -122,6 +122,8 @@ exports[`config/presets/index resolvePreset resolves eslint 1`] = `
     "@babel/eslint-parser",
   ],
   "matchPackagePrefixes": [
+    "@eslint/",
+    "@types/eslint__",
     "@typescript-eslint/",
     "eslint",
   ],
@@ -150,6 +152,8 @@ exports[`config/presets/index resolvePreset resolves linters 1`] = `
   ],
   "matchPackagePrefixes": [
     "ember-template-lint",
+    "@eslint/",
+    "@types/eslint__",
     "@typescript-eslint/",
     "eslint",
     "stylelint",
@@ -185,6 +189,8 @@ exports[`config/presets/index resolvePreset resolves nested groups 1`] = `
       ],
       "matchPackagePrefixes": [
         "ember-template-lint",
+        "@eslint/",
+        "@types/eslint__",
         "@typescript-eslint/",
         "eslint",
         "stylelint",

--- a/lib/config/presets/index.spec.ts
+++ b/lib/config/presets/index.spec.ts
@@ -238,7 +238,13 @@ describe('config/presets/index', () => {
           'babel-eslint',
           '@babel/eslint-parser',
         ],
-        matchPackagePrefixes: ['@typescript-eslint/', 'eslint', 'stylelint'],
+        matchPackagePrefixes: [
+          '@eslint/',
+          '@types/eslint__',
+          '@typescript-eslint/',
+          'eslint',
+          'stylelint',
+        ],
       });
     });
 
@@ -259,7 +265,12 @@ describe('config/presets/index', () => {
               'babel-eslint',
               '@babel/eslint-parser',
             ],
-            matchPackagePrefixes: ['@typescript-eslint/', 'eslint'],
+            matchPackagePrefixes: [
+              '@eslint/',
+              '@types/eslint__',
+              '@typescript-eslint/',
+              'eslint',
+            ],
           },
         ],
       });
@@ -269,7 +280,7 @@ describe('config/presets/index', () => {
       config.extends = ['packages:eslint'];
       const res = await presets.resolveConfigPresets(config);
       expect(res).toMatchSnapshot();
-      expect(res.matchPackagePrefixes).toHaveLength(2);
+      expect(res.matchPackagePrefixes).toHaveLength(4);
     });
 
     it('resolves linters', async () => {
@@ -278,7 +289,7 @@ describe('config/presets/index', () => {
       expect(res).toMatchSnapshot();
       expect(res.matchPackageNames).toHaveLength(10);
       expect(res.matchPackagePatterns).toHaveLength(1);
-      expect(res.matchPackagePrefixes).toHaveLength(4);
+      expect(res.matchPackagePrefixes).toHaveLength(6);
     });
 
     it('resolves nested groups', async () => {
@@ -289,7 +300,7 @@ describe('config/presets/index', () => {
       expect(rule.automerge).toBeTrue();
       expect(rule.matchPackageNames).toHaveLength(10);
       expect(rule.matchPackagePatterns).toHaveLength(1);
-      expect(rule.matchPackagePrefixes).toHaveLength(4);
+      expect(rule.matchPackagePrefixes).toHaveLength(6);
     });
 
     it('migrates automerge in presets', async () => {

--- a/lib/config/presets/internal/packages.ts
+++ b/lib/config/presets/internal/packages.ts
@@ -27,7 +27,12 @@ export const presets: Record<string, Preset> = {
       'babel-eslint',
       '@babel/eslint-parser',
     ],
-    matchPackagePrefixes: ['@typescript-eslint/', 'eslint'],
+    matchPackagePrefixes: [
+      '@eslint/',
+      '@types/eslint__',
+      '@typescript-eslint/',
+      'eslint',
+    ],
   },
   gatsby: {
     description: 'All packages published by Gatsby.',


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Adds the `@eslint/` and `@types/eslint__` package name prefixes to the `packages:eslint` preset.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

ESLint started publishing two new packages in the most recent major versions: [`@eslint/js`](https://www.npmjs.com/package/@eslint/js) ([introduced here](https://eslint.org/blog/2023/02/eslint-v8.35.0-released/#highlights)) and [`@eslint/eslintrc`](https://www.npmjs.com/package/@eslint/eslintrc) ([introduced here](https://eslint.org/blog/2022/08/new-config-system-part-2/#backwards-compatibility-utility)). These packages each have a corresponding DefinitelyTyped package, [`@types/eslint__js`](https://www.npmjs.com/package/@types/eslint__js) and [`@types/eslint__eslintrc`](https://www.npmjs.com/package/@types/eslint__eslintrc), respectively.

Note that [the convention for DefinitelyTyped packages for scoped packages](https://github.com/DefinitelyTyped/DefinitelyTyped?tab=readme-ov-file#npm) is:

> To install typings for a scoped module, remove the @ and add double-underscore after the scope. For example, to install typings for @babel/preset-env:
>
> ```sh
> npm install --save-dev @types/babel__preset-env
> ```


## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
