### PR TITLE
test(config/presets): add test to prevent handlebars in internal preset names

### DIFF
--- a/lib/config/presets/internal/index.spec.ts
+++ b/lib/config/presets/internal/index.spec.ts
@@ -43,4 +43,15 @@ describe('config/presets/internal/index', () => {
       }
     }
   }
+
+  it('internal presets should not contain handlebars', () => {
+    Object.entries(internal.groups)
+      .map(([groupName, groupPresets]) =>
+        Object.entries(groupPresets).map(
+          ([presetName]) => `${groupName}:${presetName}`,
+        ),
+      )
+      .flat()
+      .forEach((preset) => expect(preset).not.toMatch(/{{.*}}/));
+  });
 });


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
Hi everyone,
this PR introduces an additional test, which prevents [internal presets](https://github.com/renovatebot/renovate/blob/main/lib/config/presets/internal/index.ts#L20) from containing handlebars in their name. It's mandatory for supporting templating of external preset names provided in the `extends` field (see context below)

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

https://github.com/renovatebot/renovate/pull/27955

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
