### PR TITLE
feat(fleet): extract dependencies from helm blocks with OCI-based helm charts

### DIFF
--- a/lib/modules/manager/fleet/__fixtures__/valid_fleet.yaml
+++ b/lib/modules/manager/fleet/__fixtures__/valid_fleet.yaml
@@ -20,3 +20,8 @@ helm:
   repo: https://prometheus-community.github.io/helm-charts
   chart: prometheus
   version: 25.19.1
+---
+defaultNamespace: external-dns
+helm:
+  chart: oci://registry-1.docker.io/bitnamicharts/external-dns
+  version: 7.1.2

--- a/lib/modules/manager/fleet/extract.spec.ts
+++ b/lib/modules/manager/fleet/extract.spec.ts
@@ -73,7 +73,7 @@ kind: Fleet
           {
             currentValue: '7.1.2',
             datasource: 'docker',
-            depName: 'external-dns',
+            depName: 'registry-1.docker.io/bitnamicharts/external-dns',
             packageName: 'registry-1.docker.io/bitnamicharts/external-dns',
             depType: 'fleet',
             pinDigests: false,

--- a/lib/modules/manager/fleet/extract.spec.ts
+++ b/lib/modules/manager/fleet/extract.spec.ts
@@ -70,6 +70,13 @@ kind: Fleet
             ],
             depType: 'fleet',
           },
+          {
+            currentValue: '7.1.2',
+            datasource: 'docker',
+            depName: 'external-dns',
+            registryUrls: ['oci://registry-1.docker.io/bitnamicharts'],
+            depType: 'fleet',
+          },
         ]);
       });
 

--- a/lib/modules/manager/fleet/extract.spec.ts
+++ b/lib/modules/manager/fleet/extract.spec.ts
@@ -74,6 +74,7 @@ kind: Fleet
             currentValue: '7.1.2',
             datasource: 'docker',
             depName: 'external-dns',
+            packageName: 'registry-1.docker.io/bitnamicharts/external-dns',
             depType: 'fleet',
             pinDigests: false,
           },

--- a/lib/modules/manager/fleet/extract.spec.ts
+++ b/lib/modules/manager/fleet/extract.spec.ts
@@ -74,8 +74,8 @@ kind: Fleet
             currentValue: '7.1.2',
             datasource: 'docker',
             depName: 'external-dns',
-            registryUrls: ['oci://registry-1.docker.io/bitnamicharts'],
             depType: 'fleet',
+            pinDigests: false,
           },
         ]);
       });

--- a/lib/modules/manager/fleet/extract.ts
+++ b/lib/modules/manager/fleet/extract.ts
@@ -54,13 +54,15 @@ function extractFleetHelmBlock(doc: FleetHelmBlock): PackageDependency {
   }
 
   if (isOCIRegistry(doc.chart)) {
-    const ociImageRegistry = doc.chart.replace('oci://', '');
-    const dockerDep = getDep(`${ociImageRegistry}:${doc.version}`, false);
+    const dockerDep = getDep(
+      `${doc.chart.replace('oci://', '')}:${doc.version}`,
+      false,
+    );
 
     return {
       ...dockerDep,
       depType: 'fleet',
-      depName: ociImageRegistry.split('/').at(-1),
+      depName: dockerDep.depName,
       packageName: dockerDep.depName,
       // https://github.com/helm/helm/issues/10312
       // https://github.com/helm/helm/issues/10678

--- a/lib/modules/manager/fleet/index.ts
+++ b/lib/modules/manager/fleet/index.ts
@@ -1,4 +1,5 @@
 import type { Category } from '../../../constants';
+import { DockerDatasource } from '../../datasource/docker';
 import { GitTagsDatasource } from '../../datasource/git-tags';
 import { HelmDatasource } from '../../datasource/helm';
 
@@ -12,4 +13,8 @@ export const defaultConfig = {
 
 export const categories: Category[] = ['cd', 'kubernetes'];
 
-export const supportedDatasources = [GitTagsDatasource.id, HelmDatasource.id];
+export const supportedDatasources = [
+  GitTagsDatasource.id,
+  HelmDatasource.id,
+  DockerDatasource.id,
+];


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This PR updates the fleet manager to handle helm charts with OCI-based registries.

## Context

Previously, the fleet manager ignored OCI-based helm blocks because they do not set a `.repo` field. Instead, the `.chart` field is set to an oci:// URL (see (https://fleet.rancher.io/ref-fleet-yaml)[fleet.yaml docs]. Valid example:

```yaml
helm:
  chart: oci://registry-1.docker.io/bitnamicharts/external-dns
  version: 7.0.2
  releaseName: external-dns

targetCustomizations:
  - name: target-1
    helm:
      chart: oci://registry-1.docker.io/bitnamicharts/external-dns
      version: 7.0.2
```

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [X] Both unit tests + ran on a real repository: https://github.com/webD97/renovate-testrepo

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
