### PR TITLE
fix(hostRules): drop custom from platform hostTypes

### DIFF
--- a/lib/constants/platforms.ts
+++ b/lib/constants/platforms.ts
@@ -14,7 +14,6 @@ export const GITEA_API_USING_HOST_TYPES = [
   'gitea-changelog',
   'gitea-releases',
   'gitea-tags',
-  'custom',
 ];
 
 export const GITHUB_API_USING_HOST_TYPES = [
@@ -26,7 +25,6 @@ export const GITHUB_API_USING_HOST_TYPES = [
   'hermit',
   'github-changelog',
   'conan',
-  'custom',
 ];
 
 export const GITLAB_API_USING_HOST_TYPES = [
@@ -36,12 +34,10 @@ export const GITLAB_API_USING_HOST_TYPES = [
   'gitlab-packages',
   'gitlab-changelog',
   'pypi',
-  'custom',
 ];
 
 export const BITBUCKET_API_USING_HOST_TYPES = [
   'bitbucket',
   'bitbucket-changelog',
   'bitbucket-tags',
-  'custom',
 ];


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Remove 'custom' from platform hostTypes lists due to undesirable side effects (hostRules without authType)

## Context

#28367

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
