### PR TITLE
chore: disable corepack prompt in devcontainer

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -7,4 +7,4 @@ if [[ "${CODESPACES}" == true ]]; then
   sudo chmod 1777 /tmp
 fi
 
-pnpm install
+COREPACK_ENABLE_DOWNLOAD_PROMPT=0 pnpm install


### PR DESCRIPTION

## Changes

Disable corepack download prompts when starting devcontainer.

See https://github.com/nodejs/corepack?tab=readme-ov-file#environment-variables.

## Context

<img width="713" alt="image" src="https://github.com/renovatebot/renovate/assets/1540469/1c506b44-bc97-42af-8401-647a4f102c39">


## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
