### PR TITLE
feat(github): Enable HTTP cache for "findPr"

### DIFF
--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -847,11 +847,11 @@ export async function findPr({
   if (includeOtherAuthors) {
     const repo = config.parentRepo ?? config.repository;
     // PR might have been created by anyone, so don't use the cached Renovate PR list
-    const response = await githubApi.getJson<GhRestPr[]>(
+    const { body: prList } = await githubApi.getJson<GhRestPr[]>(
       `repos/${repo}/pulls?head=${repo}:${branchName}&state=open`,
+      { cacheProvider: repoCacheProvider },
     );
 
-    const { body: prList } = response;
     if (!prList.length) {
       logger.debug(`No PR found for branch ${branchName}`);
       return null;


### PR DESCRIPTION
## Changes

Use HTTP cache for `/repos/{owner}/{repo}/pulls?head={owner}/{repo}:{branchName}&state=open` requests.

## Context

- Ref: #28098

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
