### PR TITLE
fix(validation): massage config

### DIFF
--- a/lib/workers/global/config/parse/util.spec.ts
+++ b/lib/workers/global/config/parse/util.spec.ts
@@ -1,0 +1,20 @@
+import { logger } from '../../../../logger';
+import { migrateAndValidateConfig } from './util';
+
+describe('workers/global/config/parse/util', () => {
+  it('massages config', async () => {
+    const config = {
+      packageRules: [
+        {
+          description: 'haha',
+          matchPackageNames: ['name'],
+          enabled: false,
+        },
+      ],
+    };
+
+    const migratedConfig = await migrateAndValidateConfig(config, 'global');
+    expect(migratedConfig?.packageRules?.[0].description).toBeArray();
+    expect(logger.warn).toHaveBeenCalledTimes(0);
+  });
+});

--- a/lib/workers/global/config/parse/util.ts
+++ b/lib/workers/global/config/parse/util.ts
@@ -1,3 +1,5 @@
+import { dequal } from 'dequal';
+import { massageConfig } from '../../../../config/massage';
 import { migrateConfig } from '../../../../config/migration';
 import type { RenovateConfig } from '../../../../config/types';
 import { validateConfig } from '../../../../config/validation';
@@ -14,8 +16,13 @@ export async function migrateAndValidateConfig(
       `${configType} needs migrating`,
     );
   }
+  const massagedConfig = massageConfig(migratedConfig);
+  // log only if it's changed
+  if (!dequal(migratedConfig, massagedConfig)) {
+    logger.debug({ config: massagedConfig }, 'Post-massage config');
+  }
 
-  const { warnings, errors } = await validateConfig('global', migratedConfig);
+  const { warnings, errors } = await validateConfig('global', massagedConfig);
 
   if (warnings.length) {
     logger.warn(
@@ -27,5 +34,5 @@ export async function migrateAndValidateConfig(
     logger.warn({ errors }, `Config validation errors found in ${configType}`);
   }
 
-  return migratedConfig;
+  return massagedConfig;
 }

--- a/lib/workers/global/config/parse/util.ts
+++ b/lib/workers/global/config/parse/util.ts
@@ -19,7 +19,7 @@ export async function migrateAndValidateConfig(
   const massagedConfig = massageConfig(migratedConfig);
   // log only if it's changed
   if (!dequal(migratedConfig, massagedConfig)) {
-    logger.debug({ config: massagedConfig }, 'Post-massage config');
+    logger.trace({ config: massagedConfig }, 'Post-massage config');
   }
 
   const { warnings, errors } = await validateConfig('global', massagedConfig);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Massage config before validating
<!-- Describe what behavior is changed by this PR. -->

## Context
Ref: https://github.com/renovatebot/renovate/discussions/28429#discussioncomment-9133665
Fields like `description` which can be either string array or just a string, need to be massaged into an array
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository 
(tested locally both RENOVATE_CONFIG & file config are now massged before validation during repo runs)

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
