### PR TITLE
fix(gomod): go.mod directive should not bump by default

### DIFF
--- a/lib/modules/versioning/go-mod-directive/index.spec.ts
+++ b/lib/modules/versioning/go-mod-directive/index.spec.ts
@@ -2,12 +2,13 @@ import { api as semver } from '.';
 
 describe('modules/versioning/go-mod-directive/index', () => {
   it.each`
-    version     | range     | expected
-    ${'1.16.0'} | ${'1.16'} | ${true}
-    ${'1.16.1'} | ${'1.16'} | ${true}
-    ${'1.15.0'} | ${'1.16'} | ${false}
-    ${'1.19.1'} | ${'1.16'} | ${true}
-    ${'2.0.0'}  | ${'1.16'} | ${false}
+    version     | range       | expected
+    ${'1.16.0'} | ${'1.16'}   | ${true}
+    ${'1.16.1'} | ${'1.16'}   | ${true}
+    ${'1.15.0'} | ${'1.16'}   | ${false}
+    ${'1.19.1'} | ${'1.16'}   | ${true}
+    ${'2.0.0'}  | ${'1.16'}   | ${false}
+    ${'1.22.2'} | ${'1.21.9'} | ${true}
   `(
     'matches("$version", "$range") === "$expected"',
     ({ version, range, expected }) => {
@@ -70,10 +71,11 @@ describe('modules/versioning/go-mod-directive/index', () => {
     ${'1.16'}    | ${'bump'}     | ${'1.16.4'}    | ${'1.17.0'} | ${'1.17'}
     ${'1.16'}    | ${'bump'}     | ${'1.16.4'}    | ${'1.16.4'} | ${'1.16'}
     ${'1.16'}    | ${'replace'}  | ${'1.16.4'}    | ${'1.16.4'} | ${'1.16'}
-    ${'1.16'}    | ${'replace'}  | ${'1.21.2'}    | ${'1.21.2'} | ${'1.21.2'}
+    ${'1.16'}    | ${'replace'}  | ${'1.21.2'}    | ${'1.21.2'} | ${'1.16'}
     ${'1.16'}    | ${'widen'}    | ${'1.16.4'}    | ${'1.16.4'} | ${'1.16'}
     ${'1.16'}    | ${'bump'}     | ${'1.16.4'}    | ${'1.21.3'} | ${'1.21.3'}
     ${'1.21.2'}  | ${'bump'}     | ${'1.21.2'}    | ${'1.21.3'} | ${'1.21.3'}
+    ${'1.21.2'}  | ${'replace'}  | ${'1.21.2'}    | ${'1.22.2'} | ${'1.21.2'}
   `(
     'getNewValue("$currentValue", "$rangeStrategy", "$currentVersion", "$newVersion") === "$expected"',
     ({ currentValue, rangeStrategy, currentVersion, newVersion, expected }) => {

--- a/lib/modules/versioning/go-mod-directive/index.spec.ts
+++ b/lib/modules/versioning/go-mod-directive/index.spec.ts
@@ -76,6 +76,7 @@ describe('modules/versioning/go-mod-directive/index', () => {
     ${'1.16'}    | ${'bump'}     | ${'1.16.4'}    | ${'1.21.3'} | ${'1.21.3'}
     ${'1.21.2'}  | ${'bump'}     | ${'1.21.2'}    | ${'1.21.3'} | ${'1.21.3'}
     ${'1.21.2'}  | ${'replace'}  | ${'1.21.2'}    | ${'1.22.2'} | ${'1.21.2'}
+    ${'1.21.2'}  | ${'replace'}  | ${'1.21.2'}    | ${'2.0.0'}  | ${'2.0.0'}
   `(
     'getNewValue("$currentValue", "$rangeStrategy", "$currentVersion", "$newVersion") === "$expected"',
     ({ currentValue, rangeStrategy, currentVersion, newVersion, expected }) => {

--- a/lib/modules/versioning/go-mod-directive/index.ts
+++ b/lib/modules/versioning/go-mod-directive/index.ts
@@ -1,3 +1,4 @@
+import { logger } from '../../../logger';
 import type { RangeStrategy } from '../../../types/versioning';
 import { regEx } from '../../../util/regex';
 import { api as npm } from '../npm';
@@ -30,7 +31,7 @@ function getNewValue({
     }
     return shorten(newVersion);
   }
-  if (rangeStrategy === 'replace' && !matches(currentValue, newVersion)) {
+  if (rangeStrategy === 'replace' && !matches(newVersion, currentValue)) {
     if (npm.matches(newVersion, '>=1.20.0')) {
       return newVersion;
     }

--- a/lib/modules/versioning/go-mod-directive/index.ts
+++ b/lib/modules/versioning/go-mod-directive/index.ts
@@ -31,10 +31,7 @@ function getNewValue({
     return shorten(newVersion);
   }
   if (rangeStrategy === 'replace' && !matches(newVersion, currentValue)) {
-    if (npm.matches(newVersion, '>=1.20.0')) {
-      return newVersion;
-    }
-    return shorten(newVersion);
+    return newVersion;
   }
   return currentValue;
 }

--- a/lib/modules/versioning/go-mod-directive/index.ts
+++ b/lib/modules/versioning/go-mod-directive/index.ts
@@ -1,4 +1,3 @@
-import { logger } from '../../../logger';
 import type { RangeStrategy } from '../../../types/versioning';
 import { regEx } from '../../../util/regex';
 import { api as npm } from '../npm';


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Avoids bumping go.mod directive if new version is compatible

## Context

Fixes #28474

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
