### PR TITLE
refactor: Rename `validateUrl` to `isHttpUrl`

### DIFF
--- a/lib/modules/datasource/metadata.ts
+++ b/lib/modules/datasource/metadata.ts
@@ -5,7 +5,7 @@ import { detectPlatform } from '../../util/common';
 import { parseGitUrl } from '../../util/git/url';
 import * as hostRules from '../../util/host-rules';
 import { regEx } from '../../util/regex';
-import { parseUrl, trimTrailingSlash, validateUrl } from '../../util/url';
+import { isHttpUrl, parseUrl, trimTrailingSlash } from '../../util/url';
 import { manualChangelogUrls, manualSourceUrls } from './metadata-manual';
 import type { ReleaseResult } from './types';
 
@@ -195,7 +195,7 @@ export function addMetaData(
   ];
   for (const urlKey of urlKeys) {
     const urlVal = dep[urlKey];
-    if (is.string(urlVal) && validateUrl(urlVal.trim())) {
+    if (is.string(urlVal) && isHttpUrl(urlVal.trim())) {
       dep[urlKey] = urlVal.trim() as never;
     } else {
       delete dep[urlKey];

--- a/lib/modules/datasource/npm/npmrc.ts
+++ b/lib/modules/datasource/npm/npmrc.ts
@@ -8,7 +8,7 @@ import type { HostRule } from '../../../types';
 import * as hostRules from '../../../util/host-rules';
 import { regEx } from '../../../util/regex';
 import { fromBase64 } from '../../../util/string';
-import { ensureTrailingSlash, validateUrl } from '../../../util/url';
+import { ensureTrailingSlash, isHttpUrl } from '../../../util/url';
 import { defaultRegistryUrls } from './common';
 import type { NpmrcRules } from './types';
 
@@ -89,7 +89,7 @@ export function convertNpmrcToRules(npmrc: Record<string, any>): NpmrcRules {
   const { registry } = npmrc;
   // packageRules order matters, so look for a default registry first
   if (is.nonEmptyString(registry)) {
-    if (validateUrl(registry)) {
+    if (isHttpUrl(registry)) {
       // Default registry
       rules.packageRules?.push({
         matchDatasources,
@@ -108,7 +108,7 @@ export function convertNpmrcToRules(npmrc: Record<string, any>): NpmrcRules {
     const keyType = keyParts.pop();
     if (keyType === 'registry' && keyParts.length && is.nonEmptyString(value)) {
       const scope = keyParts.join(':');
-      if (validateUrl(value)) {
+      if (isHttpUrl(value)) {
         rules.packageRules?.push({
           matchDatasources,
           matchPackagePrefixes: [scope + '/'],

--- a/lib/modules/datasource/terraform-module/index.ts
+++ b/lib/modules/datasource/terraform-module/index.ts
@@ -2,7 +2,7 @@ import { logger } from '../../../logger';
 import { cache } from '../../../util/cache/package/decorator';
 import { regEx } from '../../../util/regex';
 import { coerceString } from '../../../util/string';
-import { validateUrl } from '../../../util/url';
+import { isHttpUrl } from '../../../util/url';
 import * as hashicorpVersioning from '../../versioning/hashicorp';
 import type { GetReleasesConfig, ReleaseResult } from '../types';
 import { TerraformDatasource } from './base';
@@ -162,7 +162,7 @@ export class TerraformModuleDatasource extends TerraformDatasource {
     };
 
     // Add the source URL if given
-    if (validateUrl(res.modules[0].source)) {
+    if (isHttpUrl(res.modules[0].source)) {
       dep.sourceUrl = res.modules[0].source;
     }
 

--- a/lib/modules/datasource/terraform-module/utils.ts
+++ b/lib/modules/datasource/terraform-module/utils.ts
@@ -1,4 +1,4 @@
-import { joinUrlParts, validateUrl } from '../../../util/url';
+import { isHttpUrl, joinUrlParts } from '../../../util/url';
 import type {
   ServiceDiscoveryEndpointType,
   ServiceDiscoveryResult,
@@ -12,7 +12,7 @@ export function createSDBackendURL(
 ): string {
   const sdEndpoint = sdResult[sdType] ?? '';
   const fullPath = joinUrlParts(sdEndpoint, subPath);
-  if (validateUrl(fullPath)) {
+  if (isHttpUrl(fullPath)) {
     return fullPath;
   }
   return joinUrlParts(registryURL, fullPath);

--- a/lib/modules/manager/npm/post-update/rules.ts
+++ b/lib/modules/manager/npm/post-update/rules.ts
@@ -2,7 +2,7 @@ import is from '@sindresorhus/is';
 import * as hostRules from '../../../../util/host-rules';
 import { regEx } from '../../../../util/regex';
 import { toBase64 } from '../../../../util/string';
-import { validateUrl } from '../../../../util/url';
+import { isHttpUrl } from '../../../../util/url';
 
 export interface HostRulesResult {
   additionalNpmrcContent: string[];
@@ -21,7 +21,7 @@ export function processHostRules(): HostRulesResult {
     if (hostRule.resolvedHost) {
       let uri = hostRule.matchHost;
       uri =
-        is.string(uri) && validateUrl(uri)
+        is.string(uri) && isHttpUrl(uri)
           ? uri.replace(regEx(/^https?:/), '')
           : // TODO: types (#22198)
             `//${uri}/`;

--- a/lib/util/git/auth.ts
+++ b/lib/util/git/auth.ts
@@ -4,7 +4,7 @@ import type { HostRule } from '../../types';
 import { detectPlatform } from '../common';
 import { find, getAll } from '../host-rules';
 import { regEx } from '../regex';
-import { createURLFromHostOrURL, validateUrl } from '../url';
+import { createURLFromHostOrURL, isHttpUrl } from '../url';
 import type { AuthenticationRule } from './types';
 import { parseGitUrl } from './url';
 
@@ -203,7 +203,7 @@ function addAuthFromHostRule(
 ): NodeJS.ProcessEnv {
   let environmentVariables = env;
   const httpUrl = createURLFromHostOrURL(hostRule.matchHost!)?.toString();
-  if (validateUrl(httpUrl)) {
+  if (isHttpUrl(httpUrl)) {
     logger.trace(`Adding Git authentication for ${httpUrl} using token auth.`);
     environmentVariables = getGitAuthenticatedEnvironmentVariables(
       httpUrl!,

--- a/lib/util/host-rules.ts
+++ b/lib/util/host-rules.ts
@@ -6,7 +6,7 @@ import type { CombinedHostRule, HostRule } from '../types';
 import { clone } from './clone';
 import * as sanitize from './sanitize';
 import { toBase64 } from './string';
-import { parseUrl, validateUrl } from './url';
+import { isHttpUrl, parseUrl } from './url';
 
 let hostRules: HostRule[] = [];
 
@@ -108,7 +108,7 @@ function isOnlyMatchHost(
 }
 
 function matchesHost(url: string, matchHost: string): boolean {
-  if (validateUrl(url) && validateUrl(matchHost)) {
+  if (isHttpUrl(url) && isHttpUrl(matchHost)) {
     return url.startsWith(matchHost);
   }
 

--- a/lib/util/http/gerrit.ts
+++ b/lib/util/http/gerrit.ts
@@ -1,6 +1,6 @@
 import { parseJson } from '../common';
 import { regEx } from '../regex';
-import { validateUrl } from '../url';
+import { isHttpUrl } from '../url';
 import type { HttpOptions, HttpResponse, InternalHttpOptions } from './types';
 import { Http } from './index';
 
@@ -24,7 +24,7 @@ export class GerritHttp extends Http {
     path: string,
     options?: InternalHttpOptions,
   ): Promise<HttpResponse<T>> {
-    const url = validateUrl(path) ? path : baseUrl + path;
+    const url = isHttpUrl(path) ? path : baseUrl + path;
     const opts: InternalHttpOptions = {
       parseJson: (text: string) =>
         parseJson(text.replace(GerritHttp.magicPrefix, ''), path),

--- a/lib/util/url.spec.ts
+++ b/lib/util/url.spec.ts
@@ -3,6 +3,7 @@ import {
   ensurePathPrefix,
   ensureTrailingSlash,
   getQueryString,
+  isHttpUrl,
   joinUrlParts,
   parseLinkHeader,
   parseUrl,
@@ -10,7 +11,6 @@ import {
   resolveBaseUrl,
   trimSlashes,
   trimTrailingSlash,
-  validateUrl,
 } from './url';
 
 describe('util/url', () => {
@@ -97,15 +97,22 @@ describe('util/url', () => {
     expect(getQueryString({ a: 1, b: [1, 2] })).toBe('a=1&b=1&b=2');
   });
 
-  it('validates URLs', () => {
-    expect(validateUrl(undefined)).toBeFalse();
-    expect(validateUrl('')).toBeFalse();
-    expect(validateUrl(null)).toBeFalse();
-    expect(validateUrl('foo')).toBeFalse();
-    expect(validateUrl('ssh://github.com')).toBeFalse();
-    expect(validateUrl('http://github.com')).toBeTrue();
-    expect(validateUrl('https://github.com')).toBeTrue();
-    expect(validateUrl('https://github.com', false)).toBeTrue();
+  it('validates http-based URLs', () => {
+    expect(isHttpUrl(undefined)).toBeFalse();
+    expect(isHttpUrl('')).toBeFalse();
+    expect(isHttpUrl(null)).toBeFalse();
+    expect(isHttpUrl('foo')).toBeFalse();
+    expect(isHttpUrl('ssh://github.com')).toBeFalse();
+    expect(isHttpUrl('http://github.com')).toBeTrue();
+    expect(isHttpUrl('https://github.com')).toBeTrue();
+
+    function bla(x: string | null) {
+      if (isHttpUrl(x)) {
+        x;
+      } else {
+        x;
+      }
+    }
   });
 
   it('parses URL', () => {

--- a/lib/util/url.spec.ts
+++ b/lib/util/url.spec.ts
@@ -105,14 +105,6 @@ describe('util/url', () => {
     expect(isHttpUrl('ssh://github.com')).toBeFalse();
     expect(isHttpUrl('http://github.com')).toBeTrue();
     expect(isHttpUrl('https://github.com')).toBeTrue();
-
-    function bla(x: string | null) {
-      if (isHttpUrl(x)) {
-        x;
-      } else {
-        x;
-      }
-    }
   });
 
   it('parses URL', () => {

--- a/lib/util/url.ts
+++ b/lib/util/url.ts
@@ -85,16 +85,13 @@ export function getQueryString(params: Record<string, any>): string {
   return usp.toString();
 }
 
-export function validateUrl(
-  url: string | null | undefined,
-  httpOnly = true,
-): boolean {
+export function isHttpUrl(url: unknown): boolean {
   if (!is.nonEmptyString(url)) {
     return false;
   }
   try {
     const { protocol } = new URL(url);
-    return httpOnly ? !!protocol.startsWith('http') : !!protocol;
+    return protocol === 'https:' || protocol === 'http:';
   } catch (err) {
     return false;
   }

--- a/lib/workers/repository/update/pr/changelog/release-notes.ts
+++ b/lib/workers/repository/update/pr/changelog/release-notes.ts
@@ -9,7 +9,7 @@ import { detectPlatform } from '../../../../../util/common';
 import { linkify } from '../../../../../util/markdown';
 import { newlineRegex, regEx } from '../../../../../util/regex';
 import { coerceString } from '../../../../../util/string';
-import { validateUrl } from '../../../../../util/url';
+import { isHttpUrl } from '../../../../../util/url';
 import type { BranchUpgradeConfig } from '../../../../types';
 import * as bitbucket from './bitbucket';
 import * as gitea from './gitea';
@@ -346,12 +346,12 @@ export async function getReleaseNotesMd(
             .filter(Boolean);
           let body = section.replace(regEx(/.*?\n(-{3,}\n)?/), '').trim();
           for (const word of title) {
-            if (word.includes(version) && !validateUrl(word)) {
+            if (word.includes(version) && !isHttpUrl(word)) {
               logger.trace({ body }, 'Found release notes for v' + version);
               // TODO: fix url
               const notesSourceUrl = `${baseUrl}${repository}/blob/HEAD/${changelogFile}`;
               const mdHeadingLink = title
-                .filter((word) => !validateUrl(word))
+                .filter((word) => !isHttpUrl(word))
                 .join('-')
                 .replace(regEx(/[^A-Za-z0-9-]/g), '');
               const url = `${notesSourceUrl}#${mdHeadingLink}`;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Give it more specific name
- Remove unused flag parameter

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
