### PR TITLE
docs: fix regex example syntax highlighting

### DIFF
--- a/lib/modules/manager/custom/regex/readme.md
+++ b/lib/modules/manager/custom/regex/readme.md
@@ -90,9 +90,9 @@ Instead you enhance your `Dockerfile` like this:
 ```Dockerfile
 ARG IMAGE=node:12@sha256:6e5264cd4cfaefd7174b2bc10c7f9a1c2b99d98d127fc57a802d264da9fb43bd
 FROM ${IMAGE}
- # renovate: datasource=github-tags depName=nodejs/node versioning=node
+# renovate: datasource=github-tags depName=nodejs/node versioning=node
 ENV NODE_VERSION=10.19.0
- # renovate: datasource=github-releases depName=composer/composer
+# renovate: datasource=github-releases depName=composer/composer
 ENV COMPOSER_VERSION=1.9.3
 # renovate: datasource=docker depName=docker versioning=docker
 ENV DOCKER_VERSION=19.03.1


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Fixes syntax highlighting.

## Context

The bad indentation leads to syntax highlighting in the rendered documentation not rendering these 2 lines as comments.
See https://docs.renovatebot.com/modules/manager/regex/#advanced-capture

![grafik](https://github.com/renovatebot/renovate/assets/406876/0eaa7e9a-c645-4151-9c28-98f134c90bb9)

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
