### PR TITLE
docs: improve merge confidence api base url variable doc

### DIFF
--- a/docs/usage/self-hosted-experimental.md
+++ b/docs/usage/self-hosted-experimental.md
@@ -134,6 +134,7 @@ Skip initializing `RE2` for regular expressions and instead use Node-native `Reg
 ## `RENOVATE_X_MERGE_CONFIDENCE_API_BASE_URL`
 
 If set, Renovate will query this API for Merge Confidence data.
+If using Mend Renovate Enterprise and a static merge confidence token that you set via `MEND_RNV_MC_TOKEN`, you will need to set this variable at the server as well as the workers, if you have specified the token as a [match confidence] `hostRule`, you will only need to set this variable at the workers.
 This feature is in private beta.
 
 ## `RENOVATE_X_MERGE_CONFIDENCE_SUPPORTED_DATASOURCES`

--- a/docs/usage/self-hosted-experimental.md
+++ b/docs/usage/self-hosted-experimental.md
@@ -135,7 +135,7 @@ Skip initializing `RE2` for regular expressions and instead use Node-native `Reg
 
 If set, Renovate will query this API for Merge Confidence data.
 
-If you use Mend Renovate Enterprise and:
+If you use the Mend Renovate Enterprise Edition (Renovate EE) and:
 
 - have a static merge confidence token that you set via `MEND_RNV_MC_TOKEN`
 - _or_ set `MEND_RNV_MC_TOKEN` to `auto`

--- a/docs/usage/self-hosted-experimental.md
+++ b/docs/usage/self-hosted-experimental.md
@@ -134,7 +134,7 @@ Skip initializing `RE2` for regular expressions and instead use Node-native `Reg
 ## `RENOVATE_X_MERGE_CONFIDENCE_API_BASE_URL`
 
 If set, Renovate will query this API for Merge Confidence data.
-If using Mend Renovate Enterprise and a static merge confidence token that you set via `MEND_RNV_MC_TOKEN`, you will need to set this variable at the server as well as the workers, if you have specified the token as a [match confidence] `hostRule`, you will only need to set this variable at the workers.
+If using Mend Renovate Enterprise and a static merge confidence token that you set via `MEND_RNV_MC_TOKEN` (or set `MEND_RNV_MC_TOKEN` to `auto`), you will need to set this variable at the server as well as the workers, if you have specified the token as a [match confidence](https://docs.renovatebot.com/configuration-options/#matchconfidence) `hostRule`, you will only need to set this variable at the workers.
 This feature is in private beta.
 
 ## `RENOVATE_X_MERGE_CONFIDENCE_SUPPORTED_DATASOURCES`

--- a/docs/usage/self-hosted-experimental.md
+++ b/docs/usage/self-hosted-experimental.md
@@ -134,7 +134,15 @@ Skip initializing `RE2` for regular expressions and instead use Node-native `Reg
 ## `RENOVATE_X_MERGE_CONFIDENCE_API_BASE_URL`
 
 If set, Renovate will query this API for Merge Confidence data.
-If using Mend Renovate Enterprise and a static merge confidence token that you set via `MEND_RNV_MC_TOKEN` (or set `MEND_RNV_MC_TOKEN` to `auto`), you will need to set this variable at the server as well as the workers, if you have specified the token as a [match confidence](https://docs.renovatebot.com/configuration-options/#matchconfidence) `hostRule`, you will only need to set this variable at the workers.
+
+If you use Mend Renovate Enterprise and:
+
+- have a static merge confidence token that you set via `MEND_RNV_MC_TOKEN`
+- _or_ set `MEND_RNV_MC_TOKEN` to `auto`
+
+Then you must set this variable at the _server_ and the _workers_.
+
+But if you have specified the token as a [`matchConfidence`](https://docs.renovatebot.com/configuration-options/#matchconfidence) `hostRule`, you only need to set this variable at the _workers_.
 This feature is in private beta.
 
 ## `RENOVATE_X_MERGE_CONFIDENCE_SUPPORTED_DATASOURCES`

--- a/docs/usage/self-hosted-experimental.md
+++ b/docs/usage/self-hosted-experimental.md
@@ -143,6 +143,7 @@ If you use the Mend Renovate Enterprise Edition (Renovate EE) and:
 Then you must set this variable at the _server_ and the _workers_.
 
 But if you have specified the token as a [`matchConfidence`](https://docs.renovatebot.com/configuration-options/#matchconfidence) `hostRule`, you only need to set this variable at the _workers_.
+
 This feature is in private beta.
 
 ## `RENOVATE_X_MERGE_CONFIDENCE_SUPPORTED_DATASOURCES`


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Improved the documentation for the env variable `RENOVATE_X_MERGE_CONFIDENCE_API_BASE_URL`. I have found it a bit confusing how this works, so I try to document this as I figure it out.

## Context


See https://github.com/mend/renovate-ce-ee/issues/488#issuecomment-2066195342 for some context.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
