### PR TITLE
feat(packageRules): warn for depName matching in matchPackage 

### DIFF
--- a/lib/util/package-rules/package-names.spec.ts
+++ b/lib/util/package-rules/package-names.spec.ts
@@ -17,6 +17,19 @@ describe('util/package-rules/package-names', () => {
       expect(result).toBeFalse();
     });
 
+    it('should return false if not matching', () => {
+      const result = packageNameMatcher.matches(
+        {
+          depName: 'abc',
+          packageName: 'def',
+        },
+        {
+          matchPackageNames: ['ghi'],
+        },
+      );
+      expect(result).toBeFalse();
+    });
+
     it('should matchPackageName', () => {
       const result = packageNameMatcher.matches(
         {
@@ -57,32 +70,45 @@ describe('util/package-rules/package-names', () => {
       );
       expect(result).toBeFalse();
     });
-  });
 
-  it('should excludePackageName', () => {
-    const result = packageNameMatcher.excludes(
-      {
-        depName: 'abc',
-        packageName: 'def',
-      },
-      {
-        excludePackageNames: ['def', 'ghi'],
-      },
-    );
-    expect(result).toBeTrue();
-  });
+    it('should return false if not matching', () => {
+      const result = packageNameMatcher.excludes(
+        {
+          depName: 'abc',
+          packageName: 'def',
+        },
+        {
+          excludePackageNames: ['ghi'],
+        },
+      );
+      expect(result).toBeFalse();
+    });
 
-  it('should fall back to depName excludePackageName', () => {
-    const result = packageNameMatcher.excludes(
-      {
-        depName: 'abc',
-        packageName: 'def',
-      },
-      {
-        excludePackageNames: ['abc', 'ghi'],
-      },
-    );
-    expect(result).toBeTrue();
-    expect(logger.logger.once.warn).toHaveBeenCalled();
+    it('should excludePackageName', () => {
+      const result = packageNameMatcher.excludes(
+        {
+          depName: 'abc',
+          packageName: 'def',
+        },
+        {
+          excludePackageNames: ['def', 'ghi'],
+        },
+      );
+      expect(result).toBeTrue();
+    });
+
+    it('should fall back to depName excludePackageName', () => {
+      const result = packageNameMatcher.excludes(
+        {
+          depName: 'abc',
+          packageName: 'def',
+        },
+        {
+          excludePackageNames: ['abc', 'ghi'],
+        },
+      );
+      expect(result).toBeTrue();
+      expect(logger.logger.once.warn).toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Elevate logging from info to warn when falling back to depName in packageRules matching.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
