### PR TITLE
feat(package-rules): warn for depName fallback

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2886,6 +2886,12 @@ See also `excludePackageNames`.
 
 The above will configure `rangeStrategy` to `pin` only for the package `angular`.
 
+<!-- prettier-ignore -->
+!!! note
+    `matchPackageNames` will try matching `packageName` first and then fall back to matching `depName`.
+    If the fallback is used, Renovate will log a warning, because the fallback will be removed in a future release.
+    Use `matchDepNames` instead.
+
 ### matchPackagePatterns
 
 Use this field if you want to have one or more package names patterns in your package rule.
@@ -2903,6 +2909,12 @@ See also `excludePackagePatterns`.
 ```
 
 The above will configure `rangeStrategy` to `replace` for any package starting with `angular`.
+
+<!-- prettier-ignore -->
+!!! note
+    `matchPackagePatterns` will try matching `packageName` first and then fall back to matching `depName`.
+    If the fallback is used, Renovate will log a warning, because the fallback will be removed in a future release.
+    Use `matchDepPatterns` instead.
 
 ### matchPackagePrefixes
 
@@ -2922,8 +2934,11 @@ See also `excludePackagePrefixes`.
 
 Like the earlier `matchPackagePatterns` example, the above will configure `rangeStrategy` to `replace` for any package starting with `angular`.
 
-`matchPackagePrefixes` will match against `packageName` first, and then `depName`, however `depName` matching is deprecated and will be removed in a future major release.
-If matching against `depName`, use `matchDepPatterns` instead.
+<!-- prettier-ignore -->
+!!! note
+    `matchPackagePrefixes` will try matching `packageName` first and then fall back to matching `depName`.
+    If the fallback is used, Renovate will log a warning, because the fallback will be removed in a future release.
+    Use `matchDepPatterns` instead.
 
 ### matchSourceUrlPrefixes
 

--- a/lib/util/package-rules/package-names.spec.ts
+++ b/lib/util/package-rules/package-names.spec.ts
@@ -54,7 +54,7 @@ describe('util/package-rules/package-names', () => {
         },
       );
       expect(result).toBeTrue();
-      expect(logger.logger.once.info).toHaveBeenCalled();
+      expect(logger.logger.once.warn).toHaveBeenCalled();
     });
   });
 
@@ -108,7 +108,7 @@ describe('util/package-rules/package-names', () => {
         },
       );
       expect(result).toBeTrue();
-      expect(logger.logger.once.info).toHaveBeenCalled();
+      expect(logger.logger.once.warn).toHaveBeenCalled();
     });
   });
 });

--- a/lib/util/package-rules/package-names.ts
+++ b/lib/util/package-rules/package-names.ts
@@ -21,7 +21,7 @@ export class PackageNameMatcher extends Matcher {
     }
 
     if (matchPackageNames.includes(depName)) {
-      logger.once.info(
+      logger.once.warn(
         { packageRule, packageName, depName },
         'Use matchDepNames instead of matchPackageNames',
       );
@@ -48,7 +48,7 @@ export class PackageNameMatcher extends Matcher {
     }
 
     if (excludePackageNames.includes(depName)) {
-      logger.once.info(
+      logger.once.warn(
         { packageRule, packageName, depName },
         'Use excludeDepNames instead of excludePackageNames',
       );

--- a/lib/util/package-rules/package-patterns.ts
+++ b/lib/util/package-rules/package-patterns.ts
@@ -39,7 +39,7 @@ export class PackagePatternsMatcher extends Matcher {
       return true;
     }
     if (matchPatternsAgainstName(matchPackagePatterns, depName)) {
-      logger.once.info(
+      logger.once.warn(
         { packageRule, packageName, depName },
         'Use matchDepPatterns instead of matchPackagePatterns',
       );
@@ -70,7 +70,7 @@ export class PackagePatternsMatcher extends Matcher {
     }
 
     if (matchPatternsAgainstName(excludePackagePatterns, depName)) {
-      logger.once.info(
+      logger.once.warn(
         { packageRule, packageName, depName },
         'Use excludeDepPatterns instead of excludePackagePatterns',
       );

--- a/lib/util/package-rules/package-prefixes.ts
+++ b/lib/util/package-rules/package-prefixes.ts
@@ -23,7 +23,7 @@ export class PackagePrefixesMatcher extends Matcher {
       return true;
     }
     if (matchPackagePrefixes.some((prefix) => depName.startsWith(prefix))) {
-      logger.once.info(
+      logger.once.warn(
         { packageName, depName },
         'Use matchDepPatterns instead of matchPackagePrefixes',
       );
@@ -52,7 +52,7 @@ export class PackagePrefixesMatcher extends Matcher {
       return true;
     }
     if (excludePackagePrefixes.some((prefix) => depName.startsWith(prefix))) {
-      logger.once.info(
+      logger.once.warn(
         { packageName, depName },
         'Use excludeDepPatterns instead of excludePackagePrefixes',
       );


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Log warning when depName fallback is used in packageRules

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
