### PR TITLE
feat(config): log warning if using legacy encryption

### DIFF
--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -946,6 +946,10 @@ Doing so will mean that Renovate will first try to decrypt using the GPG key but
 
 You can remove the `privateKeyOld` config option once all the old encrypted values have been migrated, or if you no longer want to support the old key and let the processing of repositories fail.
 
+<!-- prettier-ignore -->
+!!! note
+    Renovate now logs a warning whenever repositories use non-GPG encrypted config variables.
+
 ## privateKeyPath
 
 Used as an alternative to `privateKey`, if you want the key to be read from disk instead.

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -926,7 +926,7 @@ sub   rsa4096 2021-09-10 [E]
 The private key should then be added to your Renovate Bot global config (either using `privateKeyPath` or exporting it to the `RENOVATE_PRIVATE_KEY` environment variable).
 The public key can be used to replace the existing key in <https://app.renovatebot.com/encrypt> for your own use.
 
-Any encrypted secrets using GPG must have a mandatory organization/group scope, and optionally can be scoped for a single repository only.
+Any PGP-encrypted secrets must have a mandatory organization/group scope, and optionally can be scoped for a single repository only.
 The reason for this is to avoid "replay" attacks where someone could learn your encrypted secret and then reuse it in their own Renovate repositories.
 Instead, with scoped secrets it means that Renovate ensures that the organization and optionally repository values encrypted with the secret match against the running repository.
 
@@ -941,14 +941,14 @@ Instead, with scoped secrets it means that Renovate ensures that the organizatio
 Use this field if you need to perform a "key rotation" and support more than one keypair at a time.
 Decryption with this key will be tried after `privateKey`.
 
-If you are migrating from the legacy public key encryption approach to use GPG, then move your legacy private key from `privateKey` to `privateKeyOld` and then put your new GPG private key in `privateKey`.
-Doing so will mean that Renovate will first try to decrypt using the GPG key but fall back to the legacy key and try that next.
+If you are migrating from the legacy public key encryption approach to use a PGP key, then move your legacy private key from `privateKey` to `privateKeyOld` and then put your new PGP private key in `privateKey`.
+Doing so will mean that Renovate will first try to decrypt using the PGP key but fall back to the legacy key and try that next.
 
 You can remove the `privateKeyOld` config option once all the old encrypted values have been migrated, or if you no longer want to support the old key and let the processing of repositories fail.
 
 <!-- prettier-ignore -->
 !!! note
-    Renovate now logs a warning whenever repositories use non-GPG encrypted config variables.
+    Renovate now logs a warning whenever repositories use non-PGP encrypted config variables.
 
 ## privateKeyPath
 

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -865,7 +865,7 @@ This private key is used to decrypt config files.
 The corresponding public key can be used to create encrypted values for config files.
 If you want a UI to encrypt values you can put the public key in a HTML page similar to <https://app.renovatebot.com/encrypt>.
 
-To create the key pair with GPG use the following commands:
+To create the PGP key pair with GPG use the following commands:
 
 - `gpg --full-generate-key` and follow the prompts to generate a key. Name and email are not important to Renovate, and do not configure a passphrase. Use a 4096bit key.
 

--- a/lib/config/decrypt.ts
+++ b/lib/config/decrypt.ts
@@ -105,6 +105,7 @@ export async function tryDecrypt(
       );
     } else {
       decryptedStr = tryDecryptPublicKeyPKCS1(privateKey, encryptedStr);
+      // istanbul ignore if
       if (is.string(decryptedStr)) {
         logger.warn(
           { keyName },

--- a/lib/config/decrypt.ts
+++ b/lib/config/decrypt.ts
@@ -88,6 +88,7 @@ export async function tryDecrypt(
   privateKey: string,
   encryptedStr: string,
   repository: string,
+  keyName: string,
 ): Promise<string | null> {
   let decryptedStr: string | null = null;
   if (privateKey?.startsWith('-----BEGIN PGP PRIVATE KEY BLOCK-----')) {
@@ -97,8 +98,19 @@ export async function tryDecrypt(
     }
   } else {
     decryptedStr = tryDecryptPublicKeyDefault(privateKey, encryptedStr);
-    if (!is.string(decryptedStr)) {
+    if (is.string(decryptedStr)) {
+      logger.warn(
+        { keyName },
+        'Encrypted value is using deprecated default padding, please change to using PGP.',
+      );
+    } else {
       decryptedStr = tryDecryptPublicKeyPKCS1(privateKey, encryptedStr);
+      if (is.string(decryptedStr)) {
+        logger.warn(
+          { keyName },
+          'Encrypted value is using deprecated PKCS1 padding, please change to using PGP.',
+        );
+      }
     }
   }
   return decryptedStr;
@@ -191,10 +203,20 @@ export async function decryptConfig(
       if (privateKey) {
         for (const [eKey, eVal] of Object.entries(val)) {
           logger.debug('Trying to decrypt ' + eKey);
-          let decryptedStr = await tryDecrypt(privateKey, eVal, repository);
+          let decryptedStr = await tryDecrypt(
+            privateKey,
+            eVal,
+            repository,
+            eKey,
+          );
           if (privateKeyOld && !is.nonEmptyString(decryptedStr)) {
             logger.debug(`Trying to decrypt with old private key`);
-            decryptedStr = await tryDecrypt(privateKeyOld, eVal, repository);
+            decryptedStr = await tryDecrypt(
+              privateKeyOld,
+              eVal,
+              repository,
+              eKey,
+            );
           }
           if (!is.nonEmptyString(decryptedStr)) {
             const error = new Error('config-validation');

--- a/lib/config/decrypt.ts
+++ b/lib/config/decrypt.ts
@@ -101,14 +101,14 @@ export async function tryDecrypt(
     if (is.string(decryptedStr)) {
       logger.warn(
         { keyName },
-        'Encrypted value is using deprecated default padding, please change to using PGP.',
+        'Encrypted value is using deprecated default padding, please change to using PGP encryption.',
       );
     } else {
       decryptedStr = tryDecryptPublicKeyPKCS1(privateKey, encryptedStr);
       if (is.string(decryptedStr)) {
         logger.warn(
           { keyName },
-          'Encrypted value is using deprecated PKCS1 padding, please change to using PGP.',
+          'Encrypted value is using deprecated PKCS1 padding, please change to using PGP encryption.',
         );
       }
     }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Logs warning if using non-PGP encrypted variables.

## Context

Preparation for removal of these options

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
