### PR TITLE
fix(workarounds): add matchDepNames to some workarounds

### DIFF
--- a/lib/config/presets/internal/workarounds.ts
+++ b/lib/config/presets/internal/workarounds.ts
@@ -66,6 +66,12 @@ export const presets: Record<string, Preset> = {
         allowedVersions: '<20000000',
         matchCurrentVersion: '!/^\\d{8}$/',
         matchDatasources: ['docker'],
+        matchDepNames: ['alpine'],
+      },
+      {
+        allowedVersions: '<20000000',
+        matchCurrentVersion: '!/^\\d{8}$/',
+        matchDatasources: ['docker'],
         matchPackageNames: ['alpine'],
       },
     ],
@@ -123,6 +129,23 @@ export const presets: Record<string, Preset> = {
           '^azul/zulu-openjdk',
           '^bellsoft/liberica-openj(dk|re)-',
           '^cimg/openjdk',
+        ],
+        versioning:
+          'regex:^(?<major>\\d+)?(\\.(?<minor>\\d+))?(\\.(?<patch>\\d+))?([\\._+](?<build>(\\d\\.?)+)(LTS)?)?(-(?<compatibility>.*))?$',
+      },
+      {
+        allowedVersions: '/^(?:8|11|17|21)(?:\\.|-|$)/',
+        description:
+          'Limit Java runtime versions to LTS releases. To receive all major releases add `workarounds:javaLTSVersions` to the `ignorePresets` array.',
+        matchDatasources: ['docker', 'java-version'],
+        matchDepNames: [
+          'eclipse-temurin',
+          'amazoncorretto',
+          'adoptopenjdk',
+          'openjdk',
+          'java',
+          'java-jre',
+          'sapmachine',
         ],
         versioning:
           'regex:^(?<major>\\d+)?(\\.(?<minor>\\d+))?(\\.(?<patch>\\d+))?([\\._+](?<build>(\\d\\.?)+)(LTS)?)?(-(?<compatibility>.*))?$',


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Duplicate some matchPackageNames workarounds with matchDepNames, as we have seem some warnings about these in hosted logs.

## Context

Preparing to deprecated matchPackageNames fallbacks to depName

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
