### PR TITLE
docs: add pnpm/bun to JS language

### DIFF
--- a/docs/usage/javascript.md
+++ b/docs/usage/javascript.md
@@ -1,10 +1,10 @@
 ---
 title: JavaScript
-description: JavaScript (npm/Yarn) Package Manager Support in Renovate
+description: JavaScript (npm/Yarn/pnpm/Bun) Package Manager Support in Renovate
 ---
 
 # JavaScript
 
 Renovate supports upgrading JavaScript dependencies specified in `package.json` files.
 
-`npm`, `yarn`, and `pnpm` are all supported.
+`npm`, `yarn`, `pnpm` and `bun` are all supported.


### PR DESCRIPTION
## Changes

Add `pnpm` and `bun` to JS language docs.

## Context

I noticed that while bun is supported it was not mentioned in the docs on https://docs.renovatebot.com/javascript/

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
