### PR TITLE
fix(npm): replace pnpm overrides in right position

### DIFF
--- a/lib/modules/manager/npm/extract/common/package-file.ts
+++ b/lib/modules/manager/npm/extract/common/package-file.ts
@@ -90,7 +90,7 @@ export function extractPackageJson(
               if (is.string(overridesVal)) {
                 dep = {
                   depName: overridesKey,
-                  depType: 'overrides',
+                  depType: 'pnpm.overrides',
                   ...extractDependency(depName, overridesKey, overridesVal),
                 };
                 setNodeCommitTopic(dep);

--- a/lib/modules/manager/npm/extract/index.spec.ts
+++ b/lib/modules/manager/npm/extract/index.spec.ts
@@ -934,7 +934,7 @@ describe('modules/manager/npm/extract/index', () => {
             prettyDepType: 'devDependency',
           },
           {
-            depType: 'overrides',
+            depType: 'pnpm.overrides',
             depName: 'node',
             currentValue: '8.9.2',
             datasource: 'npm',
@@ -942,7 +942,7 @@ describe('modules/manager/npm/extract/index', () => {
             prettyDepType: 'overrides',
           },
           {
-            depType: 'overrides',
+            depType: 'pnpm.overrides',
             depName: '@types/react',
             currentValue: '18.0.5',
             datasource: 'npm',

--- a/lib/modules/manager/npm/extract/types.ts
+++ b/lib/modules/manager/npm/extract/types.ts
@@ -14,6 +14,9 @@ export type NpmPackage = PackageJson & {
   dependenciesMeta?: DependenciesMeta;
   overrides?: OverrideDependency;
   volta?: PackageJson.Dependency;
+  pnpm?: {
+    overrides?: PackageJson.Dependency;
+  };
 };
 
 export type LockFileEntry = Record<

--- a/lib/modules/manager/npm/update/dependency/index.spec.ts
+++ b/lib/modules/manager/npm/update/dependency/index.spec.ts
@@ -375,5 +375,32 @@ describe('modules/manager/npm/update/dependency/index', () => {
       });
       expect(testContent).toEqual(expected);
     });
+
+    it('handles pnpm.override dependency', () => {
+      const upgrade = {
+        depType: 'pnpm.overrides',
+        depName: 'typescript',
+        newValue: '0.60.0',
+      };
+      const overrideDependencies = `{
+        "pnpm": {
+          "overrides": {
+            "typescript": "0.0.5"
+          }
+        }
+      }`;
+      const expected = `{
+        "pnpm": {
+          "overrides": {
+            "typescript": "0.60.0"
+          }
+        }
+      }`;
+      const testContent = npmUpdater.updateDependency({
+        fileContent: overrideDependencies,
+        upgrade,
+      });
+      expect(testContent).toEqual(expected);
+    });
   });
 });


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Replace pnpm overrides deps on right position
- regression of #28199
<!-- Describe what behavior is changed by this PR. -->

## Context
- #28605
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
