### PR TITLE
feat(manager/gitlabci): support registry aliases

### DIFF
--- a/lib/modules/manager/gitlabci/extract.spec.ts
+++ b/lib/modules/manager/gitlabci/extract.spec.ts
@@ -354,6 +354,69 @@ describe('modules/manager/gitlabci/extract', () => {
       expect(extractFromJob({ image: 'image:test' })).toEqual(expectedRes);
     });
 
+    it('extracts component references via registry aliases', () => {
+      const registryAliases = {
+        $CI_SERVER_HOST: 'gitlab.example.com',
+      };
+      const content = codeBlock`
+        include:
+          - component: $CI_SERVER_HOST/an-org/a-project/a-component@1.0
+            inputs:
+              stage: build
+          - component: $CI_SERVER_HOST/an-org/a-subgroup/a-project/a-component@e3262fdd0914fa823210cdb79a8c421e2cef79d8
+          - component: $CI_SERVER_HOST/an-org/a-subgroup/another-project/a-component@main
+          - component: $CI_SERVER_HOST/another-org/a-project/a-component@~latest
+            inputs:
+              stage: test
+          - component: $CI_SERVER_HOST/malformed-component-reference
+          - component:
+              malformed: true
+          - component: $CI_SERVER_HOST/an-org/a-component@1.0
+          - component: other-gitlab.example.com/an-org/a-project/a-component@1.0
+      `;
+      const res = extractPackageFile(content, '', {
+        registryAliases,
+      });
+      expect(res?.deps).toMatchObject([
+        {
+          currentValue: '1.0',
+          datasource: 'gitlab-tags',
+          depName: 'an-org/a-project',
+          depType: 'repository',
+          registryUrls: ['https://gitlab.example.com'],
+        },
+        {
+          currentValue: 'e3262fdd0914fa823210cdb79a8c421e2cef79d8',
+          datasource: 'gitlab-tags',
+          depName: 'an-org/a-subgroup/a-project',
+          depType: 'repository',
+          registryUrls: ['https://gitlab.example.com'],
+        },
+        {
+          currentValue: 'main',
+          datasource: 'gitlab-tags',
+          depName: 'an-org/a-subgroup/another-project',
+          depType: 'repository',
+          registryUrls: ['https://gitlab.example.com'],
+        },
+        {
+          currentValue: '~latest',
+          datasource: 'gitlab-tags',
+          depName: 'another-org/a-project',
+          depType: 'repository',
+          registryUrls: ['https://gitlab.example.com'],
+          skipReason: 'unsupported-version',
+        },
+        {
+          currentValue: '1.0',
+          datasource: 'gitlab-tags',
+          depName: 'an-org/a-project',
+          depType: 'repository',
+          registryUrls: ['https://other-gitlab.example.com'],
+        },
+      ]);
+    });
+
     it('extracts component references', () => {
       const content = codeBlock`
         include:

--- a/lib/modules/manager/gitlabci/extract.ts
+++ b/lib/modules/manager/gitlabci/extract.ts
@@ -120,6 +120,7 @@ function getAllIncludeComponents(
 
 function extractDepFromIncludeComponent(
   includeComponent: GitlabIncludeComponent,
+  registryAliases?: Record<string, string>,
 ): PackageDependency | null {
   const componentReference = componentReferenceRegex.exec(
     includeComponent.component,
@@ -138,6 +139,12 @@ function extractDepFromIncludeComponent(
       'Ignoring component reference with incomplete project path',
     );
     return null;
+  }
+  const registryAlias = Object.entries(registryAliases ?? {}).find(
+    ([name, value]) => name === componentReference.fqdn,
+  );
+  if (registryAlias) {
+    componentReference.fqdn = registryAlias[1];
   }
 
   const dep: PackageDependency = {
@@ -209,7 +216,10 @@ export function extractPackageFile(
 
       const includedComponents = getAllIncludeComponents(doc);
       for (const includedComponent of includedComponents) {
-        const dep = extractDepFromIncludeComponent(includedComponent);
+        const dep = extractDepFromIncludeComponent(
+          includedComponent,
+          config.registryAliases,
+        );
         if (dep) {
           deps.push(dep);
         }

--- a/lib/modules/manager/gitlabci/extract.ts
+++ b/lib/modules/manager/gitlabci/extract.ts
@@ -140,11 +140,9 @@ function extractDepFromIncludeComponent(
     );
     return null;
   }
-  const registryAlias = Object.entries(registryAliases ?? {}).find(
-    ([name, value]) => name === componentReference.fqdn,
-  );
-  if (registryAlias) {
-    componentReference.fqdn = registryAlias[1];
+  const aliasValue = registryAliases?.[componentReference.fqdn];
+  if (aliasValue) {
+    componentReference.fqdn = aliasValue;
   }
 
   const dep: PackageDependency = {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Applies registry aliases in the the GitLab CI manager.

<!-- Describe what behavior is changed by this PR. -->

## Context

The GitLab CI manager should support registry aliases like many of the other managers already do.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [X] Code inspection only, or
- [X] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
