### PR TITLE
fix(terragunt): ignore port when creating registry urls

### DIFF
--- a/lib/modules/manager/terragrunt/__fixtures__/2.hcl
+++ b/lib/modules/manager/terragrunt/__fixtures__/2.hcl
@@ -170,9 +170,9 @@ terraform {
   source = "git::https://bitbucket.com/hashicorp/example?ref=v1.0.0"
 }
 
-# gitlab-tags
+# gitlab-tags with custom port
 terraform {
-  source = "git::https://gitlab.com/hashicorp/example?ref=v1.0.0"
+  source = "git::https://gitlab.com:1234/hashicorp/example?ref=v1.0.0"
 }
 
 # gitea-tags

--- a/lib/modules/manager/terragrunt/__fixtures__/2.hcl
+++ b/lib/modules/manager/terragrunt/__fixtures__/2.hcl
@@ -170,9 +170,19 @@ terraform {
   source = "git::https://bitbucket.com/hashicorp/example?ref=v1.0.0"
 }
 
-# gitlab-tags with custom port
+# gitlab-tags
 terraform {
-  source = "git::https://gitlab.com:1234/hashicorp/example?ref=v1.0.0"
+  source = "git::https://gitlab.com/hashicorp/example?ref=v1.0.0"
+}
+
+# gitlab-tags https with custom port
+terraform {
+  source = "git::https://gitlab.com:4321/hashicorp/example?ref=v1.0.1"
+}
+
+# gitlab-tags ssh with custom port
+terraform {
+  source = "git::ssh://gitlab.com:1234/hashicorp/example?ref=v1.0.2"
 }
 
 # gitea-tags

--- a/lib/modules/manager/terragrunt/__fixtures__/3.hcl
+++ b/lib/modules/manager/terragrunt/__fixtures__/3.hcl
@@ -170,9 +170,9 @@ terraform {
   source = "git::https://bitbucket.com/hashicorp/example?ref=v1.0.0"
 }
 
-# gitlab-tags
+# gitlab-tags with custom port
 terraform {
-  source = "git::https://gitlab.com/hashicorp/example?ref=v1.0.0"
+  source = "git::https://gitlab.com:1234/hashicorp/example?ref=v1.0.0"
 }
 
 # gitea-tags

--- a/lib/modules/manager/terragrunt/__fixtures__/3.hcl
+++ b/lib/modules/manager/terragrunt/__fixtures__/3.hcl
@@ -170,9 +170,19 @@ terraform {
   source = "git::https://bitbucket.com/hashicorp/example?ref=v1.0.0"
 }
 
-# gitlab-tags with custom port
+# gitlab-tags
 terraform {
-  source = "git::https://gitlab.com:1234/hashicorp/example?ref=v1.0.0"
+  source = "git::https://gitlab.com/hashicorp/example?ref=v1.0.0"
+}
+
+# gitlab-tags https with custom port
+terraform {
+  source = "git::https://gitlab.com:4321/hashicorp/example?ref=v1.0.1"
+}
+
+# gitlab-tags ssh with custom port
+terraform {
+  source = "git::ssh://gitlab.com:1234/hashicorp/example?ref=v1.0.2"
 }
 
 # gitea-tags

--- a/lib/modules/manager/terragrunt/__fixtures__/4.hcl
+++ b/lib/modules/manager/terragrunt/__fixtures__/4.hcl
@@ -171,9 +171,19 @@ terraform {
   source = "git::https://bitbucket.com/hashicorp/example?ref=v1.0.0"
 }
 
-# gitlab-tags with custom port
+# gitlab-tags
 terraform {
-  source = "git::https://gitlab.com:1234/hashicorp/example?ref=v1.0.0"
+  source = "git::https://gitlab.com/hashicorp/example?ref=v1.0.0"
+}
+
+# gitlab-tags https with custom port
+terraform {
+  source = "git::https://gitlab.com:4321/hashicorp/example?ref=v1.0.1"
+}
+
+# gitlab-tags ssh with custom port
+terraform {
+  source = "git::ssh://gitlab.com:1234/hashicorp/example?ref=v1.0.2"
 }
 
 # gitea-tags

--- a/lib/modules/manager/terragrunt/__fixtures__/4.hcl
+++ b/lib/modules/manager/terragrunt/__fixtures__/4.hcl
@@ -171,9 +171,9 @@ terraform {
   source = "git::https://bitbucket.com/hashicorp/example?ref=v1.0.0"
 }
 
-# gitlab-tags
+# gitlab-tags with custom port
 terraform {
-  source = "git::https://gitlab.com/hashicorp/example?ref=v1.0.0"
+  source = "git::https://gitlab.com:1234/hashicorp/example?ref=v1.0.0"
 }
 
 # gitea-tags

--- a/lib/modules/manager/terragrunt/extract.spec.ts
+++ b/lib/modules/manager/terragrunt/extract.spec.ts
@@ -223,6 +223,22 @@ describe('modules/manager/terragrunt/extract', () => {
             registryUrls: ['https://gitlab.com'],
           },
           {
+            currentValue: 'v1.0.1',
+            datasource: 'gitlab-tags',
+            depName: 'gitlab.com/hashicorp/example',
+            depType: 'gitTags',
+            packageName: 'hashicorp/example',
+            registryUrls: ['https://gitlab.com:4321'],
+          },
+          {
+            currentValue: 'v1.0.2',
+            datasource: 'gitlab-tags',
+            depName: 'gitlab.com/hashicorp/example',
+            depType: 'gitTags',
+            packageName: 'hashicorp/example',
+            registryUrls: ['https://gitlab.com'],
+          },
+          {
             currentValue: 'v1.0.0',
             datasource: 'gitea-tags',
             depName: 'gitea.com/hashicorp/example',
@@ -232,7 +248,7 @@ describe('modules/manager/terragrunt/extract', () => {
           },
         ],
       });
-      expect(res?.deps).toHaveLength(33);
+      expect(res?.deps).toHaveLength(35);
       expect(res?.deps.filter((dep) => dep.skipReason)).toHaveLength(4);
     });
 
@@ -418,6 +434,22 @@ describe('modules/manager/terragrunt/extract', () => {
             registryUrls: ['https://gitlab.com'],
           },
           {
+            currentValue: 'v1.0.1',
+            datasource: 'gitlab-tags',
+            depName: 'gitlab.com/hashicorp/example',
+            depType: 'gitTags',
+            packageName: 'hashicorp/example',
+            registryUrls: ['https://gitlab.com:4321'],
+          },
+          {
+            currentValue: 'v1.0.2',
+            datasource: 'gitlab-tags',
+            depName: 'gitlab.com/hashicorp/example',
+            depType: 'gitTags',
+            packageName: 'hashicorp/example',
+            registryUrls: ['https://gitlab.com'],
+          },
+          {
             currentValue: 'v1.0.0',
             datasource: 'gitea-tags',
             depName: 'gitea.com/hashicorp/example',
@@ -427,7 +459,7 @@ describe('modules/manager/terragrunt/extract', () => {
           },
         ],
       });
-      expect(res?.deps).toHaveLength(33);
+      expect(res?.deps).toHaveLength(35);
       expect(res?.deps.filter((dep) => dep.skipReason)).toHaveLength(4);
     });
 
@@ -613,6 +645,22 @@ describe('modules/manager/terragrunt/extract', () => {
             registryUrls: ['https://gitlab.com'],
           },
           {
+            currentValue: 'v1.0.1',
+            datasource: 'gitlab-tags',
+            depName: 'gitlab.com/hashicorp/example',
+            depType: 'gitTags',
+            packageName: 'hashicorp/example',
+            registryUrls: ['https://gitlab.com:4321'],
+          },
+          {
+            currentValue: 'v1.0.2',
+            datasource: 'gitlab-tags',
+            depName: 'gitlab.com/hashicorp/example',
+            depType: 'gitTags',
+            packageName: 'hashicorp/example',
+            registryUrls: ['https://gitlab.com'],
+          },
+          {
             currentValue: 'v1.0.0',
             datasource: 'gitea-tags',
             depName: 'gitea.com/hashicorp/example',
@@ -622,7 +670,7 @@ describe('modules/manager/terragrunt/extract', () => {
           },
         ],
       });
-      expect(res?.deps).toHaveLength(33);
+      expect(res?.deps).toHaveLength(35);
       expect(res?.deps.filter((dep) => dep.skipReason)).toHaveLength(4);
     });
 

--- a/lib/modules/manager/terragrunt/modules.ts
+++ b/lib/modules/manager/terragrunt/modules.ts
@@ -69,7 +69,7 @@ export function analyseTerragruntModule(
     dep.datasource = GithubTagsDatasource.id;
   } else if (gitTagsRefMatch?.groups) {
     const { url, tag } = gitTagsRefMatch.groups;
-    const { hostname, origin, pathname } = new URL(url);
+    const { hostname, host, origin, pathname, protocol } = new URL(url);
     const containsSubDirectory = pathname.includes('//');
     if (containsSubDirectory) {
       logger.debug('Terragrunt module contains subdirectory');
@@ -88,7 +88,9 @@ export function analyseTerragruntModule(
     } else {
       // The packageName should only contain the path to the repository
       dep.packageName = pathname.replace(/^\//, '').split('//')[0];
-      dep.registryUrls = [`https://${hostname}`];
+      dep.registryUrls = [
+        protocol === 'https:' ? `https://${host}` : `https://${hostname}`,
+      ];
     }
   } else if (tfrVersionMatch?.groups) {
     dep.depType = 'terragrunt';

--- a/lib/modules/manager/terragrunt/modules.ts
+++ b/lib/modules/manager/terragrunt/modules.ts
@@ -68,27 +68,27 @@ export function analyseTerragruntModule(
     dep.currentValue = githubRefMatch.groups.tag;
     dep.datasource = GithubTagsDatasource.id;
   } else if (gitTagsRefMatch?.groups) {
-    const { url, host, path, tag } = gitTagsRefMatch.groups;
-    const containsSubDirectory = path.includes('//');
+    const { url, tag } = gitTagsRefMatch.groups;
+    const { hostname, origin, pathname } = new URL(url);
+    const containsSubDirectory = pathname.includes('//');
     if (containsSubDirectory) {
       logger.debug('Terragrunt module contains subdirectory');
     }
     dep.depType = 'gitTags';
     // We don't want to have .git or subdirectory in the depName
-    dep.depName = `${host}/${path.split('//')[0].replace('.git', '')}`;
+    dep.depName = `${hostname}${pathname.split('//')[0].replace('.git', '')}`;
     dep.currentValue = tag;
     dep.datasource = detectGitTagDatasource(url);
     if (dep.datasource === GitTagsDatasource.id) {
       if (containsSubDirectory) {
-        const [protocol, hostAndPath] = url.split('//');
-        dep.packageName = `${protocol}//${hostAndPath}`;
+        dep.packageName = `${origin}${pathname.split('//')[0]}`;
       } else {
         dep.packageName = url;
       }
     } else {
       // The packageName should only contain the path to the repository
-      dep.packageName = path.split('//')[0];
-      dep.registryUrls = [`https://${host}`];
+      dep.packageName = pathname.replace(/^\//, '').split('//')[0];
+      dep.registryUrls = [`https://${hostname}`];
     }
   } else if (tfrVersionMatch?.groups) {
     dep.depType = 'terragrunt';


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
This PR fixes a small edge-case for the `terragrunt` manager, where the `registryUrl` should ignore the port defined in the terragrunt file. 

Example:

```terraform
terraform {
  source = "git::ssh://gitlab.example.com:1234/hashicorp/example?ref=v1.0.0"
}
```

Currently results in 

```json
{
  "registryUrls": ["https://gitlab.example.com:1234"]
}
```

but should result into

```json
{
  "registryUrls": ["https://gitlab.example.com"]
}
```

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

Forward fix for https://github.com/renovatebot/renovate/pull/28075

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
