### PR TITLE
fix: Correct digest resolution when the replacementName and replacementVersion options are defined #27773

### DIFF
--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -224,9 +224,8 @@ export async function lookupUpdates(
           res.warnings.push({
             topic: config.packageName,
             // TODO: types (#22198)
-            message: `Can't find version matching ${compareValue!} for ${
-              config.datasource
-            } package ${config.packageName}`,
+            message: `Can't find version matching ${compareValue!} for ${config.datasource
+              } package ${config.packageName}`,
           });
           return Result.ok(res);
         }
@@ -499,7 +498,7 @@ export async function lookupUpdates(
       if (versioning.valueToVersion) {
         // TODO #22198
         res.currentVersion = versioning.valueToVersion(res.currentVersion!);
-        for (const update of res.updates || /* istanbul ignore next*/ []) {
+        for (const update of res.updates || /* istanbul ignore next*/[]) {
           // TODO #22198
           update.newVersion = versioning.valueToVersion(update.newVersion!);
         }
@@ -515,6 +514,13 @@ export async function lookupUpdates(
             ...config,
             registryUrl: update.registryUrl ?? res.registryUrl,
             lookupName: res.lookupName,
+          };
+          //TODO #27728
+          // If the present contains the replacementName option and this update executes the replacement
+          // uses the correct lookupname based on the new replacementName, otherwise it keeps the origina one
+          if (update.updateType === 'replacement' && config.replacementName) {
+            getDigestConfig.lookupName = config.replacementName.substring(config.replacementName.indexOf("/") + 1);
+            getDigestConfig.currentDigest = undefined
           };
           // TODO #22198
           update.newDigest ??=


### PR DESCRIPTION
## Changes

* The getDigestConfig variable uses the correct lookupName when it's running a replacement and the replacementName is set

## Context

Closes https://github.com/renovatebot/renovate/issues/20304

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository
