### PR TITLE
fix(autoReplace): Correct digest resolution when the replacementName and replacementVersion options are defined

### DIFF
--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -516,6 +516,15 @@ export async function lookupUpdates(
             registryUrl: update.registryUrl ?? res.registryUrl,
             lookupName: res.lookupName,
           };
+
+          //TODO #27728
+          // If the present contains the replacementName option and this update executes the replacement
+          // uses the correct lookupname based on the new replacementName, otherwise it keeps the origina one
+          if (update.updateType === 'replacement' && config.replacementName) {
+            getDigestConfig.lookupName = config.replacementName.substring(config.replacementName.indexOf("/") + 1);
+            getDigestConfig.currentDigest = undefined
+          }; 
+
           // TODO #22198
           update.newDigest ??=
             dependency?.releases.find((r) => r.version === update.newValue)


### PR DESCRIPTION
## Changes

* The getDigestConfig variable uses the correct lookupName when it's running a replacement and the replacementName is set

## Context

Discussion https://github.com/renovatebot/renovate/discussions/27728
Closes https://github.com/renovatebot/renovate/issues/20304

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository
