### PR TITLE
feat(fvm): Support v3 config file

### DIFF
--- a/lib/modules/manager/fvm/extract.spec.ts
+++ b/lib/modules/manager/fvm/extract.spec.ts
@@ -39,10 +39,7 @@ describe('modules/manager/fvm/extract', () => {
     });
 
     it('returns a result for .fvmrc', () => {
-      const res = extractPackageFile(
-        '{"flutter": "2.10.1"}',
-        packageFile,
-      );
+      const res = extractPackageFile('{"flutter": "2.10.1"}', packageFile);
       expect(res?.deps).toEqual([
         {
           currentValue: '2.10.1',
@@ -69,10 +66,7 @@ describe('modules/manager/fvm/extract', () => {
     });
 
     it('supports non range for .fvmrc', () => {
-      const res = extractPackageFile(
-        '{"flutter": "stable"}',
-        packageFile,
-      );
+      const res = extractPackageFile('{"flutter": "stable"}', packageFile);
       expect(res?.deps).toEqual([
         {
           currentValue: 'stable',

--- a/lib/modules/manager/fvm/extract.spec.ts
+++ b/lib/modules/manager/fvm/extract.spec.ts
@@ -23,7 +23,7 @@ describe('modules/manager/fvm/extract', () => {
       ).toBeNull();
     });
 
-    it('returns a result .fvm/fvm_config.json', () => {
+    it('returns a result for .fvm/fvm_config.json', () => {
       const res = extractPackageFile(
         '{"flutterSdkVersion": "2.10.1", "flavors": {}}',
         packageFile,
@@ -38,7 +38,7 @@ describe('modules/manager/fvm/extract', () => {
       ]);
     });
 
-    it('returns a result .fvmrc', () => {
+    it('returns a result for .fvmrc', () => {
       const res = extractPackageFile(
         '{"flutter": "2.10.1"}',
         packageFile,
@@ -53,7 +53,7 @@ describe('modules/manager/fvm/extract', () => {
       ]);
     });
 
-    it('supports non range .fvm/fvm_config.json', () => {
+    it('supports non range for .fvm/fvm_config.json', () => {
       const res = extractPackageFile(
         '{"flutterSdkVersion": "stable", "flavors": {}}',
         packageFile,
@@ -68,7 +68,7 @@ describe('modules/manager/fvm/extract', () => {
       ]);
     });
 
-    it('supports non range .fvmrc', () => {
+    it('supports non range for .fvmrc', () => {
       const res = extractPackageFile(
         '{"flutter": "stable"}',
         packageFile,

--- a/lib/modules/manager/fvm/extract.spec.ts
+++ b/lib/modules/manager/fvm/extract.spec.ts
@@ -23,7 +23,7 @@ describe('modules/manager/fvm/extract', () => {
       ).toBeNull();
     });
 
-    it('returns a result', () => {
+    it('returns a result .fvm/fvm_config.json', () => {
       const res = extractPackageFile(
         '{"flutterSdkVersion": "2.10.1", "flavors": {}}',
         packageFile,
@@ -38,9 +38,39 @@ describe('modules/manager/fvm/extract', () => {
       ]);
     });
 
-    it('supports non range', () => {
+    it('returns a result .fvmrc', () => {
+      const res = extractPackageFile(
+        '{"flutter": "2.10.1"}',
+        packageFile,
+      );
+      expect(res?.deps).toEqual([
+        {
+          currentValue: '2.10.1',
+          datasource: 'flutter-version',
+          depName: 'flutter',
+          packageName: 'flutter/flutter',
+        },
+      ]);
+    });
+
+    it('supports non range .fvm/fvm_config.json', () => {
       const res = extractPackageFile(
         '{"flutterSdkVersion": "stable", "flavors": {}}',
+        packageFile,
+      );
+      expect(res?.deps).toEqual([
+        {
+          currentValue: 'stable',
+          datasource: 'flutter-version',
+          depName: 'flutter',
+          packageName: 'flutter/flutter',
+        },
+      ]);
+    });
+
+    it('supports non range .fvmrc', () => {
+      const res = extractPackageFile(
+        '{"flutter": "stable"}',
         packageFile,
       );
       expect(res?.deps).toEqual([

--- a/lib/modules/manager/fvm/extract.ts
+++ b/lib/modules/manager/fvm/extract.ts
@@ -1,8 +1,8 @@
 import { logger } from '../../../logger';
+import { Json } from '../../../util/schema-utils';
 import { FlutterVersionDatasource } from '../../datasource/flutter-version';
 import type { PackageDependency, PackageFileContent } from '../types';
 import { FvmConfig } from './schema';
-import { Json } from '../../../util/schema-utils';
 
 export function extractPackageFile(
   content: string,

--- a/lib/modules/manager/fvm/extract.ts
+++ b/lib/modules/manager/fvm/extract.ts
@@ -2,6 +2,7 @@ import { logger } from '../../../logger';
 import { FlutterVersionDatasource } from '../../datasource/flutter-version';
 import type { PackageDependency, PackageFileContent } from '../types';
 import { FvmConfig } from './schema';
+import { Json } from '../../../util/schema-utils';
 
 export function extractPackageFile(
   content: string,
@@ -9,7 +10,7 @@ export function extractPackageFile(
 ): PackageFileContent | null {
   let flutterVersion: string | undefined;
   try {
-    const config = FvmConfig.parse(JSON.parse(content));
+    const config = Json.pipe(FvmConfig).parse(content);
     flutterVersion = config.flutter ?? config.flutterSdkVersion;
 
     if (!flutterVersion) {

--- a/lib/modules/manager/fvm/extract.ts
+++ b/lib/modules/manager/fvm/extract.ts
@@ -19,7 +19,7 @@ export function extractPackageFile(
   if (!flutterVersion) {
     logger.debug(
       { contents: content },
-      'FVM config does not have flutter version specified',
+      'FVM config does not have a flutter version specified',
     );
     return null;
   }

--- a/lib/modules/manager/fvm/extract.ts
+++ b/lib/modules/manager/fvm/extract.ts
@@ -11,16 +11,16 @@ export function extractPackageFile(
   try {
     const config = FvmConfig.parse(JSON.parse(content));
     flutterVersion = config.flutter ?? config.flutterSdkVersion;
+
+    if (!flutterVersion) {
+      logger.debug(
+        { contents: config },
+        'FVM config does not have a flutter version specified',
+      );
+      return null;
+    }
   } catch (err) {
     logger.debug({ packageFile, err }, 'Invalid FVM config');
-    return null;
-  }
-
-  if (!flutterVersion) {
-    logger.debug(
-      { contents: content },
-      'FVM config does not have a flutter version specified',
-    );
     return null;
   }
 

--- a/lib/modules/manager/fvm/index.ts
+++ b/lib/modules/manager/fvm/index.ts
@@ -6,6 +6,9 @@ export { extractPackageFile } from './extract';
 export const supportedDatasources = [FlutterVersionDatasource.id];
 
 export const defaultConfig = {
-  fileMatch: ['(^|/)\\.fvm/fvm_config\\.json$'],
+  fileMatch: [
+    '(^|/)\\.fvm/fvm_config\\.json$',
+    '(^|/)\\.fvmrc$'
+    ],
   versioning: semverVersioning.id,
 };

--- a/lib/modules/manager/fvm/index.ts
+++ b/lib/modules/manager/fvm/index.ts
@@ -6,9 +6,6 @@ export { extractPackageFile } from './extract';
 export const supportedDatasources = [FlutterVersionDatasource.id];
 
 export const defaultConfig = {
-  fileMatch: [
-    '(^|/)\\.fvm/fvm_config\\.json$',
-    '(^|/)\\.fvmrc$'
-    ],
+  fileMatch: ['(^|/)\\.fvm/fvm_config\\.json$', '(^|/)\\.fvmrc$'],
   versioning: semverVersioning.id,
 };

--- a/lib/modules/manager/fvm/readme.md
+++ b/lib/modules/manager/fvm/readme.md
@@ -1,2 +1,2 @@
-Keeps both the `.fvmrc` and `.fvm/fvm_config.json` file updated.
+Keeps the `.fvmrc` file or older `.fvm/fvm_config.json` file updated.
 

--- a/lib/modules/manager/fvm/readme.md
+++ b/lib/modules/manager/fvm/readme.md
@@ -1,1 +1,2 @@
-Keeps the `.fvm/fvm_config.json` file updated.
+Keeps both the `.fvmrc` and `.fvm/fvm_config.json` file updated.
+

--- a/lib/modules/manager/fvm/readme.md
+++ b/lib/modules/manager/fvm/readme.md
@@ -1,2 +1,1 @@
 Keeps the `.fvmrc` file or older `.fvm/fvm_config.json` file updated.
-

--- a/lib/modules/manager/fvm/schema.ts
+++ b/lib/modules/manager/fvm/schema.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+export const FvmConfig = z.object({
+  flutterSdkVersion: z.string().optional(),
+  flutter: z.string().optional(),
+});
+export type FvmConfig = z.infer<typeof FvmConfig>;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
Adds support for the new FVM config file structure that was introduced in v3. The new file is located at `.fvmrc`.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->
I'm aware that there already is another [open pull request](https://github.com/renovatebot/renovate/pull/27216) implementing this functionality but it's been over a month since the last comment/changes.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
