### PR TITLE
feat(config/validation): validate options which support regex/glob matching

### DIFF
--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -13,7 +13,7 @@ const options: RenovateOptions[] = [
     default: ['X-*'],
     subType: 'string',
     globalOnly: true,
-    regexOrGlob: true,
+    patternMatch: true,
   },
   {
     name: 'allowedEnv',
@@ -23,7 +23,7 @@ const options: RenovateOptions[] = [
     default: [],
     subType: 'string',
     globalOnly: true,
-    regexOrGlob: true,
+    patternMatch: true,
   },
   {
     name: 'detectGlobalManagerConfig',
@@ -951,7 +951,7 @@ const options: RenovateOptions[] = [
     default: null,
     globalOnly: true,
     supportedPlatforms: ['bitbucket'],
-    regexOrGlob: true,
+    patternMatch: true,
   },
   {
     name: 'autodiscoverTopics',
@@ -1233,7 +1233,7 @@ const options: RenovateOptions[] = [
     mergeable: true,
     cli: false,
     env: false,
-    regexOrGlob: true,
+    patternMatch: true,
   },
   {
     name: 'excludeRepositories',

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -13,6 +13,7 @@ const options: RenovateOptions[] = [
     default: ['X-*'],
     subType: 'string',
     globalOnly: true,
+    regexOrGlob: true,
   },
   {
     name: 'allowedEnv',
@@ -22,6 +23,7 @@ const options: RenovateOptions[] = [
     default: [],
     subType: 'string',
     globalOnly: true,
+    regexOrGlob: true,
   },
   {
     name: 'detectGlobalManagerConfig',
@@ -949,6 +951,7 @@ const options: RenovateOptions[] = [
     default: null,
     globalOnly: true,
     supportedPlatforms: ['bitbucket'],
+    regexOrGlob: true,
   },
   {
     name: 'autodiscoverTopics',
@@ -1230,6 +1233,7 @@ const options: RenovateOptions[] = [
     mergeable: true,
     cli: false,
     env: false,
+    regexOrGlob: true,
   },
   {
     name: 'excludeRepositories',

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -443,7 +443,10 @@ export interface RenovateOptionBase {
    */
   deprecationMsg?: string;
 
-  regexOrGlob?: boolean;
+  /**
+   * For internal use only: helps with regexOrGlob option validation
+   */
+  patternMatch?: boolean;
 }
 
 export interface RenovateArrayOption<

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -444,7 +444,7 @@ export interface RenovateOptionBase {
   deprecationMsg?: string;
 
   /**
-   * For internal use only: add it any option that supports regex or glob matching
+   * For internal use only: add it to any config option that supports regex or glob matching
    */
   patternMatch?: boolean;
 }

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -442,6 +442,8 @@ export interface RenovateOptionBase {
    * This is used to add depreciation message in the docs
    */
   deprecationMsg?: string;
+
+  regexOrGlob?: boolean;
 }
 
 export interface RenovateArrayOption<

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -444,7 +444,7 @@ export interface RenovateOptionBase {
   deprecationMsg?: string;
 
   /**
-   * For internal use only: helps with regexOrGlob option validation
+   * For internal use only: add it any option that supports regex or glob matching
    */
   patternMatch?: boolean;
 }

--- a/lib/config/validation-helpers/regex-glob-matchers.spec.ts
+++ b/lib/config/validation-helpers/regex-glob-matchers.spec.ts
@@ -1,0 +1,25 @@
+import { check } from './regex-glob-matchers';
+
+describe('config/validation-helpers/regex-glob-matchers', () => {
+  it('should have errors', () => {
+    const res = check({
+      val: ['*', '**'],
+      currentPath: 'hostRules[0].allowedHeaders',
+    });
+    expect(res).toHaveLength(1);
+  });
+
+  it('should have errors - 2', () => {
+    const res = check({
+      val: ['*', 2] as never,
+      currentPath: 'hostRules[0].allowedHeaders',
+    });
+    expect(res).toMatchObject([
+      {
+        message:
+          'hostRules[0].allowedHeaders: should be an array of strings. You have included object.',
+        topic: 'Configuration Error',
+      },
+    ]);
+  });
+});

--- a/lib/config/validation-helpers/regex-glob-matchers.spec.ts
+++ b/lib/config/validation-helpers/regex-glob-matchers.spec.ts
@@ -11,7 +11,7 @@ describe('config/validation-helpers/regex-glob-matchers', () => {
 
   it('should have errors - 2', () => {
     const res = check({
-      val: ['*', 2] as never,
+      val: ['*', 2],
       currentPath: 'hostRules[0].allowedHeaders',
     });
     expect(res).toMatchObject([

--- a/lib/config/validation-helpers/regex-glob-matchers.spec.ts
+++ b/lib/config/validation-helpers/regex-glob-matchers.spec.ts
@@ -1,7 +1,7 @@
 import { check } from './regex-glob-matchers';
 
 describe('config/validation-helpers/regex-glob-matchers', () => {
-  it('should have errors', () => {
+  it('should error for multiple match alls', () => {
     const res = check({
       val: ['*', '**'],
       currentPath: 'hostRules[0].allowedHeaders',
@@ -9,7 +9,15 @@ describe('config/validation-helpers/regex-glob-matchers', () => {
     expect(res).toHaveLength(1);
   });
 
-  it('should have errors - 2', () => {
+  it('should error for invalid regex', () => {
+    const res = check({
+      val: ['[', '/[/', '/.*[/'],
+      currentPath: 'hostRules[0].allowedHeaders',
+    });
+    expect(res).toHaveLength(2);
+  });
+
+  it('should error for non-strings', () => {
     const res = check({
       val: ['*', 2],
       currentPath: 'hostRules[0].allowedHeaders',

--- a/lib/config/validation-helpers/regex-glob-matchers.ts
+++ b/lib/config/validation-helpers/regex-glob-matchers.ts
@@ -1,0 +1,30 @@
+import is from '@sindresorhus/is';
+import type { ValidationMessage } from '../types';
+import type { CheckMatcherArgs } from './types';
+
+/**
+ * Only if type condition or context condition violated then errors array will be mutated to store metadata
+ */
+export function check({
+  val,
+  currentPath,
+}: CheckMatcherArgs): ValidationMessage[] {
+  let errMessage: string | undefined;
+
+  if (is.array(val, is.string)) {
+    if ((val.includes('*') || val.includes('**')) && val.length > 1) {
+      errMessage = `${currentPath}: Your input contains * or ** along with other patterns. Please remove them, as * or ** matches all patterns.`;
+    }
+  } else {
+    errMessage = `${currentPath}: should be an array of strings. You have included ${typeof val}.`;
+  }
+
+  return errMessage
+    ? [
+        {
+          topic: 'Configuration Error',
+          message: errMessage,
+        },
+      ]
+    : [];
+}

--- a/lib/config/validation-helpers/regex-glob-matchers.ts
+++ b/lib/config/validation-helpers/regex-glob-matchers.ts
@@ -25,8 +25,7 @@ export function check({
     for (const matcher of matchers) {
       // Validate regex pattern
       if (isRegexMatch(matcher)) {
-        const autodiscoveryPred = getRegexPredicate(matcher);
-        if (!autodiscoveryPred) {
+        if (!getRegexPredicate(matcher)) {
           res.push({
             topic: 'Configuration Error',
             message: `Failed to parse regex pattern "${matcher}"`,

--- a/lib/config/validation-helpers/regex-glob-matchers.ts
+++ b/lib/config/validation-helpers/regex-glob-matchers.ts
@@ -7,26 +7,29 @@ import type { CheckMatcherArgs } from './types';
  * Only if type condition or context condition violated then errors array will be mutated to store metadata
  */
 export function check({
-  val,
+  val: matchers,
   currentPath,
 }: CheckMatcherArgs): ValidationMessage[] {
   const res: ValidationMessage[] = [];
 
-  if (is.array(val, is.string)) {
-    if ((val.includes('*') || val.includes('**')) && val.length > 1) {
+  if (is.array(matchers, is.string)) {
+    if (
+      (matchers.includes('*') || matchers.includes('**')) &&
+      matchers.length > 1
+    ) {
       res.push({
         topic: 'Configuration Error',
         message: `${currentPath}: Your input contains * or ** along with other patterns. Please remove them, as * or ** matches all patterns.`,
       });
     }
-    for (const pattern of val) {
+    for (const matcher of matchers) {
       // Validate regex pattern
-      if (isRegexMatch(pattern)) {
-        const autodiscoveryPred = getRegexPredicate(pattern);
+      if (isRegexMatch(matcher)) {
+        const autodiscoveryPred = getRegexPredicate(matcher);
         if (!autodiscoveryPred) {
           res.push({
             topic: 'Configuration Error',
-            message: `Failed to parse regex pattern "${pattern}"`,
+            message: `Failed to parse regex pattern "${matcher}"`,
           });
         }
       }
@@ -34,7 +37,7 @@ export function check({
   } else {
     res.push({
       topic: 'Configuration Error',
-      message: `${currentPath}: should be an array of strings. You have included ${typeof val}.`,
+      message: `${currentPath}: should be an array of strings. You have included ${typeof matchers}.`,
     });
   }
 

--- a/lib/config/validation-helpers/types.ts
+++ b/lib/config/validation-helpers/types.ts
@@ -6,6 +6,6 @@ export interface CheckManagerArgs {
 }
 
 export interface CheckMatcherArgs {
-  val: unknown[];
+  val: unknown;
   currentPath: string;
 }

--- a/lib/config/validation-helpers/types.ts
+++ b/lib/config/validation-helpers/types.ts
@@ -6,6 +6,6 @@ export interface CheckManagerArgs {
 }
 
 export interface CheckMatcherArgs {
-  val: string[];
+  val: unknown[];
   currentPath: string;
 }

--- a/lib/config/validation-helpers/types.ts
+++ b/lib/config/validation-helpers/types.ts
@@ -4,3 +4,8 @@ export interface CheckManagerArgs {
   resolvedRule: PackageRule;
   currentPath: string;
 }
+
+export interface CheckMatcherArgs {
+  val: string[];
+  currentPath: string;
+}

--- a/lib/config/validation.spec.ts
+++ b/lib/config/validation.spec.ts
@@ -1230,7 +1230,7 @@ describe('config/validation', () => {
       const config = {
         packageRules: [
           {
-            matchRepositories: ['*', 'repo'],
+            matchRepositories: ['groupA/**', 'groupB/**'],
             enabled: false,
           },
         ],

--- a/lib/config/validation.spec.ts
+++ b/lib/config/validation.spec.ts
@@ -1230,8 +1230,12 @@ describe('config/validation', () => {
       const config = {
         packageRules: [
           {
-            matchRepositories: ['groupA/**', 'groupB/**'],
+            matchRepositories: ['groupA/**', 'groupB/**'], // valid
             enabled: false,
+          },
+          {
+            matchRepositories: ['*', 'repo'], // invalid
+            enabled: true,
           },
         ],
       };
@@ -1242,7 +1246,7 @@ describe('config/validation', () => {
       expect(errors).toMatchObject([
         {
           message:
-            'packageRules[0].matchRepositories: Your input contains * or ** along with other patterns. Please remove them, as * or ** matches all patterns.',
+            'packageRules[1].matchRepositories: Your input contains * or ** along with other patterns. Please remove them, as * or ** matches all patterns.',
           topic: 'Configuration Error',
         },
       ]);

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -371,7 +371,7 @@ export async function validateConfig(
             if (isRegexOrGlobOption(key)) {
               errors.push(
                 ...regexOrGlobValidator.check({
-                  val: val as string[],
+                  val,
                   currentPath,
                 }),
               );
@@ -976,7 +976,7 @@ async function validateGlobalConfig(
         if (isRegexOrGlobOption(key)) {
           warnings.push(
             ...regexOrGlobValidator.check({
-              val: val as string[],
+              val,
               currentPath: currentPath!,
             }),
           );

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -115,6 +115,10 @@ function isGlobalOption(key: string): boolean {
 }
 
 function initOptions(): void {
+  if (optionsInitialized) {
+    return;
+  }
+
   optionParents = {};
   optionInherits = new Set();
   optionTypes = {};
@@ -160,9 +164,7 @@ export async function validateConfig(
   isPreset?: boolean,
   parentPath?: string,
 ): Promise<ValidationResult> {
-  if (!optionsInitialized) {
-    initOptions();
-  }
+  initOptions();
 
   let errors: ValidationMessage[] = [];
   let warnings: ValidationMessage[] = [];

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -980,7 +980,7 @@ async function validateGlobalConfig(
         }
         if (key === 'gitNoVerify') {
           const allowedValues = ['commit', 'push'];
-          for (const value of val) {
+          for (const value of val as string[]) {
             if (!allowedValues.includes(value)) {
               warnings.push({
                 topic: 'Configuration Error',

--- a/tools/docs/config.ts
+++ b/tools/docs/config.ts
@@ -94,6 +94,7 @@ function genTable(obj: [string, string][], type: string, def: any): string {
     'experimentalIssues',
     'advancedUse',
     'deprecationMsg',
+    'patternMatch',
   ];
   obj.forEach(([key, val]) => {
     const el = [key, val];


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- Add new fields `patternMatch` to the config options, which will be used to identify options which support regex/glob matching
- Refactor validation logic
- Add validation for options which support regex/Glob matching. This validation logic ensures that the options do not contain `*` or `**` values along with other values.

Example: (these are not ok)
```
 "matchRepositories": ["*", "!abc/def"]
  "matchRepositories": ["*", "x/y", "!abc/def"]
  "matchRepositories": ["*", "x/y"]
  "matchRepositories": ["*", "**"]
```
<!-- Describe what behavior is changed by this PR. -->

## Context
Closes: https://github.com/renovatebot/renovate/issues/28554
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
