### PR TITLE
fix(git): drop port when transforming urls

### DIFF
--- a/lib/util/git/url.spec.ts
+++ b/lib/util/git/url.spec.ts
@@ -49,6 +49,14 @@ describe('util/git/url', () => {
       expect(getHttpUrl('http://foo.bar/')).toBe('http://foo.bar/');
     });
 
+    it('returns http url for ssh url with port', () => {
+      expect(
+        getHttpUrl(
+          'ssh://git@gitlab.example.com:22222/typo3-extensions/poll-pro.git',
+        ),
+      ).toBe('https://gitlab.example.com/typo3-extensions/poll-pro.git');
+    });
+
     it('returns gitlab url with token', () => {
       expect(getHttpUrl('http://gitlab.com/', 'token')).toBe(
         'http://gitlab-ci-token:token@gitlab.com/',

--- a/lib/util/git/url.ts
+++ b/lib/util/git/url.ts
@@ -11,6 +11,11 @@ export function parseGitUrl(url: string): gitUrlParse.GitUrl {
 export function getHttpUrl(url: string, token?: string): string {
   const parsedUrl = parseGitUrl(url);
 
+  if (parsedUrl.protocol === 'ssh') {
+    // Delete port from ssh url as it definitely won't work with https
+    parsedUrl.port = 443;
+  }
+
   const protocol = regEx(/^https?$/).exec(parsedUrl.protocol)
     ? parsedUrl.protocol
     : 'https';

--- a/lib/util/git/url.ts
+++ b/lib/util/git/url.ts
@@ -11,14 +11,13 @@ export function parseGitUrl(url: string): gitUrlParse.GitUrl {
 export function getHttpUrl(url: string, token?: string): string {
   const parsedUrl = parseGitUrl(url);
 
-  if (parsedUrl.protocol === 'ssh') {
-    // Delete port from ssh url as it definitely won't work with https
-    parsedUrl.port = 443;
-  }
+  let { protocol } = parsedUrl;
 
-  const protocol = regEx(/^https?$/).exec(parsedUrl.protocol)
-    ? parsedUrl.protocol
-    : 'https';
+  // Convert non-https URLs to https and strip port
+  if (!regEx(/^https?$/).exec(protocol)) {
+    parsedUrl.port = 443;
+    protocol = 'https';
+  }
 
   parsedUrl.user = '';
   parsedUrl.token = token ?? '';

--- a/lib/util/git/url.ts
+++ b/lib/util/git/url.ts
@@ -14,7 +14,7 @@ export function getHttpUrl(url: string, token?: string): string {
   let { protocol } = parsedUrl;
 
   // Convert non-https URLs to https and strip port
-  if (!regEx(/^https?$/).exec(protocol)) {
+  if (!regEx(/^https?$/).test(protocol)) {
     parsedUrl.port = 443;
     protocol = 'https';
   }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Delete port from parsed URL whenever it's non-https

## Context

Addresses #28691

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
