### PR TITLE
fix(terragrunt): remove `.git` from package name 

### DIFF
--- a/lib/modules/manager/terragrunt/__fixtures__/2.hcl
+++ b/lib/modules/manager/terragrunt/__fixtures__/2.hcl
@@ -182,7 +182,7 @@ terraform {
 
 # gitlab-tags ssh with custom port
 terraform {
-  source = "git::ssh://gitlab.com:1234/hashicorp/example?ref=v1.0.2"
+  source = "git::ssh://gitlab.com:1234/hashicorp/example.git?ref=v1.0.2"
 }
 
 # gitea-tags

--- a/lib/modules/manager/terragrunt/__fixtures__/3.hcl
+++ b/lib/modules/manager/terragrunt/__fixtures__/3.hcl
@@ -182,7 +182,7 @@ terraform {
 
 # gitlab-tags ssh with custom port
 terraform {
-  source = "git::ssh://gitlab.com:1234/hashicorp/example?ref=v1.0.2"
+  source = "git::ssh://gitlab.com:1234/hashicorp/example.git?ref=v1.0.2"
 }
 
 # gitea-tags

--- a/lib/modules/manager/terragrunt/__fixtures__/4.hcl
+++ b/lib/modules/manager/terragrunt/__fixtures__/4.hcl
@@ -183,7 +183,7 @@ terraform {
 
 # gitlab-tags ssh with custom port
 terraform {
-  source = "git::ssh://gitlab.com:1234/hashicorp/example?ref=v1.0.2"
+  source = "git::ssh://gitlab.com:1234/hashicorp/example.git?ref=v1.0.2"
 }
 
 # gitea-tags

--- a/lib/modules/manager/terragrunt/modules.ts
+++ b/lib/modules/manager/terragrunt/modules.ts
@@ -76,7 +76,7 @@ export function analyseTerragruntModule(
     }
     dep.depType = 'gitTags';
     // We don't want to have .git or subdirectory in the depName
-    dep.depName = `${hostname}${pathname.split('//')[0].replace('.git', '')}`;
+    dep.depName = `${hostname}${pathname.split('//')[0].replace(regEx('.git$'), '')}`;
     dep.currentValue = tag;
     dep.datasource = detectGitTagDatasource(url);
     if (dep.datasource === GitTagsDatasource.id) {
@@ -88,8 +88,8 @@ export function analyseTerragruntModule(
     } else {
       // The packageName should only contain the path to the repository
       dep.packageName = pathname
-        .replace(/^\//, '')
-        .replace('.git', '')
+        .replace(regEx(/^\//), '')
+        .replace(regEx('.git$'), '')
         .split('//')[0];
       dep.registryUrls = [
         protocol === 'https:' ? `https://${host}` : `https://${hostname}`,

--- a/lib/modules/manager/terragrunt/modules.ts
+++ b/lib/modules/manager/terragrunt/modules.ts
@@ -87,7 +87,10 @@ export function analyseTerragruntModule(
       }
     } else {
       // The packageName should only contain the path to the repository
-      dep.packageName = pathname.replace(/^\//, '').split('//')[0];
+      dep.packageName = pathname
+        .replace(/^\//, '')
+        .replace('.git', '')
+        .split('//')[0];
       dep.registryUrls = [
         protocol === 'https:' ? `https://${host}` : `https://${hostname}`,
       ];


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
Unfortunately the  `.git` part in the terragrunt source URL is not cleaned up when setting the `packageName` (typically set if a ssh URL is specified). This leads to failing API calls (e.g. GitLab API). 

This PR changes the terragrunt manager to ignore the `.git` part while setting the `packageName` value.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->
Forward fix https://github.com/renovatebot/renovate/pull/28075

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
