### PR TITLE
fix(terragrunt): package name regex order

### DIFF
--- a/lib/modules/manager/terragrunt/__fixtures__/2.hcl
+++ b/lib/modules/manager/terragrunt/__fixtures__/2.hcl
@@ -182,7 +182,7 @@ terraform {
 
 # gitlab-tags ssh with custom port
 terraform {
-  source = "git::ssh://gitlab.com:1234/hashicorp/example.git?ref=v1.0.2"
+  source = "git::ssh://gitlab.com:1234/hashicorp/example.git//foo/bar?ref=v1.0.2"
 }
 
 # gitea-tags

--- a/lib/modules/manager/terragrunt/__fixtures__/3.hcl
+++ b/lib/modules/manager/terragrunt/__fixtures__/3.hcl
@@ -182,7 +182,7 @@ terraform {
 
 # gitlab-tags ssh with custom port
 terraform {
-  source = "git::ssh://gitlab.com:1234/hashicorp/example.git?ref=v1.0.2"
+  source = "git::ssh://gitlab.com:1234/hashicorp/example.git//foo/bar?ref=v1.0.2"
 }
 
 # gitea-tags

--- a/lib/modules/manager/terragrunt/__fixtures__/4.hcl
+++ b/lib/modules/manager/terragrunt/__fixtures__/4.hcl
@@ -183,7 +183,7 @@ terraform {
 
 # gitlab-tags ssh with custom port
 terraform {
-  source = "git::ssh://gitlab.com:1234/hashicorp/example.git?ref=v1.0.2"
+  source = "git::ssh://gitlab.com:1234/hashicorp/example.git//foo/bar?ref=v1.0.2"
 }
 
 # gitea-tags

--- a/lib/modules/manager/terragrunt/modules.ts
+++ b/lib/modules/manager/terragrunt/modules.ts
@@ -75,8 +75,12 @@ export function analyseTerragruntModule(
       logger.debug('Terragrunt module contains subdirectory');
     }
     dep.depType = 'gitTags';
-    // We don't want to have .git or subdirectory in the depName
-    dep.depName = `${hostname}${pathname.split('//')[0].replace(regEx('.git$'), '')}`;
+    // We don't want to have leading slash, .git or subdirectory in the repository path
+    const repositoryPath = pathname
+      .replace(regEx(/^\//), '')
+      .split('//')[0]
+      .replace(regEx('.git$'), '');
+    dep.depName = `${hostname}/${repositoryPath}`;
     dep.currentValue = tag;
     dep.datasource = detectGitTagDatasource(url);
     if (dep.datasource === GitTagsDatasource.id) {
@@ -87,10 +91,7 @@ export function analyseTerragruntModule(
       }
     } else {
       // The packageName should only contain the path to the repository
-      dep.packageName = pathname
-        .replace(regEx(/^\//), '')
-        .replace(regEx('.git$'), '')
-        .split('//')[0];
+      dep.packageName = repositoryPath;
       dep.registryUrls = [
         protocol === 'https:' ? `https://${host}` : `https://${hostname}`,
       ];


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
I've tried Renovate [v37.328.1](https://github.com/renovatebot/renovate/releases/tag/37.328.1) in our self-hosted setup. Unfortunately there is still an issue with the `.git` part... I changed the repository URL resolution to use the correct order of RegExp replacements and changed the test to contain a sub-directory in the source URL. I think now all cases should be covered, since the new `repositoryPath` variable is used for `dep.depName` AND `dep.packageName`.

I'm sorry for overseeing this case while implementing the previous "fix".

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->
Forward fix for https://github.com/renovatebot/renovate/pull/28726

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
