### PR TITLE
fix(gerrit): `commitBody` option not being effective

### DIFF
--- a/lib/modules/platform/gerrit/client.spec.ts
+++ b/lib/modules/platform/gerrit/client.spec.ts
@@ -160,7 +160,7 @@ describe('modules/platform/gerrit/client', () => {
       httpMock
         .scope(gerritEndpointUrl)
         .get(
-          '/a/changes/123456?o=SUBMITTABLE&o=CHECK&o=MESSAGES&o=DETAILED_ACCOUNTS&o=LABELS&o=CURRENT_ACTIONS&o=CURRENT_REVISION',
+          '/a/changes/123456?o=SUBMITTABLE&o=CHECK&o=MESSAGES&o=DETAILED_ACCOUNTS&o=LABELS&o=CURRENT_ACTIONS&o=CURRENT_REVISION&o=CURRENT_COMMIT',
         )
         .reply(200, gerritRestResponse(change), jsonResultHeader);
       await expect(client.getChange(123456)).resolves.toEqual(change);
@@ -215,17 +215,24 @@ describe('modules/platform/gerrit/client', () => {
     });
   });
 
-  describe('updateCommitMessage', () => {
-    it('updateCommitMessage - success', async () => {
+  describe('updateChangeSubject', () => {
+    it('updateChangeSubject - success', async () => {
       const change = partial<GerritChange>({});
+      const newSubject = 'new subject';
+      const previousSubject = 'some subject';
+      const previousBody = `some body\n\nChange-Id: some-change-id\n`;
       httpMock
         .scope(gerritEndpointUrl)
         .put('/a/changes/123456/message', {
-          message: `new message\n\nChange-Id: changeID\n`,
+          message: `${newSubject}\n\n${previousBody}`,
         })
         .reply(200, gerritRestResponse(change), jsonResultHeader);
       await expect(
-        client.updateCommitMessage(123456, 'changeID', 'new message'),
+        client.updateChangeSubject(
+          123456,
+          `${previousSubject}\n\n${previousBody}`,
+          'new subject',
+        ),
       ).toResolve();
     });
   });

--- a/lib/modules/platform/gerrit/client.ts
+++ b/lib/modules/platform/gerrit/client.ts
@@ -24,6 +24,7 @@ class GerritClient {
     'LABELS',
     'CURRENT_ACTIONS', //to check if current_revision can be "rebased"
     'CURRENT_REVISION', //get RevisionInfo::ref to fetch
+    'CURRENT_COMMIT', // to get the commit message
   ] as const;
 
   private gerritHttp = new GerritHttp();
@@ -103,15 +104,17 @@ class GerritClient {
     });
   }
 
-  async updateCommitMessage(
+  async updateChangeSubject(
     number: number,
-    gerritChangeID: string,
-    prTitle: string,
+    currentMessage: string,
+    newSubject: string,
   ): Promise<void> {
-    await this.setCommitMessage(
-      number,
-      `${prTitle}\n\nChange-Id: ${gerritChangeID}\n`,
+    // Replace first line of the commit message with the new subject
+    const newMessage = currentMessage.replace(
+      new RegExp(`^.*$`, 'm'),
+      newSubject,
     );
+    await this.setCommitMessage(number, newMessage);
   }
 
   async getMessages(changeNumber: number): Promise<GerritChangeMessageInfo[]> {

--- a/lib/modules/platform/gerrit/index.spec.ts
+++ b/lib/modules/platform/gerrit/index.spec.ts
@@ -11,6 +11,7 @@ import type {
   GerritLabelInfo,
   GerritLabelTypeInfo,
   GerritProjectInfo,
+  GerritRevisionInfo,
 } from './types';
 import { TAG_PULL_REQUEST_BODY, mapGerritChangeToPr } from './utils';
 import { writeToConfig } from '.';
@@ -187,21 +188,39 @@ describe('modules/platform/gerrit/index', () => {
     });
 
     it('updatePr() - new prTitle => copy to commit msg', async () => {
+      const oldSubject = 'old title';
+      const oldMessage = `${oldSubject}\n\nsome body\n\nChange-Id: ...`;
       const change = partial<GerritChange>({
-        change_id: '...',
-        subject: 'old title',
+        subject: oldSubject,
+        current_revision: 'some-revision',
+        revisions: {
+          'some-revision': partial<GerritRevisionInfo>({
+            commit: {
+              message: oldMessage,
+            },
+          }),
+        },
       });
       clientMock.getChange.mockResolvedValueOnce(change);
       await gerrit.updatePr({ number: 123456, prTitle: 'new title' });
-      expect(clientMock.updateCommitMessage).toHaveBeenCalledWith(
+      expect(clientMock.updateChangeSubject).toHaveBeenCalledWith(
         123456,
-        '...',
+        oldMessage,
         'new title',
       );
     });
 
     it('updatePr() - auto approve enabled', async () => {
-      const change = partial<GerritChange>({});
+      const change = partial<GerritChange>({
+        current_revision: 'some-revision',
+        revisions: {
+          'some-revision': partial<GerritRevisionInfo>({
+            commit: {
+              message: 'some message',
+            },
+          }),
+        },
+      });
       clientMock.getChange.mockResolvedValueOnce(change);
       await gerrit.updatePr({
         number: 123456,
@@ -225,7 +244,16 @@ describe('modules/platform/gerrit/index', () => {
     });
 
     it('updatePr() - existing prBody found in change.messages => nothing todo...', async () => {
-      const change = partial<GerritChange>({});
+      const change = partial<GerritChange>({
+        current_revision: 'some-revision',
+        revisions: {
+          'some-revision': partial<GerritRevisionInfo>({
+            commit: {
+              message: 'some message',
+            },
+          }),
+        },
+      });
       clientMock.getChange.mockResolvedValueOnce(change);
       clientMock.getMessages.mockResolvedValueOnce([
         partial<GerritChangeMessageInfo>({
@@ -279,9 +307,18 @@ describe('modules/platform/gerrit/index', () => {
       gerrit.writeToConfig({ labels: {} });
     });
 
+    const message = 'some subject\n\nsome body\n\nChange-Id: some-change-id';
+
     const change = partial<GerritChange>({
       _number: 123456,
-      change_id: '...',
+      current_revision: 'some-revision',
+      revisions: {
+        'some-revision': partial<GerritRevisionInfo>({
+          commit: {
+            message,
+          },
+        }),
+      },
     });
 
     beforeEach(() => {
@@ -312,9 +349,9 @@ describe('modules/platform/gerrit/index', () => {
         TAG_PULL_REQUEST_BODY,
       );
       expect(clientMock.approveChange).not.toHaveBeenCalled();
-      expect(clientMock.updateCommitMessage).toHaveBeenCalledWith(
+      expect(clientMock.updateChangeSubject).toHaveBeenCalledWith(
         123456,
-        '...',
+        message,
         'title',
       );
     });

--- a/lib/modules/platform/gerrit/index.ts
+++ b/lib/modules/platform/gerrit/index.ts
@@ -155,9 +155,9 @@ export async function updatePr(prConfig: UpdatePrConfig): Promise<void> {
   logger.debug(`updatePr(${prConfig.number}, ${prConfig.prTitle})`);
   const change = await client.getChange(prConfig.number);
   if (change.subject !== prConfig.prTitle) {
-    await client.updateCommitMessage(
+    await client.updateChangeSubject(
       prConfig.number,
-      change.change_id,
+      change.revisions[change.current_revision].commit.message,
       prConfig.prTitle,
     );
   }
@@ -200,9 +200,9 @@ export async function createPr(prConfig: CreatePRConfig): Promise<Pr | null> {
   }
   //Workaround for "Known Problems.1"
   if (pr.subject !== prConfig.prTitle) {
-    await client.updateCommitMessage(
+    await client.updateChangeSubject(
       pr._number,
-      pr.change_id,
+      pr.revisions[pr.current_revision].commit.message,
       prConfig.prTitle,
     );
   }

--- a/lib/modules/platform/gerrit/types.ts
+++ b/lib/modules/platform/gerrit/types.ts
@@ -43,12 +43,16 @@ export interface GerritChange {
   labels?: Record<string, GerritLabelInfo>;
   reviewers?: Record<GerritReviewersType, GerritAccountInfo[]>;
   messages?: GerritChangeMessageInfo[];
-  current_revision?: string;
+  current_revision: string;
   /**
    * All patch sets of this change as a map that maps the commit ID of the patch set to a RevisionInfo entity.
    */
-  revisions?: Record<string, GerritRevisionInfo>;
+  revisions: Record<string, GerritRevisionInfo>;
   problems: unknown[];
+}
+
+export interface GerritCommitInfo {
+  message: string;
 }
 
 export interface GerritRevisionInfo {
@@ -58,6 +62,7 @@ export interface GerritRevisionInfo {
    */
   ref: string;
   actions?: Record<string, GerritActionInfo>;
+  commit: GerritCommitInfo;
 }
 
 export interface GerritChangeMessageInfo {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This fixes the `commitBody` setting in `renovate.json` being ignored/removed when Renovate needs to update the change subject on Gerrit.

The previous code to update the commit message with the PR title was overriding the whole commit message with the new title. Now, it takes into account the previous commit message and only override its subject.

<!-- Describe what behavior is changed by this PR. -->

## Context

I believe the issue is self-explanatory regarding the context.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
