### PR TITLE
fix(cargo): default auto to update-lockfile

### DIFF
--- a/lib/modules/manager/cargo/range.spec.ts
+++ b/lib/modules/manager/cargo/range.spec.ts
@@ -15,11 +15,11 @@ describe('modules/manager/cargo/range', () => {
     expect(getRangeStrategy(config)).toBe('widen');
   });
 
-  it('defaults to bump', () => {
+  it('defaults to update-lockfile', () => {
     const config: RangeConfig = {
       rangeStrategy: 'auto',
       currentValue: '1.0.0',
     };
-    expect(getRangeStrategy(config)).toBe('bump');
+    expect(getRangeStrategy(config)).toBe('update-lockfile');
   });
 });

--- a/lib/modules/manager/cargo/range.ts
+++ b/lib/modules/manager/cargo/range.ts
@@ -11,5 +11,5 @@ export function getRangeStrategy({
   if (currentValue?.includes('<')) {
     return 'widen';
   }
-  return 'bump';
+  return 'update-lockfile';
 }

--- a/lib/modules/manager/cargo/readme.md
+++ b/lib/modules/manager/cargo/readme.md
@@ -3,7 +3,9 @@ Extracts dependencies from `Cargo.toml` files, and also updates `Cargo.lock` fil
 When using the default rangeStrategy=auto:
 
 - If a "less than" instruction is found (e.g. `<2`) then `rangeStrategy=widen` will be selected,
-- Otherwise, `rangeStrategy=bump` will be selected.
+- Otherwise, `rangeStrategy=update-lockfile` will be selected.
+
+The `update-lockfile` default means that most upgrades will update `Cargo.lock` files without the need to change the value in `Cargo.toml`.
 
 ### Private Modules Authentication
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

rangeStrategy=auto should default to rangeStrategy=update-lockfile for Cargo

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
