### PR TITLE
fix(pep440): fix exception matching two ranges

### DIFF
--- a/lib/modules/versioning/pep440/index.spec.ts
+++ b/lib/modules/versioning/pep440/index.spec.ts
@@ -38,6 +38,14 @@ describe('modules/versioning/pep440/index', () => {
   });
 
   it.each`
+    a          | b            | expected
+    ${'1.0'}   | ${'>=1.0.0'} | ${true}
+    ${'>=3.8'} | ${'>=3.9'}   | ${false}
+  `('matches($a, $b) === $expected', ({ a, b, expected }) => {
+    expect(pep440.matches(a, b)).toBe(expected);
+  });
+
+  it.each`
     version       | isSingle
     ${'1.2.3'}    | ${true}
     ${'1.2.3rc0'} | ${true}

--- a/lib/modules/versioning/pep440/index.ts
+++ b/lib/modules/versioning/pep440/index.ts
@@ -1,4 +1,5 @@
 import * as pep440 from '@renovatebot/pep440';
+import { logger } from '../../../logger';
 import type { RangeStrategy } from '../../../types/versioning';
 import type { VersioningApi } from '../types';
 import { getNewValue, isLessThanRange } from './range';
@@ -16,7 +17,7 @@ export const supportedRangeStrategies: RangeStrategy[] = [
 
 const {
   compare: sortVersions,
-  satisfies: matches,
+  satisfies,
   valid,
   validRange,
   explain,
@@ -73,6 +74,9 @@ export { isVersion, matches };
 
 const equals = (version1: string, version2: string): boolean =>
   isVersion(version1) && isVersion(version2) && eq(version1, version2);
+
+const matches = (version: string, range: string): boolean =>
+  isVersion(version) && isValid(range) && satisfies(version, range);
 
 export const api: VersioningApi = {
   equals,

--- a/lib/modules/versioning/pep440/index.ts
+++ b/lib/modules/versioning/pep440/index.ts
@@ -74,8 +74,9 @@ export { isVersion, matches };
 const equals = (version1: string, version2: string): boolean =>
   isVersion(version1) && isVersion(version2) && eq(version1, version2);
 
-const matches = (version: string, range: string): boolean =>
-  isVersion(version) && isValid(range) && satisfies(version, range);
+function matches(version: string, range: string): boolean {
+  return isVersion(version) && isValid(range) && satisfies(version, range);
+}
 
 export const api: VersioningApi = {
   equals,

--- a/lib/modules/versioning/pep440/index.ts
+++ b/lib/modules/versioning/pep440/index.ts
@@ -1,5 +1,4 @@
 import * as pep440 from '@renovatebot/pep440';
-import { logger } from '../../../logger';
 import type { RangeStrategy } from '../../../types/versioning';
 import type { VersioningApi } from '../types';
 import { getNewValue, isLessThanRange } from './range';


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds defensive check to pep440.matches

## Context

Fixes #28615 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
