### PR TITLE
fix: massage depName if missing

### DIFF
--- a/lib/workers/repository/extract/manager-files.spec.ts
+++ b/lib/workers/repository/extract/manager-files.spec.ts
@@ -52,13 +52,13 @@ describe('workers/repository/extract/manager-files', () => {
       fileMatch.getMatchingFiles.mockReturnValue(['Dockerfile']);
       fs.readLocalFile.mockResolvedValueOnce('some content');
       html.extractPackageFile = jest.fn(() => ({
-        deps: [{}, { replaceString: 'abc' }],
+        deps: [{}, { replaceString: 'abc', packageName: 'p' }],
       })) as never;
       const res = await getManagerPackageFiles(managerConfig);
       expect(res).toEqual([
         {
           packageFile: 'Dockerfile',
-          deps: [{}, { replaceString: 'abc' }],
+          deps: [{}, { replaceString: 'abc', packageName: 'p', depName: 'p' }],
         },
       ]);
     });

--- a/lib/workers/repository/extract/manager-files.ts
+++ b/lib/workers/repository/extract/manager-files.ts
@@ -9,6 +9,18 @@ import type { PackageFile } from '../../../modules/manager/types';
 import { readLocalFile } from '../../../util/fs';
 import type { WorkerExtractConfig } from '../../types';
 
+function massageDepNames(packageFiles: PackageFile[] | null): void {
+  if (packageFiles) {
+    for (const packageFile of packageFiles) {
+      for (const dep of packageFile.deps) {
+        if (dep.packageName && !dep.depName) {
+          dep.depName = dep.packageName;
+        }
+      }
+    }
+  }
+}
+
 export async function getManagerPackageFiles(
   config: WorkerExtractConfig,
 ): Promise<PackageFile[] | null> {
@@ -35,6 +47,7 @@ export async function getManagerPackageFiles(
       config,
       fileList,
     );
+    massageDepNames(allPackageFiles);
     return allPackageFiles;
   }
   const packageFiles: PackageFile[] = [];
@@ -58,5 +71,6 @@ export async function getManagerPackageFiles(
       logger.debug(`${packageFile} has no content`);
     }
   }
+  massageDepNames(packageFiles);
   return packageFiles;
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Massages depName to value of packageName if it's missing

## Context

Prep for migration towards packageName preferred

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
