### PR TITLE
feat(manager/custom): allow packageName instead of depName

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -689,7 +689,7 @@ The `regex` manager which is based on using Regular Expression named capture gro
 You must have a named capture group matching (e.g. `(?<depName>.*)`) _or_ configure its corresponding template (e.g. `depNameTemplate`) for these fields:
 
 - `datasource`
-- `depName` or `packageName` (either or both is OK)
+- `depName` and / or `packageName`
 - `currentValue`
 
 Use named capture group matching _or_ set a corresponding template.

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -689,7 +689,7 @@ The `regex` manager which is based on using Regular Expression named capture gro
 You must have a named capture group matching (e.g. `(?<depName>.*)`) _or_ configure its corresponding template (e.g. `depNameTemplate`) for these fields:
 
 - `datasource`
-- `depName`
+- `depName` or `packageName` (either or both is OK)
 - `currentValue`
 
 Use named capture group matching _or_ set a corresponding template.

--- a/lib/config/validation.spec.ts
+++ b/lib/config/validation.spec.ts
@@ -746,6 +746,16 @@ describe('config/validation', () => {
             extractVersionTemplate: '^(?<version>v\\d+\\.\\d+)',
             depTypeTemplate: 'apple',
           },
+          {
+            customType: 'regex',
+            fileMatch: ['Dockerfile'],
+            matchStrings: ['ENV (?<currentValue>.*?)\\s'],
+            packageNameTemplate: 'foo',
+            datasourceTemplate: 'bar',
+            registryUrlTemplate: 'foobar',
+            extractVersionTemplate: '^(?<version>v\\d+\\.\\d+)',
+            depTypeTemplate: 'apple',
+          },
         ],
       };
       const { warnings, errors } = await configValidation.validateConfig(

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -846,7 +846,7 @@ function validateRegexManagerFields(
     });
   }
 
-  const mandatoryFields = ['depName', 'currentValue', 'datasource'];
+  const mandatoryFields = ['currentValue', 'datasource'];
   for (const field of mandatoryFields) {
     if (!hasField(customManager, field)) {
       errors.push({
@@ -854,6 +854,14 @@ function validateRegexManagerFields(
         message: `Regex Managers must contain ${field}Template configuration or regex group named ${field}`,
       });
     }
+  }
+
+  const nameFields = ['depName', 'packageName'];
+  if (!nameFields.some((field) => hasField(customManager, field))) {
+    errors.push({
+      topic: 'Configuration Error',
+      message: `Regex Managers must contain depName or packageName regex groups or templates`,
+    });
   }
 }
 

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -833,15 +833,22 @@ function validateRegexManagerFields(
     });
   }
 
-  const mandatoryFields = ['depName', 'currentValue', 'datasource'];
-  for (const field of mandatoryFields) {
+  function hasField(
+    customManager: Partial<RegexManagerConfig>,
+    field: string,
+  ): boolean {
     const templateField = `${field}Template` as keyof RegexManagerTemplates;
-    if (
-      !customManager[templateField] &&
-      !customManager.matchStrings?.some((matchString) =>
+    return !!(
+      customManager[templateField] ||
+      customManager.matchStrings?.some((matchString) =>
         matchString.includes(`(?<${field}>`),
       )
-    ) {
+    );
+  }
+
+  const mandatoryFields = ['depName', 'currentValue', 'datasource'];
+  for (const field of mandatoryFields) {
+    if (!hasField(customManager, field)) {
       errors.push({
         topic: 'Configuration Error',
         message: `Regex Managers must contain ${field}Template configuration or regex group named ${field}`,

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -806,6 +806,19 @@ export async function validateConfig(
   return { errors, warnings };
 }
 
+function hasField(
+  customManager: Partial<RegexManagerConfig>,
+  field: string,
+): boolean {
+  const templateField = `${field}Template` as keyof RegexManagerTemplates;
+  return !!(
+    customManager[templateField] ||
+    customManager.matchStrings?.some((matchString) =>
+      matchString.includes(`(?<${field}>`),
+    )
+  );
+}
+
 function validateRegexManagerFields(
   customManager: Partial<RegexManagerConfig>,
   currentPath: string,
@@ -831,19 +844,6 @@ function validateRegexManagerFields(
       topic: 'Configuration Error',
       message: `Each Custom Manager must contain a non-empty matchStrings array`,
     });
-  }
-
-  function hasField(
-    customManager: Partial<RegexManagerConfig>,
-    field: string,
-  ): boolean {
-    const templateField = `${field}Template` as keyof RegexManagerTemplates;
-    return !!(
-      customManager[templateField] ||
-      customManager.matchStrings?.some((matchString) =>
-        matchString.includes(`(?<${field}>`),
-      )
-    );
   }
 
   const mandatoryFields = ['depName', 'currentValue', 'datasource'];

--- a/lib/modules/manager/custom/regex/__snapshots__/index.spec.ts.snap
+++ b/lib/modules/manager/custom/regex/__snapshots__/index.spec.ts.snap
@@ -198,7 +198,7 @@ exports[`modules/manager/custom/regex/index extracts registryUrl 1`] = `
     {
       "currentValue": "8.12.13",
       "datasource": "helm",
-      "depName": "prometheus-operator",
+      "packageName": "prometheus-operator",
       "registryUrls": [
         "https://charts.helm.sh/stable",
       ],
@@ -212,7 +212,7 @@ exports[`modules/manager/custom/regex/index extracts registryUrl 1`] = `
   "matchStrings": [
     "chart:
  *repository: (?<registryUrl>.*?)
- *name: (?<depName>.*?)
+ *name: (?<packageName>.*?)
  *version: (?<currentValue>.*)
 ",
   ],

--- a/lib/modules/manager/custom/regex/index.spec.ts
+++ b/lib/modules/manager/custom/regex/index.spec.ts
@@ -48,7 +48,7 @@ describe('modules/manager/custom/regex/index', () => {
   it('returns null if no dependencies found', async () => {
     const config = {
       matchStrings: [
-        'ENV .*?_VERSION=(?<currentValue>.*) # (?<datasource>.*?)/(?<depName>[^&]*?)(\\&versioning=(?<versioning>[^&]*?))?\\s',
+        'ENV .*?_VERSION=(?<currentValue>.*) # (?<datasource>.*?)/(?<packageName>[^&]*?)(\\&versioning=(?<versioning>[^&]*?))?\\s',
       ],
       versioningTemplate:
         '{{#if versioning}}{{versioning}}{{else}}semver{{/if}}',
@@ -95,7 +95,7 @@ describe('modules/manager/custom/regex/index', () => {
   it('extracts registryUrl', async () => {
     const config = {
       matchStrings: [
-        'chart:\n *repository: (?<registryUrl>.*?)\n *name: (?<depName>.*?)\n *version: (?<currentValue>.*)\n',
+        'chart:\n *repository: (?<registryUrl>.*?)\n *name: (?<packageName>.*?)\n *version: (?<currentValue>.*)\n',
       ],
       datasourceTemplate: 'helm',
     };
@@ -121,7 +121,7 @@ describe('modules/manager/custom/regex/index', () => {
         {
           currentValue: '8.12.13',
           datasource: 'helm',
-          depName: 'prometheus-operator',
+          packageName: 'prometheus-operator',
           registryUrls: ['https://charts.helm.sh/stable'],
         },
       ],

--- a/lib/modules/manager/custom/regex/readme.md
+++ b/lib/modules/manager/custom/regex/readme.md
@@ -30,7 +30,6 @@ Configuration-wise, it works like this:
 
 - You must capture the `currentValue` of the dependency in a named capture group
 - You must have either a `depName` capture group or a `depNameTemplate` config field, or `packageName` or `packageNameTemplate`
-- You can optionally have a `packageName` capture group or a `packageNameTemplate` if it differs from `depName`
 - You must have either a `datasource` capture group or a `datasourceTemplate` config field
 - You can optionally have a `depType` capture group or a `depTypeTemplate` config field
 - You can optionally have a `versioning` capture group or a `versioningTemplate` config field. If neither are present, Renovate will use `semver-coerced` as the default

--- a/lib/modules/manager/custom/regex/readme.md
+++ b/lib/modules/manager/custom/regex/readme.md
@@ -29,7 +29,7 @@ Before Renovate can look up a dependency and decide about updates, it needs this
 Configuration-wise, it works like this:
 
 - You must capture the `currentValue` of the dependency in a named capture group
-- You must have either a `depName` or `packageName` capture group, or use on of the respective template fields (  `depNameTemplate` and `packageNameTemplate` )
+- You must have either a `depName` or `packageName` capture group, or use on of the respective template fields ( `depNameTemplate` and `packageNameTemplate` )
 - You must have either a `datasource` capture group or a `datasourceTemplate` config field
 - You can optionally have a `depType` capture group or a `depTypeTemplate` config field
 - You can optionally have a `versioning` capture group or a `versioningTemplate` config field. If neither are present, Renovate will use `semver-coerced` as the default

--- a/lib/modules/manager/custom/regex/readme.md
+++ b/lib/modules/manager/custom/regex/readme.md
@@ -29,7 +29,7 @@ Before Renovate can look up a dependency and decide about updates, it needs this
 Configuration-wise, it works like this:
 
 - You must capture the `currentValue` of the dependency in a named capture group
-- You must have either a `depName` capture group or a `depNameTemplate` config field, or `packageName` or `packageNameTemplate`
+- You must have either a `depName` or `packageName` capture group, or use on of the respective template fields (  `depNameTemplate` and `packageNameTemplate` )
 - You must have either a `datasource` capture group or a `datasourceTemplate` config field
 - You can optionally have a `depType` capture group or a `depTypeTemplate` config field
 - You can optionally have a `versioning` capture group or a `versioningTemplate` config field. If neither are present, Renovate will use `semver-coerced` as the default

--- a/lib/modules/manager/custom/regex/utils.ts
+++ b/lib/modules/manager/custom/regex/utils.ts
@@ -124,10 +124,12 @@ export function isValidDependency({
   depName,
   currentValue,
   currentDigest,
+  packageName,
 }: PackageDependency): boolean {
   // check if all the fields are set
   return (
-    is.nonEmptyStringAndNotWhitespace(depName) &&
+    (is.nonEmptyStringAndNotWhitespace(depName) ||
+      is.nonEmptyStringAndNotWhitespace(packageName)) &&
     (is.nonEmptyStringAndNotWhitespace(currentDigest) ||
       is.nonEmptyStringAndNotWhitespace(currentValue))
   );

--- a/lib/modules/platform/gerrit/scm.ts
+++ b/lib/modules/platform/gerrit/scm.ts
@@ -34,7 +34,7 @@ export class GerritScm extends DefaultGitScm {
       .findChanges(repository, searchConfig, true)
       .then((res) => res.pop());
     if (change) {
-      return change.current_revision! as LongCommitSha;
+      return change.current_revision as LongCommitSha;
     }
     return git.getBranchCommit(branchName);
   }
@@ -52,7 +52,7 @@ export class GerritScm extends DefaultGitScm {
       .findChanges(repository, searchConfig, true)
       .then((res) => res.pop());
     if (change) {
-      const currentGerritPatchset = change.revisions![change.current_revision!];
+      const currentGerritPatchset = change.revisions[change.current_revision];
       return currentGerritPatchset.actions?.['rebase'].enabled === true;
     }
     return true;
@@ -85,7 +85,7 @@ export class GerritScm extends DefaultGitScm {
       .findChanges(repository, searchConfig, true)
       .then((res) => res.pop());
     if (change) {
-      const currentGerritPatchset = change.revisions![change.current_revision!];
+      const currentGerritPatchset = change.revisions[change.current_revision];
       return currentGerritPatchset.uploader.username !== username;
     }
     return false;
@@ -154,7 +154,7 @@ export class GerritScm extends DefaultGitScm {
       .then((res) => res.pop());
     if (change) {
       return super.mergeToLocal(
-        change.revisions![change.current_revision!].ref,
+        change.revisions[change.current_revision].ref,
       );
     }
     return super.mergeToLocal(branchName);

--- a/lib/modules/platform/gerrit/scm.ts
+++ b/lib/modules/platform/gerrit/scm.ts
@@ -153,9 +153,7 @@ export class GerritScm extends DefaultGitScm {
       .findChanges(repository, searchConfig, true)
       .then((res) => res.pop());
     if (change) {
-      return super.mergeToLocal(
-        change.revisions[change.current_revision].ref,
-      );
+      return super.mergeToLocal(change.revisions[change.current_revision].ref);
     }
     return super.mergeToLocal(branchName);
   }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Refactors regex customer manager so that packageName can be extracted instead of depName, meaning depName is no longer mandatory.

## Context

Transition to packageName-first extraction.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
