### PR TITLE
feat(replacements): standard-version to commit-and-tag-version

### DIFF
--- a/lib/config/presets/internal/replacements.ts
+++ b/lib/config/presets/internal/replacements.ts
@@ -43,6 +43,7 @@ export const presets: Record<string, Preset> = {
       'replacements:rome-to-biome',
       'replacements:semantic-release-replace-plugin-to-unscoped',
       'replacements:spectre-cli-to-spectre-console-cli',
+      'replacements:standard-version-to-maintained',
       'replacements:vso-task-lib-to-azure-pipelines-task-lib',
       'replacements:vsts-task-lib-to-azure-pipelines-task-lib',
       'replacements:xmldom-to-scoped',
@@ -898,6 +899,18 @@ export const presets: Record<string, Preset> = {
         matchPackageNames: ['Spectre.Cli'],
         replacementName: 'Spectre.Console.Cli',
         replacementVersion: '0.45.0',
+      },
+    ],
+  },
+  'standard-version-to-maintained': {
+    description:
+      '`standard-version` is now maintained as `commit-and-tag-version`.',
+    packageRules: [
+      {
+        matchDatasources: ['npm'],
+        matchPackageNames: ['standard-version'],
+        replacementName: 'commit-and-tag-version',
+        replacementVersion: '9.5.0',
       },
     ],
   },

--- a/lib/config/presets/internal/replacements.ts
+++ b/lib/config/presets/internal/replacements.ts
@@ -907,6 +907,7 @@ export const presets: Record<string, Preset> = {
       '`standard-version` is now maintained as `commit-and-tag-version`.',
     packageRules: [
       {
+        matchCurrentVersion: '^9.0.0',
         matchDatasources: ['npm'],
         matchPackageNames: ['standard-version'],
         replacementName: 'commit-and-tag-version',

--- a/lib/config/presets/internal/replacements.ts
+++ b/lib/config/presets/internal/replacements.ts
@@ -43,7 +43,7 @@ export const presets: Record<string, Preset> = {
       'replacements:rome-to-biome',
       'replacements:semantic-release-replace-plugin-to-unscoped',
       'replacements:spectre-cli-to-spectre-console-cli',
-      'replacements:standard-version-to-maintained',
+      'replacements:standard-version-to-commit-and-tag',
       'replacements:vso-task-lib-to-azure-pipelines-task-lib',
       'replacements:vsts-task-lib-to-azure-pipelines-task-lib',
       'replacements:xmldom-to-scoped',
@@ -902,7 +902,7 @@ export const presets: Record<string, Preset> = {
       },
     ],
   },
-  'standard-version-to-maintained': {
+  'standard-version-to-commit-and-tag': {
     description:
       '`standard-version` is now maintained as `commit-and-tag-version`.',
     packageRules: [


### PR DESCRIPTION
## Changes

Adds a replacement rule for [`standard-version`](https://github.com/conventional-changelog/standard-version/commit/c48005d1e365f960a2262a0a348fbb47a2b640b7) that replaces it with the maintained fork [`commit-and-tag-version`](https://github.com/absolute-version/commit-and-tag-version).

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
