### PR TITLE
fix(pypi): filter string only and deduplicate

### DIFF
--- a/lib/modules/datasource/pypi/__snapshots__/index.spec.ts.snap
+++ b/lib/modules/datasource/pypi/__snapshots__/index.spec.ts.snap
@@ -266,9 +266,6 @@ exports[`modules/datasource/pypi/index getReleases respects constraints 1`] = `
   "registryUrl": "https://pypi.org/pypi",
   "releases": [
     {
-      "version": "0.4.0",
-    },
-    {
       "version": "0.4.1",
     },
     {

--- a/lib/modules/datasource/pypi/index.ts
+++ b/lib/modules/datasource/pypi/index.ts
@@ -1,4 +1,5 @@
 import url from 'node:url';
+import is from '@sindresorhus/is';
 import changelogFilenameRegex from 'changelog-filename-regex';
 import { logger } from '../../../logger';
 import { coerceArray } from '../../../util/array';
@@ -10,7 +11,6 @@ import { Datasource } from '../datasource';
 import type { GetReleasesConfig, Release, ReleaseResult } from '../types';
 import { isGitHubRepo, normalizePythonDepName } from './common';
 import type { PypiJSON, PypiJSONRelease, Releases } from './types';
-import is from '@sindresorhus/is';
 
 export class PypiDatasource extends Datasource {
   static readonly id = 'pypi';

--- a/lib/modules/datasource/pypi/index.ts
+++ b/lib/modules/datasource/pypi/index.ts
@@ -10,6 +10,7 @@ import { Datasource } from '../datasource';
 import type { GetReleasesConfig, Release, ReleaseResult } from '../types';
 import { isGitHubRepo, normalizePythonDepName } from './common';
 import type { PypiJSON, PypiJSONRelease, Releases } from './types';
+import is from '@sindresorhus/is';
 
 export class PypiDatasource extends Datasource {
   static readonly id = 'pypi';
@@ -156,9 +157,11 @@ export class PypiDatasource extends Datasource {
           result.isDeprecated = isDeprecated;
         }
         // There may be multiple releases with different requires_python, so we return all in an array
+        const pythonConstraints = releases
+          .map(({ requires_python }) => requires_python)
+          .filter(is.string);
         result.constraints = {
-          // TODO: string[] isn't allowed here
-          python: releases.map(({ requires_python }) => requires_python) as any,
+          python: Array.from(new Set(pythonConstraints)),
         };
         return result;
       });


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Deduplicates PyPI constraints result, filters out non-string (e.g. `null`) results.

## Context

I noticed when debugging that we would have sometimes dozens of duplicated python constraints.
While de-duplicating I decided it's best to strip out `null` too, to comply with our types.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
