### PR TITLE
fix(constraintsFiltering): match exact string

### DIFF
--- a/lib/modules/datasource/common.spec.ts
+++ b/lib/modules/datasource/common.spec.ts
@@ -226,6 +226,25 @@ describe('modules/datasource/common', () => {
         releases: [{ version: '1.0.0' }, { version: '2.0.0' }],
       });
     });
+
+    it('should match exact constraints', () => {
+      const config = {
+        datasource: 'pypi',
+        packageName: 'bar',
+        versioning: 'pep440',
+        constraintsFiltering: 'strict' as const,
+        constraints: { python: '>=3.8' },
+      };
+      const releaseResult = {
+        releases: [
+          { version: '1.0.0', constraints: { python: ['^1.0.0'] } },
+          { version: '2.0.0', constraints: { python: ['>=3.8'] } },
+        ],
+      };
+      expect(applyConstraintsFiltering(releaseResult, config)).toEqual({
+        releases: [{ version: '2.0.0' }],
+      });
+    });
   });
 
   describe('applyVersionCompatibility', () => {

--- a/lib/modules/datasource/common.ts
+++ b/lib/modules/datasource/common.ts
@@ -208,6 +208,11 @@ export function applyConstraintsFiltering<
           break;
         }
 
+        if (configConstraint === releaseConstraint) {
+          satisfiesConstraints = true;
+          break;
+        }
+
         if (versioning.subset?.(configConstraint, releaseConstraint)) {
           satisfiesConstraints = true;
           break;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds exact match to constraintsFiltering=strict

## Context

pep440 doesn't have subset() but at least we can match exact

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
