### PR TITLE
feat(pipenv): better python constraints checking

### DIFF
--- a/lib/modules/manager/pipenv/__fixtures__/Pipfile1
+++ b/lib/modules/manager/pipenv/__fixtures__/Pipfile1
@@ -28,3 +28,4 @@ dev-package = "==0.1.0"
 
 [requires]
 python_version = "3.6"
+python_full_version = "3.6.2"

--- a/lib/modules/manager/pipenv/artifacts.spec.ts
+++ b/lib/modules/manager/pipenv/artifacts.spec.ts
@@ -210,7 +210,7 @@ describe('modules/manager/pipenv/artifacts', () => {
     fs.ensureCacheDir.mockResolvedValueOnce(virtualenvsCacheDir);
     fs.readLocalFile.mockResolvedValueOnce(JSON.stringify(pipFileLock));
     const execSnapshots = mockExecAll();
-    fs.getSiblingFileName.mockResolvedValueOnce('.python-version');
+    fs.getSiblingFileName.mockResolvedValueOnce('.python-version' as never);
     fs.readLocalFile.mockResolvedValueOnce('3.7.6');
 
     expect(

--- a/lib/modules/manager/pipenv/artifacts.spec.ts
+++ b/lib/modules/manager/pipenv/artifacts.spec.ts
@@ -78,6 +78,7 @@ describe('modules/manager/pipenv/artifacts', () => {
     // python
     datasource.getPkgReleases.mockResolvedValueOnce({
       releases: [
+        { version: '3.6.2' },
         { version: '3.6.5' },
         { version: '3.7.6' },
         { version: '3.8.5' },
@@ -125,6 +126,105 @@ describe('modules/manager/pipenv/artifacts', () => {
     ).toBeNull();
 
     expect(execSnapshots).toMatchObject([
+      {
+        cmd: 'pipenv lock',
+        options: {
+          cwd: '/tmp/github/some/repo',
+          env: {
+            PIPENV_CACHE_DIR: pipenvCacheDir,
+          },
+        },
+      },
+    ]);
+  });
+
+  it('gets python full version from Pipfile', async () => {
+    GlobalConfig.set({ ...adminConfig, binarySource: 'install' });
+    pipFileLock._meta!.requires!.python_full_version = '3.7.6';
+    fs.ensureCacheDir.mockResolvedValueOnce(pipenvCacheDir);
+    fs.ensureCacheDir.mockResolvedValueOnce(virtualenvsCacheDir);
+    fs.readLocalFile.mockResolvedValueOnce(JSON.stringify(pipFileLock));
+    const execSnapshots = mockExecAll();
+    fs.readLocalFile.mockResolvedValueOnce(JSON.stringify(pipFileLock));
+
+    expect(
+      await updateArtifacts({
+        packageFileName: 'Pipfile',
+        updatedDeps: [],
+        newPackageFileContent: Fixtures.get('Pipfile1'),
+        config,
+      }),
+    ).toBeNull();
+
+    expect(execSnapshots).toMatchObject([
+      { cmd: 'install-tool python 3.6.2' },
+      {},
+      {
+        cmd: 'pipenv lock',
+        options: {
+          cwd: '/tmp/github/some/repo',
+          env: {
+            PIPENV_CACHE_DIR: pipenvCacheDir,
+          },
+        },
+      },
+    ]);
+  });
+
+  it('gets python version from Pipfile', async () => {
+    GlobalConfig.set({ ...adminConfig, binarySource: 'install' });
+    pipFileLock._meta!.requires!.python_full_version = '3.7.6';
+    fs.ensureCacheDir.mockResolvedValueOnce(pipenvCacheDir);
+    fs.ensureCacheDir.mockResolvedValueOnce(virtualenvsCacheDir);
+    fs.readLocalFile.mockResolvedValueOnce(JSON.stringify(pipFileLock));
+    const execSnapshots = mockExecAll();
+    fs.readLocalFile.mockResolvedValueOnce(JSON.stringify(pipFileLock));
+
+    expect(
+      await updateArtifacts({
+        packageFileName: 'Pipfile',
+        updatedDeps: [],
+        newPackageFileContent: Fixtures.get('Pipfile2'),
+        config,
+      }),
+    ).toBeNull();
+
+    expect(execSnapshots).toMatchObject([
+      { cmd: 'install-tool python 3.6.5' },
+      {},
+      {
+        cmd: 'pipenv lock',
+        options: {
+          cwd: '/tmp/github/some/repo',
+          env: {
+            PIPENV_CACHE_DIR: pipenvCacheDir,
+          },
+        },
+      },
+    ]);
+  });
+
+  it('gets python version from .python-version', async () => {
+    GlobalConfig.set({ ...adminConfig, binarySource: 'install' });
+    fs.ensureCacheDir.mockResolvedValueOnce(pipenvCacheDir);
+    fs.ensureCacheDir.mockResolvedValueOnce(virtualenvsCacheDir);
+    fs.readLocalFile.mockResolvedValueOnce(JSON.stringify(pipFileLock));
+    const execSnapshots = mockExecAll();
+    fs.getSiblingFileName.mockResolvedValueOnce('.python-version');
+    fs.readLocalFile.mockResolvedValueOnce('3.7.6');
+
+    expect(
+      await updateArtifacts({
+        packageFileName: 'Pipfile',
+        updatedDeps: [],
+        newPackageFileContent: 'some toml',
+        config,
+      }),
+    ).toBeNull();
+
+    expect(execSnapshots).toMatchObject([
+      { cmd: 'install-tool python 3.7.6' },
+      {},
       {
         cmd: 'pipenv lock',
         options: {

--- a/lib/modules/manager/pipenv/artifacts.ts
+++ b/lib/modules/manager/pipenv/artifacts.ts
@@ -18,6 +18,7 @@ import { regEx } from '../../../util/regex';
 import { parse as parseToml } from '../../../util/toml';
 import { parseUrl } from '../../../util/url';
 import { PypiDatasource } from '../../datasource/pypi';
+import pep440 from '../../versioning/pep440';
 import type {
   UpdateArtifact,
   UpdateArtifactsConfig,
@@ -25,7 +26,6 @@ import type {
 } from '../types';
 import { extractPackageFile } from './extract';
 import { PipfileLockSchema } from './schema';
-import pep440 from '../../versioning/pep440';
 
 export async function getPythonConstraint(
   pipfileName: string,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Improves Pipenv Python constraint checking:
- Check `Pipfile` first (in preparation for updating this as a dependency)
- Check `.python-version` last

## Context

Useful for Runinstall

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
