### PR TITLE
fix(manager/terraform/lockfile): use registryURL defined in lockfile

### DIFF
--- a/lib/modules/manager/terraform/lockfile/index.spec.ts
+++ b/lib/modules/manager/terraform/lockfile/index.spec.ts
@@ -76,7 +76,7 @@ describe('modules/manager/terraform/lockfile/index', () => {
 
   it('update single dependency with exact constraint and depType provider', async () => {
     fs.readLocalFile.mockResolvedValueOnce(codeBlock`
-      provider "registry.terraform.io/hashicorp/aws" {
+      provider "registry.opentofu.org/hashicorp/aws" {
         version     = "3.0.0"
         constraints = "3.0.0"
         hashes = [
@@ -111,7 +111,7 @@ describe('modules/manager/terraform/lockfile/index', () => {
       {
         file: {
           contents: codeBlock`
-            provider "registry.terraform.io/hashicorp/aws" {
+            provider "registry.opentofu.org/hashicorp/aws" {
               version     = "3.36.0"
               constraints = "3.36.0"
               hashes = [
@@ -126,7 +126,7 @@ describe('modules/manager/terraform/lockfile/index', () => {
       },
     ]);
     expect(mockHash.mock.calls).toEqual([
-      ['https://registry.terraform.io', 'hashicorp/aws', '3.36.0'],
+      ['https://registry.opentofu.org', 'hashicorp/aws', '3.36.0'],
     ]);
   });
 

--- a/lib/modules/manager/terraform/lockfile/index.ts
+++ b/lib/modules/manager/terraform/lockfile/index.ts
@@ -3,7 +3,6 @@ import { logger } from '../../../../logger';
 import * as p from '../../../../util/promises';
 import { escapeRegExp, regEx } from '../../../../util/regex';
 import { GetPkgReleasesConfig, getPkgReleases } from '../../../datasource';
-import { TerraformProviderDatasource } from '../../../datasource/terraform-provider';
 import { get as getVersioning } from '../../../versioning';
 import type {
   UpdateArtifact,
@@ -167,9 +166,6 @@ export async function updateArtifacts({
         massageProviderLookupName(dep);
         const { registryUrls, newVersion, packageName } = dep;
 
-        const registryUrl = registryUrls
-          ? registryUrls[0]
-          : TerraformProviderDatasource.defaultRegistryUrls[0];
         const updateLock = locks.find(
           (value) => value.packageName === packageName,
         );
@@ -191,6 +187,10 @@ export async function updateArtifacts({
             continue;
           }
         }
+
+        // use registryURL defined in the update and fall back to the one defined in the lockfile
+        const registryUrl = registryUrls?.[0] ?? updateLock.registryUrl;
+
         const newConstraint = getNewConstraint(dep, updateLock.constraints);
         const update: ProviderLockUpdate = {
           // TODO #22198

--- a/lib/modules/manager/terraform/readme.md
+++ b/lib/modules/manager/terraform/readme.md
@@ -1,3 +1,20 @@
+### Terraform vs OpenTofu
+
+There is no way for Renovate to differentiate, if a user is a Terraform user or has already adopted OpenTofu.
+Therefore, Renovate defaults currently to interpret providers without a registry definition to be located at `registry.terraform.io`.
+This behaviour can be modified using `packageRules`:
+
+```json title="Prefer releases from OpenTofu"
+{
+  "packageRules": [
+    {
+      "matchDatasources": ["terraform-provider"],
+      "registryUrl": "https://registry.opentofu.org"
+    }
+  ]
+}
+```
+
 ### Supported dependencies
 
 Renovate supports updating the Terraform dependencies listed below.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Prefer the registryURL of locks defined in `.terraform.lock.hcl`. 
This allows to use OpenTofu without explicitly defining it with registryUrls. 

<!-- Describe what behavior is changed by this PR. -->

## Context
Solves https://github.com/renovatebot/renovate/discussions/28818
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository. https://github.com/secustor/reproduction-28818/pull/1

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
