### PR TITLE
fix(emoji): Use colorful version of warning emoji

### DIFF
--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -1949,7 +1949,7 @@ export function massageMarkdown(input: string): string {
     .replace(regEx(/]\(https:\/\/github\.com\//g), '](https://togithub.com/')
     .replace(regEx(/]: https:\/\/github\.com\//g), ']: https://togithub.com/')
     .replace('> ℹ **Note**\n> \n', '> [!NOTE]\n')
-    .replace('> ⚠ **Warning**\n> \n', '> [!WARNING]\n')
+    .replace('> ⚠️ **Warning**\n> \n', '> [!WARNING]\n')
     .replace('> ❗ **Important**\n> \n', '> [!IMPORTANT]\n');
   return smartTruncate(massagedInput, GitHubMaxPrBodyLen);
 }

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -1949,6 +1949,7 @@ export function massageMarkdown(input: string): string {
     .replace(regEx(/]\(https:\/\/github\.com\//g), '](https://togithub.com/')
     .replace(regEx(/]: https:\/\/github\.com\//g), ']: https://togithub.com/')
     .replace('> ℹ **Note**\n> \n', '> [!NOTE]\n')
+    .replace('> ⚠ **Warning**\n> \n', '> [!WARNING]\n')
     .replace('> ⚠️ **Warning**\n> \n', '> [!WARNING]\n')
     .replace('> ❗ **Important**\n> \n', '> [!IMPORTANT]\n');
   return smartTruncate(massagedInput, GitHubMaxPrBodyLen);

--- a/lib/util/emoji.spec.ts
+++ b/lib/util/emoji.spec.ts
@@ -68,7 +68,7 @@ describe('util/emoji', () => {
     });
   });
 
-  describe('problem characters', () => {
+  describe('problematic characters', () => {
     it.each(['🚀', '💎', '🧹', '📦', '⚠️'])(
       'converts %s forth and back',
       (char) => {

--- a/lib/util/emoji.spec.ts
+++ b/lib/util/emoji.spec.ts
@@ -21,6 +21,11 @@ describe('util/emoji', () => {
       expect(emojify(':foo: :bar: :bee:')).toBe(':foo: :bar: 🐝');
     });
 
+    it('convert warning shortcode to emoji', () => {
+      const warning = emojify(':warning:');
+      expect(warning).toBe('⚠️');
+    });
+
     it('does not encode when config option is disabled', () => {
       setEmojiConfig({ unicodeEmoji: false });
       expect(emojify('Let it :bee:')).toBe('Let it :bee:');
@@ -54,18 +59,28 @@ describe('util/emoji', () => {
         expect(unemojify(unsupported)).toBe('�');
       });
     });
+
+    it('converts warning emoji to shortcode', () => {
+      setEmojiConfig({ unicodeEmoji: false });
+      const emoji = '⚠️';
+      const result = unemojify(emoji);
+      expect(result).toBe(':warning:');
+    });
   });
 
   describe('problem characters', () => {
-    it.each(['🚀', '💎', '🧹', '📦'])('converts %s forth and back', (char) => {
-      setEmojiConfig({ unicodeEmoji: false });
-      const codified = unemojify(char);
-      expect(codified).not.toEqual(char);
+    it.each(['🚀', '💎', '🧹', '📦', '⚠️'])(
+      'converts %s forth and back',
+      (char) => {
+        setEmojiConfig({ unicodeEmoji: false });
+        const codified = unemojify(char);
+        expect(codified).not.toEqual(char);
 
-      setEmojiConfig({ unicodeEmoji: true });
-      const emojified = emojify(codified);
-      expect(emojified).toEqual(char);
-    });
+        setEmojiConfig({ unicodeEmoji: true });
+        const emojified = emojify(codified);
+        expect(emojified).toEqual(char);
+      },
+    );
   });
 
   describe('stripEmojis', () => {

--- a/lib/util/emoji.ts
+++ b/lib/util/emoji.ts
@@ -57,9 +57,12 @@ function lazyInitMappings(): void {
         initMapping(patchedEmojis);
         mappingsInitialized = true;
       })
-      .onError((error) => /* istanbul ignore */ {
-        logger.warn({ error }, 'Unable to parse emoji shortcodes');
-      });
+      .onError(
+        /* istanbul ignore next */
+        (error) => {
+          logger.warn({ error }, 'Unable to parse emoji shortcodes');
+        },
+      );
   }
 }
 

--- a/lib/workers/repository/errors-warnings.spec.ts
+++ b/lib/workers/repository/errors-warnings.spec.ts
@@ -85,7 +85,7 @@ describe('workers/repository/errors-warnings', () => {
         "
         ---
 
-        > ⚠ **Warning**
+        > ⚠️ **Warning**
         > 
         > Some dependencies could not be looked up. Check the Dependency Dashboard for more information.
 
@@ -133,7 +133,7 @@ describe('workers/repository/errors-warnings', () => {
         "
         ---
 
-        > ⚠ **Warning**
+        > ⚠️ **Warning**
         > 
         > Some dependencies could not be looked up. Check the warning logs for more information.
 
@@ -197,7 +197,7 @@ describe('workers/repository/errors-warnings', () => {
         "
         ---
 
-        > ⚠ **Warning**
+        > ⚠️ **Warning**
         > 
         > Renovate failed to look up the following dependencies: \`dependency-1\`, \`dependency-2\`.
         > 
@@ -305,7 +305,7 @@ describe('workers/repository/errors-warnings', () => {
         "
         ---
         > 
-        > ⚠ **Warning**
+        > ⚠️ **Warning**
         > 
         > Please correct - or verify that you can safely ignore - these dependency lookup failures before you merge this PR.
         > 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- patch emojibase data for GitHub shortcodes: use colorful `⚠️` instead of `⚠` (which looks cheap)
- adjust the tranform logic accordingly
- write tests to make sure it's safe

**Warning: this PR could cause lots of updates for existing PRs**

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
