### PR TITLE
refactor: always set currentVersionTimestamp

### DIFF
--- a/lib/workers/repository/process/lookup/index.spec.ts
+++ b/lib/workers/repository/process/lookup/index.spec.ts
@@ -3155,6 +3155,7 @@ describe('workers/repository/process/lookup/index', () => {
 
       expect(res).toEqual({
         currentVersion: '1.3.0',
+        currentVersionTimestamp: '2015-04-26T16:42:11.311Z',
         fixedVersion: '1.3.0',
         isSingleVersion: true,
         registryUrl: 'https://registry.npmjs.org',
@@ -3195,6 +3196,7 @@ describe('workers/repository/process/lookup/index', () => {
       ).unwrapOrThrow();
       expect(res).toEqual({
         currentVersion: '1.3.0',
+        currentVersionTimestamp: '2015-04-26T16:42:11.311Z',
         fixedVersion: '1.3.0',
         isSingleVersion: true,
         registryUrl: 'https://registry.npmjs.org',
@@ -3247,6 +3249,7 @@ describe('workers/repository/process/lookup/index', () => {
 
       expect(res).toEqual({
         currentVersion: '1.3.0',
+        currentVersionTimestamp: '2015-04-26T16:42:11.311Z',
         deprecationMessage: codeBlock`
         On registry \`https://registry.npmjs.org\`, the "latest" version of dependency \`q3\` has the following deprecation notice:
 
@@ -4039,14 +4042,15 @@ describe('workers/repository/process/lookup/index', () => {
           allowedVersions: '< 19.0.0',
         },
       ];
+      const releaseTimestamp = new Date(
+        Date.now() - 25 * 60 * 60 * 1000,
+      ).toISOString();
       getDockerReleases.mockResolvedValueOnce({
         releases: [
           {
             version: '17.0.0',
             // a day old release
-            releaseTimestamp: new Date(
-              Date.now() - 25 * 60 * 60 * 1000,
-            ).toISOString(),
+            releaseTimestamp,
           },
           {
             version: '18.0.0',
@@ -4063,6 +4067,7 @@ describe('workers/repository/process/lookup/index', () => {
 
       expect(res).toEqual({
         currentVersion: '17.0.0',
+        currentVersionTimestamp: releaseTimestamp,
         fixedVersion: '17.0.0',
         isSingleVersion: true,
         registryUrl: 'https://index.docker.io',
@@ -4078,7 +4083,6 @@ describe('workers/repository/process/lookup/index', () => {
         ],
         versioning: 'docker',
         warnings: [],
-        currentVersionTimestamp: undefined,
       });
     });
 

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -287,14 +287,13 @@ export async function lookupUpdates(
       }
 
       res.currentVersion = currentVersion!;
-      const currentVersionTimestamp =
-        allVersions.find(
-          (v) =>
-            versioning.isValid(v.version) &&
-            versioning.equals(v.version, currentVersion),
-        )?.releaseTimestamp ?? null;
+      const currentVersionTimestamp = allVersions.find(
+        (v) =>
+          versioning.isValid(v.version) &&
+          versioning.equals(v.version, currentVersion),
+      )?.releaseTimestamp;
 
-      if (is.string(currentVersionTimestamp)) {
+      if (is.nonEmptyString(currentVersionTimestamp)) {
         res.currentVersionTimestamp = currentVersionTimestamp;
         if (
           config.packageRules?.some((rules) =>

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -36,6 +36,17 @@ import {
   isReplacementRulesConfigured,
 } from './utils';
 
+function getTimestamp(
+  versions: Release[],
+  version: string,
+  versioning: allVersioning.VersioningApi,
+): string | null | undefined {
+  return versions.find(
+    (v) =>
+      versioning.isValid(v.version) && versioning.equals(v.version, version),
+  )?.releaseTimestamp;
+}
+
 export async function lookupUpdates(
   inconfig: LookupUpdateConfig,
 ): Promise<Result<UpdateResult, Error>> {
@@ -287,11 +298,11 @@ export async function lookupUpdates(
       }
 
       res.currentVersion = currentVersion!;
-      const currentVersionTimestamp = allVersions.find(
-        (v) =>
-          versioning.isValid(v.version) &&
-          versioning.equals(v.version, currentVersion),
-      )?.releaseTimestamp;
+      const currentVersionTimestamp = getTimestamp(
+        allVersions,
+        currentVersion,
+        versioning,
+      );
 
       if (is.nonEmptyString(currentVersionTimestamp)) {
         res.currentVersionTimestamp = currentVersionTimestamp;

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -287,21 +287,23 @@ export async function lookupUpdates(
       }
 
       res.currentVersion = currentVersion!;
-      const currentVersionTimestamp = allVersions.find(
-        (v) =>
-          versioning.isValid(v.version) &&
-          versioning.equals(v.version, currentVersion),
-      )?.releaseTimestamp;
+      const currentVersionTimestamp =
+        allVersions.find(
+          (v) =>
+            versioning.isValid(v.version) &&
+            versioning.equals(v.version, currentVersion),
+        )?.releaseTimestamp ?? null;
 
-      if (
-        is.nonEmptyString(currentVersionTimestamp) &&
-        config.packageRules?.some((rules) =>
-          is.nonEmptyString(rules.matchCurrentAge),
-        )
-      ) {
+      if (is.string(currentVersionTimestamp)) {
         res.currentVersionTimestamp = currentVersionTimestamp;
-        // Reapply package rules to check matches for matchCurrentAge
-        config = applyPackageRules({ ...config, currentVersionTimestamp });
+        if (
+          config.packageRules?.some((rules) =>
+            is.nonEmptyString(rules.matchCurrentAge),
+          )
+        ) {
+          // Reapply package rules to check matches for matchCurrentAge
+          config = applyPackageRules({ ...config, currentVersionTimestamp });
+        }
       }
 
       if (


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
