### PR TITLE
fix(versioning/pep440): log debug message if `newVersion` is excluded from range

### DIFF
--- a/lib/modules/versioning/pep440/range.spec.ts
+++ b/lib/modules/versioning/pep440/range.spec.ts
@@ -1,17 +1,34 @@
-import { checkRangeAndRemoveUnnecessaryRangeLimit } from './range';
+import { logger } from '../../../logger';
+import { checkRangeAndRemoveUnnecessaryRangeLimit, getNewValue } from './range';
 
-it.each`
-  rangeInput           | newVersion | expected
-  ${'==4.1.*,>=3.2.2'} | ${'4.1.1'} | ${'==4.1.*'}
-  ${'==4.0.*,>=3.2.2'} | ${'4.0.0'} | ${'==4.0.*'}
-  ${'==7.2.*'}         | ${'7.2.0'} | ${'==7.2.*'}
-`(
-  'checkRange("$rangeInput, "$newVersion"") === "$expected"',
-  ({ rangeInput, newVersion, expected }) => {
-    const res = checkRangeAndRemoveUnnecessaryRangeLimit(
-      rangeInput,
-      newVersion,
+describe('modules/versioning/pep440/range', () => {
+  it.each`
+    rangeInput           | newVersion | expected
+    ${'==4.1.*,>=3.2.2'} | ${'4.1.1'} | ${'==4.1.*'}
+    ${'==4.0.*,>=3.2.2'} | ${'4.0.0'} | ${'==4.0.*'}
+    ${'==7.2.*'}         | ${'7.2.0'} | ${'==7.2.*'}
+  `(
+    'checkRange("$rangeInput, "$newVersion"") === "$expected"',
+    ({ rangeInput, newVersion, expected }) => {
+      const res = checkRangeAndRemoveUnnecessaryRangeLimit(
+        rangeInput,
+        newVersion,
+      );
+      expect(res).toEqual(expected);
+    },
+  );
+
+  it('returns null without warning if new version is excluded from range', () => {
+    const res = getNewValue({
+      currentValue: '>=1.25.0,<2,!=1.32.0',
+      rangeStrategy: 'auto',
+      newVersion: '1.32.0',
+      currentVersion: '1.25.0',
+    });
+    expect(res).toBeNull();
+    expect(logger.debug).toHaveBeenCalledWith(
+      'Cannot calculate new value as the newVersion:`1.32.0` is excluded from range: `>=1.25.0,<2,!=1.32.0`',
     );
-    expect(res).toEqual(expected);
-  },
-);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+});

--- a/lib/modules/versioning/pep440/range.ts
+++ b/lib/modules/versioning/pep440/range.ts
@@ -129,7 +129,7 @@ export function getNewValue({
     return null;
   }
 
-  // return early newVersion is excluded from range
+  // return early if newVersion is excluded from range
   if (
     ranges.some(
       (range) => range.operator === '!=' && range.version === newVersion,
@@ -203,6 +203,7 @@ export function getNewValue({
     newVersion,
   );
 
+  // istanbul ignore if
   if (!satisfies(newVersion, checkedResult)) {
     // we failed at creating the range
     logger.warn(

--- a/lib/modules/versioning/pep440/range.ts
+++ b/lib/modules/versioning/pep440/range.ts
@@ -129,6 +129,18 @@ export function getNewValue({
     return null;
   }
 
+  // return early newVersion is excluded from range
+  if (
+    ranges.some(
+      (range) => range.operator === '!=' && range.version === newVersion,
+    )
+  ) {
+    logger.debug(
+      `Cannot calculate new value as the newVersion:\`${newVersion}\` is excluded from range: \`${currentValue}\``,
+    );
+    return null;
+  }
+
   switch (rangeStrategy) {
     case 'auto':
     case 'replace':


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Add an if-statement to check if the `newVersion` is excluded from range, so that we can return early and also log a more informational debug message instead of the less useful warning we displaly currently.
<!-- Describe what behavior is changed by this PR. -->

## Context
Closes: https://github.com/renovatebot/renovate/issues/25501
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
