### PR TITLE
feat(presets): add ktor to monorepos

### DIFF
--- a/lib/config/presets/internal/monorepo.ts
+++ b/lib/config/presets/internal/monorepo.ts
@@ -341,6 +341,7 @@ const repoGroups = {
   junit5: 'https://github.com/junit-team/junit5',
   kotlin: 'https://github.com/JetBrains/kotlin',
   kroki: 'https://github.com/yuzutech/kroki',
+  ktor: 'https://github.com/ktorio/ktor',
   lamar: 'https://github.com/JasperFx/lamar',
   lerna: 'https://github.com/lerna/lerna',
   lexical: 'https://github.com/facebook/lexical',


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Add https://github.com/ktorio/ktor as a monorepo, to group updates for it.

## Context

Too much noise created by updates of ktor which has high granularity of modules:

<img width="681" alt="Screenshot 2024-05-09 at 09 32 33" src="https://github.com/renovatebot/renovate/assets/3110813/4c9a14d8-7796-4c67-bb33-0bca77596a9f">


## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [X] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

I also verified the repo URL in several ktor packages:
* https://repo1.maven.org/maven2/io/ktor/ktor-serialization-kotlinx-json/2.3.9/ktor-serialization-kotlinx-json-2.3.9.pom
* https://repo1.maven.org/maven2/io/ktor/ktor-call-id/3.0.0-beta-1/ktor-call-id-3.0.0-beta-1.pom

They contain `<url>https://github.com/ktorio/ktor</url>`.

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
