### PR TITLE
feat(pip_requirements): Extract flags from package files with no deps

### DIFF
--- a/lib/modules/manager/pip_requirements/extract.spec.ts
+++ b/lib/modules/manager/pip_requirements/extract.spec.ts
@@ -239,5 +239,43 @@ some-package==0.3.1`;
         ],
       });
     });
+
+    it('extracts a file with only --index-url flags', () => {
+      const res = extractPackageFile('--index-url https://example.com/pypi');
+      expect(res).toMatchObject({
+        deps: [],
+        registryUrls: ['https://example.com/pypi'],
+      });
+    });
+
+    it('extracts a file with only --extra-index-url flags', () => {
+      const res = extractPackageFile(
+        '--extra-index-url https://example.com/pypi',
+      );
+      expect(res).toMatchObject({
+        deps: [],
+        additionalRegistryUrls: ['https://example.com/pypi'],
+      });
+    });
+
+    it('extracts a file with only -r flags', () => {
+      const res = extractPackageFile('-r requirements-other.txt');
+      expect(res).toMatchObject({
+        deps: [],
+        managerData: {
+          requirementsFiles: ['requirements-other.txt'],
+        },
+      });
+    });
+
+    it('extracts a file with only -c flags', () => {
+      const res = extractPackageFile('-c constraints.txt');
+      expect(res).toMatchObject({
+        deps: [],
+        managerData: {
+          constraintsFiles: ['constraints.txt'],
+        },
+      });
+    });
   });
 });

--- a/lib/modules/manager/pip_requirements/extract.ts
+++ b/lib/modules/manager/pip_requirements/extract.ts
@@ -131,7 +131,13 @@ export function extractPackageFile(
       return dep;
     })
     .filter(is.truthy);
-  if (!deps.length) {
+  if (
+    !deps.length &&
+    !registryUrls.length &&
+    !additionalRegistryUrls.length &&
+    !additionalRequirementsFiles.length &&
+    !additionalConstraintsFiles.length
+  ) {
     return null;
   }
   const res: PackageFileContent = { deps };


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

The pip_requirements manager is used by the pip-compile manager for extracting info from requirements.in files.  This change makes pip_requirements return any flags it extracted from its input file even if there are no dependencies in the file.  This allows a user to provide a requirements.in file with nothing but `--extra-index-url` flags as a second input file when using pip-compile to compile dependencies in a setup.py file so that Renovate can look those index URLs up in its `hostRules` and pass appropriate credentials to pip-compile.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->
#28960 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
