### PR TITLE
feat(preset): support _VERSION updates within bitbucket pipelines

### DIFF
--- a/lib/config/presets/internal/regex-managers.spec.ts
+++ b/lib/config/presets/internal/regex-managers.spec.ts
@@ -4,6 +4,94 @@ import { extractPackageFile } from '../../../modules/manager/custom/regex';
 import { presets } from './regex-managers';
 
 describe('config/presets/internal/regex-managers', () => {
+  describe('Update `_VERSION` variables in Bitbucket Pipelines', () => {
+    const customManager =
+      presets['bitbucketPipelinesVersions'].customManagers?.[0];
+
+    it(`find dependencies in file`, async () => {
+      const fileContent = codeBlock`
+        - script:
+          # renovate: datasource=docker depName=node versioning=docker
+          - export NODE_VERSION=18
+
+          # renovate: datasource=npm depName=pnpm
+          - export PNPM_VERSION="7.25.1"
+
+          # renovate: datasource=npm depName=yarn
+          - export YARN_VERSION 3.3.1
+
+          # renovate: datasource=custom.hashicorp depName=consul
+          - export CONSUL_VERSION 1.3.1
+
+          # renovate: datasource=github-releases depName=kubernetes-sigs/kustomize versioning=regex:^(?<compatibility>.+)/v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$ extractVersion=^kustomize/(?<version>.+)$
+          - export KUSTOMIZE_VERSION v5.2.1
+      `;
+
+      const res = await extractPackageFile(
+        fileContent,
+        'bitbucket-pipelines.yml',
+        customManager!,
+      );
+
+      expect(res?.deps).toMatchObject([
+        {
+          currentValue: '18',
+          datasource: 'docker',
+          depName: 'node',
+          replaceString:
+            '# renovate: datasource=docker depName=node versioning=docker\n- export NODE_VERSION=18\n',
+          versioning: 'docker',
+        },
+        {
+          currentValue: '7.25.1',
+          datasource: 'npm',
+          depName: 'pnpm',
+          replaceString:
+            '# renovate: datasource=npm depName=pnpm\n- export PNPM_VERSION="7.25.1"\n',
+        },
+        {
+          currentValue: '3.3.1',
+          datasource: 'npm',
+          depName: 'yarn',
+          replaceString:
+            '# renovate: datasource=npm depName=yarn\n- export YARN_VERSION 3.3.1\n',
+        },
+        {
+          currentValue: '1.3.1',
+          datasource: 'custom.hashicorp',
+          depName: 'consul',
+          replaceString:
+            '# renovate: datasource=custom.hashicorp depName=consul\n- export CONSUL_VERSION 1.3.1\n',
+        },
+        {
+          currentValue: 'v5.2.1',
+          datasource: 'github-releases',
+          depName: 'kubernetes-sigs/kustomize',
+          replaceString:
+            '# renovate: datasource=github-releases depName=kubernetes-sigs/kustomize versioning=regex:^(?<compatibility>.+)/v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$ extractVersion=^kustomize/(?<version>.+)$\n- export KUSTOMIZE_VERSION v5.2.1\n',
+          extractVersion: '^kustomize/(?<version>.+)$',
+          versioning:
+            'regex:^(?<compatibility>.+)/v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$',
+        },
+      ]);
+    });
+
+    describe('matches regexes patterns', () => {
+      it.each`
+        path                                  | expected
+        ${'bitbucket-pipelines.yml'}          | ${true}
+        ${'bitbucket-pipelines.yaml'}         | ${true}
+        ${'foo/bitbucket-pipelines.yml'}      | ${true}
+        ${'foo/bitbucket-pipelines.yaml'}     | ${true}
+        ${'foo/bar/bitbucket-pipelines.yml'}  | ${true}
+        ${'foo/bar/bitbucket-pipelines.yaml'} | ${true}
+        ${'bitbucket-pipelines'}              | ${false}
+      `('$path', ({ path, expected }) => {
+        expect(regexMatches(path, customManager!.fileMatch)).toBe(expected);
+      });
+    });
+  });
+
   describe('Update `_VERSION` variables in Dockerfiles', () => {
     const customManager = presets['dockerfileVersions'].customManagers?.[0];
 

--- a/lib/config/presets/internal/regex-managers.spec.ts
+++ b/lib/config/presets/internal/regex-managers.spec.ts
@@ -10,7 +10,7 @@ describe('config/presets/internal/regex-managers', () => {
 
     it(`find dependencies in file`, async () => {
       const fileContent = codeBlock`
-        - script:
+        script:
           # renovate: datasource=docker depName=node versioning=docker
           - export NODE_VERSION=18
 

--- a/lib/config/presets/internal/regex-managers.spec.ts
+++ b/lib/config/presets/internal/regex-managers.spec.ts
@@ -26,6 +26,15 @@ describe('config/presets/internal/regex-managers', () => {
           # renovate: datasource=github-releases depName=kubernetes-sigs/kustomize versioning=regex:^(?<compatibility>.+)/v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$ extractVersion=^kustomize/(?<version>.+)$
           - export KUSTOMIZE_VERSION v5.2.1
 
+          - pipe: something/cool:latest
+            variables:
+              # renovate: datasource=docker depName=node versioning=docker
+              NODE_VERSION: 18
+              # renovate: datasource=npm depName=pnpm
+              PNPM_VERSION:"7.25.1"
+              # renovate: datasource=npm depName=yarn
+              YARN_VERSION: '3.3.1'
+
           - echo $NODE_VERSION
       `;
 
@@ -74,6 +83,28 @@ describe('config/presets/internal/regex-managers', () => {
           extractVersion: '^kustomize/(?<version>.+)$',
           versioning:
             'regex:^(?<compatibility>.+)/v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$',
+        },
+        {
+          currentValue: '18',
+          datasource: 'docker',
+          depName: 'node',
+          replaceString:
+            '# renovate: datasource=docker depName=node versioning=docker\n      NODE_VERSION: 18\n',
+          versioning: 'docker',
+        },
+        {
+          currentValue: '7.25.1',
+          datasource: 'npm',
+          depName: 'pnpm',
+          replaceString:
+            '# renovate: datasource=npm depName=pnpm\n      PNPM_VERSION:"7.25.1"\n',
+        },
+        {
+          currentValue: '3.3.1',
+          datasource: 'npm',
+          depName: 'yarn',
+          replaceString:
+            "# renovate: datasource=npm depName=yarn\n      YARN_VERSION: '3.3.1'\n",
         },
       ]);
     });

--- a/lib/config/presets/internal/regex-managers.spec.ts
+++ b/lib/config/presets/internal/regex-managers.spec.ts
@@ -25,6 +25,8 @@ describe('config/presets/internal/regex-managers', () => {
 
           # renovate: datasource=github-releases depName=kubernetes-sigs/kustomize versioning=regex:^(?<compatibility>.+)/v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$ extractVersion=^kustomize/(?<version>.+)$
           - export KUSTOMIZE_VERSION v5.2.1
+
+          - echo $NODE_VERSION
       `;
 
       const res = await extractPackageFile(
@@ -39,7 +41,7 @@ describe('config/presets/internal/regex-managers', () => {
           datasource: 'docker',
           depName: 'node',
           replaceString:
-            '# renovate: datasource=docker depName=node versioning=docker\n- export NODE_VERSION=18\n',
+            '# renovate: datasource=docker depName=node versioning=docker\n  - export NODE_VERSION=18\n',
           versioning: 'docker',
         },
         {
@@ -47,28 +49,28 @@ describe('config/presets/internal/regex-managers', () => {
           datasource: 'npm',
           depName: 'pnpm',
           replaceString:
-            '# renovate: datasource=npm depName=pnpm\n- export PNPM_VERSION="7.25.1"\n',
+            '# renovate: datasource=npm depName=pnpm\n  - export PNPM_VERSION="7.25.1"\n',
         },
         {
           currentValue: '3.3.1',
           datasource: 'npm',
           depName: 'yarn',
           replaceString:
-            '# renovate: datasource=npm depName=yarn\n- export YARN_VERSION 3.3.1\n',
+            '# renovate: datasource=npm depName=yarn\n  - export YARN_VERSION 3.3.1\n',
         },
         {
           currentValue: '1.3.1',
           datasource: 'custom.hashicorp',
           depName: 'consul',
           replaceString:
-            '# renovate: datasource=custom.hashicorp depName=consul\n- export CONSUL_VERSION 1.3.1\n',
+            '# renovate: datasource=custom.hashicorp depName=consul\n  - export CONSUL_VERSION 1.3.1\n',
         },
         {
           currentValue: 'v5.2.1',
           datasource: 'github-releases',
           depName: 'kubernetes-sigs/kustomize',
           replaceString:
-            '# renovate: datasource=github-releases depName=kubernetes-sigs/kustomize versioning=regex:^(?<compatibility>.+)/v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$ extractVersion=^kustomize/(?<version>.+)$\n- export KUSTOMIZE_VERSION v5.2.1\n',
+            '# renovate: datasource=github-releases depName=kubernetes-sigs/kustomize versioning=regex:^(?<compatibility>.+)/v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$ extractVersion=^kustomize/(?<version>.+)$\n  - export KUSTOMIZE_VERSION v5.2.1\n',
           extractVersion: '^kustomize/(?<version>.+)$',
           versioning:
             'regex:^(?<compatibility>.+)/v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$',

--- a/lib/config/presets/internal/regex-managers.ts
+++ b/lib/config/presets/internal/regex-managers.ts
@@ -24,7 +24,7 @@ export const presets: Record<string, Preset> = {
         customType: 'regex',
         fileMatch: ['(^|/)bitbucket-pipelines\\.ya?ml$'],
         matchStrings: [
-          '# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?(?: registryUrl=(?<registryUrl>[^\\s]+?))?\\s+.*?[A-Za-z0-9_]+?_VERSION[ =]"?(?<currentValue>.+?)"?\\s',
+          '# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?(?: registryUrl=(?<registryUrl>[^\\s]+?))?\\s+.*\\s+[A-Za-z0-9_]+?_VERSION[ =]"?(?<currentValue>.+?)"?\\s',
         ],
       },
     ],

--- a/lib/config/presets/internal/regex-managers.ts
+++ b/lib/config/presets/internal/regex-managers.ts
@@ -24,7 +24,7 @@ export const presets: Record<string, Preset> = {
         customType: 'regex',
         fileMatch: ['(^|/)bitbucket-pipelines\\.ya?ml$'],
         matchStrings: [
-          '# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?(?: registryUrl=(?<registryUrl>[^\\s]+?))?\\s+.*\\s+[A-Za-z0-9_]+?_VERSION[ =]"?(?<currentValue>.+?)"?\\s',
+          '# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?(?: registryUrl=(?<registryUrl>[^\\s]+?))?\\s+.*\\s+[A-Za-z0-9_]+?_VERSION[ =:]\\s?["\']?(?<currentValue>.+?)["\']?\\s',
         ],
       },
     ],

--- a/lib/config/presets/internal/regex-managers.ts
+++ b/lib/config/presets/internal/regex-managers.ts
@@ -18,6 +18,18 @@ export const presets: Record<string, Preset> = {
     description:
       'Update `$schema` version in `biome.json` configuration files.',
   },
+  bitbucketPipelinesVersions: {
+    customManagers: [
+      {
+        customType: 'regex',
+        fileMatch: ['(^|/)bitbucket-pipelines\\.ya?ml$'],
+        matchStrings: [
+          '# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?(?: registryUrl=(?<registryUrl>[^\\s]+?))?\\s+.*?[A-Za-z0-9_]+?_VERSION[ =]"?(?<currentValue>.+?)"?\\s',
+        ],
+      },
+    ],
+    description: 'Update `_VERSION` variables in Bitbucket Pipelines',
+  },
   dockerfileVersions: {
     customManagers: [
       {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Borrowing from [regexManagers:dockerfileVersions](https://docs.renovatebot.com/presets-regexManagers/#regexmanagersdockerfileversions), create a preset regexManager for updating _VERSION variables within bitbucket-pipelines.yml

<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
