### PR TITLE
feat(gitlab): retry requests on resource locks

### DIFF
--- a/lib/util/http/gitlab.ts
+++ b/lib/util/http/gitlab.ts
@@ -85,7 +85,8 @@ export class GitlabHttp extends Http<GitlabHttpOptions> {
     }
   }
 
-  protected override calculateRetryDelay({ error, attemptCount, retryOptions }: RetryObject): number {
+  protected override calculateRetryDelay(retryObject: RetryObject): number {
+    const { error, attemptCount, retryOptions } = retryObject;
     if (
       attemptCount <= retryOptions.limit &&
       error.options.method === 'POST' &&

--- a/lib/util/http/gitlab.ts
+++ b/lib/util/http/gitlab.ts
@@ -85,11 +85,7 @@ export class GitlabHttp extends Http<GitlabHttpOptions> {
     }
   }
 
-  protected override calculateRetryDelay({
-    error,
-    attemptCount,
-    retryOptions,
-  }: RetryObject): number {
+  protected override calculateRetryDelay({ error, attemptCount, retryOptions }: RetryObject): number {
     if (
       attemptCount <= retryOptions.limit &&
       error.options.method === 'POST' &&

--- a/lib/util/http/gitlab.ts
+++ b/lib/util/http/gitlab.ts
@@ -85,7 +85,11 @@ export class GitlabHttp extends Http<GitlabHttpOptions> {
     }
   }
 
-  protected override calculateRetryDelay({ error, attemptCount, retryOptions }: RetryObject): number {
+  protected override calculateRetryDelay({
+    error,
+    attemptCount,
+    retryOptions,
+  }: RetryObject): number {
     if (
       attemptCount <= retryOptions.limit &&
       error.options.method === 'POST' &&

--- a/lib/util/http/gitlab.ts
+++ b/lib/util/http/gitlab.ts
@@ -85,8 +85,7 @@ export class GitlabHttp extends Http<GitlabHttpOptions> {
     }
   }
 
-  protected override calculateRetryDelay(retryObject: RetryObject): number {
-    const { error, attemptCount, retryOptions } = retryObject;
+  protected override calculateRetryDelay({ error, attemptCount, retryOptions }: RetryObject): number {
     if (
       attemptCount <= retryOptions.limit &&
       error.options.method === 'POST' &&

--- a/lib/util/http/index.ts
+++ b/lib/util/http/index.ts
@@ -1,6 +1,6 @@
 import is from '@sindresorhus/is';
 import merge from 'deepmerge';
-import got, { Options, RequestError } from 'got';
+import got, { Options, RequestError, RetryObject } from 'got';
 import type { SetRequired } from 'type-fest';
 import { infer as Infer, type ZodError, ZodType } from 'zod';
 import { GlobalConfig } from '../../config/global';
@@ -124,6 +124,8 @@ export class Http<Opts extends HttpOptions = HttpOptions> {
       {
         context: { hostType },
         retry: {
+          calculateDelay: (retryObject) =>
+            this.calculateRetryDelay(retryObject),
           limit: retryLimit,
           maxRetryAfter: 0, // Don't rely on `got` retry-after handling, just let it fail and then we'll handle it
         },
@@ -246,6 +248,10 @@ export class Http<Opts extends HttpOptions = HttpOptions> {
       }
       throw err;
     }
+  }
+
+  protected calculateRetryDelay({ computedValue }: RetryObject): number {
+    return computedValue;
   }
 
   get(url: string, options: HttpOptions = {}): Promise<HttpResponse> {


### PR DESCRIPTION
## Changes

This makes Renovate retry requests to the GitLab API when they fail with a resource lock error.

## Context

Closes https://github.com/renovatebot/renovate/issues/29006

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

:hammer_and_pick: with :heart: by [Siemens](https://opensource.siemens.com/) 