### PR TITLE
feat(datasource/kubernetes-api): add missing image api kinds

### DIFF
--- a/data/kubernetes-api.json5
+++ b/data/kubernetes-api.json5
@@ -143,7 +143,9 @@
     'source.toolkit.fluxcd.io/v1beta2',
     'source.toolkit.fluxcd.io/v1',
   ],
+  ImagePolicy: ['image.toolkit.fluxcd.io/v1beta2'],
   ImageRepository: ['image.toolkit.fluxcd.io/v1beta2'],
+  ImageUpdateAutomation: ['image.toolkit.fluxcd.io/v1beta2'],
   OCIRepository: ['source.toolkit.fluxcd.io/v1beta2'],
   Provider: [
     'notification.toolkit.fluxcd.io/v1beta2',

--- a/data/kubernetes-api.json5
+++ b/data/kubernetes-api.json5
@@ -145,7 +145,10 @@
   ],
   ImagePolicy: ['image.toolkit.fluxcd.io/v1beta2'],
   ImageRepository: ['image.toolkit.fluxcd.io/v1beta2'],
-  ImageUpdateAutomation: ['image.toolkit.fluxcd.io/v1beta2'],
+  ImageUpdateAutomation: [
+    'image.toolkit.fluxcd.io/v1beta1',
+    'image.toolkit.fluxcd.io/v1beta2'
+    ],
   OCIRepository: ['source.toolkit.fluxcd.io/v1beta2'],
   Provider: [
     'notification.toolkit.fluxcd.io/v1beta2',


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Add `ImagePolicy` and `ImageUpdateAutomation` kinds

## Context

[ImagePolicy](https://fluxcd.io/flux/components/image/imagepolicies/) and [ImageUpdateAutomation](https://fluxcd.io/flux/components/image/imageupdateautomations/) was missing

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
