### PR TITLE
fix(datasource/docker): use digest from header if available

### DIFF
--- a/lib/modules/datasource/docker/index.ts
+++ b/lib/modules/datasource/docker/index.ts
@@ -292,7 +292,14 @@ export class DockerDatasource extends Datasource {
     const parsed = ManifestJson.safeParse(manifestResponse.body);
     if (!parsed.success) {
       logger.debug(
-        { registry, dockerRepository, tag, err: parsed.error },
+        {
+          registry,
+          dockerRepository,
+          tag,
+          body: manifestResponse.body,
+          headers: manifestResponse.headers,
+          err: parsed.error,
+        },
         'Invalid manifest response',
       );
       return null;
@@ -856,10 +863,10 @@ export class DockerDatasource extends Datasource {
         );
 
         if (architecture && manifestResponse) {
-          const parse = ManifestJson.safeParse(manifestResponse.body);
+          const parsed = ManifestJson.safeParse(manifestResponse.body);
           /* istanbul ignore else: hard to test */
-          if (parse.success) {
-            const manifestList = parse.data;
+          if (parsed.success) {
+            const manifestList = parsed.data;
             if (
               manifestList.mediaType ===
                 'application/vnd.docker.distribution.manifest.list.v2+json' ||
@@ -891,6 +898,7 @@ export class DockerDatasource extends Datasource {
                 newTag,
                 body: manifestResponse.body,
                 headers: manifestResponse.headers,
+                err: parsed.error,
               },
               'Failed to parse manifest response',
             );


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Use digest from response header if it's a valid manifest, so we don't fallback to body computation.
Added todo's for another issue, whiuch needs more refactoring.
Added headers and body when manifest parsing fails.
<!-- Describe what behavior is changed by this PR. -->

## Context
- #28970
- https://github.com/renovate-reproductions/28970-renovate-docker-datasource
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
