### PR TITLE
feat(presets): add replacements for ZAP org moves

### DIFF
--- a/lib/config/presets/internal/replacements.ts
+++ b/lib/config/presets/internal/replacements.ts
@@ -956,7 +956,7 @@ export const presets: Record<string, Preset> = {
     packageRules: [
       {
         description:
-          'The `zap-stable` image has moved to the `zaproxy` organisation.',
+          'The `zap-stable` image has moved to the `zaproxy` organization.',
         matchCurrentVersion: '>=2.0.0 <2.14.0',
         matchDatasources: ['docker'],
         matchPackagePatterns: [
@@ -968,7 +968,7 @@ export const presets: Record<string, Preset> = {
       },
       {
         description:
-          'The `zap-bare` image has moved to the `zaproxy` organisation.',
+          'The `zap-bare` image has moved to the `zaproxy` organization.',
         matchCurrentVersion: '>=2.0.0 <2.14.0',
         matchDatasources: ['docker'],
         matchPackagePatterns: [

--- a/lib/config/presets/internal/replacements.ts
+++ b/lib/config/presets/internal/replacements.ts
@@ -47,6 +47,7 @@ export const presets: Record<string, Preset> = {
       'replacements:vso-task-lib-to-azure-pipelines-task-lib',
       'replacements:vsts-task-lib-to-azure-pipelines-task-lib',
       'replacements:xmldom-to-scoped',
+      'replacements:zap',
     ],
     ignoreDeps: [], // Hack to improve onboarding PR description
   },
@@ -947,6 +948,35 @@ export const presets: Record<string, Preset> = {
         matchPackageNames: ['xmldom', 'xmldom-alpha'],
         replacementName: '@xmldom/xmldom',
         replacementVersion: '0.7.5',
+      },
+    ],
+  },
+  zap: {
+    description: 'Replace ZAP dependencies.',
+    packageRules: [
+      {
+        description:
+          'The `zap-stable` image has moved to the `zaproxy` organisation.',
+        matchCurrentVersion: '>=2.0.0 <2.14.0',
+        matchDatasources: ['docker'],
+        matchPackagePatterns: [
+          '^(?:docker\\.io/)?owasp/zap2docker-stable$',
+          '^(?:docker\\.io/)?softwaresecurityproject/zap-stable$',
+        ],
+        replacementName: 'zaproxy/zap-stable',
+        replacementVersion: '2.14.0',
+      },
+      {
+        description:
+          'The `zap-bare` image has moved to the `zaproxy` organisation.',
+        matchCurrentVersion: '>=2.0.0 <2.14.0',
+        matchDatasources: ['docker'],
+        matchPackagePatterns: [
+          '^(?:docker\\.io/)?owasp/zap2docker-bare$',
+          '^(?:docker\\.io/)?softwaresecurityproject/zap-bare$',
+        ],
+        replacementName: 'zaproxy/zap-bare',
+        replacementVersion: '2.14.0',
       },
     ],
   },


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds replacements for the ZAP images

## Context

The ZAP images have moved to another org twice (!) this year:

- https://www.zaproxy.org/blog/2024-03-04-zap-updates-february-2024/#owasp-docker-org-depreciation
- https://www.zaproxy.org/blog/2024-05-01-zap-updates-april-2024/#new-zaproxy-dockerhub-org

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->

:hammer_and_pick: with :heart: by [Siemens](https://opensource.siemens.com/) 

/cc @nejch @dlouzan