### PR TITLE
docs(config): warn about spaces in `schedule`

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -3739,6 +3739,12 @@ every 3 months on the first day of the month
 
 <!-- prettier-ignore -->
 !!! warning
+    You _must_ keep the number and the `am`/`pm` part _together_!
+    Correct: `before 5am`, or `before 5:00am`.
+    Wrong: `before 5 am`, or `before 5:00 am`.
+
+<!-- prettier-ignore -->
+!!! warning
     For Cron schedules, you _must_ use the `*` wildcard for the minutes value, as Renovate doesn't support minute granularity.
 
 One example might be that you don't want Renovate to run during your typical business hours, so that your build machines don't get clogged up testing `package.json` updates.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Warn users that in the `schedule` config option:
  - `5am` is correct
  - `5 am` (with space) is wrong

## Context

`@rarkins` fixed a repository configuration error, they were using a space between `4` and `am`:

- https://github.com/slsa-framework/slsa-github-generator/issues/404#issue-1286144500
- https://github.com/slsa-framework/slsa-github-generator/pull/3638

The `schedule` docs only show examples of the _correct_ format, but it's easy to assume that `4 am` will work. Or to _accidentally_ add a space, because that feels natural.

I think we should warn louder about this possible gotcha. :smile: 

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
