### PR TITLE
docs(gitlab): add note about group access token rotation

### DIFF
--- a/lib/modules/platform/gitlab/readme.md
+++ b/lib/modules/platform/gitlab/readme.md
@@ -9,8 +9,9 @@ To start, create either:
 - a [Personal Access Token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html) for the bot account
 - or a [Group Access Token](https://docs.gitlab.com/ee/user/group/settings/group_access_tokens.html#bot-users-for-groups) for the bot account
 
-The bot account must have at least the Developer role in order to create issues and merge requests.
-The bot account must have the Maintainer role in order to perform automerge.
+The bot account must have at least the Developer role in order to [create issues and merge requests](https://docs.gitlab.com/ee/user/permissions.html#project-members-permissions).
+If you are using automerge, the bot account must have the appropriate "Allowed to merge" [permission on the protected branch](https://docs.gitlab.com/ee/user/project/protected_branches.html#require-everyone-to-submit-merge-requests-for-a-protected-branch) of your projects.
+If this is restricted to Maintainers, the bot account must have the Maintainer role.
 
 If you are using a group access token, to keep using the same GitLab-generated bot user you must [rotate/refresh the Group Access Token](https://docs.gitlab.com/ee/api/group_access_tokens.html#rotate-a-group-access-token) _before_ the token's expiry date.
 

--- a/lib/modules/platform/gitlab/readme.md
+++ b/lib/modules/platform/gitlab/readme.md
@@ -11,7 +11,7 @@ To start, create either:
 
 If you are using a Group access token, the token must have Developer role or higher permissions in order to create issues and merge requests.
 The token must have Maintainer permissions in order to perform Automerge.
-Ensure that you are [rotating the group access token](https://docs.gitlab.com/ee/api/group_access_tokens.html#rotate-a-group-access-token) before it expires in order to keep the same GitLab-generated bot user.
+To keep using the same GitLab-generated bot user you must [rotate/refresh the Group Access Token](https://docs.gitlab.com/ee/api/group_access_tokens.html#rotate-a-group-access-token) _before_ the token's expiry date.
 
 For real runs, give the access token these scopes:
 

--- a/lib/modules/platform/gitlab/readme.md
+++ b/lib/modules/platform/gitlab/readme.md
@@ -2,31 +2,29 @@
 
 ## Authentication
 
-First, [create a Personal Access Token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html) for the bot account.
+First, [create a Personal Access Token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html) for the bot account, or use a [Group Access Token](https://docs.gitlab.com/ee/user/group/settings/group_access_tokens.html#bot-users-for-groups).
 
 If you are using a Group access token, the token must have Developer role or higher permissions in order to create issues and merge requests.
 The token must have Maintainer permissions in order to perform Automerge.
+Ensure that you are [rotating the group access token](https://docs.gitlab.com/ee/api/group_access_tokens.html#rotate-a-group-access-token) before it expires in order to keep the same GitLab-generated bot user.
 
-For real runs, give the PAT these scopes:
+For real runs, give the access token these scopes:
 
-- `read_user`
 - `api`
 - `write_repository`
 - `read_registry` (only if Renovate needs to access the [GitLab Container registry](https://docs.gitlab.com/ee/user/packages/container_registry/))
 
-For dry runs, give the PAT these scopes:
+For dry runs, give the access token these scopes:
 
-- `read_user`
 - `read_api`
 - `read_repository`
-- `write_repository` (when using autodiscover)
 - `read_registry` (only if Renovate needs to access the [GitLab Container registry](https://docs.gitlab.com/ee/user/packages/container_registry/))
 
-Let Renovate use your PAT by doing _one_ of the following:
+Let Renovate use your access token by doing _one_ of the following:
 
-- Set your PAT as a `token` in your `config.js` file
-- Set your PAT as an environment variable `RENOVATE_TOKEN`
-- Set your PAT when you run Renovate in the CLI with `--token=`
+- Set your access token as a `token` in your `config.js` file
+- Set your access token as an environment variable `RENOVATE_TOKEN`
+- Set your access token when you run Renovate in the CLI with `--token=`
 
 Remember to set `platform=gitlab` somewhere in your Renovate config file.
 

--- a/lib/modules/platform/gitlab/readme.md
+++ b/lib/modules/platform/gitlab/readme.md
@@ -9,9 +9,10 @@ To start, create either:
 - a [Personal Access Token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html) for the bot account
 - or a [Group Access Token](https://docs.gitlab.com/ee/user/group/settings/group_access_tokens.html#bot-users-for-groups) for the bot account
 
-If you are using a Group access token, the token must have Developer role or higher permissions in order to create issues and merge requests.
-The token must have Maintainer permissions in order to perform Automerge.
-To keep using the same GitLab-generated bot user you must [rotate/refresh the Group Access Token](https://docs.gitlab.com/ee/api/group_access_tokens.html#rotate-a-group-access-token) _before_ the token's expiry date.
+The bot account must have at least the Developer role in order to create issues and merge requests.
+The bot account must have the Maintainer role in order to perform automerge.
+
+If you are using a group access token, to keep using the same GitLab-generated bot user you must [rotate/refresh the Group Access Token](https://docs.gitlab.com/ee/api/group_access_tokens.html#rotate-a-group-access-token) _before_ the token's expiry date.
 
 We refer to personal access tokens and group access tokens as _access tokens_ in the instructions that follow.
 

--- a/lib/modules/platform/gitlab/readme.md
+++ b/lib/modules/platform/gitlab/readme.md
@@ -13,6 +13,8 @@ If you are using a Group access token, the token must have Developer role or hig
 The token must have Maintainer permissions in order to perform Automerge.
 To keep using the same GitLab-generated bot user you must [rotate/refresh the Group Access Token](https://docs.gitlab.com/ee/api/group_access_tokens.html#rotate-a-group-access-token) _before_ the token's expiry date.
 
+We refer to personal access tokens and group access tokens as _access tokens_ in the instructions that follow.
+
 For real runs, give the access token these scopes:
 
 - `api`
@@ -36,8 +38,8 @@ Remember to set `platform=gitlab` somewhere in your Renovate config file.
 If you're using a private [GitLab container registry](https://docs.gitlab.com/ee/user/packages/container_registry/), you must:
 
 - Set the `RENOVATE_HOST_RULES` CI variable to `[{"matchHost": "${CI_REGISTRY}","username": "${GITLAB_USER_NAME}","password": "${RENOVATE_TOKEN}", "hostType": "docker"}]`.
-- Make sure the user that owns the `RENOVATE_TOKEN` PAT is a member of the corresponding GitLab projects/groups with the right permissions.
-- Make sure the `RENOVATE_TOKEN` PAT has the `read_registry` scope.
+- Make sure the user that owns the access token is a member of the corresponding GitLab projects/groups with the right permissions.
+- Make sure the access token has the `read_registry` scope.
 
 You may want to set `FORCE_COLOR: 3` or `TERM: ansi` to the job, in order to get colored output.
 [GitLab Runner runs the container’s shell in non-interactive mode, so the shell’s `TERM` environment variable is set to `dumb`.](https://docs.gitlab.com/ee/ci/yaml/script.html#job-log-output-is-not-formatted-as-expected-or-contains-unexpected-characters)

--- a/lib/modules/platform/gitlab/readme.md
+++ b/lib/modules/platform/gitlab/readme.md
@@ -2,7 +2,12 @@
 
 ## Authentication
 
-First, [create a Personal Access Token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html) for the bot account, or use a [Group Access Token](https://docs.gitlab.com/ee/user/group/settings/group_access_tokens.html#bot-users-for-groups).
+You can authenticate Renovate to GitLab, with a Personal Access Token, or Group Access Token.
+
+To start, create either:
+
+- a [Personal Access Token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html) for the bot account
+- or a [Group Access Token](https://docs.gitlab.com/ee/user/group/settings/group_access_tokens.html#bot-users-for-groups) for the bot account
 
 If you are using a Group access token, the token must have Developer role or higher permissions in order to create issues and merge requests.
 The token must have Maintainer permissions in order to perform Automerge.

--- a/lib/modules/platform/gitlab/readme.md
+++ b/lib/modules/platform/gitlab/readme.md
@@ -10,8 +10,8 @@ To start, create either:
 - or a [Group Access Token](https://docs.gitlab.com/ee/user/group/settings/group_access_tokens.html#bot-users-for-groups) for the bot account
 
 The bot account must have at least the Developer role in order to [create issues and merge requests](https://docs.gitlab.com/ee/user/permissions.html#project-members-permissions).
-If you are using automerge, the bot account must have the appropriate "Allowed to merge" [permission on the protected branch](https://docs.gitlab.com/ee/user/project/protected_branches.html#require-everyone-to-submit-merge-requests-for-a-protected-branch) of your projects.
-If this is restricted to Maintainers, the bot account must have the Maintainer role.
+If you are using automerge, the bot account must have the appropriate ["Allowed to merge" permission on the protected branch](https://docs.gitlab.com/ee/user/project/protected_branches.html#require-everyone-to-submit-merge-requests-for-a-protected-branch) of your projects.
+If merging is restricted to Maintainers, the bot account must have the Maintainer role.
 
 If you are using a group access token, to keep using the same GitLab-generated bot user you must [rotate/refresh the Group Access Token](https://docs.gitlab.com/ee/api/group_access_tokens.html#rotate-a-group-access-token) _before_ the token's expiry date.
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This PR adds a note about rotating the group access token to keep the same bot user.

Also updated the required scopes (`api` allows one to `read_user`, and autodiscover uses the API so `read_api` is sufficient).

## Context

See the discussion in https://github.com/renovatebot/renovate/discussions/28736#discussioncomment-9437710 

Closes #21121 

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
