### PR TITLE
feat(util/package-rules): allow glob pattens in match{Current,New}Value

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2749,14 +2749,15 @@ Use this field to restrict rules to a particular datasource. e.g.
 
 This option is matched against the `currentValue` field of a dependency.
 
-`matchCurrentValue` supports Regular Expressions and glob patterns. For example, the following enforces that only `1.*` versions will be used:
+`matchCurrentValue` supports Regular Expressions and glob patterns. For example, the following enforces that updates from `1.*` versions will be merged automatically:
 
 ```json
 {
   "packageRules": [
     {
       "matchPackagePatterns": ["io.github.resilience4j"],
-      "matchCurrentValue": "1.*"
+      "matchCurrentValue": "1.*",
+      "automerge": true
     }
   ]
 }
@@ -2903,14 +2904,15 @@ This field behaves the same as `matchPackageNames` except it matches against `de
 
 This option is matched against the `newValue` field of a dependency.
 
-`matchNewValue` supports Regular Expressions and glob patterns. For example, the following enforces that only `1.*` versions will be used:
+`matchNewValue` supports Regular Expressions and glob patterns. For example, the following enforces that updates to `1.*` versions will be merged automatically:
 
 ```json
 {
   "packageRules": [
     {
       "matchPackagePatterns": ["io.github.resilience4j"],
-      "matchNewValue": "1.*"
+      "matchNewValue": "1.*",
+      "automerge": true
     }
   ]
 }

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2749,8 +2749,20 @@ Use this field to restrict rules to a particular datasource. e.g.
 
 This option is matched against the `currentValue` field of a dependency.
 
-`matchCurrentValue` supports Regular Expressions which must begin and end with `/`.
-For example, the following enforces that only `1.*` versions will be used:
+`matchCurrentValue` supports Regular Expressions and glob patterns. For example, the following enforces that only `1.*` versions will be used:
+
+```json
+{
+  "packageRules": [
+    {
+      "matchPackagePatterns": ["io.github.resilience4j"],
+      "matchCurrentValue": "1.*"
+    }
+  ]
+}
+```
+
+Regular Expressions must begin and end with `/`.
 
 ```json
 {
@@ -2891,8 +2903,20 @@ This field behaves the same as `matchPackageNames` except it matches against `de
 
 This option is matched against the `newValue` field of a dependency.
 
-`matchNewValue` supports Regular Expressions which must begin and end with `/`.
-For example, the following enforces that only `1.*` versions will be used:
+`matchNewValue` supports Regular Expressions and glob patterns. For example, the following enforces that only `1.*` versions will be used:
+
+```json
+{
+  "packageRules": [
+    {
+      "matchPackagePatterns": ["io.github.resilience4j"],
+      "matchNewValue": "1.*"
+    }
+  ]
+}
+```
+
+Regular Expressions must begin and end with `/`.
 
 ```json
 {

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -1503,7 +1503,7 @@ const options: RenovateOptions[] = [
   {
     name: 'matchCurrentValue',
     description:
-      'A regex to match against the raw `currentValue` string of a dependency. Valid only within a `packageRules` object.',
+      'A regex or glob pattern to match against the raw `currentValue` string of a dependency. Valid only within a `packageRules` object.',
     type: 'string',
     stage: 'package',
     parents: ['packageRules'],
@@ -1525,7 +1525,7 @@ const options: RenovateOptions[] = [
   {
     name: 'matchNewValue',
     description:
-      'A regex to match against the raw `newValue` string of a dependency. Valid only within a `packageRules` object.',
+      'A regex or glob pattern to match against the raw `newValue` string of a dependency. Valid only within a `packageRules` object.',
     type: 'string',
     stage: 'package',
     parents: ['packageRules'],

--- a/lib/config/validation.spec.ts
+++ b/lib/config/validation.spec.ts
@@ -163,10 +163,15 @@ describe('config/validation', () => {
             matchCurrentValue: '/^2/i',
             enabled: true,
           },
+          {
+            matchPackageNames: ['bad'],
+            matchNewValue: '/^2(/',
+            enabled: true,
+          },
         ],
       };
       const { errors } = await configValidation.validateConfig('repo', config);
-      expect(errors).toHaveLength(2);
+      expect(errors).toHaveLength(1);
     });
 
     it('catches invalid matchNewValue', async () => {
@@ -192,10 +197,15 @@ describe('config/validation', () => {
             matchNewValue: '/^2/i',
             enabled: true,
           },
+          {
+            matchPackageNames: ['bad'],
+            matchNewValue: '/^2(/',
+            enabled: true,
+          },
         ],
       };
       const { errors } = await configValidation.validateConfig('repo', config);
-      expect(errors).toHaveLength(2);
+      expect(errors).toHaveLength(1);
     });
 
     it('catches invalid matchCurrentVersion regex', async () => {

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -298,7 +298,12 @@ export async function validateConfig(
           });
         }
       } else if (
-        ['allowedVersions', 'matchCurrentVersion'].includes(key) &&
+        [
+          'allowedVersions',
+          'matchCurrentVersion',
+          'matchCurrentValue',
+          'matchNewValue',
+        ].includes(key) &&
         isRegexMatch(val)
       ) {
         if (!getRegexPredicate(val)) {
@@ -307,24 +312,6 @@ export async function validateConfig(
             message: `Invalid regExp for ${currentPath}: \`${val}\``,
           });
         }
-      } else if (
-        key === 'matchCurrentValue' &&
-        is.string(val) &&
-        !getRegexPredicate(val)
-      ) {
-        errors.push({
-          topic: 'Configuration Error',
-          message: `Invalid regExp for ${currentPath}: \`${val}\``,
-        });
-      } else if (
-        key === 'matchNewValue' &&
-        is.string(val) &&
-        !getRegexPredicate(val)
-      ) {
-        errors.push({
-          topic: 'Configuration Error',
-          message: `Invalid regExp for ${currentPath}: \`${val}\``,
-        });
       } else if (key === 'timezone' && val !== null) {
         const [validTimezone, errorMessage] = hasValidTimezone(val as string);
         if (!validTimezone) {

--- a/lib/util/package-rules/current-value.spec.ts
+++ b/lib/util/package-rules/current-value.spec.ts
@@ -4,13 +4,37 @@ describe('util/package-rules/current-value', () => {
   const matcher = new CurrentValueMatcher();
 
   describe('match', () => {
-    it('return null if non-regex', () => {
+    it('return true for exact match', () => {
       const result = matcher.matches(
         {
-          currentValue: '"~> 1.1.0"',
+          currentValue: '1.1.0',
         },
         {
-          matchCurrentValue: '^v',
+          matchCurrentValue: '1.1.0',
+        },
+      );
+      expect(result).toBeTrue();
+    });
+
+    it('return true for glob match', () => {
+      const result = matcher.matches(
+        {
+          currentValue: '1.2.3',
+        },
+        {
+          matchCurrentValue: '1.2.*',
+        },
+      );
+      expect(result).toBeTrue();
+    });
+
+    it('return false for glob non match', () => {
+      const result = matcher.matches(
+        {
+          currentValue: '1.2.3',
+        },
+        {
+          matchCurrentValue: '1.3.*',
         },
       );
       expect(result).toBeFalse();

--- a/lib/util/package-rules/current-value.ts
+++ b/lib/util/package-rules/current-value.ts
@@ -1,7 +1,6 @@
 import is from '@sindresorhus/is';
 import type { PackageRule, PackageRuleInputConfig } from '../../config/types';
-import { logger } from '../../logger';
-import { getRegexPredicate } from '../string-match';
+import { getRegexOrGlobPredicate } from '../string-match';
 import { Matcher } from './base';
 
 export class CurrentValueMatcher extends Matcher {
@@ -12,15 +11,7 @@ export class CurrentValueMatcher extends Matcher {
     if (is.undefined(matchCurrentValue)) {
       return null;
     }
-    const matchCurrentValuePred = getRegexPredicate(matchCurrentValue);
-
-    if (!matchCurrentValuePred) {
-      logger.debug(
-        { matchCurrentValue },
-        'matchCurrentValue should be a regex, starting and ending with `/`',
-      );
-      return false;
-    }
+    const matchCurrentValuePred = getRegexOrGlobPredicate(matchCurrentValue);
 
     if (!currentValue) {
       return false;

--- a/lib/util/package-rules/new-value.spec.ts
+++ b/lib/util/package-rules/new-value.spec.ts
@@ -4,13 +4,37 @@ describe('util/package-rules/new-value', () => {
   const matcher = new NewValueMatcher();
 
   describe('match', () => {
-    it('return null if non-regex', () => {
+    it('return true for exact match', () => {
       const result = matcher.matches(
         {
-          newValue: '"~> 1.1.0"',
+          newValue: '1.1.0',
         },
         {
-          matchNewValue: '^v',
+          matchNewValue: '1.1.0',
+        },
+      );
+      expect(result).toBeTrue();
+    });
+
+    it('return true for glob match', () => {
+      const result = matcher.matches(
+        {
+          newValue: '1.2.3',
+        },
+        {
+          matchNewValue: '1.2.*',
+        },
+      );
+      expect(result).toBeTrue();
+    });
+
+    it('return false for glob non match', () => {
+      const result = matcher.matches(
+        {
+          newValue: '1.2.3',
+        },
+        {
+          matchNewValue: '1.3.*',
         },
       );
       expect(result).toBeFalse();

--- a/lib/util/package-rules/new-value.ts
+++ b/lib/util/package-rules/new-value.ts
@@ -1,7 +1,6 @@
 import is from '@sindresorhus/is';
 import type { PackageRule, PackageRuleInputConfig } from '../../config/types';
-import { logger } from '../../logger';
-import { getRegexPredicate } from '../string-match';
+import { getRegexOrGlobPredicate } from '../string-match';
 import { Matcher } from './base';
 
 export class NewValueMatcher extends Matcher {
@@ -12,15 +11,7 @@ export class NewValueMatcher extends Matcher {
     if (is.undefined(matchNewValue)) {
       return null;
     }
-    const matchNewValuePred = getRegexPredicate(matchNewValue);
-
-    if (!matchNewValuePred) {
-      logger.debug(
-        { matchNewValue },
-        'matchNewValue should be a regex, starting and ending with `/`',
-      );
-      return false;
-    }
+    const matchNewValuePred = getRegexOrGlobPredicate(matchNewValue);
 
     if (!newValue) {
       return false;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Allow glob patterns in `packageRules.match{Current,New}Value`

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

- #29167

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
