### PR TITLE
fix(pdm): change pdm update strategy to eager

### DIFF
--- a/lib/modules/manager/pep621/artifacts.spec.ts
+++ b/lib/modules/manager/pep621/artifacts.spec.ts
@@ -127,7 +127,7 @@ requires-python = "<3.9"
             '&& ' +
             'install-tool pdm v2.5.0 ' +
             '&& ' +
-            'pdm update --no-sync dep1' +
+            'pdm update --no-sync --update-eager dep1' +
             '"',
           options: {
             cwd: '/tmp/github/some/repo',

--- a/lib/modules/manager/pep621/processors/pdm.spec.ts
+++ b/lib/modules/manager/pep621/processors/pdm.spec.ts
@@ -89,7 +89,7 @@ describe('modules/manager/pep621/processors/pdm', () => {
             '&& ' +
             'install-tool pdm v2.5.0 ' +
             '&& ' +
-            'pdm update --no-sync dep1' +
+            'pdm update --no-sync --update-eager dep1' +
             '"',
         },
       ]);
@@ -177,16 +177,16 @@ describe('modules/manager/pep621/processors/pdm', () => {
       ]);
       expect(execSnapshots).toMatchObject([
         {
-          cmd: 'pdm update --no-sync dep1 dep2',
+          cmd: 'pdm update --no-sync --update-eager dep1 dep2',
         },
         {
-          cmd: 'pdm update --no-sync -G group1 dep3 dep4',
+          cmd: 'pdm update --no-sync --update-eager -G group1 dep3 dep4',
         },
         {
-          cmd: 'pdm update --no-sync -dG group2 dep5 dep6',
+          cmd: 'pdm update --no-sync --update-eager -dG group2 dep5 dep6',
         },
         {
-          cmd: 'pdm update --no-sync -dG group3 dep7 dep8',
+          cmd: 'pdm update --no-sync --update-eager -dG group3 dep7 dep8',
         },
       ]);
     });
@@ -228,7 +228,7 @@ describe('modules/manager/pep621/processors/pdm', () => {
       ]);
       expect(execSnapshots).toMatchObject([
         {
-          cmd: 'pdm update --no-sync',
+          cmd: 'pdm update --no-sync --update-eager',
           options: {
             cwd: '/tmp/github/some/repo/folder',
           },

--- a/lib/modules/manager/pep621/processors/pdm.ts
+++ b/lib/modules/manager/pep621/processors/pdm.ts
@@ -17,7 +17,7 @@ import { PdmLockfileSchema, type PyProject } from '../schema';
 import { depTypes, parseDependencyGroupRecord } from '../utils';
 import type { PyProjectProcessor } from './types';
 
-const pdmUpdateCMD = 'pdm update --no-sync';
+const pdmUpdateCMD = 'pdm update --no-sync --update-eager';
 
 export class PdmProcessor implements PyProjectProcessor {
   process(project: PyProject, deps: PackageDependency[]): PackageDependency[] {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Per discussion [here](https://github.com/pdm-project/pdm/discussions/2890), we should use `eager` update strategy when using pdm.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
