### PR TITLE
feat(asdf): Add rebar3 to asdf manager

### DIFF
--- a/lib/modules/manager/asdf/extract.spec.ts
+++ b/lib/modules/manager/asdf/extract.spec.ts
@@ -490,7 +490,6 @@ dummy 1.2.3
             datasource: 'github-tags',
             packageName: 'erlang/rebar3',
             depName: 'rebar',
-            extractVersion: '^(?<version>\\S+)',
           },
           {
             currentValue: '3.1.2',

--- a/lib/modules/manager/asdf/extract.spec.ts
+++ b/lib/modules/manager/asdf/extract.spec.ts
@@ -98,6 +98,7 @@ poetry 1.3.2
 pre-commit 3.3.1
 pulumi 3.57.1
 python 3.11.0
+rebar 3.23.0
 ruby 3.1.2
 rust 1.64.0
 sbt 1.9.7
@@ -483,6 +484,13 @@ dummy 1.2.3
             packageName: 'python/cpython',
             depName: 'python',
             extractVersion: '^v(?<version>\\S+)',
+          },
+          {
+            currentValue: '3.23.0',
+            datasource: 'github-tags',
+            packageName: 'erlang/rebar3',
+            depName: 'rebar',
+            extractVersion: '^(?<version>\\S+)',
           },
           {
             currentValue: '3.1.2',

--- a/lib/modules/manager/asdf/upgradeable-tooling.ts
+++ b/lib/modules/manager/asdf/upgradeable-tooling.ts
@@ -505,7 +505,6 @@ export const upgradeableTooling: Record<string, ToolingDefinition> = {
     config: {
       datasource: GithubTagsDatasource.id,
       packageName: 'erlang/rebar3',
-      extractVersion: '^(?<version>\\S+)',
     },
   },
   ruby: {

--- a/lib/modules/manager/asdf/upgradeable-tooling.ts
+++ b/lib/modules/manager/asdf/upgradeable-tooling.ts
@@ -500,6 +500,14 @@ export const upgradeableTooling: Record<string, ToolingDefinition> = {
       extractVersion: '^v(?<version>\\S+)',
     },
   },
+  rebar: {
+    asdfPluginUrl: 'https://github.com/Stratus3D/asdf-rebar.git',
+    config: {
+      datasource: GithubTagsDatasource.id,
+      packageName: 'erlang/rebar3',
+      extractVersion: '^(?<version>\\S+)',
+    },
+  },
   ruby: {
     asdfPluginUrl: 'https://github.com/asdf-vm/asdf-ruby',
     config: {


### PR DESCRIPTION
## Changes

This pull request adds support to bumping `rebar` entries in `.tool-versions` files, as supported by https://asdf-vm.com/.

## Context

I saw `rebar` was not supported, and the change seems small enough for a first pull request.

## Further considerations

Mind you that `rebar3` is declared as `rebar` in `.tool-versions` but fetched from [erlang/rebar3](https://github.com/erlang/rebar3).

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository