### PR TITLE
feat(asdf): Add minikube to asdf manager

### DIFF
--- a/lib/modules/manager/asdf/extract.spec.ts
+++ b/lib/modules/manager/asdf/extract.spec.ts
@@ -87,6 +87,7 @@ kustomize 4.5.7
 lua 5.4.4
 maven 3.9.6
 mimirtool 2.11.0
+minikube 1.33.1
 nim 1.6.8
 nodejs 18.12.0
 ocaml 4.14.0
@@ -410,6 +411,13 @@ dummy 1.2.3
             packageName: 'grafana/mimir',
             depName: 'mimirtool',
             extractVersion: '^mimir-(?<version>\\S+)',
+          },
+          {
+            currentValue: 'v1.33.1',
+            datasource: 'github-releases',
+            packageName: 'kubernetes/minikube',
+            depName: 'minikube',
+            extractVersion: '^v(?<version>\\S+)',
           },
           {
             currentValue: '1.6.8',

--- a/lib/modules/manager/asdf/extract.spec.ts
+++ b/lib/modules/manager/asdf/extract.spec.ts
@@ -413,7 +413,7 @@ dummy 1.2.3
             extractVersion: '^mimir-(?<version>\\S+)',
           },
           {
-            currentValue: 'v1.33.1',
+            currentValue: '1.33.1',
             datasource: 'github-releases',
             packageName: 'kubernetes/minikube',
             depName: 'minikube',

--- a/lib/modules/manager/asdf/upgradeable-tooling.ts
+++ b/lib/modules/manager/asdf/upgradeable-tooling.ts
@@ -415,6 +415,14 @@ export const upgradeableTooling: Record<string, ToolingDefinition> = {
       extractVersion: '^mimir-(?<version>\\S+)',
     },
   },
+  minikube: {
+    asdfPluginUrl: 'https://github.com/alvarobp/asdf-minikube.git',
+    config: {
+      datasource: GithubReleasesDatasource.id,
+      packageName: 'kubernetes/minikube',
+      extractVersion: '^v(?<version>\\S+)',
+    },
+  },
   nim: {
     asdfPluginUrl: 'https://github.com/asdf-community/asdf-nim',
     config: {


### PR DESCRIPTION
## Changes

This pull request adds support to bumping `minikube` entries in `.tool-versions` files, as supported by https://asdf-vm.com/.

## Context

`minikube` is not supported (by Renovate) in `.tool-versions` files, at this moment.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository