### PR TITLE
feat(bitbucket-server): enable client TLS based authN/authZ

### DIFF
--- a/lib/modules/platform/bitbucket-server/utils.spec.ts
+++ b/lib/modules/platform/bitbucket-server/utils.spec.ts
@@ -295,6 +295,18 @@ describe('modules/platform/bitbucket-server/utils', () => {
       const res = getExtraCloneOpts({ token: 'abc' });
       expect(res).toEqual({
         '-c': 'http.extraheader=Authorization: Bearer abc',
+
+        it('works with gitUrl:endpoint and no username/password', () => {
+          expect(
+            getRepoGitUrl(
+              'SOME/repo',
+              url.toString(),
+              'endpoint',
+              infoMock(url, 'SOME', 'repo'),
+              { username: '' },
+            ),
+          ).toBe(httpLink(url.toString(), 'SOME', 'repo'));
+        });
       });
     });
   });


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This diff enables the use of a TLS client cert for authentication/authorization with BitBucket Server by modifying the
configuration checks.

* We only fail the username/password/token check if no client TLS cert is provided.
* If a username is not provided, we attempt to look it up using the BitBucket Server `whoami` API. This is useful in cases
  where the username is not known in advance.

## Context

I am using renovate an environment where we do not allow password or bearer token based authentication to VCS or BitBucket's APIs. Instead we leverage Mutual TLS to identify users and apps.

References: [HTTP Authentication Handler Plugin Module](https://developer.atlassian.com/server/bitbucket/reference/plugin-module-types/http-authentication-handler/)

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [] Newly added/modified unit tests, or
- [] No unit tests but ran on a real repository, or
- [X] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
