### PR TITLE
feat(gomod): Support go work vendor

### DIFF
--- a/lib/modules/manager/gomod/artifacts.spec.ts
+++ b/lib/modules/manager/gomod/artifacts.spec.ts
@@ -268,6 +268,10 @@ describe('modules/manager/gomod/artifacts', () => {
         cmd: 'go mod tidy',
         options: { cwd: '/tmp/github/some/repo' },
       },
+      {
+        cmd: 'go mod tidy',
+        options: { cwd: '/tmp/github/some/repo' },
+      },
     ]);
   });
 
@@ -360,6 +364,10 @@ describe('modules/manager/gomod/artifacts', () => {
       },
       {
         cmd: 'go work sync',
+        options: { cwd: '/tmp/github/some/repo' },
+      },
+      {
+        cmd: 'go mod tidy',
         options: { cwd: '/tmp/github/some/repo' },
       },
       {

--- a/lib/modules/manager/gomod/artifacts.spec.ts
+++ b/lib/modules/manager/gomod/artifacts.spec.ts
@@ -268,10 +268,6 @@ describe('modules/manager/gomod/artifacts', () => {
         cmd: 'go mod tidy',
         options: { cwd: '/tmp/github/some/repo' },
       },
-      {
-        cmd: 'go mod tidy',
-        options: { cwd: '/tmp/github/some/repo' },
-      },
     ]);
   });
 

--- a/lib/modules/manager/gomod/artifacts.spec.ts
+++ b/lib/modules/manager/gomod/artifacts.spec.ts
@@ -1,10 +1,7 @@
 import { codeBlock } from 'common-tags';
 import { mockDeep } from 'jest-mock-extended';
 import { join } from 'upath';
-import {
-  envMock,
-  mockExecAll,
-} from '../../../../test/exec-util';
+import { envMock, mockExecAll } from '../../../../test/exec-util';
 import { env, fs, git, mocked, partial } from '../../../../test/util';
 import { GlobalConfig } from '../../../config/global';
 import type { RepoGlobalConfig } from '../../../config/types';

--- a/lib/modules/manager/gomod/artifacts.spec.ts
+++ b/lib/modules/manager/gomod/artifacts.spec.ts
@@ -257,10 +257,6 @@ describe('modules/manager/gomod/artifacts', () => {
 
     expect(execSnapshots).toMatchObject([
       {
-        cmd: 'go env GOWORK',
-        options: { cwd: '/tmp/github/some/repo' },
-      },
-      {
         cmd: 'go get -d -t ./...',
         options: { cwd: '/tmp/github/some/repo' },
       },
@@ -286,17 +282,8 @@ describe('modules/manager/gomod/artifacts', () => {
 
     fs.readLocalFile.mockResolvedValueOnce('Current go.sum');
     fs.readLocalFile.mockResolvedValueOnce('modules.txt content'); // vendor modules filename
-    fs.readLocalFile.mockResolvedValueOnce('Current go.work'); // go.work
-    const execSnapshots = mockExecSequence([
-      // Set the output returned by go env GOWORK
-      { stdout: '/tmp/github/some/repo/go.work', stderr: '' },
-      // Remaining output does not matter
-      { stdout: '', stderr: '' },
-      { stdout: '', stderr: '' },
-      { stdout: '', stderr: '' },
-      { stdout: '', stderr: '' },
-      { stdout: '', stderr: '' },
-    ]);
+    fs.findLocalSiblingOrParent.mockResolvedValueOnce('go.work');
+    const execSnapshots = mockExecAll();
     git.getRepoStatus.mockResolvedValueOnce(
       partial<StatusResult>({
         modified: ['go.sum', 'go.work.sum', foo],
@@ -363,10 +350,6 @@ describe('modules/manager/gomod/artifacts', () => {
     ]);
 
     expect(execSnapshots).toMatchObject([
-      {
-        cmd: 'go env GOWORK',
-        options: { cwd: '/tmp/github/some/repo' },
-      },
       {
         cmd: 'go get -d -t ./...',
         options: { cwd: '/tmp/github/some/repo' },

--- a/lib/modules/manager/gomod/artifacts.spec.ts
+++ b/lib/modules/manager/gomod/artifacts.spec.ts
@@ -1,7 +1,11 @@
 import { codeBlock } from 'common-tags';
 import { mockDeep } from 'jest-mock-extended';
 import { join } from 'upath';
-import { envMock, mockExecAll, mockExecSequence } from '../../../../test/exec-util';
+import {
+  envMock,
+  mockExecAll,
+  mockExecSequence,
+} from '../../../../test/exec-util';
 import { env, fs, git, mocked, partial } from '../../../../test/util';
 import { GlobalConfig } from '../../../config/global';
 import type { RepoGlobalConfig } from '../../../config/types';
@@ -285,13 +289,13 @@ describe('modules/manager/gomod/artifacts', () => {
     fs.readLocalFile.mockResolvedValueOnce('Current go.work'); // go.work
     const execSnapshots = mockExecSequence([
       // Set the output returned by go env GOWORK
-      {stdout: '/tmp/github/some/repo/go.work', stderr: ''},
+      { stdout: '/tmp/github/some/repo/go.work', stderr: '' },
       // Remaining output does not matter
-      {stdout: '', stderr: ''},
-      {stdout: '', stderr: ''},
-      {stdout: '', stderr: ''},
-      {stdout: '', stderr: ''},
-      {stdout: '', stderr: ''},
+      { stdout: '', stderr: '' },
+      { stdout: '', stderr: '' },
+      { stdout: '', stderr: '' },
+      { stdout: '', stderr: '' },
+      { stdout: '', stderr: '' },
     ]);
     git.getRepoStatus.mockResolvedValueOnce(
       partial<StatusResult>({

--- a/lib/modules/manager/gomod/artifacts.spec.ts
+++ b/lib/modules/manager/gomod/artifacts.spec.ts
@@ -4,7 +4,6 @@ import { join } from 'upath';
 import {
   envMock,
   mockExecAll,
-  mockExecSequence,
 } from '../../../../test/exec-util';
 import { env, fs, git, mocked, partial } from '../../../../test/util';
 import { GlobalConfig } from '../../../config/global';

--- a/lib/modules/manager/gomod/artifacts.ts
+++ b/lib/modules/manager/gomod/artifacts.ts
@@ -237,6 +237,7 @@ export async function updateArtifacts({
         throw new Error('Invalid goGetDirs');
       }
     }
+
     let args = `get -d -t ${goGetDirs ?? './...'}`;
     logger.trace({ cmd, args }, 'go get command included');
     execCommands.push(`${cmd} ${args}`);
@@ -276,7 +277,6 @@ export async function updateArtifacts({
         config.postUpdateOptions?.includes('gomodTidy1.17') === true ||
         config.postUpdateOptions?.includes('gomodTidyE') === true ||
         (config.updateType === 'major' && isImportPathUpdateRequired));
-
     if (isGoModTidyRequired) {
       args = 'mod tidy' + tidyOpts;
       logger.debug('go mod tidy command included');
@@ -290,7 +290,7 @@ export async function updateArtifacts({
       const goWorkEnv = await exec(`${cmd} env GOWORK`, execOptions);
       const goWorkFile = goWorkEnv?.stdout?.trim() || '';
       const useGoWork = goWorkFile.length && ((await readLocalFile(goWorkFile)) !== null);
-      if (useGoWork) {
+      if (!useGoWork) {
         logger.debug('No go.work found');
       }
 
@@ -308,6 +308,7 @@ export async function updateArtifacts({
         execCommands.push(`${cmd} ${args}`);
       }
     }
+
     // We tidy one more time as a solution for #6795
     if (isGoModTidyRequired) {
       args = 'mod tidy' + tidyOpts;

--- a/lib/modules/manager/gomod/artifacts.ts
+++ b/lib/modules/manager/gomod/artifacts.ts
@@ -13,6 +13,7 @@ import {
   isValidLocalPath,
   readLocalFile,
   writeLocalFile,
+  findLocalSiblingOrParent,
 } from '../../../util/fs';
 import { getRepoStatus } from '../../../util/git';
 import { getGitEnvironmentVariables } from '../../../util/git/auth';
@@ -287,15 +288,15 @@ export async function updateArtifacts({
     if (useVendor) {
       // If go env GOWORK returns a non-empty path, check that it exists and if
       // it does, then use go workspace vendoring.
-      const goWorkEnv = await exec(`${cmd} env GOWORK`, execOptions);
-      const goWorkFile = goWorkEnv?.stdout?.trim() || '';
-      const useGoWork =
-        goWorkFile.length && (await readLocalFile(goWorkFile)) !== null;
-      if (!useGoWork) {
+      const goWorkFile = await findLocalSiblingOrParent(
+        goModFileName,
+        'go.work',
+      );
+      if (!goWorkFile) {
         logger.debug('No go.work found');
       }
 
-      if (useGoWork) {
+      if (goWorkFile) {
         args = 'work vendor';
         logger.debug('using go work vendor');
         execCommands.push(`${cmd} ${args}`);

--- a/lib/modules/manager/gomod/artifacts.ts
+++ b/lib/modules/manager/gomod/artifacts.ts
@@ -286,15 +286,11 @@ export async function updateArtifacts({
 
     const goWorkSumFileName = upath.join(goModDir, 'go.work.sum');
     if (useVendor) {
-      // If go env GOWORK returns a non-empty path, check that it exists and if
-      // it does, then use go workspace vendoring.
+      // If we find a go.work, then use go workspace vendoring.
       const goWorkFile = await findLocalSiblingOrParent(
         goModFileName,
         'go.work',
       );
-      if (!goWorkFile) {
-        logger.debug('No go.work found');
-      }
 
       if (goWorkFile) {
         args = 'work vendor';

--- a/lib/modules/manager/gomod/artifacts.ts
+++ b/lib/modules/manager/gomod/artifacts.ts
@@ -285,11 +285,6 @@ export async function updateArtifacts({
       args = 'mod vendor';
       logger.debug('go mod tidy command included');
       execCommands.push(`${cmd} ${args}`);
-      if (isGoModTidyRequired) {
-        args = 'mod tidy' + tidyOpts;
-        logger.debug('go mod tidy command included');
-        execCommands.push(`${cmd} ${args}`);
-      }
     }
 
     // We tidy one more time as a solution for #6795

--- a/lib/modules/manager/gomod/artifacts.ts
+++ b/lib/modules/manager/gomod/artifacts.ts
@@ -10,10 +10,10 @@ import { exec } from '../../../util/exec';
 import type { ExecOptions } from '../../../util/exec/types';
 import {
   ensureCacheDir,
+  findLocalSiblingOrParent,
   isValidLocalPath,
   readLocalFile,
   writeLocalFile,
-  findLocalSiblingOrParent,
 } from '../../../util/fs';
 import { getRepoStatus } from '../../../util/git';
 import { getGitEnvironmentVariables } from '../../../util/git/auth';

--- a/lib/modules/manager/gomod/artifacts.ts
+++ b/lib/modules/manager/gomod/artifacts.ts
@@ -305,6 +305,12 @@ export async function updateArtifacts({
         logger.debug('using go mod vendor');
         execCommands.push(`${cmd} ${args}`);
       }
+
+      if (isGoModTidyRequired) {
+        args = 'mod tidy' + tidyOpts;
+        logger.debug('go mod tidy command included');
+        execCommands.push(`${cmd} ${args}`);
+      }
     }
 
     // We tidy one more time as a solution for #6795

--- a/lib/modules/manager/gomod/artifacts.ts
+++ b/lib/modules/manager/gomod/artifacts.ts
@@ -289,7 +289,8 @@ export async function updateArtifacts({
       // it does, then use go workspace vendoring.
       const goWorkEnv = await exec(`${cmd} env GOWORK`, execOptions);
       const goWorkFile = goWorkEnv?.stdout?.trim() || '';
-      const useGoWork = goWorkFile.length && ((await readLocalFile(goWorkFile)) !== null);
+      const useGoWork =
+        goWorkFile.length && (await readLocalFile(goWorkFile)) !== null;
       if (!useGoWork) {
         logger.debug('No go.work found');
       }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Run `go work vendor` instead of `go mod vendor` if a `go.work` is present in the module. As of Go 1.22 (https://github.com/golang/go/issues/60056) Go supports vendoring with workspaces. If a `go.work` is located in the module along with the `vendor` directory, `go mod vendor` will fail, so `go work vendor` is needed instead. 

I also run `go work sync` since pretty likely users want their dependencies synced across all their modules in the repository. If this is undesirable, an option could be added to skip this step as well.

## Context

Relates to https://github.com/renovatebot/renovate/discussions/29107. I wanted an option to disable the vendoring behavior entirely, but I figured making renovate run `go work vendor` would help more people, so I opted to do this instead.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository