### PR TITLE
fix(presets): do not ignore .NET dependencies in test directories

### DIFF
--- a/lib/config/presets/internal/default.ts
+++ b/lib/config/presets/internal/default.ts
@@ -294,15 +294,28 @@ export const presets: Record<string, Preset> = {
   ignoreModulesAndTests: {
     description:
       'Ignore `node_modules`, `bower_components`, `vendor` and various test/tests directories.',
-    ignorePaths: [
-      '**/node_modules/**',
-      '**/bower_components/**',
-      '**/vendor/**',
-      '**/examples/**',
-      '**/__tests__/**',
-      '**/test/**',
-      '**/tests/**',
-      '**/__fixtures__/**',
+    packageRules: [
+      {
+        ignorePaths: [
+          '**/vendor/**',
+          '**/examples/**',
+          '**/__tests__/**',
+          '**/__fixtures__/**',
+        ],
+        matchCategories: ['dotnet'],
+      },
+      {
+        ignorePaths: [
+          '**/node_modules/**',
+          '**/bower_components/**',
+          '**/vendor/**',
+          '**/examples/**',
+          '**/__tests__/**',
+          '**/test/**',
+          '**/tests/**',
+          '**/__fixtures__/**',
+        ],
+      },
     ],
   },
   ignoreUnstable: {


### PR DESCRIPTION
## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

https://github.com/renovatebot/renovate/discussions/12755

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
