### PR TITLE
chore: Add packageRule logging to matchPackagePrefixes and excludePackagePrefixes warnings

### DIFF
--- a/lib/util/package-rules/package-prefixes.ts
+++ b/lib/util/package-rules/package-prefixes.ts
@@ -6,8 +6,9 @@ import { Matcher } from './base';
 export class PackagePrefixesMatcher extends Matcher {
   override matches(
     { depName, packageName }: PackageRuleInputConfig,
-    { matchPackagePrefixes }: PackageRule,
+    packageRule: PackageRule,
   ): boolean | null {
+    const { matchPackagePrefixes } = packageRule;
     if (is.undefined(matchPackagePrefixes)) {
       return null;
     }
@@ -24,7 +25,7 @@ export class PackagePrefixesMatcher extends Matcher {
     }
     if (matchPackagePrefixes.some((prefix) => depName.startsWith(prefix))) {
       logger.once.warn(
-        { packageName, depName },
+        { packageRule, packageName, depName },
         'Use matchDepPatterns instead of matchPackagePrefixes',
       );
       return true;
@@ -53,7 +54,7 @@ export class PackagePrefixesMatcher extends Matcher {
     }
     if (excludePackagePrefixes.some((prefix) => depName.startsWith(prefix))) {
       logger.once.warn(
-        { packageName, depName },
+        { packageRule, packageName, depName },
         'Use excludeDepPatterns instead of excludePackagePrefixes',
       );
       return true;


### PR DESCRIPTION
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Add more information to logs to match other matchers, compare:
 * https://github.com/renovatebot/renovate/blob/e69a5f8399c1d22ce74d6acb54e553da06bff528/lib/util/package-rules/package-patterns.ts#L43
 * https://github.com/renovatebot/renovate/blob/e69a5f8399c1d22ce74d6acb54e553da06bff528/lib/util/package-rules/package-names.ts#L25
 * https://github.com/renovatebot/renovate/blob/e69a5f8399c1d22ce74d6acb54e553da06bff528/lib/util/package-rules/package-prefixes.ts#L27

## Context

Follow-up on https://github.com/renovatebot/renovate/pull/23216 to give the same amount of information for all 3 rules.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository