### PR TITLE
fix(package-rules): replacement recommendation for matchPackagePrefixes and excludePackagePrefixes

### DIFF
--- a/lib/util/package-rules/package-prefixes.ts
+++ b/lib/util/package-rules/package-prefixes.ts
@@ -25,7 +25,7 @@ export class PackagePrefixesMatcher extends Matcher {
     if (matchPackagePrefixes.some((prefix) => depName.startsWith(prefix))) {
       logger.once.warn(
         { packageName, depName },
-        'Use matchDepPatterns instead of matchPackagePrefixes',
+        'Use matchDepPrefixes instead of matchPackagePrefixes',
       );
       return true;
     }
@@ -54,7 +54,7 @@ export class PackagePrefixesMatcher extends Matcher {
     if (excludePackagePrefixes.some((prefix) => depName.startsWith(prefix))) {
       logger.once.warn(
         { packageName, depName },
-        'Use excludeDepPatterns instead of excludePackagePrefixes',
+        'Use excludeDepPrefixes instead of excludePackagePrefixes',
       );
       return true;
     }


### PR DESCRIPTION
## Changes

Change replacement recommendation to match pattern among the 3 cases.

Compare (current main):
 * https://github.com/renovatebot/renovate/blob/e69a5f8399c1d22ce74d6acb54e553da06bff528/lib/util/package-rules/package-names.ts#L26
 * https://github.com/renovatebot/renovate/blob/e69a5f8399c1d22ce74d6acb54e553da06bff528/lib/util/package-rules/package-patterns.ts#L44
 * https://github.com/renovatebot/renovate/blob/e69a5f8399c1d22ce74d6acb54e553da06bff528/lib/util/package-rules/package-prefixes.ts#L28

and
 * https://github.com/renovatebot/renovate/blob/e69a5f8399c1d22ce74d6acb54e553da06bff528/lib/util/package-rules/package-names.ts#L53
 * https://github.com/renovatebot/renovate/blob/e69a5f8399c1d22ce74d6acb54e553da06bff528/lib/util/package-rules/package-patterns.ts#L75
 * https://github.com/renovatebot/renovate/blob/e69a5f8399c1d22ce74d6acb54e553da06bff528/lib/util/package-rules/package-prefixes.ts#L57

## Context

 * This came about because at the time of adding that line the matcher did not exist.  
   Ref: https://github.com/renovatebot/renovate/pull/27047/files#r1477280422 (cc @secustor)
 * A follow-up issue was created: https://github.com/renovatebot/renovate/issues/27048,
 * and implemented in https://github.com/renovatebot/renovate/pull/28542,
 * but the original context of why it was "needed" to be added was lost, this PR closes the cycle.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository