### PR TITLE
docs: packageRules overview and evaluation details

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2384,17 +2384,17 @@ Renovate only queries the OSV database for dependencies that use one of these da
 
 `packageRules` is a powerful feature that lets you apply rules to individual packages or to groups of packages using regex pattern matching.
 
-`packageRules` is meant to contain multiple rules.
-These rules will **all** be evaluated, and any matching rules will apply configuration to the matching dependencies.
-The configuration options from matching rules will be merged together.
-The order of the rules is therefore important, as later matching rules may override configuration options from earlier matching rules, if they both specify the same option.
+`packageRules` is a collection of rules, that are **all** evaluated.
+If multiple rules match a dependency, configurations from matching rules will be merged together.
+The order of rules matters, because later rules may override configuration options from earlier ones, if they both specify the same option.
 
-Each rule in the array allows you to optionally `match...` packages, while optionally `exclude...`-ing matches, then applying some configuration on the matches.
+Each rule in the array allows you to optionally match dependencies, while optionally excluding matches, then applying some configuration for the matched dependencies.
 The matching process for each package rule follows these directives:
 
- * There must be at least one `match...` or `exclude...` (they can be combined as well), otherwise everything matches.
- * `match...` matchers are positive so that they add to the resulting matches.
- * `exclude...` matchers are negative so that they remove from the resulting matches.
+ * There must be at least one `match...` or `exclude...` matcher (they can be combined as well), otherwise everything matches.
+ * `match...` matchers are inclusive, so they add to the resulting matches.
+ * `exclude...` matchers are exclusive, so they remove from the resulting matches.
+ * If an aspect is both `match`ed and `exclude`d, the exclusion wins.
  * Multiple values in each matcher will be evaluated independently (they're OR-ed together).
  * Combining multiple matchers will restrict the resulting matches (they're AND-ed together):  
    `matchCurrentVersion`, `matchCurrentValue`, `matchNewValue`, `matchConfidence`, `matchCurrentAge`,

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2384,6 +2384,21 @@ Renovate only queries the OSV database for dependencies that use one of these da
 
 `packageRules` is a powerful feature that lets you apply rules to individual packages or to groups of packages using regex pattern matching.
 
+Each rule in the array allows you to optionally `match...` packages, while optionally `exclude...`-ing matches, then applying some configuration on the matches.
+The matching process for each package rule follows these directives:
+
+ * There must be at least one `match...` or `exclude...` (they can be combined as well), otherwise everything matches.
+ * `match...` matchers are positive so that they add to the resulting matches.
+ * `exclude...` matchers are negative so that they remove from the resulting matches.
+ * Multiple values in each matcher will be evaluated independently (they're OR-ed together).
+ * Combining multiple matchers will restrict the resulting matches (they're AND-ed together):  
+   `matchCurrentVersion`, `matchCurrentValue`, `matchNewValue`, `matchConfidence`, `matchCurrentAge`,
+   `matchManagers`, `matchDatasources`, `matchCategories`, `matchDepTypes`, `matchUpdateTypes`,
+   `matchRepositories`/`excludeRepositories`, `matchBaseBranches`, `matchFileNames`
+ * except for the following two groups of matchers (they're OR-ed together in their groups, and AND-ed together with others):
+   * `matchSourceUrls`, `matchSourceUrlPrefixes`
+   * `matchDepNames`/`excludeDepNames`, `matchDepPatterns`/`excludeDepPatterns`, `matchDepPrefixes`/`excludeDepPrefixes`, `matchPackageNames`/`excludePackageNames`, `matchPackagePatterns`/`excludePackagePatterns`, `matchPackagePrefixes`/`excludePackagePrefixes`.
+
 Here is an example if you want to group together all packages starting with `eslint` into a single branch/PR:
 
 ```json

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2384,6 +2384,11 @@ Renovate only queries the OSV database for dependencies that use one of these da
 
 `packageRules` is a powerful feature that lets you apply rules to individual packages or to groups of packages using regex pattern matching.
 
+`packageRules` is meant to contain multiple rules.
+These rules will **all** be evaluated, and any matching rules will apply configuration to the matching dependencies.
+The configuration options from matching rules will be merged together.
+The order of the rules is therefore important, as later matching rules may override configuration options from earlier matching rules, if they both specify the same option.
+
 Each rule in the array allows you to optionally `match...` packages, while optionally `exclude...`-ing matches, then applying some configuration on the matches.
 The matching process for each package rule follows these directives:
 
@@ -2478,7 +2483,6 @@ For example you have multiple `package.json` and want to use `dependencyDashboar
 
 <!-- prettier-ignore -->
 !!! tip
-    Renovate evaluates all `packageRules` and does not stop after the first match.
     Order your `packageRules` so the least important rules are at the _top_, and the most important rules at the _bottom_.
     This way important rules override settings from earlier rules if needed.
 

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2388,21 +2388,19 @@ Renovate only queries the OSV database for dependencies that use one of these da
 If multiple rules match a dependency, configurations from matching rules will be merged together.
 The order of rules matters, because later rules may override configuration options from earlier ones, if they both specify the same option.
 
-Each rule in the array allows you to optionally match dependencies, while optionally excluding matches, then applying some configuration for the matched dependencies.
-The matching process for each package rule follows these directives:
+The matching process for a package rule:
 
- * There must be at least one `match...` or `exclude...` matcher (they can be combined as well), otherwise everything matches.
- * `match...` matchers are inclusive, so they add to the resulting matches.
- * `exclude...` matchers are exclusive, so they remove from the resulting matches.
+ * Each package rule can include `match...` matchers to identify dependencies and `exclude...` matchers to filter them out.
+ * If no match/exclude matchers are defined, everything matches.
  * If an aspect is both `match`ed and `exclude`d, the exclusion wins.
- * Multiple values in each matcher will be evaluated independently (they're OR-ed together).
+ * Multiple values within a single matcher will be evaluated independently (they're OR-ed togeher).
  * Combining multiple matchers will restrict the resulting matches (they're AND-ed together):  
    `matchCurrentVersion`, `matchCurrentValue`, `matchNewValue`, `matchConfidence`, `matchCurrentAge`,
    `matchManagers`, `matchDatasources`, `matchCategories`, `matchDepTypes`, `matchUpdateTypes`,
    `matchRepositories`/`excludeRepositories`, `matchBaseBranches`, `matchFileNames`
- * except for the following two groups of matchers (they're OR-ed together in their groups, and AND-ed together with others):
-   * `matchSourceUrls`, `matchSourceUrlPrefixes`
-   * `matchDepNames`/`excludeDepNames`, `matchDepPatterns`/`excludeDepPatterns`, `matchDepPrefixes`/`excludeDepPrefixes`, `matchPackageNames`/`excludePackageNames`, `matchPackagePatterns`/`excludePackagePatterns`, `matchPackagePrefixes`/`excludePackagePrefixes`.
+ * Two special groups of matchers provide alternatives (they're OR-ed within their respective groups, and AND-ed with others):
+   * Source URL: `matchSourceUrls`, `matchSourceUrlPrefixes`
+   * Package/Dep identifiers: `matchDepNames`/`excludeDepNames`, `matchDepPatterns`/`excludeDepPatterns`, `matchDepPrefixes`/`excludeDepPrefixes`, `matchPackageNames`/`excludePackageNames`, `matchPackagePatterns`/`excludePackagePatterns`, `matchPackagePrefixes`/`excludePackagePrefixes`
 
 Here is an example if you want to group together all packages starting with `eslint` into a single branch/PR:
 

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2390,17 +2390,17 @@ The order of rules matters, because later rules may override configuration optio
 
 The matching process for a package rule:
 
- * Each package rule can include `match...` matchers to identify dependencies and `exclude...` matchers to filter them out.
- * If no match/exclude matchers are defined, everything matches.
- * If an aspect is both `match`ed and `exclude`d, the exclusion wins.
- * Multiple values within a single matcher will be evaluated independently (they're OR-ed togeher).
- * Combining multiple matchers will restrict the resulting matches (they're AND-ed together):  
-   `matchCurrentVersion`, `matchCurrentValue`, `matchNewValue`, `matchConfidence`, `matchCurrentAge`,
-   `matchManagers`, `matchDatasources`, `matchCategories`, `matchDepTypes`, `matchUpdateTypes`,
-   `matchRepositories`/`excludeRepositories`, `matchBaseBranches`, `matchFileNames`
- * Two special groups of matchers provide alternatives (they're OR-ed within their respective groups, and AND-ed with others):
-   * Source URL: `matchSourceUrls`, `matchSourceUrlPrefixes`
-   * Package/Dep identifiers: `matchDepNames`/`excludeDepNames`, `matchDepPatterns`/`excludeDepPatterns`, `matchDepPrefixes`/`excludeDepPrefixes`, `matchPackageNames`/`excludePackageNames`, `matchPackagePatterns`/`excludePackagePatterns`, `matchPackagePrefixes`/`excludePackagePrefixes`
+- Each package rule can include `match...` matchers to identify dependencies and `exclude...` matchers to filter them out.
+- If no match/exclude matchers are defined, everything matches.
+- If an aspect is both `match`ed and `exclude`d, the exclusion wins.
+- Multiple values within a single matcher will be evaluated independently (they're OR-ed together).
+- Combining multiple matchers will restrict the resulting matches (they're AND-ed together):  
+  `matchCurrentVersion`, `matchCurrentValue`, `matchNewValue`, `matchConfidence`, `matchCurrentAge`,
+  `matchManagers`, `matchDatasources`, `matchCategories`, `matchDepTypes`, `matchUpdateTypes`,
+  `matchRepositories`/`excludeRepositories`, `matchBaseBranches`, `matchFileNames`
+- Two special groups of matchers provide alternatives (they're OR-ed within their respective groups, and AND-ed with others):
+  - Source URL: `matchSourceUrls`, `matchSourceUrlPrefixes`
+  - Package/Dep identifiers: `matchDepNames`/`excludeDepNames`, `matchDepPatterns`/`excludeDepPatterns`, `matchDepPrefixes`/`excludeDepPrefixes`, `matchPackageNames`/`excludePackageNames`, `matchPackagePatterns`/`excludePackagePatterns`, `matchPackagePrefixes`/`excludePackagePrefixes`
 
 Here is an example if you want to group together all packages starting with `eslint` into a single branch/PR:
 


### PR DESCRIPTION
## Changes

This is an attempt to document how rules work in `packageRules`. This is a powerful feature, but without reading the code in the repository:

 * https://github.com/renovatebot/renovate/blob/main/lib/util/package-rules/index.ts
 * https://github.com/renovatebot/renovate/blob/main/lib/util/package-rules/utils.ts
 * https://github.com/renovatebot/renovate/blob/main/lib/util/package-rules/matchers.ts

there's no way to understand how things work.

**Live preview of latest PR state**: [in my fork](https://github.com/TWiStErRob/renovate/blob/patch-6/docs/usage/configuration-options.md#packageRules)

## Context

This keeps coming back continuously. Every time I (and others) touch these rules, we're questioning how does it work?

I aimed to fill in this gap with this PR, and hopefully document what's been said in some discussions in some way. The result might be complex, but so is `packageRules`.

Here are some references (I'm sure this is non-exhaustive):
 * https://github.com/renovatebot/renovate/discussions/13644
 * https://github.com/renovatebot/renovate/discussions/25580
 * https://github.com/renovatebot/renovate/discussions/13664

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
