### PR TITLE
feat: support Rye

### DIFF
--- a/lib/modules/manager/pep621/processors/index.ts
+++ b/lib/modules/manager/pep621/processors/index.ts
@@ -1,4 +1,9 @@
 import { HatchProcessor } from './hatch';
 import { PdmProcessor } from './pdm';
+import { RyeProcessor } from './rye';
 
-export const processors = [new HatchProcessor(), new PdmProcessor()];
+export const processors = [
+  new HatchProcessor(),
+  new PdmProcessor(),
+  new RyeProcessor(),
+];

--- a/lib/modules/manager/pep621/processors/rye.spec.ts
+++ b/lib/modules/manager/pep621/processors/rye.spec.ts
@@ -1,0 +1,284 @@
+import { join } from 'upath';
+import { mockExecAll } from '../../../../../test/exec-util';
+import { fs, mockedFunction } from '../../../../../test/util';
+import { GlobalConfig } from '../../../../config/global';
+import type { RepoGlobalConfig } from '../../../../config/types';
+import { getPkgReleases as _getPkgReleases } from '../../../datasource';
+import type { UpdateArtifactsConfig } from '../../types';
+import { depTypes } from '../utils';
+import { RyeProcessor } from './rye';
+
+jest.mock('../../../../util/fs');
+jest.mock('../../../datasource');
+
+const getPkgReleases = mockedFunction(_getPkgReleases);
+
+const config: UpdateArtifactsConfig = {};
+const adminConfig: RepoGlobalConfig = {
+  localDir: join('/tmp/github/some/repo'),
+  cacheDir: join('/tmp/cache'),
+  containerbaseDir: join('/tmp/cache/containerbase'),
+};
+
+const processor = new RyeProcessor();
+
+describe('modules/manager/pep621/processors/rye', () => {
+  describe('updateArtifacts()', () => {
+    it('return null if there is no lock file', async () => {
+      fs.getSiblingFileName.mockReturnValueOnce('requirements.lock');
+      const updatedDeps = [{ packageName: 'dep1' }];
+      const result = await processor.updateArtifacts(
+        {
+          packageFileName: 'pyproject.toml',
+          newPackageFileContent: '',
+          config,
+          updatedDeps,
+        },
+        {},
+      );
+      expect(result).toBeNull();
+    });
+
+    it('return null if the lock file is unchanged', async () => {
+      const execSnapshots = mockExecAll();
+      GlobalConfig.set({
+        ...adminConfig,
+        binarySource: 'docker',
+        dockerSidecarImage: 'ghcr.io/containerbase/sidecar',
+      });
+      fs.getSiblingFileName.mockReturnValueOnce('requirements.lock');
+      fs.readLocalFile.mockResolvedValueOnce('test content');
+      fs.readLocalFile.mockResolvedValueOnce('test content');
+      // python
+      getPkgReleases.mockResolvedValueOnce({
+        releases: [{ version: '3.11.1' }, { version: '3.11.2' }],
+      });
+      // rye
+      getPkgReleases.mockResolvedValueOnce({
+        releases: [{ version: 'v2.6.1' }, { version: 'v2.5.0' }],
+      });
+
+      const updatedDeps = [{ packageName: 'dep1' }];
+      const result = await processor.updateArtifacts(
+        {
+          packageFileName: 'pyproject.toml',
+          newPackageFileContent: '',
+          config: {},
+          updatedDeps,
+        },
+        {},
+      );
+      expect(result).toBeNull();
+      expect(execSnapshots).toMatchObject([
+        {
+          cmd: 'docker pull ghcr.io/containerbase/sidecar',
+        },
+        {
+          cmd: 'docker ps --filter name=renovate_sidecar -aq',
+        },
+        {
+          cmd:
+            'docker run --rm --name=renovate_sidecar --label=renovate_child ' +
+            '-v "/tmp/github/some/repo":"/tmp/github/some/repo" ' +
+            '-v "/tmp/cache":"/tmp/cache" ' +
+            '-e CONTAINERBASE_CACHE_DIR ' +
+            '-w "/tmp/github/some/repo" ' +
+            'ghcr.io/containerbase/sidecar ' +
+            'bash -l -c "' +
+            'install-tool python 3.11.2 ' +
+            '&& ' +
+            'install-tool rye 0.34.0 ' +
+            '&& ' +
+            'rye lock --update dep1' +
+            '"',
+        },
+      ]);
+    });
+
+    it('returns artifact error', async () => {
+      const execSnapshots = mockExecAll();
+      GlobalConfig.set({ ...adminConfig, binarySource: 'docker' });
+      fs.getSiblingFileName.mockReturnValueOnce('requirements.lock');
+      fs.getSiblingFileName.mockReturnValueOnce('requirements-dev.lock');
+
+      fs.readLocalFile.mockImplementationOnce(() => {
+        throw new Error('test error');
+      });
+
+      const updatedDeps = [{ packageName: 'dep1' }];
+      const result = await processor.updateArtifacts(
+        {
+          packageFileName: 'pyproject.toml',
+          newPackageFileContent: '',
+          config: {},
+          updatedDeps,
+        },
+        {},
+      );
+      expect(result).toEqual([
+        {
+          artifactError: {
+            lockFile: 'requirements.lock',
+            stderr: 'test error',
+          },
+        },
+        {
+          artifactError: {
+            lockFile: 'requirements-dev.lock',
+            stderr: 'test error',
+          },
+        },
+      ]);
+      expect(execSnapshots).toEqual([]);
+    });
+
+    it('return update dep update', async () => {
+      const execSnapshots = mockExecAll();
+      GlobalConfig.set(adminConfig);
+      fs.getSiblingFileName.mockReturnValueOnce('requirements.lock');
+      fs.readLocalFile.mockResolvedValueOnce('test content');
+      fs.readLocalFile.mockResolvedValueOnce('changed test content');
+      // python
+      getPkgReleases.mockResolvedValueOnce({
+        releases: [{ version: '3.11.1' }, { version: '3.11.2' }],
+      });
+      // pdm
+      getPkgReleases.mockResolvedValueOnce({
+        releases: [{ version: 'v2.6.1' }, { version: 'v2.5.0' }],
+      });
+
+      const updatedDeps = [
+        {
+          packageName: 'dep1',
+          depType: depTypes.dependencies,
+        },
+        { packageName: 'dep2', depType: depTypes.dependencies },
+        {
+          depName: 'group1/dep3',
+          depType: depTypes.optionalDependencies,
+        },
+        { depName: 'group1/dep4', depType: depTypes.optionalDependencies },
+        {
+          depName: 'group2/dep5',
+          depType: depTypes.ryeDevDependencies,
+        },
+        { depName: 'group2/dep6', depType: depTypes.ryeDevDependencies },
+        {
+          depName: 'group3/dep7',
+          depType: depTypes.ryeDevDependencies,
+        },
+        { depName: 'group3/dep8', depType: depTypes.ryeDevDependencies },
+        { depName: 'dep9', depType: depTypes.buildSystemRequires },
+      ];
+      const result = await processor.updateArtifacts(
+        {
+          packageFileName: 'pyproject.toml',
+          newPackageFileContent: '',
+          config: {},
+          updatedDeps,
+        },
+        {},
+      );
+      expect(result).toEqual([
+        {
+          file: {
+            contents: 'changed test content',
+            path: 'requirements.lock',
+            type: 'addition',
+          },
+        },
+        {
+          file: {
+            contents: 'changed test content',
+            path: 'requirements-dev.lock',
+            type: 'addition',
+          },
+        },
+      ]);
+      expect(execSnapshots).toMatchObject([
+        {
+          cmd: 'rye lock --update dep1',
+        },
+        {
+          cmd: 'rye lock --update dep2',
+        },
+        {
+          cmd: 'rye lock --feature group1 --update dep3',
+        },
+        {
+          cmd: 'rye lock --feature group1 --update dep4',
+        },
+        {
+          cmd: 'rye lock --feature group2 --update dep5',
+        },
+        {
+          cmd: 'rye lock --feature group2 --update dep6',
+        },
+        {
+          cmd: 'rye lock --feature  group3 --update dep7',
+        },
+        {
+          cmd: 'rye lock --feature  group3 --update dep8',
+        },
+      ]);
+    });
+
+    it('return update on lockfileMaintenance', async () => {
+      const execSnapshots = mockExecAll();
+      GlobalConfig.set(adminConfig);
+      fs.getSiblingFileName.mockReturnValueOnce('requirements.lock');
+      fs.getSiblingFileName.mockReturnValueOnce('requirements-dev.lock');
+
+      fs.readLocalFile.mockResolvedValueOnce('test content');
+      fs.readLocalFile.mockResolvedValueOnce('test content');
+
+      fs.readLocalFile.mockResolvedValueOnce('changed test content');
+      fs.readLocalFile.mockResolvedValueOnce('changed test content');
+
+      // python
+      getPkgReleases.mockResolvedValueOnce({
+        releases: [{ version: '3.11.1' }, { version: '3.11.2' }],
+      });
+      // rye
+      getPkgReleases.mockResolvedValueOnce({
+        releases: [{ version: 'v2.6.1' }, { version: 'v2.5.0' }],
+      });
+
+      const result = await processor.updateArtifacts(
+        {
+          packageFileName: 'folder/pyproject.toml',
+          newPackageFileContent: '',
+          config: {
+            updateType: 'lockFileMaintenance',
+          },
+          updatedDeps: [],
+        },
+        {},
+      );
+      expect(result).toEqual([
+        {
+          file: {
+            contents: 'changed test content',
+            path: 'requirements.lock',
+            type: 'addition',
+          },
+        },
+        {
+          file: {
+            contents: 'changed test content',
+            path: 'requirements-dev.lock',
+            type: 'addition',
+          },
+        },
+      ]);
+      expect(execSnapshots).toMatchObject([
+        {
+          cmd: 'rye lock --update-all',
+          options: {
+            cwd: '/tmp/github/some/repo/folder',
+          },
+        },
+      ]);
+    });
+  });
+});

--- a/lib/modules/manager/pep621/processors/rye.ts
+++ b/lib/modules/manager/pep621/processors/rye.ts
@@ -1,0 +1,278 @@
+import is from '@sindresorhus/is';
+import { quote } from 'shlex';
+import { TEMPORARY_ERROR } from '../../../../constants/error-messages';
+import { logger } from '../../../../logger';
+import { exec } from '../../../../util/exec';
+import type { ExecOptions, ToolConstraint } from '../../../../util/exec/types';
+import { getSiblingFileName, readLocalFile } from '../../../../util/fs';
+import { extractPackageFile as extractRequirementsFile } from '../../pip_requirements/extract';
+import type {
+  PackageDependency,
+  UpdateArtifact,
+  UpdateArtifactsResult,
+  Upgrade,
+} from '../../types';
+import type { PyProject } from '../schema';
+import { depTypes, parseDependencyGroupRecord } from '../utils';
+import type { PyProjectProcessor } from './types';
+
+const ryeUpdateCMD = 'rye lock --update ';
+const ryeUpdateAllCMD = 'rye lock --update-all --all-features';
+
+const lockFileName = 'requirements.lock';
+const devLockFileName = 'requirements-dev.lock';
+
+export class RyeProcessor implements PyProjectProcessor {
+  process(project: PyProject, deps: PackageDependency[]): PackageDependency[] {
+    const rye = project.tool?.rye;
+    if (is.nullOrUndefined(rye)) {
+      return deps;
+    }
+
+    deps.push(
+      ...parseDependencyGroupRecord(
+        depTypes.ryeDevDependencies,
+        rye['dev-dependencies'],
+      ),
+    );
+
+    const ryeSources = rye.sources;
+    if (is.nullOrUndefined(ryeSources)) {
+      return deps;
+    }
+
+    const registryUrls: string[] = [];
+    for (const source of ryeSources) {
+      registryUrls.push(source.url);
+    }
+    for (const dep of deps) {
+      dep.registryUrls = registryUrls;
+    }
+
+    return deps;
+  }
+
+  async extractLockedVersions(
+    project: PyProject,
+    deps: PackageDependency[],
+    packageFile: string,
+  ): Promise<PackageDependency[]> {
+    if (is.nullOrUndefined(project.tool?.rye)) {
+      return Promise.resolve(deps);
+    }
+
+    deps = await extractLockedVersions(
+      packageFile,
+      lockFileName,
+      depTypes.dependencies,
+      deps,
+    );
+    deps = await extractLockedVersions(
+      packageFile,
+      devLockFileName,
+      depTypes.ryeDevDependencies,
+      deps,
+    );
+
+    return Promise.resolve(deps);
+  }
+
+  async updateArtifacts(
+    updateArtifact: UpdateArtifact,
+    project: PyProject,
+  ): Promise<UpdateArtifactsResult[] | null> {
+    const { config, updatedDeps, packageFileName } = updateArtifact;
+
+    const isLockFileMaintenance = config.updateType === 'lockFileMaintenance';
+
+    // abort if no lockfile is defined
+    const lockFile = getSiblingFileName(packageFileName, lockFileName);
+
+    const devLockFile = getSiblingFileName(packageFileName, devLockFileName);
+
+    try {
+      const existingLockFileContent = await readLocalFile(lockFile, 'utf8');
+      if (is.nullOrUndefined(existingLockFileContent)) {
+        logger.debug(`No ${lockFileName} found`);
+        return null;
+      }
+      const existingDevLockFileContent = await readLocalFile(
+        devLockFile,
+        'utf8',
+      );
+      if (is.nullOrUndefined(existingDevLockFileContent)) {
+        logger.debug(`No ${devLockFileName} found`);
+        return null;
+      }
+
+      const pythonConstraint: ToolConstraint = {
+        toolName: 'python',
+        constraint:
+          config.constraints?.python ?? project.project?.['requires-python'],
+      };
+      const ryeConstraint: ToolConstraint = {
+        toolName: 'rye',
+        constraint: config.constraints?.rye,
+      };
+
+      const execOptions: ExecOptions = {
+        cwdFile: packageFileName,
+        docker: {},
+        userConfiguredEnv: config.env,
+        toolConstraints: [pythonConstraint, ryeConstraint],
+      };
+
+      // on lockFileMaintenance do not specify any packages and update the complete lock file
+      // else only update specific packages
+      const cmds: string[] = [];
+      if (isLockFileMaintenance) {
+        cmds.push(ryeUpdateAllCMD);
+      } else {
+        cmds.push(...generateCMDs(updatedDeps));
+      }
+      await exec(cmds, execOptions);
+
+      // check for changes
+      const fileChanges: UpdateArtifactsResult[] = [];
+      const newLockContent = await readLocalFile(lockFile, 'utf8');
+      const isLockFileChanged = existingLockFileContent !== newLockContent;
+
+      if (isLockFileChanged) {
+        fileChanges.push({
+          file: {
+            type: 'addition',
+            path: lockFile,
+            contents: newLockContent,
+          },
+        });
+      } else {
+        logger.debug(`${lockFileName} is unchanged`);
+      }
+
+      const newDevLockContent = await readLocalFile(devLockFile, 'utf8');
+      const isDevLockFileChanged =
+        existingDevLockFileContent !== newDevLockContent;
+
+      if (isDevLockFileChanged) {
+        fileChanges.push({
+          file: {
+            type: 'addition',
+            path: devLockFile,
+            contents: newDevLockContent,
+          },
+        });
+      } else {
+        logger.debug(`${devLockFileName} is unchanged`);
+      }
+
+      return fileChanges.length ? fileChanges : null;
+    } catch (err) {
+      // istanbul ignore if
+      if (err.message === TEMPORARY_ERROR) {
+        throw err;
+      }
+      logger.debug({ err }, 'Failed to update Rye lock file');
+      return [
+        {
+          artifactError: {
+            lockFile: lockFile,
+            stderr: err.message,
+          },
+        },
+        {
+          artifactError: {
+            lockFile: devLockFile,
+            stderr: err.message,
+          },
+        },
+      ];
+    }
+  }
+}
+
+async function extractLockedVersions(
+  packageFile: string,
+  lockFileName: string,
+  depType: string | undefined,
+  deps: PackageDependency[],
+): Promise<PackageDependency[]> {
+  const lockFile = getSiblingFileName(packageFile, lockFileName);
+
+  const lockFileContent = await readLocalFile(lockFile, 'utf8');
+  if (lockFileContent) {
+    const lockFileMapping = extractRequirementsFile(lockFileContent);
+    if (is.nullOrUndefined(lockFileMapping)) {
+      logger.debug(`Unable to parse ${lockFileName}`);
+      return Promise.resolve(deps);
+    }
+
+    const lockFileDeps = Object.fromEntries(
+      lockFileMapping!.deps.map((dep) => [dep.depName, dep.lockedVersion]),
+    );
+
+    for (const dep of deps) {
+      const packageName = dep.packageName;
+      if (
+        packageName &&
+        dep.depType == depType &&
+        packageName in lockFileDeps
+      ) {
+        dep.lockedVersion = lockFileDeps[packageName];
+      }
+    }
+  }
+  return deps;
+}
+
+function generateCMDs(updatedDeps: Upgrade[]): string[] {
+  const cmds: string[] = [];
+  const packagesByCMD: Record<string, string[]> = {};
+  for (const dep of updatedDeps) {
+    switch (dep.depType) {
+      case depTypes.optionalDependencies: {
+        const [group, name] = dep.depName!.split('/');
+        addPackageToCMDRecord(
+          packagesByCMD,
+          `${ryeUpdateCMD} --features ${quote(group)}`,
+          name,
+        );
+        break;
+      }
+      case depTypes.ryeDevDependencies: {
+        const [group, name] = dep.depName!.split('/');
+        addPackageToCMDRecord(
+          packagesByCMD,
+          `${ryeUpdateCMD} --features ${quote(group)}`,
+          name,
+        );
+        break;
+      }
+      case depTypes.buildSystemRequires:
+        // build requirements are not locked in the lock files, no need to update.
+        break;
+      default: {
+        addPackageToCMDRecord(packagesByCMD, ryeUpdateCMD, dep.packageName!);
+      }
+    }
+  }
+
+  for (const commandPrefix in packagesByCMD) {
+    for (const pkg in packagesByCMD[commandPrefix].map(quote)) {
+      const cmd = `${commandPrefix} ${pkg}`;
+      cmds.push(cmd);
+    }
+  }
+
+  return cmds;
+}
+
+function addPackageToCMDRecord(
+  packagesByCMD: Record<string, string[]>,
+  commandPrefix: string,
+  packageName: string,
+): void {
+  if (is.nullOrUndefined(packagesByCMD[commandPrefix])) {
+    packagesByCMD[commandPrefix] = [];
+  }
+  packagesByCMD[commandPrefix].push(packageName);
+}

--- a/lib/modules/manager/pep621/schema.ts
+++ b/lib/modules/manager/pep621/schema.ts
@@ -54,6 +54,20 @@ export const PyProjectSchema = z.object({
             .optional(),
         })
         .optional(),
+      rye: z
+        .object({
+          'dev-dependencies': DependencyRecordSchema,
+          sources: z
+            .array(
+              z.object({
+                name: z.string(),
+                url: z.string(),
+                verify_ssl: z.boolean().optional(),
+              }),
+            )
+            .optional(),
+        })
+        .optional(),
     })
     .optional(),
 });

--- a/lib/modules/manager/pep621/utils.ts
+++ b/lib/modules/manager/pep621/utils.ts
@@ -15,6 +15,7 @@ export const depTypes = {
   dependencies: 'project.dependencies',
   optionalDependencies: 'project.optional-dependencies',
   pdmDevDependencies: 'tool.pdm.dev-dependencies',
+  ryeDevDependencies: 'tool.rye.dev-dependencies',
   buildSystemRequires: 'build-system.requires',
 };
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This PR adds support for [Rye](https://rye.astral.sh/), a cargo-like tool for python.

## Context

Closes #25273 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

This is still in progress as I'm waiting for feedback on: https://github.com/containerbase/base/pull/2684
