### PR TITLE
feat(sbt): Support Scala 3 dependency resolution

### DIFF
--- a/lib/modules/manager/sbt/extract.spec.ts
+++ b/lib/modules/manager/sbt/extract.spec.ts
@@ -258,7 +258,7 @@ describe('modules/manager/sbt/extract', () => {
           {
             packageName: 'org.example:bar_3',
             currentValue: '0.0.5',
-          }
+          },
         ],
       });
     });

--- a/lib/modules/manager/sbt/extract.spec.ts
+++ b/lib/modules/manager/sbt/extract.spec.ts
@@ -243,6 +243,26 @@ describe('modules/manager/sbt/extract', () => {
       });
     });
 
+    it('extracts deps correctly when dealing with scala 3', () => {
+      const content = `
+        scalaVersion := "3.3.4"
+        libraryDependencies += "org.example" %% "bar" % "0.0.5"
+      `;
+
+      expect(extractPackageFile(content)).toMatchObject({
+        deps: [
+          {
+            packageName: 'org.scala-lang:scala3-library_3',
+            currentValue: '3.3.4',
+          },
+          {
+            packageName: 'org.example:bar_3',
+            currentValue: '0.0.5',
+          }
+        ],
+      });
+    });
+
     it('extracts deps when scala version is defined in a variable with ThisBuild scope', () => {
       const content = `
         val ScalaVersion = "2.12.10"

--- a/lib/modules/manager/sbt/extract.ts
+++ b/lib/modules/manager/sbt/extract.ts
@@ -201,9 +201,9 @@ function depHandler(ctx: Ctx): Ctx {
   delete ctx.variableName;
 
   const depName = `${groupId!}:${artifactId!}`;
-  const isScala3 = scalaVersion !== undefined && scalaVersion.length > 0 && scalaVersion.charAt(0) === '3';
+  const isScala3 = scalaVersion?.[0] === '3';
   const scalaVersionForPackageName = isScala3
-    ? scalaVersion.substring(0, scalaVersion.lastIndexOf('.'))
+    ? '3'
     : scalaVersion;
 
   const dep: PackageDependency = {

--- a/lib/modules/manager/sbt/extract.ts
+++ b/lib/modules/manager/sbt/extract.ts
@@ -202,15 +202,15 @@ function depHandler(ctx: Ctx): Ctx {
 
   const depName = `${groupId!}:${artifactId!}`;
   const isScala3 = scalaVersion?.[0] === '3';
-  const scalaVersionForPackageName = isScala3
-    ? '3'
-    : scalaVersion;
+  const scalaVersionForPackageName = isScala3 ? '3' : scalaVersion;
 
   const dep: PackageDependency = {
     datasource: SbtPackageDatasource.id,
     depName,
     packageName:
-      scalaVersionForPackageName && useScalaVersion ? `${depName}_${scalaVersionForPackageName}` : depName,
+      scalaVersionForPackageName && useScalaVersion
+        ? `${depName}_${scalaVersionForPackageName}`
+        : depName,
     currentValue,
   };
 

--- a/lib/modules/manager/sbt/extract.ts
+++ b/lib/modules/manager/sbt/extract.ts
@@ -201,12 +201,16 @@ function depHandler(ctx: Ctx): Ctx {
   delete ctx.variableName;
 
   const depName = `${groupId!}:${artifactId!}`;
+  const isScala3 = scalaVersion !== undefined && scalaVersion.length > 0 && scalaVersion.charAt(0) === '3';
+  const scalaVersionForPackageName = isScala3
+    ? scalaVersion.substring(0, scalaVersion.lastIndexOf('.'))
+    : scalaVersion;
 
   const dep: PackageDependency = {
     datasource: SbtPackageDatasource.id,
     depName,
     packageName:
-      scalaVersion && useScalaVersion ? `${depName}_${scalaVersion}` : depName,
+      scalaVersionForPackageName && useScalaVersion ? `${depName}_${scalaVersionForPackageName}` : depName,
     currentValue,
   };
 


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Scala 2 packages have their artefact name suffixed by the major and minor version, eg. `_2.13`.
Scala 3 packages are different - their names are suffixed by only the major version, `_3` rather than being suffixed by the major and minor version, eg. `_3.4`

This change detects Scala 3 code and uses the correct shorter suffix.


## Context

Closes #29087

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required
- [x] I'm not sure, but I'm happy to update documentation if necessary

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
