### PR TITLE
fix(merge-confidence): fix initialization

### DIFF
--- a/lib/config/global.ts
+++ b/lib/config/global.ts
@@ -36,8 +36,6 @@ export class GlobalConfig {
     'httpCacheTtlDays',
     'autodiscoverRepoSort',
     'autodiscoverRepoOrder',
-    'mergeConfidenceEndpoint',
-    'mergeConfidenceDatasources',
     'userAgent',
   ];
 

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -73,6 +73,7 @@ const options: RenovateOptions[] = [
     name: 'mergeConfidenceEndpoint',
     description:
       'If set, Renovate will query this API for Merge Confidence data.',
+    stage: 'global',
     type: 'string',
     default: 'https://developer.mend.io/',
     advancedUse: true,
@@ -82,6 +83,7 @@ const options: RenovateOptions[] = [
     name: 'mergeConfidenceDatasources',
     description:
       'If set, Renovate will query the merge-confidence JSON API only for datasources that are part of this list.',
+    stage: 'global',
     allowedValues: supportedDatasources,
     default: supportedDatasources,
     type: 'array',

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -116,6 +116,8 @@ export interface GlobalOnlyConfig {
   globalExtends?: string[];
   logFile?: string;
   logFileLevel?: LogLevel;
+  mergeConfidenceDatasources?: string[];
+  mergeConfidenceEndpoint?: string;
   platform?: PlatformId;
   prCommitsPerRunLimit?: number;
   privateKeyPath?: string;
@@ -155,8 +157,6 @@ export interface RepoGlobalConfig {
   githubTokenWarn?: boolean;
   includeMirrors?: boolean;
   localDir?: string;
-  mergeConfidenceEndpoint?: string;
-  mergeConfidenceDatasources?: string[];
   migratePresets?: Record<string, string>;
   platform?: PlatformId;
   presetCachePersistence?: boolean;

--- a/lib/util/merge-confidence/index.spec.ts
+++ b/lib/util/merge-confidence/index.spec.ts
@@ -377,7 +377,9 @@ describe('util/merge-confidence/index', () => {
       it('resolves when token is valid', async () => {
         httpMock.scope(apiBaseUrl).get(`/api/mc/availability`).reply(200);
 
-        await expect(initMergeConfidence({})).toResolve();
+        await expect(
+          initMergeConfidence({ mergeConfidenceEndpoint: apiBaseUrl }),
+        ).toResolve();
         expect(logger.debug).toHaveBeenCalledWith(
           expect.anything(),
           'merge confidence API - successfully authenticated',
@@ -387,9 +389,9 @@ describe('util/merge-confidence/index', () => {
       it('throws on 403-Forbidden from mc API', async () => {
         httpMock.scope(apiBaseUrl).get(`/api/mc/availability`).reply(403);
 
-        await expect(initMergeConfidence({})).rejects.toThrow(
-          EXTERNAL_HOST_ERROR,
-        );
+        await expect(
+          initMergeConfidence({ mergeConfidenceEndpoint: apiBaseUrl }),
+        ).rejects.toThrow(EXTERNAL_HOST_ERROR);
         expect(logger.error).toHaveBeenCalledWith(
           expect.anything(),
           'merge confidence API token rejected - aborting run',
@@ -399,9 +401,9 @@ describe('util/merge-confidence/index', () => {
       it('throws on 5xx host errors from mc API', async () => {
         httpMock.scope(apiBaseUrl).get(`/api/mc/availability`).reply(503);
 
-        await expect(initMergeConfidence({})).rejects.toThrow(
-          EXTERNAL_HOST_ERROR,
-        );
+        await expect(
+          initMergeConfidence({ mergeConfidenceEndpoint: apiBaseUrl }),
+        ).rejects.toThrow(EXTERNAL_HOST_ERROR);
         expect(logger.error).toHaveBeenCalledWith(
           expect.anything(),
           'merge confidence API failure: 5xx - aborting run',
@@ -414,9 +416,9 @@ describe('util/merge-confidence/index', () => {
           .get(`/api/mc/availability`)
           .replyWithError({ code: 'ECONNRESET' });
 
-        await expect(initMergeConfidence({})).rejects.toThrow(
-          EXTERNAL_HOST_ERROR,
-        );
+        await expect(
+          initMergeConfidence({ mergeConfidenceEndpoint: apiBaseUrl }),
+        ).rejects.toThrow(EXTERNAL_HOST_ERROR);
         expect(logger.error).toHaveBeenCalledWith(
           expect.anything(),
           'merge confidence API request failed - aborting run',

--- a/lib/util/merge-confidence/index.spec.ts
+++ b/lib/util/merge-confidence/index.spec.ts
@@ -1,5 +1,4 @@
 import * as httpMock from '../../../test/http-mock';
-import { GlobalConfig } from '../../config/global';
 import { EXTERNAL_HOST_ERROR } from '../../constants/error-messages';
 import { logger } from '../../logger';
 import type { HostRule } from '../../types';
@@ -10,7 +9,6 @@ import {
   initConfig,
   initMergeConfidence,
   isActiveConfidenceLevel,
-  parseSupportedDatasourceString,
   resetConfig,
   satisfiesConfidenceLevel,
 } from '.';
@@ -18,15 +16,7 @@ import {
 describe('util/merge-confidence/index', () => {
   const apiBaseUrl = 'https://www.baseurl.com/';
   const defaultApiBaseUrl = 'https://developer.mend.io/';
-  const supportedDatasources = [
-    'go',
-    'maven',
-    'npm',
-    'nuget',
-    'packagist',
-    'pypi',
-    'rubygems',
-  ];
+  const userSupportedDatasources = ['go'];
 
   describe('isActiveConfidenceLevel()', () => {
     it('returns false if null', () => {
@@ -68,9 +58,8 @@ describe('util/merge-confidence/index', () => {
 
     beforeEach(() => {
       hostRules.add(hostRule);
-      initConfig();
+      initConfig({ mergeConfidenceEndpoint: apiBaseUrl });
       memCache.reset();
-      GlobalConfig.set({ mergeConfidenceEndpoint: apiBaseUrl });
     });
 
     afterEach(() => {
@@ -311,14 +300,13 @@ describe('util/merge-confidence/index', () => {
         resetConfig();
       });
 
-      it('using default base url if none is set', async () => {
-        GlobalConfig.reset();
+      it('using default base url and supported datasources if either is set', async () => {
         httpMock
           .scope(defaultApiBaseUrl)
           .get(`/api/mc/availability`)
           .reply(200);
 
-        await expect(initMergeConfidence()).toResolve();
+        await expect(initMergeConfidence({})).toResolve();
         expect(logger.debug).toHaveBeenCalledWith(
           {
             supportedDatasources: [
@@ -336,13 +324,14 @@ describe('util/merge-confidence/index', () => {
       });
 
       it('warns and then resolves if base url is invalid', async () => {
-        GlobalConfig.set({ mergeConfidenceEndpoint: 'invalid-url.com' });
         httpMock
           .scope(defaultApiBaseUrl)
           .get(`/api/mc/availability`)
           .reply(200);
 
-        await expect(initMergeConfidence()).toResolve();
+        await expect(
+          initMergeConfidence({ mergeConfidenceEndpoint: 'invalid-url.com' }),
+        ).toResolve();
         expect(logger.warn).toHaveBeenCalledWith(
           expect.anything(),
           'invalid merge confidence API base URL found in environment variables - using default value instead',
@@ -353,19 +342,25 @@ describe('util/merge-confidence/index', () => {
         );
       });
 
-      it('uses a custom base url containing path', async () => {
+      it('uses custom supported datasources and a base URL containing a path', async () => {
         const renovateApi = 'https://domain.com/proxy/renovate-api';
-        GlobalConfig.set({ mergeConfidenceEndpoint: renovateApi });
         httpMock.scope(renovateApi).get(`/api/mc/availability`).reply(200);
 
-        await expect(initMergeConfidence()).toResolve();
+        await expect(
+          initMergeConfidence({
+            mergeConfidenceEndpoint: renovateApi,
+            mergeConfidenceDatasources: userSupportedDatasources,
+          }),
+        ).toResolve();
 
         expect(logger.trace).toHaveBeenCalledWith(
           expect.anything(),
           'using merge confidence API base found in environment variables',
         );
         expect(logger.debug).toHaveBeenCalledWith(
-          expect.anything(),
+          {
+            supportedDatasources: ['go'],
+          },
           'merge confidence API - successfully authenticated',
         );
       });
@@ -373,7 +368,7 @@ describe('util/merge-confidence/index', () => {
       it('resolves if no token', async () => {
         hostRules.clear();
 
-        await expect(initMergeConfidence()).toResolve();
+        await expect(initMergeConfidence({})).toResolve();
         expect(logger.trace).toHaveBeenCalledWith(
           'merge confidence API usage is disabled',
         );
@@ -382,7 +377,7 @@ describe('util/merge-confidence/index', () => {
       it('resolves when token is valid', async () => {
         httpMock.scope(apiBaseUrl).get(`/api/mc/availability`).reply(200);
 
-        await expect(initMergeConfidence()).toResolve();
+        await expect(initMergeConfidence({})).toResolve();
         expect(logger.debug).toHaveBeenCalledWith(
           expect.anything(),
           'merge confidence API - successfully authenticated',
@@ -392,7 +387,7 @@ describe('util/merge-confidence/index', () => {
       it('throws on 403-Forbidden from mc API', async () => {
         httpMock.scope(apiBaseUrl).get(`/api/mc/availability`).reply(403);
 
-        await expect(initMergeConfidence()).rejects.toThrow(
+        await expect(initMergeConfidence({})).rejects.toThrow(
           EXTERNAL_HOST_ERROR,
         );
         expect(logger.error).toHaveBeenCalledWith(
@@ -404,7 +399,7 @@ describe('util/merge-confidence/index', () => {
       it('throws on 5xx host errors from mc API', async () => {
         httpMock.scope(apiBaseUrl).get(`/api/mc/availability`).reply(503);
 
-        await expect(initMergeConfidence()).rejects.toThrow(
+        await expect(initMergeConfidence({})).rejects.toThrow(
           EXTERNAL_HOST_ERROR,
         );
         expect(logger.error).toHaveBeenCalledWith(
@@ -419,52 +414,13 @@ describe('util/merge-confidence/index', () => {
           .get(`/api/mc/availability`)
           .replyWithError({ code: 'ECONNRESET' });
 
-        await expect(initMergeConfidence()).rejects.toThrow(
+        await expect(initMergeConfidence({})).rejects.toThrow(
           EXTERNAL_HOST_ERROR,
         );
         expect(logger.error).toHaveBeenCalledWith(
           expect.anything(),
           'merge confidence API request failed - aborting run',
         );
-      });
-
-      describe('parseSupportedDatasourceList()', () => {
-        afterEach(() => {
-          GlobalConfig.reset();
-        });
-
-        it.each([
-          {
-            name: 'it should do return default value when the input is undefined',
-            datasources: undefined,
-            expected: supportedDatasources,
-          },
-          {
-            name: 'it should successfully parse the given datasource list',
-            datasources: ['go', 'npm'],
-            expected: ['go', 'npm'],
-          },
-          {
-            name: 'it should gracefully handle invalid JSON',
-            datasources: `{`,
-            expected: supportedDatasources,
-          },
-          {
-            name: 'it should discard non-array JSON input',
-            datasources: `{}`,
-            expected: supportedDatasources,
-          },
-          {
-            name: 'it should discard non-string array JSON input',
-            datasources: `[1,2]`,
-            expected: supportedDatasources,
-          },
-        ])(`$name`, ({ datasources, expected }) => {
-          GlobalConfig.set({
-            mergeConfidenceDatasources: datasources,
-          });
-          expect(parseSupportedDatasourceString()).toStrictEqual(expected);
-        });
       });
     });
   });

--- a/lib/workers/global/initialize.ts
+++ b/lib/workers/global/initialize.ts
@@ -88,7 +88,7 @@ export async function globalInitialize(
   setEmojiConfig(config);
   setGlobalHostRules(config);
   configureThirdPartyLibraries(config);
-  await initMergeConfidence();
+  await initMergeConfidence(config);
   return config;
 }
 

--- a/lib/workers/repository/process/lookup/index.spec.ts
+++ b/lib/workers/repository/process/lookup/index.spec.ts
@@ -4,6 +4,8 @@ import { Fixtures } from '../../../../../test/fixtures';
 import * as httpMock from '../../../../../test/http-mock';
 import { partial } from '../../../../../test/util';
 import { getConfig } from '../../../../config/defaults';
+import { supportedDatasources as presetSupportedDatasources } from '../../../../config/presets/internal/merge-confidence';
+import type { AllConfig } from '../../../../config/types';
 import { CONFIG_VALIDATION } from '../../../../constants/error-messages';
 import { CustomDatasource } from '../../../../modules/datasource/custom';
 import { DockerDatasource } from '../../../../modules/datasource/docker';
@@ -4545,6 +4547,10 @@ describe('workers/repository/process/lookup/index', () => {
 
     describe('handles merge confidence', () => {
       const defaultApiBaseUrl = 'https://developer.mend.io/';
+      const mcConfig: AllConfig = {
+        mergeConfidenceEndpoint: defaultApiBaseUrl,
+        mergeConfidenceDatasources: presetSupportedDatasources,
+      };
       const getMergeConfidenceSpy = jest.spyOn(
         McApi,
         'getMergeConfidenceLevel',
@@ -4556,7 +4562,7 @@ describe('workers/repository/process/lookup/index', () => {
 
       beforeEach(() => {
         hostRules.add(hostRule);
-        initConfig();
+        initConfig(mcConfig);
         memCache.reset();
       });
 
@@ -4637,7 +4643,7 @@ describe('workers/repository/process/lookup/index', () => {
         config.packageName = 'webpack';
         config.datasource = datasource;
         hostRules.clear(); // reset merge confidence
-        initConfig();
+        initConfig(mcConfig);
         httpMock
           .scope('https://registry.npmjs.org')
           .get('/webpack')


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
`GlobalConfig` is used before being initialized. This currently makes the base url and datasources unconfigurable.
The global config is initialized at repo init. while the confidence init is invoked at the global init phase.
Using config directly instead. 

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
