### PR TITLE
fix: `prPriority` based sorting of prs

### DIFF
--- a/lib/workers/repository/process/sort.spec.ts
+++ b/lib/workers/repository/process/sort.spec.ts
@@ -58,11 +58,16 @@ describe('workers/repository/process/sort', () => {
           prTitle: 'a minor update',
           prPriority: -1,
         },
+        {
+          updateType: 'patch' as UpdateType,
+          prTitle: 'a patch update',
+        },
       ];
       sortBranches(branches);
       expect(branches).toEqual([
         { prPriority: 1, prTitle: 'some major update', updateType: 'major' },
         { prPriority: 0, prTitle: 'some other pin', updateType: 'pin' },
+        { prTitle: 'a patch update', updateType: 'patch' },
         { prPriority: -1, prTitle: 'some pin', updateType: 'pin' },
         { prPriority: -1, prTitle: 'a minor update', updateType: 'minor' },
       ]);

--- a/lib/workers/repository/process/sort.ts
+++ b/lib/workers/repository/process/sort.ts
@@ -21,8 +21,9 @@ export function sortBranches(branches: Partial<BranchConfig>[]): void {
     }
 
     // TODO #22198
-    if (a.prPriority !== b.prPriority) {
-      return b.prPriority! - a.prPriority!;
+    const prPriorityDiff = getPrPriority(b) - getPrPriority(a);
+    if (prPriorityDiff !== 0) {
+      return prPriorityDiff;
     }
     // TODO #22198
     const sortDiff =
@@ -34,4 +35,8 @@ export function sortBranches(branches: Partial<BranchConfig>[]): void {
     // Sort by prTitle if updateType is the same
     return a.prTitle! < b.prTitle! ? -1 : 1;
   });
+}
+
+function getPrPriority(branch: Partial<BranchConfig>): number {
+  return branch.prPriority ?? 0;
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- If `prPriority` is `undefined` use `zero` instead
<!-- Describe what behavior is changed by this PR. -->

## Context
Ref: https://github.com/renovatebot/renovate/discussions/29298
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository
Before: https://github.com/Rahul-renovate-testing/repro-pr-priority/pulls
After: https://github.com/Rahul-renovate-testing/fix-pr-priority-sorting/pulls

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
