### PR TITLE
feat(replacements): add airbnb-prop-types-to-prop-types-tools

### DIFF
--- a/lib/config/presets/internal/replacements.ts
+++ b/lib/config/presets/internal/replacements.ts
@@ -53,7 +53,7 @@ export const presets: Record<string, Preset> = {
     ignoreDeps: [], // Hack to improve onboarding PR description
   },
 // eslint-disable-next-line sort-keys
-  'airbnb-prop-types-to-prop-types-tools': { // eslint-disable-line sort-keys
+  'airbnb-prop-types-to-prop-types-tools': {
     description: '`airbnb-prop-types` was given to a new maintainer and renamed to `prop-types-tools`.',
     packageRules: [
       {

--- a/lib/config/presets/internal/replacements.ts
+++ b/lib/config/presets/internal/replacements.ts
@@ -10,6 +10,7 @@ export const presets: Record<string, Preset> = {
   all: {
     description: 'Apply crowd-sourced package replacement rules.',
     extends: [
+      'replacements:airbnb-prop-types-to-prop-types-tools',
       'replacements:apollo-server-to-scoped',
       'replacements:babel-eslint-to-eslint-parser',
       'replacements:containerbase',
@@ -50,6 +51,18 @@ export const presets: Record<string, Preset> = {
       'replacements:zap',
     ],
     ignoreDeps: [], // Hack to improve onboarding PR description
+  },
+  'airbnb-prop-types-to-prop-types-tools': {
+    description: '`airbnb-prop-types` was given to a new maintainer and renamed to `prop-types-tools`.',
+    packageRules: [
+      {
+        matchCurrentVersion: '^2',
+        matchDatasources: ['npm'],
+        matchPackageNames: ['airbnb-prop-types'],
+        replacementName: 'prop-types-tools',
+        replacementVersion: '2.17.0',
+      },
+    ],
   },
   'apollo-server-to-scoped': {
     description: '`apollo-server` packages became scoped.',

--- a/lib/config/presets/internal/replacements.ts
+++ b/lib/config/presets/internal/replacements.ts
@@ -52,7 +52,7 @@ export const presets: Record<string, Preset> = {
     ],
     ignoreDeps: [], // Hack to improve onboarding PR description
   },
-  'airbnb-prop-types-to-prop-types-tools': {
+  'airbnb-prop-types-to-prop-types-tools': { // eslint-disable-line sort-keys
     description: '`airbnb-prop-types` was given to a new maintainer and renamed to `prop-types-tools`.',
     packageRules: [
       {

--- a/lib/config/presets/internal/replacements.ts
+++ b/lib/config/presets/internal/replacements.ts
@@ -52,6 +52,7 @@ export const presets: Record<string, Preset> = {
     ],
     ignoreDeps: [], // Hack to improve onboarding PR description
   },
+// eslint-disable-next-line sort-keys
   'airbnb-prop-types-to-prop-types-tools': { // eslint-disable-line sort-keys
     description: '`airbnb-prop-types` was given to a new maintainer and renamed to `prop-types-tools`.',
     packageRules: [

--- a/lib/config/presets/internal/replacements.ts
+++ b/lib/config/presets/internal/replacements.ts
@@ -52,9 +52,10 @@ export const presets: Record<string, Preset> = {
     ],
     ignoreDeps: [], // Hack to improve onboarding PR description
   },
-// eslint-disable-next-line sort-keys
+  // eslint-disable-next-line sort-keys
   'airbnb-prop-types-to-prop-types-tools': {
-    description: '`airbnb-prop-types` was given to a new maintainer and renamed to `prop-types-tools`.',
+    description:
+      '`airbnb-prop-types` was given to a new maintainer and renamed to `prop-types-tools`.',
     packageRules: [
       {
         matchCurrentVersion: '^2',


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Replace `airbnb-prop-types` with its new name, `prop-types-tools`

## Context

Airbnb gave me the repo, but made me rename the npm package to not have "airbnb" in it.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
