### PR TITLE
feat(manager/nuget): extract msbuild sdk from `Project` and `Sdk`

### DIFF
--- a/lib/modules/manager/nuget/extract.spec.ts
+++ b/lib/modules/manager/nuget/extract.spec.ts
@@ -64,12 +64,12 @@ describe('modules/manager/nuget/extract', () => {
       const packageFile = 'sample.csproj';
       const sample = `
       <Project Sdk="Microsoft.Build.NoTargets/3.4.0">
-    <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework> <!-- this is a dummy value -->
-        <NuspecFile>$(MSBuildThisFileDirectory)\tdlib.native.nuspec</NuspecFile>
-        <NuspecProperties>version=$(PackageVersion)</NuspecProperties>
-    </PropertyGroup>
-</Project>
+        <PropertyGroup>
+          <TargetFramework>net7.0</TargetFramework> <!-- this is a dummy value -->
+          <NuspecFile>$(MSBuildThisFileDirectory)\tdlib.native.nuspec</NuspecFile>
+          <NuspecProperties>version=$(PackageVersion)</NuspecProperties>
+        </PropertyGroup>
+      </Project>
       `;
       const res = await extractPackageFile(sample, packageFile, config);
       expect(res?.deps).toEqual([
@@ -87,12 +87,12 @@ describe('modules/manager/nuget/extract', () => {
       const packageFile = 'sample.csproj';
       const sample = `
       <Project Sdk="Microsoft.Build.NoTargets">
-    <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework> <!-- this is a dummy value -->
-        <NuspecFile>$(MSBuildThisFileDirectory)\tdlib.native.nuspec</NuspecFile>
-        <NuspecProperties>version=$(PackageVersion)</NuspecProperties>
-    </PropertyGroup>
-</Project>
+        <PropertyGroup>
+          <TargetFramework>net7.0</TargetFramework> <!-- this is a dummy value -->
+          <NuspecFile>$(MSBuildThisFileDirectory)\tdlib.native.nuspec</NuspecFile>
+          <NuspecProperties>version=$(PackageVersion)</NuspecProperties>
+        </PropertyGroup>
+      </Project>
       `;
       const res = await extractPackageFile(sample, packageFile, config);
       expect(res).toBeNull();
@@ -102,13 +102,13 @@ describe('modules/manager/nuget/extract', () => {
       const packageFile = 'sample.csproj';
       const sample = `
       <Project>
-      <Sdk Name="Microsoft.Build.NoTargets" Version="3.4.0" />
-    <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework> <!-- this is a dummy value -->
-        <NuspecFile>$(MSBuildThisFileDirectory)\tdlib.native.nuspec</NuspecFile>
-        <NuspecProperties>version=$(PackageVersion)</NuspecProperties>
-    </PropertyGroup>
-</Project>
+        <Sdk Name="Microsoft.Build.NoTargets" Version="3.4.0" />
+        <PropertyGroup>
+          <TargetFramework>net7.0</TargetFramework> <!-- this is a dummy value -->
+          <NuspecFile>$(MSBuildThisFileDirectory)\tdlib.native.nuspec</NuspecFile>
+          <NuspecProperties>version=$(PackageVersion)</NuspecProperties>
+        </PropertyGroup>
+      </Project>
       `;
       const res = await extractPackageFile(sample, packageFile, config);
       expect(res?.deps).toEqual([
@@ -126,13 +126,13 @@ describe('modules/manager/nuget/extract', () => {
       const packageFile = 'sample.csproj';
       const sample = `
       <Project>
-      <Sdk Name="Microsoft.Build.NoTargets" />
-    <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework> <!-- this is a dummy value -->
-        <NuspecFile>$(MSBuildThisFileDirectory)\tdlib.native.nuspec</NuspecFile>
-        <NuspecProperties>version=$(PackageVersion)</NuspecProperties>
-    </PropertyGroup>
-</Project>
+        <Sdk Name="Microsoft.Build.NoTargets" />
+        <PropertyGroup>
+          <TargetFramework>net7.0</TargetFramework> <!-- this is a dummy value -->
+          <NuspecFile>$(MSBuildThisFileDirectory)\tdlib.native.nuspec</NuspecFile>
+          <NuspecProperties>version=$(PackageVersion)</NuspecProperties>
+        </PropertyGroup>
+      </Project>
       `;
       const res = await extractPackageFile(sample, packageFile, config);
       expect(res).toBeNull();

--- a/lib/modules/manager/nuget/extract.spec.ts
+++ b/lib/modules/manager/nuget/extract.spec.ts
@@ -60,6 +60,84 @@ describe('modules/manager/nuget/extract', () => {
       expect(res?.deps).toHaveLength(17);
     });
 
+    it('extracts msbuild sdk from the Sdk attr of Project element', async () => {
+      const packageFile = 'sample.csproj';
+      const sample = `
+      <Project Sdk="Microsoft.Build.NoTargets/3.4.0">
+    <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework> <!-- this is a dummy value -->
+        <NuspecFile>$(MSBuildThisFileDirectory)\tdlib.native.nuspec</NuspecFile>
+        <NuspecProperties>version=$(PackageVersion)</NuspecProperties>
+    </PropertyGroup>
+</Project>
+      `;
+      const res = await extractPackageFile(sample, packageFile, config);
+      expect(res?.deps).toEqual([
+        {
+          depName: 'Microsoft.Build.NoTargets',
+          depType: 'msbuild-sdk',
+          currentValue: '3.4.0',
+          datasource: 'nuget',
+        },
+      ]);
+      expect(res?.deps).toHaveLength(1);
+    });
+
+    it('extracts msbuild sdk from the Sdk attr of Project element if version is missing', async () => {
+      const packageFile = 'sample.csproj';
+      const sample = `
+      <Project Sdk="Microsoft.Build.NoTargets">
+    <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework> <!-- this is a dummy value -->
+        <NuspecFile>$(MSBuildThisFileDirectory)\tdlib.native.nuspec</NuspecFile>
+        <NuspecProperties>version=$(PackageVersion)</NuspecProperties>
+    </PropertyGroup>
+</Project>
+      `;
+      const res = await extractPackageFile(sample, packageFile, config);
+      expect(res).toBeNull();
+    });
+
+    it('extracts msbuild sdk from the Sdk element', async () => {
+      const packageFile = 'sample.csproj';
+      const sample = `
+      <Project>
+      <Sdk Name="Microsoft.Build.NoTargets" Version="3.4.0" />
+    <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework> <!-- this is a dummy value -->
+        <NuspecFile>$(MSBuildThisFileDirectory)\tdlib.native.nuspec</NuspecFile>
+        <NuspecProperties>version=$(PackageVersion)</NuspecProperties>
+    </PropertyGroup>
+</Project>
+      `;
+      const res = await extractPackageFile(sample, packageFile, config);
+      expect(res?.deps).toEqual([
+        {
+          depName: 'Microsoft.Build.NoTargets',
+          depType: 'msbuild-sdk',
+          currentValue: '3.4.0',
+          datasource: 'nuget',
+        },
+      ]);
+      expect(res?.deps).toHaveLength(1);
+    });
+
+    it('does not extract msbuild sdk from the Sdk element if version is missing', async () => {
+      const packageFile = 'sample.csproj';
+      const sample = `
+      <Project>
+      <Sdk Name="Microsoft.Build.NoTargets" />
+    <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework> <!-- this is a dummy value -->
+        <NuspecFile>$(MSBuildThisFileDirectory)\tdlib.native.nuspec</NuspecFile>
+        <NuspecProperties>version=$(PackageVersion)</NuspecProperties>
+    </PropertyGroup>
+</Project>
+      `;
+      const res = await extractPackageFile(sample, packageFile, config);
+      expect(res).toBeNull();
+    });
+
     it('extracts dependency with lower-case Version attribute', async () => {
       const contents = codeBlock`
         <Project Sdk="Microsoft.NET.Sdk">

--- a/lib/modules/manager/nuget/extract.spec.ts
+++ b/lib/modules/manager/nuget/extract.spec.ts
@@ -83,7 +83,7 @@ describe('modules/manager/nuget/extract', () => {
       expect(res?.deps).toHaveLength(1);
     });
 
-    it('extracts msbuild sdk from the Sdk attr of Project element if version is missing', async () => {
+    it('does not extract msbuild sdk from the Sdk attr of Project element if version is missing', async () => {
       const packageFile = 'sample.csproj';
       const sample = `
       <Project Sdk="Microsoft.Build.NoTargets">

--- a/lib/modules/manager/nuget/extract.ts
+++ b/lib/modules/manager/nuget/extract.ts
@@ -74,7 +74,33 @@ function extractDepsFromXml(xmlNode: XmlDocument): NugetPackageDependency[] {
           currentValue,
         });
       }
+    } else if (name === 'Sdk') {
+      const depName = attr?.Name;
+      const version = attr?.Version;
+      // if sdk element is present it will always have the Name field but the Version is an optional field
+      if (depName && version) {
+        results.push({
+          depName,
+          currentValue: version,
+          depType: 'msbuild-sdk',
+          datasource: NugetDatasource.id,
+        });
+      }
     } else {
+      if (name === 'Project') {
+        if (attr?.Sdk) {
+          const str = attr?.Sdk;
+          const [name, version] = str.split('/');
+          if (name && version) {
+            results.push({
+              depName: name,
+              depType: 'msbuild-sdk',
+              currentValue: version,
+              datasource: NugetDatasource.id,
+            });
+          }
+        }
+      }
       todo.push(...(child.children.filter(isXmlElem) as XmlElement[]));
     }
   }
@@ -144,7 +170,10 @@ export async function extractPackageFile(
     return null;
   }
 
-  const res: PackageFileContent = { deps, packageFileVersion };
+  const res: PackageFileContent = {
+    deps,
+    packageFileVersion,
+  };
   const lockFileName = getSiblingFileName(packageFile, 'packages.lock.json');
   // istanbul ignore if
   if (await localPathExists(lockFileName)) {

--- a/lib/modules/manager/nuget/extract.ts
+++ b/lib/modules/manager/nuget/extract.ts
@@ -170,10 +170,7 @@ export async function extractPackageFile(
     return null;
   }
 
-  const res: PackageFileContent = {
-    deps,
-    packageFileVersion,
-  };
+  const res: PackageFileContent = { deps, packageFileVersion };
   const lockFileName = getSiblingFileName(packageFile, 'packages.lock.json');
   // istanbul ignore if
   if (await localPathExists(lockFileName)) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- extract msbuild sdk from `Project` and `Sdk`
<!-- Describe what behavior is changed by this PR. -->

## Context
Closes: https://github.com/renovatebot/renovate/issues/29101
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository
From Project : https://github.com/Rahul-renovate-testing/msbuild-sdk-usage-example/pulls
From Sdk : https://github.com/Rahul-renovate-testing/msbuild-sdk-elem/pulls
<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
