### PR TITLE
docs: improve creating/editing Renovate presets

### DIFF
--- a/docs/development/creating-editing-renovate-presets.md
+++ b/docs/development/creating-editing-renovate-presets.md
@@ -36,7 +36,7 @@ We have multiple kinds of `group:` presets, with different rules.
 1. Replacements should update the user to the first recommended version of the new dependency and not include any new changes - whether breaking or not - if they can be avoided, in short: pin the new version
 
 If possible, replacement presets should give the user a replacement version that is _functionally identical_ to the _last version_ under the _old_ name.
-We only want a user's tests to fail because of _broken references_ to the old package name, and not because the new maintainer changed the _behavior_ of the package.
+We only want a user's tests to fail because of _broken references_ to the old package name, and not because the maintainer(s) changed the _behavior_ of the package.
 
 #### Rules for monorepo presets
 

--- a/docs/development/creating-editing-renovate-presets.md
+++ b/docs/development/creating-editing-renovate-presets.md
@@ -8,7 +8,7 @@ Follow the rules below to increase the chance that your pull request gets merged
 ## General rules
 
 1. Avoid creating presets for problems which can be fixed upstream
-1. The internal preset should be helpful for a significant number of Renovate users
+1. The internal preset should help a significant number of Renovate users
 
 ### Specific rules
 
@@ -22,24 +22,23 @@ We have multiple kinds of `group:` presets, with different rules.
 
 ##### Rules for `group:recommended` presets
 
-1. The `group:recommended` preset is for related dependencies which aren't from a monorepo but which usually need to be updated together as separate PRs may each break
+1. The `group:recommended` preset is for related dependencies which aren't from a monorepo but which usually need to be updated together (as separate PRs may each break)
 
 ##### Rules for `group:*` presets
 
 1. Finally, any other `group:*` presets can be added if they are beneficial to a wide number of users
-1. They don't need to be added to `group:recommended`, meaning that users will "opt in" to them one by one and not get them automatically from `config:recommended`, which includes `group:monorepo` and `group:recommended`
+1. They don't need to be added to `group:recommended`, meaning that users will "opt in" to them one-by-one and _not_ get them automatically from `config:recommended`, which includes `group:monorepo` and `group:recommended`
 
-#### Replacement presets
-
-Rules:
+#### Rules for replacement presets
 
 1. Replacement PRs should ideally propose a replacement only once the user is on a compatible version, by specifying a compatible `matchCurrentVersion` constraint
 1. If no compatible replacement upgrade is possible, it's acceptable to propose an incompatible one (e.g. a major version upgrade)
-1. Replacements should update the user to the first recommended version of the new dependency and not include any new changes - whether breaking or not - if they can be avoided
+1. Replacements should update the user to the first recommended version of the new dependency and not include any new changes - whether breaking or not - if they can be avoided, in short: pin the new version
 
-#### Monorepo presets
+If possible, replacement presets should give the user a replacement version that is _functionally identical_ to the _last version_ under the _old_ name.
+We only want a user's tests to fail because of _broken references_ to the old package name, and not because the new maintainer changed the _behavior_ of the package.
 
-Rules:
+#### Rules for monorepo presets
 
 1. The primary use case of monorepo presets is finding packages from the same origin source repository which should be updated together
 1. Packages from the same repository which are developed and versioned independently do not need to be grouped as a monorepo, but in many cases we still do


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Rewrite a few sentences, and fix some small style things
- Add info from `@secustor` from comment: 
   - https://github.com/renovatebot/renovate/pull/29329#discussion_r1619281809
   - Add short summary of the wanted action: pin to the first recommended version of the new package
- Emphasize some key points in the docs
- Improve some headings

## Context

We should explain better:

- _why_ we want to use the first recommended version of a new package in the replacement preset
- That we mean for the replacement preset to _pin_ to the new version instead of using the _range syntax_, to avoid unrelated CI breakage

Inspired by the review comments in this PR:

- #29329

This PR does not close any issue.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
