### PR TITLE
fix(gomod): use plural for additional dependencies notice

### DIFF
--- a/lib/modules/manager/gomod/artifacts-extra.spec.ts
+++ b/lib/modules/manager/gomod/artifacts-extra.spec.ts
@@ -91,7 +91,7 @@ describe('modules/manager/gomod/artifacts-extra', () => {
       expect(res).toBeNull();
     });
 
-    it('returns a notice when there are extra dependencies', () => {
+    it('returns a notice when there is an extra dependency', () => {
       const excludeDeps = ['go', 'github.com/foo/foo'];
 
       const res = getExtraDepsNotice(goModBefore, goModAfter, excludeDeps);
@@ -107,6 +107,28 @@ describe('modules/manager/gomod/artifacts-extra', () => {
           'Details:',
           '| **Package**          | **Change**           |',
           '| :------------------- | :------------------- |',
+          '| `github.com/bar/bar` | `v2.0.0` -> `v2.2.2` |',
+        ].join('\n'),
+      );
+    });
+
+    it('returns a notice when there are extra dependencies', () => {
+      const excludeDeps = ['go'];
+
+      const res = getExtraDepsNotice(goModBefore, goModAfter, excludeDeps);
+
+      expect(res).toEqual(
+        [
+          'In order to perform the update(s) described in the table above, Renovate ran the `go get` command, which resulted in the following additional change(s):',
+          '',
+          '',
+          '- 2 additional dependencies were updated',
+          '',
+          '',
+          'Details:',
+          '| **Package**          | **Change**           |',
+          '| :------------------- | :------------------- |',
+          '| `github.com/foo/foo` | `v1.0.0` -> `v1.1.1` |',
           '| `github.com/bar/bar` | `v2.0.0` -> `v2.2.2` |',
         ].join('\n'),
       );

--- a/lib/modules/manager/gomod/artifacts-extra.ts
+++ b/lib/modules/manager/gomod/artifacts-extra.ts
@@ -94,8 +94,12 @@ export function getExtraDepsNotice(
   const goUpdated = extraDeps.some(({ depName }) => depName === 'go');
   const otherDepsCount = extraDeps.length - (goUpdated ? 1 : 0);
 
-  if (otherDepsCount > 0) {
+  if (otherDepsCount === 1) {
     noticeLines.push(`- ${otherDepsCount} additional dependency was updated`);
+  } else if (otherDepsCount > 1) {
+    noticeLines.push(
+      `- ${otherDepsCount} additional dependencies were updated`,
+    );
   }
 
   if (goUpdated) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Tiny cosmetic change to use the plural form when more than one additional dependency were updated (`dependency was` -> `dependencies were`)

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

Follow up to #28938

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
