### PR TITLE
fix(pip-compile): Correctly report errors when a lock file is unchanged

### DIFF
--- a/lib/modules/manager/pip-compile/artifacts.spec.ts
+++ b/lib/modules/manager/pip-compile/artifacts.spec.ts
@@ -1,7 +1,11 @@
 import { codeBlock } from 'common-tags';
 import { mockDeep } from 'jest-mock-extended';
 import { join } from 'upath';
-import { envMock, mockExecAll } from '../../../../test/exec-util';
+import {
+  envMock,
+  mockExecAll,
+  mockExecSequence,
+} from '../../../../test/exec-util';
 import { Fixtures } from '../../../../test/fixtures';
 import { env, fs, git, mocked, partial } from '../../../../test/util';
 import { GlobalConfig } from '../../../config/global';
@@ -614,6 +618,33 @@ describe('modules/manager/pip-compile/artifacts', () => {
       ).toBe(
         'pip-compile --output-file=requirements.txt requirements.in --upgrade-package=foo==1.0.2 --upgrade-package=bar==2.0.0',
       );
+    });
+
+    it('reports errors when a lock file is unchanged', async () => {
+      fs.readLocalFile.mockResolvedValue(simpleHeader);
+      mockExecSequence([
+        new Error('Oh noes!'),
+        { stdout: 'This one worked', stderr: '' },
+      ]);
+      git.getRepoStatus.mockResolvedValue(
+        partial<StatusResult>({
+          modified: [],
+        }),
+      );
+      const results = await updateArtifacts({
+        packageFileName: 'requirements.in',
+        updatedDeps: [],
+        newPackageFileContent: 'some new content',
+        config: {
+          ...config,
+          lockFiles: ['requirements1.txt', 'requirements2.txt'],
+        },
+      });
+      expect(results).toMatchObject([
+        {
+          artifactError: { lockFile: 'requirements1.txt', stderr: 'Oh noes!' },
+        },
+      ]);
     });
   });
 });

--- a/lib/modules/manager/pip-compile/artifacts.spec.ts
+++ b/lib/modules/manager/pip-compile/artifacts.spec.ts
@@ -84,7 +84,7 @@ describe('modules/manager/pip-compile/artifacts', () => {
     expect(execSnapshots).toEqual([]);
   });
 
-  it('returns null if unchanged', async () => {
+  it('returns null if all unchanged', async () => {
     fs.readLocalFile.mockResolvedValueOnce(simpleHeader);
     const execSnapshots = mockExecAll();
     fs.readLocalFile.mockResolvedValueOnce('new lock');

--- a/lib/modules/manager/pip-compile/artifacts.ts
+++ b/lib/modules/manager/pip-compile/artifacts.ts
@@ -125,16 +125,15 @@ export async function updateArtifacts({
       logger.trace({ env: execOptions.extraEnv }, 'pip-compile extra env vars');
       await exec(cmd, execOptions);
       const status = await getRepoStatus();
-      if (!status?.modified.includes(outputFileName)) {
-        return null;
+      if (status?.modified.includes(outputFileName)) {
+        result.push({
+          file: {
+            type: 'addition',
+            path: outputFileName,
+            contents: await readLocalFile(outputFileName, 'utf8'),
+          },
+        });
       }
-      result.push({
-        file: {
-          type: 'addition',
-          path: outputFileName,
-          contents: await readLocalFile(outputFileName, 'utf8'),
-        },
-      });
     } catch (err) {
       // istanbul ignore if
       if (err.message === TEMPORARY_ERROR) {

--- a/lib/modules/manager/pip-compile/artifacts.ts
+++ b/lib/modules/manager/pip-compile/artifacts.ts
@@ -149,5 +149,5 @@ export async function updateArtifacts({
     }
   }
   logger.debug('pip-compile: Returning updated output file(s)');
-  return result;
+  return result.length === 0 ? null : result;
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

The pip-compile manager can update multiple lock files when a single input file changes, however the manager would short-circuit and return null as soon as a single lock file remained unchanged after being re-compiled.

This was causing two issues:
1. Updates to a later lock file could be missed.  This is fairly unlikely since the manager trys not to re-compile lock files for which the input haven't changed.
2. Errors in one lock file update could be swallowed if a later lock file update succeeded but made no changes.  This scenario was quite likely, especially in the case where one lock file depends on another since the first failure will result in an unchanged upstream lock file.

This removes the short-circuit behavior so that the manager will re-compile all of the lock files that depend on the changed input file no matter what.


## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
