### PR TITLE
Support any type of private CocoaPods repository

### DIFF
--- a/lib/modules/datasource/pod/index.ts
+++ b/lib/modules/datasource/pod/index.ts
@@ -1,11 +1,19 @@
 import crypto from 'node:crypto';
+import { pathExistsSync, readdir } from 'fs-extra';
+import Git from 'simple-git';
+import upath from 'upath';
 import { HOST_DISABLED } from '../../../constants/error-messages';
 import { logger } from '../../../logger';
 import { ExternalHostError } from '../../../types/errors/external-host-error';
+import * as memCache from '../../../util/cache/memory';
 import { cache } from '../../../util/cache/package/decorator';
+import { privateCacheDir } from '../../../util/fs';
+import { simpleGitConfig } from '../../../util/git/config';
+import { toSha256 } from '../../../util/hash';
 import type { HttpError } from '../../../util/http';
 import { GithubHttp } from '../../../util/http/github';
 import { newlineRegex, regEx } from '../../../util/regex';
+import { parseUrl } from '../../../util/url';
 import { Datasource } from '../datasource';
 import { massageGithubUrl } from '../metadata';
 import type { GetReleasesConfig, ReleaseResult } from '../types';
@@ -136,6 +144,91 @@ export class PodDatasource extends Datasource {
     return null;
   }
 
+  private async getReleasesFromGit(
+    packageName: string,
+    registryUrl: string,
+  ): Promise<ReleaseResult | null> {
+    const cacheKey = `crate-datasource/registry-clone-path/${registryUrl}`;
+    const cacheKeyForError = `crate-datasource/registry-clone-path/${registryUrl}/error`;
+
+    // We need to ensure we don't run `git clone` in parallel. Therefore we store
+    // a promise of the running operation in the mem cache, which in the end resolves
+    // to the file path of the cloned repository.
+
+    const clonePathPromise: Promise<string> | null = memCache.get(cacheKey);
+    let clonePath: string;
+
+    if (clonePathPromise) {
+      clonePath = await clonePathPromise;
+    } else {
+      const url = parseUrl(registryUrl);
+      if (!url) {
+        logger.debug(`Could not parse registry URL ${registryUrl}`);
+        return null;
+      }
+
+      clonePath = upath.join(
+        privateCacheDir(),
+        PodDatasource.cacheDirFromUrl(url),
+      );
+      logger.info(
+        { clonePath, registryUrl },
+        `Cloning private cocoapods registry`,
+      );
+
+      const git = Git({ ...simpleGitConfig(), maxConcurrentProcesses: 1 });
+      const clonePromise = git.clone(registryUrl, clonePath, {
+        '--depth': 1,
+      });
+
+      memCache.set(
+        cacheKey,
+        clonePromise.then(() => clonePath).catch(() => null),
+      );
+
+      try {
+        await clonePromise;
+      } catch (err) {
+        logger.warn(
+          { err, packageName, registryUrl },
+          'failed cloning git registry',
+        );
+        memCache.set(cacheKeyForError, err);
+
+        return null;
+      }
+    }
+
+    if (!clonePath) {
+      const err = memCache.get(cacheKeyForError);
+      logger.warn(
+        { err, packageName, registryUrl },
+        'Previous git clone failed, bailing out.',
+      );
+
+      return null;
+    }
+    // Recursively get directory contents
+    const modulePath = upath.join(clonePath, packageName);
+    if (!pathExistsSync(modulePath)) {
+      return null;
+    }
+    const spec_files = (await readdir(modulePath, { recursive: true }))
+      .map((item) => item.toString()) // Convert buffers to strings
+      .filter(
+        (item) => item.endsWith('.podspec.json') || item.endsWith('.podspec'),
+      );
+    const modulesByVersion = spec_files.map((item) => {
+      const parts = item.split('/');
+      const version = parts[0];
+      return {
+        version,
+      };
+    });
+    // todo: Not return but use a single let result
+    return { releases: modulesByVersion };
+  }
+
   private async getReleasesFromGithub(
     packageName: string,
     opts: { hostURL: string; account: string; repo: string },
@@ -202,6 +295,14 @@ export class PodDatasource extends Datasource {
     return null;
   }
 
+  private static cacheDirFromUrl(url: URL): string {
+    const proto = url.protocol.replace(regEx(/:$/), '');
+    const host = url.hostname;
+    const hash = toSha256(url.pathname).substring(0, 7);
+
+    return `cocoapods-registry-${proto}-${host}-${hash}`;
+  }
+
   @cache({
     ttlMinutes: 30,
     namespace: `datasource-${PodDatasource.id}`,
@@ -224,15 +325,19 @@ export class PodDatasource extends Datasource {
     if (isDefaultRepo(baseUrl)) {
       [baseUrl] = this.defaultRegistryUrls;
     }
-
     let result: ReleaseResult | null = null;
     const match = githubRegex.exec(baseUrl);
-    if (match?.groups) {
+    const privateGitRegistry =
+      process.env.COCOAPODS_GIT_REPOSITORIES?.split(',');
+
+    if (privateGitRegistry?.includes(registryUrl)) {
+      result = await this.getReleasesFromGit(podName, registryUrl);
+    } else if (match?.groups) {
       baseUrl = massageGithubUrl(baseUrl);
       const { hostURL, account, repo } = match.groups;
       const opts = { hostURL, account, repo };
       result = await this.getReleasesFromGithub(podName, opts);
-    } else {
+    } else if (this.defaultRegistryUrls.includes(baseUrl)) {
       result = await this.getReleasesFromCDN(podName, baseUrl);
     }
 

--- a/lib/modules/datasource/pod/readme.md
+++ b/lib/modules/datasource/pod/readme.md
@@ -1,0 +1,38 @@
+This datasource will return releases from the Cocoapods public CDN by default.
+
+### Private Cocoapods Repositories
+
+It can also be configured to return releases from a private Cocoapods repository via the environment variable `COCOAPODS_GIT_REPOSITORIES` which takes a comma separated list of one or more repository URLs.
+These URLs should be exactly the same as what is in the Podfile of your project like so:
+
+Podfile:
+
+```ruby
+source 'https://myorg.visualstudio.com/myproject/_git/podspecs'
+source 'https://cdn.cocoapods.org/'
+
+target 'MyApp' do
+  pod 'RxSwift' # Comes from 'https://cdn.cocoapods.org'
+  pod 'MyPrivatePod' # Comes from 'https://myorg.visualstudio.com/myproject/_git/podspecs'
+end
+```
+
+config.js:
+
+```javascript
+module.exports = {
+  platform: "azure",
+  endpoint: "https://myorg.visualstudio.com",
+  token: process.env.TOKEN,
+  COCOAPODS_GIT_REPOSITORIES: "https://myorg.visualstudio.com/myproject/_git/podspecs",
+  repositories: [
+    "myproject/my-mobile-app",
+  ],
+  packageRules: [
+    {
+      "matchDatasources": ["pod"],
+      "matchPackageNames": ["MyPrivatePod"]
+    }
+  ]
+};
+```


### PR DESCRIPTION
## Changes

Support private cocoapod repositories from any arbitrary git repisotory (not just GitHub) and in the basic format (not the complex sharding format that GitHub master uses).

## Context

As per our discussion https://github.com/renovatebot/renovate/discussions/29049#:
Private repositories (used for various private libraries and mirroring of vendored libraries etc) currently don't work if it can't be accessed via the GitHub API v3, the format is also more complex as it matches production with _contents or sharding folder structure.

Given that enterprise repositories from GitHub and others can take differing formats of domain (subdomains etc), configuration is explicit via the `COCOAPODS_GIT_REPOSITORIES` environment variable in the update documentation. When this value matches exactly to one of the `source` values from Podfile, it will pull down the repository via git. In this way any repository will be able to work regardless of the hosting provider as cocoapods require folder structure.

The structure of the most basic cocoapods repository is:
```
.
└── MyPrivatePod
    └── 1.2.3
        └── MyPrivatePod.podspec.json

```

## Documentation (please check one with an [x])

- [X] I have updated the documentation

## How I've tested my work (please select one)

I have verified these changes via:

- [X] Both unit tests + ran on a real repository