### PR TITLE
fix(manager/terragrunt): use git-tags datasource for bitbucket-server

### DIFF
--- a/lib/modules/manager/terragrunt/__fixtures__/2.hcl
+++ b/lib/modules/manager/terragrunt/__fixtures__/2.hcl
@@ -189,3 +189,8 @@ terraform {
 terraform {
   source = "git::https://gitea.com/hashicorp/example?ref=v1.0.0"
 }
+
+# gittags fallback for bitbucket-server
+terraform {
+  source = "git::https://bitbucket.example.com/hashicorp/example?ref=v1.0.0"
+}

--- a/lib/modules/manager/terragrunt/extract.spec.ts
+++ b/lib/modules/manager/terragrunt/extract.spec.ts
@@ -246,9 +246,16 @@ describe('modules/manager/terragrunt/extract', () => {
             packageName: 'hashicorp/example',
             registryUrls: ['https://gitea.com'],
           },
+          {
+            currentValue: 'v1.0.0',
+            datasource: 'git-tags',
+            depName: 'bitbucket.example.com/hashicorp/example',
+            depType: 'gitTags',
+            packageName: 'https://bitbucket.example.com/hashicorp/example',
+          },
         ],
       });
-      expect(res?.deps).toHaveLength(35);
+      expect(res?.deps).toHaveLength(36);
       expect(res?.deps.filter((dep) => dep.skipReason)).toHaveLength(4);
     });
 

--- a/lib/util/common.spec.ts
+++ b/lib/util/common.spec.ts
@@ -40,6 +40,7 @@ describe('util/common', () => {
       ${'https://myorg.visualstudio.com/my-project/_git/my-repo.git'}        | ${'azure'}
       ${'https://bitbucket.org/some-org/some-repo'}                          | ${'bitbucket'}
       ${'https://bitbucket.com/some-org/some-repo'}                          | ${'bitbucket'}
+      ${'https://bitbucket.example.com/some-org/some-repo'}                  | ${'bitbucket-server'}
       ${'https://gitea.com/semantic-release/gitlab'}                         | ${'gitea'}
       ${'https://forgejo.example.com/semantic-release/gitlab'}               | ${'gitea'}
       ${'https://github.com/semantic-release/gitlab'}                        | ${'github'}

--- a/lib/util/common.ts
+++ b/lib/util/common.ts
@@ -17,13 +17,23 @@ import { parseUrl } from './url';
  */
 export function detectPlatform(
   url: string,
-): 'azure' | 'bitbucket' | 'gitea' | 'github' | 'gitlab' | null {
+):
+  | 'azure'
+  | 'bitbucket'
+  | 'bitbucket-server'
+  | 'gitea'
+  | 'github'
+  | 'gitlab'
+  | null {
   const { hostname } = parseUrl(url) ?? {};
   if (hostname === 'dev.azure.com' || hostname?.endsWith('.visualstudio.com')) {
     return 'azure';
   }
-  if (hostname === 'bitbucket.org' || hostname?.includes('bitbucket')) {
+  if (hostname === 'bitbucket.org' || hostname === 'bitbucket.com') {
     return 'bitbucket';
+  }
+  if (hostname?.includes('bitbucket')) {
+    return 'bitbucket-server';
   }
   if (
     hostname &&


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

* Restricts the detection of Bitbucket Cloud to bitbucket.org and bitbucket.com
* Adds a regression safeguard to terragrunt manager that showcases the effect of this change

I also verified that terragrunt was the only manager with special handling for the case `detectPlatform() == "bitbucket"`.

<!-- Describe what behavior is changed by this PR. -->

## Context

- https://github.com/renovatebot/renovate/discussions/29400

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
