### PR TITLE
docs(yarn): docs to clarify expected setup for yarn 2+

### DIFF
--- a/docs/usage/getting-started/private-packages.md
+++ b/docs/usage/getting-started/private-packages.md
@@ -399,13 +399,13 @@ npmRegistries:
     npmAuthToken: <Decrypted PAT Token>
 ```
 
-Thus, to allow for private registries to be used locally via the `NPM_TOKEN` environment variable AND with renovate, your local `.yarnrc.yml` should contain
+Thus, to allow for private registries to be used locally via the `NPM_TOKEN` environment variable _and_ with Renovate, your local `.yarnrc.yml` must contain:
+
+
 ```yaml
 npmRegistries:
    //npm.pkg.github.com/:
     npmAuthToken: "${NPM_TOKEN}"
-```
-which will be automatically updated by renovate via the hostRules. You *cannot* set a top level `npmAuthToken` in your `.yarnrc.yml` file, as it is not overriden.
 
 ### maven
 

--- a/docs/usage/getting-started/private-packages.md
+++ b/docs/usage/getting-started/private-packages.md
@@ -409,12 +409,6 @@ npmRegistries:
     npmAuthToken: "${NPM_TOKEN}"
 ```
 
-or
-
-```yaml
-npmAuthToke: "${NPM_TOKEN:-}"
-```
-
 
 ### maven
 

--- a/docs/usage/getting-started/private-packages.md
+++ b/docs/usage/getting-started/private-packages.md
@@ -360,9 +360,10 @@ The end-result looks like this:
 
 #### Yarn 2+
 
-Renovate doesn't support reading `npmRegistries` and `npmScopes` from `.yarnrc.yml`, so `hostRules` (or `npmToken`) and `npmrc` should be configured like above. The `${NPM_TOKEN}` substitution that takes place for `.npmrc` will also not occur for `.yarnrc.yml`.
+In Yarn 2+, a [.yarnrc.yml](https://yarnpkg.com/configuration/yarnrc) file can be used with to configure npm authentication for private registries via `npmRegistries` or via a top level `npmAuthToken`.
 
-Renovate updates `npmRegistries` in `.yarnrc.yml` with resolved `hostRules` before running Yarn.
+Renovate updates `npmRegistries` in `.yarnrc.yml` with resolved `hostRules` before running Yarn, but does not overwrite `npmAuthToken`.
+
 For Renovate to overwrite existing `npmRegistries` entry, the key should match the `matchHost` minus the protocol (`http:` or `https:`) plus the trailing slash.
 
 For example, the Renovate configuration:
@@ -406,6 +407,14 @@ Thus, to allow for private registries to be used locally via the `NPM_TOKEN` env
 npmRegistries:
    //npm.pkg.github.com/:
     npmAuthToken: "${NPM_TOKEN}"
+```
+
+or
+
+```yaml
+npmAuthToke: "${NPM_TOKEN:-}"
+```
+
 
 ### maven
 

--- a/docs/usage/getting-started/private-packages.md
+++ b/docs/usage/getting-started/private-packages.md
@@ -360,7 +360,8 @@ The end-result looks like this:
 
 #### Yarn 2+
 
-Renovate doesn't support reading `npmRegistries` and `npmScopes` from `.yarnrc.yml`, so `hostRules` (or `npmToken`) and `npmrc` should be configured like above.
+Renovate doesn't support reading `npmRegistries` and `npmScopes` from `.yarnrc.yml`, so `hostRules` (or `npmToken`) and `npmrc` should be configured like above. The `${NPM_TOKEN}` substitution that takes place for `.npmrc` will also not occur for `.yarnrc.yml`.
+
 Renovate updates `npmRegistries` in `.yarnrc.yml` with resolved `hostRules` before running Yarn.
 For Renovate to overwrite existing `npmRegistries` entry, the key should match the `matchHost` minus the protocol (`http:` or `https:`) plus the trailing slash.
 
@@ -397,6 +398,14 @@ npmRegistries:
   https://npm.pkg.github.com:
     npmAuthToken: <Decrypted PAT Token>
 ```
+
+Thus, to allow for private registries to be used locally via the `NPM_TOKEN` environment variable AND with renovate, your local `.yarnrc.yml` should contain
+```yaml
+npmRegistries:
+   //npm.pkg.github.com/:
+    npmAuthToken: "${NPM_TOKEN}"
+```
+which will be automatically updated by renovate via the hostRules. You *cannot* set a top level `npmAuthToken` in your `.yarnrc.yml` file, as it is not overriden.
 
 ### maven
 


### PR DESCRIPTION
This documents what the local .yarnrc.yml should look like, and that it CANNOT contain a top level reference to NPM_TOKEN (unlike .npmrc)

## Changes

Doc-only change

## Context

Clarify yarn 2+ private registry support https://github.com/renovatebot/renovate/issues/14756 

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository