### PR TITLE
docs(pip-compile): Add note re proper usage of index-url

### DIFF
--- a/docs/usage/getting-started/private-packages.md
+++ b/docs/usage/getting-started/private-packages.md
@@ -466,6 +466,9 @@ name = "pypi"
 The pip-compile manager extracts `--index-url` and `--extra-index-url` directives from its input file.
 Renovate will match those URLs with credentials from matching `hostRules` blocks in its configuration and pass them to `pip-compile` via environment variables.
 
+> [!NOTE]
+> Placing the `--[extra-]index-url` in the lockfile is not supported; it must go in the `.in` file for it to be used by pip-compile during renovate jobs.
+
 ```title="requirements.in"
 --extra-index-url https://pypi.my.domain/simple
 


### PR DESCRIPTION


<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Renovate doesn't parse the `--index-url` option from the lockfiles, it just runs pip-compile and pip-compile finds its own `--index-url` (from the `.in` files instead.)

The docs actually already do state which file the `--index-url` should go in, but since some of the other config comes from the lockfile, I didn't expect to have to add the index URL in the `.in` file and so I glossed over that.

This PR draws attention to that detail so other people won't gloss over it :)
## Context

borne from my confusion [here](https://github.com/renovatebot/renovate/discussions/29334#discussioncomment-9636121). 
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
