### PR TITLE
chore(lookup): increase log level of "Found no results ..." message

### DIFF
--- a/lib/workers/repository/process/lookup/index.spec.ts
+++ b/lib/workers/repository/process/lookup/index.spec.ts
@@ -3749,7 +3749,12 @@ describe('workers/repository/process/lookup/index', () => {
         sourceUrl: 'https://github.com/nodejs/node',
         updates: [],
         versioning: 'node',
-        warnings: [],
+        warnings: [
+          {
+            message: 'Found no versions of package node in datasource docker',
+            topic: 'node',
+          },
+        ],
       });
     });
 

--- a/lib/workers/repository/process/lookup/index.spec.ts
+++ b/lib/workers/repository/process/lookup/index.spec.ts
@@ -3749,12 +3749,7 @@ describe('workers/repository/process/lookup/index', () => {
         sourceUrl: 'https://github.com/nodejs/node',
         updates: [],
         versioning: 'node',
-        warnings: [
-          {
-            message: 'Found no versions of package node in datasource docker',
-            topic: 'node',
-          },
-        ],
+        warnings: [],
       });
     });
 

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -194,6 +194,11 @@ export async function lookupUpdates(
           },
           message,
         );
+        const warning: ValidationMessage = {
+          topic: config.packageName,
+          message: `Found no versions of package ${config.packageName} in datasource ${config.datasource}`,
+        };
+        res.warnings.push(warning);
         if (!config.currentDigest) {
           return Result.ok(res);
         }

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -187,18 +187,13 @@ export async function lookupUpdates(
       // istanbul ignore if
       if (allVersions.length === 0) {
         const message = `Found no results from datasource that look like a version`;
-        logger.debug(
+        logger.info(
           {
             dependency: config.packageName,
             result: dependency,
           },
           message,
         );
-        const warning: ValidationMessage = {
-          topic: config.packageName,
-          message: `Found no versions of package ${config.packageName} in datasource ${config.datasource}`,
-        };
-        res.warnings.push(warning);
         if (!config.currentDigest) {
           return Result.ok(res);
         }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Add a warning when no valid package versions can be found in the datasource.

## Context

This is almost always a configuration error. It happened to me multiple times when I configured versioning or extractVersion incorrectly. And the issue is hard to notice when there are no updates available immediately, because logs and reports only show newer versions from lookup results.

There is a debug-level log message already, which I currently remap to warning. But I'm a bit afraid that it'll change or disappear.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
