### PR TITLE
fix: Revert "build(deps): update dependency re2 to v1.21.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -252,7 +252,7 @@
   "optionalDependencies": {
     "better-sqlite3": "9.6.0",
     "openpgp": "5.11.1",
-    "re2": "1.21.0"
+    "re2": "1.20.12"
   },
   "devDependencies": {
     "@hyrious/marshal": "0.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -337,8 +337,8 @@ importers:
         specifier: 5.11.1
         version: 5.11.1
       re2:
-        specifier: 1.21.0
-        version: 1.21.0
+        specifier: 1.20.12
+        version: 1.20.12
     devDependencies:
       '@hyrious/marshal':
         specifier: 0.3.3
@@ -5005,8 +5005,8 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
-  re2@1.21.0:
-    resolution: {integrity: sha512-4KvJJQTCfkUbMWCTxwtMVsVlWi/o3RrEpKYFbj0vkbi6Qk+UlI7xlIyVsgMSjxEvxeec7IhqOOfsU/KQcF+PUw==}
+  re2@1.20.12:
+    resolution: {integrity: sha512-pfCHx+j0agxahWorhQZ2hyaZh/LH2e/vpoAilggksI3fFt+62oF0AY7UP7uvmpWleYLy6UoBTz4r/Kif0LfB/g==}
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
@@ -11755,7 +11755,7 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
-  re2@1.21.0:
+  re2@1.20.12:
     dependencies:
       install-artifact-from-github: 1.3.5
       nan: 2.19.0


### PR DESCRIPTION
Reverts renovatebot/renovate#29413

- https://github.com/renovatebot/renovate/discussions/29448
- https://github.com/uhop/node-re2/issues/210