### PR TITLE
feat(pip-compile): Treat .txt files as pip_requirements files

### DIFF
--- a/lib/modules/manager/pip-compile/common.spec.ts
+++ b/lib/modules/manager/pip-compile/common.spec.ts
@@ -342,5 +342,10 @@ describe('modules/manager/pip-compile/common', () => {
       expect(matchManager('file.in')).toBe('pip_requirements');
       expect(matchManager('another_file.in')).toBe('pip_requirements');
     });
+
+    it('matches pip_requirements any .txt file', () => {
+      expect(matchManager('file.txt')).toBe('pip_requirements');
+      expect(matchManager('another_file.txt')).toBe('pip_requirements');
+    });
   });
 });

--- a/lib/modules/manager/pip-compile/common.ts
+++ b/lib/modules/manager/pip-compile/common.ts
@@ -320,7 +320,7 @@ export function matchManager(filename: string): SupportedManagers | 'unknown' {
     return 'pep621';
   }
   // naive, could be improved, maybe use pip_requirements.fileMatch
-  if (filename.endsWith('.in')) {
+  if (filename.endsWith('.in') || filename.endsWith('.txt')) {
     return 'pip_requirements';
   }
   return 'unknown';


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This fixes a case I missed in #28959 where a lock file uses another lock file as an input file.  In that case, we need to treat the input lock file as a pip_requirements file so that we extract the `--[extra-]index-url` flags from it and pass the correct credentials to pip-compile.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->
#28959

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
