### PR TITLE
fix(changelogUrl): migrate and fix

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -3120,19 +3120,17 @@ Tokens can be configured via `hostRules` using the `"merge-confidence"` `hostTyp
 }
 ```
 
-### customChangelogUrl
+### changelogUrl
 
-Use this field to set the source URL for a package, including overriding an existing one.
-Source URLs are necessary in order to look up changelogs.
-
+Use this field to set the changelog URL for a package, including overriding any existing one.
 Using this field we can specify the exact URL to fetch changelogs from.
 
-```json title="Setting the source URL for the dummy package"
+```json title="Setting the changelog URL for the dummy package"
 {
   "packageRules": [
     {
       "matchPackageNames": ["dummy"],
-      "customChangelogUrl": "https://github.com/org/dummy"
+      "changelogUrl": "https://github.com/org/dummy"
     }
   ]
 }

--- a/docs/usage/key-concepts/changelogs.md
+++ b/docs/usage/key-concepts/changelogs.md
@@ -34,7 +34,7 @@ Set to `off` if changelog fetching is causing a problem.
 
 Set to `branch` if you have an advanced use case where you're embedding changelogs in the Git commit itself, we don't recommend this due to its potential size.
 
-### [`customChangelogUrl`](../configuration-options.md#customchangelogurl)
+### [`changelogUrl`](../configuration-options.md#changelogurl)
 
 This doesn't help with _fetching_ the changelogs, but if you configure it then Renovate will include a link to this URL in the PR body, so users can click through to read the changelog.
 

--- a/lib/config/migrations/migrations-service.ts
+++ b/lib/config/migrations/migrations-service.ts
@@ -81,6 +81,7 @@ export class MigrationsService {
   static readonly renamedProperties: ReadonlyMap<string, string> = new Map([
     ['adoptium-java', 'java-version'],
     ['azureAutoApprove', 'autoApprove'],
+    ['customChangelogUrl', 'changelogUrl'],
     ['endpoints', 'hostRules'],
     ['excludedPackageNames', 'excludePackageNames'],
     ['exposeEnv', 'exposeAllEnv'],

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -1703,7 +1703,7 @@ const options: RenovateOptions[] = [
     env: false,
   },
   {
-    name: 'customChangelogUrl',
+    name: 'changelogUrl',
     description:
       'If set, Renovate will use this URL to fetch changelogs for a matched dependency. Valid only within a `packageRules` object.',
     type: 'string',

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -46,7 +46,7 @@ export interface RenovateSharedConfig {
   commitMessagePrefix?: string;
   commitMessageTopic?: string;
   confidential?: boolean;
-  customChangelogUrl?: string;
+  changelogUrl?: string;
   dependencyDashboardApproval?: boolean;
   draftPR?: boolean;
   enabled?: boolean;

--- a/lib/workers/repository/update/pr/changelog/gitea/index.spec.ts
+++ b/lib/workers/repository/update/pr/changelog/gitea/index.spec.ts
@@ -395,41 +395,6 @@ describe('workers/repository/update/pr/changelog/gitea/index', () => {
       // TODO: find right mocks
       httpMock.clear(false);
     });
-
-    it('supports overwriting sourceUrl for self-hosted gitea changelog', async () => {
-      httpMock.scope('https://git.test.com').persist().get(/.*/).reply(200, []);
-      const sourceUrl = 'https://git.test.com/meno/dropzone/';
-      const replacementSourceUrl =
-        'https://git.test.com/replacement/sourceurl/';
-      const config = {
-        ...upgrade,
-        platform: 'gitea',
-        endpoint: 'https://git.test.com/api/v1/',
-        sourceUrl,
-        customChangelogUrl: replacementSourceUrl,
-      };
-      hostRules.add({
-        hostType: 'gitea',
-        matchHost: 'https://git.test.com/',
-        token: 'abc',
-      });
-      expect(await getChangeLogJSON(config)).toMatchObject({
-        hasReleaseNotes: false,
-        project: {
-          apiBaseUrl: 'https://git.test.com/api/v1/',
-          baseUrl: 'https://git.test.com/',
-          packageName: 'renovate',
-          repository: 'replacement/sourceurl',
-          sourceDirectory: undefined,
-          sourceUrl: 'https://git.test.com/replacement/sourceurl/',
-          type: 'gitea',
-        },
-      });
-      expect(config.sourceUrl).toBe(sourceUrl); // ensure unmodified function argument
-
-      // TODO: find right mocks
-      httpMock.clear(false);
-    });
   });
 
   describe('hasValidRepository', () => {

--- a/lib/workers/repository/update/pr/changelog/github/index.spec.ts
+++ b/lib/workers/repository/update/pr/changelog/github/index.spec.ts
@@ -275,34 +275,6 @@ describe('workers/repository/update/pr/changelog/github/index', () => {
       });
     });
 
-    it('supports overwriting sourceUrl for supports github enterprise and github.com changelog', async () => {
-      const sourceUrl = upgrade.sourceUrl;
-      const replacementSourceUrl = 'https://github.com/sindresorhus/got';
-      const config = {
-        ...upgrade,
-        endpoint: 'https://github-enterprise.example.com/',
-        customChangelogUrl: replacementSourceUrl,
-      };
-      hostRules.add({
-        hostType: 'github',
-        token: 'super_secret',
-        matchHost: 'https://github-enterprise.example.com/',
-      });
-      expect(await getChangeLogJSON(config)).toMatchObject({
-        hasReleaseNotes: true,
-        project: {
-          apiBaseUrl: 'https://api.github.com/',
-          baseUrl: 'https://github.com/',
-          packageName: 'renovate',
-          repository: 'sindresorhus/got',
-          sourceDirectory: undefined,
-          sourceUrl: 'https://github.com/sindresorhus/got',
-          type: 'github',
-        },
-      });
-      expect(upgrade.sourceUrl).toBe(sourceUrl); // ensure unmodified function argument
-    });
-
     it('supports github enterprise and github enterprise changelog', async () => {
       hostRules.add({
         hostType: 'github',
@@ -334,37 +306,6 @@ describe('workers/repository/update/pr/changelog/github/index', () => {
           { version: '2.2.2' },
         ],
       });
-    });
-
-    it('supports overwriting sourceUrl for github enterprise and github enterprise changelog', async () => {
-      const sourceUrl = 'https://github-enterprise.example.com/chalk/chalk';
-      const replacementSourceUrl =
-        'https://github-enterprise.example.com/sindresorhus/got';
-      const config = {
-        ...upgrade,
-        sourceUrl,
-        endpoint: 'https://github-enterprise.example.com/',
-        customChangelogUrl: replacementSourceUrl,
-      };
-      hostRules.add({
-        hostType: 'github',
-        matchHost: 'https://github-enterprise.example.com/',
-        token: 'abc',
-      });
-      process.env.GITHUB_ENDPOINT = '';
-      expect(await getChangeLogJSON(config)).toMatchObject({
-        hasReleaseNotes: true,
-        project: {
-          apiBaseUrl: 'https://github-enterprise.example.com/api/v3/',
-          baseUrl: 'https://github-enterprise.example.com/',
-          packageName: 'renovate',
-          repository: 'sindresorhus/got',
-          sourceDirectory: undefined,
-          sourceUrl: 'https://github-enterprise.example.com/sindresorhus/got',
-          type: 'github',
-        },
-      });
-      expect(config.sourceUrl).toBe(sourceUrl); // ensure unmodified function argument
     });
 
     it('works with same version releases but different prefix', async () => {

--- a/lib/workers/repository/update/pr/changelog/gitlab/index.spec.ts
+++ b/lib/workers/repository/update/pr/changelog/gitlab/index.spec.ts
@@ -316,39 +316,6 @@ describe('workers/repository/update/pr/changelog/gitlab/index', () => {
         ],
       });
     });
-
-    it('supports overwriting sourceUrl for self-hosted gitlab changelog', async () => {
-      httpMock.scope('https://git.test.com').persist().get(/.*/).reply(200, []);
-      const sourceUrl = 'https://git.test.com/meno/dropzone/';
-      const replacementSourceUrl =
-        'https://git.test.com/replacement/sourceurl/';
-      const config = {
-        ...upgrade,
-        platform: 'gitlab',
-        endpoint: 'https://git.test.com/api/v4/',
-        sourceUrl,
-        customChangelogUrl: replacementSourceUrl,
-      };
-      hostRules.add({
-        hostType: 'gitlab',
-        matchHost: 'https://git.test.com/',
-        token: 'abc',
-      });
-      process.env.GITHUB_ENDPOINT = '';
-      expect(await getChangeLogJSON(config)).toMatchObject({
-        hasReleaseNotes: false,
-        project: {
-          apiBaseUrl: 'https://git.test.com/api/v4/',
-          baseUrl: 'https://git.test.com/',
-          packageName: 'renovate',
-          repository: 'replacement/sourceurl',
-          sourceDirectory: undefined,
-          sourceUrl: 'https://git.test.com/replacement/sourceurl/',
-          type: 'gitlab',
-        },
-      });
-      expect(config.sourceUrl).toBe(sourceUrl); // ensure unmodified function argument
-    });
   });
 
   describe('hasValidRepository', () => {

--- a/lib/workers/repository/update/pr/changelog/index.ts
+++ b/lib/workers/repository/update/pr/changelog/index.ts
@@ -10,11 +10,9 @@ import type { ChangeLogResult } from './types';
 export * from './types';
 
 export async function getChangeLogJSON(
-  _config: BranchUpgradeConfig,
+  config: BranchUpgradeConfig,
 ): Promise<ChangeLogResult | null> {
-  const sourceUrl = _config.customChangelogUrl ?? _config.sourceUrl!;
-  const config: BranchUpgradeConfig = { ..._config, sourceUrl };
-  const { versioning, currentVersion, newVersion } = config;
+  const { sourceUrl, versioning, currentVersion, newVersion } = config;
   try {
     if (!(sourceUrl && currentVersion && newVersion)) {
       return null;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

customChangelogUrl did not do what it was documented to do. Renamed it and fixed it to do what it was documented to. We now support sourceUrl in packageRules which can satisfy the (undocumented) previous behavior.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
