### PR TITLE
refactor(package-rules): correct matcher order

### DIFF
--- a/lib/util/package-rules/matchers.ts
+++ b/lib/util/package-rules/matchers.ts
@@ -30,6 +30,12 @@ export default matchers;
 // Therefore, when multiple matchers are set in a single packageRule, some may not be checked.
 // Since matchConfidence matcher can abort the run due to unauthenticated use, it should be evaluated first.
 matchers.push([new MergeConfidenceMatcher()]);
+matchers.push([new RepositoriesMatcher()]);
+matchers.push([new BaseBranchesMatcher()]);
+matchers.push([new CategoriesMatcher()]);
+matchers.push([new ManagersMatcher()]);
+matchers.push([new FileNamesMatcher()]);
+matchers.push([new DatasourcesMatcher()]);
 matchers.push([
   new DepNameMatcher(),
   new DepPatternsMatcher(),
@@ -38,16 +44,10 @@ matchers.push([
   new PackagePatternsMatcher(),
   new PackagePrefixesMatcher(),
 ]);
-matchers.push([new FileNamesMatcher()]);
 matchers.push([new DepTypesMatcher()]);
-matchers.push([new BaseBranchesMatcher()]);
-matchers.push([new ManagersMatcher()]);
-matchers.push([new DatasourcesMatcher()]);
+matchers.push([new CurrentValueMatcher()]);
+matchers.push([new CurrentVersionMatcher()]);
 matchers.push([new UpdateTypesMatcher()]);
 matchers.push([new SourceUrlsMatcher(), new SourceUrlPrefixesMatcher()]);
-matchers.push([new CurrentValueMatcher()]);
 matchers.push([new NewValueMatcher()]);
-matchers.push([new CurrentVersionMatcher()]);
-matchers.push([new RepositoriesMatcher()]);
-matchers.push([new CategoriesMatcher()]);
 matchers.push([new CurrentAgeMatcher()]);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Reorders packageRules matcher execution order to be more efficient and also avoid unnecessary matchPackageNames warning.

## Context

#29406

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
