### PR TITLE
feat(pip-compile): Treat included paths as relative to the package file

### DIFF
--- a/lib/modules/manager/pip-compile/extract.ts
+++ b/lib/modules/manager/pip-compile/extract.ts
@@ -138,6 +138,10 @@ export async function extractAllPackageFiles(
       );
       if (packageFileContent) {
         if (packageFileContent.managerData?.requirementsFiles) {
+          packageFileContent.managerData.requirementsFiles =
+            packageFileContent.managerData.requirementsFiles.map(
+              (file: string) => upath.normalize(upath.join(compileDir, file)),
+            );
           for (const file of packageFileContent.managerData.requirementsFiles) {
             depsBetweenFiles.push({
               sourceFile: file,
@@ -147,6 +151,10 @@ export async function extractAllPackageFiles(
           }
         }
         if (packageFileContent.managerData?.constraintsFiles) {
+          packageFileContent.managerData.constraintsFiles =
+            packageFileContent.managerData.constraintsFiles.map(
+              (file: string) => upath.normalize(upath.join(compileDir, file)),
+            );
           for (const file of packageFileContent.managerData.constraintsFiles) {
             depsBetweenFiles.push({
               sourceFile: file,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

For instance, when 'some-dir/file.in' specifies '-r other-file.txt', we need to treat 'other-file.txt' as being relative to 'some-dir' so that we correctly figure out that 'some-dir/file.in' depends on 'some-dir/other-file.txt'.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
