### PR TITLE
feat: Add support for bitbucket CODEOWNERS location

### DIFF
--- a/lib/workers/repository/update/pr/code-owners.ts
+++ b/lib/workers/repository/update/pr/code-owners.ts
@@ -81,6 +81,7 @@ export async function codeOwnersForPr(pr: Pr): Promise<string[]> {
     // Find CODEOWNERS file
     const codeOwnersFile =
       (await readLocalFile('CODEOWNERS', 'utf8')) ??
+      (await readLocalFile('.bitbucket/CODEOWNERS', 'utf8')) ??
       (await readLocalFile('.github/CODEOWNERS', 'utf8')) ??
       (await readLocalFile('.gitlab/CODEOWNERS', 'utf8')) ??
       (await readLocalFile('docs/CODEOWNERS', 'utf8'));


### PR DESCRIPTION
## Changes

BitBucket requires the CODEOWNERS file to be placed in a .bitbucket folder. https://confluence.atlassian.com/display/BitbucketServer/Code+owners 
This change enhances renovate to also search for a CODEOWNERS file in this location.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository