### PR TITLE
fix(git-url): fix SSH to HTTPS conversion for bitbucket-server

### DIFF
--- a/lib/constants/platforms.ts
+++ b/lib/constants/platforms.ts
@@ -41,3 +41,5 @@ export const BITBUCKET_API_USING_HOST_TYPES = [
   'bitbucket-changelog',
   'bitbucket-tags',
 ];
+
+export const BITBUCKET_SERVER_API_USING_HOST_TYPES = ['bitbucket-server'];

--- a/lib/util/common.ts
+++ b/lib/util/common.ts
@@ -1,6 +1,7 @@
 import JSON5 from 'json5';
 import {
   BITBUCKET_API_USING_HOST_TYPES,
+  BITBUCKET_SERVER_API_USING_HOST_TYPES,
   GITEA_API_USING_HOST_TYPES,
   GITHUB_API_USING_HOST_TYPES,
   GITLAB_API_USING_HOST_TYPES,
@@ -56,6 +57,9 @@ export function detectPlatform(
     return null;
   }
 
+  if (BITBUCKET_SERVER_API_USING_HOST_TYPES.includes(hostType)) {
+    return 'bitbucket-server';
+  }
   if (BITBUCKET_API_USING_HOST_TYPES.includes(hostType)) {
     return 'bitbucket';
   }

--- a/lib/util/git/url.spec.ts
+++ b/lib/util/git/url.spec.ts
@@ -88,6 +88,9 @@ describe('util/git/url', () => {
     });
 
     it('returns bitbucket-server url', () => {
+      expect(getHttpUrl('http://git.mycompany.com/scm/proj/repo.git')).toBe(
+        'http://git.mycompany.com/scm/proj/repo.git',
+      );
       hostRules.hostType.mockReturnValueOnce('bitbucket-server');
       expect(getHttpUrl('ssh://git@git.mycompany.com:7999/proj/repo.git')).toBe(
         'https://git.mycompany.com/scm/proj/repo.git',

--- a/lib/util/git/url.spec.ts
+++ b/lib/util/git/url.spec.ts
@@ -87,6 +87,13 @@ describe('util/git/url', () => {
       );
     });
 
+    it('returns bitbucket-server url', () => {
+      hostRules.hostType.mockReturnValueOnce('bitbucket-server');
+      expect(getHttpUrl('ssh://git@git.mycompany.com:7999/proj/repo.git')).toBe(
+        'https://git.mycompany.com/scm/proj/repo.git',
+      );
+    });
+
     it('removes username/password from URL', () => {
       expect(getHttpUrl('https://user:password@foo.bar/someOrg/someRepo')).toBe(
         'https://foo.bar/someOrg/someRepo',


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Force git-url-parse to insert `/scm/` when converting SSH URLs to HTTPS on `bitbucket-server`.

Adjust `detectPlatform()` to detect `bitbucket-server` from host type.

## Context

Fixes git submodules on BitBucket Server.

SSH URLs on BitBucket Server look like this: `ssh://git@git.my.com:7999/project/repo.git`.
HTTPS URLs look like this: `https://git.mycompany.com/scm/proj/repo.git`.

git-url-parse doesn't recognize the SSH URL as BitBucket Server. And it likely can't: the only hint is the default SSH port number, which can be changed, or can be used by other service.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
