### PR TITLE
feat(instrumentation): add option to overwrite otlp service name/namespace/version with env var

### DIFF
--- a/docs/usage/opentelemetry.md
+++ b/docs/usage/opentelemetry.md
@@ -31,9 +31,10 @@ To activate the instrumentation, you must set the `OTEL_EXPORTER_OTLP_ENDPOINT` 
 This variable controls the endpoint for the telemetry data.
 Once this endpoint is set, you can use all environment variables listed in the [OpenTelemetry specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md).
 You can also set the following environment variables:
-OTEL_SERVICE_NAME: to control the service name that will be emitted in traces, defaults to `renovate`
-OTEL_SERVICE_NAMESPACE: to control the service namespace that will be emitted in traces, defaults to `renovatebot.com`
-OTEL_SERVICE_VERSION: to control the service version that will be emitted in traces, defaults to using the pkg version
+
+- `OTEL_SERVICE_NAME`: to control the service name that will be emitted in traces, defaults to `renovate`
+- `OTEL_SERVICE_NAMESPAC`E: to control the service namespace that will be emitted in traces, defaults to `renovatebot.com`
+- `OTEL_SERVICE_VERSION`: to control the service version that will be emitted in traces, defaults to using the pkg version
 
 ## Debugging
 

--- a/docs/usage/opentelemetry.md
+++ b/docs/usage/opentelemetry.md
@@ -33,7 +33,7 @@ Once this endpoint is set, you can use all environment variables listed in the [
 You can also set the following environment variables:
 
 - `OTEL_SERVICE_NAME`: to control the service name that will be emitted in traces, defaults to `renovate`
-- `OTEL_SERVICE_NAMESPAC`E: to control the service namespace that will be emitted in traces, defaults to `renovatebot.com`
+- `OTEL_SERVICE_NAMESPACE`: to control the service namespace that will be emitted in traces, defaults to `renovatebot.com`
 - `OTEL_SERVICE_VERSION`: to control the service version that will be emitted in traces, defaults to using the pkg version
 
 ## Debugging

--- a/docs/usage/opentelemetry.md
+++ b/docs/usage/opentelemetry.md
@@ -30,6 +30,10 @@ This means that Renovate sends traces via [OTLP/HTTP](https://opentelemetry.io/d
 To activate the instrumentation, you must set the `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable.
 This variable controls the endpoint for the telemetry data.
 Once this endpoint is set, you can use all environment variables listed in the [OpenTelemetry specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md).
+You can also set the following environment variables:
+OTEL_SERVICE_NAME: to control the service name that will be emitted in traces
+OTEL_SERVICE_NAMESPACE: to control the service namespace that will be emitted in traces
+OTEL_SERVICE_VERSION: to control the service version that will be emitted in traces
 
 ## Debugging
 

--- a/docs/usage/opentelemetry.md
+++ b/docs/usage/opentelemetry.md
@@ -31,9 +31,9 @@ To activate the instrumentation, you must set the `OTEL_EXPORTER_OTLP_ENDPOINT` 
 This variable controls the endpoint for the telemetry data.
 Once this endpoint is set, you can use all environment variables listed in the [OpenTelemetry specification](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md).
 You can also set the following environment variables:
-OTEL_SERVICE_NAME: to control the service name that will be emitted in traces
-OTEL_SERVICE_NAMESPACE: to control the service namespace that will be emitted in traces
-OTEL_SERVICE_VERSION: to control the service version that will be emitted in traces
+OTEL_SERVICE_NAME: to control the service name that will be emitted in traces, defaults to `renovate`
+OTEL_SERVICE_NAMESPACE: to control the service namespace that will be emitted in traces, defaults to `renovatebot.com`
+OTEL_SERVICE_VERSION: to control the service version that will be emitted in traces, defaults to using the pkg version
 
 ## Debugging
 

--- a/docs/usage/opentelemetry.md
+++ b/docs/usage/opentelemetry.md
@@ -34,7 +34,7 @@ You can also set the following environment variables:
 
 - `OTEL_SERVICE_NAME`: to control the service name that will be emitted in traces, defaults to `renovate`
 - `OTEL_SERVICE_NAMESPACE`: to control the service namespace that will be emitted in traces, defaults to `renovatebot.com`
-- `OTEL_SERVICE_VERSION`: to control the service version that will be emitted in traces, defaults to using the pkg version
+- `OTEL_SERVICE_VERSION`: to control the service version that will be emitted in traces, defaults to using the release version of Renovate
 
 ## Debugging
 

--- a/lib/instrumentation/index.ts
+++ b/lib/instrumentation/index.ts
@@ -43,17 +43,12 @@ export function init(): void {
   const traceProvider = new NodeTracerProvider({
     resource: new Resource({
       // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/README.md#semantic-attributes-with-sdk-provided-default-value
-      [SemanticResourceAttributes.SERVICE_NAME]: process.env.OTEL_SERVICE_NAME
-        ? process.env.OTEL_SERVICE_NAME
-        : 'renovate',
-      [SemanticResourceAttributes.SERVICE_NAMESPACE]: process.env
-        .OTEL_SERVICE_NAMESPACE
-        ? process.env.OTEL_SERVICE_NAMESPACE
-        : 'renovatebot.com',
-      [SemanticResourceAttributes.SERVICE_VERSION]: process.env
-        .OTEL_SERVICE_VERSION
-        ? process.env.OTEL_SERVICE_VERSION
-        : pkg.version,
+      [SemanticResourceAttributes.SERVICE_NAME]:
+        process.env.OTEL_SERVICE_NAME ?? 'renovate',
+      [SemanticResourceAttributes.SERVICE_NAMESPACE]:
+        process.env.OTEL_SERVICE_NAMESPACE ?? 'renovatebot.com',
+      [SemanticResourceAttributes.SERVICE_VERSION]:
+        process.env.OTEL_SERVICE_VERSION ?? pkg.version,
     }),
   });
 

--- a/lib/instrumentation/index.ts
+++ b/lib/instrumentation/index.ts
@@ -43,9 +43,17 @@ export function init(): void {
   const traceProvider = new NodeTracerProvider({
     resource: new Resource({
       // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/README.md#semantic-attributes-with-sdk-provided-default-value
-      [SemanticResourceAttributes.SERVICE_NAME]: 'renovate',
-      [SemanticResourceAttributes.SERVICE_NAMESPACE]: 'renovatebot.com',
-      [SemanticResourceAttributes.SERVICE_VERSION]: pkg.version,
+      [SemanticResourceAttributes.SERVICE_NAME]: process.env.OTEL_SERVICE_NAME
+        ? process.env.OTEL_SERVICE_NAME
+        : 'renovate',
+      [SemanticResourceAttributes.SERVICE_NAMESPACE]: process.env
+        .OTEL_SERVICE_NAMESPACE
+        ? process.env.OTEL_SERVICE_NAMESPACE
+        : 'renovatebot.com',
+      [SemanticResourceAttributes.SERVICE_VERSION]: process.env
+        .OTEL_SERVICE_VERSION
+        ? process.env.OTEL_SERVICE_VERSION
+        : pkg.version,
     }),
   });
 


### PR DESCRIPTION
## Changes

add the option to overwrite the following otlp attrributes
OTEL_SERVICE_NAME
OTEL_SERVICE_NAMESPACE
OTEL_SERVICE_VERSION 
if one of those values is not set in as env var then a default is used (same as always was)
## Context
closes #28986 
## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [X] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

