### PR TITLE
fix(vulnerabilities): do not force exact patch version for PyPI datasource in GitHub alerts

### DIFF
--- a/lib/workers/repository/init/__snapshots__/vulnerability.spec.ts.snap
+++ b/lib/workers/repository/init/__snapshots__/vulnerability.spec.ts.snap
@@ -108,7 +108,7 @@ An issue was discovered in FasterXML jackson-databind prior to 2.7.9.4, 2.8.11.2
 exports[`workers/repository/init/vulnerability detectVulnerabilityAlerts() returns pip alerts 1`] = `
 [
   {
-    "allowedVersions": "==2.2.1.0",
+    "allowedVersions": ">=2.2.1.0",
     "force": {
       "branchTopic": "{{{datasource}}}-{{{depName}}}-vulnerability",
       "commitMessageSuffix": "[SECURITY]",

--- a/lib/workers/repository/init/vulnerability.ts
+++ b/lib/workers/repository/init/vulnerability.ts
@@ -207,7 +207,7 @@ export async function detectVulnerabilityAlerts(
           // TODO: types (#22198)
           const allowedVersions =
             datasource === PypiDatasource.id
-              ? `==${val.firstPatchedVersion!}`
+              ? `>=${val.firstPatchedVersion!}`
               : val.firstPatchedVersion;
           const matchFileNames =
             datasource === GoDatasource.id


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

GitHub vulnerability alerts may suggest a particular patch version for PyPI dependencies that could be retracted, currently resulting in no PR being created at all. This change relaxes `==` to `>=`, so that the first available version is picked.

<!-- Describe what behavior is changed by this PR. -->

## Context

- Fixes https://github.com/renovatebot/renovate/discussions/29572

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

Test repo: https://github.com/renovate-demo/29572-renovate-python-requests/pull/2

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
