### PR TITLE
feat(manager/gradle): Use dependencies task when generating verification metadata

### DIFF
--- a/lib/modules/manager/gradle/artifacts.spec.ts
+++ b/lib/modules/manager/gradle/artifacts.spec.ts
@@ -592,7 +592,7 @@ describe('modules/manager/gradle/artifacts', () => {
       ]);
       expect(execSnapshots).toMatchObject([
         {
-          cmd: './gradlew --console=plain --dependency-verification lenient -q --write-verification-metadata sha256 help',
+          cmd: './gradlew --console=plain --dependency-verification lenient -q --write-verification-metadata sha256 dependencies',
           options: {
             cwd: '/tmp/github/some/repo',
             stdio: ['pipe', 'ignore', 'pipe'],
@@ -662,7 +662,7 @@ describe('modules/manager/gradle/artifacts', () => {
           },
         },
         {
-          cmd: './gradlew --console=plain --dependency-verification lenient -q --write-verification-metadata sha256 help',
+          cmd: './gradlew --console=plain --dependency-verification lenient -q --write-verification-metadata sha256 dependencies',
           options: {
             cwd: '/tmp/github/some/repo',
             stdio: ['pipe', 'ignore', 'pipe'],
@@ -705,7 +705,7 @@ describe('modules/manager/gradle/artifacts', () => {
 
       expect(execSnapshots).toMatchObject([
         {
-          cmd: './gradlew --console=plain --dependency-verification lenient -q --write-verification-metadata sha256 help',
+          cmd: './gradlew --console=plain --dependency-verification lenient -q --write-verification-metadata sha256 dependencies',
           options: {
             cwd: '/tmp/github/some/repo',
             stdio: ['pipe', 'ignore', 'pipe'],
@@ -747,7 +747,7 @@ describe('modules/manager/gradle/artifacts', () => {
 
       expect(execSnapshots).toMatchObject([
         {
-          cmd: './gradlew --console=plain --dependency-verification lenient -q --write-verification-metadata sha256,pgp help',
+          cmd: './gradlew --console=plain --dependency-verification lenient -q --write-verification-metadata sha256,pgp dependencies',
           options: {
             cwd: '/tmp/github/some/repo',
             stdio: ['pipe', 'ignore', 'pipe'],

--- a/lib/modules/manager/gradle/artifacts.ts
+++ b/lib/modules/manager/gradle/artifacts.ts
@@ -128,7 +128,7 @@ async function buildUpdateVerificationMetadataCmd(
   if (!hashTypes.length) {
     return null;
   }
-  return `${baseCmd} --write-verification-metadata ${hashTypes.join(',')} help`;
+  return `${baseCmd} --write-verification-metadata ${hashTypes.join(',')} dependencies`;
 }
 
 export async function updateArtifacts({

--- a/lib/modules/manager/gradle/readme.md
+++ b/lib/modules/manager/gradle/readme.md
@@ -11,7 +11,7 @@ As the output of these commands can be very large, any text other than errors (i
 
 ### Dependency verification
 
-If Renovate finds a `gradle/verification-metadata.xml` file, it updates the content by using the `gradle --write-verification-metadata <hashTypes>` command.
+If Renovate finds a `gradle/verification-metadata.xml` file, it updates the content by using the `gradle --write-verification-metadata <hashTypes> dependencies` command.
 Renovate will check the file for existing hash types (like `sha256`) and use them as `<hashTypes>`.
 
 <!-- prettier-ignore -->


### PR DESCRIPTION
## Changes

As [discussed here](https://github.com/renovatebot/renovate/discussions/29259#discussioncomment-9735907), use `dependencies` task when generating verification metadata.

## Context

Currently, the[ `help` task is called to generate the `verification-metadata.xml`](https://github.com/renovatebot/renovate/blob/e6b04dab1b48097c96f89661ef03a1d1bef3f0b4/lib/modules/manager/gradle/artifacts.ts#L131) (e.g. `./gradlew --write-verification-metadata sha256 help`). Gradle is lazy and [may not evaluate the required dependencies](https://docs.gradle.org/current/userguide/dependency_verification.html#sec:bootstrapping-verification):

> [...] Gradle may discover more dependencies and artifacts depending on the tasks you execute. [...] 

In my tests, using the built-in `dependencies` task instead of `help` works quite well (`./gradlew --write-verification-metadata sha256 dependencies`). The `dependencies` task is also called for lockfile generation.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
