### PR TITLE
fix(devcontainer): do not pin digests with docker:pinDigests

### DIFF
--- a/lib/config/presets/internal/docker.ts
+++ b/lib/config/presets/internal/docker.ts
@@ -42,6 +42,10 @@ export const presets: Record<string, Preset> = {
         matchDatasources: ['docker'],
         pinDigests: true,
       },
+      {
+        matchManagers: ['devcontainer'],
+        pinDigests: false,
+      },
     ],
   },
 };


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Exclude devcontainer manager from docker:pinDigests

## Context

#29604

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
