### PR TITLE
feat: add variable to skip getting labels from docker hub

### DIFF
--- a/docs/usage/self-hosted-experimental.md
+++ b/docs/usage/self-hosted-experimental.md
@@ -39,6 +39,10 @@ You can set the config file Renovate should read with the `RENOVATE_CONFIG_FILE`
 
 The process that runs Renovate must have the correct permissions to delete the config file.
 
+## `RENOVATE_X_DISABLE_DOCKER_HUB_LABELS`
+
+If set to any value, Renovate will skip attempting to get release labels (e.g. gitRef, sourceUrl) from manifest annotations for `https://index.docker.io`.
+
 ## `RENOVATE_X_DOCKER_HUB_TAGS`
 
 If set to any value, Renovate will use the Docker Hub API (`https://hub.docker.com`) to fetch tags instead of the normal Docker API for images pulled from `https://index.docker.io`.

--- a/docs/usage/self-hosted-experimental.md
+++ b/docs/usage/self-hosted-experimental.md
@@ -39,7 +39,7 @@ You can set the config file Renovate should read with the `RENOVATE_CONFIG_FILE`
 
 The process that runs Renovate must have the correct permissions to delete the config file.
 
-## `RENOVATE_X_DISABLE_DOCKER_HUB_LABELS`
+## `RENOVATE_X_DOCKER_HUB_DISABLE_LABEL_LOOKUP`
 
 If set to any value, Renovate will skip attempting to get release labels (e.g. gitRef, sourceUrl) from manifest annotations for `https://index.docker.io`.
 

--- a/docs/usage/self-hosted-experimental.md
+++ b/docs/usage/self-hosted-experimental.md
@@ -43,6 +43,14 @@ The process that runs Renovate must have the correct permissions to delete the c
 
 If set to any value, Renovate will skip attempting to get release labels (e.g. gitRef, sourceUrl) from manifest annotations for `https://index.docker.io`.
 
+Due to the missing label information like sourceUrl, Renovate will not be able to perform certain actions dependent on these information for the images.
+
+This includes the following:
+
+- Generating changelogs
+- Applying package rules dependent on the labels
+- Including the sourceUrls in PR bodies
+
 ## `RENOVATE_X_DOCKER_HUB_TAGS`
 
 If set to any value, Renovate will use the Docker Hub API (`https://hub.docker.com`) to fetch tags instead of the normal Docker API for images pulled from `https://index.docker.io`.

--- a/lib/modules/datasource/docker/index.spec.ts
+++ b/lib/modules/datasource/docker/index.spec.ts
@@ -2665,5 +2665,88 @@ describe('modules/datasource/docker/index', () => {
         },
       );
     });
+
+    it('uses annotations for docker hub', async () => {
+      httpMock
+        .scope('https://index.docker.io/v2')
+        .get('/')
+        .reply(200)
+        .get('/renovate/renovate/manifests/37.405.1-full')
+        .reply(200, {
+          schemaVersion: 2,
+          mediaType: 'application/vnd.oci.image.manifest.v1+json',
+          config: {
+            digest:
+              'sha256:a3e34dca3519abb558a58384414cc69b6afbbb80e3992064f3e1c24e069c9168',
+            mediaType: 'application/vnd.oci.image.config.v1+json',
+          },
+          annotations: {
+            'org.opencontainers.image.source':
+              'https://github.com/renovatebot/renovate',
+            'org.opencontainers.image.revision':
+              'e11f9d9882395deaf5fbbb81b3327cb8c2ef069c',
+          },
+        });
+
+      expect(
+        await ds.getLabels(
+          'https://index.docker.io',
+          'renovate/renovate',
+          '37.405.1-full',
+        ),
+      ).toEqual({
+        'org.opencontainers.image.source':
+          'https://github.com/renovatebot/renovate',
+        'org.opencontainers.image.revision':
+          'e11f9d9882395deaf5fbbb81b3327cb8c2ef069c',
+      });
+    });
+
+    it('skips docker hub labels', async () => {
+      process.env.RENOVATE_X_DISABLE_DOCKER_HUB_LABELS = 'true';
+
+      httpMock.scope('https://index.docker.io/v2');
+
+      expect(
+        await ds.getLabels(
+          'https://index.docker.io',
+          'renovate/renovate',
+          '37.405.1-full',
+        ),
+      ).toEqual({});
+    });
+
+    it('does not skip non docker hub registry labels', async () => {
+      process.env.RENOVATE_X_DISABLE_DOCKER_HUB_LABELS = 'true';
+
+      httpMock
+        .scope('https://ghcr.io/v2')
+        .get('/')
+        .reply(200)
+        .get('/node/manifests/2-alpine')
+        .reply(200, {
+          schemaVersion: 2,
+          mediaType: 'application/vnd.oci.image.manifest.v1+json',
+          config: {
+            digest: 'some-config-digest',
+            mediaType: 'application/vnd.oci.image.config.v1+json',
+          },
+          annotations: {
+            'org.opencontainers.image.source':
+              'https://github.com/renovatebot/renovate',
+            'org.opencontainers.image.revision':
+              'ab7ddb5e3c5c3b402acd7c3679d4e415f8092dde',
+          },
+        });
+
+      expect(await ds.getLabels('https://ghcr.io', 'node', '2-alpine')).toEqual(
+        {
+          'org.opencontainers.image.source':
+            'https://github.com/renovatebot/renovate',
+          'org.opencontainers.image.revision':
+            'ab7ddb5e3c5c3b402acd7c3679d4e415f8092dde',
+        },
+      );
+    });
   });
 });

--- a/lib/modules/datasource/docker/index.spec.ts
+++ b/lib/modules/datasource/docker/index.spec.ts
@@ -2703,7 +2703,7 @@ describe('modules/datasource/docker/index', () => {
     });
 
     it('skips docker hub labels', async () => {
-      process.env.RENOVATE_X_DISABLE_DOCKER_HUB_LABELS = 'true';
+      process.env.RENOVATE_X_DOCKER_HUB_DISABLE_LABEL_LOOKUP = 'true';
 
       httpMock.scope('https://index.docker.io/v2');
 
@@ -2717,7 +2717,7 @@ describe('modules/datasource/docker/index', () => {
     });
 
     it('does not skip non docker hub registry labels', async () => {
-      process.env.RENOVATE_X_DISABLE_DOCKER_HUB_LABELS = 'true';
+      process.env.RENOVATE_X_DOCKER_HUB_DISABLE_LABEL_LOOKUP = 'true';
 
       httpMock
         .scope('https://ghcr.io/v2')

--- a/lib/modules/datasource/docker/index.ts
+++ b/lib/modules/datasource/docker/index.ts
@@ -455,13 +455,13 @@ export class DockerDatasource extends Datasource {
     tag: string,
   ): Promise<Record<string, string> | undefined> {
     logger.debug(`getLabels(${registryHost}, ${dockerRepository}, ${tag})`);
-    // Skip Docker Hub image if RENOVATE_X_DISABLE_DOCKER_HUB_LABELS is set
+    // Skip Docker Hub image if RENOVATE_X_DOCKER_HUB_DISABLE_LABEL_LOOKUP is set
     if (
-      process.env.RENOVATE_X_DISABLE_DOCKER_HUB_LABELS &&
+      process.env.RENOVATE_X_DOCKER_HUB_DISABLE_LABEL_LOOKUP &&
       registryHost === 'https://index.docker.io'
     ) {
       logger.debug(
-        'Docker Hub image - skipping label lookup due to RENOVATE_X_DISABLE_DOCKER_HUB_LABELS',
+        'Docker Hub image - skipping label lookup due to RENOVATE_X_DOCKER_HUB_DISABLE_LABEL_LOOKUP',
       );
       return {};
     }

--- a/lib/modules/datasource/docker/index.ts
+++ b/lib/modules/datasource/docker/index.ts
@@ -455,6 +455,16 @@ export class DockerDatasource extends Datasource {
     tag: string,
   ): Promise<Record<string, string> | undefined> {
     logger.debug(`getLabels(${registryHost}, ${dockerRepository}, ${tag})`);
+    // Skip Docker Hub image if RENOVATE_X_DISABLE_DOCKER_HUB_LABELS is set
+    if (
+      process.env.RENOVATE_X_DISABLE_DOCKER_HUB_LABELS &&
+      registryHost === 'https://index.docker.io'
+    ) {
+      logger.debug(
+        'Docker Hub image - skipping label lookup due to RENOVATE_X_DISABLE_DOCKER_HUB_LABELS',
+      );
+      return {};
+    }
     // Docker Hub library images don't have labels we need
     if (
       registryHost === 'https://index.docker.io' &&


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

A self-hosted experimental environment variable `RENOVATE_X_DISABLE_DOCKER_HUB_LABELS` which disables label requests to https://index.docker.io/.

## Context
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->


This implements the proposed option from #29582.

This aims to optionally reduce the impact on the DockerHub rate limit further in scenarios where labels are not required (e.g. dry-run lookups).

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
