### PR TITLE
docs: fix note visibility on gpg 2.4+ usage

### DIFF
--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -972,8 +972,8 @@ sub   rsa4096 2021-09-10 [E]
 <!-- prettier-ignore -->
 
 !!! note
-    If you use GnuPG `v2.4` (or newer) to generate the key, then you must disable `AEAD` preferences.
-    This is needed to allow  Renovate to decrypt the encrypted values.
+If you use GnuPG `v2.4` (or newer) to generate the key, then you must disable `AEAD` preferences.
+This is needed to allow Renovate to decrypt the encrypted values.
 
 <details><summary>key edit log</summary>
 

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -968,10 +968,14 @@ uid                      Renovate Bot <renovate@whitesourcesoftware.com>
 sub   rsa4096 2021-09-10 [E]
 ```
 
+</details>
 <!-- prettier-ignore -->
+
 !!! note
     If you use GnuPG `v2.4` (or newer) to generate the key, then you must disable `AEAD` preferences.
     This is needed to allow  Renovate to decrypt the encrypted values.
+
+<details><summary>key edit log</summary>
 
 ```bash
 ❯ gpg --edit-key renovate@whitesourcesoftware.com


### PR DESCRIPTION
The details section was encompassing the whole key creation section hiding an important note for  gpg 2.4+ users

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

The details section was encompassing the whole key creation section hiding an important note for  gpg 2.4+ users

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [X] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
