### PR TITLE
fix(vulnerabilities): do not force exact patch version in OSV alerts

### DIFF
--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -361,7 +361,7 @@ export async function lookupUpdates(
           unconstrainedValue ||
           versioning.isCompatible(v.version, compareValue),
       );
-      if (config.isVulnerabilityAlert && !config.osvVulnerabilityAlerts) {
+      if (config.isVulnerabilityAlert) {
         filteredReleases = filteredReleases.slice(0, 1);
       }
       const buckets: Record<string, [Release]> = {};

--- a/lib/workers/repository/process/vulnerabilities.spec.ts
+++ b/lib/workers/repository/process/vulnerabilities.spec.ts
@@ -104,13 +104,13 @@ describe('workers/repository/process/vulnerabilities', () => {
         {
           packageName: 'django',
           depVersion: '3.2',
-          fixedVersion: '==3.3.8',
+          fixedVersion: '>=3.3.8',
           datasource: 'pypi',
         },
         {
           packageName: 'django',
           depVersion: '3.2',
-          fixedVersion: '==3.2.16',
+          fixedVersion: '>=3.2.16',
           datasource: 'pypi',
         },
       ]);
@@ -581,7 +581,7 @@ describe('workers/repository/process/vulnerabilities', () => {
           matchDatasources: ['pypi'],
           matchPackageNames: ['django'],
           matchCurrentVersion: '3.2',
-          allowedVersions: '==3.2.16',
+          allowedVersions: '>=3.2.16',
           isVulnerabilityAlert: true,
         },
       ]);
@@ -643,14 +643,14 @@ describe('workers/repository/process/vulnerabilities', () => {
           matchDatasources: ['pypi'],
           matchPackageNames: ['django'],
           matchCurrentVersion: '3.2',
-          allowedVersions: '==3.2.16',
+          allowedVersions: '>=3.2.16',
           isVulnerabilityAlert: true,
         },
         {
           matchDatasources: ['pypi'],
           matchPackageNames: ['django'],
           matchCurrentVersion: '3.2',
-          allowedVersions: '==3.3.8',
+          allowedVersions: '>=3.3.8',
           isVulnerabilityAlert: true,
         },
       ]);
@@ -1065,7 +1065,7 @@ describe('workers/repository/process/vulnerabilities', () => {
           matchDatasources: ['pypi'],
           matchPackageNames: ['django-mfa2'],
           matchCurrentVersion: '2.5.0',
-          allowedVersions: '==2.5.1',
+          allowedVersions: '>=2.5.1',
           isVulnerabilityAlert: true,
           prBodyNotes: [
             '\n\n' +

--- a/lib/workers/repository/process/vulnerabilities.spec.ts
+++ b/lib/workers/repository/process/vulnerabilities.spec.ts
@@ -104,13 +104,13 @@ describe('workers/repository/process/vulnerabilities', () => {
         {
           packageName: 'django',
           depVersion: '3.2',
-          fixedVersion: '>=3.3.8',
+          fixedVersion: '>= 3.3.8',
           datasource: 'pypi',
         },
         {
           packageName: 'django',
           depVersion: '3.2',
-          fixedVersion: '>=3.2.16',
+          fixedVersion: '>= 3.2.16',
           datasource: 'pypi',
         },
       ]);
@@ -501,7 +501,7 @@ describe('workers/repository/process/vulnerabilities', () => {
         'Vulnerability GO-2022-0187 affects stdlib 1.7.5',
       );
       expect(logger.logger.debug).toHaveBeenCalledWith(
-        'Setting allowed version 1.7.6 to fix vulnerability GO-2022-0187 in stdlib 1.7.5',
+        'Setting allowed version >= 1.7.6 to fix vulnerability GO-2022-0187 in stdlib 1.7.5',
       );
       expect(config.packageRules).toHaveLength(1);
       expect(config.packageRules).toMatchObject([
@@ -509,7 +509,7 @@ describe('workers/repository/process/vulnerabilities', () => {
           matchDatasources: ['go'],
           matchPackageNames: ['stdlib'],
           matchCurrentVersion: '1.7.5',
-          allowedVersions: '1.7.6',
+          allowedVersions: '>= 1.7.6',
           isVulnerabilityAlert: true,
         },
       ]);
@@ -581,7 +581,7 @@ describe('workers/repository/process/vulnerabilities', () => {
           matchDatasources: ['pypi'],
           matchPackageNames: ['django'],
           matchCurrentVersion: '3.2',
-          allowedVersions: '>=3.2.16',
+          allowedVersions: '>= 3.2.16',
           isVulnerabilityAlert: true,
         },
       ]);
@@ -643,14 +643,14 @@ describe('workers/repository/process/vulnerabilities', () => {
           matchDatasources: ['pypi'],
           matchPackageNames: ['django'],
           matchCurrentVersion: '3.2',
-          allowedVersions: '>=3.2.16',
+          allowedVersions: '>= 3.2.16',
           isVulnerabilityAlert: true,
         },
         {
           matchDatasources: ['pypi'],
           matchPackageNames: ['django'],
           matchCurrentVersion: '3.2',
-          allowedVersions: '>=3.3.8',
+          allowedVersions: '>= 3.3.8',
           isVulnerabilityAlert: true,
         },
       ]);
@@ -744,7 +744,7 @@ describe('workers/repository/process/vulnerabilities', () => {
           matchDatasources: ['crate'],
           matchPackageNames: ['tiny_http'],
           matchCurrentVersion: '0.1.2',
-          allowedVersions: '0.6.3',
+          allowedVersions: '>= 0.6.3',
           isVulnerabilityAlert: true,
           prBodyNotes: [
             '\n\n' +
@@ -826,14 +826,14 @@ describe('workers/repository/process/vulnerabilities', () => {
           matchDatasources: ['npm'],
           matchPackageNames: ['lodash'],
           matchCurrentVersion: '4.17.10',
-          allowedVersions: '4.17.11',
+          allowedVersions: '>= 4.17.11',
           isVulnerabilityAlert: true,
         },
         {
           matchDatasources: ['npm'],
           matchPackageNames: ['lodash'],
           matchCurrentVersion: '4.17.10',
-          allowedVersions: '4.17.20',
+          allowedVersions: '>= 4.17.20',
           isVulnerabilityAlert: true,
         },
       ]);
@@ -880,6 +880,131 @@ describe('workers/repository/process/vulnerabilities', () => {
         'OSV advisory GHSA-xxxx-yyyy-zzzz lists quokka 1.2.3 as vulnerable',
       );
       expect(config.packageRules).toHaveLength(0);
+    });
+
+    it('describe fixed version as ecosystem-specific version constraint', async () => {
+      const packageFiles: Record<string, PackageFile[]> = {
+        maven: [
+          {
+            deps: [
+              {
+                depName: 'com.guicedee.services:log4j-core',
+                currentValue: '1.0.10.1',
+                datasource: 'maven',
+              },
+            ],
+            packageFile: 'some-file1',
+          },
+        ],
+        nuget: [
+          {
+            deps: [
+              {
+                depName: 'SharpZipLib',
+                currentValue: '1.3.0',
+                datasource: 'nuget',
+              },
+            ],
+            packageFile: 'some-file2',
+          },
+        ],
+        npm: [
+          {
+            deps: [
+              {
+                depName: 'lodash',
+                currentValue: '4.17.15',
+                datasource: 'npm',
+              },
+            ],
+            packageFile: 'some-file3',
+          },
+        ],
+      };
+      getVulnerabilitiesMock.mockResolvedValue([
+        {
+          id: 'GHSA-jfh8-c2jp-5v3q',
+          modified: '',
+          affected: [
+            {
+              package: {
+                name: 'com.guicedee.services:log4j-core',
+                ecosystem: 'Maven',
+                purl: 'pkg:maven/com.guicedee.services/log4j-core',
+              },
+              ranges: [
+                {
+                  type: 'ECOSYSTEM',
+                  events: [{ introduced: '0' }, { fixed: '1.2.1.2-jre17' }],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          id: ' GHSA-mm6g-mmq6-53ff',
+          modified: '',
+          affected: [
+            {
+              package: {
+                name: 'SharpZipLib',
+                ecosystem: 'NuGet',
+                purl: 'pkg:nuget/SharpZipLib',
+              },
+              ranges: [
+                {
+                  type: 'ECOSYSTEM',
+                  events: [{ introduced: '0' }, { fixed: '1.3.3' }],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          id: 'GHSA-29mw-wpgm-hmr9',
+          modified: '',
+          affected: [
+            {
+              package: {
+                name: 'lodash',
+                ecosystem: 'npm',
+                purl: 'pkg:npm/lodash',
+              },
+              ranges: [
+                {
+                  type: 'SEMVER',
+                  events: [{ introduced: '0' }, { fixed: '4.17.21' }],
+                },
+              ],
+            },
+          ],
+        },
+      ]);
+
+      await vulnerabilities.appendVulnerabilityPackageRules(
+        config,
+        packageFiles,
+      );
+      expect(config.packageRules).toMatchObject([
+        {
+          matchDatasources: ['maven'],
+          matchPackageNames: ['com.guicedee.services:log4j-core'],
+          matchCurrentVersion: '1.0.10.1',
+          allowedVersions: '[1.2.1.2-jre17,)',
+        },
+        {
+          matchDatasources: ['nuget'],
+          matchPackageNames: ['SharpZipLib'],
+          matchCurrentVersion: '1.3.0',
+          allowedVersions: '1.3.3',
+        },
+        {
+          matchDatasources: ['npm'],
+          matchPackageNames: ['lodash'],
+          matchCurrentVersion: '4.17.15',
+          allowedVersions: '>= 4.17.21',
+        },
+      ]);
     });
 
     it('describe last_affected version as ecosystem-specific version constraint', async () => {
@@ -1065,7 +1190,7 @@ describe('workers/repository/process/vulnerabilities', () => {
           matchDatasources: ['pypi'],
           matchPackageNames: ['django-mfa2'],
           matchCurrentVersion: '2.5.0',
-          allowedVersions: '>=2.5.1',
+          allowedVersions: '>= 2.5.1',
           isVulnerabilityAlert: true,
           prBodyNotes: [
             '\n\n' +
@@ -1127,7 +1252,7 @@ describe('workers/repository/process/vulnerabilities', () => {
           matchDatasources: ['npm'],
           matchPackageNames: ['lodash'],
           matchCurrentVersion: '4.17.10',
-          allowedVersions: '4.17.11',
+          allowedVersions: '>= 4.17.11',
           isVulnerabilityAlert: true,
           prBodyNotes: [
             '\n\n' +
@@ -1212,7 +1337,7 @@ describe('workers/repository/process/vulnerabilities', () => {
           matchDatasources: ['crate'],
           matchPackageNames: ['sys-info'],
           matchCurrentVersion: '0.6.0',
-          allowedVersions: '0.8.0',
+          allowedVersions: '>= 0.8.0',
           isVulnerabilityAlert: true,
           prBodyNotes: [
             '\n\n' +

--- a/lib/workers/repository/process/vulnerabilities.ts
+++ b/lib/workers/repository/process/vulnerabilities.ts
@@ -409,7 +409,7 @@ export class Vulnerabilities {
       this.isVersionGt(version, depVersion, versioningApi),
     );
     if (fixedVersion) {
-      return ecosystem === 'PyPI' ? `==${fixedVersion}` : fixedVersion;
+      return ecosystem === 'PyPI' ? `>=${fixedVersion}` : fixedVersion;
     }
 
     lastAffectedVersions.sort((a, b) => versioningApi.sortVersions(a, b));

--- a/lib/workers/repository/process/vulnerabilities.ts
+++ b/lib/workers/repository/process/vulnerabilities.ts
@@ -409,7 +409,7 @@ export class Vulnerabilities {
       this.isVersionGt(version, depVersion, versioningApi),
     );
     if (fixedVersion) {
-      return ecosystem === 'PyPI' ? `>=${fixedVersion}` : fixedVersion;
+      return this.getFixedVersionByEcosystem(fixedVersion, ecosystem);
     }
 
     lastAffectedVersions.sort((a, b) => versioningApi.sortVersions(a, b));
@@ -421,6 +421,21 @@ export class Vulnerabilities {
     }
 
     return null;
+  }
+
+  private getFixedVersionByEcosystem(
+    fixedVersion: string,
+    ecosystem: Ecosystem,
+  ): string {
+    if (ecosystem === 'Maven') {
+      return `[${fixedVersion},)`;
+    } else if (ecosystem === 'NuGet') {
+      // TODO: add support for nuget version ranges when #26150 is merged
+      return fixedVersion;
+    }
+
+    // crates.io, Go, Hex, npm, RubyGems, PyPI
+    return `>= ${fixedVersion}`;
   }
 
   private getLastAffectedByEcosystem(


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

OSV vulnerability alerts may suggest a particular patch version that could be retracted, currently resulting in no PR being created at all. This change relaxes `==` to `>=`, so that the first available version is picked.

This PR also removes an extra condition for OSV that caused advisories with `last_affected` field set to suggest the newest version, rather than the minimal patched version. Advisories usually populate the `fixed` version, not the `last_affected` field, so this was infrequently used. Now this the change to `>=` e.g., for pypi, the security fix PR would suggest version 2.32.3 to address CVE-2024-35195 in `requests <= 2.32.0`, whereas the minimal patched version is 2.32.2 (see test repo).

<!-- Describe what behavior is changed by this PR. -->

## Context

- Closes https://github.com/renovatebot/renovate/issues/29342
- Fixes https://github.com/renovatebot/renovate/discussions/29280
- https://github.com/renovatebot/renovate/issues/29600
- https://github.com/renovatebot/renovate/discussions/29572
- https://github.com/renovatebot/renovate/pull/27363#pullrequestreview-1885643289

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

* Test repo with requests: https://github.com/renovate-demo/29280-osv-requests/pull/1
* Test repo with different managers: https://github.com/renovate-demo/29666-osv/pulls

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
