### PR TITLE
fix(vulnerabilities): strip equals for nuget in Github alerts

### DIFF
--- a/lib/workers/repository/init/vulnerability.spec.ts
+++ b/lib/workers/repository/init/vulnerability.spec.ts
@@ -220,6 +220,63 @@ describe('workers/repository/init/vulnerability', () => {
       expect(res.packageRules).toHaveLength(1);
     });
 
+    it('returns nuget alerts', async () => {
+      // TODO #22198
+      delete config.vulnerabilityAlerts!.enabled;
+      platform.getVulnerabilityAlerts.mockResolvedValue([
+        {
+          dismissReason: null,
+          vulnerableManifestFilename: 'test.csproj',
+          vulnerableManifestPath: 'test.csproj',
+          vulnerableRequirements: '= 2.0.0',
+          securityAdvisory: {
+            description:
+              '.NET Core 1.0, 1.1, and 2.0 allow an unauthenticated attacker to remotely cause a denial of service attack.',
+            identifiers: [
+              { type: 'GHSA', value: 'GHSA-7mfr-774f-w5r9' },
+              { type: 'CVE', value: 'CVE-2017-11770' },
+            ],
+            references: [],
+            severity: 'HIGH',
+          },
+          securityVulnerability: {
+            package: {
+              name: 'Microsoft.NETCore.App',
+              ecosystem: 'NUGET',
+            },
+            firstPatchedVersion: { identifier: '2.0.3' },
+            vulnerableVersionRange: '>= 1.0.0, < 2.0.3',
+          },
+        },
+      ]);
+
+      const res = await detectVulnerabilityAlerts(config);
+      expect(res.packageRules).toStrictEqual([
+        {
+          matchDatasources: ['nuget'],
+          matchPackageNames: ['Microsoft.NETCore.App'],
+          matchCurrentVersion: '2.0.0',
+          matchFileNames: ['test.csproj'],
+          allowedVersions: '2.0.3',
+          prBodyNotes: [
+            '### GitHub Vulnerability Alerts',
+            '#### CVE-2017-11770\n\n.NET Core 1.0, 1.1, and 2.0 allow an unauthenticated attacker to remotely cause a denial of service attack.',
+          ],
+          isVulnerabilityAlert: true,
+          force: {
+            groupName: null,
+            schedule: [],
+            dependencyDashboardApproval: false,
+            minimumReleaseAge: null,
+            rangeStrategy: 'update-lockfile',
+            commitMessageSuffix: '[SECURITY]',
+            branchTopic: '{{{datasource}}}-{{{depName}}}-vulnerability',
+            prCreation: 'immediate',
+          },
+        },
+      ]);
+    });
+
     it('returns pip alerts', async () => {
       // TODO #22198
       delete config.vulnerabilityAlerts!.enabled;

--- a/lib/workers/repository/init/vulnerability.ts
+++ b/lib/workers/repository/init/vulnerability.ts
@@ -133,7 +133,8 @@ export async function detectVulnerabilityAlerts(
       }
       if (
         datasource === GithubTagsDatasource.id ||
-        datasource === MavenDatasource.id
+        datasource === MavenDatasource.id ||
+        datasource === NugetDatasource.id
       ) {
         // GitHub Actions uses docker versioning, which doesn't support `= 1.2.3` matching, so we strip the equals
         vulnerableRequirements = vulnerableRequirements.replace(/^=\s*/, '');


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

While testing a solution for https://github.com/renovatebot/renovate/issues/29600, I found that GitHub vuln alerts for nuget don't raise security fix PRs. This change strips `=` analogous to what was done before for maven and go, so that package rules become applicable to nuget deps.

The underlying issue is that GitHub prefixes the version in the `vulnerableRequirements` field with `=`, e.g., `vulnerableRequirements": "= 2.0.0",` eventually leading to package rules that include `"matchCurrentVersion": "= 2.0.0"`. The beginning `=` causes the rule never to match, resulting in no security fix PRs.

<!-- Describe what behavior is changed by this PR. -->

## Context

- https://github.com/renovatebot/renovate/issues/29600

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

Test repo: https://github.com/renovate-demo/29600-github-vuln-alerts-nuget/pulls

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
