### PR TITLE
feat(dashboard): show deprecated dependency warnings

### DIFF
--- a/docs/usage/key-concepts/dashboard.md
+++ b/docs/usage/key-concepts/dashboard.md
@@ -51,7 +51,12 @@ This section explains some common use cases where having the Dependency Dashboar
 
 ### Warnings for deprecated dependencies
 
-If deprecated packages are found - or any packages have community-sourced replacement PRs available - then Renovate will add a prominent warning about these packages near the top of the Dependency Dashboard.
+If Renovate finds: 
+
+- packages flagged as deprecated on their registry, or
+- packages that have a community-sourced replacement PR available
+
+Then Renovate adds a prominent warning about these packages near the top of the Dependency Dashboard.
 Here is an example of how this can look:
 
 > [!WARNING]

--- a/docs/usage/key-concepts/dashboard.md
+++ b/docs/usage/key-concepts/dashboard.md
@@ -59,7 +59,6 @@ If Renovate finds:
 Then Renovate adds a prominent warning about these packages near the top of the Dependency Dashboard.
 Here is an example of how this can look:
 
-> [!WARNING]
 > The following dependencies are deprecated:
 
 | Datasource | Name                | Replacement?                                                                      |

--- a/docs/usage/key-concepts/dashboard.md
+++ b/docs/usage/key-concepts/dashboard.md
@@ -51,7 +51,7 @@ This section explains some common use cases where having the Dependency Dashboar
 
 ### Warnings for deprecated dependencies
 
-If Renovate finds: 
+If Renovate finds:
 
 - packages flagged as deprecated on their registry, or
 - packages that have a community-sourced replacement PR available

--- a/docs/usage/key-concepts/dashboard.md
+++ b/docs/usage/key-concepts/dashboard.md
@@ -49,6 +49,19 @@ To disable the Dependency Dashboard, add the preset `:disableDependencyDashboard
 
 This section explains some common use cases where having the Dependency Dashboard can help.
 
+### Warnings for deprecated dependencies
+
+If deprecated packages are found - or any packages have community-sourced replacement PRs available - then Renovate will add a prominent warning about these packages near the top of the Dependency Dashboard.
+Here is an example of how this can look:
+
+> [!WARNING]
+> The following dependencies are deprecated:
+
+| Datasource | Name                | Replacement?                                                                      |
+| ---------- | ------------------- | --------------------------------------------------------------------------------- |
+| npm        | `airbnb-prop-types` | ![Available](https://img.shields.io/badge/available-green?style=flat-square)      |
+| npm        | `left-pad`          | ![Unavailable](https://img.shields.io/badge/unavailable-orange?style=flat-square) |
+
 ### Visibility into rejected/deferred updates
 
 Renovate's Dependency Dashboard shows an overview of all updates that are still "to do".

--- a/lib/workers/repository/dependency-dashboard.spec.ts
+++ b/lib/workers/repository/dependency-dashboard.spec.ts
@@ -1002,7 +1002,7 @@ None detected
           );
           expect(platform.ensureIssue).toHaveBeenCalledTimes(1);
           expect(platform.ensureIssue.mock.calls[0][0].body).toInclude(
-            'The following dependencies are deprecated',
+            'These dependencies are deprecated',
           );
           expect(platform.ensureIssue.mock.calls[0][0].body).toInclude(
             '| npm | `cookie-parser` | ![Unavailable]',

--- a/lib/workers/repository/dependency-dashboard.spec.ts
+++ b/lib/workers/repository/dependency-dashboard.spec.ts
@@ -19,12 +19,12 @@ import {
   GitHubMaxPrBodyLen,
   massageMarkdown,
 } from '../../modules/platform/github';
+import { clone } from '../../util/clone';
 import { regEx } from '../../util/regex';
 import type { BranchConfig, BranchUpgradeConfig } from '../types';
 import * as dependencyDashboard from './dependency-dashboard';
 import { getDashboardMarkdownVulnerabilities } from './dependency-dashboard';
 import { PackageFiles } from './package-files';
-import { clone } from '../../util/clone';
 
 const createVulnerabilitiesMock = jest.fn();
 jest.mock('./process/vulnerabilities', () => {

--- a/lib/workers/repository/dependency-dashboard.ts
+++ b/lib/workers/repository/dependency-dashboard.ts
@@ -269,7 +269,7 @@ export async function ensureDependencyDashboard(
   if (hasDeprecations) {
     issueBody += '> ⚠ **Warning**\n> \n';
     issueBody += 'The following dependencies are deprecated:\n\n';
-    issueBody += '| Datasource | Name | Replacement? |\n';
+    issueBody += '| Datasource | Name | Replacement PR? |\n';
     issueBody += '|------------|------|--------------|\n';
     for (const manager of Object.keys(deprecatedPackages).sort()) {
       const deps = deprecatedPackages[manager];

--- a/lib/workers/repository/dependency-dashboard.ts
+++ b/lib/workers/repository/dependency-dashboard.ts
@@ -228,7 +228,7 @@ export async function ensureDependencyDashboard(
   // Check packageFiles for any deprecations
   let hasDeprecations = false;
   const deprecatedPackages: Record<string, Record<string, boolean>> = {};
-  logger.debug({ packageFiles }, 'Checking packageFiles for deprecations');
+  logger.debug({ packageFiles }, 'Checking packageFiles for deprecated packages');
   for (const [manager, fileNames] of Object.entries(packageFiles)) {
     for (const fileName of fileNames) {
       for (const dep of fileName.deps) {
@@ -268,7 +268,7 @@ export async function ensureDependencyDashboard(
 
   if (hasDeprecations) {
     issueBody += '> ⚠ **Warning**\n> \n';
-    issueBody += 'The following dependencies are deprecated:\n\n';
+    issueBody += 'These dependencies are deprecated:\n\n';
     issueBody += '| Datasource | Name | Replacement PR? |\n';
     issueBody += '|------------|------|--------------|\n';
     for (const manager of Object.keys(deprecatedPackages).sort()) {

--- a/lib/workers/repository/dependency-dashboard.ts
+++ b/lib/workers/repository/dependency-dashboard.ts
@@ -236,7 +236,7 @@ export async function ensureDependencyDashboard(
         const hasReplacement = !!dep.updates?.find(
           (updates) => updates.updateType === 'replacement',
         );
-        if (name && (dep.deprecationMessage || hasReplacement)) {
+        if (name && (dep.deprecationMessage ?? hasReplacement)) {
           hasDeprecations = true;
           deprecatedPackages[manager] ??= {};
           deprecatedPackages[manager][name] ??= hasReplacement;

--- a/lib/workers/repository/dependency-dashboard.ts
+++ b/lib/workers/repository/dependency-dashboard.ts
@@ -224,8 +224,29 @@ export async function ensureDependencyDashboard(
     return;
   }
   logger.debug('Ensuring Dependency Dashboard');
+
+  // Check packageFiles for any deprecations
+  let hasDeprecations = false;
+  const deprecatedPackages: Record<string, Record<string, boolean>> = {};
+  logger.debug({ packageFiles }, 'Checking packageFiles for deprecations');
+  for (const [manager, fileNames] of Object.entries(packageFiles)) {
+    for (const fileName of fileNames) {
+      for (const dep of fileName.deps) {
+        const name = dep.packageName ?? dep.depName;
+        const hasReplacement = !!dep.updates?.find(
+          (updates) => updates.updateType === 'replacement',
+        );
+        if (name && (dep.deprecationMessage || hasReplacement)) {
+          hasDeprecations = true;
+          deprecatedPackages[manager] ??= {};
+          deprecatedPackages[manager][name] ??= hasReplacement;
+        }
+      }
+    }
+  }
+
   const hasBranches = is.nonEmptyArray(branches);
-  if (config.dependencyDashboardAutoclose && !hasBranches) {
+  if (config.dependencyDashboardAutoclose && !hasBranches && !hasDeprecations) {
     if (GlobalConfig.get('dryRun')) {
       logger.info(
         { title: config.dependencyDashboardTitle },
@@ -244,6 +265,25 @@ export async function ensureDependencyDashboard(
   }
 
   issueBody = appendRepoProblems(config, issueBody);
+
+  if (hasDeprecations) {
+    issueBody += '> [!WARNING]\n';
+    issueBody += 'The following dependencies are deprecated:\n\n';
+    issueBody += '| Datasource | Name | Replacement? |\n';
+    issueBody += '|------------|------|--------------|\n';
+    for (const manager of Object.keys(deprecatedPackages).sort()) {
+      const deps = deprecatedPackages[manager];
+      for (const depName of Object.keys(deps).sort()) {
+        const hasReplacement = deps[depName];
+        issueBody += `| ${manager} | \`${depName}\` | ${
+          hasReplacement
+            ? '![Available](https://img.shields.io/badge/available-green?style=flat-square)'
+            : '![Unavailable](https://img.shields.io/badge/unavailable-orange?style=flat-square)'
+        } |\n`;
+      }
+    }
+    issueBody += '\n';
+  }
 
   const pendingApprovals = branches.filter(
     (branch) => branch.result === 'needs-approval',

--- a/lib/workers/repository/dependency-dashboard.ts
+++ b/lib/workers/repository/dependency-dashboard.ts
@@ -267,7 +267,7 @@ export async function ensureDependencyDashboard(
   issueBody = appendRepoProblems(config, issueBody);
 
   if (hasDeprecations) {
-    issueBody += '> [!WARNING]\n';
+    issueBody += '> ⚠ **Warning**\n> \n';
     issueBody += 'The following dependencies are deprecated:\n\n';
     issueBody += '| Datasource | Name | Replacement? |\n';
     issueBody += '|------------|------|--------------|\n';

--- a/lib/workers/repository/dependency-dashboard.ts
+++ b/lib/workers/repository/dependency-dashboard.ts
@@ -228,7 +228,10 @@ export async function ensureDependencyDashboard(
   // Check packageFiles for any deprecations
   let hasDeprecations = false;
   const deprecatedPackages: Record<string, Record<string, boolean>> = {};
-  logger.debug({ packageFiles }, 'Checking packageFiles for deprecated packages');
+  logger.debug(
+    { packageFiles },
+    'Checking packageFiles for deprecated packages',
+  );
   for (const [manager, fileNames] of Object.entries(packageFiles)) {
     for (const fileName of fileNames) {
       for (const dep of fileName.deps) {


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds a new warning to the Dependency Dashboard if deprecated dependencies and/or dependencies with replacements are found.

Example screenshot:

<img width="934" alt="image" src="https://github.com/renovatebot/renovate/assets/6311784/e019a1cb-8b7d-402d-ae42-1dd726dd1a5f">

## Context

Closes #5098


<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
