### PR TITLE
fix(vulnerabilities): do not force exact patch version in GitHub alerts

### DIFF
--- a/lib/workers/repository/init/__snapshots__/vulnerability.spec.ts.snap
+++ b/lib/workers/repository/init/__snapshots__/vulnerability.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`workers/repository/init/vulnerability detectVulnerabilityAlerts() returns github actions alerts 1`] = `
 [
   {
-    "allowedVersions": "1.8.3",
+    "allowedVersions": ">= 1.8.3",
     "force": {
       "branchTopic": "{{{datasource}}}-{{{depName}}}-vulnerability",
       "commitMessageSuffix": "[SECURITY]",
@@ -38,7 +38,7 @@ actions",
 exports[`workers/repository/init/vulnerability detectVulnerabilityAlerts() returns go alerts 1`] = `
 [
   {
-    "allowedVersions": "1.8.3",
+    "allowedVersions": ">= 1.8.3",
     "force": {
       "branchTopic": "{{{datasource}}}-{{{depName}}}-vulnerability",
       "commitMessageSuffix": "[SECURITY]",
@@ -73,7 +73,7 @@ go",
 exports[`workers/repository/init/vulnerability detectVulnerabilityAlerts() returns maven alerts 1`] = `
 [
   {
-    "allowedVersions": "2.7.9.4",
+    "allowedVersions": "[2.7.9.4,)",
     "force": {
       "branchTopic": "{{{datasource}}}-{{{depName}}}-vulnerability",
       "commitMessageSuffix": "[SECURITY]",
@@ -108,7 +108,7 @@ An issue was discovered in FasterXML jackson-databind prior to 2.7.9.4, 2.8.11.2
 exports[`workers/repository/init/vulnerability detectVulnerabilityAlerts() returns pip alerts 1`] = `
 [
   {
-    "allowedVersions": ">=2.2.1.0",
+    "allowedVersions": ">= 2.2.1.0",
     "force": {
       "branchTopic": "{{{datasource}}}-{{{depName}}}-vulnerability",
       "commitMessageSuffix": "[SECURITY]",
@@ -162,7 +162,7 @@ exports[`workers/repository/init/vulnerability detectVulnerabilityAlerts() retur
       "currentVersion": "1.8.2",
       "datasource": "npm",
       "depName": "electron",
-      "newVersion": "1.8.3",
+      "newVersion": ">= 1.8.3",
       "prBodyNotes": [
         "### GitHub Vulnerability Alerts",
         "#### [GHSA-8xwg-wv7v-4vqp](https://nvd.nist.gov/vuln/detail/CVE-2018-1000136)

--- a/lib/workers/repository/init/vulnerability.spec.ts
+++ b/lib/workers/repository/init/vulnerability.spec.ts
@@ -1,8 +1,14 @@
 import { RenovateConfig, partial, platform } from '../../../../test/util';
 import { getConfig } from '../../../config/defaults';
 import { NO_VULNERABILITY_ALERTS } from '../../../constants/error-messages';
+import { MavenDatasource } from '../../../modules/datasource/maven';
+import { NpmDatasource } from '../../../modules/datasource/npm';
+import { NugetDatasource } from '../../../modules/datasource/nuget';
 import type { VulnerabilityAlert } from '../../../types';
-import { detectVulnerabilityAlerts } from './vulnerability';
+import {
+  detectVulnerabilityAlerts,
+  getFixedVersionByDatasource,
+} from './vulnerability';
 
 let config: RenovateConfig;
 
@@ -495,7 +501,7 @@ describe('workers/repository/init/vulnerability', () => {
             currentVersion: '1.8.2',
             datasource: 'npm',
             depName: 'electron',
-            newVersion: '1.8.3',
+            newVersion: '>= 1.8.3',
           },
         ],
       });
@@ -531,6 +537,18 @@ describe('workers/repository/init/vulnerability', () => {
       const res = await detectVulnerabilityAlerts(config);
       expect(res.packageRules).toHaveLength(1);
       expect(res.remediations).toBeEmptyObject();
+    });
+  });
+
+  describe('getFixedVersionByDatasource', () => {
+    it.each`
+      version    | datasource            | result
+      ${'1.2.3'} | ${MavenDatasource.id} | ${'[1.2.3,)'}
+      ${'1.2.3'} | ${NugetDatasource.id} | ${'1.2.3'}
+      ${'1.2.3'} | ${NpmDatasource.id}   | ${'>= 1.2.3'}
+    `('$version | $datasource', ({ version, datasource, result }) => {
+      const res = getFixedVersionByDatasource(version, datasource);
+      expect(res).toStrictEqual(result);
     });
   });
 });

--- a/lib/workers/repository/init/vulnerability.ts
+++ b/lib/workers/repository/init/vulnerability.ts
@@ -223,7 +223,7 @@ export async function detectVulnerabilityAlerts(
           // TODO: types (#22198)
           const allowedVersions = val.firstPatchedVersion
             ? getFixedVersionByDatasource(val.firstPatchedVersion, datasource)
-            : undefined;
+            : /* istanbul ignore next: cannot happen */ undefined;
           const matchFileNames =
             datasource === GoDatasource.id
               ? [fileName.replace('go.sum', 'go.mod')]

--- a/lib/workers/repository/init/vulnerability.ts
+++ b/lib/workers/repository/init/vulnerability.ts
@@ -46,6 +46,21 @@ type CombinedAlert = Record<
   >
 >;
 
+export function getFixedVersionByDatasource(
+  fixedVersion: string,
+  datasource: string,
+): string {
+  if (datasource === MavenDatasource.id) {
+    return `[${fixedVersion},)`;
+  } else if (datasource === NugetDatasource.id) {
+    // TODO: add support for nuget version ranges when #26150 is merged
+    return fixedVersion;
+  }
+
+  // crates.io, Go, Hex, npm, RubyGems, PyPI
+  return `>= ${fixedVersion}`;
+}
+
 // TODO can return `null` and `undefined` (#22198)
 export async function detectVulnerabilityAlerts(
   input: RenovateConfig,
@@ -206,10 +221,9 @@ export async function detectVulnerabilityAlerts(
             logger.warn({ err }, 'Error generating vulnerability PR notes');
           }
           // TODO: types (#22198)
-          const allowedVersions =
-            datasource === PypiDatasource.id
-              ? `>=${val.firstPatchedVersion!}`
-              : val.firstPatchedVersion;
+          const allowedVersions = val.firstPatchedVersion
+            ? getFixedVersionByDatasource(val.firstPatchedVersion, datasource)
+            : undefined;
           const matchFileNames =
             datasource === GoDatasource.id
               ? [fileName.replace('go.sum', 'go.mod')]


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Relaxes the requirement of exact patch versions for security fix PRs that are generated based on GitHub vuln alerts.

`istanbul ignore next` is used to workaround a types issue with `firstPatchedVersion`. Due to https://github.com/renovatebot/renovate/blob/c3bd354792b605bd3321fa3b58d3bbbbf1d603cf/lib/workers/repository/init/vulnerability.ts#L92-L98 alerts with missing patched versions are skipped early onwards.

<!-- Describe what behavior is changed by this PR. -->

## Context

- Closes https://github.com/renovatebot/renovate/issues/29600
- https://github.com/renovatebot/renovate/pull/29666

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

Test repo: https://github.com/renovate-demo/29600-github-vuln-alerts/pulls

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
