### PR TITLE
feat(presets/custom-managers): Add Makefile custom manager preset

### DIFF
--- a/lib/config/presets/internal/custom-managers.ts
+++ b/lib/config/presets/internal/custom-managers.ts
@@ -87,6 +87,23 @@ export const presets: Record<string, Preset> = {
     ],
     description: 'Update `appVersion` value in Helm chart `Chart.yaml`.',
   },
+  makefileVersions: {
+    customManagers: [
+      {
+        customType: 'regex',
+        fileMatch: [
+          '(^|/)Makefile$',
+          '(^|/)makefile$',
+          '(^|/)GNUMakefile$',
+          '\\.mk$',
+        ],
+        matchStrings: [
+          '# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (?:packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?(?: registryUrl=(?<registryUrl>[^\\s]+?))?\\s+[A-Za-z0-9_]+?_VERSION\\s*:*\\??=\\s*["\']?(?<currentValue>.+?)["\']?\\s',
+        ],
+      },
+    ],
+    description: 'Update `_VERSION` variables in Makefiles.',
+  },
   mavenPropertyVersions: {
     customManagers: [
       {


### PR DESCRIPTION
## Changes

Add a custom manager preset for `Makefiles` very similar to existing custom manager presets:

```Makefile
# renovate: datasource=node depName=node versioning=node
NODE_VERSION=18.13.0
# renovate: datasource=npm depName=pnpm
PNPM_VERSION = "7.25.1"
# renovate: datasource=npm depName=yarn
YARN_VERSION := '3.3.1'
# renovate: datasource=custom.hashicorp depName=consul
CONSUL_VERSION ?= 1.3.1
```

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

The documentation for custom manager preset is auto-generated, right?

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
