### PR TITLE
docs: correct custom managers edit url

### DIFF
--- a/tools/docs/presets.ts
+++ b/tools/docs/presets.ts
@@ -11,8 +11,8 @@ function getEditUrl(name: string): string {
     'https://github.com/renovatebot/renovate/edit/main/lib/config/presets/internal/';
 
   switch (name) {
-    case 'regexManagers':
-      return `${url}regex-managers.ts`;
+    case 'customManagers':
+      return `${url}custom-managers.ts`;
     case 'mergeConfidence':
       return `${url}merge-confidence.ts`;
     default:


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Fix the custom manager edit url in the docs (the link that gets opened, if you click on the pencil icon on the docs page).

Currently this leads to a 404: https://docs.renovatebot.com/presets-customManagers/ -> https://github.com/renovatebot/renovate/edit/main/lib/config/presets/internal/customManagers.ts

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

A leftover from renaming regex managers to custom managers.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
