### PR TITLE
fix(util/git): pass no-verify flag to deleteBranch

### DIFF
--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -424,6 +424,30 @@ describe('util/git/index', () => {
       const branches = await Git(origin.path).branch({});
       expect(branches.all).not.toContain('renovate/past_branch');
     });
+
+    it('should add no verify flag', async () => {
+      const rawSpy = jest.spyOn(SimpleGit.prototype, 'raw');
+      await git.deleteBranch('renovate/something');
+      expect(rawSpy).toHaveBeenCalledWith([
+        'push',
+        '--delete',
+        'origin',
+        'renovate/something',
+      ]);
+    });
+
+    it('should not add no verify flag', async () => {
+      const rawSpy = jest.spyOn(SimpleGit.prototype, 'raw');
+      setNoVerify(['push']);
+      await git.deleteBranch('renovate/something');
+      expect(rawSpy).toHaveBeenCalledWith([
+        'push',
+        '--delete',
+        'origin',
+        'renovate/something',
+        '--no-verify',
+      ]);
+    });
   });
 
   describe('getBranchLastCommitTime', () => {

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -767,7 +767,13 @@ export async function isBranchConflicted(
 export async function deleteBranch(branchName: string): Promise<void> {
   await syncGit();
   try {
-    await gitRetry(() => git.raw(['push', '--delete', 'origin', branchName]));
+    const deleteCommand = ['push', '--delete', 'origin', branchName];
+
+    if (getNoVerify().includes('push')) {
+      deleteCommand.push('--no-verify');
+    }
+
+    await gitRetry(() => git.raw(deleteCommand));
     logger.debug(`Deleted remote branch: ${branchName}`);
   } catch (err) /* istanbul ignore next */ {
     const errChecked = checkForPlatformFailure(err);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- Pass no-verify flag to the `deleteBranch` fn
<!-- Describe what behavior is changed by this PR. -->

## Context
Closes: https://github.com/renovatebot/renovate/issues/29472
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository (tested locally)

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
