### PR TITLE
chore(regex): add additional logging for `isValidDependency` failures

### DIFF
--- a/lib/modules/manager/custom/regex/strategies.ts
+++ b/lib/modules/manager/custom/regex/strategies.ts
@@ -31,19 +31,9 @@ export function handleAny(
       ),
     )
     .filter(is.truthy)
-    .filter((dep: PackageDependency) => {
-      const isValid = isValidDependency(dep)
-      if (!isValid) {
-        const meta = {
-          packageDependency: dep,
-          packageFile,
-        }
-        logger.trace(meta, "Discovered a package dependency by matching regex, but it did not pass validation. Discarding")
-        return isValid
-      }
-
-      return isValid
-    });
+    .filter((dep: PackageDependency) =>
+      checkIsValidDependency(dep, packageFile),
+    );
 }
 
 export function handleCombination(
@@ -70,19 +60,9 @@ export function handleCombination(
     .reduce((base, addition) => mergeExtractionTemplate(base, addition));
   return [createDependency(extraction, config)]
     .filter(is.truthy)
-    .filter((dep: PackageDependency) => {
-      const isValid = isValidDependency(dep)
-      if (!isValid) {
-        const meta = {
-          packageDependency: dep,
-          packageFile,
-        }
-        logger.trace(meta, "Discovered a package dependency by matching regex, but it did not pass validation. Discarding")
-        return isValid
-      }
-
-      return isValid
-    });
+    .filter((dep: PackageDependency) =>
+      checkIsValidDependency(dep, packageFile),
+    );
 }
 
 export function handleRecursive(
@@ -103,19 +83,9 @@ export function handleRecursive(
     regexes,
   })
     .filter(is.truthy)
-    .filter((dep: PackageDependency) => {
-      const isValid = isValidDependency(dep)
-      if (!isValid) {
-        const meta = {
-          packageDependency: dep,
-          packageFile,
-        }
-        logger.trace(meta, "Discovered a package dependency by matching regex, but it did not pass validation. Discarding")
-        return isValid
-      }
-
-      return isValid
-    });
+    .filter((dep: PackageDependency) =>
+      checkIsValidDependency(dep, packageFile),
+    );
 }
 
 function processRecursive(parameters: RecursionParameter): PackageDependency[] {
@@ -135,7 +105,7 @@ function processRecursive(parameters: RecursionParameter): PackageDependency[] {
       },
       config,
     );
-    return result ? [result] : /* istanbul ignore next: can this happen? */ [];
+    return result ? [result] : /* istanbul ignore next: can this happen? */[];
   }
   return regexMatchAll(regexes[index], content).flatMap((match) => {
     return processRecursive({
@@ -145,4 +115,24 @@ function processRecursive(parameters: RecursionParameter): PackageDependency[] {
       combinedGroups: mergeGroups(combinedGroups, match.groups ?? {}),
     });
   });
+}
+
+function checkIsValidDependency(
+  dep: PackageDependency,
+  packageFile: string,
+): boolean {
+  const isValid = isValidDependency(dep);
+  if (!isValid) {
+    const meta = {
+      packageDependency: dep,
+      packageFile,
+    };
+    logger.trace(
+      meta,
+      'Discovered a package dependency by matching regex, but it did not pass validation. Discarding',
+    );
+    return isValid;
+  }
+
+  return isValid;
 }

--- a/lib/modules/manager/custom/regex/strategies.ts
+++ b/lib/modules/manager/custom/regex/strategies.ts
@@ -1,4 +1,5 @@
 import is from '@sindresorhus/is';
+import { logger } from '../../../../logger';
 import { regEx } from '../../../../util/regex';
 import type { PackageDependency } from '../../types';
 import type { RecursionParameter, RegexManagerConfig } from './types';
@@ -12,7 +13,7 @@ import {
 
 export function handleAny(
   content: string,
-  _packageFile: string,
+  packageFile: string,
   config: RegexManagerConfig,
 ): PackageDependency[] {
   return config.matchStrings
@@ -30,12 +31,24 @@ export function handleAny(
       ),
     )
     .filter(is.truthy)
-    .filter(isValidDependency);
+    .filter((dep: PackageDependency) => {
+      const isValid = isValidDependency(dep)
+      if (!isValid) {
+        const meta = {
+          packageDependency: dep,
+          packageFile,
+        }
+        logger.trace(meta, "Discovered a package dependency by matching regex, but it did not pass validation. Discarding")
+        return isValid
+      }
+
+      return isValid
+    });
 }
 
 export function handleCombination(
   content: string,
-  _packageFile: string,
+  packageFile: string,
   config: RegexManagerConfig,
 ): PackageDependency[] {
   const matches = config.matchStrings
@@ -57,7 +70,19 @@ export function handleCombination(
     .reduce((base, addition) => mergeExtractionTemplate(base, addition));
   return [createDependency(extraction, config)]
     .filter(is.truthy)
-    .filter(isValidDependency);
+    .filter((dep: PackageDependency) => {
+      const isValid = isValidDependency(dep)
+      if (!isValid) {
+        const meta = {
+          packageDependency: dep,
+          packageFile,
+        }
+        logger.trace(meta, "Discovered a package dependency by matching regex, but it did not pass validation. Discarding")
+        return isValid
+      }
+
+      return isValid
+    });
 }
 
 export function handleRecursive(
@@ -78,7 +103,19 @@ export function handleRecursive(
     regexes,
   })
     .filter(is.truthy)
-    .filter(isValidDependency);
+    .filter((dep: PackageDependency) => {
+      const isValid = isValidDependency(dep)
+      if (!isValid) {
+        const meta = {
+          packageDependency: dep,
+          packageFile,
+        }
+        logger.trace(meta, "Discovered a package dependency by matching regex, but it did not pass validation. Discarding")
+        return isValid
+      }
+
+      return isValid
+    });
 }
 
 function processRecursive(parameters: RecursionParameter): PackageDependency[] {

--- a/lib/modules/manager/custom/regex/strategies.ts
+++ b/lib/modules/manager/custom/regex/strategies.ts
@@ -105,7 +105,7 @@ function processRecursive(parameters: RecursionParameter): PackageDependency[] {
       },
       config,
     );
-    return result ? [result] : /* istanbul ignore next: can this happen? */[];
+    return result ? [result] : /* istanbul ignore next: can this happen? */ [];
   }
   return regexMatchAll(regexes[index], content).flatMap((match) => {
     return processRecursive({


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Adds TRACE level logging, as per discussion on Renovate Slack.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

When writing regexes to match custom file formats, it may not be obvious
why a valid regex may not be resulting in a match.

This is often because we have written a perfectly correct regex which
has matched the line(s), but then our `isValidDependency` check fails.

To make it easier to discover this, we can add a TRACE log, and note
that we will discard the dependency, giving suitable context for what is
being rejected.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
