### PR TITLE
refactor: sort sub-headings of options

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -709,6 +709,46 @@ For template fields, use the triple brace `{{{ }}}` notation to avoid Handlebars
 !!! tip
     Look at our [Custom Manager Presets](./presets-customManagers.md), they may have what you need.
 
+### autoReplaceStringTemplate
+
+Allows overwriting how the matched string is replaced.
+This allows for some migration strategies.
+E.g. moving from one Docker image repository to another one.
+
+```yaml title="helm-values.yaml"
+# The image of the service <registry>/<repo>/<image>:<tag>
+image: my.old.registry/aRepository/andImage:1.18-alpine
+```
+
+```json title="The regex definition"
+{
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["values.yaml$"],
+      "matchStrings": [
+        "image:\\s+(?<depName>my\\.old\\.registry/aRepository/andImage):(?<currentValue>[^\\s]+)"
+      ],
+      "depNameTemplate": "my.new.registry/aRepository/andImage",
+      "autoReplaceStringTemplate": "image: {{{depName}}}:{{{newValue}}}",
+      "datasourceTemplate": "docker"
+    }
+  ]
+}
+```
+
+This will lead to following update where `1.21-alpine` is the newest version of `my.new.registry/aRepository/andImage`:
+
+```yaml
+# The image of the service <registry>/<repo>/<image>:<tag>
+image: my.new.registry/aRepository/andImage:1.21-alpine
+```
+
+### currentValueTemplate
+
+If the `currentValue` for a dependency is not captured with a named group then it can be defined in config using this field.
+It will be compiled using Handlebars and the regex `groups` result.
+
 ### customType
 
 Example:
@@ -725,6 +765,26 @@ Example:
   ]
 }
 ```
+
+### datasourceTemplate
+
+If the `datasource` for a dependency is not captured with a named group then it can be defined in config using this field.
+It will be compiled using Handlebars and the regex `groups` result.
+
+### depNameTemplate
+
+If `depName` cannot be captured with a named capture group in `matchString` then it can be defined manually using this field.
+It will be compiled using Handlebars and the regex `groups` result.
+
+### depTypeTemplate
+
+If `depType` cannot be captured with a named capture group in `matchString` then it can be defined manually using this field.
+It will be compiled using Handlebars and the regex `groups` result.
+
+### extractVersionTemplate
+
+If `extractVersion` cannot be captured with a named capture group in `matchString` then it can be defined manually using this field.
+It will be compiled using Handlebars and the regex `groups` result.
 
 ### matchStrings
 
@@ -886,81 +946,21 @@ thanos_version: "0.15.0" // a comment
 
 In the above example, each custom manager will match a single dependency each.
 
-### depNameTemplate
-
-If `depName` cannot be captured with a named capture group in `matchString` then it can be defined manually using this field.
-It will be compiled using Handlebars and the regex `groups` result.
-
-### extractVersionTemplate
-
-If `extractVersion` cannot be captured with a named capture group in `matchString` then it can be defined manually using this field.
-It will be compiled using Handlebars and the regex `groups` result.
-
 ### packageNameTemplate
 
 `packageName` is used for looking up dependency versions.
 It will be compiled using Handlebars and the regex `groups` result.
 It will default to the value of `depName` if left unconfigured/undefined.
 
-### currentValueTemplate
+### registryUrlTemplate
 
-If the `currentValue` for a dependency is not captured with a named group then it can be defined in config using this field.
-It will be compiled using Handlebars and the regex `groups` result.
-
-### datasourceTemplate
-
-If the `datasource` for a dependency is not captured with a named group then it can be defined in config using this field.
-It will be compiled using Handlebars and the regex `groups` result.
-
-### depTypeTemplate
-
-If `depType` cannot be captured with a named capture group in `matchString` then it can be defined manually using this field.
+If the `registryUrls` for a dependency is not captured with a named group then it can be defined in config using this field.
 It will be compiled using Handlebars and the regex `groups` result.
 
 ### versioningTemplate
 
 If the `versioning` for a dependency is not captured with a named group then it can be defined in config using this field.
 It will be compiled using Handlebars and the regex `groups` result.
-
-### registryUrlTemplate
-
-If the `registryUrls` for a dependency is not captured with a named group then it can be defined in config using this field.
-It will be compiled using Handlebars and the regex `groups` result.
-
-### autoReplaceStringTemplate
-
-Allows overwriting how the matched string is replaced.
-This allows for some migration strategies.
-E.g. moving from one Docker image repository to another one.
-
-```yaml title="helm-values.yaml"
-# The image of the service <registry>/<repo>/<image>:<tag>
-image: my.old.registry/aRepository/andImage:1.18-alpine
-```
-
-```json title="The regex definition"
-{
-  "customManagers": [
-    {
-      "customType": "regex",
-      "fileMatch": ["values.yaml$"],
-      "matchStrings": [
-        "image:\\s+(?<depName>my\\.old\\.registry/aRepository/andImage):(?<currentValue>[^\\s]+)"
-      ],
-      "depNameTemplate": "my.new.registry/aRepository/andImage",
-      "autoReplaceStringTemplate": "image: {{{depName}}}:{{{newValue}}}",
-      "datasourceTemplate": "docker"
-    }
-  ]
-}
-```
-
-This will lead to following update where `1.21-alpine` is the newest version of `my.new.registry/aRepository/andImage`:
-
-```yaml
-# The image of the service <registry>/<repo>/<image>:<tag>
-image: my.new.registry/aRepository/andImage:1.21-alpine
-```
 
 ## customizeDashboard
 
@@ -1721,6 +1721,31 @@ To abort Renovate for errors for a specific `docker` host:
 
 When this field is enabled, Renovate will abort its run if it encounters either (a) any low-level http error (e.g. `ETIMEDOUT`) or (b) gets a response _not_ matching any of the configured `abortIgnoreStatusCodes` (e.g. `500 Internal Error`);
 
+### artifactAuth
+
+You may use this field whenever it is needed to only enable authentication for a specific set of managers.
+
+For example, using this option could be used whenever authentication using Git for private composer packages is already being handled through the use of SSH keys, which results in no need for also setting up authentication using tokens.
+
+```json
+{
+  "hostRules": [
+    {
+      "hostType": "gitlab",
+      "matchHost": "gitlab.myorg.com",
+      "token": "abc123",
+      "artifactAuth": ["composer"]
+    }
+  ]
+}
+```
+
+Supported artifactAuth and hostType combinations:
+
+| artifactAuth | hostTypes                                   |
+| ------------ | ------------------------------------------- |
+| `composer`   | `gitlab`, `packagist`, `github`, `git-tags` |
+
 ### authType
 
 You may use the `authType` option to create a custom HTTP `authorization` header.
@@ -1783,6 +1808,115 @@ Example config:
 Use an exact host for `matchHost` and not a domain (e.g. `api.github.com` as shown above and not `github.com`).
 Do not combine with `hostType` in the same rule or it won't work.
 
+### dnsCache
+
+Enable got [dnsCache](https://github.com/sindresorhus/got/blob/v11.5.2/readme.md#dnsCache) support.
+It uses [`lru-cache`](https://github.com/isaacs/node-lru-cache) with the `max` option set to `1000`.
+
+### enableHttp2
+
+Enable got [http2](https://github.com/sindresorhus/got/blob/v11.5.2/readme.md#http2) support.
+
+### headers
+
+You can provide a `headers` object that includes fields to be forwarded to the HTTP request headers.
+By default, all headers starting with "X-" are allowed.
+
+A bot administrator may configure an override for [`allowedHeaders`](./self-hosted-configuration.md#allowedheaders) to configure more permitted headers.
+
+`headers` value(s) configured in the bot admin `hostRules` (for example in a `config.js` file) are _not_ validated, so it may contain any header regardless of `allowedHeaders`.
+
+For example:
+
+```json
+{
+  "hostRules": [
+    {
+      "matchHost": "https://domain.com/all-versions",
+      "headers": {
+        "X-custom-header": "secret"
+      }
+    }
+  ]
+}
+```
+
+### hostType
+
+`hostType` is another way to filter rules and can be either a platform such as `github` and `bitbucket-server`, or it can be a datasource such as `docker` and `rubygems`.
+You usually don't need to configure it in a host rule if you have already configured `matchHost` and only one host type is in use for those, as is usually the case.
+`hostType` can help for cases like an enterprise registry that serves multiple package types and has different authentication for each, although it's often the case that multiple `matchHost` rules could achieve the same thing.
+
+### httpsCertificate
+
+Specifies the [Certificate chains](https://en.wikipedia.org/wiki/X.509#Certificate_chains_and_cross-certification) in [PEM format](https://en.wikipedia.org/wiki/Privacy-Enhanced_Mail) for mTLS authentication.
+
+### httpsCertificateAuthority
+
+By default, Renovate uses the curated list of well-known [CA](https://en.wikipedia.org/wiki/Certificate_authority)s by Mozilla.
+You may use another Certificate Authority instead, by setting it in the `httpsCertificateAuthority` config option.
+
+### httpsPrivateKey
+
+Specifies the private key in [PEM format](https://en.wikipedia.org/wiki/Privacy-Enhanced_Mail) for mTLS authentication.
+
+<!-- prettier-ignore -->
+!!! warning
+    Do _not_ put your private key into this field, to avoid losing confidentiality completely.
+    You must use [secrets](./self-hosted-configuration.md#secrets) to pass it down securely instead.
+
+### insecureRegistry
+
+Enable this option to allow Renovate to connect to an [insecure Docker registry](https://docs.docker.com/registry/insecure/) that is HTTP only.
+This is insecure and is not recommended.
+
+Example:
+
+```json
+{
+  "hostRules": [
+    {
+      "matchHost": "reg.insecure.com",
+      "insecureRegistry": true
+    }
+  ]
+}
+```
+
+### keepAlive
+
+If enabled, this allows a single TCP connection to remain open for multiple HTTP(S) requests/responses.
+
+### matchHost
+
+This can be a base URL (e.g. `https://api.github.com`) or a hostname like `github.com` or `api.github.com`.
+If the value starts with `http(s)` then it will only match against URLs which start with the full base URL.
+Otherwise, it will be matched by checking if the URL's hostname matches the `matchHost` directly or ends with it.
+When checking the end of the hostname, a single dot is prefixed to the value of `matchHost`, if one is not already present, to ensure it can only match against whole domain segments.
+
+The `matchHost` URL must be the same as the `registryUrl` set in `.npmrc`, or you'll get authentication issues when the artifacts are updated when yarn or npm runs.
+
+```json
+{
+  "hostRules": [
+    {
+      "matchHost": "https://gitlab.myorg.com/api/v4/packages/npm/",
+      "token": "abc123"
+    }
+  ]
+}
+```
+
+The above corresponds with an `.npmrc` like the following:
+
+```
+registry=https://gitlab.myorg.com/api/v4/packages/npm/
+```
+
+<!-- prettier-ignore -->
+!!! note
+    Values containing a URL path but missing a scheme will be prepended with 'https://' (e.g. `domain.com/path` -> `https://domain.com/path`)
+
 ### maxRequestsPerSecond
 
 In addition to `concurrentRequestLimit`, you can limit the maximum number of requests that can be made per one second.
@@ -1838,122 +1972,6 @@ For log level remapping, `newLogLevel` will set for the particular log message:
 }
 ```
 
-### dnsCache
-
-Enable got [dnsCache](https://github.com/sindresorhus/got/blob/v11.5.2/readme.md#dnsCache) support.
-It uses [`lru-cache`](https://github.com/isaacs/node-lru-cache) with the `max` option set to `1000`.
-
-### enableHttp2
-
-Enable got [http2](https://github.com/sindresorhus/got/blob/v11.5.2/readme.md#http2) support.
-
-### headers
-
-You can provide a `headers` object that includes fields to be forwarded to the HTTP request headers.
-By default, all headers starting with "X-" are allowed.
-
-A bot administrator may configure an override for [`allowedHeaders`](./self-hosted-configuration.md#allowedheaders) to configure more permitted headers.
-
-`headers` value(s) configured in the bot admin `hostRules` (for example in a `config.js` file) are _not_ validated, so it may contain any header regardless of `allowedHeaders`.
-
-For example:
-
-```json
-{
-  "hostRules": [
-    {
-      "matchHost": "https://domain.com/all-versions",
-      "headers": {
-        "X-custom-header": "secret"
-      }
-    }
-  ]
-}
-```
-
-### hostType
-
-`hostType` is another way to filter rules and can be either a platform such as `github` and `bitbucket-server`, or it can be a datasource such as `docker` and `rubygems`.
-You usually don't need to configure it in a host rule if you have already configured `matchHost` and only one host type is in use for those, as is usually the case.
-`hostType` can help for cases like an enterprise registry that serves multiple package types and has different authentication for each, although it's often the case that multiple `matchHost` rules could achieve the same thing.
-
-### insecureRegistry
-
-Enable this option to allow Renovate to connect to an [insecure Docker registry](https://docs.docker.com/registry/insecure/) that is HTTP only.
-This is insecure and is not recommended.
-
-Example:
-
-```json
-{
-  "hostRules": [
-    {
-      "matchHost": "reg.insecure.com",
-      "insecureRegistry": true
-    }
-  ]
-}
-```
-
-### keepAlive
-
-If enabled, this allows a single TCP connection to remain open for multiple HTTP(S) requests/responses.
-
-### artifactAuth
-
-You may use this field whenever it is needed to only enable authentication for a specific set of managers.
-
-For example, using this option could be used whenever authentication using Git for private composer packages is already being handled through the use of SSH keys, which results in no need for also setting up authentication using tokens.
-
-```json
-{
-  "hostRules": [
-    {
-      "hostType": "gitlab",
-      "matchHost": "gitlab.myorg.com",
-      "token": "abc123",
-      "artifactAuth": ["composer"]
-    }
-  ]
-}
-```
-
-Supported artifactAuth and hostType combinations:
-
-| artifactAuth | hostTypes                                   |
-| ------------ | ------------------------------------------- |
-| `composer`   | `gitlab`, `packagist`, `github`, `git-tags` |
-
-### matchHost
-
-This can be a base URL (e.g. `https://api.github.com`) or a hostname like `github.com` or `api.github.com`.
-If the value starts with `http(s)` then it will only match against URLs which start with the full base URL.
-Otherwise, it will be matched by checking if the URL's hostname matches the `matchHost` directly or ends with it.
-When checking the end of the hostname, a single dot is prefixed to the value of `matchHost`, if one is not already present, to ensure it can only match against whole domain segments.
-
-The `matchHost` URL must be the same as the `registryUrl` set in `.npmrc`, or you'll get authentication issues when the artifacts are updated when yarn or npm runs.
-
-```json
-{
-  "hostRules": [
-    {
-      "matchHost": "https://gitlab.myorg.com/api/v4/packages/npm/",
-      "token": "abc123"
-    }
-  ]
-}
-```
-
-The above corresponds with an `.npmrc` like the following:
-
-```
-registry=https://gitlab.myorg.com/api/v4/packages/npm/
-```
-
-<!-- prettier-ignore -->
-!!! note
-    Values containing a URL path but missing a scheme will be prepended with 'https://' (e.g. `domain.com/path` -> `https://domain.com/path`)
-
 ### readOnly
 
 If the `readOnly` field is being set to `true` inside the host rule, it will match only against the requests that are known to be read operations.
@@ -1990,24 +2008,6 @@ To adjust it down to 10s for all queries, do this:
   ]
 }
 ```
-
-### httpsCertificateAuthority
-
-By default, Renovate uses the curated list of well-known [CA](https://en.wikipedia.org/wiki/Certificate_authority)s by Mozilla.
-You may use another Certificate Authority instead, by setting it in the `httpsCertificateAuthority` config option.
-
-### httpsPrivateKey
-
-Specifies the private key in [PEM format](https://en.wikipedia.org/wiki/Privacy-Enhanced_Mail) for mTLS authentication.
-
-<!-- prettier-ignore -->
-!!! warning
-    Do _not_ put your private key into this field, to avoid losing confidentiality completely.
-    You must use [secrets](./self-hosted-configuration.md#secrets) to pass it down securely instead.
-
-### httpsCertificate
-
-Specifies the [Certificate chains](https://en.wikipedia.org/wiki/X.509#Certificate_chains_and_cross-certification) in [PEM format](https://en.wikipedia.org/wiki/Privacy-Enhanced_Mail) for mTLS authentication.
 
 ## ignoreDeprecated
 
@@ -2547,36 +2547,25 @@ You must use the `!/ /` syntax, like this:
 }
 ```
 
-### matchCurrentAge
+### changelogUrl
 
-Use this field if you want to match packages based on the age of the _current_ (existing, in-repo) version.
+Use this field to set the changelog URL for a package, including overriding any existing one.
+Using this field we can specify the exact URL to fetch changelogs from.
 
-For example, if you want to group updates for dependencies where the existing version is more than 2 years old:
-
-```json
+```json title="Setting the changelog URL for the dummy package"
 {
   "packageRules": [
     {
-      "matchCurrentAge": "> 2 years",
-      "groupName": "old dependencies"
+      "matchPackageNames": ["dummy"],
+      "changelogUrl": "https://github.com/org/dummy"
     }
   ]
 }
 ```
 
-The `matchCurrentAge` string must start with one of `>`, `>=`, `<` or `<=`.
-
-Only _one_ date part is supported, so you _cannot_ do `> 1 year 1 month`.
-Instead you should do `> 13 months`.
-
 <!-- prettier-ignore -->
 !!! note
-    We recommend you only use the words hour(s), day(s), week(s), month(s) and year(s) in your time ranges.
-
-### matchDepTypes
-
-Use this field if you want to limit a `packageRule` to certain `depType` values.
-Invalid if used outside of a `packageRule`.
+    Renovate can fetch changelogs from Bitbucket, Gitea (Forgejo), GitHub and GitLab platforms only, and setting the URL to an unsupported host/platform type won't change that.
 
 ### excludeDepNames
 
@@ -2658,45 +2647,6 @@ Use this field to restrict rules to a particular repository. e.g.
 
 This field supports Regular Expressions if they begin and end with `/`, otherwise it will use `minimatch`.
 
-### matchCategories
-
-Use `matchCategories` to restrict rules to a particular language or group.
-Matching is done using "any" logic, i.e. "match any of the following categories".
-The categories can be found in the [manager documentation](modules/manager/index.md).
-
-<!-- prettier-ignore -->
-!!! note
-    Rules with `matchCategories` are only applied _after_ extraction of dependencies.
-    If you want to configure which managers are being extracted at all, use `enabledManagers` instead.
-
-```json
-{
-  "packageRules": [
-    {
-      "matchCategories": ["python"],
-      "addLabels": ["py"]
-    }
-  ]
-}
-```
-
-### matchRepositories
-
-Use this field to restrict rules to a particular repository. e.g.
-
-```json
-{
-  "packageRules": [
-    {
-      "matchRepositories": ["literal/repo", "/^some/.*$/", "**/*-archived"],
-      "enabled": false
-    }
-  ]
-}
-```
-
-For more details on supported syntax see Renovate's [string pattern matching documentation](./string-pattern-matching.md).
-
 ### matchBaseBranches
 
 Use this field to restrict rules to a particular branch. e.g.
@@ -2727,44 +2677,71 @@ This field also supports Regular Expressions if they begin and end with `/`. e.g
 }
 ```
 
-### matchManagers
+### matchCategories
 
-Use this field to restrict rules to a particular package manager. e.g.
+Use `matchCategories` to restrict rules to a particular language or group.
+Matching is done using "any" logic, i.e. "match any of the following categories".
+The categories can be found in the [manager documentation](modules/manager/index.md).
 
-```json
-{
-  "packageRules": [
-    {
-      "matchPackageNames": ["node"],
-      "matchManagers": ["dockerfile"],
-      "enabled": false
-    }
-  ]
-}
-```
-
-For the full list of available managers, see the [Supported Managers](modules/manager/index.md#supported-managers) documentation.
-
-### matchMessage
-
-For log level remapping, use this field to match against the particular log messages.
-
-For more details on supported syntax see Renovate's [string pattern matching documentation](./string-pattern-matching.md).
-
-### matchDatasources
-
-Use this field to restrict rules to a particular datasource. e.g.
+<!-- prettier-ignore -->
+!!! note
+    Rules with `matchCategories` are only applied _after_ extraction of dependencies.
+    If you want to configure which managers are being extracted at all, use `enabledManagers` instead.
 
 ```json
 {
   "packageRules": [
     {
-      "matchDatasources": ["orb"],
-      "labels": ["circleci-orb!!"]
+      "matchCategories": ["python"],
+      "addLabels": ["py"]
     }
   ]
 }
 ```
+
+### matchConfidence
+
+<!-- prettier-ignore -->
+!!! warning
+    This configuration option needs a Mend API key, and is in private beta testing only.
+    API keys are not available for free or via the `renovatebot/renovate` repository.
+
+```json title="Grouping high merge confidence updates"
+{
+  "packageRules": [
+    {
+      "matchConfidence": ["high", "very high"],
+      "groupName": "high merge confidence"
+    }
+  ]
+}
+```
+
+### matchCurrentAge
+
+Use this field if you want to match packages based on the age of the _current_ (existing, in-repo) version.
+
+For example, if you want to group updates for dependencies where the existing version is more than 2 years old:
+
+```json
+{
+  "packageRules": [
+    {
+      "matchCurrentAge": "> 2 years",
+      "groupName": "old dependencies"
+    }
+  ]
+}
+```
+
+The `matchCurrentAge` string must start with one of `>`, `>=`, `<` or `<=`.
+
+Only _one_ date part is supported, so you _cannot_ do `> 1 year 1 month`.
+Instead you should do `> 13 months`.
+
+<!-- prettier-ignore -->
+!!! note
+    We recommend you only use the words hour(s), day(s), week(s), month(s) and year(s) in your time ranges.
 
 ### matchCurrentValue
 
@@ -2866,6 +2843,34 @@ Use the syntax `!/ /` like this:
 }
 ```
 
+### matchDatasources
+
+Use this field to restrict rules to a particular datasource. e.g.
+
+```json
+{
+  "packageRules": [
+    {
+      "matchDatasources": ["orb"],
+      "labels": ["circleci-orb!!"]
+    }
+  ]
+}
+```
+
+### matchDepNames
+
+This field behaves the same as `matchPackageNames` except it matches against `depName` instead of `packageName`.
+
+### matchDepPatterns
+
+### matchDepPrefixes
+
+### matchDepTypes
+
+Use this field if you want to limit a `packageRule` to certain `depType` values.
+Invalid if used outside of a `packageRule`.
+
 ### matchFileNames
 
 Renovate will compare `matchFileNames` glob matching against the dependency's package file and also lock file if one exists.
@@ -2913,13 +2918,29 @@ The following example matches any file in directories starting with `app/`:
 
 It is recommended that you avoid using "negative" globs, like `**/!(package.json)`, because such patterns might still return true if they match against the lock file name (e.g. `package-lock.json`).
 
-### matchDepNames
+### matchManagers
 
-This field behaves the same as `matchPackageNames` except it matches against `depName` instead of `packageName`.
+Use this field to restrict rules to a particular package manager. e.g.
 
-### matchDepPatterns
+```json
+{
+  "packageRules": [
+    {
+      "matchPackageNames": ["node"],
+      "matchManagers": ["dockerfile"],
+      "enabled": false
+    }
+  ]
+}
+```
 
-### matchDepPrefixes
+For the full list of available managers, see the [Supported Managers](modules/manager/index.md#supported-managers) documentation.
+
+### matchMessage
+
+For log level remapping, use this field to match against the particular log messages.
+
+For more details on supported syntax see Renovate's [string pattern matching documentation](./string-pattern-matching.md).
 
 ### matchNewValue
 
@@ -3040,6 +3061,23 @@ Like the earlier `matchPackagePatterns` example, the above will configure `range
     If the fallback is used, Renovate will log a warning, because the fallback will be removed in a future release.
     Use `matchDepPatterns` instead.
 
+### matchRepositories
+
+Use this field to restrict rules to a particular repository. e.g.
+
+```json
+{
+  "packageRules": [
+    {
+      "matchRepositories": ["literal/repo", "/^some/.*$/", "**/*-archived"],
+      "enabled": false
+    }
+  ]
+}
+```
+
+For more details on supported syntax see Renovate's [string pattern matching documentation](./string-pattern-matching.md).
+
 ### matchSourceUrlPrefixes
 
 Here's an example of where you use this to group together all packages from the `renovatebot` GitHub org:
@@ -3093,24 +3131,6 @@ For example to apply a special label to `major` updates:
     When setting up automerge for dependencies, make sure to stop accidental automerges of `0.x` versions.
     Read the [automerge non-major updates](./key-concepts/automerge.md#automerge-non-major-updates) docs for a config example that blocks `0.x` updates.
 
-### matchConfidence
-
-<!-- prettier-ignore -->
-!!! warning
-    This configuration option needs a Mend API key, and is in private beta testing only.
-    API keys are not available for free or via the `renovatebot/renovate` repository.
-
-```json title="Grouping high merge confidence updates"
-{
-  "packageRules": [
-    {
-      "matchConfidence": ["high", "very high"],
-      "groupName": "high merge confidence"
-    }
-  ]
-}
-```
-
 Tokens can be configured via `hostRules` using the `"merge-confidence"` `hostType`:
 
 ```json
@@ -3124,25 +3144,38 @@ Tokens can be configured via `hostRules` using the `"merge-confidence"` `hostTyp
 }
 ```
 
-### changelogUrl
+### prPriority
 
-Use this field to set the changelog URL for a package, including overriding any existing one.
-Using this field we can specify the exact URL to fetch changelogs from.
+Sometimes Renovate needs to rate limit its creation of PRs, e.g. hourly or concurrent PR limits.
+By default, Renovate sorts/prioritizes based on the update type, going from smallest update to biggest update.
+Renovate creates update PRs in this order:
 
-```json title="Setting the changelog URL for the dummy package"
+1. `pinDigest`
+1. `pin`
+1. `digest`
+1. `patch`
+1. `minor`
+1. `major`
+
+If you have dependencies that are more or less important than others then you can use the `prPriority` field for PR sorting.
+The default value is 0, so setting a negative value will make dependencies sort last, while higher values sort first.
+
+Here's an example of how you would define PR priority so that `devDependencies` are raised last and `react` is raised first:
+
+```json
 {
   "packageRules": [
     {
-      "matchPackageNames": ["dummy"],
-      "changelogUrl": "https://github.com/org/dummy"
+      "matchDepTypes": ["devDependencies"],
+      "prPriority": -1
+    },
+    {
+      "matchPackageNames": ["react"],
+      "prPriority": 5
     }
   ]
 }
 ```
-
-<!-- prettier-ignore -->
-!!! note
-    Renovate can fetch changelogs from Bitbucket, Gitea (Forgejo), GitHub and GitLab platforms only, and setting the URL to an unsupported host/platform type won't change that.
 
 ### replacementName
 
@@ -3234,22 +3267,6 @@ For example to replace the npm package `jade` with version `2.0.0` of the packag
 }
 ```
 
-### sourceUrl
-
-Use this field to set the source URL for a package, including overriding an existing one.
-Source URLs are necessary to link to the source of the package and in order to look up changelogs.
-
-```json title="Setting the source URL for the dummy package"
-{
-  "packageRules": [
-    {
-      "matchPackageNames": ["dummy"],
-      "sourceUrl": "https://github.com/org/dummy"
-    }
-  ]
-}
-```
-
 ### sourceDirectory
 
 Use this field to set the directory in which the package is present at the source of the package.
@@ -3270,34 +3287,17 @@ Use this field to set the directory in which the package is present at the sourc
 !!! note
     `sourceDirectory` should be only be configured along with `sourceUrl`.
 
-### prPriority
+### sourceUrl
 
-Sometimes Renovate needs to rate limit its creation of PRs, e.g. hourly or concurrent PR limits.
-By default, Renovate sorts/prioritizes based on the update type, going from smallest update to biggest update.
-Renovate creates update PRs in this order:
+Use this field to set the source URL for a package, including overriding an existing one.
+Source URLs are necessary to link to the source of the package and in order to look up changelogs.
 
-1. `pinDigest`
-1. `pin`
-1. `digest`
-1. `patch`
-1. `minor`
-1. `major`
-
-If you have dependencies that are more or less important than others then you can use the `prPriority` field for PR sorting.
-The default value is 0, so setting a negative value will make dependencies sort last, while higher values sort first.
-
-Here's an example of how you would define PR priority so that `devDependencies` are raised last and `react` is raised first:
-
-```json
+```json title="Setting the source URL for the dummy package"
 {
   "packageRules": [
     {
-      "matchDepTypes": ["devDependencies"],
-      "prPriority": -1
-    },
-    {
-      "matchPackageNames": ["react"],
-      "prPriority": 5
+      "matchPackageNames": ["dummy"],
+      "sourceUrl": "https://github.com/org/dummy"
     }
   ]
 }
@@ -3411,6 +3411,12 @@ You can use variable templating in your commands as long as [`allowPostUpgradeCo
 !!! note
     Do not use `git add` in your commands to add new files to be tracked, add them by including them in your [`fileFilters`](#filefilters) instead.
 
+### executionMode
+
+Defaults to `update`, but can also be set to `branch`.
+This sets the level the postUpgradeTask runs on, if set to `update` the postUpgradeTask will be executed for every dependency on the branch.
+If set to `branch` the postUpgradeTask is executed for the whole branch.
+
 ### fileFilters
 
 A list of glob-style matchers that determine which files will be included in the final commit made by Renovate.
@@ -3418,12 +3424,6 @@ Dotfiles are included.
 
 Optional field which defaults to any non-ignored file in the repo (`**/*` glob pattern).
 Specify a custom value for this if you wish to exclude certain files which are modified by your `postUpgradeTasks` and you don't want committed.
-
-### executionMode
-
-Defaults to `update`, but can also be set to `branch`.
-This sets the level the postUpgradeTask runs on, if set to `update` the postUpgradeTask will be executed for every dependency on the branch.
-If set to `branch` the postUpgradeTask is executed for the whole branch.
 
 ## prBodyColumns
 

--- a/test/documentation.spec.ts
+++ b/test/documentation.spec.ts
@@ -25,8 +25,8 @@ describe('documentation', () => {
     ): string[] {
       const subHeadings = [];
       const content = fs.readFileSync(`docs/usage/${file}`, 'utf8');
-      const reg = `##\\s${configOption}(?<subHeadersStr>[\\s\\S]+?)\n##\\s`;
-      const match = content.match(reg);
+      const reg = regEx(`##\\s${configOption}[\\s\\S]+?\n##\\s`);
+      const match = reg.exec(content);
       const subHeadersMatch = match?.[0]?.matchAll(/\n###\s(?<child>\w+)\n/g);
       if (subHeadersMatch) {
         for (const subHeaderStr of subHeadersMatch) {

--- a/test/documentation.spec.ts
+++ b/test/documentation.spec.ts
@@ -27,7 +27,7 @@ describe('documentation', () => {
       const content = fs.readFileSync(`docs/usage/${file}`, 'utf8');
       const reg = `##\\s${configOption}(?<subHeadersStr>[\\s\\S]+?)\n##\\s`;
       const match = content.match(reg);
-      const subHeadersMatch = match?.[0]?.matchAll(/\n###\s(?<child>\w+)+\n/g);
+      const subHeadersMatch = match?.[0]?.matchAll(/\n###\s(?<child>\w+)\n/g);
       if (subHeadersMatch) {
         for (const subHeaderStr of subHeadersMatch) {
           if (subHeaderStr?.groups?.child) {

--- a/test/documentation.spec.ts
+++ b/test/documentation.spec.ts
@@ -19,6 +19,25 @@ describe('documentation', () => {
   });
 
   describe('website-documentation', () => {
+    function getConfigOptionSubHeaders(
+      file: string,
+      configOption: string,
+    ): string[] {
+      const subHeadings = [];
+      const content = fs.readFileSync(`docs/usage/${file}`, 'utf8');
+      const reg = `##\\s${configOption}(?<subHeadersStr>[\\s\\S]+?)\n##\\s`;
+      const match = content.match(reg);
+      const subHeadersMatch = match?.[0]?.matchAll(/\n###\s(?<child>\w+)+\n/g);
+      if (subHeadersMatch) {
+        for (const subHeaderStr of subHeadersMatch) {
+          if (subHeaderStr?.groups?.child) {
+            subHeadings.push(subHeaderStr.groups.child);
+          }
+        }
+      }
+      return subHeadings;
+    }
+
     describe('docs/usage/configuration-options.md', () => {
       function getConfigHeaders(file: string): string[] {
         const content = fs.readFileSync(`docs/usage/${file}`, 'utf8');
@@ -64,11 +83,42 @@ describe('documentation', () => {
           .sort();
       }
 
+      function getParentNames(): Set<string> {
+        const childrens = options
+          .filter((option) => option.stage !== 'global')
+          .filter((option) => !option.globalOnly)
+          .filter((option) => option.parents);
+
+        const parentNames = new Set<string>();
+        for (const children of childrens) {
+          const parents = children.parents ?? [];
+          for (const parent of parents) {
+            parentNames.add(parent);
+          }
+        }
+
+        return parentNames;
+      }
+
       it('has headers for every required sub-option', () => {
         expect(getConfigSubHeaders('configuration-options.md')).toEqual(
           getRequiredConfigSubOptions(),
         );
       });
+
+      it.each([...getParentNames()])(
+        '%s has sub-headers sorted alphabetically',
+        (parentName: string) => {
+          expect(
+            getConfigOptionSubHeaders('configuration-options.md', parentName),
+          ).toEqual(
+            getConfigOptionSubHeaders(
+              'configuration-options.md',
+              parentName,
+            ).sort(),
+          );
+        },
+      );
     });
 
     describe('docs/usage/self-hosted-configuration.md', () => {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- Add test to validate the sub headings are sorted
- edit the order of sub-headings to match alphabetical order

<!-- Describe what behavior is changed by this PR. -->

## Context
Closes: https://github.com/renovatebot/renovate/issues/29703
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
