### PR TITLE
fix(config/presets): correct `security-only` preset matcher

### DIFF
--- a/lib/config/presets/internal/security.ts
+++ b/lib/config/presets/internal/security.ts
@@ -28,7 +28,7 @@ export const presets: Record<string, Preset> = {
     packageRules: [
       {
         enabled: false,
-        matchPackageNames: ['*'],
+        matchPackagePatterns: ['*'],
       },
     ],
     vulnerabilityAlerts: {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

The `security-only` preset currenly includes `matchPackageNames: ['*']` which doesn't work because names are not evaluated as patterns. This PR makes it work by using `matchPackagePatterns` instead.

Unlike `matchPackagePatterns` (see [here](https://github.com/renovatebot/renovate/blob/f5fc65970ee445dea0fda60bfc5e63b70b8c80fe/lib/util/package-rules/package-patterns.ts#L14)), the `matchPackageNames` matcher (see [here](https://github.com/renovatebot/renovate/blob/main/lib/util/package-rules/package-names.ts)) doesn't massage `*` to `.*` and doesn't attempt matching names against it. Hence, the `security-only` preset didn't work so far.

<!-- Describe what behavior is changed by this PR. -->

## Context

- https://github.com/renovatebot/renovate/discussions/29509
- https://github.com/renovatebot/renovate/discussions/15490
- https://github.com/renovatebot/renovate/pull/28320

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
