### PR TITLE
feat(datasource/custom): expose `tags` in result so that we can use `followTag`

### DIFF
--- a/lib/modules/datasource/custom/index.spec.ts
+++ b/lib/modules/datasource/custom/index.spec.ts
@@ -119,6 +119,49 @@ describe('modules/datasource/custom/index', () => {
       expect(result).toEqual(expected);
     });
 
+    it('return releases with tags and other optional fields for api directly exposing in renovate format', async () => {
+      const expected = {
+        releases: [
+          {
+            version: 'v1.0.0',
+          },
+        ],
+        tags: {
+          latest: 'v1.0.0',
+        },
+        sourceUrl: 'https://example.com/foo.git',
+        sourceDirectory: '/',
+        changelogUrl: 'https://example.com/foo/blob/main/CHANGELOG.md',
+        homepage: 'https://example.com/foo',
+      };
+      const content = {
+        releases: [
+          {
+            version: 'v1.0.0',
+          },
+        ],
+        tags: {
+          latest: 'v1.0.0',
+        },
+        sourceUrl: 'https://example.com/foo.git',
+        sourceDirectory: '/',
+        changelogUrl: 'https://example.com/foo/blob/main/CHANGELOG.md',
+        homepage: 'https://example.com/foo',
+        unknown: {},
+      };
+      httpMock.scope('https://example.com').get('/v1').reply(200, content);
+      const result = await getPkgReleases({
+        datasource: `${CustomDatasource.id}.foo`,
+        packageName: 'myPackage',
+        customDatasources: {
+          foo: {
+            defaultRegistryUrlTemplate: 'https://example.com/v1',
+          },
+        },
+      });
+      expect(result).toEqual(expected);
+    });
+
     it('return releases for plain text API directly exposing in Renovate format', async () => {
       const expected = {
         releases: [

--- a/lib/modules/datasource/custom/schema.ts
+++ b/lib/modules/datasource/custom/schema.ts
@@ -20,6 +20,7 @@ export const ReleaseResultZodSchema = z.object({
         };
       }),
   ),
+  tags: z.record(z.string(), z.string()).optional(),
   sourceUrl: z.string().optional(),
   sourceDirectory: z.string().optional(),
   changelogUrl: z.string().optional(),


### PR DESCRIPTION
## Changes
Added `tags` field to the schema for custom datasources.

## Context
I created a repository with custom datasource, and it's expected that the dependencies always update to the latest version. but the registry always returns the latest version only, and Renovate found no updates.
As I debugged, the `allSatisfyingVersions` and `dependency.tags` in `lib/workers/repository/process/lookup/index.ts` are both empty, so the `followTag` is also unavailable for my custom datasource.
This PR fixes the issue.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
