### PR TITLE
feat(manager/helm-values): add image support in helm values manager

### DIFF
--- a/lib/modules/manager/helm-values/__fixtures__/values_with_image_instead_of_repo.yaml
+++ b/lib/modules/manager/helm-values/__fixtures__/values_with_image_instead_of_repo.yaml
@@ -1,0 +1,68 @@
+# Default values for test-chart.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repo: nginx
+  tag: 1.16.1
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths: []
+
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/lib/modules/manager/helm-values/extract.spec.ts
+++ b/lib/modules/manager/helm-values/extract.spec.ts
@@ -11,6 +11,10 @@ const helmMultiAndNestedImageValues = Fixtures.get(
   'multi_and_nested_image_values.yaml',
 );
 
+const helmImageInsteadOfRepository = Fixtures.get(
+  'values_with_image_instead_of_repo.yaml',
+);
+
 const config = partial<ExtractConfig>({});
 
 const configAliases = partial<ExtractConfig>({
@@ -107,6 +111,15 @@ describe('modules/manager/helm-values/extract', () => {
           },
         ],
       });
+    });
+
+    it('return null if image and repo are not defined', () => {
+      const result = extractPackageFile(
+        helmImageInsteadOfRepository,
+        packageFile,
+        config,
+      );
+      expect(result).toBeNull();
     });
   });
 });

--- a/lib/modules/manager/helm-values/extract.ts
+++ b/lib/modules/manager/helm-values/extract.ts
@@ -55,6 +55,7 @@ function findDependencies(
         currentItem.image === undefined
       ) {
         logger.debug('repository and image are both undefined');
+        return null;
       }
       const repository = `${currentItem.repository ?? currentItem.image}`;
       const tag = `${currentItem.tag ?? currentItem.version}`;

--- a/lib/modules/manager/helm-values/extract.ts
+++ b/lib/modules/manager/helm-values/extract.ts
@@ -48,10 +48,15 @@ function findDependencies(
   Object.entries(parsedContent).forEach(([key, value]) => {
     if (matchesHelmValuesDockerHeuristic(key, value)) {
       const currentItem = value;
-
       let registry = currentItem.registry;
       registry = registry ? `${registry}/` : '';
-      const repository = String(currentItem.repository);
+      if (
+        currentItem.repository == undefined &&
+        currentItem.image == undefined
+      ) {
+        logger.debug('repository and image are both undefined');
+      }
+      const repository = `${currentItem.repository ?? currentItem.image}`;
       const tag = `${currentItem.tag ?? currentItem.version}`;
       packageDependencies.push(getHelmDep(registry, repository, tag, config));
     } else if (matchesHelmValuesInlineImage(key, value)) {

--- a/lib/modules/manager/helm-values/extract.ts
+++ b/lib/modules/manager/helm-values/extract.ts
@@ -51,8 +51,8 @@ function findDependencies(
       let registry = currentItem.registry;
       registry = registry ? `${registry}/` : '';
       if (
-        currentItem.repository == undefined &&
-        currentItem.image == undefined
+        currentItem.repository === undefined &&
+        currentItem.image === undefined
       ) {
         logger.debug('repository and image are both undefined');
       }

--- a/lib/modules/manager/helm-values/readme.md
+++ b/lib/modules/manager/helm-values/readme.md
@@ -7,8 +7,13 @@ image:
   tag: v1.0.0
   registry: registry.example.com # optional key, will default to "docker.io"
 
+
 image:
   repository: 'some-docker/dependency'
+  version: v1.0.0
+
+image:
+  image: 'some-docker/dependency'
   version: v1.0.0
 
 coreImage:

--- a/lib/modules/manager/helm-values/readme.md
+++ b/lib/modules/manager/helm-values/readme.md
@@ -7,7 +7,6 @@ image:
   tag: v1.0.0
   registry: registry.example.com # optional key, will default to "docker.io"
 
-
 image:
   repository: 'some-docker/dependency'
   version: v1.0.0

--- a/lib/modules/manager/helm-values/types.ts
+++ b/lib/modules/manager/helm-values/types.ts
@@ -1,6 +1,7 @@
 export interface HelmDockerImageDependencyBasic {
   registry?: string;
-  repository: string;
+  repository?: string;
+  image?: string;
 }
 
 export interface HelmDockerImageDependencyTag

--- a/lib/modules/manager/helm-values/util.ts
+++ b/lib/modules/manager/helm-values/util.ts
@@ -30,7 +30,7 @@ export function matchesHelmValuesDockerHeuristic(
     parentKeyRe.test(parentKey) &&
     data &&
     typeof data === 'object' &&
-    hasKey('repository', data) &&
+    (hasKey('repository', data)|| hasKey("image", data)) &&
     (hasKey('tag', data) || hasKey('version', data))
   );
 }

--- a/lib/modules/manager/helm-values/util.ts
+++ b/lib/modules/manager/helm-values/util.ts
@@ -30,7 +30,7 @@ export function matchesHelmValuesDockerHeuristic(
     parentKeyRe.test(parentKey) &&
     data &&
     typeof data === 'object' &&
-    (hasKey('repository', data)|| hasKey("image", data)) &&
+    (hasKey('repository', data) || hasKey('image', data)) &&
     (hasKey('tag', data) || hasKey('version', data))
   );
 }


### PR DESCRIPTION
## Changes
This PR adds the `image` as viable option in helm-values manager
as some charts use `image` and not `repository` in the values.yaml

## Context
Some of our internal charts use image instead of repository 

## Documentation (please check one with an [x])

- [X] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [X] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

