### PR TITLE
fix: Only use GitHub releases to update Bazelisk

### DIFF
--- a/lib/modules/manager/bazelisk/extract.spec.ts
+++ b/lib/modules/manager/bazelisk/extract.spec.ts
@@ -7,7 +7,7 @@ describe('modules/manager/bazelisk/extract', () => {
       expect(res.deps).toEqual([
         {
           currentValue: '5.2.0',
-          datasource: 'github-tags',
+          datasource: 'github-releases',
           depName: 'bazel',
           packageName: 'bazelbuild/bazel',
         },
@@ -19,7 +19,7 @@ describe('modules/manager/bazelisk/extract', () => {
       expect(res.deps).toEqual([
         {
           currentValue: '5.2',
-          datasource: 'github-tags',
+          datasource: 'github-releases',
           depName: 'bazel',
           packageName: 'bazelbuild/bazel',
         },
@@ -31,7 +31,7 @@ describe('modules/manager/bazelisk/extract', () => {
       expect(res.deps).toEqual([
         {
           currentValue: 'latestn',
-          datasource: 'github-tags',
+          datasource: 'github-releases',
           depName: 'bazel',
           packageName: 'bazelbuild/bazel',
         },
@@ -43,7 +43,7 @@ describe('modules/manager/bazelisk/extract', () => {
       expect(res.deps).toEqual([
         {
           currentValue: '5.2.0',
-          datasource: 'github-tags',
+          datasource: 'github-releases',
           depName: 'bazel',
           packageName: 'bazelbuild/bazel',
         },

--- a/lib/modules/manager/bazelisk/extract.ts
+++ b/lib/modules/manager/bazelisk/extract.ts
@@ -1,11 +1,11 @@
-import { GithubTagsDatasource } from '../../datasource/github-tags';
+import { GithubReleasesDatasource } from '../../datasource/github-releases';
 import type { PackageDependency, PackageFileContent } from '../types';
 
 export function extractPackageFile(content: string): PackageFileContent {
   const dep: PackageDependency = {
     depName: 'bazel',
     currentValue: content.split('\n', 2)[0].trim(),
-    datasource: GithubTagsDatasource.id,
+    datasource: GithubReleasesDatasource.id,
     packageName: 'bazelbuild/bazel',
   };
   return { deps: [dep] };

--- a/lib/modules/manager/bazelisk/index.ts
+++ b/lib/modules/manager/bazelisk/index.ts
@@ -1,5 +1,5 @@
 import type { Category } from '../../../constants';
-import { GithubTagsDatasource } from '../../datasource/github-tags';
+import { GithubTagsDatasource } from '../../datasource/github-releases';
 import * as semverVersioning from '../../versioning/semver';
 
 export { extractPackageFile } from './extract';
@@ -12,4 +12,4 @@ export const defaultConfig = {
 
 export const categories: Category[] = ['bazel'];
 
-export const supportedDatasources = [GithubTagsDatasource.id];
+export const supportedDatasources = [GithubReleasesDatasource.id];

--- a/lib/modules/manager/bazelisk/index.ts
+++ b/lib/modules/manager/bazelisk/index.ts
@@ -1,5 +1,5 @@
 import type { Category } from '../../../constants';
-import { GithubTagsDatasource } from '../../datasource/github-releases';
+import { GithubReleasesDatasource } from '../../datasource/github-releases';
 import * as semverVersioning from '../../versioning/semver';
 
 export { extractPackageFile } from './extract';


### PR DESCRIPTION
## Changes

Change Bazelisk to use GitHub Releases datasource instead of GitHub Tags datasource.

## Context

Bazel's release process is to first create a tag, and then only to create a GitHub release once all artifacts have been built and are ready/available. The GitHub tag will exist before the real Bazel release artifacts are available, which causes Renovate to create PRs that may fail or only partially succed.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
