### PR TITLE
fix(versioning/poetry): improve poetry2semver validation

### DIFF
--- a/lib/modules/versioning/poetry/transform.ts
+++ b/lib/modules/versioning/poetry/transform.ts
@@ -78,7 +78,7 @@ export function poetry2semver(
     parts.push(`-${dev.letter}.${dev.number}`);
   }
 
-  return parts.join('');
+  return semver.valid(parts.join(''));
 }
 
 /** Reverse normalizations applied by poetry2semver */


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds extra validation to poetry2semver function

## Context

#29827

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
