### PR TITLE
refactor(git): prepare support for commit signing with other key formats

### DIFF
--- a/lib/util/git/private-key.ts
+++ b/lib/util/git/private-key.ts
@@ -8,56 +8,69 @@ import { exec } from '../exec';
 import { newlineRegex } from '../regex';
 import { addSecretForSanitizing } from '../sanitize';
 
-let gitPrivateKey: string | undefined;
-let keyId: string | undefined;
+let gitPrivateKey: PrivateKey | undefined;
+
+abstract class PrivateKey {
+  protected readonly key: string;
+  protected keyId: string | undefined;
+
+  constructor(key: string) {
+    this.key = key.trim();
+    addSecretForSanitizing(this.key, 'global');
+    logger.debug(
+      'gitPrivateKey: successfully set (but not yet written/configured)',
+    );
+  }
+
+  async writeKey(): Promise<void> {
+    try {
+      if (!this.keyId) {
+        this.keyId = await this.importKey();
+      }
+      logger.debug('gitPrivateKey: imported');
+    } catch (err) {
+      logger.warn({ err }, 'gitPrivateKey: error importing');
+      throw new Error(PLATFORM_GPG_FAILED);
+    }
+  }
+
+  async configSigningKey(cwd: string): Promise<void> {
+    logger.debug('gitPrivateKey: configuring commit signing');
+    // TODO: types (#22198)
+    await exec(`git config user.signingkey ${this.keyId!}`, { cwd });
+    await exec(`git config commit.gpgsign true`, { cwd });
+  }
+
+  protected abstract importKey(): Promise<string | undefined>;
+}
+
+class GPGKey extends PrivateKey {
+  protected async importKey(): Promise<string | undefined> {
+    const keyFileName = upath.join(os.tmpdir() + '/git-private-gpg.key');
+    await fs.outputFile(keyFileName, this.key);
+    const { stdout, stderr } = await exec(`gpg --import ${keyFileName}`);
+    logger.debug({ stdout, stderr }, 'Private key import result');
+    await fs.remove(keyFileName);
+    return `${stdout}${stderr}`
+      .split(newlineRegex)
+      .find((line) => line.includes('secret key imported'))
+      ?.replace('gpg: key ', '')
+      .split(':')
+      .shift();
+  }
+}
 
 export function setPrivateKey(key: string | undefined): void {
   if (!is.nonEmptyStringAndNotWhitespace(key)) {
     return;
   }
-  addSecretForSanitizing(key.trim(), 'global');
-  logger.debug(
-    'gitPrivateKey: successfully set (but not yet written/configured)',
-  );
-  gitPrivateKey = key.trim();
-}
-
-async function importKey(): Promise<void> {
-  if (keyId) {
-    return;
-  }
-  const keyFileName = upath.join(os.tmpdir() + '/git-private.key');
-  await fs.outputFile(keyFileName, gitPrivateKey!);
-  const { stdout, stderr } = await exec(`gpg --import ${keyFileName}`);
-  logger.debug({ stdout, stderr }, 'Private key import result');
-  keyId = `${stdout}${stderr}`
-    .split(newlineRegex)
-    .find((line) => line.includes('secret key imported'))
-    ?.replace('gpg: key ', '')
-    .split(':')
-    .shift();
-  await fs.remove(keyFileName);
+  gitPrivateKey = new GPGKey(key);
 }
 
 export async function writePrivateKey(): Promise<void> {
-  if (!gitPrivateKey) {
-    return;
-  }
-  try {
-    await importKey();
-    logger.debug('gitPrivateKey: imported');
-  } catch (err) {
-    logger.warn({ err }, 'gitPrivateKey: error importing');
-    throw new Error(PLATFORM_GPG_FAILED);
-  }
+  await gitPrivateKey?.writeKey();
 }
 
 export async function configSigningKey(cwd: string): Promise<void> {
-  if (!gitPrivateKey) {
-    return;
-  }
-  logger.debug('gitPrivateKey: configuring commit signing');
-  // TODO: types (#22198)
-  await exec(`git config user.signingkey ${keyId!}`, { cwd });
-  await exec(`git config commit.gpgsign true`, { cwd });
+  await gitPrivateKey?.configSigningKey(cwd);
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

I've refactored the implementation for commit signing as a preparatory step for supporting other key formats like SSH.

## Context

I submitted a PR (#29550) that adds support for SSH-based commit signing which currently includes a refactoring to support multiple key formats. During review, it was suggested to do the refactoring in a separate PR (https://github.com/renovatebot/renovate/pull/29550#discussion_r1642817476).

Once this PR has been merged, I'll update #29550 accordingly.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
