### PR TITLE
fix(template): allow `prBodyDefinitions` in templates

### DIFF
--- a/lib/util/template/index.spec.ts
+++ b/lib/util/template/index.spec.ts
@@ -114,6 +114,22 @@ describe('util/template/index', () => {
     expect(output).toBe('CUSTOM_FOO is foo');
   });
 
+  it('and has access to prBodyDefinitions', () => {
+    const userTemplate =
+      'Issues: {{#each upgrades}}{{{prBodyDefinitions.Issue}}} {{/each}}';
+    const config = {
+      upgrades: [
+        {
+          prBodyDefinitions: {
+            Issue: '1234',
+          },
+        },
+      ],
+    };
+    const output = template.compile(userTemplate, config);
+    expect(output).toBe('Issues: 1234 ');
+  });
+
   it('replace', () => {
     const userTemplate =
       "{{ replace '[a-z]+\\.github\\.com' 'ghc' depName }}{{ replace 'some' 'other' depType }}";

--- a/lib/util/template/index.ts
+++ b/lib/util/template/index.ts
@@ -207,6 +207,11 @@ const compileInputProxyHandler: ProxyHandler<CompileInput> = {
 
     const value = target[prop];
 
+    if (prop === 'prBodyDefinitions') {
+      // Expose all prBodyDefinitions.*
+      return value;
+    }
+
     if (is.array(value)) {
       return value.map((element) =>
         is.primitive(element)
@@ -248,6 +253,10 @@ export function compile(
         continue;
       }
       for (const varName of varNames) {
+        if (varName === 'prBodyDefinitions') {
+          // Allow all prBodyDefinitions.*
+          break;
+        }
         if (!allowedFieldsList.includes(varName)) {
           logger.info(
             { varName, template },


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Allow `prBodyDefinitions` in templates. According to https://docs.renovatebot.com/templates/#exposed-config-options it should be allowed.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

- https://github.com/renovatebot/renovate/discussions/29546

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
