### PR TITLE
feat(datasource/custom): allow `isStable` in output

### DIFF
--- a/lib/modules/datasource/custom/readme.md
+++ b/lib/modules/datasource/custom/readme.md
@@ -70,7 +70,8 @@ All available options:
       "changelogUrl": "https://github.com/demo-org/demo/blob/main/CHANGELOG.md#v0710",
       "sourceUrl": "https://github.com/demo-org/demo",
       "sourceDirectory": "monorepo/folder",
-      "digest": "c667f758f9e46e1d8111698e8d3a181c0b10f430"
+      "digest": "c667f758f9e46e1d8111698e8d3a181c0b10f430",
+      "isStable": true
     }
   ],
   "sourceUrl": "https://github.com/demo-org/demo",

--- a/lib/modules/datasource/custom/schema.ts
+++ b/lib/modules/datasource/custom/schema.ts
@@ -11,6 +11,7 @@ export const ReleaseResultZodSchema = z.object({
         sourceDirectory: z.string().optional(),
         changelogUrl: z.string().optional(),
         digest: z.string().optional(),
+        isStable: z.boolean().optional(),
       })
       .transform((input) => {
         return {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Allow marking versions as stable/unstable in custom datasource output. Essentially all bug reports should be closed with one of these three outcomes.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
