### PR TITLE
chore: add more label-actions for bugs

### DIFF
--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -339,3 +339,45 @@
 
 
     Thanks, the Renovate team
+
+'auto:bug-to-idea':
+  comment: >
+    Hi there,
+
+
+    The bad news is that you've submitted a bug report for something which a maintainer has assessed is not a bug, and this Discussion will be closed to avoid confusing other users. Bugs are things which are not working as intended or documented, and that is not the case here. This doesn't mean that the behavior is good, but we can't treat every missing or unforeseen feature as a bug or else the term bug loses its meaning.
+
+
+    The good news is that a maintainer agrees with your idea in general and would like you to resubmit with [Suggest an Idea](https://github.com/renovatebot/renovate/discussions/new?category=suggest-an-idea) so that it can be converted into a feature request issue.
+
+
+    You're welcome to copy/paste as much of this Discussion as you wish, but please make sure to explain the problem in terms of a feature request, focusing on what intelligence Renovate needs to add, and how/when it should know to do so.
+
+
+    Thanks, the Renovate team
+
+'auto:bug-invalid':
+  comment: >
+    Hi there,
+
+
+    This is an automated message to flag to future readers of this discussion that it has been closed because it is not a bug, and behaving as designed.
+
+
+    The behavior which the the original poster thought was a bug is intentional behavior, for reasons which have hopefully been explained in addition to this message.
+
+
+    We're now closing this discussion to avoid confusion for future readers. If you have an idea for a new feature or an improvement to an existing one, please submit it as a [Suggest an Idea](https://github.com/renovatebot/renovate/discussions/new?category=suggest-an-idea).
+
+
+    Thanks, the Renovate team
+
+'auto:bug-converted':
+  comment: >
+    Hi there,
+
+
+    This is an automated message to flag that this bug has been confirmed and converted to an issue. This Discussion will be closed so that any further discussion can happen in the issue.
+
+
+    Thanks, the Renovate team

--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -416,3 +416,17 @@
 
 
     Thanks, the Renovate team
+
+'auto:no-slas':
+  comment: >
+    Hi there,
+
+
+    This is a reminder that there are no SLAs in Open Source, and when you post messages like "Any update on this?" or "When will this be fixed?" or chase a maintainer to answer your personal question then it will be seen as demanding or impatient and may result in a block if occurring multiple times.
+
+
+    Learn more about how we prioritize Renovate work here: https://github.com/renovatebot/renovate/blob/main/CODE_OF_CONDUCT.md#how-we-prioritize-work.
+    If you're already a paying Mend.io customer, please get in touch with your support or customer contact to let them know that this issue is important to you.
+
+
+    Thanks, the Renovate team

--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -370,6 +370,9 @@
     You're welcome to copy/paste as much of this Discussion as you wish, but please make sure to explain the problem in terms of a feature request, focusing on what intelligence Renovate needs to add, and how/when it should know to do so.
 
 
+    For more details on Bug report handling in this repo, please see https://github.com/renovatebot/renovate/blob/main/docs/development/bug-handling.md
+
+
     Thanks, the Renovate team
 
 'auto:bug-invalid':
@@ -384,6 +387,9 @@
 
 
     We're now closing this discussion to avoid confusion for future readers. If you have an idea for a new feature or an improvement to an existing one, please submit it as a [Suggest an Idea](https://github.com/renovatebot/renovate/discussions/new?category=suggest-an-idea).
+
+
+    For more details on Bug report handling in this repo, please see https://github.com/renovatebot/renovate/blob/main/docs/development/bug-handling.md
 
 
     Thanks, the Renovate team

--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -112,13 +112,16 @@
     Hi there,
 
 
-    This issue or discussion needs some particular logs, in order to help you more.
+    Please give us specific logs, so we can help you more.
 
 
-    Please ensure you are running with `LOG_LEVEL=debug` in order to get debug log messages. Next, look for the log message `packageFiles with updates`. This is often a large, structured log message which includes every detected package file, dependency, and update found.
+    If you self-host Renovate: make sure you run Renovate with `LOG_LEVEL=debug` to get the debug log messages! Next, open the debug-level logs and search for `packageFiles with updates`. This text marks the start of a structured log message that shows every package file, dependency, and update that Renovate found.
 
 
-    Locate the relevant dependency/dependencies in that log message and then copy/paste them into this discussion. If in doubt you can copy/paste the full log message but it's usually not necessary.
+    Find the relevant dependency/dependencies in the log message, and copy/paste those parts into this discussion. If you do not know which bits we need, you can copy/paste the full log message.
+
+
+    Read the [Renovate docs, Troubleshooting](https://docs.renovatebot.com/troubleshooting/) to learn more about getting the docs, and getting the correct type of logs.
 
 
     Thanks, the Renovate team
@@ -361,16 +364,16 @@
     Hi there,
 
 
-    The bad news is that you've submitted a bug report for something which a maintainer has assessed is not a bug, and this Discussion will be closed to avoid confusing other users. Bugs are things which are not working as intended or documented, and that is not the case here. This doesn't mean that the behavior is good, but we can't treat every missing or unforeseen feature as a bug or else the term bug loses its meaning.
+    A maintainer reviewed the information, and decided that this is not a bug. To avoid confusing others, we will close this Discussion. Please keep reading as there is good news too!
 
 
-    The good news is that a maintainer agrees with your idea in general and would like you to resubmit with [Suggest an Idea](https://github.com/renovatebot/renovate/discussions/new?category=suggest-an-idea) so that it can be converted into a feature request issue.
+    The good news is that the maintainer likes your idea, in general. Please create a new [Suggest an Idea](https://github.com/renovatebot/renovate/discussions/new?category=suggest-an-idea) Discussion. Feel free to copy/paste what you need from this Discussion. Please focus on the feature request: explain what Renovate should do, and how Renovate can know when/what to do. We may convert that Discussion to an Issue when it is ready. Note that you will still have to wait for a maintainer, or someone else, to do the work needed for your feature.
 
 
-    You're welcome to copy/paste as much of this Discussion as you wish, but please make sure to explain the problem in terms of a feature request, focusing on what intelligence Renovate needs to add, and how/when it should know to do so.
+    Why are we closing your Discussion? For us, bug reports are about things that are not working as intended, or things that are not working as described in the docs. What you found may be bad behavior, but we do not think it is a bug.
 
 
-    For more details on Bug report handling in this repo, please see https://github.com/renovatebot/renovate/blob/main/docs/development/bug-handling.md
+    For more details, please read [our development docs about bug handling](https://github.com/renovatebot/renovate/blob/main/docs/development/bug-handling.md).
 
 
     Thanks, the Renovate team
@@ -380,16 +383,13 @@
     Hi there,
 
 
-    This is an automated message to flag to future readers of this discussion that it has been closed because it is not a bug, and behaving as designed.
+    A maintainer decided this is not a bug, and behaving as designed. The maintainer will explain why this behavior is correct. To avoid confusing future readers, we will close this Discussion.
 
 
-    The behavior which the the original poster thought was a bug is intentional behavior, for reasons which have hopefully been explained in addition to this message.
+    We want Bug-type Discussions to be about things that we rate as bugs. For more details, please read [our development docs about bug handling](https://github.com/renovatebot/renovate/blob/main/docs/development/bug-handling.md).
 
 
-    We're now closing this discussion to avoid confusion for future readers. If you have an idea for a new feature or an improvement to an existing one, please submit it as a [Suggest an Idea](https://github.com/renovatebot/renovate/discussions/new?category=suggest-an-idea).
-
-
-    For more details on Bug report handling in this repo, please see https://github.com/renovatebot/renovate/blob/main/docs/development/bug-handling.md
+    If this bug report makes you think of an idea for a new feature, or how to improve a current feature, feel free to create a new [Suggest an Idea](https://github.com/renovatebot/renovate/discussions/new?category=suggest-an-idea) Discussion.
 
 
     Thanks, the Renovate team
@@ -399,7 +399,10 @@
     Hi there,
 
 
-    This is an automated message to flag that this bug has been confirmed and converted to an issue. This Discussion will be closed so that any further discussion can happen in the issue.
+    A maintainer confirmed this is a bug, and converted this Discussion to an Issue. If you have more thoughts/info about the bug, please post them in the Issue.
+
+
+    We will close this Discussion, as we want new info to go in the Issue.
 
 
     Thanks, the Renovate team
@@ -409,10 +412,13 @@
     Hi there,
 
 
-    The repository maintainers would like to convert this idea into a Feature Request issue, but either the original title/description is either not ready.
+    The maintainers want to convert this idea into a Feature Request issue. Before we can convert, we need you update the Discussion title and/or the description(s).
 
 
-    Please review the title/description to reflect the current state of the idea so that it's ready for direct conversion into an issue. You may need to copy/pate examples, links or other text from comments into the original description. Once this is done to your satisfaction, please let us know and we'll convert it into an issue.
+   We want the top post, and title, to match the current state of your idea/feature request. This is because a discussion often has lots of info, thoughts and comments. There may also be ideas that turn out to be dead ends. In simple terms, we only want the good stuff to go in the top post.
+
+
+    So please put the current information in the top post and update the title. Feel free to copy/paste examples, links or comments into the description. Let us know when you are finished updating, and we will convert your discussion to an Issue.
 
 
     Thanks, the Renovate team
@@ -422,11 +428,14 @@
     Hi there,
 
 
-    This is a reminder that there are no SLAs in Open Source, and when you post messages like "Any update on this?" or "When will this be fixed?" or chase a maintainer to answer your personal question then it will be seen as demanding or impatient and may result in a block if occurring multiple times.
+    Please remember that there are no Service Level Agreements (SLAs) or roadmap commitments in Open Source projects like Renovate. The maintainers and contributors work on bugs/features/docs at their own pace. This means that sometimes you will have to wait for things to happen, or to get a response.
 
 
-    Learn more about how we prioritize Renovate work here: https://github.com/renovatebot/renovate/blob/main/CODE_OF_CONDUCT.md#how-we-prioritize-work.
-    If you're already a paying Mend.io customer, please get in touch with your support or customer contact to let them know that this issue is important to you.
+    Please avoid comments like: "Any update on this?" or "When will this be fixed?". Do not chase a maintainer to get answers quickly. We will block you if you nudge us frequently.
+
+
+    Please read our [Code of Conduct, how we prioritize work](https://github.com/renovatebot/renovate/blob/main/CODE_OF_CONDUCT.md#how-we-prioritize-work) to learn more about how we prioritize what to work on.
+    If you are a paying Mend.io customer, please tell your support or customer contact that this issue is important to you.
 
 
     Thanks, the Renovate team

--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -381,3 +381,16 @@
 
 
     Thanks, the Renovate team
+
+'auto:idea-rewrite':
+  comment: >
+    Hi there,
+
+
+    The repository maintainers would like to convert this idea into a Feature Request issue, but either the original title/description is either not ready.
+
+
+    Please review the title/description to reflect the current state of the idea so that it's ready for direct conversion into an issue. You may need to copy/pate examples, links or other text from comments into the original description. Once this is done to your satisfaction, please let us know and we'll convert it into an issue.
+
+
+    Thanks, the Renovate team

--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -107,6 +107,22 @@
 
     The Renovate team
 
+'auto:logs-packages':
+  comment: >
+    Hi there,
+
+
+    This issue or discussion needs some particular logs, in order to help you more.
+
+
+    Please ensure you are running with `LOG_LEVEL=debug` in order to get debug log messages. Next, look for the log message `packageFiles with updates`. This is often a large, structured log message which includes every detected package file, dependency, and update found.
+
+
+    Locate the relevant dependency/dependencies in that log message and then copy/paste them into this discussion. If in doubt you can copy/paste the full log message but it's usually not necessary.
+
+
+    Thanks, the Renovate team
+
 'new package manager':
   comment: >
     Hi there,

--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -415,7 +415,7 @@
     The maintainers want to convert this idea into a Feature Request issue. Before we can convert, we need you update the Discussion title and/or the description(s).
 
 
-   We want the top post, and title, to match the current state of your idea/feature request. This is because a discussion often has lots of info, thoughts and comments. There may also be ideas that turn out to be dead ends. In simple terms, we only want the good stuff to go in the top post.
+    We want the top post, and title, to match the current state of your idea/feature request. This is because a discussion often has lots of info, thoughts and comments. There may also be ideas that turn out to be dead ends. In simple terms, we only want the good stuff to go in the top post.
 
 
     So please put the current information in the top post and update the title. Feel free to copy/paste examples, links or comments into the description. Let us know when you are finished updating, and we will convert your discussion to an Issue.

--- a/docs/development/bug-handling.md
+++ b/docs/development/bug-handling.md
@@ -1,0 +1,51 @@
+# Bug report handling
+
+## Start with a Discussion
+
+We use GitHub Discussions as a triaging stage for bug reports.
+Users should [create a new Request Help discussion](https://github.com/renovatebot/renovate/discussions/new?category=request-help) and choose from the options there.
+
+Bug reports often require additional information to resolve, so maintainers might ask directly for such information, or use automated label comments, or both.
+Bug reports which are missing the required additional information may be closed by maintainers if they feel that the Discussion as it exists is not beneficial to other users to leave open.
+
+We only create issues in this repository when we consider them to be actionable and work is ready to begin.
+Even if it seems highly likely that behavior is buggy, if there's no way to reproduce it or logs which can pinpoint it, then we usually won't create an Issue because it will just grow stale.
+
+## Discussion Resolution
+
+Bug reports can be resolved in one of three ways:
+
+1. Confirmed as a bug. The Discussion will be converted to an issue an issue and then closed, so that any future comments go to the Issue and not the Discussion.
+2. Rejected as "behaving as designed" with no further action needed. The Discussion will be closed with a relevant note.
+3. Rejected as not a bug, but accepted as a feature request. The Discussion will be closed with a note suggesting that the poster create a new "Suggest an Idea" Discussion instead, which can then be converted to an Issue once actionable.
+
+## FAQ
+
+### What's your definition of bug?
+
+A bug is classified as behavior in Renovate which is not as intended or documented.
+Missing functionality or incomplete support is not automatically a bug.
+For example, there's probably at least one feature of every package manager which is missing, and if we classified them all as "bugs" then the meaning of real bugs would be lost.
+
+### Why can't I create Bug Issues directly?
+
+Users have proven themselves to be poor judges of when something is a bug or not. Only a fraction of bug reports are actually bugs, and the remainder once used to pollute the repo issues, making it worse for maintainers and users alike to know what's "really" going on.
+
+### What if I disagree with your definition of bug?
+
+We're not interesting in debating you - we prefer to spend our time helping users solve their problems.
+We don't mind evolving our approach or improvements to this document, but if you wholesale disagree with us on this (e.g. "how dare you block users from creating issues" or "if the behavior was unexpected to me then that means it's a bug") then you're better to keep the opinion to yourself or find a different project.
+Users who want to make our life difficult as maintainers will be [blocked](https://github.com/renovatebot/renovate/blob/main/CODE_OF_CONDUCT.md).
+
+### Why do you close Bug discussions?
+
+It's important to move relevant reports to the next step of an Issue, and focus attention there.
+For those which aren't eligible to become an issue, it's important to mark them as "not a bug" for the benefit of future users browsing or searching the repo for similar terms, to reduce the chance of them getting confused by invalid Bug reports.
+
+No one forces you to "report a bug", just like nobody forces you to "report a crime" to the police.
+If you're unsure, ask a question, instead of creating an accusation.
+
+### When will you fix my bug?
+
+There are no SLAs in Open Source.
+See our [Code of Conduct section on how we prioritize work](https://github.com/renovatebot/renovate/blob/main/CODE_OF_CONDUCT.md#how-we-prioritize-work).

--- a/docs/development/bug-handling.md
+++ b/docs/development/bug-handling.md
@@ -5,47 +5,74 @@
 We use GitHub Discussions as a triaging stage for bug reports.
 Users should [create a new Request Help discussion](https://github.com/renovatebot/renovate/discussions/new?category=request-help) and choose from the options there.
 
-Bug reports often require additional information to resolve, so maintainers might ask directly for such information, or use automated label comments, or both.
-Bug reports which are missing the required additional information may be closed by maintainers if they feel that the Discussion as it exists is not beneficial to other users to leave open.
+We often need more information to resolve your bug report.
+Maintainers may ask for such information directly, or use automated label comments, or both.
+Maintainers may close bug reports that lack the extra information, for example when keeping the Discussion open does not help other users anymore.
 
-We only create issues in this repository when we consider them to be actionable and work is ready to begin.
-Even if it seems highly likely that behavior is buggy, if there's no way to reproduce it or logs which can pinpoint it, then we usually won't create an Issue because it will just grow stale.
+We only create issues in this repository when we:
+
+- consider them to be actionable
+- are in a state where someone could work on it
+
+We often need a minimal reproduction or logs, or even _both_, to pinpoint the exact problem.
+Because we need enough information for a actionable bug report, we may close Discussions that lack the needed info, even if it's highly likely the behavior is buggy.
+
+We have found that keeping Issues around that are not actionable just leads to them getting stale, and then closed.
+The Issues list is meant as a list of actionable things for a contributor or maintainer to pick up eventually.
 
 ## Discussion Resolution
 
-Bug reports can be resolved in one of three ways:
+Bug reports are resolved in one of three ways:
 
-1. Confirmed as a bug. The Discussion will be converted to an issue an issue and then closed, so that any future comments go to the Issue and not the Discussion.
-2. Rejected as "behaving as designed" with no further action needed. The Discussion will be closed with a relevant note.
-3. Rejected as not a bug, but accepted as a feature request. The Discussion will be closed with a note suggesting that the poster create a new "Suggest an Idea" Discussion instead, which can then be converted to an Issue once actionable.
+1. Confirmed as a bug. The Discussion will be converted to an Issue, and then closed. Any future comments go to the Issue and _not_ the Discussion.
+1. Closed as "behaving as designed" with no further action. The Discussion will be closed with a relevant note.
+1. Rejected as not a _bug_, but accepted as a _feature request_. The Discussion will be closed with a note suggesting that the poster create a new "Suggest an Idea" Discussion instead, which can then be converted to an Issue once actionable.
 
 ## FAQ
 
 ### What's your definition of bug?
 
-A bug is classified as behavior in Renovate which is not as intended or documented.
-Missing functionality or incomplete support is not automatically a bug.
-For example, there's probably at least one feature of every package manager which is missing, and if we classified them all as "bugs" then the meaning of real bugs would be lost.
+Bugs are behavior in Renovate which is _not_ as intended or documented.
+Missing functionality or partial support is not automatically a bug.
+For example, we're probably missing at least one feature from each package manager that Renovate supports.
+If we labeled all those missing features as bugs, we lose sight of real bugs.
 
 ### Why can't I create Bug Issues directly?
 
-Users have proven themselves to be poor judges of when something is a bug or not. Only a fraction of bug reports are actually bugs, and the remainder once used to pollute the repo issues, making it worse for maintainers and users alike to know what's "really" going on.
+It is really hard for users to decide if something is a bug.
+Only a fraction of the incoming bug reports are for things we consider proper bugs.
+
+A while ago, users were allowed to create Bug Issues.
+We ended up with many "bug, but not really" type issues, that polluted the repository.
+Those issues made it tricky for maintainers and users to see what's really going on in the repository.
+We have since closed many old user-created bug Issues, and now only allow maintainers to create bug Issues.
+This way we do not end up in the same situation again.
 
 ### What if I disagree with your definition of bug?
 
-We're not interesting in debating you - we prefer to spend our time helping users solve their problems.
-We don't mind evolving our approach or improvements to this document, but if you wholesale disagree with us on this (e.g. "how dare you block users from creating issues" or "if the behavior was unexpected to me then that means it's a bug") then you're better to keep the opinion to yourself or find a different project.
-Users who want to make our life difficult as maintainers will be [blocked](https://github.com/renovatebot/renovate/blob/main/CODE_OF_CONDUCT.md).
+We are not interested in debating you, we prefer to spend our time helping users solve their problems.
+We are open to improve our approach to bugs, or this document, in good spirit.
+Please do _not_ post comments like these:
+
+- "How dare you block users from creating Issues?!"
+- "If the behavior was unexpected to me then that means it's a bug."
+
+Users who want to make our life difficult as maintainers will be blocked.
+Read our [Code of Conduct](https://github.com/renovatebot/renovate/blob/main/CODE_OF_CONDUCT.md) to learn more.
 
 ### Why do you close Bug discussions?
 
-It's important to move relevant reports to the next step of an Issue, and focus attention there.
-For those which aren't eligible to become an issue, it's important to mark them as "not a bug" for the benefit of future users browsing or searching the repo for similar terms, to reduce the chance of them getting confused by invalid Bug reports.
+It's important to move relevant reports to the next step of an Issue, and focus our attention there.
+Bug reports that are not (going to be) an Issue, are marked as "not a bug".
+This helps future users who browse or search the repository for similar terms, as they will not see any invalid Bug reports.
 
-No one forces you to "report a bug", just like nobody forces you to "report a crime" to the police.
-If you're unsure, ask a question, instead of creating an accusation.
+If you are not sure if you have an _actual_ bug to report, please use the "Request Help" Discussion category.
 
 ### When will you fix my bug?
 
-There are no SLAs in Open Source.
-See our [Code of Conduct section on how we prioritize work](https://github.com/renovatebot/renovate/blob/main/CODE_OF_CONDUCT.md#how-we-prioritize-work).
+There are no Service Level Agreements (SLAs) in Open Source.
+This means we are not required to respond to, or fix your problem within a certain time.
+
+If you are a paying Mend.io customer, please tell your support or customer contact that this bug is important to you.
+
+Please read our [Code of Conduct, how we prioritize work](https://github.com/renovatebot/renovate/blob/main/CODE_OF_CONDUCT.md#how-we-prioritize-work) to learn more.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds three labels to close bug Discussions with one of three outcomes:
- Encourage a feature request/idea instead
- Invalid/not a bug
- Confirmed/converted to issue

## Context

Save us typing the same over and over, and make it less personal

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
