### PR TITLE
fix: Revert "chore(deps): update dependency conventional-changelog-conventionalcommits to v8"

### DIFF
--- a/package.json
+++ b/package.json
@@ -312,7 +312,7 @@
     "aws-sdk-client-mock": "4.0.1",
     "callsite": "1.0.0",
     "common-tags": "1.8.2",
-    "conventional-changelog-conventionalcommits": "8.0.0",
+    "conventional-changelog-conventionalcommits": "7.0.2",
     "emojibase-data": "15.3.2",
     "eslint": "8.57.0",
     "eslint-formatter-gha": "1.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -512,8 +512,8 @@ importers:
         specifier: 1.8.2
         version: 1.8.2
       conventional-changelog-conventionalcommits:
-        specifier: 8.0.0
-        version: 8.0.0
+        specifier: 7.0.2
+        version: 7.0.2
       emojibase-data:
         specifier: 15.3.2
         version: 15.3.2(emojibase@15.3.1)
@@ -2712,9 +2712,9 @@ packages:
     resolution: {integrity: sha512-ROjNchA9LgfNMTTFSIWPzebCwOGFdgkEq45EnvvrmSLvCtAw0HSmrCs7/ty+wAeYUZyNay0YMUNYFTRL72PkBQ==}
     engines: {node: '>=16'}
 
-  conventional-changelog-conventionalcommits@8.0.0:
-    resolution: {integrity: sha512-eOvlTO6OcySPyyyk8pKz2dP4jjElYunj9hn9/s0OB+gapTO8zwS9UQWrZ1pmF2hFs3vw1xhonOLGcGjy/zgsuA==}
-    engines: {node: '>=18'}
+  conventional-changelog-conventionalcommits@7.0.2:
+    resolution: {integrity: sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==}
+    engines: {node: '>=16'}
 
   conventional-changelog-writer@7.0.1:
     resolution: {integrity: sha512-Uo+R9neH3r/foIvQ0MKcsXkX642hdm9odUp7TqgFS7BsalTcjzRlIfWZrZR1gbxOozKucaKt5KAbjW8J8xRSmA==}
@@ -9185,7 +9185,7 @@ snapshots:
     dependencies:
       compare-func: 2.0.0
 
-  conventional-changelog-conventionalcommits@8.0.0:
+  conventional-changelog-conventionalcommits@7.0.2:
     dependencies:
       compare-func: 2.0.0
 


### PR DESCRIPTION
Reverts renovatebot/renovate#29889