### PR TITLE
fix(git/auth): fix `insteadOf` for bitbucket-server

### DIFF
--- a/lib/util/git/auth.spec.ts
+++ b/lib/util/git/auth.spec.ts
@@ -350,6 +350,27 @@ describe('util/git/auth', () => {
         GIT_CONFIG_VALUE_2: 'https://github.com:89/org/repo.git',
       });
     });
+
+    it('returns url with token for bitbucket-server', () => {
+      expect(
+        getGitAuthenticatedEnvironmentVariables('https://git.mycompany.com/', {
+          token: 'token1234',
+          hostType: 'bitbucket-server',
+          matchHost: 'git.mycompay.com',
+        }),
+      ).toStrictEqual({
+        GIT_CONFIG_COUNT: '3',
+        GIT_CONFIG_KEY_0:
+          'url.https://ssh:token1234@git.mycompany.com/scm/.insteadOf',
+        GIT_CONFIG_KEY_1:
+          'url.https://git:token1234@git.mycompany.com/scm/.insteadOf',
+        GIT_CONFIG_KEY_2:
+          'url.https://token1234@git.mycompany.com/scm/.insteadOf',
+        GIT_CONFIG_VALUE_0: 'ssh://git@git.mycompany.com:7999/',
+        GIT_CONFIG_VALUE_1: 'ssh://git@git.mycompany.com:7999/',
+        GIT_CONFIG_VALUE_2: 'https://git.mycompany.com/scm/',
+      });
+    });
   });
 
   describe('getGitEnvironmentVariables()', () => {
@@ -537,6 +558,26 @@ describe('util/git/auth', () => {
         token: 'token123',
       });
       expect(getGitEnvironmentVariables(['custom'])).toStrictEqual({});
+    });
+
+    it('returns environment variables for bitbucket-server', () => {
+      add({
+        hostType: 'bitbucket-server',
+        matchHost: 'git.mycompany.com',
+        token: 'token123',
+      });
+      expect(getGitEnvironmentVariables()).toStrictEqual({
+        GIT_CONFIG_COUNT: '3',
+        GIT_CONFIG_KEY_0:
+          'url.https://ssh:token123@git.mycompany.com/scm/.insteadOf',
+        GIT_CONFIG_KEY_1:
+          'url.https://git:token123@git.mycompany.com/scm/.insteadOf',
+        GIT_CONFIG_KEY_2:
+          'url.https://token123@git.mycompany.com/scm/.insteadOf',
+        GIT_CONFIG_VALUE_0: 'ssh://git@git.mycompany.com:7999/',
+        GIT_CONFIG_VALUE_1: 'ssh://git@git.mycompany.com:7999/',
+        GIT_CONFIG_VALUE_2: 'https://git.mycompany.com/scm/',
+      });
     });
   });
 });

--- a/lib/util/git/auth.spec.ts
+++ b/lib/util/git/auth.spec.ts
@@ -356,7 +356,7 @@ describe('util/git/auth', () => {
         getGitAuthenticatedEnvironmentVariables('https://git.mycompany.com/', {
           token: 'token1234',
           hostType: 'bitbucket-server',
-          matchHost: 'git.mycompay.com',
+          matchHost: 'git.mycompany.com',
         }),
       ).toStrictEqual({
         GIT_CONFIG_COUNT: '3',

--- a/lib/util/git/auth.ts
+++ b/lib/util/git/auth.ts
@@ -113,6 +113,9 @@ function getAuthenticationRulesWithToken(
 /**
  * Generates the authentication rules for later git usage for the given host
  * @link https://coolaj86.com/articles/vanilla-devops-git-credentials-cheatsheet/
+ * @param gitUrl Git repository URL
+ * @param hostType Git host type
+ * @param token Authentication token or `username:password` string
  */
 export function getAuthenticationRules(
   gitUrl: string,
@@ -125,6 +128,9 @@ export function getAuthenticationRules(
   let sshPort = insteadUrl.port;
 
   if (hostType === 'bitbucket-server') {
+    // For Bitbucket Server/Data Center, `source` must be `bitbucket-server`
+    // to generate HTTP(s) URLs correctly.
+    // https://github.com/IonicaBizau/git-url-parse/blob/28828546c148d58bbcff61409915a4e1e8f7eb11/lib/index.js#L304
     insteadUrl.source = 'bitbucket-server';
 
     if (!sshPort) {

--- a/lib/util/git/auth.ts
+++ b/lib/util/git/auth.ts
@@ -122,22 +122,22 @@ export function getAuthenticationRules(
   const authenticationRules = [];
   const hasUser = token.split(':').length > 1;
   const insteadUrl = parseGitUrl(gitUrl);
+  let sshPort = insteadUrl.port;
 
   if (hostType === 'bitbucket-server') {
     insteadUrl.source = 'bitbucket-server';
+
+    if (!sshPort) {
+      // By default, bitbucket-server SSH port is 7999.
+      // For non-default port, the generated auth config will likely be incorrect.
+      sshPort = 7999;
+    }
   }
 
   const url = { ...insteadUrl };
   const protocol = regEx(/^https?$/).test(url.protocol)
     ? url.protocol
     : 'https';
-
-  let sshPort = insteadUrl.port;
-  if (hostType === 'bitbucket-server' && !sshPort) {
-    // By default, bitbucket-server SSH port is 7999.
-    // For non-default port, the generated auth config will likely be incorrect.
-    sshPort = 7999;
-  }
 
   // ssh protocol with user if empty
   url.token = hasUser ? token : `ssh:${token}`;

--- a/lib/util/git/auth.ts
+++ b/lib/util/git/auth.ts
@@ -122,12 +122,8 @@ export function getAuthenticationRules(
   const authenticationRules = [];
   const hasUser = token.split(':').length > 1;
   const insteadUrl = parseGitUrl(gitUrl);
-  let type = hostType;
-  if (!type) {
-    type = detectPlatform(gitUrl);
-  }
 
-  if (type === 'bitbucket-server') {
+  if (hostType === 'bitbucket-server') {
     insteadUrl.source = 'bitbucket-server';
   }
 
@@ -137,7 +133,7 @@ export function getAuthenticationRules(
     : 'https';
 
   const sshUrl = { ...insteadUrl };
-  if (type === 'bitbucket-server' && !sshUrl.port) {
+  if (hostType === 'bitbucket-server' && !sshUrl.port) {
     // By default, bitbucket-server SSH port is 7999.
     // For non-default port, the generated auth config will likely be incorrect.
     sshUrl.port = 7999;

--- a/lib/util/git/auth.ts
+++ b/lib/util/git/auth.ts
@@ -132,11 +132,11 @@ export function getAuthenticationRules(
     ? url.protocol
     : 'https';
 
-  const sshUrl = { ...insteadUrl };
-  if (hostType === 'bitbucket-server' && !sshUrl.port) {
+  let sshPort = insteadUrl.port;
+  if (hostType === 'bitbucket-server' && !sshPort) {
     // By default, bitbucket-server SSH port is 7999.
     // For non-default port, the generated auth config will likely be incorrect.
-    sshUrl.port = 7999;
+    sshPort = 7999;
   }
 
   // ssh protocol with user if empty
@@ -145,16 +145,16 @@ export function getAuthenticationRules(
     url: url.toString(protocol),
     // only edge case, need to stringify ourself because the exact syntax is not supported by the library
     // https://github.com/IonicaBizau/git-url-parse/blob/246c9119fb42c2ea1c280028fe77c53eb34c190c/lib/index.js#L246
-    insteadOf: `ssh://git@${sshUrl.resource}${
-      sshUrl.port ? `:${sshUrl.port}` : ''
-    }/${sshUrl.full_name}${sshUrl.git_suffix ? '.git' : ''}`,
+    insteadOf: `ssh://git@${insteadUrl.resource}${
+      sshPort ? `:${sshPort}` : ''
+    }/${insteadUrl.full_name}${insteadUrl.git_suffix ? '.git' : ''}`,
   });
 
   // alternative ssh protocol with user if empty
   url.token = hasUser ? token : `git:${token}`;
   authenticationRules.push({
     url: url.toString(protocol),
-    insteadOf: sshUrl.toString('ssh'),
+    insteadOf: { ...insteadUrl, port: sshPort }.toString('ssh'),
   });
 
   // https protocol with no user as default fallback


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Fix git submodule update on Bitbucket Server/Data Center.

## Context

https://github.com/renovatebot/renovate/pull/29527 fixed dependency extraction, but update still fails - Renovate tries to clone submodules over SSH, because none of generated `url.*.instanceOf` matches.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
