### PR TITLE
fix(config): Remove usePlatformAutomerge restriction with gitLabIgnoreApprovals

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -1510,7 +1510,7 @@ Example:
 
 Ignore the default project level approval(s), so that Renovate bot can automerge its merge requests, without needing approval(s).
 Under the hood, it creates a MR-level approval rule where `approvals_required` is set to `0`.
-This option works only when `automerge=true`, `automergeType=pr` or `automergeType=branch`, and `platformAutomerge=true`.
+This option works only when `automerge=true` and either `automergeType=pr` or `automergeType=branch`.
 Also, approval rules overriding should not be [prevented in GitLab settings](https://docs.gitlab.com/ee/user/project/merge_requests/approvals/settings.html#prevent-editing-approval-rules-in-merge-requests).
 
 ## goGetDirs

--- a/lib/modules/platform/gitlab/index.spec.ts
+++ b/lib/modules/platform/gitlab/index.spec.ts
@@ -2262,7 +2262,7 @@ describe('modules/platform/gitlab/index', () => {
             gitLabIgnoreApprovals: true,
           },
         }),
-      ).toMatchInlineSnapshot(`
+      ).toEqual(
         {
           "id": 1,
           "iid": 12345,
@@ -2270,7 +2270,7 @@ describe('modules/platform/gitlab/index', () => {
           "sourceBranch": "some-branch",
           "title": "some title",
         }
-      `);
+      );
     });
 
     it('will modify a rule of type any_approvers, if such a rule exists', async () => {

--- a/lib/modules/platform/gitlab/index.spec.ts
+++ b/lib/modules/platform/gitlab/index.spec.ts
@@ -2262,15 +2262,13 @@ describe('modules/platform/gitlab/index', () => {
             gitLabIgnoreApprovals: true,
           },
         }),
-      ).toEqual(
-        {
-          "id": 1,
-          "iid": 12345,
-          "number": 12345,
-          "sourceBranch": "some-branch",
-          "title": "some title",
-        }
-      );
+      ).toEqual({
+        id: 1,
+        iid: 12345,
+        number: 12345,
+        sourceBranch: 'some-branch',
+        title: 'some title',
+      });
     });
 
     it('will modify a rule of type any_approvers, if such a rule exists', async () => {

--- a/lib/modules/platform/gitlab/index.spec.ts
+++ b/lib/modules/platform/gitlab/index.spec.ts
@@ -2228,6 +2228,51 @@ describe('modules/platform/gitlab/index', () => {
       `);
     });
 
+    it('adds approval rule to ignore all approvals when platformAutomerge is false', async () => {
+      await initPlatform('13.3.6-ee');
+      httpMock
+        .scope(gitlabApiHost)
+        .post('/api/v4/projects/undefined/merge_requests')
+        .reply(200, {
+          id: 1,
+          iid: 12345,
+          title: 'some title',
+        })
+        .get('/api/v4/projects/undefined/merge_requests/12345/approval_rules')
+        .reply(200, [
+          {
+            name: 'AnyApproverRule',
+            rule_type: 'any_approver',
+            id: 50005,
+          },
+        ])
+        .put(
+          '/api/v4/projects/undefined/merge_requests/12345/approval_rules/50005',
+        )
+        .reply(200);
+      expect(
+        await gitlab.createPr({
+          sourceBranch: 'some-branch',
+          targetBranch: 'master',
+          prTitle: 'some-title',
+          prBody: 'the-body',
+          labels: [],
+          platformOptions: {
+            usePlatformAutomerge: false,
+            gitLabIgnoreApprovals: true,
+          },
+        }),
+      ).toMatchInlineSnapshot(`
+        {
+          "id": 1,
+          "iid": 12345,
+          "number": 12345,
+          "sourceBranch": "some-branch",
+          "title": "some title",
+        }
+      `);
+    });
+
     it('will modify a rule of type any_approvers, if such a rule exists', async () => {
       await initPlatform('13.3.6-ee');
       httpMock

--- a/lib/modules/platform/gitlab/index.ts
+++ b/lib/modules/platform/gitlab/index.ts
@@ -648,12 +648,12 @@ async function tryPrAutomerge(
   pr: number,
   platformOptions: PlatformPrOptions | undefined,
 ): Promise<void> {
-  if (platformOptions?.usePlatformAutomerge) {
-    try {
-      if (platformOptions?.gitLabIgnoreApprovals) {
-        await ignoreApprovals(pr);
-      }
+  try {
+    if (platformOptions?.gitLabIgnoreApprovals) {
+      await ignoreApprovals(pr);
+    }
 
+    if (platformOptions?.usePlatformAutomerge) {
       // https://docs.gitlab.com/ee/api/merge_requests.html#merge-status
       const desiredDetailedMergeStatus = [
         'mergeable',
@@ -730,9 +730,9 @@ async function tryPrAutomerge(
         }
         await setTimeout(mergeDelay * attempt ** 2); // exponential backoff
       }
-    } catch (err) /* istanbul ignore next */ {
-      logger.debug({ err }, 'Automerge on PR creation failed');
     }
+  } catch (err) /* istanbul ignore next */ {
+    logger.debug({ err }, 'Automerge on PR creation failed');
   }
 }
 


### PR DESCRIPTION
## Changes

Remove `usePlatformAutomerge` restriction with `gitLabIgnoreApprovals`.

## Context

Discussed in https://github.com/renovatebot/renovate/discussions/29968.

I took a non-invasive approach minimize any impact elsewhere by users. 

- We use `gitLabIgnoreApprovals` to bypass approver restrictions on GitLab to auto-merge MRs that pass our pipeline.
- We want to auto-merge our MRs and use `automergeSchedule` to enforce this during business hours. 
- We can't `automergeSchedule` if `platformAutomerge=true`, so we make `platformAutomerge=false`
- Now we can't use `gitLabIgnoreApprovals` anymore since it's gated behind `platformAutomerge=true`

We remove this check since it doesn't look like it's necessary. 

Original PR with this addition even includes a comment wondering if it can be used with normal auto-merge.

https://github.com/renovatebot/renovate/pull/10981/files#r679454321

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
