### PR TITLE
feat(datasource/docker): Enable additional authentication mechansim for private ECR repositories

### DIFF
--- a/docs/usage/docker.md
+++ b/docs/usage/docker.md
@@ -237,6 +237,8 @@ module.exports = {
 
 #### AWS ECR (Amazon Web Services Elastic Container Registry)
 
+#### Using access key id & secret
+
 Renovate can authenticate with AWS ECR using AWS access key id & secret as the username & password, for example:
 
 ```json
@@ -246,6 +248,27 @@ Renovate can authenticate with AWS ECR using AWS access key id & secret as the u
       "hostType": "docker",
       "matchHost": "12345612312.dkr.ecr.us-east-1.amazonaws.com",
       "username": "AKIAABCDEFGHIJKLMNOPQ",
+      "encrypted": {
+        "password": "w...A"
+      }
+    }
+  ]
+}
+```
+
+##### Using `get-login-password`
+
+Renovate can also authenticate with AWS ECR using the output from the `aws ecr get-login-password` command as outlined in
+the [AWS documentation](https://docs.aws.amazon.com/AmazonECR/latest/userguide/registry_auth.html#registry-auth-token).
+To make use of this authentication mechanism, specify the username as `AWS`:
+
+```json
+{
+  "hostRules": [
+    {
+      "hostType": "docker",
+      "matchHost": "12345612312.dkr.ecr.us-east-1.amazonaws.com",
+      "username": "AWS",
       "encrypted": {
         "password": "w...A"
       }

--- a/lib/modules/datasource/docker/ecr.ts
+++ b/lib/modules/datasource/docker/ecr.ts
@@ -17,10 +17,14 @@ export async function getECRAuthToken(
 ): Promise<string | null> {
   const config: ECRClientConfig = { region };
   if (opts.username === `AWS` && opts.password) {
-    logger.trace(`AWS user specified, encoding basic auth credentials for ECR registry`);
+    logger.trace(
+      `AWS user specified, encoding basic auth credentials for ECR registry`,
+    );
     return Buffer.from(`AWS:${opts.password}`).toString('base64');
   } else if (opts.username && opts.password) {
-    logger.trace(`Using AWS accessKey to get Authorization token for ECR registry`);
+    logger.trace(
+      `Using AWS accessKey to get Authorization token for ECR registry`,
+    );
     config.credentials = {
       accessKeyId: opts.username,
       secretAccessKey: opts.password,

--- a/lib/modules/datasource/docker/ecr.ts
+++ b/lib/modules/datasource/docker/ecr.ts
@@ -16,7 +16,11 @@ export async function getECRAuthToken(
   opts: HostRule,
 ): Promise<string | null> {
   const config: ECRClientConfig = { region };
-  if (opts.username && opts.password) {
+  if (opts.username === `AWS` && opts.password) {
+    logger.trace(`AWS user specified, encoding basic auth credentials for ECR registry`);
+    return Buffer.from(`AWS:${opts.password}`).toString('base64');
+  } else if (opts.username && opts.password) {
+    logger.trace(`Using AWS accessKey to get Authorization token for ECR registry`);
     config.credentials = {
       accessKeyId: opts.username,
       secretAccessKey: opts.password,

--- a/lib/modules/datasource/docker/index.spec.ts
+++ b/lib/modules/datasource/docker/index.spec.ts
@@ -374,10 +374,6 @@ describe('modules/datasource/docker/index', () => {
         password: 'some-password',
       });
 
-      mockEcrAuthResolve({
-        authorizationData: [{ authorizationToken: 'test' }],
-      });
-
       const res = await getDigest(
         {
           datasource: 'docker',

--- a/lib/modules/datasource/docker/index.spec.ts
+++ b/lib/modules/datasource/docker/index.spec.ts
@@ -358,6 +358,37 @@ describe('modules/datasource/docker/index', () => {
       expect(res).toBeNull();
     });
 
+    it('supports ECR authentication for private repositories', async () => {
+      httpMock
+        .scope(amazonUrl)
+        .get('/')
+        .reply(401, '', {
+          'www-authenticate': 'Basic realm="My Private Docker Registry Server"',
+        })
+        .head('/node/manifests/some-tag')
+        .matchHeader('authorization', 'Basic QVdTOnNvbWUtcGFzc3dvcmQ=')
+        .reply(200, '', { 'docker-content-digest': 'some-digest' });
+
+      hostRules.find.mockReturnValue({
+        username: 'AWS',
+        password: 'some-password',
+      });
+
+      mockEcrAuthResolve({
+        authorizationData: [{ authorizationToken: 'test' }],
+      });
+
+      const res = await getDigest(
+        {
+          datasource: 'docker',
+          packageName: '123456789.dkr.ecr.us-east-1.amazonaws.com/node',
+        },
+        'some-tag',
+      );
+
+      expect(res).toBe('some-digest');
+    });
+
     it('supports Google ADC authentication for gcr', async () => {
       httpMock
         .scope(gcrUrl)


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
Support using the output from `aws ecr get-login-password` as outlined in the AWS documentation - https://docs.aws.amazon.com/AmazonECR/latest/userguide/registry_auth.html#registry-auth-token

## Context

Currently it is only possible to use AWS Access Key and Secret to access a private ECR repository.  There are scenarios particularly in CI where no such key/secret is available, and it is preferrable to utilise the `aws ecr get-login-password` mechanism.  There are several open discussions on this one example being - https://github.com/renovatebot/renovate/discussions/27014

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
