### PR TITLE
refactor: Lookup filtering of unstable releases

### DIFF
--- a/lib/workers/repository/process/lookup/filter.spec.ts
+++ b/lib/workers/repository/process/lookup/filter.spec.ts
@@ -1,5 +1,5 @@
 import { partial } from '../../../../../test/util';
-import type { Release } from '../../../../modules/datasource';
+import type { Release } from '../../../../modules/datasource/types';
 import * as allVersioning from '../../../../modules/versioning';
 import { filterVersions } from './filter';
 import type { FilterConfig } from './types';

--- a/lib/workers/repository/process/lookup/filter.spec.ts
+++ b/lib/workers/repository/process/lookup/filter.spec.ts
@@ -1,37 +1,38 @@
 import { partial } from '../../../../../test/util';
+import { Release } from '../../../../modules/datasource';
 import * as allVersioning from '../../../../modules/versioning';
 import { filterVersions } from './filter';
 import type { FilterConfig } from './types';
 
 const versioning = allVersioning.get('semver');
 
-const releases = [
-  {
-    version: '1.0.1',
-    releaseTimestamp: '2021-01-01T00:00:01.000Z',
-  },
-  {
-    version: '1.2.0',
-    releaseTimestamp: '2021-01-03T00:00:00.000Z',
-  },
-  {
-    version: '2.0.0',
-    releaseTimestamp: '2021-01-05T00:00:00.000Z',
-  },
-  {
-    version: '2.1.0',
-    releaseTimestamp: '2021-01-07T00:00:00.000Z',
-  },
-  // for coverage
-  {
-    version: 'invalid.version',
-    releaseTimestamp: '2021-01-07T00:00:00.000Z',
-  },
-];
-
 describe('workers/repository/process/lookup/filter', () => {
   describe('.filterVersions()', () => {
     it('should filter versions allowed by semver syntax when allowedVersions is not valid version, range or pypi syntax', () => {
+      const releases = [
+        {
+          version: '1.0.1',
+          releaseTimestamp: '2021-01-01T00:00:01.000Z',
+        },
+        {
+          version: '1.2.0',
+          releaseTimestamp: '2021-01-03T00:00:00.000Z',
+        },
+        {
+          version: '2.0.0',
+          releaseTimestamp: '2021-01-05T00:00:00.000Z',
+        },
+        {
+          version: '2.1.0',
+          releaseTimestamp: '2021-01-07T00:00:00.000Z',
+        },
+        // for coverage
+        {
+          version: 'invalid.version',
+          releaseTimestamp: '2021-01-07T00:00:00.000Z',
+        },
+      ] satisfies Release[];
+
       const config = partial<FilterConfig>({
         ignoreUnstable: false,
         ignoreDeprecated: false,
@@ -40,9 +41,6 @@ describe('workers/repository/process/lookup/filter', () => {
       });
       const currentVersion = '1.0.0';
       const latestVersion = '2.0.0';
-
-      jest.spyOn(versioning, 'isVersion').mockReturnValue(true);
-      jest.spyOn(versioning, 'isGreaterThan').mockReturnValue(true);
 
       const filteredVersions = filterVersions(
         config,
@@ -56,6 +54,32 @@ describe('workers/repository/process/lookup/filter', () => {
         { version: '2.0.0', releaseTimestamp: '2021-01-05T00:00:00.000Z' },
         { version: '2.1.0', releaseTimestamp: '2021-01-07T00:00:00.000Z' },
       ]);
+    });
+
+    it('allows unstable major upgrades', () => {
+      const nodeVersioning = allVersioning.get('node');
+
+      const releases = [
+        { version: '1.0.0-alpha' },
+        { version: '1.2.3-beta' },
+      ] satisfies Release[];
+
+      const config = partial<FilterConfig>({
+        ignoreUnstable: true,
+        ignoreDeprecated: true,
+      });
+      const currentVersion = '1.0.0-alpha';
+      const latestVersion = '1.2.3-beta';
+
+      const filteredVersions = filterVersions(
+        config,
+        currentVersion,
+        latestVersion,
+        releases,
+        nodeVersioning,
+      );
+
+      expect(filteredVersions).toEqual([{ version: '1.2.3-beta' }]);
     });
   });
 });

--- a/lib/workers/repository/process/lookup/filter.spec.ts
+++ b/lib/workers/repository/process/lookup/filter.spec.ts
@@ -1,5 +1,5 @@
 import { partial } from '../../../../../test/util';
-import { Release } from '../../../../modules/datasource';
+import type { Release } from '../../../../modules/datasource';
 import * as allVersioning from '../../../../modules/versioning';
 import { filterVersions } from './filter';
 import type { FilterConfig } from './types';

--- a/lib/workers/repository/process/lookup/filter.ts
+++ b/lib/workers/repository/process/lookup/filter.ts
@@ -77,7 +77,14 @@ export function filterVersions(
         'Falling back to npm semver syntax for allowedVersions',
       );
       filteredReleases = filteredReleases.filter((r) =>
-        semver.satisfies(r.version, allowedVersions),
+        semver.satisfies(
+          semver.valid(r.version)
+            ? r.version
+            : /** istanbul ignore next: not reachable, but it's safer to preserve it */ semver.coerce(
+                r.version,
+              )!,
+          allowedVersions,
+        ),
       );
     } else if (
       config.versioning === poetryVersioning.id &&

--- a/lib/workers/repository/process/lookup/filter.ts
+++ b/lib/workers/repository/process/lookup/filter.ts
@@ -126,24 +126,28 @@ export function filterVersions(
     return filteredReleases.filter((r) => isReleaseStable(r, versioning));
   }
 
-  // if current is unstable then allow unstable in the current major only
-  // Allow unstable only in current major
+  const currentMajor = versioning.getMajor(currentVersion);
+  const currentMinor = versioning.getMinor(currentVersion);
+  const currentPatch = versioning.getPatch(currentVersion);
+
   return filteredReleases.filter((r) => {
     if (isReleaseStable(r, versioning)) {
       return true;
     }
-    if (
-      versioning.getMajor(r.version) !== versioning.getMajor(currentVersion)
-    ) {
+
+    const major = versioning.getMajor(r.version);
+
+    if (major !== currentMajor) {
       return false;
     }
-    // istanbul ignore if: test passes without touching this
+
     if (versioning.allowUnstableMajorUpgrades) {
       return true;
     }
-    return (
-      versioning.getMinor(r.version) === versioning.getMinor(currentVersion) &&
-      versioning.getPatch(r.version) === versioning.getPatch(currentVersion)
-    );
+
+    const minor = versioning.getMinor(r.version);
+    const patch = versioning.getPatch(r.version);
+
+    return minor === currentMinor && patch === currentPatch;
   });
 }

--- a/lib/workers/repository/process/lookup/filter.ts
+++ b/lib/workers/repository/process/lookup/filter.ts
@@ -80,7 +80,7 @@ export function filterVersions(
         semver.satisfies(
           semver.valid(r.version)
             ? r.version
-            : /** istanbul ignore next: not reachable, but it's safer to preserve it */ semver.coerce(
+            : /* istanbul ignore next: not reachable, but it's safer to preserve it */ semver.coerce(
                 r.version,
               )!,
           allowedVersions,

--- a/lib/workers/repository/process/lookup/filter.ts
+++ b/lib/workers/repository/process/lookup/filter.ts
@@ -77,10 +77,7 @@ export function filterVersions(
         'Falling back to npm semver syntax for allowedVersions',
       );
       filteredReleases = filteredReleases.filter((r) =>
-        semver.satisfies(
-          semver.valid(r.version) ? r.version : semver.coerce(r.version)!,
-          allowedVersions,
-        ),
+        semver.satisfies(r.version, allowedVersions),
       );
     } else if (
       config.versioning === poetryVersioning.id &&


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
