### PR TITLE
feat(managers/npm): add entries with protocol prefix in temporary .yarnrc.yml file

### DIFF
--- a/lib/modules/manager/npm/post-update/rules.spec.ts
+++ b/lib/modules/manager/npm/post-update/rules.spec.ts
@@ -91,6 +91,12 @@ describe('modules/manager/npm/post-update/rules', () => {
 
           additionalYarnRcYml: {
             npmRegistries: {
+              '//https://registry.npmjs.org/': {
+                npmAuthToken: 'token123',
+              },
+              '//https://registry.other.org/': {
+                npmAuthIdent: 'basictoken123',
+              },
               '//registry.company.com/': {
                 npmAuthIdent: 'user123:pass123',
               },
@@ -115,6 +121,12 @@ describe('modules/manager/npm/post-update/rules', () => {
           ],
           "additionalYarnRcYml": {
             "npmRegistries": {
+              "//https://registry.npmjs.org/": {
+                "npmAuthToken": "token123",
+              },
+              "//https://registry.other.org/": {
+                "npmAuthIdent": "basictoken123",
+              },
               "//registry.company.com/": {
                 "npmAuthIdent": "user123:pass123",
               },

--- a/lib/modules/manager/npm/post-update/rules.ts
+++ b/lib/modules/manager/npm/post-update/rules.ts
@@ -32,7 +32,7 @@ export function processHostRules(): HostRulesResult {
 
     const uri = `//${matchedHost}/`;
     let cleanedUri = uri;
-    if (is.string(matchedHost) && isHttpUrl(matchedHost)) {
+    if (isHttpUrl(matchedHost)) {
       cleanedUri = matchedHost.replace(regEx(/^https?:/), '');
     }
 
@@ -74,11 +74,11 @@ export function processHostRules(): HostRulesResult {
     }
   }
 
-  const hasYarnRCNPMRegistries =
+  const hasYarnRcNpmRegistries =
     Object.keys(additionalYarnRcYml.npmRegistries).length > 0;
   return {
     additionalNpmrcContent,
-    additionalYarnRcYml: hasYarnRCNPMRegistries
+    additionalYarnRcYml: hasYarnRcNpmRegistries
       ? additionalYarnRcYml
       : undefined,
   };

--- a/lib/modules/manager/npm/post-update/rules.ts
+++ b/lib/modules/manager/npm/post-update/rules.ts
@@ -3,6 +3,7 @@ import * as hostRules from '../../../../util/host-rules';
 import { regEx } from '../../../../util/regex';
 import { toBase64 } from '../../../../util/string';
 import { isHttpUrl } from '../../../../util/url';
+import type { YarnRcYmlFile } from './types';
 
 export interface HostRulesResult {
   additionalNpmrcContent: string[];
@@ -10,7 +11,7 @@ export interface HostRulesResult {
 }
 
 export function processHostRules(): HostRulesResult {
-  let additionalYarnRcYml: any;
+  const additionalYarnRcYml: YarnRcYmlFile = { npmRegistries: {} };
 
   // Determine the additional npmrc content to add based on host rules
   const additionalNpmrcContent = [];
@@ -18,36 +19,67 @@ export function processHostRules(): HostRulesResult {
     hostType: 'npm',
   });
   for (const hostRule of npmHostRules) {
-    if (hostRule.resolvedHost) {
-      let uri = hostRule.matchHost;
-      uri =
-        is.string(uri) && isHttpUrl(uri)
-          ? uri.replace(regEx(/^https?:/), '')
-          : // TODO: types (#22198)
-            `//${uri}/`;
-      if (hostRule.token) {
-        const key = hostRule.authType === 'Basic' ? '_auth' : '_authToken';
-        additionalNpmrcContent.push(`${uri}:${key}=${hostRule.token}`);
-        additionalYarnRcYml ||= { npmRegistries: {} };
-        if (hostRule.authType === 'Basic') {
-          additionalYarnRcYml.npmRegistries[uri] = {
-            npmAuthIdent: hostRule.token,
-          };
-        } else {
-          additionalYarnRcYml.npmRegistries[uri] = {
-            npmAuthToken: hostRule.token,
-          };
-        }
-      } else if (is.string(hostRule.username) && is.string(hostRule.password)) {
-        const password = toBase64(hostRule.password);
-        additionalNpmrcContent.push(`${uri}:username=${hostRule.username}`);
-        additionalNpmrcContent.push(`${uri}:_password=${password}`);
-        additionalYarnRcYml ||= { npmRegistries: {} };
-        additionalYarnRcYml.npmRegistries[uri] = {
-          npmAuthIdent: `${hostRule.username}:${hostRule.password}`,
+    if (!hostRule.resolvedHost) {
+      continue;
+    }
+
+    const matchedHost = hostRule.matchHost;
+    // Should never be needed as if we have a resolvedHost there has to be a matchHost
+    // istanbul ignore next
+    if (!matchedHost) {
+      continue;
+    }
+
+    const uri = `//${matchedHost}/`;
+    let cleanedUri = uri;
+    if (is.string(matchedHost) && isHttpUrl(matchedHost)) {
+      cleanedUri = matchedHost.replace(regEx(/^https?:/), '');
+    }
+
+    if (hostRule.token) {
+      const key = hostRule.authType === 'Basic' ? '_auth' : '_authToken';
+      additionalNpmrcContent.push(`${cleanedUri}:${key}=${hostRule.token}`);
+
+      if (hostRule.authType === 'Basic') {
+        const registry = {
+          npmAuthIdent: hostRule.token,
         };
+        additionalYarnRcYml.npmRegistries[cleanedUri] = registry;
+        additionalYarnRcYml.npmRegistries[uri] = registry;
+
+        continue;
       }
+
+      const registry = {
+        npmAuthToken: hostRule.token,
+      };
+      additionalYarnRcYml.npmRegistries[cleanedUri] = registry;
+      additionalYarnRcYml.npmRegistries[uri] = registry;
+
+      continue;
+    }
+
+    if (is.string(hostRule.username) && is.string(hostRule.password)) {
+      const password = toBase64(hostRule.password);
+      additionalNpmrcContent.push(
+        `${cleanedUri}:username=${hostRule.username}`,
+      );
+      additionalNpmrcContent.push(`${cleanedUri}:_password=${password}`);
+
+      const registries = {
+        npmAuthIdent: `${hostRule.username}:${hostRule.password}`,
+      };
+      additionalYarnRcYml.npmRegistries[cleanedUri] = registries;
+      additionalYarnRcYml.npmRegistries[uri] = registries;
     }
   }
-  return { additionalNpmrcContent, additionalYarnRcYml };
+
+  const hasYarnRCNPMRegistries =
+    Object.keys(additionalYarnRcYml.npmRegistries).length > 0;
+  return {
+    additionalNpmrcContent,
+    additionalYarnRcYml: hasYarnRCNPMRegistries
+      ? additionalYarnRcYml
+      : undefined,
+  };
 }

--- a/lib/modules/manager/npm/post-update/rules.ts
+++ b/lib/modules/manager/npm/post-update/rules.ts
@@ -24,7 +24,7 @@ export function processHostRules(): HostRulesResult {
     }
 
     const matchedHost = hostRule.matchHost;
-    // Should never be needed as if we have a resolvedHost there has to be a matchHost
+    // Should never be necessary as if we have a resolvedHost, there has to be a matchHost
     // istanbul ignore next
     if (!matchedHost) {
       continue;

--- a/lib/modules/manager/npm/post-update/types.ts
+++ b/lib/modules/manager/npm/post-update/types.ts
@@ -41,6 +41,13 @@ export interface PnpmLockFile {
   optionalDependencies: PnpmDependencySchema;
 }
 
+export interface YarnRcNpmRegistry {
+  npmAlwaysAuth?: boolean;
+  npmAuthIdent?: string;
+  npmAuthToken?: string;
+}
+
 export interface YarnRcYmlFile {
   yarnPath?: string | null;
+  npmRegistries: Record<string, YarnRcNpmRegistry>;
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Add entries with protocol prefix, it supplied to temporary`.yarnrc.yml`. 
I have done also some small refactoring. 

<!-- Describe what behavior is changed by this PR. -->

## Context
Yarn allows to pin to add the protocol prefix to the host, though does merge configuration if only the host is supplied. 
This is similar to our host rules logic. 


<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
