### PR TITLE
fix: Use versioning comparison for release lookup filtering

### DIFF
--- a/lib/workers/repository/process/lookup/filter.spec.ts
+++ b/lib/workers/repository/process/lookup/filter.spec.ts
@@ -81,5 +81,34 @@ describe('workers/repository/process/lookup/filter', () => {
 
       expect(filteredVersions).toEqual([{ version: '1.2.3-beta' }]);
     });
+
+    it('ignores version insufficient prefixes', () => {
+      const releases = [
+        { version: '1.0.1' },
+        { version: '1.2.0' },
+        { version: '2.0.0', isDeprecated: true },
+        { version: '2.1.0' },
+      ] satisfies Release[];
+
+      const config = partial<FilterConfig>({
+        ignoreUnstable: true,
+        ignoreDeprecated: true,
+      });
+      const currentVersion = 'v1.0.1';
+      const latestVersion = 'v2.0.0';
+
+      const filteredVersions = filterVersions(
+        config,
+        currentVersion,
+        latestVersion,
+        releases,
+        versioning,
+      );
+
+      expect(filteredVersions).toEqual([
+        { version: '1.2.0' },
+        { version: '2.1.0' },
+      ]);
+    });
   });
 });

--- a/lib/workers/repository/process/lookup/filter.ts
+++ b/lib/workers/repository/process/lookup/filter.ts
@@ -43,7 +43,14 @@ export function filterVersions(
       versioning.isGreaterThan(r.version, currentVersion),
   );
 
-  const currentRelease = releases.find((r) => r.version === currentVersion);
+  const currentRelease = releases.find(
+    (r) =>
+      versioning.isValid(r.version) &&
+      versioning.isVersion(r.version) &&
+      versioning.isValid(currentVersion) &&
+      versioning.isVersion(currentVersion) &&
+      versioning.equals(r.version, currentVersion),
+  );
 
   // Don't upgrade from non-deprecated to deprecated
   if (ignoreDeprecated && currentRelease && !currentRelease.isDeprecated) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
