### PR TITLE
fix(azure): getRawFile not handling 404 for Azure DevOps

### DIFF
--- a/lib/modules/platform/azure/__snapshots__/index.spec.ts.snap
+++ b/lib/modules/platform/azure/__snapshots__/index.spec.ts.snap
@@ -147,6 +147,7 @@ exports[`modules/platform/azure/index getJsonFile() supports fetch from another 
     undefined,
     undefined,
     undefined,
+    true,
   ],
 ]
 `;

--- a/lib/modules/platform/azure/index.spec.ts
+++ b/lib/modules/platform/azure/index.spec.ts
@@ -1886,12 +1886,11 @@ describe('modules/platform/azure/index', () => {
     it('returns file content', async () => {
       const data = { foo: 'bar' };
       azureApi.gitApi.mockImplementationOnce(
-        () =>
-          ({
-            getItem: jest.fn(() =>
-              Promise.resolve({ content: JSON.stringify(data) }),
-            ),
-          }) as any,
+        jest.fn().mockImplementationOnce(() => ({
+          getItem: jest.fn(() =>
+            Promise.resolve({ content: JSON.stringify(data) }),
+          ),
+        })),
       );
       const res = await azure.getJsonFile('file.json');
       expect(res).toEqual(data);
@@ -1899,10 +1898,9 @@ describe('modules/platform/azure/index', () => {
 
     it('returns null when file not found', async () => {
       azureApi.gitApi.mockImplementationOnce(
-        () =>
-          ({
-            getItem: jest.fn(() => Promise.resolve(null)),
-          }) as any,
+        jest.fn().mockImplementationOnce(() => ({
+          getItem: jest.fn(() => Promise.resolve(null)),
+        })),
       );
       const res = await azure.getJsonFile('file.json');
       expect(res).toBeNull();
@@ -1916,10 +1914,9 @@ describe('modules/platform/azure/index', () => {
         }
       `;
       azureApi.gitApi.mockImplementationOnce(
-        () =>
-          ({
-            getItem: jest.fn(() => Promise.resolve({ content: json5Data })),
-          }) as any,
+        jest.fn().mockImplementationOnce(() => ({
+          getItem: jest.fn(() => Promise.resolve({ content: json5Data })),
+        })),
       );
       const res = await azure.getJsonFile('file.json5');
       expect(res).toEqual({ foo: 'bar' });
@@ -1927,58 +1924,55 @@ describe('modules/platform/azure/index', () => {
 
     it('returns file content from branch or tag', async () => {
       const data = { foo: 'bar' };
-      azureApi.gitApi.mockImplementationOnce(
-        () =>
-          ({
-            getItem: jest.fn(() =>
-              Promise.resolve({ content: JSON.stringify(data) }),
-            ),
-          }) as any,
+      azureApi.gitApi.mockResolvedValueOnce(
+        partial<IGitApi>({
+          getItem: jest.fn(() =>
+            Promise.resolve({ content: JSON.stringify(data) }),
+          ),
+        }),
       );
       const res = await azure.getJsonFile('file.json', undefined, 'dev');
       expect(res).toEqual(data);
     });
 
     it('throws on malformed JSON', async () => {
-      azureApi.gitApi.mockImplementationOnce(
-        () =>
-          ({
-            getItemContent: jest.fn(() =>
-              Promise.resolve(Readable.from('!@#')),
-            ),
-          }) as any,
+      azureApi.gitApi.mockResolvedValueOnce(
+        partial<IGitApi>({
+          getItemContent: jest.fn(() => Promise.resolve(Readable.from('!@#'))),
+        }),
       );
       await expect(azure.getJsonFile('file.json')).rejects.toThrow();
     });
 
     it('throws on errors', async () => {
-      azureApi.gitApi.mockImplementationOnce(
-        () =>
-          ({
-            getItemContent: jest.fn(() => {
-              throw new Error('some error');
-            }),
-          }) as any,
+      azureApi.gitApi.mockResolvedValueOnce(
+        partial<IGitApi>({
+          getItemContent: jest.fn(() => {
+            throw new Error('some error');
+          }),
+        }),
       );
       await expect(azure.getJsonFile('file.json')).rejects.toThrow();
     });
 
     it('supports fetch from another repo', async () => {
       const data = { foo: 'bar' };
-      const gitApiMock = {
-        getItem: jest.fn(() =>
-          Promise.resolve({ content: JSON.stringify(data) }),
-        ),
-        getRepositories: jest.fn(() =>
-          Promise.resolve([
-            { id: '123456', name: 'bar', project: { name: 'foo' } },
-          ]),
-        ),
-      };
-      azureApi.gitApi.mockImplementationOnce(() => gitApiMock as any);
+      const getItemFn = jest
+        .fn()
+        .mockResolvedValueOnce({ content: JSON.stringify(data) });
+      azureApi.gitApi.mockResolvedValueOnce(
+        partial<IGitApi>({
+          getItem: getItemFn,
+          getRepositories: jest
+            .fn()
+            .mockResolvedValue([
+              { id: '123456', name: 'bar', project: { name: 'foo' } },
+            ]),
+        }),
+      );
       const res = await azure.getJsonFile('file.json', 'foo/bar');
       expect(res).toEqual(data);
-      expect(gitApiMock.getItem.mock.calls).toMatchSnapshot();
+      expect(getItemFn.mock.calls).toMatchSnapshot();
     });
 
     it('returns null', async () => {

--- a/lib/modules/platform/azure/index.spec.ts
+++ b/lib/modules/platform/azure/index.spec.ts
@@ -1888,8 +1888,8 @@ describe('modules/platform/azure/index', () => {
       azureApi.gitApi.mockImplementationOnce(
         () =>
           ({
-            getItemContent: jest.fn(() =>
-              Promise.resolve(Readable.from(JSON.stringify(data))),
+            getItem: jest.fn(() =>
+              Promise.resolve({ content: JSON.stringify(data) }),
             ),
           }) as any,
       );
@@ -1907,9 +1907,7 @@ describe('modules/platform/azure/index', () => {
       azureApi.gitApi.mockImplementationOnce(
         () =>
           ({
-            getItemContent: jest.fn(() =>
-              Promise.resolve(Readable.from(json5Data)),
-            ),
+            getItem: jest.fn(() => Promise.resolve({ content: json5Data })),
           }) as any,
       );
       const res = await azure.getJsonFile('file.json5');
@@ -1921,8 +1919,8 @@ describe('modules/platform/azure/index', () => {
       azureApi.gitApi.mockImplementationOnce(
         () =>
           ({
-            getItemContent: jest.fn(() =>
-              Promise.resolve(Readable.from(JSON.stringify(data))),
+            getItem: jest.fn(() =>
+              Promise.resolve({ content: JSON.stringify(data) }),
             ),
           }) as any,
       );
@@ -1957,8 +1955,8 @@ describe('modules/platform/azure/index', () => {
     it('supports fetch from another repo', async () => {
       const data = { foo: 'bar' };
       const gitApiMock = {
-        getItemContent: jest.fn(() =>
-          Promise.resolve(Readable.from(JSON.stringify(data))),
+        getItem: jest.fn(() =>
+          Promise.resolve({ content: JSON.stringify(data) }),
         ),
         getRepositories: jest.fn(() =>
           Promise.resolve([
@@ -1969,7 +1967,7 @@ describe('modules/platform/azure/index', () => {
       azureApi.gitApi.mockImplementationOnce(() => gitApiMock as any);
       const res = await azure.getJsonFile('file.json', 'foo/bar');
       expect(res).toEqual(data);
-      expect(gitApiMock.getItemContent.mock.calls).toMatchSnapshot();
+      expect(gitApiMock.getItem.mock.calls).toMatchSnapshot();
     });
 
     it('returns null', async () => {

--- a/lib/modules/platform/azure/index.spec.ts
+++ b/lib/modules/platform/azure/index.spec.ts
@@ -1897,6 +1897,17 @@ describe('modules/platform/azure/index', () => {
       expect(res).toEqual(data);
     });
 
+    it('returns null when file not found', async () => {
+      azureApi.gitApi.mockImplementationOnce(
+        () =>
+          ({
+            getItem: jest.fn(() => Promise.resolve(null)),
+          }) as any,
+      );
+      const res = await azure.getJsonFile('file.json');
+      expect(res).toBeNull();
+    });
+
     it('returns file content in json5 format', async () => {
       const json5Data = `
         {

--- a/lib/modules/platform/azure/index.ts
+++ b/lib/modules/platform/azure/index.ts
@@ -1,3 +1,4 @@
+import { IncomingMessage } from 'http';
 import { setTimeout } from 'timers/promises';
 import is from '@sindresorhus/is';
 import {
@@ -146,7 +147,7 @@ export async function getRawFile(
       version: branchOrTag,
     } satisfies GitVersionDescriptor;
 
-    const buf = await azureApiGit.getItemContent(
+    const item = await azureApiGit.getItem(
       repoId,
       fileName,
       undefined,
@@ -156,10 +157,10 @@ export async function getRawFile(
       undefined,
       undefined,
       branchOrTag ? versionDescriptor : undefined,
+      true,
     );
 
-    const str = await streamToString(buf);
-    return str;
+    return item.content ?? null;
   } catch (err) /* istanbul ignore next */ {
     if (
       err.message?.includes('<title>Azure DevOps Services Unavailable</title>')

--- a/lib/modules/platform/azure/index.ts
+++ b/lib/modules/platform/azure/index.ts
@@ -1,4 +1,3 @@
-import { IncomingMessage } from 'http';
 import { setTimeout } from 'timers/promises';
 import is from '@sindresorhus/is';
 import {
@@ -23,7 +22,6 @@ import * as git from '../../../util/git';
 import * as hostRules from '../../../util/host-rules';
 import { regEx } from '../../../util/regex';
 import { sanitize } from '../../../util/sanitize';
-import { streamToString } from '../../../util/streams';
 import { ensureTrailingSlash } from '../../../util/url';
 import type {
   BranchStatusConfig,

--- a/lib/modules/platform/azure/index.ts
+++ b/lib/modules/platform/azure/index.ts
@@ -158,7 +158,7 @@ export async function getRawFile(
       true,
     );
 
-    return item.content ?? null;
+    return item?.content ?? null;
   } catch (err) /* istanbul ignore next */ {
     if (
       err.message?.includes('<title>Azure DevOps Services Unavailable</title>')

--- a/lib/modules/platform/azure/index.ts
+++ b/lib/modules/platform/azure/index.ts
@@ -146,16 +146,16 @@ export async function getRawFile(
     } satisfies GitVersionDescriptor;
 
     const item = await azureApiGit.getItem(
-      repoId,
-      fileName,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      branchOrTag ? versionDescriptor : undefined,
-      true,
+      repoId, // repositoryId
+      fileName, // path
+      undefined, // project
+      undefined, // scopePath
+      undefined, // recursionLevel
+      undefined, // includeContentMetadata
+      undefined, // latestProcessedChange
+      undefined, // download
+      branchOrTag ? versionDescriptor : undefined, // versionDescriptor
+      true, // includeContent
     );
 
     return item?.content ?? null;


### PR DESCRIPTION
## Changes

Replaced the getItemContent call in getRawFile with getItem

## Context

When getting a file that doesn't exist, the getItemContent function in azure-devops-node-api will still return a stream with json content. But it's a json describing the error (that the file doesn't exist). When Renovate tries to read this json as a config file it fails with validation errors. 
This happens for repositories that are not onboarded, when repositoryCache is enabled. Renovate tries to read the renovate.json file from the default branch, where it doesn't exist yet, and because it gets a non-empty response it tries to use the error response as a config file.
(Not sure if it's a bug that Renovate tries to read the config file from the default branch when the repository hasn't been onboarded)

Switching to getItem will fetch more data, since it includes some metadata. But it makes error handling easier, since azure-devops-node-api then returns null for 404 and throws for errors. Instead of just returning the raw stream.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository