### PR TITLE
feat(replacements): typeorm-seeding to scoped

### DIFF
--- a/lib/data/replacements.json
+++ b/lib/data/replacements.json
@@ -38,6 +38,7 @@
       "replacements:semantic-release-replace-plugin-to-unscoped",
       "replacements:spectre-cli-to-spectre-console-cli",
       "replacements:standard-version-to-commit-and-tag",
+      "replacements:typeorm-seeding-to-scoped",
       "replacements:vso-task-lib-to-azure-pipelines-task-lib",
       "replacements:vsts-task-lib-to-azure-pipelines-task-lib",
       "replacements:xmldom-to-scoped",
@@ -927,6 +928,18 @@
         "matchPackageNames": ["standard-version"],
         "replacementName": "commit-and-tag-version",
         "replacementVersion": "9.5.0"
+      }
+    ]
+  },
+  "typeorm-seeding-to-scoped": {
+    "description": "`typeorm-seeding` is now maintained as scoped package.",
+    "packageRules": [
+      {
+        "matchCurrentVersion": "1.6.1",
+        "matchDatasources": ["npm"],
+        "matchPackageNames": ["typeorm-seeding"],
+        "replacementName": "@jorgebodega/typeorm-seeding",
+        "replacementVersion": "2.0.0"
       }
     ]
   },


### PR DESCRIPTION
## Changes

Created a replacement rule for the unmaintained [typeorm-seeding](https://www.npmjs.com/package/typeorm-seeding) with its successor [@jorgebodega/typeorm-seeding](https://www.npmjs.com/package/@jorgebodega/typeorm-seeding).

## Context

`typeorm-seeding` hasn't been released in 4 years, as the publish access has been lost.
`@jorgebodega/typeorm-seeding` has received numerous updates since then.

- https://github.com/w3tecch/typeorm-seeding/issues/201
- https://github.com/jorgebodega/typeorm-seeding

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

---

Ping @jorgebodega / maintainers of `typeorm-seeding`: FYI