### PR TITLE
feat(asdf): Add gleam to asdf manager

### DIFF
--- a/lib/modules/manager/asdf/extract.spec.ts
+++ b/lib/modules/manager/asdf/extract.spec.ts
@@ -287,7 +287,7 @@ dummy 1.2.3
           },
           {
             currentValue: '1.3.1',
-            datasource: 'github-releases',
+            datasource: 'github-tags',
             packageName: 'gleam-lang/gleam',
             depName: 'gleam',
             extractVersion: '^v(?<version>\\S+)',

--- a/lib/modules/manager/asdf/extract.spec.ts
+++ b/lib/modules/manager/asdf/extract.spec.ts
@@ -290,7 +290,7 @@ dummy 1.2.3
             datasource: 'github-tags',
             packageName: 'gleam-lang/gleam',
             depName: 'gleam',
-            extractVersion: '^v(?<version>\\S+)',
+            extractVersion: '^v(?<version>.+)',
           },
           {
             currentValue: '0.104.3',

--- a/lib/modules/manager/asdf/extract.spec.ts
+++ b/lib/modules/manager/asdf/extract.spec.ts
@@ -68,6 +68,7 @@ flutter 3.7.6-stable
 flux2 0.41.2
 gauche 0.9.12
 github-cli 2.32.1
+gleam 1.3.1
 gohugo extended_0.104.3
 golang 1.19.2
 golangci-lint 1.52.2
@@ -282,6 +283,13 @@ dummy 1.2.3
             datasource: 'github-releases',
             packageName: 'cli/cli',
             depName: 'github-cli',
+            extractVersion: '^v(?<version>\\S+)',
+          },
+          {
+            currentValue: '1.3.1',
+            datasource: 'github-releases',
+            packageName: 'gleam-lang/gleam',
+            depName: 'gleam',
             extractVersion: '^v(?<version>\\S+)',
           },
           {

--- a/lib/modules/manager/asdf/upgradeable-tooling.ts
+++ b/lib/modules/manager/asdf/upgradeable-tooling.ts
@@ -220,6 +220,14 @@ export const upgradeableTooling: Record<string, ToolingDefinition> = {
       extractVersion: '^v(?<version>\\S+)',
     },
   },
+  gleam: {
+    asdfPluginUrl: 'https://github.com/asdf-community/asdf-gleam.git',
+    config: {
+      datasource: GithubTagsDatasource.id,
+      packageName: 'gleam-lang/gleam',
+      extractVersion: '^v(?<version>.+)',
+    },
+  },
   gohugo: hugoDefinition,
   golang: {
     asdfPluginUrl: 'https://github.com/kennyp/asdf-golang',


### PR DESCRIPTION
## Changes

This pull request adds support to bumping `gleam` entries in `.tool-versions` files, as supported by https://asdf-vm.com/.

## Context

`gleam` is not supported (by Renovate) in `.tool-versions` files, at this moment.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository