### PR TITLE
fix: check for explicit preset during onboarding config build

### DIFF
--- a/lib/workers/repository/onboarding/branch/config.spec.ts
+++ b/lib/workers/repository/onboarding/branch/config.spec.ts
@@ -116,6 +116,23 @@ describe('workers/repository/onboarding/branch/config', () => {
       });
     });
 
+    it('handles not overwriting explicit onboarding extends version', async () => {
+      config.repository = 'org/group/repo';
+      config.onboardingConfig!.extends = ['local>org/renovate-config#v1.23.0'];
+      mockedPresets.getPreset.mockImplementation(({ repo }) => {
+        if (repo === 'org/group/renovate-config') {
+          return Promise.resolve({ enabled: true });
+        }
+        return Promise.reject(new Error(PRESET_DEP_NOT_FOUND));
+      });
+      const onboardingConfig = await getOnboardingConfig(config);
+      expect(mockedPresets.getPreset).toHaveBeenCalledTimes(1);
+      expect(onboardingConfig).toEqual({
+        $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+        extends: ['local>org/renovate-config#v1.23.0'],
+      });
+    });
+
     it('handles not finding any preset', async () => {
       mockedPresets.getPreset.mockRejectedValue(
         new Error(PRESET_DEP_NOT_FOUND),

--- a/lib/workers/repository/onboarding/branch/config.ts
+++ b/lib/workers/repository/onboarding/branch/config.ts
@@ -77,7 +77,10 @@ async function getOnboardingConfig(
     }
   }
 
-  if (foundPreset) {
+  const hasPredefinedPreset =
+    onboardingConfig?.extends !== undefined &&
+    onboardingConfig.extends.length !== 0;
+  if (foundPreset && !hasPredefinedPreset) {
     logger.debug(`Found preset ${foundPreset} - using it in onboarding config`);
     onboardingConfig = {
       $schema: 'https://docs.renovatebot.com/renovate-schema.json',


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Currently renovate ignores whether the extends field is explicitly set in the onboardingConfig template. Instead the repo's are iterated, and if a preset repo is found overwritten. This becomes a problem when the user:
- Explicitly sets a preset version (e.g. like in the added test case)
- There are mulitple preset configs within an organization's group (e.g. the default preset is `org/renovate-config`, the repo is in `org/group/repo` and there also exists a `org/group/renovate-config` that is only required in a handful of manually selected repos)

## Context


## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
