### PR TITLE
chore: enabled json imports

### DIFF
--- a/lib/expose.cjs
+++ b/lib/expose.cjs
@@ -2,9 +2,11 @@
 
 /**
  * returns renovates package.json
- * @type {import('./types').RenovatePackageJson}
  */
-const pkg = (() => require('../package.json'))();
+const path = (() => require('path'))();
+// need to use dynamic strings so that typescript does not include package.json in dist folder after compilation
+const filePath = path.join(__dirname, '..', 'package.json');
+const pkg = (() => require(filePath))();
 
 /**
  * return's re2

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig",
   "compilerOptions": {
     "declaration": true,
-    "resolveJsonModule": false,
     "sourceMap": true,
     "inlineSources": true,
     "importHelpers": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "sourceMap": true,
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
-    "resolveJsonModule": false,
+    "resolveJsonModule": true,
     "noUnusedLocals": true,
     "noImplicitOverride": true,
     "experimentalDecorators": true,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- `resolveJsonModule` -> `true`
- we still want to import `package.json` dynamically, so used dynamic string in the `require`, this prevents ts compiler from inclusing `package.json` in the `dist` folder after compilation
<!-- Describe what behavior is changed by this PR. -->

## Context
Related: https://github.com/renovatebot/renovate/issues/29942
It is necessary so that we can include json files in the `lib` folder and import them using static json import. Else, TS won't include the json files in the `dist` folder after compilation
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository https://github.com/Rahul-renovate-testing/test0101

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
