### PR TITLE
fix(cargo): Only use `cargo update --precise` in case of lockfile updates

### DIFF
--- a/lib/modules/manager/cargo/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/modules/manager/cargo/__snapshots__/artifacts.spec.ts.snap
@@ -3,6 +3,24 @@
 exports[`modules/manager/cargo/artifacts returns null if unchanged 1`] = `
 [
   {
+    "cmd": "cargo fetch --config net.git-fetch-with-cli=true --manifest-path Cargo.toml",
+    "options": {
+      "cwd": "/tmp/github/some/repo",
+      "encoding": "utf-8",
+      "env": {
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+  {
     "cmd": "cargo update --config net.git-fetch-with-cli=true --manifest-path Cargo.toml --workspace",
     "options": {
       "cwd": "/tmp/github/some/repo",
@@ -25,6 +43,24 @@ exports[`modules/manager/cargo/artifacts returns null if unchanged 1`] = `
 
 exports[`modules/manager/cargo/artifacts returns updated Cargo.lock 1`] = `
 [
+  {
+    "cmd": "cargo fetch --config net.git-fetch-with-cli=true --manifest-path Cargo.toml",
+    "options": {
+      "cwd": "/tmp/github/some/repo",
+      "encoding": "utf-8",
+      "env": {
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
   {
     "cmd": "cargo update --config net.git-fetch-with-cli=true --manifest-path Cargo.toml --workspace",
     "options": {
@@ -72,7 +108,84 @@ exports[`modules/manager/cargo/artifacts returns updated Cargo.lock for lockfile
 exports[`modules/manager/cargo/artifacts returns updated workspace Cargo.lock 1`] = `
 [
   {
+    "cmd": "cargo fetch --config net.git-fetch-with-cli=true --manifest-path crates/one/Cargo.toml",
+    "options": {
+      "cwd": "/tmp/github/some/repo",
+      "encoding": "utf-8",
+      "env": {
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+  {
     "cmd": "cargo update --config net.git-fetch-with-cli=true --manifest-path crates/one/Cargo.toml --workspace",
+    "options": {
+      "cwd": "/tmp/github/some/repo",
+      "encoding": "utf-8",
+      "env": {
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+]
+`;
+
+exports[`modules/manager/cargo/artifacts supports mixed lockfile and non-lockfile updates 1`] = `
+[
+  {
+    "cmd": "cargo fetch --config net.git-fetch-with-cli=true --manifest-path Cargo.toml",
+    "options": {
+      "cwd": "/tmp/github/some/repo",
+      "encoding": "utf-8",
+      "env": {
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+  {
+    "cmd": "cargo update --config net.git-fetch-with-cli=true --manifest-path Cargo.toml --workspace",
+    "options": {
+      "cwd": "/tmp/github/some/repo",
+      "encoding": "utf-8",
+      "env": {
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
+  {
+    "cmd": "cargo update --config net.git-fetch-with-cli=true --manifest-path Cargo.toml --package dep2@1.0.0 --precise 1.0.1",
     "options": {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -94,6 +207,24 @@ exports[`modules/manager/cargo/artifacts returns updated workspace Cargo.lock 1`
 
 exports[`modules/manager/cargo/artifacts updates Cargo.lock based on the packageName, when given 1`] = `
 [
+  {
+    "cmd": "cargo fetch --config net.git-fetch-with-cli=true --manifest-path Cargo.toml",
+    "options": {
+      "cwd": "/tmp/github/some/repo",
+      "encoding": "utf-8",
+      "env": {
+        "HOME": "/home/user",
+        "HTTPS_PROXY": "https://example.com",
+        "HTTP_PROXY": "http://example.com",
+        "LANG": "en_US.UTF-8",
+        "LC_ALL": "en_US",
+        "NO_PROXY": "localhost",
+        "PATH": "/tmp/path",
+      },
+      "maxBuffer": 10485760,
+      "timeout": 900000,
+    },
+  },
   {
     "cmd": "cargo update --config net.git-fetch-with-cli=true --manifest-path Cargo.toml --workspace",
     "options": {

--- a/lib/modules/manager/cargo/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/modules/manager/cargo/__snapshots__/artifacts.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`modules/manager/cargo/artifacts returns null if unchanged 1`] = `
 [
   {
-    "cmd": "cargo fetch --config net.git-fetch-with-cli=true --manifest-path Cargo.toml",
+    "cmd": "cargo update --config net.git-fetch-with-cli=true --manifest-path Cargo.toml --workspace",
     "options": {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -44,7 +44,7 @@ exports[`modules/manager/cargo/artifacts returns null if unchanged 1`] = `
 exports[`modules/manager/cargo/artifacts returns updated Cargo.lock 1`] = `
 [
   {
-    "cmd": "cargo fetch --config net.git-fetch-with-cli=true --manifest-path Cargo.toml",
+    "cmd": "cargo update --config net.git-fetch-with-cli=true --manifest-path Cargo.toml --workspace",
     "options": {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -108,7 +108,7 @@ exports[`modules/manager/cargo/artifacts returns updated Cargo.lock for lockfile
 exports[`modules/manager/cargo/artifacts returns updated workspace Cargo.lock 1`] = `
 [
   {
-    "cmd": "cargo fetch --config net.git-fetch-with-cli=true --manifest-path crates/one/Cargo.toml",
+    "cmd": "cargo update --config net.git-fetch-with-cli=true --manifest-path crates/one/Cargo.toml --workspace",
     "options": {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -149,7 +149,7 @@ exports[`modules/manager/cargo/artifacts returns updated workspace Cargo.lock 1`
 exports[`modules/manager/cargo/artifacts updates Cargo.lock based on the packageName, when given 1`] = `
 [
   {
-    "cmd": "cargo fetch --config net.git-fetch-with-cli=true --manifest-path Cargo.toml",
+    "cmd": "cargo update --config net.git-fetch-with-cli=true --manifest-path Cargo.toml --workspace",
     "options": {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",

--- a/lib/modules/manager/cargo/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/modules/manager/cargo/__snapshots__/artifacts.spec.ts.snap
@@ -146,65 +146,6 @@ exports[`modules/manager/cargo/artifacts returns updated workspace Cargo.lock 1`
 ]
 `;
 
-exports[`modules/manager/cargo/artifacts supports mixed lockfile and non-lockfile updates 1`] = `
-[
-  {
-    "cmd": "cargo fetch --config net.git-fetch-with-cli=true --manifest-path Cargo.toml",
-    "options": {
-      "cwd": "/tmp/github/some/repo",
-      "encoding": "utf-8",
-      "env": {
-        "HOME": "/home/user",
-        "HTTPS_PROXY": "https://example.com",
-        "HTTP_PROXY": "http://example.com",
-        "LANG": "en_US.UTF-8",
-        "LC_ALL": "en_US",
-        "NO_PROXY": "localhost",
-        "PATH": "/tmp/path",
-      },
-      "maxBuffer": 10485760,
-      "timeout": 900000,
-    },
-  },
-  {
-    "cmd": "cargo update --config net.git-fetch-with-cli=true --manifest-path Cargo.toml --workspace",
-    "options": {
-      "cwd": "/tmp/github/some/repo",
-      "encoding": "utf-8",
-      "env": {
-        "HOME": "/home/user",
-        "HTTPS_PROXY": "https://example.com",
-        "HTTP_PROXY": "http://example.com",
-        "LANG": "en_US.UTF-8",
-        "LC_ALL": "en_US",
-        "NO_PROXY": "localhost",
-        "PATH": "/tmp/path",
-      },
-      "maxBuffer": 10485760,
-      "timeout": 900000,
-    },
-  },
-  {
-    "cmd": "cargo update --config net.git-fetch-with-cli=true --manifest-path Cargo.toml --package dep2@1.0.0 --precise 1.0.1",
-    "options": {
-      "cwd": "/tmp/github/some/repo",
-      "encoding": "utf-8",
-      "env": {
-        "HOME": "/home/user",
-        "HTTPS_PROXY": "https://example.com",
-        "HTTP_PROXY": "http://example.com",
-        "LANG": "en_US.UTF-8",
-        "LC_ALL": "en_US",
-        "NO_PROXY": "localhost",
-        "PATH": "/tmp/path",
-      },
-      "maxBuffer": 10485760,
-      "timeout": 900000,
-    },
-  },
-]
-`;
-
 exports[`modules/manager/cargo/artifacts updates Cargo.lock based on the packageName, when given 1`] = `
 [
   {

--- a/lib/modules/manager/cargo/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/modules/manager/cargo/__snapshots__/artifacts.spec.ts.snap
@@ -20,47 +20,11 @@ exports[`modules/manager/cargo/artifacts returns null if unchanged 1`] = `
       "timeout": 900000,
     },
   },
-  {
-    "cmd": "cargo update --config net.git-fetch-with-cli=true --manifest-path Cargo.toml --workspace",
-    "options": {
-      "cwd": "/tmp/github/some/repo",
-      "encoding": "utf-8",
-      "env": {
-        "HOME": "/home/user",
-        "HTTPS_PROXY": "https://example.com",
-        "HTTP_PROXY": "http://example.com",
-        "LANG": "en_US.UTF-8",
-        "LC_ALL": "en_US",
-        "NO_PROXY": "localhost",
-        "PATH": "/tmp/path",
-      },
-      "maxBuffer": 10485760,
-      "timeout": 900000,
-    },
-  },
 ]
 `;
 
 exports[`modules/manager/cargo/artifacts returns updated Cargo.lock 1`] = `
 [
-  {
-    "cmd": "cargo update --config net.git-fetch-with-cli=true --manifest-path Cargo.toml --workspace",
-    "options": {
-      "cwd": "/tmp/github/some/repo",
-      "encoding": "utf-8",
-      "env": {
-        "HOME": "/home/user",
-        "HTTPS_PROXY": "https://example.com",
-        "HTTP_PROXY": "http://example.com",
-        "LANG": "en_US.UTF-8",
-        "LC_ALL": "en_US",
-        "NO_PROXY": "localhost",
-        "PATH": "/tmp/path",
-      },
-      "maxBuffer": 10485760,
-      "timeout": 900000,
-    },
-  },
   {
     "cmd": "cargo update --config net.git-fetch-with-cli=true --manifest-path Cargo.toml --workspace",
     "options": {
@@ -125,47 +89,11 @@ exports[`modules/manager/cargo/artifacts returns updated workspace Cargo.lock 1`
       "timeout": 900000,
     },
   },
-  {
-    "cmd": "cargo update --config net.git-fetch-with-cli=true --manifest-path crates/one/Cargo.toml --workspace",
-    "options": {
-      "cwd": "/tmp/github/some/repo",
-      "encoding": "utf-8",
-      "env": {
-        "HOME": "/home/user",
-        "HTTPS_PROXY": "https://example.com",
-        "HTTP_PROXY": "http://example.com",
-        "LANG": "en_US.UTF-8",
-        "LC_ALL": "en_US",
-        "NO_PROXY": "localhost",
-        "PATH": "/tmp/path",
-      },
-      "maxBuffer": 10485760,
-      "timeout": 900000,
-    },
-  },
 ]
 `;
 
 exports[`modules/manager/cargo/artifacts updates Cargo.lock based on the packageName, when given 1`] = `
 [
-  {
-    "cmd": "cargo update --config net.git-fetch-with-cli=true --manifest-path Cargo.toml --workspace",
-    "options": {
-      "cwd": "/tmp/github/some/repo",
-      "encoding": "utf-8",
-      "env": {
-        "HOME": "/home/user",
-        "HTTPS_PROXY": "https://example.com",
-        "HTTP_PROXY": "http://example.com",
-        "LANG": "en_US.UTF-8",
-        "LC_ALL": "en_US",
-        "NO_PROXY": "localhost",
-        "PATH": "/tmp/path",
-      },
-      "maxBuffer": 10485760,
-      "timeout": 900000,
-    },
-  },
   {
     "cmd": "cargo update --config net.git-fetch-with-cli=true --manifest-path Cargo.toml --workspace",
     "options": {

--- a/lib/modules/manager/cargo/artifacts.spec.ts
+++ b/lib/modules/manager/cargo/artifacts.spec.ts
@@ -132,7 +132,7 @@ describe('modules/manager/cargo/artifacts', () => {
         packageName: 'dep1',
         lockedVersion: '1.0.0',
         newVersion: '1.0.1',
-        updateType: 'lockfileUpdate' as UpdateType,
+        updateType: 'lockfileUpdate' satisfies UpdateType as UpdateType,
       },
     ];
     expect(
@@ -291,21 +291,21 @@ describe('modules/manager/cargo/artifacts', () => {
         packageName: 'dep1',
         lockedVersion: '1.0.0',
         newVersion: '1.0.1',
-        updateType: 'lockfileUpdate' as UpdateType,
+        updateType: 'lockfileUpdate' satisfies UpdateType as UpdateType,
       },
       {
         depName: 'dep2',
         packageName: 'dep2',
         lockedVersion: '1.0.0',
         newVersion: '1.0.2',
-        updateType: 'lockfileUpdate' as UpdateType,
+        updateType: 'lockfileUpdate' satisfies UpdateType as UpdateType,
       },
       {
         depName: 'dep3',
         packageName: 'dep3',
         lockedVersion: '1.0.0',
         newVersion: '1.0.3',
-        updateType: 'lockfileUpdate' as UpdateType,
+        updateType: 'lockfileUpdate' satisfies UpdateType as UpdateType,
       },
     ];
 
@@ -343,21 +343,21 @@ describe('modules/manager/cargo/artifacts', () => {
       {
         depName: 'dep1',
         packageName: 'dep1',
-        updateType: 'minorUpdate' as UpdateType,
+        updateType: 'minor' satisfies UpdateType as UpdateType,
         lockedVersion: '1.0.0',
         newVersion: '1.0.1',
       },
       {
         depName: 'dep2',
         packageName: 'dep2',
-        updateType: 'minorUpdate' as UpdateType,
+        updateType: 'minor' satisfies UpdateType as UpdateType,
         lockedVersion: '1.0.0',
         newVersion: '1.0.2',
       },
       {
         depName: 'dep3',
         packageName: 'dep3',
-        updateType: 'lockfileUpdate' as UpdateType,
+        updateType: 'lockfileUpdate' satisfies UpdateType as UpdateType,
         lockedVersion: '1.0.0',
         newVersion: '1.0.3',
       },

--- a/lib/modules/manager/cargo/artifacts.spec.ts
+++ b/lib/modules/manager/cargo/artifacts.spec.ts
@@ -332,7 +332,7 @@ describe('modules/manager/cargo/artifacts', () => {
     ]);
   });
 
-  it('runs cargo fetch if there is any non-lockfile update', async () => {
+  it('runs cargo update precise only for lockfile update', async () => {
     fs.statLocalFile.mockResolvedValueOnce({ name: 'Cargo.lock' } as any);
     fs.findLocalSiblingOrParent.mockResolvedValueOnce('Cargo.lock');
     git.getFile.mockResolvedValueOnce('Old Cargo.lock');
@@ -376,11 +376,6 @@ describe('modules/manager/cargo/artifacts', () => {
           'cargo update --config net.git-fetch-with-cli=true' +
           ' --manifest-path Cargo.toml' +
           ' --workspace',
-      },
-      {
-        cmd:
-          'cargo fetch --config net.git-fetch-with-cli=true' +
-          ' --manifest-path Cargo.toml',
       },
       {
         cmd:

--- a/lib/modules/manager/cargo/artifacts.spec.ts
+++ b/lib/modules/manager/cargo/artifacts.spec.ts
@@ -369,7 +369,9 @@ describe('modules/manager/cargo/artifacts', () => {
         newPackageFileContent: '{}',
         config,
       }),
-    ).not.toBeNull();
+    ).toEqual([
+      { file: { contents: undefined, path: 'Cargo.lock', type: 'addition' } },
+    ]);
     expect(execSnapshots).toMatchObject([
       {
         cmd:

--- a/lib/modules/manager/cargo/artifacts.spec.ts
+++ b/lib/modules/manager/cargo/artifacts.spec.ts
@@ -473,27 +473,6 @@ describe('modules/manager/cargo/artifacts', () => {
           },
         },
       },
-      {},
-      {
-        cmd:
-          'docker run --rm --name=renovate_sidecar --label=renovate_child ' +
-          '-v "/tmp/github/some/repo":"/tmp/github/some/repo" ' +
-          '-v "/tmp/cache":"/tmp/cache" ' +
-          '-e CONTAINERBASE_CACHE_DIR ' +
-          '-w "/tmp/github/some/repo" ' +
-          'ghcr.io/containerbase/sidecar ' +
-          'bash -l -c "' +
-          'install-tool rust 1.65.0' +
-          ' && ' +
-          'cargo update --config net.git-fetch-with-cli=true --manifest-path Cargo.toml --workspace' +
-          '"',
-        options: {
-          cwd: '/tmp/github/some/repo',
-          env: {
-            CONTAINERBASE_CACHE_DIR: '/tmp/cache/containerbase',
-          },
-        },
-      },
     ]);
   });
 
@@ -587,27 +566,6 @@ describe('modules/manager/cargo/artifacts', () => {
             GIT_CONFIG_VALUE_3: 'ssh://git@gitea.com/',
             GIT_CONFIG_VALUE_4: 'git@gitea.com:',
             GIT_CONFIG_VALUE_5: 'https://gitea.com/',
-          },
-        },
-      },
-      {},
-      {
-        cmd:
-          'docker run --rm --name=renovate_sidecar --label=renovate_child ' +
-          '-v "/tmp/github/some/repo":"/tmp/github/some/repo" ' +
-          '-v "/tmp/cache":"/tmp/cache" ' +
-          '-e CONTAINERBASE_CACHE_DIR ' +
-          '-w "/tmp/github/some/repo" ' +
-          'ghcr.io/containerbase/sidecar ' +
-          'bash -l -c "' +
-          'install-tool rust 1.65.0' +
-          ' && ' +
-          'cargo update --config net.git-fetch-with-cli=true --manifest-path Cargo.toml --workspace' +
-          '"',
-        options: {
-          cwd: '/tmp/github/some/repo',
-          env: {
-            CONTAINERBASE_CACHE_DIR: '/tmp/cache/containerbase',
           },
         },
       },
@@ -856,25 +814,6 @@ describe('modules/manager/cargo/artifacts', () => {
       },
     ]);
     expect(execSnapshots).toMatchObject([
-      {
-        cmd: 'install-tool rust 1.65.0',
-        options: {
-          cwd: '/tmp/github/some/repo',
-          encoding: 'utf-8',
-          env: {
-            CONTAINERBASE_CACHE_DIR: '/tmp/cache/containerbase',
-          },
-        },
-      },
-      {
-        cmd: 'cargo update --config net.git-fetch-with-cli=true --manifest-path Cargo.toml --workspace',
-        options: {
-          cwd: '/tmp/github/some/repo',
-          env: {
-            CONTAINERBASE_CACHE_DIR: '/tmp/cache/containerbase',
-          },
-        },
-      },
       {
         cmd: 'install-tool rust 1.65.0',
         options: {

--- a/lib/modules/manager/cargo/artifacts.spec.ts
+++ b/lib/modules/manager/cargo/artifacts.spec.ts
@@ -464,7 +464,28 @@ describe('modules/manager/cargo/artifacts', () => {
           'bash -l -c "' +
           'install-tool rust 1.65.0' +
           ' && ' +
-          'cargo fetch --config net.git-fetch-with-cli=true --manifest-path Cargo.toml' +
+          'cargo update --config net.git-fetch-with-cli=true --manifest-path Cargo.toml --workspace' +
+          '"',
+        options: {
+          cwd: '/tmp/github/some/repo',
+          env: {
+            CONTAINERBASE_CACHE_DIR: '/tmp/cache/containerbase',
+          },
+        },
+      },
+      {},
+      {
+        cmd:
+          'docker run --rm --name=renovate_sidecar --label=renovate_child ' +
+          '-v "/tmp/github/some/repo":"/tmp/github/some/repo" ' +
+          '-v "/tmp/cache":"/tmp/cache" ' +
+          '-e CONTAINERBASE_CACHE_DIR ' +
+          '-w "/tmp/github/some/repo" ' +
+          'ghcr.io/containerbase/sidecar ' +
+          'bash -l -c "' +
+          'install-tool rust 1.65.0' +
+          ' && ' +
+          'cargo update --config net.git-fetch-with-cli=true --manifest-path Cargo.toml --workspace' +
           '"',
         options: {
           cwd: '/tmp/github/some/repo',
@@ -542,7 +563,7 @@ describe('modules/manager/cargo/artifacts', () => {
           'bash -l -c "' +
           'install-tool rust 1.65.0' +
           ' && ' +
-          'cargo fetch --config net.git-fetch-with-cli=true --manifest-path Cargo.toml' +
+          'cargo update --config net.git-fetch-with-cli=true --manifest-path Cargo.toml --workspace' +
           '"',
         options: {
           cwd: '/tmp/github/some/repo',
@@ -566,6 +587,27 @@ describe('modules/manager/cargo/artifacts', () => {
             GIT_CONFIG_VALUE_3: 'ssh://git@gitea.com/',
             GIT_CONFIG_VALUE_4: 'git@gitea.com:',
             GIT_CONFIG_VALUE_5: 'https://gitea.com/',
+          },
+        },
+      },
+      {},
+      {
+        cmd:
+          'docker run --rm --name=renovate_sidecar --label=renovate_child ' +
+          '-v "/tmp/github/some/repo":"/tmp/github/some/repo" ' +
+          '-v "/tmp/cache":"/tmp/cache" ' +
+          '-e CONTAINERBASE_CACHE_DIR ' +
+          '-w "/tmp/github/some/repo" ' +
+          'ghcr.io/containerbase/sidecar ' +
+          'bash -l -c "' +
+          'install-tool rust 1.65.0' +
+          ' && ' +
+          'cargo update --config net.git-fetch-with-cli=true --manifest-path Cargo.toml --workspace' +
+          '"',
+        options: {
+          cwd: '/tmp/github/some/repo',
+          env: {
+            CONTAINERBASE_CACHE_DIR: '/tmp/cache/containerbase',
           },
         },
       },
@@ -825,7 +867,26 @@ describe('modules/manager/cargo/artifacts', () => {
         },
       },
       {
-        cmd: 'cargo fetch --config net.git-fetch-with-cli=true --manifest-path Cargo.toml',
+        cmd: 'cargo update --config net.git-fetch-with-cli=true --manifest-path Cargo.toml --workspace',
+        options: {
+          cwd: '/tmp/github/some/repo',
+          env: {
+            CONTAINERBASE_CACHE_DIR: '/tmp/cache/containerbase',
+          },
+        },
+      },
+      {
+        cmd: 'install-tool rust 1.65.0',
+        options: {
+          cwd: '/tmp/github/some/repo',
+          encoding: 'utf-8',
+          env: {
+            CONTAINERBASE_CACHE_DIR: '/tmp/cache/containerbase',
+          },
+        },
+      },
+      {
+        cmd: 'cargo update --config net.git-fetch-with-cli=true --manifest-path Cargo.toml --workspace',
         options: {
           cwd: '/tmp/github/some/repo',
           env: {

--- a/lib/modules/manager/cargo/artifacts.spec.ts
+++ b/lib/modules/manager/cargo/artifacts.spec.ts
@@ -132,6 +132,7 @@ describe('modules/manager/cargo/artifacts', () => {
         packageName: 'dep1',
         lockedVersion: '1.0.0',
         newVersion: '1.0.1',
+        updateType: 'lockfileUpdate',
       },
     ];
     expect(
@@ -162,7 +163,7 @@ describe('modules/manager/cargo/artifacts', () => {
 
   it('returns an artifact error when cargo update fails', async () => {
     const cmd =
-      'cargo update --config net.git-fetch-with-cli=true --manifest-path Cargo.toml --workspace';
+      'cargo fetch --config net.git-fetch-with-cli=true --manifest-path Cargo.toml';
     const execError = new ExecError('Exec error', {
       cmd,
       stdout: '',
@@ -290,18 +291,21 @@ describe('modules/manager/cargo/artifacts', () => {
         packageName: 'dep1',
         lockedVersion: '1.0.0',
         newVersion: '1.0.1',
+        updateType: 'lockfileUpdate',
       },
       {
         depName: 'dep2',
         packageName: 'dep2',
         lockedVersion: '1.0.0',
         newVersion: '1.0.2',
+        updateType: 'lockfileUpdate',
       },
       {
         depName: 'dep3',
         packageName: 'dep3',
         lockedVersion: '1.0.0',
         newVersion: '1.0.3',
+        updateType: 'lockfileUpdate',
       },
     ];
 
@@ -460,7 +464,7 @@ describe('modules/manager/cargo/artifacts', () => {
           'bash -l -c "' +
           'install-tool rust 1.65.0' +
           ' && ' +
-          'cargo update --config net.git-fetch-with-cli=true --manifest-path Cargo.toml --workspace' +
+          'cargo fetch --config net.git-fetch-with-cli=true --manifest-path Cargo.toml' +
           '"',
         options: {
           cwd: '/tmp/github/some/repo',
@@ -538,7 +542,7 @@ describe('modules/manager/cargo/artifacts', () => {
           'bash -l -c "' +
           'install-tool rust 1.65.0' +
           ' && ' +
-          'cargo update --config net.git-fetch-with-cli=true --manifest-path Cargo.toml --workspace' +
+          'cargo fetch --config net.git-fetch-with-cli=true --manifest-path Cargo.toml' +
           '"',
         options: {
           cwd: '/tmp/github/some/repo',
@@ -821,7 +825,7 @@ describe('modules/manager/cargo/artifacts', () => {
         },
       },
       {
-        cmd: 'cargo update --config net.git-fetch-with-cli=true --manifest-path Cargo.toml --workspace',
+        cmd: 'cargo fetch --config net.git-fetch-with-cli=true --manifest-path Cargo.toml',
         options: {
           cwd: '/tmp/github/some/repo',
           env: {

--- a/lib/modules/manager/cargo/artifacts.spec.ts
+++ b/lib/modules/manager/cargo/artifacts.spec.ts
@@ -7,7 +7,7 @@ import {
 } from '../../../../test/exec-util';
 import { env, fs, git, mocked } from '../../../../test/util';
 import { GlobalConfig } from '../../../config/global';
-import type { RepoGlobalConfig } from '../../../config/types';
+import type { RepoGlobalConfig, UpdateType } from '../../../config/types';
 import * as docker from '../../../util/exec/docker';
 import { ExecError } from '../../../util/exec/exec-error';
 import * as _hostRules from '../../../util/host-rules';
@@ -132,7 +132,7 @@ describe('modules/manager/cargo/artifacts', () => {
         packageName: 'dep1',
         lockedVersion: '1.0.0',
         newVersion: '1.0.1',
-        updateType: 'lockfileUpdate',
+        updateType: 'lockfileUpdate' as UpdateType,
       },
     ];
     expect(
@@ -291,21 +291,21 @@ describe('modules/manager/cargo/artifacts', () => {
         packageName: 'dep1',
         lockedVersion: '1.0.0',
         newVersion: '1.0.1',
-        updateType: 'lockfileUpdate',
+        updateType: 'lockfileUpdate' as UpdateType,
       },
       {
         depName: 'dep2',
         packageName: 'dep2',
         lockedVersion: '1.0.0',
         newVersion: '1.0.2',
-        updateType: 'lockfileUpdate',
+        updateType: 'lockfileUpdate' as UpdateType,
       },
       {
         depName: 'dep3',
         packageName: 'dep3',
         lockedVersion: '1.0.0',
         newVersion: '1.0.3',
-        updateType: 'lockfileUpdate',
+        updateType: 'lockfileUpdate' as UpdateType,
       },
     ];
 

--- a/lib/modules/manager/cargo/artifacts.ts
+++ b/lib/modules/manager/cargo/artifacts.ts
@@ -51,20 +51,10 @@ async function cargoUpdatePrecise(
       ` --manifest-path ${quote(manifestPath)} --workspace`,
   ];
 
-  const anyNonLockfileUpdate = updatedDeps.some(
-    (dep) => dep.updateType !== 'lockfileUpdate',
-  );
-  if (anyNonLockfileUpdate) {
-    cmds.push(
-      `cargo fetch --config net.git-fetch-with-cli=true` +
-        ` --manifest-path ${quote(manifestPath)}`,
-    );
-  }
-
   // Update individual dependencies to their `newVersion`. Necessary when
   // using the `update-lockfile` rangeStrategy which doesn't touch Cargo.toml.
   for (const dep of updatedDeps) {
-    // Cargo fetch should already have handled any non-lockfile updates
+    // Cargo update should already have handled any non-lockfile updates
     if (dep.updateType !== 'lockfileUpdate') {
       continue;
     }

--- a/lib/modules/manager/cargo/artifacts.ts
+++ b/lib/modules/manager/cargo/artifacts.ts
@@ -160,32 +160,33 @@ async function updateArtifactsImpl(
           config.env ?? {},
           config.constraints?.rust,
         );
-      }
+      } else {
 
-      const anyNonLockfileUpdate = updatedDeps.some(
-        (dep) => dep.updateType !== 'lockfileUpdate' && dep.lockedVersion,
-      );
-      if (anyNonLockfileUpdate) {
-        // Cargo fetch is safer to use for non-lockfile updates, because it
-        // has fewer issues with duplicate dependencies.
-        await cargoFetch(
-          packageFileName,
-          config.env ?? {},
-          config.constraints?.rust,
+        const anyNonLockfileUpdate = updatedDeps.some(
+          (dep) => dep.updateType !== 'lockfileUpdate',
         );
-      }
+        if (anyNonLockfileUpdate) {
+          // Cargo fetch is safer to use for non-lockfile updates, because it
+          // has fewer issues with duplicate dependencies.
+          await cargoFetch(
+            packageFileName,
+            config.env ?? {},
+            config.constraints?.rust,
+          );
+        }
 
-      // Cargo fetch should already have handled any non-lockfile updates and missing deps
-      const lockfileOnlyDeps = updatedDeps.filter(
-        (dep) => dep.updateType === 'lockfileUpdate' && dep.lockedVersion,
-      );
-      if (lockfileOnlyDeps) {
-        await cargoUpdatePrecise(
-          packageFileName,
-          lockfileOnlyDeps,
-          config.env ?? {},
-          config.constraints?.rust,
+        // Cargo fetch should already have handled any non-lockfile updates
+        const lockfileOnlyDeps = updatedDeps.filter(
+          (dep) => dep.updateType === 'lockfileUpdate',
         );
+        if (lockfileOnlyDeps) {
+          await cargoUpdatePrecise(
+            packageFileName,
+            lockfileOnlyDeps,
+            config.env ?? {},
+            config.constraints?.rust,
+          );
+        }
       }
     }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
`cargo update --workspace` has better support for duplicate dependency versions, which `cargo update --precise` can fail to update. To avoid issues, only use it for `lockfile`-style updates.

The initial approach followed the proposal in #29620:
> * If there are any non-lockfile-only updates (i.e. Cargo.toml is updated) then we run a single `cargo fetch`
> * If there are any lockfile-only updates then we run `cargo update` targeting only those dependencies (similar to today)

~~In addition, I also moved the missing-dep case to `cargo fetch` because it is the less invasive approach.~~ (Reverted)

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

Closes #29620
Discussed in #29539

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

I modified the unit test to run, but I did not extend them. I confirmed that my issue was solved, but did not do any more in-depth testing of different test scenarios.

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
