### PR TITLE
chore(datasource/custom): log data before jsonata processing

### DIFF
--- a/lib/modules/datasource/custom/index.ts
+++ b/lib/modules/datasource/custom/index.ts
@@ -43,6 +43,8 @@ export class CustomDatasource extends Datasource {
       return null;
     }
 
+    logger.trace({ data }, `Custom manager fetcher '${format}' returned data.`);
+
     for (const transformTemplate of transformTemplates) {
       const expression = jsonata(transformTemplate);
       data = await expression.evaluate(data);

--- a/lib/modules/datasource/custom/readme.md
+++ b/lib/modules/datasource/custom/readme.md
@@ -81,6 +81,22 @@ All available options:
 }
 ```
 
+### Debugging
+
+Renovate writes tracing log entries before transformation starts and after if Renovate finds an unexpected data format.
+To surface this data you can use `logLevelRemap` to surface this data on the App or run Renovate in dryRun mode and log level set to `trace` locally.
+
+```json
+{
+  "logLevelRemap": [
+    {
+      "matchMessage": "/^Custom manager fetcher/",
+      "newLogLevel": "info"
+    }
+  ]
+}
+```
+
 ### Formats
 
 #### JSON


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Adds a trace log for the raw data returned by a fetcher of the custom datasource
<!-- Describe what behavior is changed by this PR. -->

## Context
https://github.com/renovatebot/renovate/discussions/23286#discussioncomment-10087652
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
