### PR TITLE
fix(manager/circleci): optional jobs parameter

### DIFF
--- a/lib/modules/manager/circleci/__fixtures__/config4.yml
+++ b/lib/modules/manager/circleci/__fixtures__/config4.yml
@@ -1,0 +1,9 @@
+version: 2.1
+
+orbs:
+  nodejs: circleci/node@5.2.0
+
+workflows:
+  Test:
+    jobs:
+      - nodejs/test

--- a/lib/modules/manager/circleci/extract.spec.ts
+++ b/lib/modules/manager/circleci/extract.spec.ts
@@ -4,6 +4,7 @@ import { extractPackageFile } from '.';
 const file1 = Fixtures.get('config.yml');
 const file2 = Fixtures.get('config2.yml');
 const file3 = Fixtures.get('config3.yml');
+const file4 = Fixtures.get('config4.yml');
 
 describe('modules/manager/circleci/extract', () => {
   describe('extractPackageFile()', () => {
@@ -64,6 +65,18 @@ describe('modules/manager/circleci/extract', () => {
             '      image: android:202102-01',
         ),
       ).toBeNull();
+    });
+
+    it('extracts orbs without jobs', () => {
+      const res = extractPackageFile(file4);
+      expect(res?.deps).toMatchObject([
+        {
+          depName: 'nodejs',
+          currentValue: '5.2.0',
+          datasource: 'orb',
+          depType: 'orb',
+        },
+      ]);
     });
   });
 });

--- a/lib/modules/manager/circleci/extract.ts
+++ b/lib/modules/manager/circleci/extract.ts
@@ -30,7 +30,7 @@ export function extractPackageFile(
       });
     }
 
-    for (const job of Object.values(parsed.jobs)) {
+    for (const job of Object.values(parsed.jobs ?? {})) {
       for (const dockerElement of coerceArray(job.docker)) {
         deps.push({
           ...getDep(dockerElement.image),

--- a/lib/modules/manager/circleci/schema.ts
+++ b/lib/modules/manager/circleci/schema.ts
@@ -10,6 +10,6 @@ export const CircleCiJob = z.object({
 
 export const CircleCiFile = z.object({
   aliases: z.array(CircleCiDocker).optional(),
-  jobs: z.record(z.string(), CircleCiJob),
+  jobs: z.record(z.string(), CircleCiJob).optional(),
   orbs: z.record(z.string()).optional(),
 });


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

I change the `jobs` CircleCI configuration YAML parameter to be processed as optional.

## Context

The following error message was faced when running Renovate on my project.

```shell
DEBUG: Error extracting circleci images
{
  "err": {
    "message": "Schema error",
    "stack": "ZodError: Schema error\n    at Object.get error [as error] (/usr/local/renovate/node_modules/.pnpm/zod@3.23.8/node_modules/zod/lib/types.js:55:31)\n    at ZodObject.parse (/usr/local/renovate/node_modules/.pnpm/zod@3.23.8/node_modules/zod/lib/types.js:160:22)\n    at parseSingleYaml (/usr/local/renovate/lib/util/yaml.ts:72:17)\n    at Object.extractPackageFile (/usr/local/renovate/lib/modules/manager/circleci/extract.ts:16:35)\n    at extractPackageFile (/usr/local/renovate/lib/modules/manager/index.ts:75:9)\n    at getManagerPackageFiles (/usr/local/renovate/lib/workers/repository/extract/manager-files.ts:58:43)\n    at /usr/local/renovate/lib/workers/repository/extract/index.ts:57:28\n    at async Promise.all (index 0)\n    at extractAllDependencies (/usr/local/renovate/lib/workers/repository/extract/index.ts:54:26)\n    at extract (/usr/local/renovate/lib/workers/repository/process/extract-update.ts:139:28)\n    at extractDependencies (/usr/local/renovate/lib/workers/repository/process/index.ts:154:26)\n    at Object.renovateRepository (/usr/local/renovate/lib/workers/repository/index.ts:69:9)\n    at attributes.repository (/usr/local/renovate/lib/workers/global/index.ts:218:11)\n    at start (/usr/local/renovate/lib/workers/global/index.ts:203:7)\n    at /usr/local/renovate/lib/renovate.ts:18:22",
    "issues": {
      "jobs": "Required"
    }
  }
  "packageFile": ".circleci/config.yml"
}
```

The `jobs` parameter is optional, so CircleCI will also work with a YAML file with the following contents:

```yaml
version: 2.1

orbs:
  nodejs: circleci/node@5.2.0

nodejs-version: &nodejs-version 20.15.1

workflows:
  Test:
    jobs:
      - nodejs/test:
          version: *nodejs-version
```

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
