### PR TITLE
fix(mise): add config filenames

### DIFF
--- a/lib/modules/manager/mise/index.ts
+++ b/lib/modules/manager/mise/index.ts
@@ -5,7 +5,7 @@ export { extractPackageFile } from './extract';
 export const displayName = 'mise';
 
 export const defaultConfig = {
-  fileMatch: ['(^|/)\\.mise\\.toml$'],
+  fileMatch: ['(^|/)\\.?mise\\.toml$', '(^|/)\\.?mise/config\\.toml$'],
 };
 
 // Re-use the asdf datasources, as mise and asdf support the same plugins.

--- a/lib/modules/manager/mise/readme.md
+++ b/lib/modules/manager/mise/readme.md
@@ -7,7 +7,7 @@ Renovate's `mise` manager can version these tools:
 
 ### Renovate only updates primary versions
 
-Renovate's `mise` manager is designed to automatically update the _first_ (primary) version listed for each tool in the `mise.toml` file.
+Renovate's `mise` manager is designed to automatically update the _first_ (primary) version listed for each tool in the `.mise.toml` file.
 
 Secondary or fallback versions require manual updates.
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Add missing config filenames of mise.
https://github.com/renovatebot/renovate/discussions/26596#discussioncomment-9208536

As mentioned in the above questionnaire, `.mise.local.toml` or other environment-specific config are not included.

<!-- Describe what behavior is changed by this PR. -->

## Context

The new package manager questionnaire of mise.

https://github.com/renovatebot/renovate/discussions/26596#discussioncomment-9208536

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

I just made the config filename consistent to use `.mise.toml` for the documentation.

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
