### PR TITLE
fix(bitbucket-server): Clarify error when both BB password and access token are set

### DIFF
--- a/lib/modules/platform/bitbucket-server/index.ts
+++ b/lib/modules/platform/bitbucket-server/index.ts
@@ -98,7 +98,7 @@ export async function initPlatform({
     );
   } else if (password && token) {
     throw new Error(
-      'Init: You must either configure a Bitbucket Server password or a HTTP access token',
+      'Init: You must configure either a Bitbucket Server password or a HTTP access token, not both',
     );
   }
   // TODO: Add a connection check that endpoint/username/password combination are valid (#9595)


### PR DESCRIPTION
## Changes

This Pull Request changes the wording of the Error thrown when both a HTTP Access token and a password is provided for BitBucket Server to more clearly indicate that both were set and that there can be only one.

## Context

I was running some local experiments with the Renovate configuration and got confused by the original message, thinking I had set neither. Turns out I had set both, so wanted to clarify the message for anyone encountering it in the future

## Documentation

- [x] No documentation update is required

## How I've tested my work

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
