### PR TITLE
docs: fix `changelogUrl` description

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2558,8 +2558,7 @@ You must use the `!/ /` syntax, like this:
 
 ### changelogUrl
 
-Use this field to set the changelog URL for a package, including overriding any existing one.
-Using this field we can specify the exact URL to fetch changelogs from.
+This doesn't help with _fetching_ the changelogs, but if you configure it then Renovate will include a link to this URL in the PR body, so users can click through to read the changelog.
 
 ```json title="Setting the changelog URL for the dummy package"
 {

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2558,7 +2558,12 @@ You must use the `!/ /` syntax, like this:
 
 ### changelogUrl
 
-This doesn't help with _fetching_ the changelogs, but if you configure it then Renovate will include a link to this URL in the PR body, so users can click through to read the changelog.
+Sometimes Renovate does not show the correct changelog for a package.
+As a workaround for this problem, you can give Renovate the URL to the changelog with the `changelogUrl` config option.
+When set, Renovate will put a _link_ to the changelogs in the Renovate PR body.
+
+Renovate does _not_ show the complete changelogs from the `changelogUrl` in its PR body text, you only get the URL from Renovate.
+To read the changelogs you must use the link.
 
 ```json title="Setting the changelog URL for the dummy package"
 {

--- a/docs/usage/key-concepts/changelogs.md
+++ b/docs/usage/key-concepts/changelogs.md
@@ -36,7 +36,7 @@ Set to `branch` if you have an advanced use case where you're embedding changelo
 
 ### [`changelogUrl`](../configuration-options.md#changelogurl)
 
-This doesn't help with _fetching_ the changelogs, but if you configure it then Renovate will include a link to this URL in the PR body, so users can click through to read the changelog.
+Use this field to set or override the specific URL for fetching a package's changelog.
 
 ## Platforms that Renovate can fetch changelogs from
 

--- a/docs/usage/key-concepts/changelogs.md
+++ b/docs/usage/key-concepts/changelogs.md
@@ -36,7 +36,7 @@ Set to `branch` if you have an advanced use case where you're embedding changelo
 
 ### [`changelogUrl`](../configuration-options.md#changelogurl)
 
-Use this field to set or override the specific URL for fetching a package's changelog.
+This doesn't help with _fetching_ the changelogs, but if you configure it then Renovate will include a link to this URL in the PR body, so users can click through to read the changelog.
 
 ## Platforms that Renovate can fetch changelogs from
 

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -1706,7 +1706,7 @@ const options: RenovateOptions[] = [
   {
     name: 'changelogUrl',
     description:
-      'If set, Renovate will use this URL to fetch changelogs for a matched dependency. Valid only within a `packageRules` object.',
+      'Allows you to specify a custom URL for the changelog, which Renovate will include in PR descriptions for easy access.',
     type: 'string',
     stage: 'pr',
     parents: ['packageRules'],

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -1706,7 +1706,7 @@ const options: RenovateOptions[] = [
   {
     name: 'changelogUrl',
     description:
-      'Allows you to specify a custom URL for the changelog, which Renovate will include in PR descriptions for easy access.',
+      'Set a custom URL for the changelog. Renovate will put this URL in the PR body text.',
     type: 'string',
     stage: 'pr',
     parents: ['packageRules'],


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- rectify the description for `changelogUrl` 
<!-- Describe what behavior is changed by this PR. -->

## Context
Ref: https://github.com/renovatebot/renovate/discussions/30299
I think this was missed during migration from `customChangelogUrl` -> `changelogUrl`
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
