### PR TITLE
fix: check for explicit preset during onboarding

### DIFF
--- a/lib/workers/repository/onboarding/branch/config.spec.ts
+++ b/lib/workers/repository/onboarding/branch/config.spec.ts
@@ -117,6 +117,40 @@ describe('workers/repository/onboarding/branch/config', () => {
       });
     });
 
+    it('handles not overwriting explicit onboarding extends version', async () => {
+      config.repository = 'org/group/repo';
+      config.onboardingConfig!.extends = ['local>org/renovate-config#v1.23.0'];
+      mockedPresets.getPreset.mockImplementation(({ repo }) => {
+        if (repo === 'org/group/renovate-config') {
+          return Promise.resolve({ enabled: true });
+        }
+        return Promise.reject(new Error(PRESET_DEP_NOT_FOUND));
+      });
+      const onboardingConfig = await getOnboardingConfig(config);
+      expect(mockedPresets.getPreset).toHaveBeenCalledTimes(0);
+      expect(onboardingConfig).toEqual({
+        $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+        extends: ['local>org/renovate-config#v1.23.0'],
+      });
+    });
+
+    it('handles not overwriting explicit empty onboarding extends', async () => {
+      config.repository = 'org/group/repo';
+      config.onboardingConfig!.extends = [];
+      mockedPresets.getPreset.mockImplementation(({ repo }) => {
+        if (repo === 'org/group2/renovate-config') {
+          return Promise.resolve({ enabled: true });
+        }
+        return Promise.reject(new Error(PRESET_DEP_NOT_FOUND));
+      });
+      const onboardingConfig = await getOnboardingConfig(config);
+      expect(mockedPresets.getPreset).toHaveBeenCalledTimes(0);
+      expect(onboardingConfig).toEqual({
+        $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+        extends: [],
+      });
+    });
+
     it('handles not finding any preset', async () => {
       mockedPresets.getPreset.mockRejectedValue(
         new Error(PRESET_DEP_NOT_FOUND),

--- a/lib/workers/repository/onboarding/branch/config.ts
+++ b/lib/workers/repository/onboarding/branch/config.ts
@@ -14,20 +14,26 @@ async function getOnboardingConfig(
 ): Promise<RenovateSharedConfig | undefined> {
   let onboardingConfig = clone(config.onboardingConfig);
 
-  // TODO #22198 fix types
-  const foundPreset = await searchDefaultOnboardingPreset(config.repository!);
+  const hasPredefinedPreset = onboardingConfig?.extends !== undefined;
 
-  if (foundPreset) {
-    logger.debug(`Found preset ${foundPreset} - using it in onboarding config`);
-    onboardingConfig = {
-      $schema: 'https://docs.renovatebot.com/renovate-schema.json',
-      extends: [foundPreset],
-    };
-  } else {
-    // Organization preset did not exist
-    logger.debug(
-      'No default org/owner preset found, so the default onboarding config will be used instead.',
-    );
+  if (!hasPredefinedPreset) {
+    // TODO #22198 fix types
+    const foundPreset = await searchDefaultOnboardingPreset(config.repository!);
+
+    if (foundPreset) {
+      logger.debug(
+        `Found preset ${foundPreset} - using it in onboarding config`,
+      );
+      onboardingConfig = {
+        $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+        extends: [foundPreset],
+      };
+    } else {
+      // Organization preset did not exist
+      logger.debug(
+        'No default org/owner preset found, so the default onboarding config will be used instead.',
+      );
+    }
   }
 
   logger.debug({ config: onboardingConfig }, 'onboarding config');

--- a/lib/workers/repository/onboarding/branch/config.ts
+++ b/lib/workers/repository/onboarding/branch/config.ts
@@ -16,9 +16,10 @@ async function getOnboardingConfig(
 
   const hasPredefinedPreset = onboardingConfig?.extends !== undefined;
   if (hasPredefinedPreset) {
-    logger.debug('Predefined onboardingConfig.extends found, so default org presets won't be used');
-  }
-  if (!hasPredefinedPreset) {
+    logger.debug(
+      "Predefined onboardingConfig.extends found, so default org presets won't be used",
+    );
+  } else {
     // TODO #22198 fix types
     const foundPreset = await searchDefaultOnboardingPreset(config.repository!);
 

--- a/lib/workers/repository/onboarding/branch/config.ts
+++ b/lib/workers/repository/onboarding/branch/config.ts
@@ -15,7 +15,9 @@ async function getOnboardingConfig(
   let onboardingConfig = clone(config.onboardingConfig);
 
   const hasPredefinedPreset = onboardingConfig?.extends !== undefined;
-
+  if (hasPredefinedPreset) {
+    logger.debug('Predefined onboardingConfig.extends found, so default org presets won't be used');
+  }
   if (!hasPredefinedPreset) {
     // TODO #22198 fix types
     const foundPreset = await searchDefaultOnboardingPreset(config.repository!);


### PR DESCRIPTION
## Changes
Updates the onboarding handling to ensure explicitly set `onboardingConfig.extends` in the renovate `config.js` don't get overwritten by the default renovate-config repo lookup. See https://github.com/renovatebot/renovate/discussions/30202#discussioncomment-10064964 for more detailed discussion about the expected behaviour.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
