### PR TITLE
feat(package-rules): matchReleaseAge

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2412,7 +2412,7 @@ The matching process for a package rule:
 - Multiple values within a single matcher will be evaluated independently (they're OR-ed together).
 - Combining multiple matchers will restrict the resulting matches (they're AND-ed together):
   `matchCurrentVersion`, `matchCurrentValue`, `matchNewValue`, `matchConfidence`, `matchCurrentAge`,
-  `matchManagers`, `matchDatasources`, `matchCategories`, `matchDepTypes`, `matchUpdateTypes`,
+  `matchManagers`, `matchDatasources`, `matchCategories`, `matchDepTypes`, `matchUpdateTypes`, `matchReleaseAge`,
   `matchRepositories`/`excludeRepositories`, `matchBaseBranches`, `matchFileNames`
 - Two special groups of matchers provide alternatives (they're OR-ed within their respective groups, and AND-ed with others):
   - Source URL: `matchSourceUrls`, `matchSourceUrlPrefixes`
@@ -3076,6 +3076,32 @@ Like the earlier `matchPackagePatterns` example, the above will configure `range
     `matchPackagePrefixes` will try matching `packageName` first and then fall back to matching `depName`.
     If the fallback is used, Renovate will log a warning, because the fallback will be removed in a future release.
     Use `matchDepPatterns` instead.
+
+### matchReleaseAge
+
+Use this field if you want to match packages based on the age of the _new_ (released) version.
+
+For example, if you want to group updates for dependencies where the new version is more than 1 month old:
+
+```json
+{
+  "packageRules": [
+    {
+      "matchReleaseAge": "> 1 month",
+      "groupName": "overdue dependencies"
+    }
+  ]
+}
+```
+
+The `matchReleaseAge` string must start with one of `>`, `>=`, `<` or `<=`.
+
+Only _one_ date part is supported, so you _cannot_ do `> 1 year 1 month`.
+Instead you should do `> 13 months`.
+
+<!-- prettier-ignore -->
+!!! note
+    We recommend you only use the words hour(s), day(s), week(s), month(s) and year(s) in your time ranges.
 
 ### matchRepositories
 

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -1287,6 +1287,17 @@ const options: RenovateOptions[] = [
     env: false,
   },
   {
+    name: 'matchReleaseAge',
+    description:
+      'Matches the age of the package derived from its release timestamp. Valid only within a `packageRules` object.',
+    type: 'string',
+    parents: ['packageRules'],
+    stage: 'package',
+    mergeable: true,
+    cli: false,
+    env: false,
+  },
+  {
     name: 'matchRepositories',
     description:
       'List of repositories to match (e.g. `["**/*-archived"]`). Valid only within a `packageRules` object.',

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -385,6 +385,7 @@ export interface PackageRule
   matchPackageNames?: string[];
   matchPackagePatterns?: string[];
   matchPackagePrefixes?: string[];
+  matchReleaseAge?: string;
   matchRepositories?: string[];
   matchSourceUrlPrefixes?: string[];
   matchSourceUrls?: string[];

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -451,6 +451,7 @@ export async function validateConfig(
               'matchUpdateTypes',
               'matchConfidence',
               'matchCurrentAge',
+              'matchReleaseAge',
               'matchRepositories',
               'matchNewValue',
             ];

--- a/lib/util/package-rules/release-age.spec.ts
+++ b/lib/util/package-rules/release-age.spec.ts
@@ -1,0 +1,90 @@
+import { DateTime } from 'luxon';
+import { ReleaseAgeMatcher } from './release-age';
+
+describe('util/package-rules/release-age', () => {
+  const matcher = new ReleaseAgeMatcher();
+
+  describe('match', () => {
+    const t0 = DateTime.fromISO('2023-07-07', { zone: 'utc' });
+
+    beforeAll(() => {
+      jest.useFakeTimers();
+    });
+
+    beforeEach(() => {
+      jest.setSystemTime(t0.toMillis());
+    });
+
+    it('returns false if release is older', () => {
+      const result = matcher.matches(
+        {
+          releaseTimestamp: '2020-01-01',
+        },
+        {
+          matchReleaseAge: '< 1 year', // younger than 1 year
+        },
+      );
+      expect(result).toBeFalse();
+    });
+
+    it('returns false if release is younger', () => {
+      const result = matcher.matches(
+        {
+          releaseTimestamp: '2020-01-01',
+        },
+        {
+          matchReleaseAge: '> 10 years', // older than 10 yrs
+        },
+      );
+      expect(result).toBeFalse();
+    });
+
+    it('returns null if release invalid', () => {
+      const result = matcher.matches(
+        {
+          releaseTimestamp: 'abc',
+        },
+        {
+          matchReleaseAge: '> 2 days', // older than 2 days
+        },
+      );
+      expect(result).toBeNull();
+    });
+
+    it('returns false if release undefined', () => {
+      const result = matcher.matches(
+        {
+          releaseTimestamp: undefined,
+        },
+        {
+          matchReleaseAge: '> 2 days', // older than 2 days
+        },
+      );
+      expect(result).toBeFalse();
+    });
+
+    it('returns false if release null', () => {
+      const result = matcher.matches(
+        {
+          releaseTimestamp: null,
+        },
+        {
+          matchReleaseAge: '> 2 days', // older than 2 days
+        },
+      );
+      expect(result).toBeFalse();
+    });
+
+    it('returns true if age matches', () => {
+      const result = matcher.matches(
+        {
+          releaseTimestamp: '2020-01-01',
+        },
+        {
+          matchReleaseAge: '> 3 years', // older than 3 years
+        },
+      );
+      expect(result).toBeTrue();
+    });
+  });
+});

--- a/lib/util/package-rules/release-age.ts
+++ b/lib/util/package-rules/release-age.ts
@@ -1,0 +1,21 @@
+import is from '@sindresorhus/is';
+import type { PackageRule, PackageRuleInputConfig } from '../../config/types';
+import { satisfiesDateRange } from '../pretty-time';
+import { Matcher } from './base';
+
+export class ReleaseAgeMatcher extends Matcher {
+  override matches(
+    { releaseTimestamp }: PackageRuleInputConfig,
+    { matchReleaseAge }: PackageRule,
+  ): boolean | null {
+    if (!is.string(matchReleaseAge)) {
+      return null;
+    }
+
+    if (!is.string(releaseTimestamp)) {
+      return false;
+    }
+
+    return satisfiesDateRange(releaseTimestamp, matchReleaseAge);
+  }
+}


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Implement and add `matchReleaseAge` matcher to the packageRules, equivalent to `matchCurrentAge`.

## Context

For noise impression reasons. My organization requires all PRs not to fall behind a default branch. In a situation where the repository owner ignores the PR for too long, it is updated every time there is a change pushed to the default branch, resulting in constant notifications and unnecessary CI resource consumption. With this rule, we can bundle "forgotten" dependencies into a single PR to be dealt with at a convenient time for the owner. 

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
