### PR TITLE
fix(config/migration): migrate wildcard patterns for matchPackagePatterns

### DIFF
--- a/lib/config/migrations/custom/package-rules-migration.spec.ts
+++ b/lib/config/migrations/custom/package-rules-migration.spec.ts
@@ -141,6 +141,10 @@ describe('config/migrations/custom/package-rules-migration', () => {
       {
         packageRules: [
           {
+            matchPackagePatterns: ['*'],
+            automerge: true,
+          },
+          {
             matchPackagePatterns: ['foo', 'bar'],
             automerge: true,
           },
@@ -153,6 +157,10 @@ describe('config/migrations/custom/package-rules-migration', () => {
       },
       {
         packageRules: [
+          {
+            automerge: true,
+            matchPackageNames: ['/.*/'],
+          },
           {
             automerge: true,
             matchPackageNames: ['/foo/', '/bar/'],

--- a/lib/config/migrations/custom/package-rules-migration.spec.ts
+++ b/lib/config/migrations/custom/package-rules-migration.spec.ts
@@ -159,7 +159,7 @@ describe('config/migrations/custom/package-rules-migration', () => {
         packageRules: [
           {
             automerge: true,
-            matchPackageNames: ['/.*/'],
+            matchPackageNames: ['*'],
           },
           {
             automerge: true,

--- a/lib/config/migrations/custom/package-rules-migration.ts
+++ b/lib/config/migrations/custom/package-rules-migration.ts
@@ -78,7 +78,15 @@ function mergeMatchers(packageRule: PackageRule): PackageRule {
       const patterns = is.string(val) ? [val] : val;
       if (is.array(patterns, is.string)) {
         newPackageRule.matchPackageNames ??= [];
-        newPackageRule.matchPackageNames.push(...patterns.map((v) => `/${v}/`));
+        newPackageRule.matchPackageNames.push(
+          ...patterns.map((v) => {
+            let value = v;
+            if (value === '*') {
+              value = '.*';
+            }
+            return `/${value}/`;
+          }),
+        );
       }
       delete newPackageRule.matchPackagePatterns;
     }

--- a/lib/config/migrations/custom/package-rules-migration.ts
+++ b/lib/config/migrations/custom/package-rules-migration.ts
@@ -80,11 +80,10 @@ function mergeMatchers(packageRule: PackageRule): PackageRule {
         newPackageRule.matchPackageNames ??= [];
         newPackageRule.matchPackageNames.push(
           ...patterns.map((v) => {
-            let value = v;
-            if (value === '*') {
-              value = '.*';
+            if (v === '*') {
+              return '*';
             }
-            return `/${value}/`;
+            return `/${v}/`;
           }),
         );
       }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Migrates `"matchPackagePatterns": ["*"]` to `"matchPackageNames": ["/.*/"]`
<!-- Describe what behavior is changed by this PR. -->

## Context
Closes #30379
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
