### PR TITLE
feat(datasource/maven)!: skip pom check by default

### DIFF
--- a/docs/usage/self-hosted-experimental.md
+++ b/docs/usage/self-hosted-experimental.md
@@ -19,10 +19,10 @@ We will try to keep breakage to a minimum, but make no guarantees that an experi
 If set, Renovate will export OpenTelemetry data to the supplied endpoint.
 For more information see [the OpenTelemetry docs](opentelemetry.md).
 
-## `RENOVATE_EXPERIMENTAL_NO_MAVEN_POM_CHECK`
+## `RENOVATE_EXPERIMENTAL_MAVEN_POM_CHECK`
 
-If set to any value, Renovate will skip its default artifacts filter check in the Maven datasource.
-Skipping the check will speed things up, but may result in versions being returned which don't properly exist on the server.
+If set to any `"true"`, Renovate will perform an artifacts filter check in the Maven datasource.
+Skipping the check speeds things up, but may result in versions being returned which don't properly exist on the server.
 
 ## `RENOVATE_PAGINATE_ALL`
 

--- a/lib/modules/datasource/maven/index.ts
+++ b/lib/modules/datasource/maven/index.ts
@@ -218,7 +218,7 @@ export class MavenDatasource extends Datasource {
   ): Promise<ReleaseMap> {
     const releaseMap = { ...inputReleaseMap };
 
-    if (process.env.RENOVATE_EXPERIMENTAL_NO_MAVEN_POM_CHECK) {
+    if (process.env.RENOVATE_EXPERIMENTAL_MAVEN_POM_CHECK !== 'true') {
       return releaseMap;
     }
 


### PR DESCRIPTION


<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Change from opt-out (RENOVATE_EXPERIMENTAL_NO_MAVEN_POM_CHECK) to opt-in (RENOVATE_EXPERIMENTAL_MAVEN_POM_CHECK) for POM validity checking.

## Context

This causes many API requests and decreases performance, so should no longer be the default.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
