### PR TITLE
docs: fix typo in poetry/readme.md

### DIFF
--- a/lib/modules/manager/poetry/readme.md
+++ b/lib/modules/manager/poetry/readme.md
@@ -15,6 +15,6 @@ The following `depTypes` are supported by the Poetry manager:
     We recommended that you pin dependency versions in your `pyproject.toml` instead.
 
 Renovate cannot accurately update locked versions of Poetry dependency ranges due to limitations in Poetry.
-For example, if the `pyproject.toml` has a constraint like `coverage = "^7.2"`, and the version ion `poetry.lock` is `7.4.1`, and we know that `7.4.3` is available, then Renovate can only run `poetry update --lock --no-interaction coverage` and _hope_ the result is `7.4.3`.
+For example, if the `pyproject.toml` has a constraint like `coverage = "^7.2"`, and the version in `poetry.lock` is `7.4.1`, and we know that `7.4.3` is available, then Renovate can only run `poetry update --lock --no-interaction coverage` and _hope_ the result is `7.4.3`.
 Poetry does not support updating to a specific/exact version with the `update` command, and the above `update` command may not even update at all sometimes.
 For this reason it's much better to pin dependency versions in `pyproject.toml`, such as `coverage = "7.4.1"` because it then gives Renovate more control and the ability to accurate upgrade dependencies in increments like `7.4.1` to `7.4.3`.


### PR DESCRIPTION
s/ion/in/

## Changes

Fix typo in poetry documentation

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Eyeballs
- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository