### PR TITLE
docs: fix typo in json example in config-presets.md

### DIFF
--- a/docs/usage/config-presets.md
+++ b/docs/usage/config-presets.md
@@ -115,7 +115,7 @@ It mostly uses Renovate config defaults but adds a few smart customizations such
 
 ## How to Use Preset Configs
 
-By default, Renovate App's onboarding PR suggests the `["config:recommended]"` preset.
+By default, Renovate App's onboarding PR suggests the `["config:recommended"]` preset.
 If you're self hosting, and want to use the `config:recommended` preset, then you must add `"onboardingConfig": { "extends": ["config:recommended"] }` to your bot's config.
 
 Read the [Full Config Presets](./presets-config.md) page to learn more about our `config:` presets.


### PR DESCRIPTION
## Changes

Typo in the JSON of one of the examples in config-presets.md

## Documentation

- [X] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work

I have verified these changes via:

- [X] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
