### PR TITLE
feat(nuget): Support sourcing release notes from nuspec files

### DIFF
--- a/lib/modules/datasource/nuget/__snapshots__/index.spec.ts.snap
+++ b/lib/modules/datasource/nuget/__snapshots__/index.spec.ts.snap
@@ -211,6 +211,10 @@ exports[`modules/datasource/nuget/index getReleases processes real data (v2) 1`]
 
 exports[`modules/datasource/nuget/index getReleases processes real data (v3) feed is a nuget.org 1`] = `
 {
+  "datasourceProvidedReleaseNotes": "This package includes the NUnit 3 framework assembly, which is referenced by your tests. You will need
+      to install version 3 of the nunit3-console program or a third-party runner that supports NUnit 3 in order to
+      execute tests. Runners intended for use with NUnit 2.x will not run NUnit 3 tests correctly.
+    ",
   "homepage": "https://nunit.org/",
   "registryUrl": "https://api.nuget.org/v3/index.json",
   "releases": [
@@ -402,6 +406,10 @@ exports[`modules/datasource/nuget/index getReleases processes real data (v3) fee
 
 exports[`modules/datasource/nuget/index getReleases processes real data (v3) feed is not a nuget.org 1`] = `
 {
+  "datasourceProvidedReleaseNotes": "This package includes the NUnit 3 framework assembly, which is referenced by your tests. You will need
+        to install version 3 of the nunit3-console program or a third-party runner that supports NUnit 3 in order to
+        execute tests. Runners intended for use with NUnit 2.x will not run NUnit 3 tests correctly.
+      ",
   "registryUrl": "https://myprivatefeed/index.json",
   "releases": [
     {
@@ -591,6 +599,33 @@ exports[`modules/datasource/nuget/index getReleases processes real data (v3) fee
 
 exports[`modules/datasource/nuget/index getReleases processes real data (v3) for several catalog pages 1`] = `
 {
+  "datasourceProvidedReleaseNotes": "## Features
+           - Allow to change the RuleName of a LoggingRule (#4017) (@304NotModified)
+           - logging of AggregrateException.Data to prevent it from losing it after Flatten call (#3974) (@chaos0307)
+
+           ## Bugfixes
+           - LocalIpAddressLayoutRenderer - IsDnsEligible and PrefixOrigin throws PlatformNotSupportedException on Linux
+           (#4011) (@snakefoot)
+
+           ## Improvements
+           - ObjectReflectionCache - Reduce noise from properties that throws exceptions like Stream.ReadTimeout (#4057)
+           (@snakefoot)
+           - MessageTemplates - Changed Literal.Skip to be Int32 to support message templates longer than short.MaxValue
+           (#4053) (@snakefoot)
+           - ObjectReflectionCache - Skip reflection for Stream objects (#4043) (@snakefoot)
+           - LogFactory Shutdown is public so it can be used from NLogLoggerProvider (#3999) (@snakefoot)
+           - Editor config with File header template (#3972) (@304NotModified)
+
+           ## Performance
+           - FileTarget - Skip delegate capture in GetFileCreationTimeSource. Fallback only necessary when appender has been
+           closed. (#4058) (@snakefoot)
+           - ObjectReflectionCache - Reduce initial memory allocation until needed (#4021) (@snakefoot)
+           - FilteringTargetWrapper - Remove delegate allocation (#3977) (@snakefoot)
+
+           Full changelog: https://github.com/NLog/NLog/blob/master/CHANGELOG.md
+
+           For all config options and platform support, check https://nlog-project.org/config/
+         ",
   "homepage": "https://nlog-project.org/",
   "registryUrl": "https://api.nuget.org/v3/index.json",
   "releases": [
@@ -1848,6 +1883,10 @@ exports[`modules/datasource/nuget/index getReleases processes real data without 
 
 exports[`modules/datasource/nuget/index getReleases returns deduplicated results 1`] = `
 {
+  "datasourceProvidedReleaseNotes": "This package includes the NUnit 3 framework assembly, which is referenced by your tests. You will need
+      to install version 3 of the nunit3-console program or a third-party runner that supports NUnit 3 in order to
+      execute tests. Runners intended for use with NUnit 2.x will not run NUnit 3 tests correctly.
+    ",
   "homepage": "https://nunit.org/",
   "releases": [
     {

--- a/lib/modules/datasource/nuget/__snapshots__/index.spec.ts.snap
+++ b/lib/modules/datasource/nuget/__snapshots__/index.spec.ts.snap
@@ -600,32 +600,32 @@ exports[`modules/datasource/nuget/index getReleases processes real data (v3) fee
 exports[`modules/datasource/nuget/index getReleases processes real data (v3) for several catalog pages 1`] = `
 {
   "datasourceProvidedReleaseNotes": "## Features
-           - Allow to change the RuleName of a LoggingRule (#4017) (@304NotModified)
-           - logging of AggregrateException.Data to prevent it from losing it after Flatten call (#3974) (@chaos0307)
+      - Allow to change the RuleName of a LoggingRule (#4017) (@304NotModified)
+      - logging of AggregrateException.Data to prevent it from losing it after Flatten call (#3974) (@chaos0307)
 
-           ## Bugfixes
-           - LocalIpAddressLayoutRenderer - IsDnsEligible and PrefixOrigin throws PlatformNotSupportedException on Linux
-           (#4011) (@snakefoot)
+      ## Bugfixes
+      - LocalIpAddressLayoutRenderer - IsDnsEligible and PrefixOrigin throws PlatformNotSupportedException on Linux
+      (#4011) (@snakefoot)
 
-           ## Improvements
-           - ObjectReflectionCache - Reduce noise from properties that throws exceptions like Stream.ReadTimeout (#4057)
-           (@snakefoot)
-           - MessageTemplates - Changed Literal.Skip to be Int32 to support message templates longer than short.MaxValue
-           (#4053) (@snakefoot)
-           - ObjectReflectionCache - Skip reflection for Stream objects (#4043) (@snakefoot)
-           - LogFactory Shutdown is public so it can be used from NLogLoggerProvider (#3999) (@snakefoot)
-           - Editor config with File header template (#3972) (@304NotModified)
+      ## Improvements
+      - ObjectReflectionCache - Reduce noise from properties that throws exceptions like Stream.ReadTimeout (#4057)
+      (@snakefoot)
+      - MessageTemplates - Changed Literal.Skip to be Int32 to support message templates longer than short.MaxValue
+      (#4053) (@snakefoot)
+      - ObjectReflectionCache - Skip reflection for Stream objects (#4043) (@snakefoot)
+      - LogFactory Shutdown is public so it can be used from NLogLoggerProvider (#3999) (@snakefoot)
+      - Editor config with File header template (#3972) (@304NotModified)
 
-           ## Performance
-           - FileTarget - Skip delegate capture in GetFileCreationTimeSource. Fallback only necessary when appender has been
-           closed. (#4058) (@snakefoot)
-           - ObjectReflectionCache - Reduce initial memory allocation until needed (#4021) (@snakefoot)
-           - FilteringTargetWrapper - Remove delegate allocation (#3977) (@snakefoot)
+      ## Performance
+      - FileTarget - Skip delegate capture in GetFileCreationTimeSource. Fallback only necessary when appender has been
+      closed. (#4058) (@snakefoot)
+      - ObjectReflectionCache - Reduce initial memory allocation until needed (#4021) (@snakefoot)
+      - FilteringTargetWrapper - Remove delegate allocation (#3977) (@snakefoot)
 
-           Full changelog: https://github.com/NLog/NLog/blob/master/CHANGELOG.md
+      Full changelog: https://github.com/NLog/NLog/blob/master/CHANGELOG.md
 
-           For all config options and platform support, check https://nlog-project.org/config/
-         ",
+      For all config options and platform support, check https://nlog-project.org/config/
+    ",
   "homepage": "https://nlog-project.org/",
   "registryUrl": "https://api.nuget.org/v3/index.json",
   "releases": [

--- a/lib/modules/datasource/nuget/__snapshots__/index.spec.ts.snap
+++ b/lib/modules/datasource/nuget/__snapshots__/index.spec.ts.snap
@@ -407,9 +407,9 @@ exports[`modules/datasource/nuget/index getReleases processes real data (v3) fee
 exports[`modules/datasource/nuget/index getReleases processes real data (v3) feed is not a nuget.org 1`] = `
 {
   "datasourceProvidedReleaseNotes": "This package includes the NUnit 3 framework assembly, which is referenced by your tests. You will need
-        to install version 3 of the nunit3-console program or a third-party runner that supports NUnit 3 in order to
-        execute tests. Runners intended for use with NUnit 2.x will not run NUnit 3 tests correctly.
-      ",
+      to install version 3 of the nunit3-console program or a third-party runner that supports NUnit 3 in order to
+      execute tests. Runners intended for use with NUnit 2.x will not run NUnit 3 tests correctly.
+    ",
   "registryUrl": "https://myprivatefeed/index.json",
   "releases": [
     {

--- a/lib/modules/datasource/nuget/index.spec.ts
+++ b/lib/modules/datasource/nuget/index.spec.ts
@@ -611,11 +611,20 @@ describe('modules/datasource/nuget/index', () => {
       httpMock
         .scope('https://api.nuget.org')
         .get('/v3/index.json')
+        .twice()
         .reply(200, nugetIndexV3)
+        .get('/v3/registration5-gz-semver2/nunit/index.json')
+        .reply(200, pkgListV3Registration)
+        .get('/v3-flatcontainer/nunit/3.12.0/nunit.nuspec')
+        .reply(200, pkgInfoV3FromNuget);
       const res = await getPkgReleases({
         ...configV3,
       });
-      expect(res).toBeNull();
+      expect(res.datasourceProvidedReleaseNotes)
+        .toBe(`This package includes the NUnit 3 framework assembly, which is referenced by your tests. You will need
+      to install version 3 of the nunit3-console program or a third-party runner that supports NUnit 3 in order to
+      execute tests. Runners intended for use with NUnit 2.x will not run NUnit 3 tests correctly.
+    `);
     });
 
     it('processes real data (v3) feed is azure devops', async () => {

--- a/lib/modules/datasource/nuget/index.spec.ts
+++ b/lib/modules/datasource/nuget/index.spec.ts
@@ -607,6 +607,17 @@ describe('modules/datasource/nuget/index', () => {
       expect(res?.sourceUrl).toBeDefined();
     });
 
+    it('captures release notes', async () => {
+      httpMock
+        .scope('https://api.nuget.org')
+        .get('/v3/index.json')
+        .reply(200, nugetIndexV3)
+      const res = await getPkgReleases({
+        ...configV3,
+      });
+      expect(res).toBeNull();
+    });
+
     it('processes real data (v3) feed is azure devops', async () => {
       httpMock
         .scope('https://pkgs.dev.azure.com')

--- a/lib/modules/datasource/nuget/v3.ts
+++ b/lib/modules/datasource/nuget/v3.ts
@@ -213,6 +213,7 @@ export class NugetV3Api {
         const metaresult = await http.get(nuspecUrl);
         const nuspec = new XmlDocument(metaresult.body);
         const sourceUrl = nuspec.valueWithPath('metadata.repository@url');
+        dep.datasourceProvidedReleaseNotes = nuspec.valueWithPath('metadata.releaseNotes');
         if (sourceUrl) {
           dep.sourceUrl = massageUrl(sourceUrl);
         }

--- a/lib/modules/datasource/types.ts
+++ b/lib/modules/datasource/types.ts
@@ -69,6 +69,7 @@ export interface Release {
   sourceUrl?: string | undefined;
   sourceDirectory?: string;
   currentAge?: string;
+  datasourceProvidedReleaseNotes?: string | undefined;
 }
 
 export interface ReleaseResult {

--- a/lib/modules/datasource/types.ts
+++ b/lib/modules/datasource/types.ts
@@ -69,7 +69,6 @@ export interface Release {
   sourceUrl?: string | undefined;
   sourceDirectory?: string;
   currentAge?: string;
-  datasourceProvidedReleaseNotes?: string | undefined;
 }
 
 export interface ReleaseResult {
@@ -89,6 +88,7 @@ export interface ReleaseResult {
   replacementVersion?: string;
   lookupName?: string;
   packageScope?: string;
+  datasourceProvidedReleaseNotes?: string | undefined;
 }
 
 export type RegistryStrategy = 'first' | 'hunt' | 'merge';


### PR DESCRIPTION
ℹ️ To be clear, I'm fumbling my way through this one. I'm doing my best to read the docs as I go but this is my first time in this codebase and blunt redirection is absolutely welcome if I'm going against the grain. I don't mind pivoting the PR to adjust; I'll be happy to keep moving it forward.

____

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

(Using this as a mini work tracker; will clean up before moving out of draft status)

* [x] Introduces the concept of `datasourceProvidedReleaseNotes` (open to feedback on name) to capture when a datasource, such as a NuGet package, provides information directly within its data source (nuspec xml file)
* [x] Populates that new field with data from the nuspec xml file where available
* [ ] Falls back to that data for release notes when other sources of release notes are not available.
* [ ] Review docs for possible updates

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->

- #14128

NuGet packages sometimes are not public, but may have release notes contained within their nuspec xml file. My current use case is IronPDF. This is a non-public repository whose public packages contain release notes ([example here](https://www.nuget.org/packages/IronPdf/2024.8.3#releasenotes-body-tab))

We typically want this case to be a fallback when notes would otherwise be unavailable, as oftentimes nuget packages do have public repositories with public releases and release notes, and oftentimes the release notes in a nuspec file are lacking.

<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
