### PR TITLE
refactor: move onboading repo lookup into dedicated function

### DIFF
--- a/lib/workers/repository/onboarding/branch/config.ts
+++ b/lib/workers/repository/onboarding/branch/config.ts
@@ -14,6 +14,7 @@ async function getOnboardingConfig(
 ): Promise<RenovateSharedConfig | undefined> {
   let onboardingConfig = clone(config.onboardingConfig);
 
+  // TODO #22198 fix types
   const foundPreset = await searchDefaultOnboardingPreset(config.repository!);
 
   if (foundPreset) {
@@ -39,7 +40,6 @@ async function searchDefaultOnboardingPreset(
   let foundPreset: string | undefined;
   logger.debug('Checking for a default Renovate preset which can be used.');
 
-  // TODO #22198
   const repoPathParts = repository.split('/');
 
   for (

--- a/lib/workers/repository/onboarding/branch/config.ts
+++ b/lib/workers/repository/onboarding/branch/config.ts
@@ -14,12 +14,33 @@ async function getOnboardingConfig(
 ): Promise<RenovateSharedConfig | undefined> {
   let onboardingConfig = clone(config.onboardingConfig);
 
-  let foundPreset: string | undefined;
+  const foundPreset = await searchDefaultOnboardingPreset(config.repository!);
 
+  if (foundPreset) {
+    logger.debug(`Found preset ${foundPreset} - using it in onboarding config`);
+    onboardingConfig = {
+      $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+      extends: [foundPreset],
+    };
+  } else {
+    // Organization preset did not exist
+    logger.debug(
+      'No default org/owner preset found, so the default onboarding config will be used instead.',
+    );
+  }
+
+  logger.debug({ config: onboardingConfig }, 'onboarding config');
+  return onboardingConfig;
+}
+
+async function searchDefaultOnboardingPreset(
+  repository: string,
+): Promise<string | undefined> {
+  let foundPreset: string | undefined;
   logger.debug('Checking for a default Renovate preset which can be used.');
 
   // TODO #22198
-  const repoPathParts = config.repository!.split('/');
+  const repoPathParts = repository.split('/');
 
   for (
     let index = repoPathParts.length - 1;
@@ -77,21 +98,7 @@ async function getOnboardingConfig(
     }
   }
 
-  if (foundPreset) {
-    logger.debug(`Found preset ${foundPreset} - using it in onboarding config`);
-    onboardingConfig = {
-      $schema: 'https://docs.renovatebot.com/renovate-schema.json',
-      extends: [foundPreset],
-    };
-  } else {
-    // Organization preset did not exist
-    logger.debug(
-      'No default org/owner preset found, so the default onboarding config will be used instead.',
-    );
-  }
-
-  logger.debug({ config: onboardingConfig }, 'onboarding config');
-  return onboardingConfig;
+  return foundPreset;
 }
 
 async function getOnboardingConfigContents(


### PR DESCRIPTION
## Changes

Moves the onboarding repo lookup into a dedicated function to make it possible to have more complex logic in `getOnboardingConfig` without mixing multiple things being done (iterating through the groups, looking for an existing renovate-config repo, ...)

This change was initially part of https://github.com/renovatebot/renovate/pull/30350 and is moved to a separate PR.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
