### PR TITLE
fix: disable docker:pinDigests for ArgoCD

### DIFF
--- a/lib/config/presets/internal/docker.ts
+++ b/lib/config/presets/internal/docker.ts
@@ -43,7 +43,7 @@ export const presets: Record<string, Preset> = {
         pinDigests: true,
       },
       {
-        matchManagers: ['devcontainer', 'pyenv'],
+        matchManagers: ['argocd', 'devcontainer', 'helmv3', 'pyenv'],
         pinDigests: false,
       },
     ],


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This disables Docker digest pinning for the ArgoCD manager in the `docker:pinDigests` preset.

<!-- Describe what behavior is changed by this PR. -->

## Context

The `argocd` manager uses the Docker datasource [only for helm chart target versions](https://github.com/renovatebot/renovate/blob/d7989b0de840074d596fc1784e14e57467cf8a99/lib/modules/manager/argocd/extract.ts#L59-L70).

However, helm does not yet support digest pinning, see

- https://github.com/helm/helm/issues/10312#issuecomment-961396434
- https://github.com/helm/helm/issues/10678

Trying to pin them anyway leads to `WARN: Error updating branch: update failure` warnings from renovate.

The same applies to the `helmv3` manager, when it tries to pin the chart version of an OCI chart in a `Chart.yaml` file.

Because pinning is not supported, pinning digests for helm charts should be disabled in these managers.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

I updated the Anaconda base configuration in https://github.com/anaconda/renovate-config/pull/101 to have the same configuration as this PR, which was successful for our repositories and resolved all `WARN: Error updating branch: update failure` errors.

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
