### PR TITLE
fix(presets): Add typescript-eslint top-level package to eslint preset

### DIFF
--- a/lib/config/presets/__snapshots__/index.spec.ts.snap
+++ b/lib/config/presets/__snapshots__/index.spec.ts.snap
@@ -123,6 +123,7 @@ exports[`config/presets/index resolvePreset resolves eslint 1`] = `
     "@eslint/**",
     "@types/eslint__**",
     "@typescript-eslint/**",
+    "typescript-eslint",
     "eslint**",
   ],
 }
@@ -141,6 +142,7 @@ exports[`config/presets/index resolvePreset resolves linters 1`] = `
     "@eslint/**",
     "@types/eslint__**",
     "@typescript-eslint/**",
+    "typescript-eslint",
     "eslint**",
     "friendsofphp/php-cs-fixer",
     "squizlabs/php_codesniffer",
@@ -174,6 +176,7 @@ exports[`config/presets/index resolvePreset resolves nested groups 1`] = `
         "@eslint/**",
         "@types/eslint__**",
         "@typescript-eslint/**",
+        "typescript-eslint",
         "eslint**",
         "friendsofphp/php-cs-fixer",
         "squizlabs/php_codesniffer",

--- a/lib/config/presets/index.spec.ts
+++ b/lib/config/presets/index.spec.ts
@@ -248,6 +248,7 @@ describe('config/presets/index', () => {
               '@eslint/**',
               '@types/eslint__**',
               '@typescript-eslint/**',
+              'typescript-eslint',
               'eslint**',
             ],
           },
@@ -259,14 +260,14 @@ describe('config/presets/index', () => {
       config.extends = ['packages:eslint'];
       const res = await presets.resolveConfigPresets(config);
       expect(res).toMatchSnapshot();
-      expect(res.matchPackageNames).toHaveLength(7);
+      expect(res.matchPackageNames).toHaveLength(8);
     });
 
     it('resolves linters', async () => {
       config.extends = ['packages:linters'];
       const res = await presets.resolveConfigPresets(config);
       expect(res).toMatchSnapshot();
-      expect(res.matchPackageNames).toHaveLength(17);
+      expect(res.matchPackageNames).toHaveLength(18);
     });
 
     it('resolves nested groups', async () => {
@@ -275,7 +276,7 @@ describe('config/presets/index', () => {
       expect(res).toMatchSnapshot();
       const rule = res.packageRules![0];
       expect(rule.automerge).toBeTrue();
-      expect(rule.matchPackageNames).toHaveLength(17);
+      expect(rule.matchPackageNames).toHaveLength(18);
     });
 
     it('migrates automerge in presets', async () => {

--- a/lib/config/presets/internal/packages.ts
+++ b/lib/config/presets/internal/packages.ts
@@ -29,6 +29,7 @@ export const presets: Record<string, Preset> = {
       '@eslint/**',
       '@types/eslint__**',
       '@typescript-eslint/**',
+      'typescript-eslint',
       'eslint**',
     ],
   },


### PR DESCRIPTION
## Changes

Added the standalone `typescript-eslint` npm package alongside the existing `@typescript-eslint/**` matching rule in the `eslint` preset.

## Context

The `typescript-eslint` project previously only published packages under its scoped namespace (`@typescript-eslint/*`). To make it easier to work with ESLint's new flat config format, the project now publishes a top-level `typescript-eslint` package which wraps the other scoped packages.

[This top-level package](https://typescript-eslint.io/packages/typescript-eslint) is now the default recommended way to install add the project as a dependency. But it's not currently caught by Renovate's `eslint` present, which is only looking for the scoped packages.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
