### PR TITLE
refactor: move cron schedule logging

### DIFF
--- a/lib/workers/repository/update/branch/schedule.spec.ts
+++ b/lib/workers/repository/update/branch/schedule.spec.ts
@@ -409,29 +409,30 @@ describe('workers/repository/update/branch/schedule', () => {
     });
   });
 
-  describe('cronstrue', () => {
-    it('should correctly convert "0 22 4 * *" to human-readable format', () => {
-      const result = cronstrue.toString('0 22 4 * *');
-      expect(result).toBe('At 10:00 PM, on day 4 of the month');
-    });
-
-    it('should correctly convert "*/2 * * * *" to human-readable format', () => {
-      const result = cronstrue.toString('*/2 * * * *');
-      expect(result).toBe('Every 2 minutes');
-    });
-
-    it('should correctly convert "0 23 * * *" to human-readable format', () => {
-      const result = cronstrue.toString('0 23 * * *');
-      expect(result).toBe('At 11:00 PM');
-    });
-
-    it('should throw an error for an invalid cron expression "* * */2 6#1"', () => {
-      const result = cronstrue.toString('* * */2 6#1', {
-        throwExceptionOnParseError: false,
-      });
+  describe('log cron schedules', () => {
+    it('should correctly convert "* 22 4 * *" to human-readable format', () => {
+      const result = cronstrue.toString('* 22 4 * *');
       expect(result).toBe(
-        'An error occured when generating the expression description.  Check the cron expression syntax.',
+        'Every minute, between 10:00 PM and 10:59 PM, on day 4 of the month',
       );
+    });
+
+    it('should correctly convert "* */2 * * *" to human-readable format', () => {
+      const result = cronstrue.toString('* */2 * * *');
+      expect(result).toBe('Every minute, every 2 hours');
+    });
+
+    it('should correctly convert "* 23 * * *" to human-readable format', () => {
+      const result = cronstrue.toString('* 23 * * *');
+      expect(result).toBe('Every minute, between 11:00 PM and 11:59 PM');
+    });
+
+    it('should not throw an error for an invalid cron expression "* * */2 6#1"', () => {
+      expect(() => {
+        cronstrue.toString('* * */2 6#1', {
+          throwExceptionOnParseError: false,
+        });
+      }).not.toThrow();
     });
   });
 });

--- a/lib/workers/repository/update/branch/schedule.ts
+++ b/lib/workers/repository/update/branch/schedule.ts
@@ -26,10 +26,6 @@ function parseCron(
   timezone?: string,
 ): CronExpression | undefined {
   try {
-    const cronScheduleSummary = cronstrue.toString(scheduleText, {
-      throwExceptionOnParseError: false,
-    });
-    logger.debug(`Human-readable summary for cron:: ${cronScheduleSummary}`);
     return parseExpression(scheduleText, { tz: timezone });
   } catch (err) {
     return undefined;
@@ -203,6 +199,10 @@ export function isScheduledNow(
   const isWithinSchedule = configSchedule.some((scheduleText) => {
     const cronSchedule = parseCron(scheduleText);
     if (cronSchedule) {
+      const cronScheduleSummary = cronstrue.toString(scheduleText, {
+        throwExceptionOnParseError: false,
+      });
+      logger.debug(`Human-readable summary for cron:: ${cronScheduleSummary}`);
       // We have Cron syntax
       if (cronMatches(scheduleText, now, config.timezone)) {
         logger.debug(`Matches schedule ${scheduleText}`);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- move cron schedule summary logging inside `isScheduleNow` & only log if syntax is cron
- use * for minutes in test and fix a test
<!-- Describe what behavior is changed by this PR. -->

## Context
https://github.com/renovatebot/renovate/pull/30472#discussion_r1701652174
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
