### PR TITLE
feat(preset): add `phpstan/extension-installer` to PHPStan group

### DIFF
--- a/lib/config/presets/internal/group.ts
+++ b/lib/config/presets/internal/group.ts
@@ -354,7 +354,12 @@ const staticGroups = {
       {
         groupName: 'PHPStan packages',
         matchDatasources: ['packagist'],
-        matchPackageNames: ['phpstan/phpstan', '//phpstan-/', '//larastan/', 'phpstan/extension-installer'],
+        matchPackageNames: [
+          'phpstan/phpstan',
+          '//phpstan-/',
+          '//larastan/',
+          'phpstan/extension-installer',
+        ],
       },
     ],
   },

--- a/lib/config/presets/internal/group.ts
+++ b/lib/config/presets/internal/group.ts
@@ -354,7 +354,7 @@ const staticGroups = {
       {
         groupName: 'PHPStan packages',
         matchDatasources: ['packagist'],
-        matchPackageNames: ['phpstan/phpstan', '//phpstan-/', '//larastan/'],
+        matchPackageNames: ['phpstan/phpstan', '//phpstan-/', '//larastan/', 'phpstan/extension-installer'],
       },
     ],
   },


### PR DESCRIPTION
## Changes

Add `phpstan/extension-installer` to PHPStan group

## Context

As PHPStan extensions are part of the group it makes sense to also include the extension installer itself in this group.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
