### PR TITLE
docs(docker): add ghworkflows example for GAR with Workload Identity

### DIFF
--- a/docs/usage/docker.md
+++ b/docs/usage/docker.md
@@ -281,16 +281,17 @@ To make use of this authentication mechanism, specify the username as `AWS`:
 
 ##### Using Workload Identity
 
-[Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) has to be configured and the Service Account needs `artifactregistry.repositories.downloadArtifacts` permission.
+[Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) must be configured and the Service Account must have the `artifactregistry.repositories.downloadArtifacts` permission.
 
 ###### With Application Default Credentials (Self-Hosted only)
 
-Just configure [ADC](https://cloud.google.com/docs/authentication/provide-credentials-adc) as normal and _don't_ provide a username, password or token.
-Renovate will automatically retrieve the credentials using the google-auth-library.
+Configure [ADC](https://cloud.google.com/docs/authentication/provide-credentials-adc) as normal.
+Do not provide a username, password or token.
+Renovate will get the credentials with the [`google-auth-library`](https://www.npmjs.com/package/google-auth-library).
 
 ###### With short-lived access token / GitHub Actions (Self-hosted only)
 
-Below you find the example configuration for both Workload Identity and the Renovate Host rules. For a full GitHub Workflow example see [renovatebot/github-action](https://github.com/renovatebot/github-action) repo.
+Example configuration for Workload Identity and Renovate's host rules:
 
 ```yaml
 - name: authenticate to google cloud
@@ -317,6 +318,8 @@ Below you find the example configuration for both Workload Identity and the Reno
     token: ${{ secrets.RENOVATE_TOKEN }}
     configurationFile: .github/renovate.json5
 ```
+
+You can find a full GitHub Workflow example on the [renovatebot/github-action](https://github.com/renovatebot/github-action) repository.
 
 ##### Using long-lived service account credentials
 

--- a/docs/usage/docker.md
+++ b/docs/usage/docker.md
@@ -281,19 +281,23 @@ To make use of this authentication mechanism, specify the username as `AWS`:
 
 ##### Using Workload Identity
 
-[Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) must be configured and the Service Account must have the `artifactregistry.repositories.downloadArtifacts` permission.
+To let Renovate authenticate with [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity), you must:
 
-###### With Application Default Credentials (Self-Hosted only)
+- Configure Workload Identity
+- Give the Service Account the `artifactregistry.repositories.downloadArtifacts` permission
 
-Configure [ADC](https://cloud.google.com/docs/authentication/provide-credentials-adc) as normal.
-Do not provide a username, password or token.
+###### With Application Default Credentials (self-hosted only)
+
+To let Renovate authenticate with [ADC](https://cloud.google.com/docs/authentication/provide-credentials-adc), you must:
+
+- Configure ADC as normal
+- _Not_ provide a username, password or token
+
 Renovate will get the credentials with the [`google-auth-library`](https://www.npmjs.com/package/google-auth-library).
 
-###### With short-lived access token / GitHub Actions (Self-hosted only)
+###### With short-lived access token / GitHub Actions (self-hosted only)
 
-Example configuration for Workload Identity and Renovate's host rules:
-
-```yaml
+```yaml title="Example for Workload Identity plus Renovate host rules"
 - name: authenticate to google cloud
   id: auth
   uses: google-github-actions/auth@v2.1.3

--- a/docs/usage/docker.md
+++ b/docs/usage/docker.md
@@ -293,29 +293,29 @@ Renovate will automatically retrieve the credentials using the google-auth-libra
 Below you find the example configuration for both Workload Identity and the Renovate Host rules. For a full GitHub Workflow example see [renovatebot/github-action](https://github.com/renovatebot/github-action) repo.
 
 ```yaml
-      - name: authenticate to google cloud
-        id: auth
-        uses: google-github-actions/auth@v2.1.3
-        with:
-          token_format: "access_token"
-          workload_identity_provider: ${{ env.WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ env.SERVICE_ACCOUNT }}
+- name: authenticate to google cloud
+  id: auth
+  uses: google-github-actions/auth@v2.1.3
+  with:
+    token_format: 'access_token'
+    workload_identity_provider: ${{ env.WORKLOAD_IDENTITY_PROVIDER }}
+    service_account: ${{ env.SERVICE_ACCOUNT }}
 
-      - name: renovate
-        uses: renovatebot/github-action@v40.2.4
-        env:
-          RENOVATE_HOST_RULES: |
-            [
-              {
-                matchHost: "us-central1-docker.pkg.dev",
-                hostType: "docker",
-                username: "oauth2accesstoken",
-                password: "${{ steps.auth.outputs.access_token }}"
-              }
-            ]
-        with:
-          token: ${{ secrets.RENOVATE_TOKEN }}
-          configurationFile: .github/renovate.json5
+- name: renovate
+  uses: renovatebot/github-action@v40.2.4
+  env:
+    RENOVATE_HOST_RULES: |
+      [
+        {
+          matchHost: "us-central1-docker.pkg.dev",
+          hostType: "docker",
+          username: "oauth2accesstoken",
+          password: "${{ steps.auth.outputs.access_token }}"
+        }
+      ]
+  with:
+    token: ${{ secrets.RENOVATE_TOKEN }}
+    configurationFile: .github/renovate.json5
 ```
 
 ##### Using long-lived service account credentials


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

update documentation to show a proper example of docker data source configuration with GitHub workflows, workload identity and Google artifact registry.

## Context

https://github.com/renovatebot/renovate/discussions/29618#discussioncomment-9761641

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
