### PR TITLE
fix(manager/copier): process update templates outside repository root

### DIFF
--- a/lib/modules/manager/copier/artifacts.spec.ts
+++ b/lib/modules/manager/copier/artifacts.spec.ts
@@ -120,7 +120,7 @@ describe('modules/manager/copier/artifacts', () => {
           cmd: 'copier update --skip-answered --defaults --answers-file .copier-answers.yml --vcs-ref 1.1.0',
         },
       ]);
-      expect(execSnapshots[0].options?.cwd).toBe('.');
+      expect(execSnapshots[0].options?.cwd).toBe('/tmp/github/some/repo');
     });
 
     it('invokes copier update with nested destination and answer file', async () => {
@@ -138,7 +138,9 @@ describe('modules/manager/copier/artifacts', () => {
           cmd: 'copier update --skip-answered --defaults --answers-file .copier-answers.yml --vcs-ref 1.1.0',
         },
       ]);
-      expect(execSnapshots[0].options?.cwd).toBe('apps/my-app');
+      expect(execSnapshots[0].options?.cwd).toBe(
+        '/tmp/github/some/repo/apps/my-app',
+      );
     });
 
     it.each`

--- a/lib/modules/manager/copier/artifacts.spec.ts
+++ b/lib/modules/manager/copier/artifacts.spec.ts
@@ -118,9 +118,11 @@ describe('modules/manager/copier/artifacts', () => {
       expect(execSnapshots).toMatchObject([
         {
           cmd: 'copier update --skip-answered --defaults --answers-file .copier-answers.yml --vcs-ref 1.1.0',
+          options: {
+            cwd: '/tmp/github/some/repo',
+          },
         },
       ]);
-      expect(execSnapshots[0].options?.cwd).toBe('/tmp/github/some/repo');
     });
 
     it('invokes copier update with nested destination and answer file', async () => {
@@ -136,11 +138,11 @@ describe('modules/manager/copier/artifacts', () => {
       expect(execSnapshots).toMatchObject([
         {
           cmd: 'copier update --skip-answered --defaults --answers-file .copier-answers.yml --vcs-ref 1.1.0',
+          options: {
+            cwd: '/tmp/github/some/repo/apps/my-app',
+          },
         },
       ]);
-      expect(execSnapshots[0].options?.cwd).toBe(
-        '/tmp/github/some/repo/apps/my-app',
-      );
     });
 
     it.each`

--- a/lib/modules/manager/copier/artifacts.spec.ts
+++ b/lib/modules/manager/copier/artifacts.spec.ts
@@ -120,6 +120,7 @@ describe('modules/manager/copier/artifacts', () => {
           cmd: 'copier update --skip-answered --defaults --answers-file .copier-answers.yml --vcs-ref 1.1.0',
         },
       ]);
+      expect(execSnapshots[0].options?.cwd).toBe('.');
     });
 
     it('invokes copier update with nested destination and answer file', async () => {
@@ -137,7 +138,7 @@ describe('modules/manager/copier/artifacts', () => {
           cmd: 'copier update --skip-answered --defaults --answers-file .copier-answers.yml --vcs-ref 1.1.0',
         },
       ]);
-      // test the cwd where the command was executed
+      expect(execSnapshots[0].options?.cwd).toBe('apps/my-app');
     });
 
     it.each`

--- a/lib/modules/manager/copier/artifacts.spec.ts
+++ b/lib/modules/manager/copier/artifacts.spec.ts
@@ -122,6 +122,23 @@ describe('modules/manager/copier/artifacts', () => {
       ]);
     });
 
+    it('invokes copier update with nested destination and answer file', async () => {
+      const execSnapshots = mockExecAll();
+
+      await updateArtifacts({
+        packageFileName: 'apps/my-app/.copier-answers.yml',
+        updatedDeps: upgrades,
+        newPackageFileContent: '',
+        config: {},
+      });
+
+      expect(execSnapshots).toMatchObject([
+        {
+          cmd: 'copier update --skip-answered --defaults --answers-file .copier-answers.yml --vcs-ref 1.1.0 apps/my-app',
+        },
+      ]);
+    });
+
     it.each`
       pythonConstraint | copierConstraint
       ${null}          | ${null}

--- a/lib/modules/manager/copier/artifacts.spec.ts
+++ b/lib/modules/manager/copier/artifacts.spec.ts
@@ -134,9 +134,10 @@ describe('modules/manager/copier/artifacts', () => {
 
       expect(execSnapshots).toMatchObject([
         {
-          cmd: 'copier update --skip-answered --defaults --answers-file .copier-answers.yml --vcs-ref 1.1.0 apps/my-app',
+          cmd: 'copier update --skip-answered --defaults --answers-file .copier-answers.yml --vcs-ref 1.1.0',
         },
       ]);
+      // test the cwd where the command was executed
     });
 
     it.each`

--- a/lib/modules/manager/copier/artifacts.ts
+++ b/lib/modules/manager/copier/artifacts.ts
@@ -1,5 +1,5 @@
 import { quote } from 'shlex';
-import { basename, dirname } from 'upath';
+import upath from 'upath';
 import { GlobalConfig } from '../../../config/global';
 import { logger } from '../../../logger';
 import { exec } from '../../../util/exec';
@@ -29,7 +29,7 @@ function buildCommand(
   }
   command.push(
     '--answers-file',
-    quote(basename(packageFileName)),
+    quote(upath.basename(packageFileName)),
     '--vcs-ref',
     quote(newVersion),
   );
@@ -73,7 +73,7 @@ export async function updateArtifacts({
 
   const command = buildCommand(config, packageFileName, newVersion);
   const execOptions: ExecOptions = {
-    cwd: dirname(packageFileName),
+    cwd: upath.dirname(packageFileName),
     docker: {},
     userConfiguredEnv: config.env,
     toolConstraints: [

--- a/lib/modules/manager/copier/artifacts.ts
+++ b/lib/modules/manager/copier/artifacts.ts
@@ -26,12 +26,29 @@ function buildCommand(
   if (GlobalConfig.get('allowScripts') && !config.ignoreScripts) {
     command.push('--trust');
   }
+  let destination: string;
+  let answersFile: string;
+  // Check if there is a separator in packageFileName
+  const lastSeparatorIndex = packageFileName.lastIndexOf('/');
+  if (lastSeparatorIndex === -1) {
+    // No separator found
+    destination = "";
+    answersFile = packageFileName;
+  } else {
+    // Separator found, split into destination and answersFile
+    destination = packageFileName.slice(0, lastSeparatorIndex);
+    answersFile = packageFileName.slice(lastSeparatorIndex + 1);
+  }
   command.push(
     '--answers-file',
-    quote(packageFileName),
+    quote(answersFile),
     '--vcs-ref',
-    quote(newVersion),
+    quote(newVersion)
   );
+  // Only push destination if it is not an empty string
+  if (destination) {
+    command.push(quote(destination));
+  }
   return command.join(' ');
 }
 

--- a/lib/modules/manager/copier/artifacts.ts
+++ b/lib/modules/manager/copier/artifacts.ts
@@ -31,7 +31,7 @@ function buildCommand(
     '--answers-file',
     quote(basename(packageFileName)),
     '--vcs-ref',
-    quote(newVersion)
+    quote(newVersion),
   );
   return command.join(' ');
 }

--- a/lib/modules/manager/copier/artifacts.ts
+++ b/lib/modules/manager/copier/artifacts.ts
@@ -73,7 +73,7 @@ export async function updateArtifacts({
 
   const command = buildCommand(config, packageFileName, newVersion);
   const execOptions: ExecOptions = {
-    cwd: upath.dirname(packageFileName),
+    cwdFile: packageFileName,
     docker: {},
     userConfiguredEnv: config.env,
     toolConstraints: [

--- a/lib/modules/manager/copier/artifacts.ts
+++ b/lib/modules/manager/copier/artifacts.ts
@@ -45,7 +45,7 @@ function buildCommand(
     '--vcs-ref',
     quote(newVersion)
   );
-  // Only push destination if it is not an empty string
+  // Only push to destination if the string has content
   if (destination) {
     command.push(quote(destination));
   }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

I fixed the behavior described in #30684 where the update from a copier dependency takes place in the wrong path. I changed the function where the `copier update` command is created. I split up the path to the `.copier-answers` file give with `packageFileName` at the last separator and use the path to the answer file as destination and the last part as name for the `copy-answers` file

## Context

#30684 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
