### PR TITLE
fix(platform/gerrit): URI encode branch in gerrit's getFile()

### DIFF
--- a/lib/modules/platform/gerrit/client.spec.ts
+++ b/lib/modules/platform/gerrit/client.spec.ts
@@ -415,11 +415,11 @@ describe('modules/platform/gerrit/client', () => {
       httpMock
         .scope(gerritEndpointUrl)
         .get(
-          '/a/projects/test%2Frepo/branches/main/files/renovate.json/content',
+          '/a/projects/test%2Frepo/branches/base%2Fbranch/files/renovate.json/content',
         )
         .reply(200, gerritFileResponse('{}'));
       await expect(
-        client.getFile('test/repo', 'main', 'renovate.json'),
+        client.getFile('test/repo', 'base/branch', 'renovate.json'),
       ).resolves.toBe('{}');
     });
   });

--- a/lib/modules/platform/gerrit/client.ts
+++ b/lib/modules/platform/gerrit/client.ts
@@ -195,7 +195,7 @@ class GerritClient {
     const base64Content = await this.gerritHttp.get(
       `a/projects/${encodeURIComponent(
         repo,
-      )}/branches/${branch}/files/${encodeURIComponent(fileName)}/content`,
+      )}/branches/${encodeURIComponent(branch)}/files/${encodeURIComponent(fileName)}/content`,
     );
     return Buffer.from(base64Content.body, 'base64').toString();
   }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

gerrit's `client.ts` now properly URI encodes the branch name, making it possible to for example use base branches containing slashes with gerrit.

## Context

I was unable to use renovate with gerrit and a base branch containing a slash.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
