### PR TITLE
feat(preset): Add monorepo group for 'rust-analyzer' crates

### DIFF
--- a/lib/data/monorepo.json
+++ b/lib/data/monorepo.json
@@ -440,6 +440,7 @@
     "retrofit": "https://github.com/square/retrofit",
     "rjsf": "https://github.com/rjsf-team/react-jsonschema-form",
     "router5": "https://github.com/router5/router5",
+    "rust-analyzer": "https://github.com/rust-lang/rust-analyzer",
     "rust-futures": "https://github.com/rust-lang/futures-rs",
     "rust-wasm-bindgen": "https://github.com/rustwasm/wasm-bindgen",
     "sanity": "https://github.com/sanity-io/sanity",


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This PR adds a monorepo group for the "rust-analyzer" library crates:

```json
{
  "repoGroups": {
    ...
    "rust-analyzer": "https://github.com/rust-lang/rust-analyzer",
    ...
  }
}
```

<!-- Describe what behavior is changed by this PR. -->

## Context

The [rust-lang](https://www.rust-lang.org) devs publish the library crates powering Rust's official LSP client ['rust-analyzer'](https://github.com/rust-lang/rust-analyzer/) on a weekly schedule (having reached v0.0.228 this week), where internal crate dependencies are always pinned.

They always get updated altogether and depend on each other via version pinning, so it only ever makes sense to update them in a single swoop, or not at all.

The use of pre-stable 1.0 patch versioning (`0.0.x`) also seems to make renovatebot not consider them breaking changes (it just marks them as `patch`), even though point 4 of the SemVer 2.0 spec defines all `0.x.y` updates as non-stable ("4) Major version zero (0.y.z) is for initial development. Anything MAY change at any time. The public API SHOULD NOT be considered stable.").

Given their pinned inter-dependencies and their tendency to occasionally introduce breaking changes (as they are published but with no guarantee of stability, irregardless of the version) makes having rust-analyzer's library crates grouped in a separate PR pretty much a requirement for a smooth update workflow with renovatebot.

As such it would be nice to have them grouped as part of the default presets.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

Until recently the crates were missing a `profile.repository` in their `Cargo.toml` manifest files, thus requiring one to match on `"matchPackagePatterns": ["^ra_ap_"]`, but I recently got a [PR merged](https://github.com/rust-lang/rust-analyzer/pull/17745) that fixes this, allowing for `"matchSourceUrls": ["https://github.com/rust-lang/rust-analyzer"]`.

A test project showing the following config in action and working (see the open [pull requests](https://github.com/regexident/renovate-test/pulls)) can be found at https://github.com/regexident/renovate-test:

```json
{
  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
  "extends": ["config:recommended"],
  "packageRules": [
    {
      "matchPackagePatterns": ["*"],
      "rangeStrategy": "update-lockfile"
    },
    {
      "groupName": "other dependencies",
      "groupSlug": "other",
      "matchPackagePatterns": ["*"],
      "separateMajorMinor": true
    },
    {
      "groupName": "rust-analyzer dependencies",
      "groupSlug": "rust-analyzer",
      "matchSourceUrls": ["https://github.com/rust-lang/rust-analyzer"],
      "separateMajorMinor": true,
      "separateMultipleMajor": true
    }
  ]
}
```

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
