### PR TITLE
feat(manager/bundler): improve ruby version detection

### DIFF
--- a/lib/modules/manager/bundler/artifacts.spec.ts
+++ b/lib/modules/manager/bundler/artifacts.spec.ts
@@ -126,7 +126,9 @@ describe('modules/manager/bundler/artifacts', () => {
 
     it('works for default binarySource', async () => {
       fs.readLocalFile.mockResolvedValueOnce('Current Gemfile.lock');
-      fs.readLocalFile.mockResolvedValueOnce(null);
+      fs.readLocalFile.mockResolvedValueOnce(null); // .ruby-version
+      fs.readLocalFile.mockResolvedValueOnce(null); // .tool-versions
+      fs.readLocalFile.mockResolvedValueOnce(null); // Gemfile.lock
       const execSnapshots = mockExecAll();
       git.getRepoStatus.mockResolvedValueOnce(
         partial<StatusResult>({
@@ -150,7 +152,9 @@ describe('modules/manager/bundler/artifacts', () => {
     it('works explicit global binarySource', async () => {
       GlobalConfig.set({ ...adminConfig, binarySource: 'global' });
       fs.readLocalFile.mockResolvedValueOnce('Current Gemfile.lock');
-      fs.readLocalFile.mockResolvedValueOnce(null);
+      fs.readLocalFile.mockResolvedValueOnce(null); // .ruby-version
+      fs.readLocalFile.mockResolvedValueOnce(null); // .tool-versions
+      fs.readLocalFile.mockResolvedValueOnce(null); // Gemfile.lock
       const execSnapshots = mockExecAll();
       git.getRepoStatus.mockResolvedValueOnce(
         partial<StatusResult>({
@@ -173,7 +177,9 @@ describe('modules/manager/bundler/artifacts', () => {
 
     it('supports conservative mode and updateType option', async () => {
       fs.readLocalFile.mockResolvedValueOnce('Current Gemfile.lock');
-      fs.readLocalFile.mockResolvedValueOnce(null);
+      fs.readLocalFile.mockResolvedValueOnce(null); // .ruby-version
+      fs.readLocalFile.mockResolvedValueOnce(null); // .tool-versions
+      fs.readLocalFile.mockResolvedValueOnce(null); // Gemfile.lock
       const execSnapshots = mockExecAll();
       git.getRepoStatus.mockResolvedValueOnce(
         partial<StatusResult>({

--- a/lib/modules/manager/bundler/artifacts.spec.ts
+++ b/lib/modules/manager/bundler/artifacts.spec.ts
@@ -128,6 +128,7 @@ describe('modules/manager/bundler/artifacts', () => {
       fs.readLocalFile.mockResolvedValueOnce('Current Gemfile.lock');
       fs.readLocalFile.mockResolvedValueOnce(null); // .ruby-version
       fs.readLocalFile.mockResolvedValueOnce(null); // .tool-versions
+      fs.localPathExists.mockResolvedValueOnce(true); // Gemfile.lock
       fs.readLocalFile.mockResolvedValueOnce(null); // Gemfile.lock
       const execSnapshots = mockExecAll();
       git.getRepoStatus.mockResolvedValueOnce(
@@ -154,6 +155,7 @@ describe('modules/manager/bundler/artifacts', () => {
       fs.readLocalFile.mockResolvedValueOnce('Current Gemfile.lock');
       fs.readLocalFile.mockResolvedValueOnce(null); // .ruby-version
       fs.readLocalFile.mockResolvedValueOnce(null); // .tool-versions
+      fs.localPathExists.mockResolvedValueOnce(true); // Gemfile.lock
       fs.readLocalFile.mockResolvedValueOnce(null); // Gemfile.lock
       const execSnapshots = mockExecAll();
       git.getRepoStatus.mockResolvedValueOnce(
@@ -179,6 +181,7 @@ describe('modules/manager/bundler/artifacts', () => {
       fs.readLocalFile.mockResolvedValueOnce('Current Gemfile.lock');
       fs.readLocalFile.mockResolvedValueOnce(null); // .ruby-version
       fs.readLocalFile.mockResolvedValueOnce(null); // .tool-versions
+      fs.localPathExists.mockResolvedValueOnce(true); // Gemfile.lock
       fs.readLocalFile.mockResolvedValueOnce(null); // Gemfile.lock
       const execSnapshots = mockExecAll();
       git.getRepoStatus.mockResolvedValueOnce(

--- a/lib/modules/manager/bundler/common.spec.ts
+++ b/lib/modules/manager/bundler/common.spec.ts
@@ -68,7 +68,7 @@ describe('modules/manager/bundler/common', () => {
       expect(version).toBe('2.1.0');
     });
 
-    it('extracts from lockfile', async () => {
+    it('extracts from gemfile', async () => {
       const config = partial<UpdateArtifact>({
         packageFileName: 'Gemfile',
         newPackageFileContent: gemfile,
@@ -84,9 +84,37 @@ describe('modules/manager/bundler/common', () => {
         newPackageFileContent: '',
         config: {},
       });
-      fs.readLocalFile.mockResolvedValueOnce('ruby-1.2.3');
+      fs.readLocalFile.mockResolvedValueOnce('2.7.8');
       const version = await getRubyConstraint(config);
-      expect(version).toBe('1.2.3');
+      expect(version).toBe('2.7.8');
+    });
+
+    it('extracts from .tool-versions', async () => {
+      const config = partial<UpdateArtifact>({
+        packageFileName: 'Gemfile',
+        newPackageFileContent: '',
+        config: {},
+      });
+      fs.readLocalFile
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce('python\t3.8.10\nruby\t3.3.4\n');
+      const version = await getRubyConstraint(config);
+      expect(version).toBe('3.3.4');
+    });
+
+    it('extracts from lockfile', async () => {
+      const config = partial<UpdateArtifact>({
+        packageFileName: 'Gemfile',
+        newPackageFileContent: '',
+        config: {},
+      });
+      fs.localPathExists.mockResolvedValueOnce(true);
+      fs.readLocalFile
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(Fixtures.get('Gemfile.rubyci.lock'));
+      const version = await getRubyConstraint(config);
+      expect(version).toBe('2.6.5');
     });
 
     it('returns null', async () => {

--- a/lib/modules/manager/bundler/common.ts
+++ b/lib/modules/manager/bundler/common.ts
@@ -34,17 +34,24 @@ export async function getRubyConstraint(
       logger.debug('Using ruby version from gemfile');
       return rubyMatch;
     }
-    const rubyVersionFile = getSiblingFileName(
-      packageFileName,
-      '.ruby-version',
-    );
-    const rubyVersionFileContent = await readLocalFile(rubyVersionFile, 'utf8');
-    if (rubyVersionFileContent) {
-      logger.debug('Using ruby version specified in .ruby-version');
-      return rubyVersionFileContent
-        .replace(regEx(/^ruby-/), '')
-        .replace(regEx(/\n/g), '')
-        .trim();
+    for (const file of ['.ruby-version', '.tool-versions']) {
+      const rubyVersion = (
+        await readLocalFile(getSiblingFileName(packageFileName, file), 'utf8')
+      )?.match(/^(?:ruby(?:-|\s+))?(\d[\d.]*)/m)?.[1];
+      if (rubyVersion) {
+        logger.debug(`Using ruby version specified in ${file}`);
+        return rubyVersion;
+      }
+    }
+    const lockFile = await getLockFilePath(packageFileName);
+    if (lockFile) {
+      const rubyVersion = (await readLocalFile(lockFile, 'utf8'))?.match(
+        /^ {3}ruby (\d[\d.]*)(?:[a-z]|\s|$)/m,
+      )?.[1];
+      if (rubyVersion) {
+        logger.debug(`Using ruby version specified in lock file`);
+        return rubyVersion;
+      }
     }
   }
   return null;

--- a/lib/modules/manager/bundler/common.ts
+++ b/lib/modules/manager/bundler/common.ts
@@ -46,7 +46,7 @@ export async function getRubyConstraint(
     const lockFile = await getLockFilePath(packageFileName);
     if (lockFile) {
       const rubyVersion = (await readLocalFile(lockFile, 'utf8'))?.match(
-        /^ {3}ruby (\d[\d.]*)(?:[a-z]|\s|$)/m,
+        regEx(/^ {3}ruby (\d[\d.]*)(?:[a-z]|\s|$)/m),
       )?.[1];
       if (rubyVersion) {
         logger.debug(`Using ruby version specified in lock file`);

--- a/lib/modules/manager/bundler/common.ts
+++ b/lib/modules/manager/bundler/common.ts
@@ -37,7 +37,7 @@ export async function getRubyConstraint(
     for (const file of ['.ruby-version', '.tool-versions']) {
       const rubyVersion = (
         await readLocalFile(getSiblingFileName(packageFileName, file), 'utf8')
-      )?.match(/^(?:ruby(?:-|\s+))?(\d[\d.]*)/m)?.[1];
+      )?.match(regEx(/^(?:ruby(?:-|\s+))?(\d[\d.]*)/m))?.[1];
       if (rubyVersion) {
         logger.debug(`Using ruby version specified in ${file}`);
         return rubyVersion;


### PR DESCRIPTION
## Changes

This PR adds support for reading ruby version from `.tool-versions` in addition to `.ruby-version`, and implements the fallback to reading the currently used ruby version from `Gemfile.lock` when every method fails.

## Context

The bundler manager currently only supports `Gemfile` and `.ruby-version` as the only sources of the ruby version constraints.

Nowadays, asdf and mise have been increasingly adopted as the ruby version manager, and they use `.tool-versions` instead of `.ruby-version`.

`Gemfile` recently added support for specifying the ruby version via file name (https://bundler.io/guides/gemfile_ruby.html) which eliminates literal version constraints from `Gemfile`.

As a result, if a project has `.tool-versions` and uses it in `Gemfile` (`ruby file: ".tool-versions"`) Renovate cannot detect the ruby version correctly and ends up installing the latest stable version of ruby to update gems, which may cause unwanted updates and build failures.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
