### PR TITLE
docs(contributing): improve instructions for batch applying review suggestions

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -71,7 +71,7 @@ And some options:
 Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again.
 This makes it harder for us to review your work because we don't know what has changed.
 PRs will always be squashed by us when we merge your work.
-Commit as many times as you need in your pull request branch.
+Commit as many times as you need in your pull request branch, but please batch apply review suggestions.
 
 If you're updating your PR branch from within the GitHub PR interface, use the default "Update branch" button.
 This is the "Update with merge commit" option in the dropdown.
@@ -83,7 +83,8 @@ Force pushing a PR, or using the "Update with rebase" button is OK when you:
 
 ## Apply maintainer provided review suggestions
 
-Maintainers can suggest changes while reviewing your pull request, please follow these steps to apply them:
+Maintainers can suggest changes while reviewing your pull request.
+To apply these suggestions, please:
 
 1. Batch the suggestions into a logical group by selecting the **Add suggestion to batch** button
 1. Select the **Commit suggestions** button


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- You can "commit as often as you want", but we still want you to batch apply review suggestions
- Small rewrite of the section about applying review suggestions

## Context

A new contributor read "commit as often" to also mean one commit per review suggestion:

- https://github.com/renovatebot/renovate/pull/30799#issuecomment-2293442901

So I'm improving the instructions in the docs. :smile: 

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
