### PR TITLE
docs: workaround nested list format conflict

### DIFF
--- a/lib/modules/manager/conan/readme.md
+++ b/lib/modules/manager/conan/readme.md
@@ -7,11 +7,17 @@ Renovate can upgrade dependencies in `conanfile.txt` or `conanfile.py` files.
 
 How it works:
 
+<!--
+  TODO: remove ignore
+  prettier & markdownlint conflicting nested list format
+  see: https://github.com/renovatebot/renovate/pull/30608
+-->
+<!-- prettier-ignore -->
 1. Renovate searches in each repository for any `conanfile.txt` or `conanfile.py` file
 1. Renovate extracts existing dependencies from:
-   - the `[requires]` and `[build_requires]` sections in the `conanfile.txt` format
-   - the `requirements()` and `build_requirements()` functions in the `conanfile.py` format
-   - and the `python_requires`, `requires` and `build_requires` variables in the `conanfile.py` format
+    - the `[requires]` and `[build_requires]` sections in the `conanfile.txt` format
+    - the `requirements()` and `build_requirements()` functions in the `conanfile.py` format
+    - and the `python_requires`, `requires` and `build_requires` variables in the `conanfile.py` format
 1. Renovate resolves the dependency's version using the Conan v2 API
 1. If Renovate finds an update, Renovate will update `conanfile.txt` or `conanfile.py`
 

--- a/lib/modules/manager/gleam/readme.md
+++ b/lib/modules/manager/gleam/readme.md
@@ -15,6 +15,11 @@ The `gleam` manager, however, uses `gleam` itself to keep `manifest.toml` up-to-
 
 Renovate's `"auto"` strategy defaults to `"widen"` and works like this for `gleam`:
 
+<!--
+  TODO: remove ignore
+  prettier & markdownlint conflicting nested list format
+  see: https://github.com/renovatebot/renovate/pull/30608
+-->
 <!-- prettier-ignore -->
 1. If an existing range is a complex range (contains multiple range specifications), Renovate widens it to include the new version.
     - Example: `>= 0.14.0 and < 0.15.0` becomes `>= 0.14.0 and < 0.16.1` for a new `0.16.0` version.

--- a/lib/modules/manager/gomod/readme.md
+++ b/lib/modules/manager/gomod/readme.md
@@ -2,8 +2,14 @@
 
 You might be interested in the following `postUpdateOptions`:
 
+<!--
+  TODO: remove ignore
+  prettier & markdownlint conflicting nested list format
+  see: https://github.com/renovatebot/renovate/pull/30608
+-->
+<!-- prettier-ignore -->
 1. `gomodTidy` - if you'd like Renovate to run `go mod tidy` after every update before raising the PR
-   1. This is implicitly enabled for major updates if the user has enabled the option `gomodUpdateImportPaths`
+    1. This is implicitly enabled for major updates if the user has enabled the option `gomodUpdateImportPaths`
 1. `gomodTidy1.17` - if you'd like Renovate to run `go mod tidy -compat=1.17` after every update before raising the PR
 1. `gomodTidyE` - if you'd like Renovate to run `go mod tidy -e` after every update before raising the PR
 1. `gomodUpdateImportPaths` - if you'd like Renovate to update your source import paths on major updates before raising the PR

--- a/lib/modules/platform/codecommit/readme.md
+++ b/lib/modules/platform/codecommit/readme.md
@@ -16,11 +16,16 @@
 
 #### Machine pre-requisites
 
+<!--
+  TODO: remove ignore
+  prettier & markdownlint conflicting nested list format
+  see: https://github.com/renovatebot/renovate/pull/30608
+-->
+<!-- prettier-ignore -->
 1. Install the `aws-cli` program on the machine.
 2. Set up the environment with the `git-credentials-helper`:
-
-   - For EC2 or Linux: [EC2 codecommit git integration](https://aws.amazon.com/premiumsupport/knowledge-center/codecommit-git-repositories-ec2/).
-   - For Windows: [windows codecommit git integration](https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-https-windows.html).
+    - For EC2 or Linux: [EC2 codecommit git integration](https://aws.amazon.com/premiumsupport/knowledge-center/codecommit-git-repositories-ec2/).
+    - For Windows: [windows codecommit git integration](https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-https-windows.html).
 
 3. Set the environment variable `AWS_REGION`.
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Applies a workaround to a nested list format conflict between `prettier` and `markdownlint`, first identified in #30569.

I excluded any nested list that was part of a `codeblock`, found in `__fixtures__`, found in `docs/` and anywhere not used by `mkdocs` to generate html for the renovate website. Let me know if my exclusions are incorrect.

<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

A more permanent solution is being tracked in #30608.

This PR is to address the formatting issue until #30608 is resolved. 

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
