### PR TITLE
fix: Align cache decorator parameters

### DIFF
--- a/lib/modules/datasource/bitbucket-tags/index.ts
+++ b/lib/modules/datasource/bitbucket-tags/index.ts
@@ -108,7 +108,7 @@ export class BitbucketTagsDatasource extends Datasource {
       BitbucketTagsDatasource.getCacheKey(registryUrl, repo, 'mainbranch'),
     ttlMinutes: 60,
   })
-  async getMainBranch(repo: string): Promise<string> {
+  async getMainBranch(_registryUrl: string, repo: string): Promise<string> {
     return (
       await this.bitbucketHttp.getJson(`/2.0/repositories/${repo}`, RepoInfo)
     ).body.mainbranch;
@@ -129,7 +129,10 @@ export class BitbucketTagsDatasource extends Datasource {
       return this.getTagCommit(registryUrl, repo, newValue);
     }
 
-    const mainBranch = await this.getMainBranch(repo);
+    const mainBranch = await this.getMainBranch(
+      BitbucketTagsDatasource.getRegistryURL(registryUrl),
+      repo,
+    );
 
     const url = `/2.0/repositories/${repo}/commits/${mainBranch}`;
     const bitbucketCommits = (

--- a/lib/modules/datasource/galaxy-collection/index.ts
+++ b/lib/modules/datasource/galaxy-collection/index.ts
@@ -120,7 +120,8 @@ export class GalaxyCollectionDatasource extends Datasource {
 
   @cache({
     namespace: `datasource-${GalaxyCollectionDatasource.id}-detailed-version`,
-    key: (versionsUrl, basicRelease: Release) => basicRelease.version,
+    key: (_packageName: string, _versionsUrl: string, basicRelease: Release) =>
+      basicRelease.version,
     ttlMinutes: 10080, // 1 week
   })
   async getVersionDetails(


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Since decorator types aren't strict enough, sometimes signatures of the method and its caching `key(...)` parameter are different.

This PR fixes such cases.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
