### PR TITLE
refactor: Use separate cache namespace for `GithubReleaseAttachmentsDatasource` class

### DIFF
--- a/lib/modules/datasource/github-release-attachments/index.ts
+++ b/lib/modules/datasource/github-release-attachments/index.ts
@@ -53,7 +53,7 @@ export class GithubReleaseAttachmentsDatasource extends Datasource {
 
   @cache({
     ttlMinutes: 1440,
-    namespace: 'datasource-github-releases',
+    namespace: `datasource-${GithubReleaseAttachmentsDatasource.id}`,
     key: (release: GithubRestRelease, digest: string) =>
       `${release.html_url}:${digest}`,
   })

--- a/lib/util/cache/package/types.ts
+++ b/lib/util/cache/package/types.ts
@@ -64,6 +64,7 @@ export type PackageCacheNamespace =
   | 'datasource-gitea-releases'
   | 'datasource-gitea-tags'
   | 'datasource-github-releases'
+  | 'datasource-github-release-attachments'
   | 'datasource-gitlab-packages'
   | 'datasource-gitlab-releases'
   | 'datasource-gitlab-tags-commit'


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
