### PR TITLE
refactor(template): remove unused `containsTemplates()`

### DIFF
--- a/lib/util/template/index.spec.ts
+++ b/lib/util/template/index.spec.ts
@@ -253,37 +253,6 @@ describe('util/template/index', () => {
     });
   });
 
-  describe('containsTemplate', () => {
-    it('supports null', () => {
-      expect(template.containsTemplates(null, 'logJSON')).toBeFalse();
-    });
-
-    it('contains template', () => {
-      expect(
-        template.containsTemplates(
-          '{{#if logJSON}}{{logJSON}}{{/if}}',
-          'logJSON',
-        ),
-      ).toBeTrue();
-      expect(
-        template.containsTemplates(
-          '{{#with logJSON.hasReleaseNotes as | hasNotes |}}{{hasNotes}}{{/if}}',
-          'logJSON',
-        ),
-      ).toBeTrue();
-      expect(
-        template.containsTemplates(
-          '{{#if logJSON.hasReleaseNotes}}has notes{{/if}}',
-          'logJSON',
-        ),
-      ).toBeTrue();
-    });
-
-    it('does not contain template', () => {
-      expect(template.containsTemplates('{{body}}', ['logJSON'])).toBeFalse();
-    });
-  });
-
   describe('percent encoding', () => {
     it('encodes values', () => {
       const output = template.compile(

--- a/lib/util/template/index.ts
+++ b/lib/util/template/index.ts
@@ -291,10 +291,6 @@ export function proxyCompileInput(
   );
 }
 
-const templateRegex = regEx(
-  /{{(?:#(?:if|unless|with|each) )?([a-zA-Z.]+)(?: as \| [a-zA-Z.]+ \|)?}}/g,
-);
-
 export function compile(
   template: string,
   input: CompileInput,
@@ -331,22 +327,4 @@ export function safeCompile(
     logger.warn({ err, template }, 'Error compiling template');
     return '';
   }
-}
-
-export function containsTemplates(
-  value: unknown,
-  templates: string | string[],
-): boolean {
-  if (!is.string(value)) {
-    return false;
-  }
-  for (const m of [...value.matchAll(templateRegex)]) {
-    for (const template of is.string(templates) ? [templates] : templates) {
-      if (m[1] === template || m[1].startsWith(`${template}.`)) {
-        return true;
-      }
-    }
-  }
-
-  return false;
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Remove unused `containsTemplates()` function

## Context

1. It's not used
2. It's not correct: the regex doesn't accept any non-trivial Handlebars syntax, only simple variable substitution and a small predefined list of helpers, and doesn't even handle arbitrary whitespace

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
