### PR TITLE
fix(git): fix gpg commit signing

### DIFF
--- a/lib/util/git/private-key.spec.ts
+++ b/lib/util/git/private-key.spec.ts
@@ -66,7 +66,7 @@ describe('util/git/private-key', () => {
       expect(exec.exec).toHaveBeenCalledWith('git config commit.gpgsign true', {
         cwd: repoDir,
       });
-      expect(exec.exec).toHaveBeenCalledWith('git config gpg.format opengpg', {
+      expect(exec.exec).toHaveBeenCalledWith('git config gpg.format openpgp', {
         cwd: repoDir,
       });
     });

--- a/lib/util/git/private-key.ts
+++ b/lib/util/git/private-key.ts
@@ -55,7 +55,7 @@ abstract class PrivateKey {
 }
 
 class GPGKey extends PrivateKey {
-  protected readonly gpgFormat = 'opengpg';
+  protected readonly gpgFormat = 'openpgp';
 
   protected async importKey(): Promise<string | undefined> {
     const keyFileName = upath.join(os.tmpdir() + '/git-private-gpg.key');


### PR DESCRIPTION
## Changes

The value for git `gpg.format` should be `openpgp` not `opengpg`

See: https://git-scm.com/docs/git-config#Documentation/git-config.txt-gpgformat

This confusion is well described by https://sethmlarson.dev/switching-git-back-to-gpg-signing

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Context

Fixed regression introduced by https://github.com/renovatebot/renovate/pull/29550#issuecomment-2302446707 in Renovate 38.46.0

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [X] Code inspection only, or
- [X] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
