### PR TITLE
docs(docker): Specify authType in code example

### DIFF
--- a/docs/usage/docker.md
+++ b/docs/usage/docker.md
@@ -312,6 +312,7 @@ If all your dependencies are on the Google Artifact Registry, you can base64 enc
             "matchHost": "europe-docker.pkg.dev",
             "username": "_json_key_base64",
             "password": "<base64 service account>"
+            "authType": "Basic",
           }
         ]
       }
@@ -328,6 +329,7 @@ If all your dependencies are on the Google Artifact Registry, you can base64 enc
             "encrypted": {
               "password": "<encrypted base64 service account>"
             }
+            "authType": "Basic",
           }
         ]
       }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Documentation update: While basic auth is mentioned above, the code example doesn't include that. My experimentation has shown that this auth doesn't work without specifying the authType as basic

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
