### PR TITLE
fix(manager/git-submodules): get recorded submodule commit

### DIFF
--- a/lib/modules/manager/git-submodules/extract.ts
+++ b/lib/modules/manager/git-submodules/extract.ts
@@ -123,7 +123,9 @@ export default async function extractPackageFile(
   const deps = [];
   for (const { name, path } of depNames) {
     try {
-      const [currentDigest] = (await git.subModule(['status', path]))
+      const [currentDigest] = (
+        await git.subModule(['status', '--cached', path])
+      )
         .trim()
         .replace(regEx(/^[-+]/), '')
         .split(regEx(/\s/));


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Get submodule state recorded in git commit, not the state of the current working copy.

## Context

https://github.com/amezin/renovate-submodule-fail

When `persistRepoData` is enabled, Renovate updates the submodule(s), and leaves the repository in that state. Next time `currentDigest` for the submodule(s) is detected incorrectly (because they are already updated in the working copy), so no update is detected, and pull requests are closed.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
