### PR TITLE
fix(git): keep trailing newline in private SSH key

### DIFF
--- a/lib/util/git/private-key.spec.ts
+++ b/lib/util/git/private-key.spec.ts
@@ -89,7 +89,8 @@ describe('util/git/private-key', () => {
 -----BEGIN OPENSSH PRIVATE KEY-----
 some-private-key with-passphrase
 some-private-key with-passphrase
------END OPENSSH PRIVATE KEY-----`);
+-----END OPENSSH PRIVATE KEY-----
+`);
       await expect(writePrivateKey()).rejects.toThrow();
     });
 
@@ -98,7 +99,8 @@ some-private-key with-passphrase
 -----BEGIN OPENSSH PRIVATE KEY-----
 some-private-key
 some-private-key
------END OPENSSH PRIVATE KEY-----`;
+-----END OPENSSH PRIVATE KEY-----
+`;
       const privateKeyFile = upath.join(os.tmpdir() + '/git-private-ssh.key');
       const publicKeyFile = `${privateKeyFile}.pub`;
       const publicKey = 'some-public-key';

--- a/lib/util/git/private-key.ts
+++ b/lib/util/git/private-key.ts
@@ -24,7 +24,7 @@ abstract class PrivateKey {
   protected abstract readonly gpgFormat: string;
 
   constructor(key: string) {
-    this.key = key.trim();
+    this.key = key;
     addSecretForSanitizing(this.key, 'global');
     logger.debug(
       'gitPrivateKey: successfully set (but not yet written/configured)',
@@ -56,6 +56,10 @@ abstract class PrivateKey {
 
 class GPGKey extends PrivateKey {
   protected readonly gpgFormat = 'openpgp';
+
+  constructor(key: string) {
+    super(key.trim());
+  }
 
   protected async importKey(): Promise<string | undefined> {
     const keyFileName = upath.join(os.tmpdir() + '/git-private-gpg.key');


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Private SSH keys require a trailing newline, otherwise a parser error occurs when, e.g., generating a public key via `ssh-keygen -y -f <private_key_file>`.

## Context

I added support for SSH-based commit signing in #29550 and accidentally blindly reused `key.trim()` from the GPG-based commit signing implementation, which is required according to #9855. My manual test back then was faulty where I was using `nano` to remove the trailing newline in a generated private SSH key, but I just realized that `nano` automatically adds a trailing newline when saving a text file, so a manual call of `ssh-keygen -y -P "" -f <private_key_file>` was working because the trailing newline was still present.

As discovered in https://github.com/renovatebot/renovate/discussions/30999, a private SSH key requires a trailing newline. Hence, I've fixed the implementation to only use `key.strip()` for GPG keys but not for SSH keys.

I'm sorry for the oversight and negligence. :bow:

Fixes https://github.com/renovatebot/renovate/discussions/30999.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
