### PR TITLE
fix(local): don't validate `reconfigure` branch

### DIFF
--- a/lib/workers/repository/reconfigure/index.spec.ts
+++ b/lib/workers/repository/reconfigure/index.spec.ts
@@ -37,6 +37,14 @@ describe('workers/repository/reconfigure/index', () => {
     GlobalConfig.reset();
   });
 
+  it('no effect when running with platform=local', async () => {
+    GlobalConfig.set({ platform: 'local' });
+    await validateReconfigureBranch(config);
+    expect(logger.debug).toHaveBeenCalledWith(
+      'Not attempting to reconfigure when running with local platform',
+    );
+  });
+
   it('no effect on repo with no reconfigure branch', async () => {
     scm.branchExists.mockResolvedValueOnce(false);
     await validateReconfigureBranch(config);

--- a/lib/workers/repository/reconfigure/index.ts
+++ b/lib/workers/repository/reconfigure/index.ts
@@ -1,5 +1,6 @@
 import is from '@sindresorhus/is';
 import JSON5 from 'json5';
+import { GlobalConfig } from '../../../config/global';
 import type { RenovateConfig } from '../../../config/types';
 import { validateConfig } from '../../../config/validation';
 import { logger } from '../../../logger';
@@ -43,6 +44,13 @@ export async function validateReconfigureBranch(
   config: RenovateConfig,
 ): Promise<void> {
   logger.debug('validateReconfigureBranch()');
+  if (GlobalConfig.get('platform') === 'local') {
+    logger.debug(
+      'Not attempting to reconfigure when running with local platform',
+    );
+    return;
+  }
+
   const context = config.statusCheckNames?.configValidation;
 
   const branchName = getReconfigureBranchName(config.branchPrefix!);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
Don't validate the `reconfigure` branch on the local platform.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

As noted in #31007, validating the `renovate/reconfigure` branch when
running with the local platform ends up in an error reported to the
user:

```
TypeError: Cannot read properties of undefined (reading 'renovate/reconfigure')
```

This error is because we're trying to do something we shouldn't do with
the local platform - interact with branches - and as there's no way for
the user to fix it, this error isn't useful.

Users aren't impacted by anything as part of this behaviour, nor can
they do anything to resolve this, so this error reporting isn't useful.

To avoid this, we can perform an early return (and log) to skip this
error condition.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
