### PR TITLE
feat(presets/workarounds): add `rancher/rke2` versioning

### DIFF
--- a/lib/config/presets/internal/workarounds.ts
+++ b/lib/config/presets/internal/workarounds.ts
@@ -22,6 +22,7 @@ export const presets: Record<string, Preset> = {
       'workarounds:containerbase',
       'workarounds:bitnamiDockerImageVersioning',
       'workarounds:k3sKubernetesVersioning',
+      'workarounds:rke2KubernetesVersioning',
     ],
     ignoreDeps: [], // Hack to improve onboarding PR description
   },
@@ -176,6 +177,17 @@ export const presets: Record<string, Preset> = {
         matchPackageNames: ['k3s-io/k3s'],
         versioning:
           'regex:^v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(?:-(?<prerelease>[a-z]+\\d+))?(?<compatibility>\\+k3s)(?<build>\\d+)$',
+      },
+    ],
+  },
+  rke2KubernetesVersioning: {
+    description: 'Use custom regex versioning for rancher/rke2',
+    packageRules: [
+      {
+        matchDatasources: ['github-releases'],
+        matchPackageNames: ['rancher/rke2'],
+        versioning:
+          'regex:^v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(?:-(?<prerelease>[a-z]+\\d+))?(?<compatibility>\\+rke2r)(?<build>\\d+)$',
       },
     ],
   },

--- a/lib/config/presets/internal/workarounds.ts
+++ b/lib/config/presets/internal/workarounds.ts
@@ -180,17 +180,6 @@ export const presets: Record<string, Preset> = {
       },
     ],
   },
-  rke2KubernetesVersioning: {
-    description: 'Use custom regex versioning for rancher/rke2',
-    packageRules: [
-      {
-        matchDatasources: ['github-releases'],
-        matchPackageNames: ['rancher/rke2'],
-        versioning:
-          'regex:^v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(?:-(?<prerelease>[a-z]+\\d+))?(?<compatibility>\\+rke2r)(?<build>\\d+)$',
-      },
-    ],
-  },
   mavenCommonsAncientVersion: {
     description: 'Fix some problems with very old Maven commons versions.',
     packageRules: [
@@ -209,6 +198,17 @@ export const presets: Record<string, Preset> = {
         matchDepNames: ['node'],
         versionCompatibility: '^(?<version>[^-]+)(?<compatibility>-.*)?$',
         versioning: 'node',
+      },
+    ],
+  },
+  rke2KubernetesVersioning: {
+    description: 'Use custom regex versioning for rancher/rke2',
+    packageRules: [
+      {
+        matchDatasources: ['github-releases'],
+        matchPackageNames: ['rancher/rke2'],
+        versioning:
+          'regex:^v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(?:-(?<prerelease>[a-z]+\\d+))?(?<compatibility>\\+rke2r)(?<build>\\d+)$',
       },
     ],
   },


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

RKE2 uses a similar versioning as k3s (https://github.com/renovatebot/renovate/pull/30957).

https://github.com/rancher/rke2/releases

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
