### PR TITLE
refactor(github): Use single cache namespace for release attachments

### DIFF
--- a/lib/modules/datasource/github-release-attachments/index.ts
+++ b/lib/modules/datasource/github-release-attachments/index.ts
@@ -55,7 +55,7 @@ export class GithubReleaseAttachmentsDatasource extends Datasource {
     ttlMinutes: 1440,
     namespace: `datasource-${GithubReleaseAttachmentsDatasource.id}`,
     key: (release: GithubRestRelease, digest: string) =>
-      `${release.html_url}:${digest}`,
+      `findDigestFile:${release.html_url}:${digest}`,
   })
   async findDigestFile(
     release: GithubRestRelease,
@@ -83,9 +83,9 @@ export class GithubReleaseAttachmentsDatasource extends Datasource {
 
   @cache({
     ttlMinutes: 1440,
-    namespace: 'datasource-github-releases',
+    namespace: `datasource-${GithubReleaseAttachmentsDatasource.id}`,
     key: (asset: GithubRestAsset, algorithm: string) =>
-      `${asset.browser_download_url}:${algorithm}:assetDigest`,
+      `downloadAndDigest:${asset.browser_download_url}:${algorithm}`,
   })
   async downloadAndDigest(
     asset: GithubRestAsset,

--- a/lib/util/cache/package/key.spec.ts
+++ b/lib/util/cache/package/key.spec.ts
@@ -3,8 +3,8 @@ import { getCombinedKey } from './key';
 describe('util/cache/package/key', () => {
   describe('getCombinedKey', () => {
     it('works', () => {
-      expect(getCombinedKey('datasource-github-releases', 'foo:bar')).toBe(
-        'global%%datasource-github-releases%%foo:bar',
+      expect(getCombinedKey('_test-namespace', 'foo:bar')).toBe(
+        'global%%_test-namespace%%foo:bar',
       );
     });
   });

--- a/lib/util/cache/package/types.ts
+++ b/lib/util/cache/package/types.ts
@@ -63,7 +63,6 @@ export type PackageCacheNamespace =
   | 'datasource-git'
   | 'datasource-gitea-releases'
   | 'datasource-gitea-tags'
-  | 'datasource-github-releases'
   | 'datasource-github-release-attachments'
   | 'datasource-gitlab-packages'
   | 'datasource-gitlab-releases'


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
