### PR TITLE
feat(presets/workarounds): Support bellsoft/liberica-runtime-container Image

### DIFF
--- a/lib/config/presets/internal/workarounds.spec.ts
+++ b/lib/config/presets/internal/workarounds.spec.ts
@@ -172,4 +172,35 @@ describe('config/presets/internal/workarounds', () => {
       });
     });
   });
+
+  describe('javaLTSVersions', () => {
+    const preset = presets.javaLTSVersions;
+
+    describe('bellsoft/liberica-runtime-container', () => {
+      const packageRule = preset.packageRules![2];
+
+      const allowedVersions = packageRule.allowedVersions as string;
+      const allowedVersionsRe = regEx(
+        allowedVersions.substring(1, allowedVersions.length - 1),
+      );
+
+      it.each`
+        input                           | expected
+        ${'jdk-11-slim-musl'}           | ${true}
+        ${'jdk-all-11-slim-musl'}       | ${true}
+        ${'jre-11-slim-musl'}           | ${true}
+        ${'jdk-17-glibc'}               | ${true}
+        ${'jdk-all-17-glibc'}           | ${true}
+        ${'jre-17-glibc'}               | ${true}
+        ${'jdk-21-crac-slim-glibc'}     | ${true}
+        ${'jdk-all-21-crac-slim-glibc'} | ${true}
+        ${'jre-21-crac-slim-glibc'}     | ${true}
+        ${'jdk-22-crac-slim-glibc'}     | ${false}
+        ${'jdk-all-22-crac-slim-glibc'} | ${false}
+        ${'jre-22-crac-slim-glibc'}     | ${false}
+      `('allowedVersisons("$input") == "$expected"', ({ input, expected }) => {
+        expect(allowedVersionsRe.test(input)).toEqual(expected);
+      });
+    });
+  });
 });

--- a/lib/config/presets/internal/workarounds.spec.ts
+++ b/lib/config/presets/internal/workarounds.spec.ts
@@ -1,11 +1,11 @@
+import * as versionings from '../../../modules/versioning';
 import { regEx } from '../../../util/regex';
 import { presets } from './workarounds';
 
 describe('config/presets/internal/workarounds', () => {
   describe('bitnamiDockerImageVersioning', () => {
-    const versioning = presets.bitnamiDockerImageVersioning.packageRules![0]
-      .versioning as string;
-    const versioningRe = regEx(versioning.substring(6));
+    const versioning = versionings.get(presets.bitnamiDockerImageVersioning.packageRules![0]
+      .versioning as string);
     const matchCurrentValue = presets.bitnamiDockerImageVersioning
       .packageRules![0].matchCurrentValue as string;
     const matchCurrentValueRe = regEx(
@@ -24,7 +24,7 @@ describe('config/presets/internal/workarounds', () => {
       ${'1.24.0-debian-12'}     | ${true}
       ${'1.24.0-debian-12-r24'} | ${true}
     `('versioning("$input") == "$expected"', ({ input, expected }) => {
-      expect(versioningRe.test(input)).toEqual(expected);
+      expect(versioning.isValid(input)).toEqual(expected);
     });
 
     it.each`
@@ -49,8 +49,7 @@ describe('config/presets/internal/workarounds', () => {
     describe('Liberica JDK Lite', () => {
       const packageRule = preset.packageRules![0];
 
-      const versioning = packageRule.versioning as string;
-      const versioningRe = regEx(versioning.substring(6));
+      const versioning = versionings.get(packageRule.versioning as string);
 
       const matchCurrentValue = packageRule.matchCurrentValue as string;
       const matchCurrentValueRe = regEx(
@@ -69,7 +68,7 @@ describe('config/presets/internal/workarounds', () => {
         ${'jdk-all-11-slim-musl'}       | ${false}
         ${'jre-11-slim-musl'}           | ${false}
       `('versioning("$input") == "$expected"', ({ input, expected }) => {
-        expect(versioningRe.test(input)).toEqual(expected);
+        expect(versioning.isValid(input)).toEqual(expected);
       });
 
       it.each`
@@ -91,8 +90,7 @@ describe('config/presets/internal/workarounds', () => {
     describe('Liberica JDK', () => {
       const packageRule = preset.packageRules![1];
 
-      const versioning = packageRule.versioning as string;
-      const versioningRe = regEx(versioning.substring(6));
+      const versioning = versionings.get(packageRule.versioning as string);
 
       const matchCurrentValue = packageRule.matchCurrentValue as string;
       const matchCurrentValueRe = regEx(
@@ -111,7 +109,7 @@ describe('config/presets/internal/workarounds', () => {
         ${'jdk-all-11-slim-musl'}       | ${true}
         ${'jre-11-slim-musl'}           | ${false}
       `('versioning("$input") == "$expected"', ({ input, expected }) => {
-        expect(versioningRe.test(input)).toEqual(expected);
+        expect(versioning.isValid(input)).toEqual(expected);
       });
 
       it.each`
@@ -133,8 +131,7 @@ describe('config/presets/internal/workarounds', () => {
     describe('Liberica JRE', () => {
       const packageRule = preset.packageRules![2];
 
-      const versioning = packageRule.versioning as string;
-      const versioningRe = regEx(versioning.substring(6));
+      const versioning = versionings.get(packageRule.versioning as string);
 
       const matchCurrentValue = packageRule.matchCurrentValue as string;
       const matchCurrentValueRe = regEx(
@@ -153,7 +150,7 @@ describe('config/presets/internal/workarounds', () => {
         ${'jdk-all-11-slim-musl'}       | ${false}
         ${'jre-11-slim-musl'}           | ${true}
       `('versioning("$input") == "$expected"', ({ input, expected }) => {
-        expect(versioningRe.test(input)).toEqual(expected);
+        expect(versioning.isValid(input)).toEqual(expected);
       });
 
       it.each`

--- a/lib/config/presets/internal/workarounds.spec.ts
+++ b/lib/config/presets/internal/workarounds.spec.ts
@@ -42,4 +42,134 @@ describe('config/presets/internal/workarounds', () => {
       expect(matchCurrentValueRe.test(input)).toEqual(expected);
     });
   });
+
+  describe('libericaJdkDockerVersioning', () => {
+    const preset = presets.libericaJdkDockerVersioning;
+
+    describe('Liberica JDK Lite', () => {
+      const packageRule = preset.packageRules![0];
+
+      const versioning = packageRule.versioning as string;
+      const versioningRe = regEx(versioning.substring(6));
+
+      const matchCurrentValue = packageRule.matchCurrentValue as string;
+      const matchCurrentValueRe = regEx(
+        matchCurrentValue.substring(1, matchCurrentValue.length - 1),
+      );
+
+      it.each`
+        input                           | expected
+        ${'jdk-17-glibc'}               | ${true}
+        ${'jdk-all-17-glibc'}           | ${false}
+        ${'jre-17-glibc'}               | ${false}
+        ${'jdk-21-crac-slim-glibc'}     | ${true}
+        ${'jdk-all-21-crac-slim-glibc'} | ${false}
+        ${'jre-21-crac-slim-glibc'}     | ${false}
+        ${'jdk-11-slim-musl'}           | ${true}
+        ${'jdk-all-11-slim-musl'}       | ${false}
+        ${'jre-11-slim-musl'}           | ${false}
+      `('versioning("$input") == "$expected"', ({ input, expected }) => {
+        expect(versioningRe.test(input)).toEqual(expected);
+      });
+
+      it.each`
+        input                           | expected
+        ${'jdk-17-glibc'}               | ${true}
+        ${'jdk-all-17-glibc'}           | ${false}
+        ${'jre-17-glibc'}               | ${false}
+        ${'jdk-21-crac-slim-glibc'}     | ${true}
+        ${'jdk-all-21-crac-slim-glibc'} | ${false}
+        ${'jre-21-crac-slim-glibc'}     | ${false}
+        ${'jdk-11-slim-musl'}           | ${true}
+        ${'jdk-all-11-slim-musl'}       | ${false}
+        ${'jre-11-slim-musl'}           | ${false}
+      `('matchCurrentValue("$input") == "$expected"', ({ input, expected }) => {
+        expect(matchCurrentValueRe.test(input)).toEqual(expected);
+      });
+    });
+
+    describe('Liberica JDK', () => {
+      const packageRule = preset.packageRules![1];
+
+      const versioning = packageRule.versioning as string;
+      const versioningRe = regEx(versioning.substring(6));
+
+      const matchCurrentValue = packageRule.matchCurrentValue as string;
+      const matchCurrentValueRe = regEx(
+        matchCurrentValue.substring(1, matchCurrentValue.length - 1),
+      );
+
+      it.each`
+        input                           | expected
+        ${'jdk-17-glibc'}               | ${false}
+        ${'jdk-all-17-glibc'}           | ${true}
+        ${'jre-17-glibc'}               | ${false}
+        ${'jdk-21-crac-slim-glibc'}     | ${false}
+        ${'jdk-all-21-crac-slim-glibc'} | ${true}
+        ${'jre-21-crac-slim-glibc'}     | ${false}
+        ${'jdk-11-slim-musl'}           | ${false}
+        ${'jdk-all-11-slim-musl'}       | ${true}
+        ${'jre-11-slim-musl'}           | ${false}
+      `('versioning("$input") == "$expected"', ({ input, expected }) => {
+        expect(versioningRe.test(input)).toEqual(expected);
+      });
+
+      it.each`
+        input                           | expected
+        ${'jdk-17-glibc'}               | ${false}
+        ${'jdk-all-17-glibc'}           | ${true}
+        ${'jre-17-glibc'}               | ${false}
+        ${'jdk-21-crac-slim-glibc'}     | ${false}
+        ${'jdk-all-21-crac-slim-glibc'} | ${true}
+        ${'jre-21-crac-slim-glibc'}     | ${false}
+        ${'jdk-11-slim-musl'}           | ${false}
+        ${'jdk-all-11-slim-musl'}       | ${true}
+        ${'jre-11-slim-musl'}           | ${false}
+      `('matchCurrentValue("$input") == "$expected"', ({ input, expected }) => {
+        expect(matchCurrentValueRe.test(input)).toEqual(expected);
+      });
+    });
+
+    describe('Liberica JRE', () => {
+      const packageRule = preset.packageRules![2];
+
+      const versioning = packageRule.versioning as string;
+      const versioningRe = regEx(versioning.substring(6));
+
+      const matchCurrentValue = packageRule.matchCurrentValue as string;
+      const matchCurrentValueRe = regEx(
+        matchCurrentValue.substring(1, matchCurrentValue.length - 1),
+      );
+
+      it.each`
+        input                           | expected
+        ${'jdk-17-glibc'}               | ${false}
+        ${'jdk-all-17-glibc'}           | ${false}
+        ${'jre-17-glibc'}               | ${true}
+        ${'jdk-21-crac-slim-glibc'}     | ${false}
+        ${'jdk-all-21-crac-slim-glibc'} | ${false}
+        ${'jre-21-crac-slim-glibc'}     | ${true}
+        ${'jdk-11-slim-musl'}           | ${false}
+        ${'jdk-all-11-slim-musl'}       | ${false}
+        ${'jre-11-slim-musl'}           | ${true}
+      `('versioning("$input") == "$expected"', ({ input, expected }) => {
+        expect(versioningRe.test(input)).toEqual(expected);
+      });
+
+      it.each`
+        input                           | expected
+        ${'jdk-17-glibc'}               | ${false}
+        ${'jdk-all-17-glibc'}           | ${false}
+        ${'jre-17-glibc'}               | ${true}
+        ${'jdk-21-crac-slim-glibc'}     | ${false}
+        ${'jdk-all-21-crac-slim-glibc'} | ${false}
+        ${'jre-21-crac-slim-glibc'}     | ${true}
+        ${'jdk-11-slim-musl'}           | ${false}
+        ${'jdk-all-11-slim-musl'}       | ${false}
+        ${'jre-11-slim-musl'}           | ${true}
+      `('matchCurrentValue("$input") == "$expected"', ({ input, expected }) => {
+        expect(matchCurrentValueRe.test(input)).toEqual(expected);
+      });
+    });
+  });
 });

--- a/lib/config/presets/internal/workarounds.spec.ts
+++ b/lib/config/presets/internal/workarounds.spec.ts
@@ -4,8 +4,10 @@ import { presets } from './workarounds';
 
 describe('config/presets/internal/workarounds', () => {
   describe('bitnamiDockerImageVersioning', () => {
-    const versioning = versionings.get(presets.bitnamiDockerImageVersioning.packageRules![0]
-      .versioning as string);
+    const versioning = versionings.get(
+      presets.bitnamiDockerImageVersioning.packageRules![0]
+        .versioning as string,
+    );
     const matchCurrentValue = presets.bitnamiDockerImageVersioning
       .packageRules![0].matchCurrentValue as string;
     const matchCurrentValueRe = regEx(

--- a/lib/config/presets/internal/workarounds.spec.ts
+++ b/lib/config/presets/internal/workarounds.spec.ts
@@ -1,18 +1,14 @@
 import * as versionings from '../../../modules/versioning';
-import { regEx } from '../../../util/regex';
+import { matchRegexOrGlob } from '../../../util/string-match';
 import { presets } from './workarounds';
 
 describe('config/presets/internal/workarounds', () => {
   describe('bitnamiDockerImageVersioning', () => {
-    const versioning = versionings.get(
-      presets.bitnamiDockerImageVersioning.packageRules![0]
-        .versioning as string,
-    );
-    const matchCurrentValue = presets.bitnamiDockerImageVersioning
-      .packageRules![0].matchCurrentValue as string;
-    const matchCurrentValueRe = regEx(
-      matchCurrentValue.substring(1, matchCurrentValue.length - 1),
-    );
+    const preset = presets.bitnamiDockerImageVersioning;
+    const packageRule = preset.packageRules![0];
+
+    const versioning = versionings.get(packageRule.versioning as string);
+    const matchCurrentValue = packageRule.matchCurrentValue!;
 
     it.each`
       input                     | expected
@@ -41,7 +37,7 @@ describe('config/presets/internal/workarounds', () => {
       ${'1.24.0-debian-12'}     | ${true}
       ${'1.24.0-debian-12-r24'} | ${true}
     `('matchCurrentValue("$input") == "$expected"', ({ input, expected }) => {
-      expect(matchCurrentValueRe.test(input)).toEqual(expected);
+      expect(matchRegexOrGlob(input, matchCurrentValue)).toEqual(expected);
     });
   });
 
@@ -53,10 +49,7 @@ describe('config/presets/internal/workarounds', () => {
 
       const versioning = versionings.get(packageRule.versioning as string);
 
-      const matchCurrentValue = packageRule.matchCurrentValue as string;
-      const matchCurrentValueRe = regEx(
-        matchCurrentValue.substring(1, matchCurrentValue.length - 1),
-      );
+      const matchCurrentValue = packageRule.matchCurrentValue!;
 
       it.each`
         input                           | expected
@@ -85,7 +78,7 @@ describe('config/presets/internal/workarounds', () => {
         ${'jdk-all-11-slim-musl'}       | ${false}
         ${'jre-11-slim-musl'}           | ${false}
       `('matchCurrentValue("$input") == "$expected"', ({ input, expected }) => {
-        expect(matchCurrentValueRe.test(input)).toEqual(expected);
+        expect(matchRegexOrGlob(input, matchCurrentValue)).toEqual(expected);
       });
     });
 
@@ -94,10 +87,7 @@ describe('config/presets/internal/workarounds', () => {
 
       const versioning = versionings.get(packageRule.versioning as string);
 
-      const matchCurrentValue = packageRule.matchCurrentValue as string;
-      const matchCurrentValueRe = regEx(
-        matchCurrentValue.substring(1, matchCurrentValue.length - 1),
-      );
+      const matchCurrentValue = packageRule.matchCurrentValue!;
 
       it.each`
         input                           | expected
@@ -126,7 +116,7 @@ describe('config/presets/internal/workarounds', () => {
         ${'jdk-all-11-slim-musl'}       | ${true}
         ${'jre-11-slim-musl'}           | ${false}
       `('matchCurrentValue("$input") == "$expected"', ({ input, expected }) => {
-        expect(matchCurrentValueRe.test(input)).toEqual(expected);
+        expect(matchRegexOrGlob(input, matchCurrentValue)).toEqual(expected);
       });
     });
 
@@ -135,10 +125,7 @@ describe('config/presets/internal/workarounds', () => {
 
       const versioning = versionings.get(packageRule.versioning as string);
 
-      const matchCurrentValue = packageRule.matchCurrentValue as string;
-      const matchCurrentValueRe = regEx(
-        matchCurrentValue.substring(1, matchCurrentValue.length - 1),
-      );
+      const matchCurrentValue = packageRule.matchCurrentValue!;
 
       it.each`
         input                           | expected
@@ -167,7 +154,7 @@ describe('config/presets/internal/workarounds', () => {
         ${'jdk-all-11-slim-musl'}       | ${false}
         ${'jre-11-slim-musl'}           | ${true}
       `('matchCurrentValue("$input") == "$expected"', ({ input, expected }) => {
-        expect(matchCurrentValueRe.test(input)).toEqual(expected);
+        expect(matchRegexOrGlob(input, matchCurrentValue)).toEqual(expected);
       });
     });
   });
@@ -179,9 +166,6 @@ describe('config/presets/internal/workarounds', () => {
       const packageRule = preset.packageRules![2];
 
       const allowedVersions = packageRule.allowedVersions as string;
-      const allowedVersionsRe = regEx(
-        allowedVersions.substring(1, allowedVersions.length - 1),
-      );
 
       it.each`
         input                           | expected
@@ -198,7 +182,7 @@ describe('config/presets/internal/workarounds', () => {
         ${'jdk-all-22-crac-slim-glibc'} | ${false}
         ${'jre-22-crac-slim-glibc'}     | ${false}
       `('allowedVersisons("$input") == "$expected"', ({ input, expected }) => {
-        expect(allowedVersionsRe.test(input)).toEqual(expected);
+        expect(matchRegexOrGlob(input, allowedVersions)).toEqual(expected);
       });
     });
   });

--- a/lib/config/presets/internal/workarounds.ts
+++ b/lib/config/presets/internal/workarounds.ts
@@ -23,6 +23,7 @@ export const presets: Record<string, Preset> = {
       'workarounds:bitnamiDockerImageVersioning',
       'workarounds:k3sKubernetesVersioning',
       'workarounds:rke2KubernetesVersioning',
+      'workarounds:libericaJdkDockerVersioning',
     ],
     ignoreDeps: [], // Hack to improve onboarding PR description
   },
@@ -177,6 +178,38 @@ export const presets: Record<string, Preset> = {
         matchPackageNames: ['k3s-io/k3s'],
         versioning:
           'regex:^v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(?:-(?<prerelease>[a-z]+\\d+))?(?<compatibility>\\+k3s)(?<build>\\d+)$',
+      },
+    ],
+  },
+  libericaJdkDockerVersioning: {
+    description:
+      'Use custom regex versioning for bellsoft/liberica-runtime-container',
+    packageRules: [
+      {
+        description: 'Liberica JDK Lite version optimized for the Cloud',
+        matchCurrentValue: '/^jdk-[^a][^l]{2}/',
+        matchDatasources: ['docker'],
+        matchPackageNames: ['bellsoft/liberica-runtime-container'],
+        versioning:
+          'regex:^jdk-(?<major>\\d+)?(\\.(?<minor>\\d+))?(\\.(?<patch>\\d+))?([\\._+](?<build>(\\d\\.?)+))?(-(?<compatibility>.*))?$',
+      },
+      {
+        description:
+          'Liberica JDK that can be used to create a custom runtime with a help of jlink tool',
+        matchCurrentValue: '/^jdk-all/',
+        matchDatasources: ['docker'],
+        matchPackageNames: ['bellsoft/liberica-runtime-container'],
+        versioning:
+          'regex:^jdk-all-(?<major>\\d+)?(\\.(?<minor>\\d+))?(\\.(?<patch>\\d+))?([\\._+](?<build>(\\d\\.?)+))?(-(?<compatibility>.*))?$',
+      },
+      {
+        description:
+          'Liberica JRE (only the runtime without the rest of JDK tools) for running Java applications',
+        matchCurrentValue: '/^jre-/',
+        matchDatasources: ['docker'],
+        matchPackageNames: ['bellsoft/liberica-runtime-container'],
+        versioning:
+          'regex:^jre-(?<major>\\d+)?(\\.(?<minor>\\d+))?(\\.(?<patch>\\d+))?([\\._+](?<build>(\\d\\.?)+))?(-(?<compatibility>.*))?$',
       },
     ],
   },

--- a/lib/config/presets/internal/workarounds.ts
+++ b/lib/config/presets/internal/workarounds.ts
@@ -168,6 +168,13 @@ export const presets: Record<string, Preset> = {
         versioning:
           'regex:^(?<major>\\d+)?(\\.(?<minor>\\d+))?(\\.(?<patch>\\d+))?([\\._+](?<build>(\\d\\.?)+)(LTS)?)?(-(?<compatibility>.*))?$',
       },
+      {
+        allowedVersions: '/^(?:jdk|jdk-all|jre)-(?:8|11|17|21)(?:\\.|-|$)/',
+        description:
+          'Limit Java runtime versions to LTS releases. To receive all major releases add `workarounds:javaLTSVersions` to the `ignorePresets` array.',
+        matchDatasources: ['docker'],
+        matchPackageNames: ['bellsoft/liberica-runtime-container'],
+      },
     ],
   },
   k3sKubernetesVersioning: {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
This adds support for the `bellsoft/liberica-runtime-container` image by adding a new preset `workarounds:libericaJdkDockerVersioning` which supports their versioning scheme and by adding support for this image to the existing `workarounds:javaLTSVersions`.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->
Closes: #31071

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
