### PR TITLE
fix(buildkite): correctly parse plugins that are quoted

### DIFF
--- a/lib/modules/manager/buildkite/extract.spec.ts
+++ b/lib/modules/manager/buildkite/extract.spec.ts
@@ -174,5 +174,38 @@ describe('modules/manager/buildkite/extract', () => {
       };
       expect(res).toEqual([bitbucketDependency, githubDependency]);
     });
+
+    it('extracts plugin tags with quotes', () => {
+      const fileContent = codeBlock`
+        steps:
+          - name: "When single quoted"
+            command: true
+            plugins:
+              - 'test-collector#v1.8.0':
+                  files: junit.xml
+                  format: junit
+
+          - name: "Docker Test %n"
+            command: test.sh
+            parallelism: 25
+            plugins:
+              "docker-compose#v1.3.2":
+                run: app
+      `;
+      const res = extractPackageFile(fileContent)?.deps;
+      const singleQuotesDependency: PackageDependency = {
+        currentValue: 'v1.8.0',
+        datasource: 'github-tags',
+        depName: 'test-collector',
+        packageName: 'buildkite-plugins/test-collector-buildkite-plugin',
+      };
+      const doubleQuotesDependency: PackageDependency = {
+        currentValue: 'v1.3.2',
+        datasource: 'github-tags',
+        depName: 'docker-compose',
+        packageName: 'buildkite-plugins/docker-compose-buildkite-plugin',
+      };
+      expect(res).toEqual([singleQuotesDependency, doubleQuotesDependency]);
+    });
   });
 });

--- a/lib/modules/manager/buildkite/extract.ts
+++ b/lib/modules/manager/buildkite/extract.ts
@@ -17,7 +17,7 @@ export function extractPackageFile(
     for (const line of lines) {
       // Search each line for plugin names
       const depLineMatch = regEx(
-        /^\s*(?:-\s+(?:\?\s+)?)?(?<depName>[^#\s]+)#(?<currentValue>[^:]+)/,
+        /^\s*(?:-\s+(?:\?\s+)?)?['"]?(?<depName>[^#\s'"]+)#(?<currentValue>[^:'"]+)['"]?/,
       ).exec(line);
 
       if (depLineMatch?.groups) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

It was noticed that when there are quotes around Buildkite plugin usages,
Renovate would include the quote at the start of the `depName` and the
tail of the `currentValue`.

This makes the regex a little less greedy by excluding either single or
double quotes.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

It was noticed that when there are quotes around Buildkite plugin usages,
Renovate would include the quote at the start of the `depName` and the
tail of the `currentValue`.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
