### PR TITLE
fix(vulnerability-alerts): allow `null` for `first_patched_version`

### DIFF
--- a/lib/modules/platform/github/schema.ts
+++ b/lib/modules/platform/github/schema.ts
@@ -18,7 +18,7 @@ const PackageSchema = z.object({
 
 const SecurityVulnerabilitySchema = z
   .object({
-    first_patched_version: z.object({ identifier: z.string() }).optional(),
+    first_patched_version: z.object({ identifier: z.string() }).optional().nullable(),
     package: PackageSchema,
     vulnerable_version_range: z.string(),
   })


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Follow-up on https://github.com/renovatebot/renovate/pull/27378, which refactored Github vulnerability alerts to REST API. In the PR, `first_patched_version` has been introduced as an optional field but not `nullable`, which [fails zod validations](https://zod-playground.vercel.app?appdata=N4IgzgxgFgpgtgQxALhALwHQHsBGArGCAFwApgAdAOwAJbqAzASwCcwiB9ABwSOhgBN2ANxitGWSsmqZcBYmWqN%2BMSkUZNRUzG2aNKAcxIBKagF8j2TmokIANsYA0VWuZAOQQuwFcYYFAG0QYCZWDm5eWEERMQkpSi9bW1M3IOSAXXdosHFKFBAAZgwAJkKADhBTIA).

## Context

While investigating missing PRs for security vulnerabilities, I stumbled upon this message:

```
DEBUG: Vulnerability Alert: Failed to parse some alerts
{
  "error": {
    "message": "Schema error",
    "stack": "ZodError: Schema error\n    at Object.transform (/usr/local/renovate/lib/util/schema-utils.ts:66:21)\n    at /usr/local/renovate/node_modules/.pnpm/zod@3.23.8/node_modules/zod/lib/types.js:3236:51\n    at processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at ZodEffects.safeParseAsync (/usr/local/renovate/node_modules/.pnpm/zod@3.23.8/node_modules/zod/lib/types.js:199:24)\n    at ZodEffects.parseAsync (/usr/local/renovate/node_modules/.pnpm/zod@3.23.8/node_modules/zod/lib/types.js:180:24)\n    at GithubHttp.requestJson (/usr/local/renovate/lib/util/http/index.ts:297:16)\n    at Proxy.getVulnerabilityAlerts (/usr/local/renovate/lib/modules/platform/github/index.ts:1973:7)\n    at detectVulnerabilityAlerts (/usr/local/renovate/lib/workers/repository/init/vulnerability.ts:68:18)\n    at initRepo (/usr/local/renovate/lib/workers/repository/init/index.ts:67:12)\n    at Object.renovateRepository (/usr/local/renovate/lib/workers/repository/index.ts:64:14)\n    at attributes.repository (/usr/local/renovate/lib/workers/global/index.ts:202:11)\n    at start (/usr/local/renovate/lib/workers/global/index.ts:187:7)\n    at /usr/local/renovate/lib/renovate.ts:18:22",
    "issues": {
      "0": {
        "security_vulnerability": {
          "first_patched_version": "Expected object, received null"
        }
      },
      "1": {
        "security_vulnerability": {
          "first_patched_version": "Expected object, received null"
        }
      },
      "6": {
        "security_vulnerability": {
          "first_patched_version": "Expected object, received null"
        }
      },
      "___": "... 1 more"
    }
  }
}
```

## Documentation (please check one with an [x])

- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
