### PR TITLE
fix(vulnerabilities): do not force exact patch version for NuGet datasource

### DIFF
--- a/lib/workers/repository/init/vulnerability.spec.ts
+++ b/lib/workers/repository/init/vulnerability.spec.ts
@@ -17,12 +17,9 @@ beforeEach(() => {
 
 describe('workers/repository/init/vulnerability', () => {
   describe('getFixedVersionByDatasource()', () => {
-    it('returns Maven version range', () => {
+    it('returns ecosystem-specific version range', () => {
       expect(getFixedVersionByDatasource('1.2.3', 'maven')).toBe('[1.2.3,)');
-    });
-
-    it('returns Nuget version', () => {
-      expect(getFixedVersionByDatasource('1.2.3', 'nuget')).toBe('1.2.3');
+      expect(getFixedVersionByDatasource('1.2.3', 'nuget')).toBe('[1.2.3,)');
     });
 
     it('returns default version range', () => {

--- a/lib/workers/repository/init/vulnerability.ts
+++ b/lib/workers/repository/init/vulnerability.ts
@@ -43,11 +43,8 @@ export function getFixedVersionByDatasource(
   fixedVersion: string,
   datasource: string,
 ): string {
-  if (datasource === MavenDatasource.id) {
+  if (datasource === MavenDatasource.id || datasource === NugetDatasource.id) {
     return `[${fixedVersion},)`;
-  } else if (datasource === NugetDatasource.id) {
-    // TODO: add support for nuget version ranges when #26150 is merged
-    return fixedVersion;
   }
 
   // crates.io, Go, Hex, npm, RubyGems, PyPI

--- a/lib/workers/repository/process/vulnerabilities.spec.ts
+++ b/lib/workers/repository/process/vulnerabilities.spec.ts
@@ -997,7 +997,7 @@ describe('workers/repository/process/vulnerabilities', () => {
           matchDatasources: ['nuget'],
           matchPackageNames: ['SharpZipLib'],
           matchCurrentVersion: '1.3.0',
-          allowedVersions: '1.3.3',
+          allowedVersions: '[1.3.3,)',
         },
         {
           matchDatasources: ['npm'],

--- a/lib/workers/repository/process/vulnerabilities.ts
+++ b/lib/workers/repository/process/vulnerabilities.ts
@@ -426,11 +426,8 @@ export class Vulnerabilities {
     fixedVersion: string,
     ecosystem: Ecosystem,
   ): string {
-    if (ecosystem === 'Maven') {
+    if (ecosystem === 'Maven' || ecosystem === 'NuGet') {
       return `[${fixedVersion},)`;
-    } else if (ecosystem === 'NuGet') {
-      // TODO: add support for nuget version ranges when #26150 is merged
-      return fixedVersion;
     }
 
     // crates.io, Go, Hex, npm, RubyGems, PyPI


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

PR #26150 added support for NuGet version ranges and thereby unlocked the possibility to also use them as version constraints in vulnerability fix PRs.

<!-- Describe what behavior is changed by this PR. -->

## Context

- https://github.com/renovatebot/renovate/pull/29666

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

Test repos:
* GitHub alerts: https://github.com/renovate-demo/26150-nuget-github/pull/2
* OSV: https://github.com/renovate-demo/26150-nuget-osv/pull/1

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
