### PR TITLE
feat(monorepo): Add lerna-lite repository

### DIFF
--- a/lib/data/monorepo.json
+++ b/lib/data/monorepo.json
@@ -337,6 +337,7 @@
     "ktor": "https://github.com/ktorio/ktor",
     "lamar": "https://github.com/JasperFx/lamar",
     "lerna": "https://github.com/lerna/lerna",
+    "lerna-lite": "https://github.com/lerna-lite/lerna-lite",
     "lexical": "https://github.com/facebook/lexical",
     "linguijs": "https://github.com/lingui/js-lingui",
     "log4j2": "https://github.com/apache/logging-log4j2",


### PR DESCRIPTION
# Changes

Added the lerna-lite monorepo URL https://github.com/lerna-lite/lerna-lite to the monorepo-preset.

Lerna-Lite has 467 GitHub stars and about [9k weekly downloads](https://www.npmjs.com/package/@lerna-lite/version).

<!-- Describe what behavior is changed by this PR. -->

# Context

Lerna-Lite is a super light version of the original [Lerna](https://github.com/lerna/lerna). Lerna-Lite differs from the original [Lerna](https://github.com/lerna/lerna) since it only has a limited subset of its original commands (which itself has 15 commands) and they are all optional in Lerna-Lite making its install footprint a lot smaller.

As a consequence of this, Lerna-Lite is organized in a monorepo, where the monorepo contains the Lerna-Lite packages, which in turn share the same version number

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository