### PR TITLE
fix(datasource/orb): retrieve more releases

### DIFF
--- a/lib/modules/datasource/orb/index.ts
+++ b/lib/modules/datasource/orb/index.ts
@@ -4,13 +4,15 @@ import { Datasource } from '../datasource';
 import type { GetReleasesConfig, ReleaseResult } from '../types';
 import type { OrbResponse } from './types';
 
+const MAX_VERSIONS = 100;
+
 const query = `
-query($packageName: String!) {
+query($packageName: String!, $maxVersions: Int!) {
   orb(name: $packageName) {
     name,
     homeUrl,
     isPrivate,
-    versions {
+    versions(count: $maxVersions) {
       version,
       createdAt
     }
@@ -48,7 +50,7 @@ export class OrbDatasource extends Datasource {
     const url = `${registryUrl}graphql-unstable`;
     const body = {
       query,
-      variables: { packageName },
+      variables: { packageName, maxVersions: MAX_VERSIONS },
     };
     const res = (
       await this.http.postJson<OrbResponse>(url, {


### PR DESCRIPTION
## Changes

Closes #31164.

Update the GraphQL query that retrieves orb releases from CircleCI to retrieve more items by default.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

Ran Renovate with the changes locally against https://github.com/backmarket-oss/renovate-repro-orb-max-items-issue.

We can see that:
- [Renovate GitHub app](https://github.com/backmarket-oss/renovate-repro-orb-max-items-issue/issues/3) was only able to detect updates for the orb being less than 10 releases late
- [Local Renovate](https://github.com/backmarket-oss/renovate-repro-orb-max-items-issue/issues/2) was able to detect updates for both orbs (the one being more than 10 releases late, the one being less than 10 releases late)

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
