### PR TITLE
fix(versioning/pep440): match function should match on equality

### DIFF
--- a/lib/modules/versioning/pep440/index.spec.ts
+++ b/lib/modules/versioning/pep440/index.spec.ts
@@ -41,6 +41,7 @@ describe('modules/versioning/pep440/index', () => {
   it.each`
     a          | b             | expected
     ${'1.0'}   | ${'>=1.0.0'}  | ${true}
+    ${'3.0.0'} | ${'3.0.0'}    | ${true}
     ${'1.6.2'} | ${'<2.2.1.0'} | ${true}
     ${'>=3.8'} | ${'>=3.9'}    | ${false}
   `('matches($a, $b) === $expected', ({ a, b, expected }) => {

--- a/lib/modules/versioning/pep440/index.ts
+++ b/lib/modules/versioning/pep440/index.ts
@@ -75,7 +75,13 @@ const equals = (version1: string, version2: string): boolean =>
   isVersion(version1) && isVersion(version2) && eq(version1, version2);
 
 function matches(version: string, range: string): boolean {
-  return isVersion(version) && isValid(range) && satisfies(version, range);
+  if (!isVersion(version)) {
+    return false;
+  }
+  if (isVersion(range)) {
+    return equals(version, range);
+  }
+  return isValid(range) && satisfies(version, range);
 }
 
 export const api: VersioningApi = {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
`pep440.matches` should return true if the range and version supplied are equal
<!-- Describe what behavior is changed by this PR. -->

## Context
https://github.com/renovatebot/renovate/discussions/31084

Ansible releases are discarded as the are not matching the expected range at: 
https://github.com/renovatebot/renovate/blob/3f2637b4614d695e750bb65c42a234a3cbd7fe94/lib/workers/repository/process/lookup/index.ts#L226-L230

Probably a regression from: 
https://github.com/renovatebot/renovate/commit/cec37bb214c1be207dbabc05f822829408a8c20a

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
