### PR TITLE
fix(managers/pep621): replace missing depName group with managerData

### DIFF
--- a/lib/modules/manager/pep621/artifacts.spec.ts
+++ b/lib/modules/manager/pep621/artifacts.spec.ts
@@ -8,7 +8,6 @@ import type { RepoGlobalConfig } from '../../../config/types';
 import { getPkgReleases as _getPkgReleases } from '../../datasource';
 import type { UpdateArtifactsConfig } from '../types';
 import { updateArtifacts } from './artifacts';
-import { depTypes } from './utils';
 
 jest.mock('../../../util/fs');
 jest.mock('../../datasource', () => mockDeep());
@@ -81,12 +80,7 @@ describe('modules/manager/pep621/artifacts', () => {
         releases: [{ version: 'v2.6.1' }, { version: 'v2.5.0' }],
       });
 
-      const updatedDeps = [
-        { packageName: 'dep1' },
-        { packageName: 'dep2' },
-        { packageName: 'dep3', depType: depTypes.pdmDevDependencies },
-        { packageName: 'dep4', depType: depTypes.pdmDevDependencies },
-      ];
+      const updatedDeps = [{ packageName: 'dep1' }];
       const result = await updateArtifacts({
         packageFileName: 'pyproject.toml',
         newPackageFileContent: codeBlock`
@@ -133,9 +127,7 @@ requires-python = "<3.9"
             '&& ' +
             'install-tool pdm v2.5.0 ' +
             '&& ' +
-            'pdm update --no-sync --update-eager dep1 dep2 ' +
-            '&& ' +
-            'pdm update --no-sync --update-eager -d dep3 dep4' +
+            'pdm update --no-sync --update-eager dep1' +
             '"',
           options: {
             cwd: '/tmp/github/some/repo',

--- a/lib/modules/manager/pep621/artifacts.spec.ts
+++ b/lib/modules/manager/pep621/artifacts.spec.ts
@@ -8,6 +8,7 @@ import type { RepoGlobalConfig } from '../../../config/types';
 import { getPkgReleases as _getPkgReleases } from '../../datasource';
 import type { UpdateArtifactsConfig } from '../types';
 import { updateArtifacts } from './artifacts';
+import { depTypes } from './utils';
 
 jest.mock('../../../util/fs');
 jest.mock('../../datasource', () => mockDeep());
@@ -80,7 +81,12 @@ describe('modules/manager/pep621/artifacts', () => {
         releases: [{ version: 'v2.6.1' }, { version: 'v2.5.0' }],
       });
 
-      const updatedDeps = [{ packageName: 'dep1' }];
+      const updatedDeps = [
+        { packageName: 'dep1' },
+        { packageName: 'dep2' },
+        { packageName: 'dep3', depType: depTypes.pdmDevDependencies },
+        { packageName: 'dep4', depType: depTypes.pdmDevDependencies },
+      ];
       const result = await updateArtifacts({
         packageFileName: 'pyproject.toml',
         newPackageFileContent: codeBlock`
@@ -127,7 +133,9 @@ requires-python = "<3.9"
             '&& ' +
             'install-tool pdm v2.5.0 ' +
             '&& ' +
-            'pdm update --no-sync --update-eager dep1' +
+            'pdm update --no-sync --update-eager dep1 dep2 ' +
+            '&& ' +
+            'pdm update --no-sync --update-eager -d dep3 dep4' +
             '"',
           options: {
             cwd: '/tmp/github/some/repo',

--- a/lib/modules/manager/pep621/extract.spec.ts
+++ b/lib/modules/manager/pep621/extract.spec.ts
@@ -135,6 +135,7 @@ describe('modules/manager/pep621/extract', () => {
           depType: 'project.optional-dependencies',
           currentValue: '>12',
           depName: 'pytest',
+          managerData: { depGroup: 'pytest' },
         },
         {
           packageName: 'pytest-mock',
@@ -142,6 +143,7 @@ describe('modules/manager/pep621/extract', () => {
           depType: 'project.optional-dependencies',
           skipReason: 'unspecified-version',
           depName: 'pytest-mock',
+          managerData: { depGroup: 'pytest' },
         },
       ]);
 
@@ -155,6 +157,7 @@ describe('modules/manager/pep621/extract', () => {
           depType: 'tool.pdm.dev-dependencies',
           skipReason: 'unspecified-version',
           depName: 'pdm',
+          managerData: { depGroup: 'test' },
         },
         {
           packageName: 'pytest-rerunfailures',
@@ -162,6 +165,7 @@ describe('modules/manager/pep621/extract', () => {
           depType: 'tool.pdm.dev-dependencies',
           currentValue: '>=10.2',
           depName: 'pytest-rerunfailures',
+          managerData: { depGroup: 'test' },
         },
         {
           packageName: 'tox',
@@ -169,6 +173,7 @@ describe('modules/manager/pep621/extract', () => {
           depType: 'tool.pdm.dev-dependencies',
           skipReason: 'unspecified-version',
           depName: 'tox',
+          managerData: { depGroup: 'tox' },
         },
         {
           packageName: 'tox-pdm',
@@ -176,6 +181,7 @@ describe('modules/manager/pep621/extract', () => {
           depType: 'tool.pdm.dev-dependencies',
           currentValue: '>=0.5',
           depName: 'tox-pdm',
+          managerData: { depGroup: 'tox' },
         },
       ]);
     });
@@ -219,6 +225,7 @@ describe('modules/manager/pep621/extract', () => {
             'https://private-site.org/pypi/simple',
             'https://private.pypi.org/simple',
           ],
+          managerData: { depGroup: 'pytest' },
         },
         {
           packageName: 'pytest-rerunfailures',
@@ -230,6 +237,7 @@ describe('modules/manager/pep621/extract', () => {
             'https://private-site.org/pypi/simple',
             'https://private.pypi.org/simple',
           ],
+          managerData: { depGroup: 'test' },
         },
         {
           packageName: 'tox-pdm',
@@ -241,6 +249,7 @@ describe('modules/manager/pep621/extract', () => {
             'https://private-site.org/pypi/simple',
             'https://private.pypi.org/simple',
           ],
+          managerData: { depGroup: 'tox' },
         },
       ]);
     });

--- a/lib/modules/manager/pep621/processors/pdm.spec.ts
+++ b/lib/modules/manager/pep621/processors/pdm.spec.ts
@@ -3,6 +3,7 @@ import { mockExecAll } from '../../../../../test/exec-util';
 import { fs, mockedFunction } from '../../../../../test/util';
 import { GlobalConfig } from '../../../../config/global';
 import type { RepoGlobalConfig } from '../../../../config/types';
+import { logger } from '../../../../logger';
 import { getPkgReleases as _getPkgReleases } from '../../../datasource';
 import type { UpdateArtifactsConfig } from '../../types';
 import { depTypes } from '../utils';
@@ -141,21 +142,36 @@ describe('modules/manager/pep621/processors/pdm', () => {
         },
         { packageName: 'dep2', depType: depTypes.dependencies },
         {
-          depName: 'group1/dep3',
+          packageName: 'dep3',
+          managerData: { depGroup: 'group1' },
           depType: depTypes.optionalDependencies,
         },
-        { depName: 'group1/dep4', depType: depTypes.optionalDependencies },
         {
-          depName: 'group2/dep5',
-          depType: depTypes.pdmDevDependencies,
+          packageName: 'dep4',
+          depType: depTypes.optionalDependencies,
+          managerData: { depGroup: 'group1' },
         },
-        { depName: 'group2/dep6', depType: depTypes.pdmDevDependencies },
         {
-          depName: 'group3/dep7',
+          packageName: 'dep5',
           depType: depTypes.pdmDevDependencies,
+          managerData: { depGroup: 'group2' },
         },
-        { depName: 'group3/dep8', depType: depTypes.pdmDevDependencies },
-        { depName: 'dep9', depType: depTypes.buildSystemRequires },
+        {
+          packageName: 'dep6',
+          depType: depTypes.pdmDevDependencies,
+          managerData: { depGroup: 'group2' },
+        },
+        {
+          packageName: 'dep7',
+          depType: depTypes.pdmDevDependencies,
+          managerData: { depGroup: 'group3' },
+        },
+        {
+          packageName: 'dep8',
+          depType: depTypes.pdmDevDependencies,
+          managerData: { depGroup: 'group3' },
+        },
+        { packageName: 'dep9', depType: depTypes.buildSystemRequires },
       ];
       const result = await processor.updateArtifacts(
         {
@@ -189,6 +205,45 @@ describe('modules/manager/pep621/processors/pdm', () => {
           cmd: 'pdm update --no-sync --update-eager -dG group3 dep7 dep8',
         },
       ]);
+    });
+
+    it('discard dependencies if the devGroup is missing', async () => {
+      const execSnapshots = mockExecAll();
+      GlobalConfig.set(adminConfig);
+      fs.getSiblingFileName.mockReturnValueOnce('pdm.lock');
+      fs.readLocalFile.mockResolvedValueOnce('test content');
+      fs.readLocalFile.mockResolvedValueOnce('test content');
+      // python
+      getPkgReleases.mockResolvedValueOnce({
+        releases: [{ version: '3.11.1' }, { version: '3.11.2' }],
+      });
+      // pdm
+      getPkgReleases.mockResolvedValueOnce({
+        releases: [{ version: 'v2.6.1' }, { version: 'v2.5.0' }],
+      });
+
+      const updatedDeps = [
+        {
+          packageName: 'dep3',
+          depType: depTypes.optionalDependencies,
+        },
+        {
+          packageName: 'dep5',
+          depType: depTypes.pdmDevDependencies,
+        },
+      ];
+      const result = await processor.updateArtifacts(
+        {
+          packageFileName: 'pyproject.toml',
+          newPackageFileContent: '',
+          config: {},
+          updatedDeps,
+        },
+        {},
+      );
+      expect(result).toBeNull();
+      expect(execSnapshots).toEqual([]);
+      expect(logger.once.warn).toHaveBeenCalledTimes(2);
     });
 
     it('return update on lockfileMaintenance', async () => {

--- a/lib/modules/manager/pep621/processors/pdm.spec.ts
+++ b/lib/modules/manager/pep621/processors/pdm.spec.ts
@@ -141,21 +141,21 @@ describe('modules/manager/pep621/processors/pdm', () => {
         },
         { packageName: 'dep2', depType: depTypes.dependencies },
         {
-          depName: 'group1/dep3',
+          packageName: 'dep3',
           depType: depTypes.optionalDependencies,
         },
-        { depName: 'group1/dep4', depType: depTypes.optionalDependencies },
+        { packageName: 'dep4', depType: depTypes.optionalDependencies },
         {
-          depName: 'group2/dep5',
+          packageName: 'dep5',
           depType: depTypes.pdmDevDependencies,
         },
-        { depName: 'group2/dep6', depType: depTypes.pdmDevDependencies },
+        { packageName: 'dep6', depType: depTypes.pdmDevDependencies },
         {
-          depName: 'group3/dep7',
+          packageName: 'dep7',
           depType: depTypes.pdmDevDependencies,
         },
-        { depName: 'group3/dep8', depType: depTypes.pdmDevDependencies },
-        { depName: 'dep9', depType: depTypes.buildSystemRequires },
+        { packageName: 'dep8', depType: depTypes.pdmDevDependencies },
+        { packageName: 'dep9', depType: depTypes.buildSystemRequires },
       ];
       const result = await processor.updateArtifacts(
         {
@@ -177,16 +177,10 @@ describe('modules/manager/pep621/processors/pdm', () => {
       ]);
       expect(execSnapshots).toMatchObject([
         {
-          cmd: 'pdm update --no-sync --update-eager dep1 dep2',
+          cmd: 'pdm update --no-sync --update-eager dep1 dep2 dep3 dep4',
         },
         {
-          cmd: 'pdm update --no-sync --update-eager -G group1 dep3 dep4',
-        },
-        {
-          cmd: 'pdm update --no-sync --update-eager -dG group2 dep5 dep6',
-        },
-        {
-          cmd: 'pdm update --no-sync --update-eager -dG group3 dep7 dep8',
+          cmd: 'pdm update --no-sync --update-eager -d dep5 dep6 dep7 dep8',
         },
       ]);
     });

--- a/lib/modules/manager/pep621/processors/pdm.spec.ts
+++ b/lib/modules/manager/pep621/processors/pdm.spec.ts
@@ -141,21 +141,21 @@ describe('modules/manager/pep621/processors/pdm', () => {
         },
         { packageName: 'dep2', depType: depTypes.dependencies },
         {
-          packageName: 'dep3',
+          depName: 'group1/dep3',
           depType: depTypes.optionalDependencies,
         },
-        { packageName: 'dep4', depType: depTypes.optionalDependencies },
+        { depName: 'group1/dep4', depType: depTypes.optionalDependencies },
         {
-          packageName: 'dep5',
+          depName: 'group2/dep5',
           depType: depTypes.pdmDevDependencies,
         },
-        { packageName: 'dep6', depType: depTypes.pdmDevDependencies },
+        { depName: 'group2/dep6', depType: depTypes.pdmDevDependencies },
         {
-          packageName: 'dep7',
+          depName: 'group3/dep7',
           depType: depTypes.pdmDevDependencies,
         },
-        { packageName: 'dep8', depType: depTypes.pdmDevDependencies },
-        { packageName: 'dep9', depType: depTypes.buildSystemRequires },
+        { depName: 'group3/dep8', depType: depTypes.pdmDevDependencies },
+        { depName: 'dep9', depType: depTypes.buildSystemRequires },
       ];
       const result = await processor.updateArtifacts(
         {
@@ -177,10 +177,16 @@ describe('modules/manager/pep621/processors/pdm', () => {
       ]);
       expect(execSnapshots).toMatchObject([
         {
-          cmd: 'pdm update --no-sync --update-eager dep1 dep2 dep3 dep4',
+          cmd: 'pdm update --no-sync --update-eager dep1 dep2',
         },
         {
-          cmd: 'pdm update --no-sync --update-eager -d dep5 dep6 dep7 dep8',
+          cmd: 'pdm update --no-sync --update-eager -G group1 dep3 dep4',
+        },
+        {
+          cmd: 'pdm update --no-sync --update-eager -dG group2 dep5 dep6',
+        },
+        {
+          cmd: 'pdm update --no-sync --update-eager -dG group3 dep7 dep8',
         },
       ]);
     });

--- a/lib/modules/manager/pep621/processors/pdm.ts
+++ b/lib/modules/manager/pep621/processors/pdm.ts
@@ -14,13 +14,17 @@ import type {
   Upgrade,
 } from '../../types';
 import { PdmLockfileSchema, type PyProject } from '../schema';
+import type { Pep621ManagerData } from '../types';
 import { depTypes, parseDependencyGroupRecord } from '../utils';
 import type { PyProjectProcessor } from './types';
 
 const pdmUpdateCMD = 'pdm update --no-sync --update-eager';
 
 export class PdmProcessor implements PyProjectProcessor {
-  process(project: PyProject, deps: PackageDependency[]): PackageDependency[] {
+  process(
+    project: PyProject,
+    deps: PackageDependency[],
+  ): PackageDependency<Pep621ManagerData>[] {
     const pdm = project.tool?.pdm;
     if (is.nullOrUndefined(pdm)) {
       return deps;
@@ -164,26 +168,38 @@ export class PdmProcessor implements PyProjectProcessor {
   }
 }
 
-function generateCMDs(updatedDeps: Upgrade[]): string[] {
+function generateCMDs(updatedDeps: Upgrade<Pep621ManagerData>[]): string[] {
   const cmds: string[] = [];
   const packagesByCMD: Record<string, string[]> = {};
   for (const dep of updatedDeps) {
     switch (dep.depType) {
       case depTypes.optionalDependencies: {
-        const [group, name] = dep.depName!.split('/');
+        if (is.nullOrUndefined(dep.managerData?.depGroup)) {
+          logger.once.warn(
+            { dep: dep.depName },
+            'Unexpected optional dependency without group',
+          );
+          continue;
+        }
         addPackageToCMDRecord(
           packagesByCMD,
-          `${pdmUpdateCMD} -G ${quote(group)}`,
-          name,
+          `${pdmUpdateCMD} -G ${quote(dep.managerData.depGroup)}`,
+          dep.packageName!,
         );
         break;
       }
       case depTypes.pdmDevDependencies: {
-        const [group, name] = dep.depName!.split('/');
+        if (is.nullOrUndefined(dep.managerData?.depGroup)) {
+          logger.once.warn(
+            { dep: dep.depName },
+            'Unexpected dev dependency without group',
+          );
+          continue;
+        }
         addPackageToCMDRecord(
           packagesByCMD,
-          `${pdmUpdateCMD} -dG ${quote(group)}`,
-          name,
+          `${pdmUpdateCMD} -dG ${quote(dep.managerData.depGroup)}`,
+          dep.packageName!,
         );
         break;
       }

--- a/lib/modules/manager/pep621/processors/pdm.ts
+++ b/lib/modules/manager/pep621/processors/pdm.ts
@@ -169,18 +169,10 @@ function generateCMDs(updatedDeps: Upgrade[]): string[] {
   const packagesByCMD: Record<string, string[]> = {};
   for (const dep of updatedDeps) {
     switch (dep.depType) {
-      case depTypes.optionalDependencies: {
-        addPackageToCMDRecord(
-          packagesByCMD,
-          `${pdmUpdateCMD} -G ":all"`,
-          dep.packageName!,
-        );
-        break;
-      }
       case depTypes.pdmDevDependencies: {
         addPackageToCMDRecord(
           packagesByCMD,
-          `${pdmUpdateCMD} -d -G ":all"`,
+          `${pdmUpdateCMD} -d`,
           dep.packageName!,
         );
         break;

--- a/lib/modules/manager/pep621/processors/pdm.ts
+++ b/lib/modules/manager/pep621/processors/pdm.ts
@@ -169,10 +169,18 @@ function generateCMDs(updatedDeps: Upgrade[]): string[] {
   const packagesByCMD: Record<string, string[]> = {};
   for (const dep of updatedDeps) {
     switch (dep.depType) {
+      case depTypes.optionalDependencies: {
+        addPackageToCMDRecord(
+          packagesByCMD,
+          `${pdmUpdateCMD} -G ":all"`,
+          dep.packageName!,
+        );
+        break;
+      }
       case depTypes.pdmDevDependencies: {
         addPackageToCMDRecord(
           packagesByCMD,
-          `${pdmUpdateCMD} -d`,
+          `${pdmUpdateCMD} -d -G ":all"`,
           dep.packageName!,
         );
         break;

--- a/lib/modules/manager/pep621/processors/pdm.ts
+++ b/lib/modules/manager/pep621/processors/pdm.ts
@@ -169,21 +169,11 @@ function generateCMDs(updatedDeps: Upgrade[]): string[] {
   const packagesByCMD: Record<string, string[]> = {};
   for (const dep of updatedDeps) {
     switch (dep.depType) {
-      case depTypes.optionalDependencies: {
-        const [group, name] = dep.depName!.split('/');
-        addPackageToCMDRecord(
-          packagesByCMD,
-          `${pdmUpdateCMD} -G ${quote(group)}`,
-          name,
-        );
-        break;
-      }
       case depTypes.pdmDevDependencies: {
-        const [group, name] = dep.depName!.split('/');
         addPackageToCMDRecord(
           packagesByCMD,
-          `${pdmUpdateCMD} -dG ${quote(group)}`,
-          name,
+          `${pdmUpdateCMD} -d`,
+          dep.packageName!,
         );
         break;
       }

--- a/lib/modules/manager/pep621/processors/pdm.ts
+++ b/lib/modules/manager/pep621/processors/pdm.ts
@@ -169,11 +169,21 @@ function generateCMDs(updatedDeps: Upgrade[]): string[] {
   const packagesByCMD: Record<string, string[]> = {};
   for (const dep of updatedDeps) {
     switch (dep.depType) {
-      case depTypes.pdmDevDependencies: {
+      case depTypes.optionalDependencies: {
+        const [group, name] = dep.depName!.split('/');
         addPackageToCMDRecord(
           packagesByCMD,
-          `${pdmUpdateCMD} -d`,
-          dep.packageName!,
+          `${pdmUpdateCMD} -G ${quote(group)}`,
+          name,
+        );
+        break;
+      }
+      case depTypes.pdmDevDependencies: {
+        const [group, name] = dep.depName!.split('/');
+        addPackageToCMDRecord(
+          packagesByCMD,
+          `${pdmUpdateCMD} -dG ${quote(group)}`,
+          name,
         );
         break;
       }

--- a/lib/modules/manager/pep621/types.ts
+++ b/lib/modules/manager/pep621/types.ts
@@ -4,3 +4,7 @@ export interface Pep508ParseResult {
   extras?: string[];
   marker?: string;
 }
+
+export interface Pep621ManagerData {
+  depGroup?: string;
+}

--- a/lib/modules/manager/pep621/utils.ts
+++ b/lib/modules/manager/pep621/utils.ts
@@ -7,7 +7,7 @@ import { normalizePythonDepName } from '../../datasource/pypi/common';
 import type { PackageDependency } from '../types';
 import type { PyProject } from './schema';
 import { PyProjectSchema } from './schema';
-import type { Pep508ParseResult } from './types';
+import type { Pep508ParseResult, Pep621ManagerData } from './types';
 
 const pep508Regex = regEx(
   /^(?<packageName>[A-Z0-9._-]+)\s*(\[(?<extras>[A-Z0-9,._-]+)\])?\s*(?<currentValue>[^;]+)?(;\s*(?<marker>.*))?/i,
@@ -89,10 +89,14 @@ export function parseDependencyGroupRecord(
     return [];
   }
 
-  const deps: PackageDependency[] = [];
-  for (const pep508Strings of Object.values(records)) {
+  const deps: PackageDependency<Pep621ManagerData>[] = [];
+  for (const [depGroup, pep508Strings] of Object.entries(records)) {
     for (const dep of parseDependencyList(depType, pep508Strings)) {
-      deps.push({ ...dep, depName: dep.packageName! });
+      deps.push({
+        ...dep,
+        depName: dep.packageName!,
+        managerData: { depGroup },
+      });
     }
   }
   return deps;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
This is a v38 regression, which changed the behaviour regarding groups of dependencies in `pyproject.toml`. 

The PR changes that Renovate directly updates packages all occurrences of the same package at once. 
Further all packages of the same type ( general vs dev dependencies)  are upgraded together, as this is required by PDM

<!-- Describe what behavior is changed by this PR. -->

## Context
https://github.com/renovatebot/renovate/discussions/31162#discussioncomment-10532945

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository
https://github.com/secustor/renovate-reproduction-31162
<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
