### PR TITLE
feat(manager/uv): support `uv.toml` configuration

### DIFF
--- a/lib/modules/manager/pep621/extract.ts
+++ b/lib/modules/manager/pep621/extract.ts
@@ -53,7 +53,7 @@ export async function extractPackageFile(
   // process specific tool sets
   let processedDeps = deps;
   for (const processor of processors) {
-    processedDeps = processor.process(def, processedDeps);
+    processedDeps = await processor.process(def, processedDeps);
     processedDeps = await processor.extractLockedVersions(
       def,
       processedDeps,

--- a/lib/modules/manager/pep621/processors/hatch.ts
+++ b/lib/modules/manager/pep621/processors/hatch.ts
@@ -12,10 +12,10 @@ export class HatchProcessor implements PyProjectProcessor {
   process(
     pyproject: PyProject,
     deps: PackageDependency[],
-  ): PackageDependency[] {
+  ): Promise<PackageDependency[]> {
     const hatch_envs = pyproject.tool?.hatch?.envs;
     if (is.nullOrUndefined(hatch_envs)) {
-      return deps;
+      return Promise.resolve(deps);
     }
 
     for (const [envName, env] of Object.entries(hatch_envs)) {
@@ -29,7 +29,7 @@ export class HatchProcessor implements PyProjectProcessor {
       deps.push(...extraDeps);
     }
 
-    return deps;
+    return Promise.resolve(deps);
   }
 
   extractLockedVersions(

--- a/lib/modules/manager/pep621/processors/pdm.ts
+++ b/lib/modules/manager/pep621/processors/pdm.ts
@@ -20,10 +20,13 @@ import type { PyProjectProcessor } from './types';
 const pdmUpdateCMD = 'pdm update --no-sync --update-eager';
 
 export class PdmProcessor implements PyProjectProcessor {
-  process(project: PyProject, deps: PackageDependency[]): PackageDependency[] {
+  process(
+    project: PyProject,
+    deps: PackageDependency[],
+  ): Promise<PackageDependency[]> {
     const pdm = project.tool?.pdm;
     if (is.nullOrUndefined(pdm)) {
-      return deps;
+      return Promise.resolve(deps);
     }
 
     deps.push(
@@ -35,7 +38,7 @@ export class PdmProcessor implements PyProjectProcessor {
 
     const pdmSource = pdm.source;
     if (is.nullOrUndefined(pdmSource)) {
-      return deps;
+      return Promise.resolve(deps);
     }
 
     // add pypi default url, if there is no source declared with the name `pypi`. https://daobook.github.io/pdm/pyproject/tool-pdm/#specify-other-sources-for-finding-packages
@@ -51,7 +54,7 @@ export class PdmProcessor implements PyProjectProcessor {
       dep.registryUrls = [...registryUrls];
     }
 
-    return deps;
+    return Promise.resolve(deps);
   }
 
   async extractLockedVersions(

--- a/lib/modules/manager/pep621/processors/types.ts
+++ b/lib/modules/manager/pep621/processors/types.ts
@@ -17,7 +17,10 @@ export interface PyProjectProcessor {
    * @param project PyProject object
    * @param deps List of already extracted/processed dependencies
    */
-  process(project: PyProject, deps: PackageDependency[]): PackageDependency[];
+  process(
+    project: PyProject,
+    deps: PackageDependency[],
+  ): Promise<PackageDependency[]>;
 
   extractLockedVersions(
     project: PyProject,

--- a/lib/modules/manager/pep621/processors/uv.spec.ts
+++ b/lib/modules/manager/pep621/processors/uv.spec.ts
@@ -42,7 +42,10 @@ describe('modules/manager/pep621/processors/uv', () => {
       const result = processor.process(pyproject, dependencies);
 
       expect(result).toEqual([
-        { packageName: 'dep1' },
+        {
+          packageName: 'dep1',
+          registryUrls: ['https://pypi.org/pypi/'],
+        },
         {
           currentValue: '==1.2.3',
           currentVersion: '1.2.3',
@@ -50,6 +53,7 @@ describe('modules/manager/pep621/processors/uv', () => {
           depName: 'dep2',
           depType: 'tool.uv.dev-dependencies',
           packageName: 'dep2',
+          registryUrls: ['https://pypi.org/pypi/'],
         },
         {
           currentValue: '==2.3.4',
@@ -58,6 +62,62 @@ describe('modules/manager/pep621/processors/uv', () => {
           depName: 'dep3',
           depType: 'tool.uv.dev-dependencies',
           packageName: 'dep3',
+          registryUrls: ['https://pypi.org/pypi/'],
+        },
+      ]);
+    });
+
+    it('uses default PyPI and extra URLs when setting extra-index-url', () => {
+      const pyproject = {
+        tool: {
+          uv: {
+            'extra-index-url': [
+              'https://foo.example.com',
+              'https://bar.example.com',
+            ],
+          },
+        },
+      };
+      const dependencies = [{ packageName: 'dep1' }];
+
+      const result = processor.process(pyproject, dependencies);
+
+      expect(result).toEqual([
+        {
+          packageName: 'dep1',
+          registryUrls: [
+            'https://foo.example.com',
+            'https://bar.example.com',
+            'https://pypi.org/pypi/',
+          ],
+        },
+      ]);
+    });
+
+    it('uses index and extra URLs when setting index-url and extra-index-url', () => {
+      const pyproject = {
+        tool: {
+          uv: {
+            'index-url': 'https://foobar.example.com',
+            'extra-index-url': [
+              'https://foo.example.com',
+              'https://bar.example.com',
+            ],
+          },
+        },
+      };
+      const dependencies = [{ packageName: 'dep1' }];
+
+      const result = processor.process(pyproject, dependencies);
+
+      expect(result).toEqual([
+        {
+          packageName: 'dep1',
+          registryUrls: [
+            'https://foo.example.com',
+            'https://bar.example.com',
+            'https://foobar.example.com',
+          ],
         },
       ]);
     });

--- a/lib/modules/manager/pep621/schema.ts
+++ b/lib/modules/manager/pep621/schema.ts
@@ -37,7 +37,11 @@ const HatchSchema = z.object({
 
 const UvSchema = z.object({
   'dev-dependencies': DependencyListSchema,
+  'index-url': z.string().optional(),
+  'extra-index-url': z.array(z.string()).optional(),
 });
+
+export type Uv = z.infer<typeof UvSchema>;
 
 export const PyProjectSchema = z.object({
   project: z

--- a/lib/modules/manager/pep621/schema.ts
+++ b/lib/modules/manager/pep621/schema.ts
@@ -8,6 +8,37 @@ const DependencyRecordSchema = z
   .record(z.string(), z.array(z.string()))
   .optional();
 
+const PdmSchema = z.object({
+  'dev-dependencies': DependencyRecordSchema,
+  source: z
+    .array(
+      z.object({
+        url: z.string(),
+        name: z.string(),
+        verify_ssl: z.boolean().optional(),
+      }),
+    )
+    .optional(),
+});
+
+const HatchSchema = z.object({
+  envs: z
+    .record(
+      z.string(),
+      z
+        .object({
+          dependencies: DependencyListSchema,
+          'extra-dependencies': DependencyListSchema,
+        })
+        .optional(),
+    )
+    .optional(),
+});
+
+const UvSchema = z.object({
+  'dev-dependencies': DependencyListSchema,
+});
+
 export const PyProjectSchema = z.object({
   project: z
     .object({
@@ -25,40 +56,9 @@ export const PyProjectSchema = z.object({
     .optional(),
   tool: z
     .object({
-      pdm: z
-        .object({
-          'dev-dependencies': DependencyRecordSchema,
-          source: z
-            .array(
-              z.object({
-                url: z.string(),
-                name: z.string(),
-                verify_ssl: z.boolean().optional(),
-              }),
-            )
-            .optional(),
-        })
-        .optional(),
-      hatch: z
-        .object({
-          envs: z
-            .record(
-              z.string(),
-              z
-                .object({
-                  dependencies: DependencyListSchema,
-                  'extra-dependencies': DependencyListSchema,
-                })
-                .optional(),
-            )
-            .optional(),
-        })
-        .optional(),
-      uv: z
-        .object({
-          'dev-dependencies': DependencyListSchema,
-        })
-        .optional(),
+      pdm: PdmSchema.optional(),
+      hatch: HatchSchema.optional(),
+      uv: UvSchema.optional(),
     })
     .optional(),
 });


### PR DESCRIPTION
> [!note]
> Keeping the PR as a draft for now, because it requires some changes in the end (https://github.com/astral-sh/uv/issues/7007), and it's based on the changes made in https://github.com/renovatebot/renovate/pull/31186.

## Changes

Additionally to reading uv configuration from `[tool.uv]` in `pyproject.toml`, support reading configuration from `uv.toml`, which supports a subset of the options available in `pyproject.toml`.

## Context

Closes https://github.com/renovatebot/renovate/discussions/31188.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
