### PR TITLE
feat(manager/bun): Support allowScripts and ignoreScripts

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2103,7 +2103,7 @@ In the case that a user is automatically added as reviewer (such as Renovate App
 
 ## ignoreScripts
 
-Applicable for npm, Composer and Copier only for now. Set this to `true` if running scripts causes problems.
+Applicable for npm, bun, Composer and Copier only for now. Set this to `true` if running scripts causes problems.
 
 ## ignoreTests
 

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -888,7 +888,7 @@ const options: RenovateOptions[] = [
       'Set this to `false` if `allowScripts=true` and you wish to run scripts when updating lock files.',
     type: 'boolean',
     default: true,
-    supportedManagers: ['npm', 'composer', 'copier'],
+    supportedManagers: ['npm', 'bun', 'composer', 'copier'],
   },
   {
     name: 'platform',

--- a/lib/modules/manager/bun/artifacts.ts
+++ b/lib/modules/manager/bun/artifacts.ts
@@ -1,4 +1,5 @@
 import is from '@sindresorhus/is';
+import { GlobalConfig } from '../../../config/global';
 import { TEMPORARY_ERROR } from '../../../constants/error-messages';
 import { logger } from '../../../logger';
 import { exec } from '../../../util/exec';
@@ -44,6 +45,12 @@ export async function updateArtifacts(
       await deleteLocalFile(lockFileName);
     }
 
+    let cmd = 'bun install';
+
+    if (!GlobalConfig.get('allowScripts') || config.ignoreScripts) {
+      cmd += ' --ignore-scripts';
+    }
+
     const execOptions: ExecOptions = {
       userConfiguredEnv: config.env,
       cwdFile: packageFileName,
@@ -56,7 +63,7 @@ export async function updateArtifacts(
       ],
     };
 
-    await exec('bun install', execOptions);
+    await exec(cmd, execOptions);
     const newLockFileContent = await readLocalFile(lockFileName);
     if (
       !newLockFileContent ||


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This PR introduces support for the allowScripts and ignoreScripts options for the bun manager.

This PR contains the following breaking changes:
- Execute bun install with the --ignoreScripts flag on default configurations.
  - This behavior aligns with that of the npm manager (including pnpm and Yarn).

Related discussions: #24511

<!-- Describe what behavior is changed by this PR. -->

## Context

The motivation behind this change is to address potential errors that can occur when updating dependencies with bun install. These errors often arise due to the presence of prepare scripts within package.json, such as the following:

```json
{
  "scripts": {
    "prepare": "lefthook install"
  },
}
```

If an error occurs during bun install, the lockfile is not updated. This can be problematic for tools like lefthook, which rely on prepare scripts to set up their environment. Therefore, Renovate should support ignoreScripts for the bun manager in such use cases.

See also: https://github.com/evilmartians/lefthook/issues/669

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

I have checked this changes work as expected on [this repository](https://github.com/ronnnnn/renovate-test/pull/2).

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
