### PR TITLE
feat: do not mask secrets templates

### DIFF
--- a/lib/logger/utils.spec.ts
+++ b/lib/logger/utils.spec.ts
@@ -53,6 +53,34 @@ describe('logger/utils', () => {
     expect(sanitizeValue(input)).toBe(output);
   });
 
+  it('preserves secret template strings in redacted fields', () => {
+    const input = {
+      normal: 'value',
+      token: '{{ secrets.MY_SECRET }}',
+      password: '{{secrets.ANOTHER_SECRET}}',
+      content: '{{ secrets.CONTENT_SECRET }}',
+      npmToken: '{{ secrets.NPM_TOKEN }}',
+      forkToken: 'some-token',
+      nested: {
+        authorization: '{{ secrets.NESTED_SECRET }}',
+        password: 'some-password',
+      },
+    };
+    const expected = {
+      normal: 'value',
+      token: '{{ secrets.MY_SECRET }}',
+      password: '{{secrets.ANOTHER_SECRET}}',
+      content: '[content]',
+      npmToken: '{{ secrets.NPM_TOKEN }}',
+      forkToken: '***********',
+      nested: {
+        authorization: '{{ secrets.NESTED_SECRET }}',
+        password: '***********',
+      },
+    };
+    expect(sanitizeValue(input)).toEqual(expected);
+  });
+
   describe('prepareError', () => {
     function getError<T extends z.ZodType>(
       schema: T,

--- a/lib/logger/utils.ts
+++ b/lib/logger/utils.ts
@@ -4,6 +4,7 @@ import bunyan from 'bunyan';
 import fs from 'fs-extra';
 import { RequestError as HttpError } from 'got';
 import { ZodError } from 'zod';
+import { regEx } from '../util/regex';
 import { redactedFields, sanitize } from '../util/sanitize';
 import type { BunyanRecord, BunyanStream } from './types';
 
@@ -214,7 +215,12 @@ export function sanitizeValue(
       if (!val) {
         curValue = val;
       } else if (redactedFields.includes(key)) {
-        curValue = '***********';
+        // Do not mask/sanitize secrets templates
+        if (is.string(val) && regEx(/^{{\s*secrets\..*}}$/).test(val)) {
+          curValue = val;
+        } else {
+          curValue = '***********';
+        }
       } else if (contentFields.includes(key)) {
         curValue = '[content]';
       } else if (key === 'secrets') {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- Do not mask secrets templates from redacted fields
- Add tests
<!-- Describe what behavior is changed by this PR. -->

## Context
Closes: #31199 
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository [local-run-logs](https://github.com/Rahul-renovate-testing/repro-31199)

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
