### PR TITLE
refactor: Fix return type for `filterInternalChecks` function

### DIFF
--- a/lib/workers/repository/process/lookup/filter-checks.spec.ts
+++ b/lib/workers/repository/process/lookup/filter-checks.spec.ts
@@ -61,7 +61,7 @@ describe('workers/repository/process/lookup/filter-checks', () => {
       expect(res).toMatchSnapshot();
       expect(res.pendingChecks).toBeFalse();
       expect(res.pendingReleases).toHaveLength(0);
-      expect(res.release.version).toBe('1.0.4');
+      expect(res.release?.version).toBe('1.0.4');
     });
 
     it('returns non-pending latest release if internalChecksFilter=flexible and none pass checks', async () => {
@@ -76,7 +76,7 @@ describe('workers/repository/process/lookup/filter-checks', () => {
       expect(res).toMatchSnapshot();
       expect(res.pendingChecks).toBeFalse();
       expect(res.pendingReleases).toHaveLength(0);
-      expect(res.release.version).toBe('1.0.4');
+      expect(res.release?.version).toBe('1.0.4');
     });
 
     it('returns pending latest release if internalChecksFilter=strict and none pass checks', async () => {
@@ -91,7 +91,7 @@ describe('workers/repository/process/lookup/filter-checks', () => {
       expect(res).toMatchSnapshot();
       expect(res.pendingChecks).toBeTrue();
       expect(res.pendingReleases).toHaveLength(0);
-      expect(res.release.version).toBe('1.0.4');
+      expect(res.release?.version).toBe('1.0.4');
     });
 
     it('returns non-latest release if internalChecksFilter=strict and some pass checks', async () => {
@@ -106,7 +106,7 @@ describe('workers/repository/process/lookup/filter-checks', () => {
       expect(res).toMatchSnapshot();
       expect(res.pendingChecks).toBeFalse();
       expect(res.pendingReleases).toHaveLength(2);
-      expect(res.release.version).toBe('1.0.2');
+      expect(res.release?.version).toBe('1.0.2');
     });
 
     it('returns non-latest release if internalChecksFilter=flexible and some pass checks', async () => {
@@ -121,7 +121,7 @@ describe('workers/repository/process/lookup/filter-checks', () => {
       expect(res).toMatchSnapshot();
       expect(res.pendingChecks).toBeFalse();
       expect(res.pendingReleases).toHaveLength(2);
-      expect(res.release.version).toBe('1.0.2');
+      expect(res.release?.version).toBe('1.0.2');
     });
 
     it('picks up minimumReleaseAge settings from hostRules', async () => {
@@ -139,7 +139,7 @@ describe('workers/repository/process/lookup/filter-checks', () => {
       expect(res).toMatchSnapshot();
       expect(res.pendingChecks).toBeFalse();
       expect(res.pendingReleases).toHaveLength(0);
-      expect(res.release.version).toBe('1.0.4');
+      expect(res.release?.version).toBe('1.0.4');
     });
 
     it('picks up minimumReleaseAge settings from updateType', async () => {
@@ -154,7 +154,7 @@ describe('workers/repository/process/lookup/filter-checks', () => {
       expect(res).toMatchSnapshot();
       expect(res.pendingChecks).toBeFalse();
       expect(res.pendingReleases).toHaveLength(1);
-      expect(res.release.version).toBe('1.0.3');
+      expect(res.release?.version).toBe('1.0.3');
     });
 
     it('picks up minimumConfidence settings from updateType', async () => {
@@ -174,7 +174,7 @@ describe('workers/repository/process/lookup/filter-checks', () => {
       expect(res).toMatchSnapshot();
       expect(res.pendingChecks).toBeFalse();
       expect(res.pendingReleases).toHaveLength(3);
-      expect(res.release.version).toBe('1.0.1');
+      expect(res.release?.version).toBe('1.0.1');
     });
   });
 });

--- a/lib/workers/repository/process/lookup/filter-checks.ts
+++ b/lib/workers/repository/process/lookup/filter-checks.ts
@@ -16,7 +16,7 @@ import type { LookupUpdateConfig, UpdateResult } from './types';
 import { getUpdateType } from './update-type';
 
 export interface InternalChecksResult {
-  release: Release;
+  release?: Release;
   pendingChecks: boolean;
   pendingReleases?: Release[];
 }
@@ -117,6 +117,5 @@ export async function filterInternalChecks(
     }
   }
 
-  // TODO #22198
-  return { release: release!, pendingChecks, pendingReleases };
+  return { release, pendingChecks, pendingReleases };
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
