### PR TITLE
fix(manager/uv): skip unsupported sources

### DIFF
--- a/lib/modules/manager/pep621/processors/uv.spec.ts
+++ b/lib/modules/manager/pep621/processors/uv.spec.ts
@@ -71,7 +71,8 @@ describe('modules/manager/pep621/processors/uv', () => {
               dep3: { path: '/local-dep.whl' },
               dep4: { url: 'https://example.com' },
               dep5: { workspace: true },
-              dep6: {},
+              dep6: { workspace: false },
+              dep7: {},
             },
           },
         },
@@ -84,6 +85,7 @@ describe('modules/manager/pep621/processors/uv', () => {
         { depName: 'dep4' },
         { depName: 'dep5' },
         { depName: 'dep6' },
+        { depName: 'dep7' },
       ];
 
       const result = processor.process(pyproject, dependencies);
@@ -111,6 +113,10 @@ describe('modules/manager/pep621/processors/uv', () => {
         },
         {
           depName: 'dep6',
+          skipReason: 'invalid-dependency-specification',
+        },
+        {
+          depName: 'dep7',
           skipReason: 'invalid-dependency-specification',
         },
       ]);

--- a/lib/modules/manager/pep621/processors/uv.spec.ts
+++ b/lib/modules/manager/pep621/processors/uv.spec.ts
@@ -77,6 +77,7 @@ describe('modules/manager/pep621/processors/uv', () => {
         },
       };
       const dependencies = [
+        {},
         { depName: 'dep1' },
         { depName: 'dep2' },
         { depName: 'dep3' },
@@ -88,6 +89,7 @@ describe('modules/manager/pep621/processors/uv', () => {
       const result = processor.process(pyproject, dependencies);
 
       expect(result).toEqual([
+        {},
         {
           depName: 'dep1',
         },

--- a/lib/modules/manager/pep621/processors/uv.spec.ts
+++ b/lib/modules/manager/pep621/processors/uv.spec.ts
@@ -95,27 +95,22 @@ describe('modules/manager/pep621/processors/uv', () => {
         },
         {
           depName: 'dep2',
-          currentValue: '',
           skipReason: 'git-dependency',
         },
         {
           depName: 'dep3',
-          currentValue: '',
           skipReason: 'path-dependency',
         },
         {
           depName: 'dep4',
-          currentValue: '',
           skipReason: 'unsupported-url',
         },
         {
           depName: 'dep5',
-          currentValue: '',
           skipReason: 'inherited-dependency',
         },
         {
           depName: 'dep6',
-          currentValue: '',
           skipReason: 'invalid-dependency-specification',
         },
       ]);

--- a/lib/modules/manager/pep621/processors/uv.ts
+++ b/lib/modules/manager/pep621/processors/uv.ts
@@ -2,7 +2,6 @@ import is from '@sindresorhus/is';
 import { quote } from 'shlex';
 import { TEMPORARY_ERROR } from '../../../../constants/error-messages';
 import { logger } from '../../../../logger';
-import type { SkipReason } from '../../../../types';
 import { exec } from '../../../../util/exec';
 import type { ExecOptions, ToolConstraint } from '../../../../util/exec/types';
 import { getSiblingFileName, readLocalFile } from '../../../../util/fs';
@@ -43,23 +42,16 @@ export class UvProcessor implements PyProjectProcessor {
 
         const depSource = uv.sources[dep.depName];
         if (depSource) {
-          let skipReason: SkipReason | undefined;
-
           if (depSource.git) {
-            skipReason = 'git-dependency';
+            dep.skipReason = 'git-dependency';
           } else if (depSource.url) {
-            skipReason = 'unsupported-url';
+            dep.skipReason = 'unsupported-url';
           } else if (depSource.path) {
-            skipReason = 'path-dependency';
+            dep.skipReason = 'path-dependency';
           } else if (depSource.workspace) {
-            skipReason = 'inherited-dependency';
+            dep.skipReason = 'inherited-dependency';
           } else {
-            skipReason = 'invalid-dependency-specification';
-          }
-
-          if (skipReason) {
-            dep.currentValue = '';
-            dep.skipReason = skipReason;
+            dep.skipReason = 'invalid-dependency-specification';
           }
         }
       }

--- a/lib/modules/manager/pep621/schema.ts
+++ b/lib/modules/manager/pep621/schema.ts
@@ -35,8 +35,17 @@ const HatchSchema = z.object({
     .optional(),
 });
 
+// https://docs.astral.sh/uv/concepts/dependencies/#dependency-sources
+const UvSource = z.object({
+  git: z.string().optional(),
+  path: z.string().optional(),
+  url: z.string().optional(),
+  workspace: z.boolean(z.literal(true)).optional(),
+});
+
 const UvSchema = z.object({
   'dev-dependencies': DependencyListSchema,
+  sources: z.record(z.string(), UvSource).optional(),
 });
 
 export const PyProjectSchema = z.object({

--- a/lib/modules/manager/pep621/schema.ts
+++ b/lib/modules/manager/pep621/schema.ts
@@ -40,7 +40,7 @@ const UvSource = z.object({
   git: z.string().optional(),
   path: z.string().optional(),
   url: z.string().optional(),
-  workspace: z.boolean(z.literal(true)).optional(),
+  workspace: z.boolean().optional(),
 });
 
 const UvSchema = z.object({

--- a/lib/modules/manager/pep621/schema.ts
+++ b/lib/modules/manager/pep621/schema.ts
@@ -8,6 +8,37 @@ const DependencyRecordSchema = z
   .record(z.string(), z.array(z.string()))
   .optional();
 
+const PdmSchema = z.object({
+  'dev-dependencies': DependencyRecordSchema,
+  source: z
+    .array(
+      z.object({
+        url: z.string(),
+        name: z.string(),
+        verify_ssl: z.boolean().optional(),
+      }),
+    )
+    .optional(),
+});
+
+const HatchSchema = z.object({
+  envs: z
+    .record(
+      z.string(),
+      z
+        .object({
+          dependencies: DependencyListSchema,
+          'extra-dependencies': DependencyListSchema,
+        })
+        .optional(),
+    )
+    .optional(),
+});
+
+const UvSchema = z.object({
+  'dev-dependencies': DependencyListSchema,
+});
+
 export const PyProjectSchema = z.object({
   project: z
     .object({
@@ -25,40 +56,9 @@ export const PyProjectSchema = z.object({
     .optional(),
   tool: z
     .object({
-      pdm: z
-        .object({
-          'dev-dependencies': DependencyRecordSchema,
-          source: z
-            .array(
-              z.object({
-                url: z.string(),
-                name: z.string(),
-                verify_ssl: z.boolean().optional(),
-              }),
-            )
-            .optional(),
-        })
-        .optional(),
-      hatch: z
-        .object({
-          envs: z
-            .record(
-              z.string(),
-              z
-                .object({
-                  dependencies: DependencyListSchema,
-                  'extra-dependencies': DependencyListSchema,
-                })
-                .optional(),
-            )
-            .optional(),
-        })
-        .optional(),
-      uv: z
-        .object({
-          'dev-dependencies': DependencyListSchema,
-        })
-        .optional(),
+      pdm: PdmSchema.optional(),
+      hatch: HatchSchema.optional(),
+      uv: UvSchema.optional(),
     })
     .optional(),
 });


### PR DESCRIPTION
## Changes

Skip dependencies that define [a source](https://docs.astral.sh/uv/concepts/dependencies/#dependency-sources) that is not yet supported by Renovate.

## Context

This emerges from discussion in https://github.com/renovatebot/renovate/pull/31186#discussion_r1747961696. This will avoid having Renovate try to search for dependencies in PyPI if the dependencies are actually mapped to other sources (like a git repository, or a local path).

The end result is really similar to [what is done in Cargo](https://github.com/renovatebot/renovate/blob/3374bd1ce1e13da8129804e119c7643a5eef72bd/lib/modules/manager/cargo/extract.ts#L79-L91), and is defensive against potential new sources that could be added.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
