### PR TITLE
chore: add auto responses for log and question complexity

### DIFF
--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -131,7 +131,7 @@
     Hi there,
 
 
-    Please try to reduce the amount of logs you're pasting into this discussion. Maintainers have a limited amount of time to help you, and often to do from mobile devices, and it's easier for us to help you if you provide only the relevant parts of the logs and/or make a good attempt to look through them first and point to the lines you think are relevant.
+    Please try to reduce the amount of logs you're pasting into this discussion. Maintainers have a limited amount of time to help you, and often do so from mobile devices, so it's easier for us to help you if you provide only the relevant parts of the logs and/or make a good attempt to look through them first and point to the lines you think are relevant.
 
 
     As an example, if your problem is about a certain dependency, find the log sections which apply to that dependency and paste only those sections. Similarly, if your problem is about a particular branch/PR, find the log sections which apply to that branch/PR and paste only those sections.

--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -131,13 +131,13 @@
     Hi there,
 
 
-    Please try to reduce the amount of logs you're pasting into this discussion. Maintainers have a limited amount of time to help you, and often do so from mobile devices, so it's easier for us to help you if you provide only the relevant parts of the logs and/or make a good attempt to look through them first and point to the lines you think are relevant.
+    Please limit the amount of logs you're pasting into this discussion. The maintainers have a limited amount of time to help you, and often do so from mobile devices. It's easier for us if you only paste the relevant parts of the logs, and point us to the lines you think are relevant.
 
 
-    As an example, if your problem is about a certain dependency, find the log sections which apply to that dependency and paste only those sections. Similarly, if your problem is about a particular branch/PR, find the log sections which apply to that branch/PR and paste only those sections.
+    For example, if your problem is about a certain dependency, find the log sections which apply to that dependency and paste only those sections. Similarly, if your problem is about a particular branch/PR, find the log sections which apply to that branch/PR and paste only those sections.
 
 
-    If you're unsure, it's also perfectly acceptable to paste the full logs, including into a gist, but if that's the only thing you do, it's likely to take longer for us to help you or we may not start.
+    If you're not sure, it's acceptable to paste the full logs, including into a gist. Please try to explain the problem in enough detail to give us starting points to debug. If you only paste the full log, and do nothing else, it is likely that we will take longer to help you, or we may not start to help you at all.
 
 
     Thanks, the Renovate team
@@ -461,16 +461,16 @@
     Hi there,
 
 
-    This discussion is too complex, and we recommend you simplify it to increase chances of getting help and finding a solution.
+    This discussion is too complex, and we want you to simplify. This way you are more likely to get help or a solution.
 
 
-    For example, if you've included your _whole_ config, and it's quite complex, while your problem relates to just one specific part, consider removing the parts that are not relevant to the problem. The best way to do this is to usually create a minimal reproduction repository.
+    For example, if you've pasted your _whole_ complex config, while your problem is about just one part, consider removing the parts that are not relevant to your problem. The best way to do this is to create a [minimal reproduction](https://github.com/renovatebot/renovate/blob/main/docs/development/minimal-reproductions.md).
 
 
-    You may have also tried many ways to achieve something, and described them all here, but if none of them work then it's best to focus on the one that you think is the most promising or the ideal solution and not complicate the description or logs with the other attempts.
+    You may have tried many ways to do something, and described all the methods you tried. If none of the methods worked, please focus on the most promising method, or the ideal solution. Avoid complicating the description (or logs) with the failed attempts.
 
 
-    Ultimately, if you reduce the complexity of your discussion, you'll increase the chances of getting help.
+    To summarize: please reduce the complexity of your discussion, to increase the chances of getting help.
 
 
     Thanks, the Renovate team

--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -126,6 +126,22 @@
 
     Thanks, the Renovate team
 
+'auto:logs-reduction':
+  comment: >
+    Hi there,
+
+
+    Please try to reduce the amount of logs you're pasting into this discussion. Maintainers have a limited amount of time to help you, and often to do from mobile devices, and it's easier for us to help you if you provide only the relevant parts of the logs and/or make a good attempt to look through them first and point to the lines you think are relevant.
+
+
+    As an example, if your problem is about a certain dependency, find the log sections which apply to that dependency and paste only those sections. Similarly, if your problem is about a particular branch/PR, find the log sections which apply to that branch/PR and paste only those sections.
+
+
+    If you're unsure, it's also perfectly acceptable to paste the full logs, including into a gist, but if that's the only thing you do, it's likely to take longer for us to help you or we may not start.
+
+
+    Thanks, the Renovate team
+
 'new package manager':
   comment: >
     Hi there,
@@ -436,6 +452,25 @@
 
     Please read our [Code of Conduct, how we prioritize work](https://github.com/renovatebot/renovate/blob/main/CODE_OF_CONDUCT.md#how-we-prioritize-work) to learn more about how we prioritize what to work on.
     If you are a paying Mend.io customer, please tell your support or customer contact that this issue is important to you.
+
+
+    Thanks, the Renovate team
+
+'auto:reduce-complexity':
+  comment: >
+    Hi there,
+
+
+    This discussion is too complex, and we recommend you simplify it to increase chances of getting help and finding a solution.
+
+
+    For example, if you've included your _whole_ config, and it's quite complex, while your problem relates to just one specific part, consider removing the parts that are not relevant to the problem. The best way to do this is to usually create a minimal reproduction repository.
+
+
+    You may have also tried many ways to achieve something, and described them all here, but if none of them work then it's best to focus on the one that you think is the most promising or the ideal solution and not complicate the description or logs with the other attempts.
+
+
+    Ultimately, if you reduce the complexity of your discussion, you'll increase the chances of getting help.
 
 
     Thanks, the Renovate team


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds two new label actions addressing question and log complexity we often see

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
