### PR TITLE
refactor(manager/pep621): extract custom managers

### DIFF
--- a/lib/modules/manager/pep621/schema.ts
+++ b/lib/modules/manager/pep621/schema.ts
@@ -8,6 +8,37 @@ const DependencyRecordSchema = z
   .record(z.string(), z.array(z.string()))
   .optional();
 
+const PdmSchema = z.object({
+  'dev-dependencies': DependencyRecordSchema,
+  source: z
+    .array(
+      z.object({
+        url: z.string(),
+        name: z.string(),
+        verify_ssl: z.boolean().optional(),
+      }),
+    )
+    .optional(),
+});
+
+const HatchSchema = z.object({
+  envs: z
+    .record(
+      z.string(),
+      z
+        .object({
+          dependencies: DependencyListSchema,
+          'extra-dependencies': DependencyListSchema,
+        })
+        .optional(),
+    )
+    .optional(),
+});
+
+const UvSchema = z.object({
+  'dev-dependencies': DependencyListSchema,
+});
+
 export const PyProjectSchema = z.object({
   project: z
     .object({
@@ -25,40 +56,9 @@ export const PyProjectSchema = z.object({
     .optional(),
   tool: z
     .object({
-      pdm: z
-        .object({
-          'dev-dependencies': DependencyRecordSchema,
-          source: z
-            .array(
-              z.object({
-                url: z.string(),
-                name: z.string(),
-                verify_ssl: z.boolean().optional(),
-              }),
-            )
-            .optional(),
-        })
-        .optional(),
-      hatch: z
-        .object({
-          envs: z
-            .record(
-              z.string(),
-              z
-                .object({
-                  dependencies: DependencyListSchema,
-                  'extra-dependencies': DependencyListSchema,
-                })
-                .optional(),
-            )
-            .optional(),
-        })
-        .optional(),
-      uv: z
-        .object({
-          'dev-dependencies': DependencyListSchema,
-        })
-        .optional(),
+      pdm: PdmSchema.optional(),
+      hatch: HatchSchema.optional(),
+      uv: UvSchema.optional(),
     })
     .optional(),
 });


### PR DESCRIPTION
## Changes

Preliminary refactoring to make PEP 621 schema more readable, extracted from https://github.com/renovatebot/renovate/pull/31270 and https://github.com/renovatebot/renovate/pull/31186.

## Context

This was suggested in https://github.com/renovatebot/renovate/pull/31270#discussion_r1749810942.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

Neither of the above, relying on already existing unit tests.

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
