### PR TITLE
feat(template): allow `releaseTimestamp` & `currentVersionTimestamp`

### DIFF
--- a/lib/util/template/index.ts
+++ b/lib/util/template/index.ts
@@ -156,6 +156,7 @@ export const allowedFields = {
   currentValue: 'The extracted current value of the dependency being updated',
   currentVersion:
     'The version that would be currently installed. For example, if currentValue is ^3.0.0 then currentVersion might be 3.1.0.',
+  currentVersionTimestamp: 'The timestamp of the current version',
   currentDigest: 'The extracted current digest of the dependency being updated',
   currentDigestShort:
     'The extracted current short digest of the dependency being updated',
@@ -219,6 +220,7 @@ export const allowedFields = {
   references: 'A list of references for the upgrade',
   releases: 'An array of releases for an upgrade',
   releaseNotes: 'A ChangeLogNotes object for the release',
+  releaseTimestamp: 'The timestamp of the release',
   repository: 'The current repository',
   semanticPrefix: 'The fully generated semantic prefix for commit messages',
   sourceRepo: 'The repository in the sourceUrl, if present',


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

We would like to identify the pull requests of packages that have not been updated for some time, determined by the `currentVersionTimestamp` in the beginning of the PR title.

On the other hand, we are also interested in the date of the new version, determined by the `releaseTimestamp` to know it's age and maybe wait until the adoption is higher.

## Context

I've started a discussion #31228 to calculate the days between both dates but it turns out that this is not suitable as it would be very "noisy". Instead it would be great to define those timestamps statically inside the template.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository


```json
{
  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
  "extends": [
    "config:recommended",
    "schedule:weekly"
  ],
  "packageRules": [
    {
      "commitMessagePrefix": "currentVersionTimestamp={{ lookup (split currentVersionTimestamp 'T') 0 }}, releaseTimestamp={{ lookup (split releaseTimestamp 'T') 0 }} -"
    }
  ]
}
```


```
DEBUG: packageFiles with updates (repository=xxxx/my-app, baseBranch=main)
       "config": {
         "gomod": [
           {
             "packageFile": "go.mod",
             "deps": [
                  ...
                 {
                   "datasource": "go",
                   "depType": "require",
                   "depName": "k8s.io/client-go",
                   "currentValue": "v0.30.3",
                   "managerData": {"multiLine": true, "lineNumber": 31},
                   "updates": [
                     {
                       "bucket": "non-major",
                       "newVersion": "v0.31.0",
                       "newValue": "v0.31.0",
                       "releaseTimestamp": "2024-08-13T14:19:25.000Z",
                       "newMajor": 0,
                       "newMinor": 31,
                       "newPatch": 0,
                       "updateType": "minor",
                       "branchName": "renovate/kubernetes-go"
                     }
                   ],
                   "packageName": "k8s.io/client-go",
                   "versioning": "semver",
                   "warnings": [],
                   "sourceUrl": "https://github.com/kubernetes/client-go",
                   "currentVersion": "v0.30.3",
                   "currentVersionTimestamp": "2024-07-17T18:49:23.000Z",
                   "isSingleVersion": true,
                   "fixedVersion": "v0.30.3"
               },
               {
                 "datasource": "go",
                 "depType": "require",
                 "depName": "github.com/docker/docker",
                 "currentValue": "v26.1.5+incompatible",
                 "managerData": {"multiLine": true, "lineNumber": 21},
                 "updates": [
                   {
                     "bucket": "major",
                     "newVersion": "v27.2.1+incompatible",
                     "newValue": "v27.2.1+incompatible",
                     "releaseTimestamp": "2024-09-06T09:57:40.000Z",
                     "newMajor": 27,
                     "newMinor": 2,
                     "newPatch": 1,
                     "updateType": "major",
                     "branchName": "renovate/github.com-docker-docker-27.x"
                   }
                 ],
                 "packageName": "github.com/docker/docker",
                 "versioning": "semver",
                 "warnings": [],
                 "sourceUrl": "https://github.com/docker/docker",
                 "currentVersion": "v26.1.5+incompatible",
                 "currentVersionTimestamp": "2024-07-23T19:36:28.000Z",
                 "isSingleVersion": true,
                 "fixedVersion": "v26.1.5+incompatible"
               },
               ...
         ]
       }
...

DEBUG: branches info extended (repository=xxxx/my-app)
       "branchesInformation": [
         {
           "branchName": "renovate/kubernetes-go",
           "prNo": null,
           "prTitle": "currentVersionTimestamp=2024-07-17, releaseTimestamp=2024-08-13 - Update module k8s.io/client-go to v0.31.0",
           "result": "no-work",
           "upgrades": [
             {
               "datasource": "go",
               "depName": "k8s.io/client-go",
               "displayPending": "",
               "fixedVersion": "v0.30.3",
               "currentVersion": "v0.30.3",
               "currentValue": "v0.30.3",
               "newValue": "v0.31.0",
               "newVersion": "v0.31.0",
               "packageFile": "go.mod",
               "updateType": "minor",
               "packageName": "k8s.io/client-go"
             }
           ]
         },
         {
           "branchName": "renovate/github.com-docker-docker-27.x",
           "prNo": null,
           "prTitle": "currentVersionTimestamp=2024-07-23, releaseTimestamp=2024-09-06 - Update module github.com/docker/docker to v27",
           "result": "no-work",
           "upgrades": [
             {
               "datasource": "go",
               "depName": "github.com/docker/docker",
               "displayPending": "",
               "fixedVersion": "v26.1.5+incompatible",
               "currentVersion": "v26.1.5+incompatible",
               "currentValue": "v26.1.5+incompatible",
               "newValue": "v27.2.1+incompatible",
               "newVersion": "v27.2.1+incompatible",
               "packageFile": "go.mod",
               "updateType": "major",
               "packageName": "github.com/docker/docker"
             }
           ]
         }
       ]
```


<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
