### PR TITLE
docs(key-concepts/presets): rewrite

### DIFF
--- a/docs/usage/key-concepts/presets.md
+++ b/docs/usage/key-concepts/presets.md
@@ -12,15 +12,15 @@ To learn how to create your own presets, how to host them, and how to extend fro
 Use presets to:
 
 - Set up the bot with good default settings
-- Reduce duplication of your configuration
+- Avoid duplicating your configuration
 - Share your configuration with others
-- Use somebody else's configuration and extend it with your own rules
+- Use somebody else's configuration as-is, or extend it with your own rules
 
 ## How to use presets
 
-Let's say you're using the `config:recommended` preset, and want to pin your GitHub Action digests.
-Instead of writing your own Renovate config, you search through Renovate's built-in presets.
-You find the the `helpers:pinGitHubActionDigests` preset and add it to the `extends` array:
+Say you're using the `config:recommended` preset, and want to pin your GitHub Action digests.
+Instead of writing your own Renovate config, you search the docs, and find the `helpers:pinGitHubActionDigests` preset.
+Then you add the preset to the `"extends"` array in your Renovate configuration file:
 
 ```json
 {
@@ -28,35 +28,42 @@ You find the the `helpers:pinGitHubActionDigests` preset and add it to the `exte
 }
 ```
 
-Renovate now follows the rules for `config:recommended` plus the rules for `helpers:pinGitHubActionDigests`.
-If there is a logical conflict between presets, then the last preset in the array wins.
+In the example above, Renovate follows the rules from the `config:recommended` preset, plus the rules for `helpers:pinGitHubActionDigests`.
+
+<!-- prettier-ignore -->
+!!! tip
+    If there is a logical conflict between presets, then the _last_ preset in the `"extends"` array "wins".
 
 ## Managing config for many repositories
 
-If you manage Renovate for many repositories, then you should create a global preset configuration.
-Then you extend the global preset in each repository.
-This way you have all global configuration in a single file, in a single repository.
+If you manage the Renovate configuration for many repositories, we recommend that you:
+
+1. Create a global preset configuration
+1. Extend from the global preset in all of the repositories that should use your global preset as base
+
+This way, when you want to change your global Renovate configuration, you only need to edit the global preset file.
 
 ## Presets are modular
 
-Preset configs are modular, they can be as small as a single package rule or as large as an entire configuration.
-This is similar to the way you can share ESLint configurations.
+Preset configs are modular: a preset can be as small or large as you need.
+A preset can even extend from _other_ presets.
 
 ## Built-in presets
 
-Renovate comes with a lot of built-in presets that you can use.
-Browse [Renovate's default presets](../presets-default.md) to find any that are useful to you.
-Once you find a preset you like, put it in an `extends` array in your config file.
+Renovate comes with many built-in presets.
+We recommend you browse [Renovate's default presets](../presets-default.md).
+Again, to use the preset: add it to the `"extends"` array in your Renovate config file.
 
 ### Contributing a new built-in preset
 
 If you have a Renovate config that may help others, you can put it into Renovate's built-in presets.
-
 Read [Contributing to presets](../config-presets.md#contributing-to-presets) to learn how.
 
 ## Summary
 
 In short:
 
-- Browse [Renovate's default presets](../presets-default.md) to find any that are useful to you
-- Publish your own if you wish to reuse them across repositories
+- Browse [Renovate's default presets](../presets-default.md), or our other presets, to find helpful presets
+- Use presets by putting them in the `"extends"` array in your Renovate config file
+- To manage the Renovate configuration for many repositories at once, create a global preset config file
+- The order of presets matters: in a logical conflict, the last preset in the `"extends"` array "wins"


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Rewrite the key concepts page for the presets
- Write short sentences
- Use simple terms and phrases, where possible
- Use lists
- Add admonition to emphasize that the order of operations is important for presets in the `"extends"` array

## Context

A general rewrite, plus I'm trying to resolve a old discussion. :smile: 

### Add user suggested bit to docs, or not?

A user suggested we add this explanation to the docs:

> if folks want to group by mono repo first, and then major/minor: they should import `group:allNonMajor` first, and then `config:recommended`. This gives the desired result.

I changed the quote a bit, to match current terms, and to make it more readable. But the idea is the same. :wink: Source:

- https://github.com/renovatebot/renovate/discussions/21099#discussioncomment-5594571

I'm not sure _if_, or where, I should put this in the preset docs. It feels very in-depth, so _if_ it goes in, it should go under a new sub-heading, somewhere suitable.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
