### PR TITLE
improve commit message for Nix lockfile maintenance

### DIFF
--- a/lib/modules/manager/nix/index.ts
+++ b/lib/modules/manager/nix/index.ts
@@ -7,7 +7,7 @@ export const supportsLockFileMaintenance = true;
 
 export const defaultConfig = {
   fileMatch: ['(^|/)flake\\.nix$'],
-  commitMessageAction: 'NiX Lock file maintenance',
+  commitMessageAction: 'Nix Lock file maintenance',
   commitMessageTopic: 'nixpkgs',
   commitMessageExtra: 'to {{newValue}}',
   enabled: false,

--- a/lib/modules/manager/nix/index.ts
+++ b/lib/modules/manager/nix/index.ts
@@ -7,6 +7,7 @@ export const supportsLockFileMaintenance = true;
 
 export const defaultConfig = {
   fileMatch: ['(^|/)flake\\.nix$'],
+  commitMessageAction: 'NiX Lock file maintenance',
   commitMessageTopic: 'nixpkgs',
   commitMessageExtra: 'to {{newValue}}',
   enabled: false,


### PR DESCRIPTION

## Changes

improve commit message for Nix lockfile maintenance

## Context

Why: because changelogs with generic "build(deps): lock file maintenance" are not self-explanatory

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
