### PR TITLE
fix(vulnerability-alerts): fix handling of first_patched_version: null

### DIFF
--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -3808,10 +3808,28 @@ describe('modules/platform/github/index', () => {
               manifest_path: 'bar/foo',
             },
           },
+          {
+            security_advisory: {
+              description: 'description',
+              identifiers: [{ type: 'type', value: 'value' }],
+              references: [],
+            },
+            security_vulnerability: {
+              package: {
+                ecosystem: 'npm',
+                name: 'foo',
+              },
+              vulnerable_version_range: '0.0.2',
+              first_patched_version: null,
+            },
+            dependency: {
+              manifest_path: 'bar/foo',
+            },
+          },
         ]);
       await github.initRepo({ repository: 'some/repo' });
       const res = await github.getVulnerabilityAlerts();
-      expect(res).toHaveLength(1);
+      expect(res).toHaveLength(2);
     });
 
     it('returns empty if disabled', async () => {

--- a/lib/modules/platform/github/schema.ts
+++ b/lib/modules/platform/github/schema.ts
@@ -18,7 +18,7 @@ const PackageSchema = z.object({
 
 const SecurityVulnerabilitySchema = z
   .object({
-    first_patched_version: z.object({ identifier: z.string() }).optional(),
+    first_patched_version: z.object({ identifier: z.string() }).nullish(),
     package: PackageSchema,
     vulnerable_version_range: z.string(),
   })

--- a/lib/types/vulnerability-alert.ts
+++ b/lib/types/vulnerability-alert.ts
@@ -11,7 +11,7 @@ export interface VulnerabilityPackage {
   name: string;
 }
 export interface SecurityVulnerability {
-  first_patched_version?: { identifier: string };
+  first_patched_version?: { identifier: string } | null;
   package: VulnerabilityPackage;
   vulnerable_version_range: string;
 }

--- a/lib/workers/repository/init/vulnerability.spec.ts
+++ b/lib/workers/repository/init/vulnerability.spec.ts
@@ -120,7 +120,7 @@ describe('workers/repository/init/vulnerability', () => {
       delete config.vulnerabilityAlerts!.enabled;
       platform.getVulnerabilityAlerts.mockResolvedValue([
         {
-          // will be ignored - no firstPatchVersion
+          // will be ignored - firstPatchVersion is null
           dismissed_reason: null,
           dependency: {
             manifest_path: 'requirements.txt',

--- a/lib/workers/repository/init/vulnerability.spec.ts
+++ b/lib/workers/repository/init/vulnerability.spec.ts
@@ -116,6 +116,37 @@ describe('workers/repository/init/vulnerability', () => {
       expect(res.packageRules).toHaveLength(0);
     });
 
+    it('ignores alert if firstPatchVersion is null', async () => {
+      delete config.vulnerabilityAlerts!.enabled;
+      platform.getVulnerabilityAlerts.mockResolvedValue([
+        {
+          // will be ignored - no firstPatchVersion
+          dismissed_reason: null,
+          dependency: {
+            manifest_path: 'requirements.txt',
+          },
+          security_advisory: {
+            description:
+              'The create_script function in the lxc_container module in Ansible before 1.9.6-1 and 2.x before 2.0.2.0 allows local users to write to arbitrary files or gain privileges via a symlink attack on (1) /opt/.lxc-attach-script, (2) the archived container in the archive_path directory, or the (3) lxc-attach-script.log or (4) lxc-attach-script.err files in the temporary directory.',
+            identifiers: [
+              { type: 'GHSA', value: 'GHSA-rh6x-qvg7-rrmj' },
+              { type: 'CVE', value: 'CVE-2016-3096' },
+            ],
+            references: [
+              { url: 'https://nvd.nist.gov/vuln/detail/CVE-2016-3096' },
+            ],
+          },
+          security_vulnerability: {
+            package: { name: 'ansible', ecosystem: 'pip' },
+            vulnerable_version_range: '< 1.9.6.1',
+            first_patched_version: null,
+          },
+        },
+      ]);
+      const res = await detectVulnerabilityAlerts(config);
+      expect(res.packageRules).toHaveLength(0);
+    });
+
     it('returns go alerts', async () => {
       // TODO #22198
       delete config.vulnerabilityAlerts!.enabled;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Fix type for `first_patched_version: null` in GitHub vulnerability alerts response.

## Context

I just updated to renovate [v38.0.0](https://github.com/renovatebot/renovate/releases/tag/38.0.0) and suddenly we start getting lots of errors such as these:
```
"message": "Schema error",
"issues": {
	"17": {
		"security_vulnerability": {
			"first_patched_version": "Expected object, received null"
		}
	},
	"31": {
		"security_vulnerability": {
			"first_patched_version": "Expected object, received null"
		}
	},
	"38": {
		"security_vulnerability": {
			"first_patched_version": "Expected object, received null"
		}
	}
}
```

<details>

<summary>Full logs</summary>

```
{
	"id": "AgAAAZIAUxk_n4X8ZAAAAAAAAAAYAAAAAEFaSUFVeXBVQUFBemdkVUtJUHo3UXdBQgAAACQAAAAAMDE5MjAwNTMtM2M2Yy00ODFjLWFkMTgtN2U0NDQ3ZWEwOGE1",
	"content": {
		"timestamp": "2024-09-17T14:11:38.943Z",
		"tags": [
			"image_name:ghcr.io/mend/renovate-ce",
			"kube_container_name:mend-renovate-ce",
			"kube_replica_set:renovate-mend-renovate-ce-7644f9864b",
			"image_id:ghcr.io/mend/renovate-ce@sha256:47b6e092d527f4b2be3e365b62357f0e014ba95257e8282b4b6dd03e1621526c",
			"display_container_name:mend-renovate-ce_renovate-mend-renovate-ce-7644f9864b-j6s92",
			"container_name:mend-renovate-ce",
			"service:renovate-ce",
			"kube_app_name:mend-renovate-ce",
			"kube_namespace:renovate",
			"container_id:0e3c57c4284f1894b15b4d7f3d3481e5843879cd277d594ce18ffbb784c40ded",
			"pod_phase:running",
			"kube_qos:besteffort",
			"kube_ownerref_kind:replicaset",
			"dirname:/var/log/pods/renovate_renovate-mend-renovate-ce-7644f9864b-j6s92_3dc55c30-b803-4f3b-8026-458ebd7c4635/mend-renovate-ce",
			"kube_deployment:renovate-mend-renovate-ce",
			"kube_ownerref_name:renovate-mend-renovate-ce-7644f9864b",
			"kube_app_instance:renovate",
			"kube_service:renovate-mend-renovate-ce",
			"pod_name:renovate-mend-renovate-ce-7644f9864b-j6s92",
			"source:renovate-ce",
			"filename:0.log",
			"short_image:renovate-ce",
			"image_tag:8.2.0-full",
			"datadog.submission_auth:api_key"
		],
		"host": "renovate-mend-renovate-ce-7644f9864b-j6s92",
		"service": "renovate-ce",
		"message": "Vulnerability Alert: Failed to parse some alerts",
		"attributes": {
			"hostname": "renovate-mend-renovate-ce-7644f9864b-j6s92",
			"level": 20,
			"v": 0,
			"name": "renovate",
			"pid": 4491,
			"logContext": "3f07cb4f-9838-4fab-9fa1-5440da4376db",
			"time": "2024-09-17T14:11:38.069Z",
			"repository": "peakon/saml-idp",
			"error": {
				"stack": "ZodError: Schema error\n    at Object.transform (/usr/src/app/node_modules/renovate/lib/util/schema-utils.ts:66:21)\n    at /usr/src/app/node_modules/renovate/node_modules/zod/lib/types.js:3236:51\n    at processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at ZodEffects.safeParseAsync (/usr/src/app/node_modules/renovate/node_modules/zod/lib/types.js:199:24)\n    at ZodEffects.parseAsync (/usr/src/app/node_modules/renovate/node_modules/zod/lib/types.js:180:24)\n    at GithubHttp.requestJson (/usr/src/app/node_modules/renovate/lib/util/http/index.ts:297:16)\n    at Proxy.getVulnerabilityAlerts (/usr/src/app/node_modules/renovate/lib/modules/platform/github/index.ts:1979:7)\n    at detectVulnerabilityAlerts (/usr/src/app/node_modules/renovate/lib/workers/repository/init/vulnerability.ts:65:18)\n    at initRepo (/usr/src/app/node_modules/renovate/lib/workers/repository/init/index.ts:67:12)\n    at Object.renovateRepository (/usr/src/app/node_modules/renovate/lib/workers/repository/index.ts:64:14)\n    at attributes.repository (/usr/src/app/node_modules/renovate/lib/workers/global/index.ts:202:11)\n    at start (/usr/src/app/node_modules/renovate/lib/workers/global/index.ts:187:7)\n    at /usr/src/app/node_modules/renovate/lib/renovate.ts:18:22",
				"message": "Schema error",
				"issues": {
					"17": {
						"security_vulnerability": {
							"first_patched_version": "Expected object, received null"
						}
					},
					"31": {
						"security_vulnerability": {
							"first_patched_version": "Expected object, received null"
						}
					},
					"38": {
						"security_vulnerability": {
							"first_patched_version": "Expected object, received null"
						}
					}
				}
			},
			"status": "Debug"
		}
	}
}

```

</details>

I suspect that changes introduced via this PR: https://github.com/renovatebot/renovate/pull/27378 have broken how we deal with `first_patched_version` that is `null`.
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
