### PR TITLE
fix(instrumentation/otel): only use strings for span status and record exception

### DIFF
--- a/lib/instrumentation/index.ts
+++ b/lib/instrumentation/index.ts
@@ -21,12 +21,17 @@ import {
   SimpleSpanProcessor,
 } from '@opentelemetry/sdk-trace-base';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
-import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import {
+  ATTR_SERVICE_NAME,
+  ATTR_SERVICE_VERSION,
+} from '@opentelemetry/semantic-conventions';
+import { ATTR_SERVICE_NAMESPACE } from '@opentelemetry/semantic-conventions/incubating';
 import { pkg } from '../expose.cjs';
 import {
   isTraceDebuggingEnabled,
   isTraceSendingEnabled,
   isTracingEnabled,
+  massageThrowable,
 } from './utils';
 
 let instrumentations: Instrumentation[] = [];
@@ -41,12 +46,10 @@ export function init(): void {
   const traceProvider = new NodeTracerProvider({
     resource: new Resource({
       // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/README.md#semantic-attributes-with-sdk-provided-default-value
-      [SemanticResourceAttributes.SERVICE_NAME]:
-        process.env.OTEL_SERVICE_NAME ?? 'renovate',
-      [SemanticResourceAttributes.SERVICE_NAMESPACE]:
+      [ATTR_SERVICE_NAME]: process.env.OTEL_SERVICE_NAME ?? 'renovate',
+      [ATTR_SERVICE_NAMESPACE]:
         process.env.OTEL_SERVICE_NAMESPACE ?? 'renovatebot.com',
-      [SemanticResourceAttributes.SERVICE_VERSION]:
-        process.env.OTEL_SERVICE_VERSION ?? pkg.version,
+      [ATTR_SERVICE_VERSION]: process.env.OTEL_SERVICE_VERSION ?? pkg.version,
     }),
   });
 
@@ -144,9 +147,10 @@ export function instrument<F extends () => ReturnType<F>>(
       if (ret instanceof Promise) {
         return ret
           .catch((e) => {
+            span.recordException(e)
             span.setStatus({
               code: SpanStatusCode.ERROR,
-              message: e,
+              message: massageThrowable(e),
             });
             throw e;
           })
@@ -155,9 +159,10 @@ export function instrument<F extends () => ReturnType<F>>(
       span.end();
       return ret;
     } catch (e) {
+      span.recordException(e)
       span.setStatus({
         code: SpanStatusCode.ERROR,
-        message: e,
+        message: massageThrowable(e),
       });
       span.end();
       throw e;

--- a/lib/instrumentation/index.ts
+++ b/lib/instrumentation/index.ts
@@ -147,7 +147,7 @@ export function instrument<F extends () => ReturnType<F>>(
       if (ret instanceof Promise) {
         return ret
           .catch((e) => {
-            span.recordException(e)
+            span.recordException(e);
             span.setStatus({
               code: SpanStatusCode.ERROR,
               message: massageThrowable(e),
@@ -159,7 +159,7 @@ export function instrument<F extends () => ReturnType<F>>(
       span.end();
       return ret;
     } catch (e) {
-      span.recordException(e)
+      span.recordException(e);
       span.setStatus({
         code: SpanStatusCode.ERROR,
         message: massageThrowable(e),

--- a/lib/instrumentation/utils.spec.ts
+++ b/lib/instrumentation/utils.spec.ts
@@ -1,0 +1,16 @@
+import { massageThrowable } from './utils';
+
+describe('instrumentation/utils', () => {
+  describe('massageThrowable', () => {
+    it.each`
+      input                | expected
+      ${null}              | ${undefined}
+      ${undefined}         | ${undefined}
+      ${new Error('test')} | ${'test'}
+      ${'test'}            | ${'test'}
+      ${123}               | ${'123'}
+    `('should return $expected for $input', ({ input, expected }) => {
+      expect(massageThrowable(input)).toEqual(expected);
+    });
+  });
+});

--- a/lib/instrumentation/utils.ts
+++ b/lib/instrumentation/utils.ts
@@ -1,3 +1,5 @@
+import is from '@sindresorhus/is';
+
 export function isTracingEnabled(): boolean {
   return isTraceDebuggingEnabled() || isTraceSendingEnabled();
 }
@@ -8,4 +10,14 @@ export function isTraceDebuggingEnabled(): boolean {
 
 export function isTraceSendingEnabled(): boolean {
   return !!process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+}
+
+export function massageThrowable(e: unknown): string | undefined {
+  if (is.nullOrUndefined(e)) {
+    return undefined;
+  }
+  if (e instanceof Error) {
+    return e.message;
+  }
+  return String(e);
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- Use `recordException` to in case of rejections
- massage error messages to string
- remove usage of deprecated constants
<!-- Describe what behavior is changed by this PR. -->

## Context
- https://github.com/renovatebot/renovate/discussions/31459

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
