### PR TITLE
feat(replacements): eslint-plugin-vitest to scoped

### DIFF
--- a/lib/data/replacements.json
+++ b/lib/data/replacements.json
@@ -253,7 +253,7 @@
     "description": "`eslint-plugin-vitest` became scoped.",
     "packageRules": [
       {
-        "matchCurrentVersion": "0.5.4",
+        "matchCurrentVersion": ">=0.5.4",
         "matchDatasources": ["npm"],
         "matchPackageNames": ["eslint-plugin-vitest"],
         "replacementName": "@vitest/eslint-plugin",

--- a/lib/data/replacements.json
+++ b/lib/data/replacements.json
@@ -11,6 +11,7 @@
       "replacements:eslint-plugin-eslint-comments-to-maintained-fork",
       "replacements:eslint-config-standard-with-typescript-to-eslint-config-love",
       "replacements:eslint-plugin-node-to-maintained-fork",
+      "replacements:eslint-plugin-vitest-to-scoped",
       "replacements:fakerjs-to-scoped",
       "replacements:fastify-to-scoped",
       "replacements:hapi-to-scoped",
@@ -245,6 +246,18 @@
         "matchPackageNames": ["eslint-plugin-node"],
         "replacementName": "eslint-plugin-n",
         "replacementVersion": "14.0.0"
+      }
+    ]
+  },
+  "eslint-plugin-vitest-to-scoped": {
+    "description": "`eslint-plugin-vitest` became scoped.",
+    "packageRules": [
+      {
+        "matchCurrentVersion": "0.5.4",
+        "matchDatasources": ["npm"],
+        "matchPackageNames": ["eslint-plugin-vitest"],
+        "replacementName": "@vitest/eslint-plugin",
+        "replacementVersion": "1.0.0"
       }
     ]
   },


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Created a replacement rule for the [`eslint-plugin-vitest`](https://www.npmjs.com/package/eslint-plugin-vitest) with its continuation/scoped package.

## Context

The package is now published as scoped package [@vitest/eslint-plugin](https://www.npmjs.com/package/@vitest/eslint-plugin).

Proof:

- Click on https://github.com/veritem/eslint-plugin-vitest (from npmjs.com repository)
- End up https://github.com/vitest-dev/eslint-plugin-vitest

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
