### PR TITLE
docs(usage): clarify that `packageRules` must have a selector

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2410,12 +2410,11 @@ The order of rules matters, because later rules may override configuration optio
 
 The matching process for a package rule:
 
-- Each package rule must include at least one `match...` matcher to include or exclude dependencies.
-- Each matcher must contain at least one pattern and may contain a mix of positive and negative patterns.
-- A matcher includes a package if it matches at least one positive pattern, or if there are no positive patterns.
-- A matcher exludes a package if it matches any negative pattern.
-- If a package is both included and excluded, the negative pattern wins and the package is excluded.
-- A package rule matches a dependency if it is included by every matcher (they're AND-ed together).
+- Each package rule must include at least one `match...` matcher.
+- If multiple matchers are included in one package rule, all of them must match.
+- Each matcher must contain at least one pattern. Some matchers allow both positive and negative patterns.
+- If a matcher includes any positive patterns, it must match at least one of them.
+- A matcher returns `false` if it matches _any_ negative pattern, even if a positive match also occurred.
 
 For more details on positive and negative pattern syntax see Renovate's [string pattern matching documentation](./string-pattern-matching.md).
 

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2410,11 +2410,11 @@ The order of rules matters, because later rules may override configuration optio
 
 The matching process for a package rule:
 
-- Each package rule can include `match...` matchers to identify dependencies and `exclude...` matchers to filter them out.
-- If no match/exclude matchers are defined, everything matches.
+- Each package rule can include `match...` selectors to identify dependencies and `exclude...` selectors to filter them out.
+- Each package rule must include at least one `match...` or `exclude...` selector.
 - If an aspect is both `match`ed and `exclude`d, the exclusion wins.
-- Multiple values within a single matcher will be evaluated independently (they're OR-ed together).
-- Combining multiple matchers will restrict the resulting matches (they're AND-ed together):
+- Multiple values within a single selector will be evaluated independently (they're OR-ed together).
+- Combining multiple selector will restrict the resulting matches (they're AND-ed together):
   `matchCurrentVersion`, `matchCurrentValue`, `matchNewValue`, `matchConfidence`, `matchCurrentAge`,
   `matchManagers`, `matchDatasources`, `matchCategories`, `matchDepTypes`, `matchUpdateTypes`,
   `matchRepositories`, `matchBaseBranches`, `matchFileNames`

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2410,14 +2410,14 @@ The order of rules matters, because later rules may override configuration optio
 
 The matching process for a package rule:
 
-- Each package rule can include `match...` selectors to identify dependencies and `exclude...` selectors to filter them out.
-- Each package rule must include at least one `match...` or `exclude...` selector.
-- If an aspect is both `match`ed and `exclude`d, the exclusion wins.
-- Multiple values within a single selector will be evaluated independently (they're OR-ed together).
-- Combining multiple selector will restrict the resulting matches (they're AND-ed together):
-  `matchCurrentVersion`, `matchCurrentValue`, `matchNewValue`, `matchConfidence`, `matchCurrentAge`,
-  `matchManagers`, `matchDatasources`, `matchCategories`, `matchDepTypes`, `matchUpdateTypes`,
-  `matchRepositories`, `matchBaseBranches`, `matchFileNames`
+- Each package rule must include at least one `match...` matcher to include or exclude dependencies.
+- Each matcher must contain at least one pattern and may contain a mix of positive and negative patterns.
+- A matcher includes a package if it matches at least one positive pattern, or if there are no positive patterns.
+- A matcher exludes a package if it matches any negative pattern.
+- If a package is both included and excluded, the negative pattern wins and the package is excluded.
+- A package rule matches a dependency if it is included by every matcher (they're AND-ed together).
+
+For more details on positive and negative pattern syntax see Renovate's [string pattern matching documentation](./string-pattern-matching.md).
 
 Here is an example if you want to group together all packages starting with `eslint` into a single branch/PR:
 


### PR DESCRIPTION
## Changes
Per [this discussion](https://github.com/renovatebot/renovate/discussions/31509), I updated the documentation to match the behavior and "selector" terminology consistent with `packageRules` validation.

## Context
See the linked discussion.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository