### PR TITLE
fix(config): improve config:best-practices description

### DIFF
--- a/lib/config/presets/internal/config.ts
+++ b/lib/config/presets/internal/config.ts
@@ -4,13 +4,13 @@ import type { Preset } from '../types';
 
 export const presets: Record<string, Preset> = {
   'best-practices': {
-    configMigration: true,
     description:
       'Preset with best practices from the Renovate maintainers. Recommended for advanced users, who want to follow our best practices.',
     extends: [
       'config:recommended',
       'docker:pinDigests',
       'helpers:pinGitHubActionDigests',
+      ':configMigration',
       ':pinDevDependencies',
     ],
   },

--- a/lib/config/presets/internal/default.ts
+++ b/lib/config/presets/internal/default.ts
@@ -124,6 +124,10 @@ export const presets: Record<string, Preset> = {
       'Do not separate `patch` and `minor` upgrades into separate PRs for the same dependency.',
     separateMinorPatch: false,
   },
+  configMigration: {
+    configMigration: true,
+    description: 'Enable Renovate configuration migration PRs when needed.',
+  },
   dependencyDashboard: {
     dependencyDashboard: true,
     description: 'Enable Renovate Dependency Dashboard creation.',


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Makes all parts of config:best-practices be presets so that the description is correctly generated.

## Context

#31500

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
