### PR TITLE
docs: remove schedule Tip linking to CodePen

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -3765,10 +3765,6 @@ Renovate does not support scheduled minutes or "at an exact time" granularity.
 !!! note
     Actions triggered via the [Dependency Dashboard](#dependencydashboard) are not restricted by a configured schedule.
 
-<!-- prettier-ignore -->
-!!! tip
-    To validate your `later` schedule before updating your `renovate.json`, you can use [this CodePen](https://codepen.io/rationaltiger24/full/ZExQEgK).
-
 ## semanticCommitScope
 
 By default you will see Angular-style commit prefixes like `"chore(deps):"`.


### PR DESCRIPTION
## Changes

Updated docs for "schedule" config to remove the Tip to use CodePen to validate 'later' scheduling config.

## Context

The CodePen schedule validation page provides false positives and is unreliable.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
