### PR TITLE
refactor(sbt): Remove default parameter from `parseIndexDir`

### DIFF
--- a/lib/modules/datasource/sbt-package/index.spec.ts
+++ b/lib/modules/datasource/sbt-package/index.spec.ts
@@ -1,6 +1,7 @@
 import { getPkgReleases } from '..';
 import { Fixtures } from '../../../../test/fixtures';
 import * as httpMock from '../../../../test/http-mock';
+import { regEx } from '../../../util/regex';
 import * as mavenVersioning from '../../versioning/maven';
 import { MAVEN_REPO } from '../maven/common';
 import { parseIndexDir } from './util';
@@ -8,12 +9,20 @@ import { SbtPackageDatasource } from '.';
 
 describe('modules/datasource/sbt-package/index', () => {
   it('parses Maven index directory', () => {
-    expect(parseIndexDir(Fixtures.get(`maven-index.html`))).toMatchSnapshot();
+    expect(
+      parseIndexDir(
+        Fixtures.get(`maven-index.html`),
+        (x) => !regEx(/^\.+/).test(x),
+      ),
+    ).toMatchSnapshot();
   });
 
   it('parses sbt index directory', () => {
     expect(
-      parseIndexDir(Fixtures.get(`sbt-plugins-index.html`)),
+      parseIndexDir(
+        Fixtures.get(`sbt-plugins-index.html`),
+        (x) => !regEx(/^\.+/).test(x),
+      ),
     ).toMatchSnapshot();
   });
 

--- a/lib/modules/datasource/sbt-package/util.ts
+++ b/lib/modules/datasource/sbt-package/util.ts
@@ -1,12 +1,11 @@
 import { coerceArray } from '../../../util/array';
-import { regEx } from '../../../util/regex';
 import { compare } from '../../versioning/maven/compare';
 
 const linkRegExp = /(?<=href=['"])[^'"]*(?=\/['"])/gi;
 
 export function parseIndexDir(
   content: string,
-  filterFn = (x: string): boolean => !regEx(/^\.+/).test(x),
+  filterFn: (x: string) => boolean,
 ): string[] {
   const unfiltered = coerceArray(content.match(linkRegExp));
   return unfiltered.filter(filterFn);

--- a/lib/modules/datasource/sbt-plugin/index.spec.ts
+++ b/lib/modules/datasource/sbt-plugin/index.spec.ts
@@ -2,6 +2,7 @@ import { codeBlock, html } from 'common-tags';
 import { getPkgReleases } from '..';
 import { Fixtures } from '../../../../test/fixtures';
 import * as httpMock from '../../../../test/http-mock';
+import { regEx } from '../../../util/regex';
 import * as mavenVersioning from '../../versioning/maven';
 import { MAVEN_REPO } from '../maven/common';
 import { parseIndexDir } from '../sbt-package/util';
@@ -12,11 +13,15 @@ const sbtPluginIndex = Fixtures.get(`sbt-plugins-index.html`);
 
 describe('modules/datasource/sbt-plugin/index', () => {
   it('parses Maven index directory', () => {
-    expect(parseIndexDir(mavenIndexHtml)).toMatchSnapshot();
+    expect(
+      parseIndexDir(mavenIndexHtml, (x) => !regEx(/^\.+/).test(x)),
+    ).toMatchSnapshot();
   });
 
   it('parses sbt index directory', () => {
-    expect(parseIndexDir(sbtPluginIndex)).toMatchSnapshot();
+    expect(
+      parseIndexDir(sbtPluginIndex, (x) => !regEx(/^\.+/).test(x)),
+    ).toMatchSnapshot();
   });
 
   it('uses proper hostType', () => {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
