### PR TITLE
fix(vulnerabilities): set matchCurrentVersion for github alerts

### DIFF
--- a/lib/workers/repository/init/__snapshots__/vulnerability.spec.ts.snap
+++ b/lib/workers/repository/init/__snapshots__/vulnerability.spec.ts.snap
@@ -15,6 +15,7 @@ exports[`workers/repository/init/vulnerability detectVulnerabilityAlerts() retur
       "vulnerabilityFixStrategy": "lowest",
     },
     "isVulnerabilityAlert": true,
+    "matchCurrentVersion": "< 1.8.3",
     "matchDatasources": [
       "go",
     ],
@@ -50,6 +51,7 @@ exports[`workers/repository/init/vulnerability detectVulnerabilityAlerts() retur
       "vulnerabilityFixStrategy": "lowest",
     },
     "isVulnerabilityAlert": true,
+    "matchCurrentVersion": "(,2.7.9.4)",
     "matchDatasources": [
       "maven",
     ],
@@ -85,6 +87,7 @@ exports[`workers/repository/init/vulnerability detectVulnerabilityAlerts() retur
       "vulnerabilityFixStrategy": "lowest",
     },
     "isVulnerabilityAlert": true,
+    "matchCurrentVersion": "< 2.2.1.0",
     "matchDatasources": [
       "pypi",
     ],

--- a/lib/workers/repository/init/vulnerability.ts
+++ b/lib/workers/repository/init/vulnerability.ts
@@ -184,9 +184,15 @@ export async function detectVulnerabilityAlerts(
           matchFileNames,
         };
 
+        let matchCurrentVersion = `< ${val.firstPatchedVersion}`;
+        if (datasource === MavenDatasource.id) {
+          matchCurrentVersion = `(,${val.firstPatchedVersion})`;
+        }
+
         // Remediate only direct dependencies
         matchRule = {
           ...matchRule,
+          matchCurrentVersion,
           vulnerabilityFixVersion: val.firstPatchedVersion,
           prBodyNotes,
           isVulnerabilityAlert: true,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds `matchCurrentVersion` to package rules generated from github alerts

## Context

My `vulnerabilityFixVersion` exposed an existing problem and made it worse. We've never had `matchCurrentVersion` in our alert rules, and there's an edge case where a dependency exists both as a direct dependency plus a vulnerable indirect dependency (lock file). In such cases the non-vulnerable direct dependency would match the rule intended for the indirect dependency.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
