### PR TITLE
refactor: Restrict `postprocessRelease` method types

### DIFF
--- a/lib/modules/datasource/datasource.ts
+++ b/lib/modules/datasource/datasource.ts
@@ -4,7 +4,10 @@ import type {
   DatasourceApi,
   DigestConfig,
   GetReleasesConfig,
+  PostprocessReleaseConfig,
+  PostprocessReleaseResult,
   RegistryStrategy,
+  Release,
   ReleaseResult,
   SourceUrlSupport,
 } from './types';
@@ -60,5 +63,13 @@ export abstract class Datasource implements DatasourceApi {
     }
 
     throw err;
+  }
+
+  // no-op implementation
+  postprocessRelease(
+    config: PostprocessReleaseConfig,
+    release: Release,
+  ): Promise<PostprocessReleaseResult> {
+    return Promise.resolve(release);
   }
 }

--- a/lib/modules/datasource/datasource.ts
+++ b/lib/modules/datasource/datasource.ts
@@ -65,9 +65,9 @@ export abstract class Datasource implements DatasourceApi {
     throw err;
   }
 
-  // no-op implementation
+  // istanbul ignore: no-op implementation, never called
   postprocessRelease(
-    config: PostprocessReleaseConfig,
+    _config: PostprocessReleaseConfig,
     release: Release,
   ): Promise<PostprocessReleaseResult> {
     return Promise.resolve(release);

--- a/lib/modules/datasource/datasource.ts
+++ b/lib/modules/datasource/datasource.ts
@@ -65,7 +65,7 @@ export abstract class Datasource implements DatasourceApi {
     throw err;
   }
 
-  // istanbul ignore: no-op implementation, never called
+  // istanbul ignore next: no-op implementation, never called
   postprocessRelease(
     _config: PostprocessReleaseConfig,
     release: Release,

--- a/lib/modules/datasource/postprocess-release.spec.ts
+++ b/lib/modules/datasource/postprocess-release.spec.ts
@@ -59,7 +59,7 @@ describe('modules/datasource/postprocess-release', () => {
 
   it('returns original release for datasource with missing `packageName` field', async () => {
     class SomeDatasource extends DummyDatasource {
-      postprocessRelease(
+      override postprocessRelease(
         _config: PostprocessReleaseConfig,
         release: Release,
       ): Promise<PostprocessReleaseResult> {
@@ -82,7 +82,7 @@ describe('modules/datasource/postprocess-release', () => {
     const releaseOrig: Release = { version: '1.2.3' };
 
     class SomeDatasource extends DummyDatasource {
-      postprocessRelease(
+      override postprocessRelease(
         _config: PostprocessReleaseConfig,
         release: Release,
       ): Promise<PostprocessReleaseResult> {
@@ -107,7 +107,7 @@ describe('modules/datasource/postprocess-release', () => {
     const releaseOrig: Release = { version: '1.2.3' };
 
     class SomeDatasource extends DummyDatasource {
-      postprocessRelease(
+      override postprocessRelease(
         _config: PostprocessReleaseConfig,
         _release: Release,
       ): Promise<PostprocessReleaseResult> {
@@ -128,7 +128,7 @@ describe('modules/datasource/postprocess-release', () => {
     const releaseOrig: Release = { version: '1.2.3' };
 
     class SomeDatasource extends DummyDatasource {
-      postprocessRelease(
+      override postprocessRelease(
         _config: PostprocessReleaseConfig,
         _release: Release,
       ): Promise<PostprocessReleaseResult> {

--- a/lib/modules/datasource/postprocess-release.ts
+++ b/lib/modules/datasource/postprocess-release.ts
@@ -4,6 +4,7 @@ import type {
   UpdateResult,
 } from '../../workers/repository/process/lookup/types';
 import { getDatasourceFor } from './common';
+import { Datasource } from './datasource';
 import type { Release } from './types';
 
 type Config = Partial<LookupUpdateConfig & UpdateResult>;
@@ -23,7 +24,10 @@ export async function postprocessRelease(
     return release;
   }
 
-  if (!ds.postprocessRelease) {
+  if (
+    ds.constructor.prototype.postprocessRelease ===
+    Datasource.prototype.postprocessRelease
+  ) {
     return release;
   }
 

--- a/lib/modules/datasource/types.ts
+++ b/lib/modules/datasource/types.ts
@@ -160,7 +160,7 @@ export interface DatasourceApi extends ModuleApi {
    *
    * In other cases, the original `Release` parameter should be returned.
    */
-  postprocessRelease?(
+  postprocessRelease(
     config: PostprocessReleaseConfig,
     release: Release,
   ): Promise<PostprocessReleaseResult>;

--- a/lib/workers/repository/process/lookup/filter-checks.spec.ts
+++ b/lib/workers/repository/process/lookup/filter-checks.spec.ts
@@ -91,7 +91,7 @@ describe('workers/repository/process/lookup/filter-checks', () => {
       config.internalChecksFilter = 'strict';
 
       class SomeDatasource extends DummyDatasource {
-        postprocessRelease(
+        override postprocessRelease(
           _: PostprocessReleaseConfig,
           release: Release,
         ): Promise<PostprocessReleaseResult> {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Make it harder to use with wrong signature

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
