### PR TITLE
feat(monorepo): add riverqueue/river monorepo

### DIFF
--- a/lib/data/monorepo.json
+++ b/lib/data/monorepo.json
@@ -451,6 +451,7 @@
     "remark": "https://github.com/remarkjs/remark",
     "remix": "https://github.com/remix-run/remix",
     "retrofit": "https://github.com/square/retrofit",
+    "river": "https://github.com/riverqueue/river",
     "rjsf": "https://github.com/rjsf-team/react-jsonschema-form",
     "router5": "https://github.com/router5/router5",
     "ruby-on-rails": "https://github.com/rails/rails",


### PR DESCRIPTION
## Changes

Add `github.com/riverqueue/river` to the monorepo configuration.

## Context

Multiple binaries are built on the same repositories. 

- `github.com/riverqueue/river/cmd/river`
- `github.com/riverqueue/river/riverdriver/riverpgxv5`
- `github.com/riverqueue/river`
- ...

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [X] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
