### PR TITLE
feat(manager/gitlab-include): support multi-document package files

### DIFF
--- a/lib/modules/manager/gitlabci-include/extract.spec.ts
+++ b/lib/modules/manager/gitlabci-include/extract.spec.ts
@@ -1,3 +1,4 @@
+import { codeBlock } from 'common-tags';
 import { Fixtures } from '../../../../test/fixtures';
 import { GlobalConfig } from '../../../config/global';
 import { extractPackageFile } from '.';
@@ -67,6 +68,38 @@ describe('modules/manager/gitlabci-include/extract', () => {
         const res = extractPackageFile(yamlFileMultiConfig);
         expect(res?.deps[0].registryUrls).toEqual(['http://gitlab.test']);
       }
+    });
+
+    it('supports multi-document files', () => {
+      const multiDocFile = codeBlock`
+        other:
+          content: to be ignored
+        ---
+        include:
+          - project: mikebryant/include-source-example
+            ref: 1.0.0
+        ---
+        include:
+          - project: mikebryant/include-source-example2
+            ref: 2.0.0
+        ---
+        more:
+          content: to be ignored
+      `;
+      const res = extractPackageFile(multiDocFile);
+      expect(res?.deps).toHaveLength(2);
+      expect(res?.deps).toMatchObject([
+        {
+          currentValue: '1.0.0',
+          datasource: 'gitlab-tags',
+          depName: 'mikebryant/include-source-example',
+        },
+        {
+          currentValue: '2.0.0',
+          datasource: 'gitlab-tags',
+          depName: 'mikebryant/include-source-example2',
+        },
+      ]);
     });
   });
 });

--- a/lib/modules/manager/gitlabci-include/extract.spec.ts
+++ b/lib/modules/manager/gitlabci-include/extract.spec.ts
@@ -87,19 +87,20 @@ describe('modules/manager/gitlabci-include/extract', () => {
           content: to be ignored
       `;
       const res = extractPackageFile(multiDocFile);
-      expect(res?.deps).toHaveLength(2);
-      expect(res?.deps).toMatchObject([
-        {
-          currentValue: '1.0.0',
-          datasource: 'gitlab-tags',
-          depName: 'mikebryant/include-source-example',
-        },
-        {
-          currentValue: '2.0.0',
-          datasource: 'gitlab-tags',
-          depName: 'mikebryant/include-source-example2',
-        },
-      ]);
+      expect(res).toMatchObject({
+        deps: [
+          {
+            currentValue: '1.0.0',
+            datasource: 'gitlab-tags',
+            depName: 'mikebryant/include-source-example',
+          },
+          {
+            currentValue: '2.0.0',
+            datasource: 'gitlab-tags',
+            depName: 'mikebryant/include-source-example2',
+          },
+        ],
+      });
     });
   });
 });

--- a/lib/modules/manager/gitlabci-include/extract.ts
+++ b/lib/modules/manager/gitlabci-include/extract.ts
@@ -70,6 +70,10 @@ export function extractPackageFile(
   const deps: PackageDependency[] = [];
   const platform = GlobalConfig.get('platform');
   const endpoint = GlobalConfig.get('endpoint');
+  const registryUrls =
+    platform === 'gitlab' && endpoint
+      ? [endpoint.replace(regEx(/\/api\/v4\/?/), '')]
+      : null;
   try {
     // TODO: use schema (#9610)
     const docs = parseYaml<GitlabPipeline>(replaceReferenceTags(content), {
@@ -80,8 +84,8 @@ export function extractPackageFile(
         const includes = getAllIncludeProjects(doc);
         for (const includeObj of includes) {
           const dep = extractDepFromIncludeFile(includeObj);
-          if (platform === 'gitlab' && endpoint) {
-            dep.registryUrls = [endpoint.replace(regEx(/\/api\/v4\/?/), '')];
+          if (registryUrls) {
+            dep.registryUrls = registryUrls;
           }
           deps.push(dep);
         }

--- a/lib/modules/manager/gitlabci-include/extract.ts
+++ b/lib/modules/manager/gitlabci-include/extract.ts
@@ -2,7 +2,7 @@ import is from '@sindresorhus/is';
 import { GlobalConfig } from '../../../config/global';
 import { logger } from '../../../logger';
 import { regEx } from '../../../util/regex';
-import { parseSingleYaml } from '../../../util/yaml';
+import { parseYaml } from '../../../util/yaml';
 import { GitlabTagsDatasource } from '../../datasource/gitlab-tags';
 import {
   filterIncludeFromGitlabPipeline,
@@ -72,14 +72,20 @@ export function extractPackageFile(
   const endpoint = GlobalConfig.get('endpoint');
   try {
     // TODO: use schema (#9610)
-    const doc = parseSingleYaml<GitlabPipeline>(replaceReferenceTags(content));
-    const includes = getAllIncludeProjects(doc);
-    for (const includeObj of includes) {
-      const dep = extractDepFromIncludeFile(includeObj);
-      if (platform === 'gitlab' && endpoint) {
-        dep.registryUrls = [endpoint.replace(regEx(/\/api\/v4\/?/), '')];
+    const docs = parseYaml<GitlabPipeline>(replaceReferenceTags(content), {
+      uniqueKeys: false,
+    });
+    for (const doc of docs) {
+      if (is.object(doc)) {
+        const includes = getAllIncludeProjects(doc);
+        for (const includeObj of includes) {
+          const dep = extractDepFromIncludeFile(includeObj);
+          if (platform === 'gitlab' && endpoint) {
+            dep.registryUrls = [endpoint.replace(regEx(/\/api\/v4\/?/), '')];
+          }
+          deps.push(dep);
+        }
       }
-      deps.push(dep);
     }
   } catch (err) /* istanbul ignore next */ {
     if (err.stack?.startsWith('YAMLException:')) {


### PR DESCRIPTION
## Changes

Extract `gitlabci-include` dependencies from multi-document YAML files.

## Context

Closes https://github.com/renovatebot/renovate/issues/24567

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

---

:hammer_and_pick: with :heart: by [Siemens](https://opensource.siemens.com/)