### PR TITLE
test(lib/data): `ReplacementsSchema`

### DIFF
--- a/lib/config/presets/internal/replacements.ts
+++ b/lib/config/presets/internal/replacements.ts
@@ -1,12 +1,12 @@
-import replacementGroups from '../../../data/replacements.json';
+import replacementGroupsJson from '../../../data/replacements.json';
 import type { Preset } from '../types';
 import type { PresetTemplate, Replacement } from './auto-generate-replacements';
 import { addPresets } from './auto-generate-replacements';
 
-const { $schema, ...tempPresets } = replacementGroups;
+const { $schema, ...replacementPresets } = replacementGroupsJson;
 
 /* eslint sort-keys: ["error", "asc", {"caseSensitive": false, "natural": true}] */
-export const presets: Record<string, Preset> = tempPresets;
+export const presets: Record<string, Preset> = replacementPresets;
 
 const muiReplacement: Replacement[] = [
   [['@material-ui/codemod'], '@mui/codemod'],

--- a/lib/config/presets/internal/replacements.ts
+++ b/lib/config/presets/internal/replacements.ts
@@ -3,8 +3,10 @@ import type { Preset } from '../types';
 import type { PresetTemplate, Replacement } from './auto-generate-replacements';
 import { addPresets } from './auto-generate-replacements';
 
+const { $schema, ...tempPresets } = replacementGroups;
+
 /* eslint sort-keys: ["error", "asc", {"caseSensitive": false, "natural": true}] */
-export const presets: Record<string, Preset> = replacementGroups;
+export const presets: Record<string, Preset> = tempPresets;
 
 const muiReplacement: Replacement[] = [
   [['@material-ui/codemod'], '@mui/codemod'],

--- a/lib/data/replacements.json
+++ b/lib/data/replacements.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "../../tools/schemas/replacements-schema.json",
   "all": {
     "description": "Apply crowd-sourced package replacement rules.",
     "extends": [

--- a/tools/schemas/monorepo-schema.json
+++ b/tools/schemas/monorepo-schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "https://json-schema.org/draft-04/schema#",
   "type": "object",
   "properties": {
     "repoGroups": {

--- a/tools/schemas/replacements-schema.json
+++ b/tools/schemas/replacements-schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "all": {
+      "type": "object",
+      "properties": {
+        "description": { "type": "string" },
+        "extends": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "ignoreDeps": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      },
+      "required": ["description", "extends"]
+    }
+  },
+  "patternProperties": {
+    "^[a-zA-Z0-9-]+$": {
+      "type": "object",
+      "properties": {
+        "description": { "type": "string" },
+        "packageRules": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "matchCurrentVersion": { "type": "string" },
+              "matchDatasources": {
+                "type": "array",
+                "items": { "type": "string" }
+              },
+              "matchPackageNames": {
+                "type": "array",
+                "items": { "type": "string" }
+              },
+              "replacementName": { "type": "string" },
+              "replacementVersion": { "type": "string" },
+              "description": { "type": "string" },
+              "replacementNameTemplate": { "type": "string" }
+            },
+            "required": ["matchDatasources", "matchPackageNames"]
+          },
+          "contains": {
+            "type": "object",
+            "oneOf": [
+              { "required": ["replacementName"] },
+              { "required": ["replacementNameTemplate"] }
+            ]
+          },
+          "minItems": 1
+        }
+      },
+      "required": ["description", "packageRules"]
+    }
+  },
+  "additionalProperties": false
+}

--- a/tools/schemas/replacements-schema.json
+++ b/tools/schemas/replacements-schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "https://json-schema.org/draft-04/schema#",
   "type": "object",
   "properties": {
     "all": {

--- a/tools/schemas/schema.ts
+++ b/tools/schemas/schema.ts
@@ -11,4 +11,46 @@ const MonorepoSchema = z.object({
   patternGroups: UrlSchema,
 });
 
-export { MonorepoSchema };
+const PackageRuleSchema = z.object({
+  matchCurrentVersion: z.string().optional(),
+  matchDatasources: z.array(z.string()),
+  matchPackageNames: z.array(z.string()),
+  replacementName: z.string().optional(),
+  replacementVersion: z.string().optional(),
+  description: z.string().optional(),
+  replacementNameTemplate: z.string().optional(),
+});
+
+const RuleSetSchema = z.object({
+  description: z.string(),
+  packageRules: z
+    .array(PackageRuleSchema)
+    .min(1)
+    .refine(
+      (rules) =>
+        rules.some(
+          (rule) =>
+            rule.replacementName !== undefined ||
+            rule.replacementNameTemplate !== undefined,
+        ),
+      {
+        message:
+          'At least one package rule must have either replacementName or replacementNameTemplate',
+      },
+    ),
+});
+
+const AllSchema = z.object({
+  description: z.string(),
+  extends: z.array(z.string()),
+  ignoreDeps: z.array(z.string()).optional(),
+});
+
+const ReplacementsSchema = z
+  .object({
+    $schema: z.string(),
+    all: AllSchema,
+  })
+  .catchall(RuleSetSchema);
+
+export { MonorepoSchema, ReplacementsSchema };

--- a/tools/schemas/schema.ts
+++ b/tools/schemas/schema.ts
@@ -35,7 +35,7 @@ const RuleSetSchema = z.object({
         ),
       {
         message:
-          'At least one package rule must have either replacementName or replacementNameTemplate',
+          'At least one package rule must use either the replacementName config option, or the replacementNameTemplate config option',
       },
     ),
 });

--- a/tools/schemas/schema.ts
+++ b/tools/schemas/schema.ts
@@ -5,7 +5,7 @@ const UrlSchema = z.record(
   z.union([z.string(), z.array(z.string())]),
 );
 
-const MonorepoSchema = z.object({
+export const MonorepoSchema = z.object({
   repoGroups: UrlSchema,
   orgGroups: UrlSchema,
   patternGroups: UrlSchema,
@@ -46,11 +46,9 @@ const AllSchema = z.object({
   ignoreDeps: z.array(z.string()).optional(),
 });
 
-const ReplacementsSchema = z
+export const ReplacementsSchema = z
   .object({
     $schema: z.string(),
     all: AllSchema,
   })
   .catchall(RuleSetSchema);
-
-export { MonorepoSchema, ReplacementsSchema };


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Add JsonSchema and ZodSchema for the `replacements.json` file.
<!-- Describe what behavior is changed by this PR. -->

## Context
It will help users detect errors when adding new replacements instantly + he updated file will get validated against the zod schema during CI, leading to quicker PR merges & less reviews.
Ref: https://github.com/renovatebot/renovate/issues/29942#issuecomment-2241499559
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
