### PR TITLE
feat(manager/azure-pipelines): Include `.azuredevops` folder paths

### DIFF
--- a/lib/modules/manager/azure-pipelines/index.ts
+++ b/lib/modules/manager/azure-pipelines/index.ts
@@ -4,7 +4,10 @@ import { GitTagsDatasource } from '../../datasource/git-tags';
 export { extractPackageFile } from './extract';
 
 export const defaultConfig = {
-  fileMatch: ['azure.*pipelines?.*\\.ya?ml$'],
+  fileMatch: [
+    '(^|/).azuredevops/.+\\.ya?ml$',
+    'azure.*pipelines?.+\\.ya?ml$',
+  ],
   enabled: false,
 };
 

--- a/lib/modules/manager/azure-pipelines/index.ts
+++ b/lib/modules/manager/azure-pipelines/index.ts
@@ -4,10 +4,7 @@ import { GitTagsDatasource } from '../../datasource/git-tags';
 export { extractPackageFile } from './extract';
 
 export const defaultConfig = {
-  fileMatch: [
-    '(^|/).azuredevops/.+\\.ya?ml$',
-    'azure.*pipelines?.*\\.ya?ml$',
-  ],
+  fileMatch: ['(^|/).azuredevops/.+\\.ya?ml$', 'azure.*pipelines?.*\\.ya?ml$'],
   enabled: false,
 };
 

--- a/lib/modules/manager/azure-pipelines/index.ts
+++ b/lib/modules/manager/azure-pipelines/index.ts
@@ -6,7 +6,7 @@ export { extractPackageFile } from './extract';
 export const defaultConfig = {
   fileMatch: [
     '(^|/).azuredevops/.+\\.ya?ml$',
-    'azure.*pipelines?.+\\.ya?ml$',
+    'azure.*pipelines?.*\\.ya?ml$',
   ],
   enabled: false,
 };


### PR DESCRIPTION
Revised the `fileMatch` patterns to include `.azuredevops` folder paths (#31730).

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required
  - https://docs.renovatebot.com/modules/manager/azure-pipelines/ seems to be auto generated from source?!

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository