### PR TITLE
fix(azure): update cache after PR create or update

### DIFF
--- a/lib/modules/platform/azure/index.spec.ts
+++ b/lib/modules/platform/azure/index.spec.ts
@@ -1173,7 +1173,7 @@ describe('modules/platform/azure/index', () => {
   describe('updatePr(prNo, title, body, platformPrOptions)', () => {
     it('should update the PR', async () => {
       await initRepo({ repository: 'some/repo' });
-      const updatePullRequest = jest.fn();
+      const updatePullRequest = jest.fn(() => ({}));
       azureApi.gitApi.mockImplementationOnce(
         () =>
           ({
@@ -1189,9 +1189,45 @@ describe('modules/platform/azure/index', () => {
       expect(updatePullRequest.mock.calls).toMatchSnapshot();
     });
 
+    it('should update the PR including cache', async () => {
+      await initRepo({ repository: 'some/repo' });
+      azureApi.gitApi.mockImplementation(
+        () =>
+          ({
+            createPullRequest: jest.fn(() => ({
+              pullRequestId: 456,
+              title: 'Title 1',
+            })),
+            createPullRequestLabel: jest.fn(() => ({})),
+            getPullRequests: jest.fn(() => []),
+            updatePullRequest: jest.fn(() => ({
+              pullRequestId: 456,
+              title: 'Title 2',
+            })),
+          }) as any,
+      );
+      expect(await azure.getPrList()).toEqual([]);
+      const createdPr = await azure.createPr({
+        sourceBranch: 'some-branch',
+        targetBranch: 'master',
+        prTitle: 'Title 1',
+        prBody: 'Hello world',
+        labels: [],
+      });
+      expect(createdPr).toMatchObject({ number: 456, title: 'Title 1' });
+      expect(await azure.getPrList()).toHaveLength(1);
+      await azure.updatePr({
+        number: 456,
+        prTitle: 'Title 2',
+      });
+      const prList = await azure.getPrList();
+      expect(prList).toHaveLength(1);
+      expect(prList[0]).toMatchObject({ number: 456, title: 'Title 2' });
+    });
+
     it('should update the PR without description', async () => {
       await initRepo({ repository: 'some/repo' });
-      const updatePullRequest = jest.fn();
+      const updatePullRequest = jest.fn(() => ({}));
       azureApi.gitApi.mockImplementationOnce(
         () =>
           ({
@@ -1207,7 +1243,7 @@ describe('modules/platform/azure/index', () => {
 
     it('should close the PR', async () => {
       await initRepo({ repository: 'some/repo' });
-      const updatePullRequest = jest.fn();
+      const updatePullRequest = jest.fn(() => ({}));
       azureApi.gitApi.mockImplementationOnce(
         () =>
           ({
@@ -1225,7 +1261,7 @@ describe('modules/platform/azure/index', () => {
 
     it('should reopen the PR', async () => {
       await initRepo({ repository: 'some/repo' });
-      const updatePullRequest = jest.fn();
+      const updatePullRequest = jest.fn(() => ({}));
       azureApi.gitApi.mockImplementationOnce(
         () =>
           ({


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Ensures newly created PRs or updated PRs are present in the PR cache if it already existed

## Context

Replaces #31726

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
