### PR TITLE
feat(manager/mix): set versioning for git dependencies

### DIFF
--- a/lib/modules/manager/mix/__fixtures__/mix.exs
+++ b/lib/modules/manager/mix/__fixtures__/mix.exs
@@ -23,6 +23,7 @@ defmodule MyProject.MixProject do
       {:foo_bar, ">2.1.0 or <=3.0.0"},
       {:cowboy, github: "ninenines/cowboy", tag: "v0.4.1"},
       {:phoenix, git: "https://github.com/phoenixframework/phoenix.git", branch: "main"},
+      {:nonexistentpackage, git: "git@github:some/nonexistentpackage.git", tag: "v0.1.1"},
       {:ecto, github: "elixir-ecto/ecto", ref: "795036d997c7503b21fb64d6bf1a89b83c44f2b5"},
       {:secret, "~> 1.0", organization: "acme"},
       {:also_secret, "~> 1.0", only: [:dev, :test], organization: "acme", runtime: false},

--- a/lib/modules/manager/mix/__fixtures__/mix.lock
+++ b/lib/modules/manager/mix/__fixtures__/mix.lock
@@ -3,6 +3,7 @@
   "postgrex": {:hex, :postgrex, "0.8.2", "83e8daf59631d632b171faabafb4a9f4242c514b0a06ba3df493951c08f64d07", [:mix], [], "hexpm", "b1f2343568eed6928f3e751cf2dffde95bfaa19dd95d09e8a9ea92ccfd6f7d85"},
   "jason": {:hex, :jason, "1.4.1", "af1504e35f629ddcdd6addb3513c3853991f694921b1b9368b0bd32beb9f1b63", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "fbb01ecdfd565b56261302f7e1fcc27c4fb8f32d56eab74db621fc154604a7a1"},
   "cowboy": {:git, "https://github.com/ninenines/cowboy.git", "81f3a21474155f68fbf494b7026b9678027d303e", [tag: "v0.4.1"]},
+  "nonexistentpackage": {:git "git@github:some/nonexistentpackage.git", "81f3a21474155f68fbf494b7026b9678027d3123", [tag: "v0.4.1"]},,
   "phoenix": {:git, "https://github.com/phoenixframework/phoenix.git", "61f3a21474155f68fbf494b7026b9678027d303e", [branch: "main]},
   "ecto": {:git, "https://github.com/elixir-ecto/ecto.git", "344dbbf6610d205760ec37e2848bff2aab5a2de182bb5cdaa72cc2fd19d74535", [ref: "795036d997c7503b21fb64d6bf1a89b83c44f2b5"]},
   "secret": {:hex, :secret, "1.5.0", "344dbbf6610d205760ec37e2848bff2aab5a2de182bb5cdaa72cc2fd19d74535", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: false]}], "hexpm", "19c205c8de0e2e5817f2250100281c58e717cb11ff1bb410bf661ee78c24e79b"},

--- a/lib/modules/manager/mix/extract.spec.ts
+++ b/lib/modules/manager/mix/extract.spec.ts
@@ -34,6 +34,7 @@ describe('modules/manager/mix/extract', () => {
           datasource: 'github-tags',
           depName: 'cowboy',
           packageName: 'ninenines/cowboy',
+          versioning: 'loose',
         },
         {
           currentDigest: undefined,
@@ -41,6 +42,15 @@ describe('modules/manager/mix/extract', () => {
           datasource: 'git-tags',
           depName: 'phoenix',
           packageName: 'https://github.com/phoenixframework/phoenix.git',
+          versioning: 'loose',
+        },
+        {
+          currentDigest: undefined,
+          currentValue: 'v0.1.1',
+          datasource: 'git-tags',
+          depName: 'nonexistentpackage',
+          packageName: 'git@github:some/nonexistentpackage.git',
+          versioning: 'loose',
         },
         {
           currentDigest: '795036d997c7503b21fb64d6bf1a89b83c44f2b5',
@@ -48,6 +58,7 @@ describe('modules/manager/mix/extract', () => {
           datasource: 'github-tags',
           depName: 'ecto',
           packageName: 'elixir-ecto/ecto',
+          versioning: 'loose',
         },
         {
           currentValue: '~> 1.0',

--- a/lib/modules/manager/mix/extract.ts
+++ b/lib/modules/manager/mix/extract.ts
@@ -49,6 +49,7 @@ export async function extractPackageFile(
 
         if (git ?? github) {
           dep = {
+            versioning: 'loose',
             depName: app,
             currentDigest: ref,
             currentValue: branchOrTag,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This change should address [Bad Tag name for git dependencies in Elixir project](https://github.com/renovatebot/renovate/discussions/23535#top)

As far as I understand [mix](https://hexdocs.pm/mix/1.12/Mix.Tasks.Deps.html) does not support version ranges for git dependencies.
However for whatever reason when `"datasource": "git-tags", "versioning": "hex"` renovate runs the hex versioning and reaches this line
https://github.com/renovatebot/renovate/blob/8b2d1fa101476880e075f57f4c28773101cefd9e/lib/modules/versioning/hex/index.ts#L104

It produces an invalid tag from `v.0.1` -> `== v0.1` which fails to download the tag and `mix deps.update`

## Documentation (please check one with an [x])

- [] I have updated the documentation, or
- [] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
