### PR TITLE
refactor(manager/gitlabci): remove method "replaceReferenceTags"

### DIFF
--- a/lib/modules/manager/gitlabci-include/extract.ts
+++ b/lib/modules/manager/gitlabci-include/extract.ts
@@ -14,7 +14,6 @@ import type {
   GitlabIncludeProject,
   GitlabPipeline,
 } from '../gitlabci/types';
-import { replaceReferenceTags } from '../gitlabci/utils';
 import type { PackageDependency, PackageFileContent } from '../types';
 
 function extractDepFromIncludeFile(
@@ -76,7 +75,7 @@ export function extractPackageFile(
       : null;
   try {
     // TODO: use schema (#9610)
-    const docs = parseYaml<GitlabPipeline>(replaceReferenceTags(content), {
+    const docs = parseYaml<GitlabPipeline>(content, {
       uniqueKeys: false,
     });
     for (const doc of docs) {

--- a/lib/modules/manager/gitlabci/common.spec.ts
+++ b/lib/modules/manager/gitlabci/common.spec.ts
@@ -1,7 +1,6 @@
 import { codeBlock } from 'common-tags';
 import { parseSingleYaml } from '../../../util/yaml';
 import type { GitlabPipeline } from '../gitlabci/types';
-import { replaceReferenceTags } from '../gitlabci/utils';
 import {
   filterIncludeFromGitlabPipeline,
   isGitlabIncludeComponent,
@@ -12,7 +11,7 @@ import {
 
 // TODO: use schema (#9610)
 const pipeline = parseSingleYaml<GitlabPipeline>(
-  replaceReferenceTags(codeBlock`
+  codeBlock`
     include:
     - project: mikebryant/include-source-example
       file: /template.yaml
@@ -25,7 +24,7 @@ const pipeline = parseSingleYaml<GitlabPipeline>(
 
     script:
     - !reference [.setup, script]
-    - !reference [arbitrary job name with space and no starting dot, nested1, nested2, nested3]`),
+    - !reference [arbitrary job name with space and no starting dot, nested1, nested2, nested3]`,
 );
 const includeLocal = { local: 'something' };
 const includeProject = { project: 'something' };
@@ -37,7 +36,15 @@ describe('modules/manager/gitlabci/common', () => {
       const filtered_pipeline = filterIncludeFromGitlabPipeline(pipeline);
       expect(filtered_pipeline).not.toHaveProperty('include');
       expect(filtered_pipeline).toEqual({
-        script: [null, null],
+        script: [
+          ['.setup', 'script'],
+          [
+            'arbitrary job name with space and no starting dot',
+            'nested1',
+            'nested2',
+            'nested3',
+          ],
+        ],
       });
     });
   });

--- a/lib/modules/manager/gitlabci/utils.spec.ts
+++ b/lib/modules/manager/gitlabci/utils.spec.ts
@@ -1,6 +1,5 @@
-import { Fixtures } from '../../../../test/fixtures';
 import type { PackageDependency } from '../types';
-import { getGitlabDep, replaceReferenceTags } from './utils';
+import { getGitlabDep } from './utils';
 
 describe('modules/manager/gitlabci/utils', () => {
   describe('getGitlabDep', () => {
@@ -80,14 +79,6 @@ describe('modules/manager/gitlabci/utils', () => {
         depName: 'quay.io/prometheus/node-exporter',
         currentValue: 'v1.3.1',
       });
-    });
-  });
-
-  describe('replaceReferenceTags', () => {
-    it('replaces all !reference tags with empty strings', () => {
-      const yamlFileReferenceConfig = Fixtures.get('gitlab-ci.reference.yaml');
-      const replaced = replaceReferenceTags(yamlFileReferenceConfig);
-      expect(replaced).not.toContain('!reference');
     });
   });
 });

--- a/lib/modules/manager/gitlabci/utils.ts
+++ b/lib/modules/manager/gitlabci/utils.ts
@@ -2,19 +2,6 @@ import { regEx } from '../../../util/regex';
 import { getDep } from '../dockerfile/extract';
 import type { PackageDependency } from '../types';
 
-const re = /!reference \[[^\]]+\]/g;
-
-/**
- * Replaces GitLab reference tags before parsing, because our yaml parser cannot process them anyway.
- * @param content pipeline yaml
- * @returns replaced pipeline content
- * https://docs.gitlab.com/ee/ci/yaml/#reference-tags
- */
-export function replaceReferenceTags(content: string): string {
-  const res = content.replace(re, '');
-  return res;
-}
-
 const depProxyRe = regEx(
   `(?<prefix>\\$\\{?CI_DEPENDENCY_PROXY_(?:DIRECT_)?GROUP_IMAGE_PREFIX\\}?/)(?<depName>.+)`,
 );


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Remove the method "replaceReferenceTags" for GitLab Manager.
With #31336 the support for YAML tags were introduced.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
