### PR TITLE
feat(maven-wrapper): `wrapperVersion` support

### DIFF
--- a/lib/modules/manager/maven-wrapper/extract.spec.ts
+++ b/lib/modules/manager/maven-wrapper/extract.spec.ts
@@ -49,6 +49,20 @@ describe('modules/manager/maven-wrapper/extract', () => {
       ]);
     });
 
+    it('extracts version for property file with only a wrapper version', () => {
+      const res = extractPackageFile('wrapperVersion=3.3.1');
+      expect(res?.deps).toEqual([
+        {
+          currentValue: '3.3.1',
+          replaceString: '3.3.1',
+          datasource: 'maven',
+          depName: 'maven-wrapper',
+          packageName: 'org.apache.maven.wrapper:maven-wrapper',
+          versioning: 'maven',
+        },
+      ]);
+    });
+
     it('extracts version for property file with only a maven url', () => {
       const res = extractPackageFile(onlyMavenProperties);
       expect(res?.deps).toEqual([

--- a/lib/modules/manager/maven-wrapper/extract.ts
+++ b/lib/modules/manager/maven-wrapper/extract.ts
@@ -23,7 +23,9 @@ const WRAPPER_VERSION_REGEX = regEx(
 function extractVersions(fileContent: string): MavenVersionExtract {
   const lines = coerceArray(fileContent?.split(newlineRegex));
   const maven = extractLineInfo(lines, DISTRIBUTION_URL_REGEX) ?? undefined;
-  const wrapper = extractLineInfo(lines, WRAPPER_URL_REGEX, WRAPPER_VERSION_REGEX) ?? undefined;
+  const wrapper =
+    extractLineInfo(lines, WRAPPER_URL_REGEX, WRAPPER_VERSION_REGEX) ??
+    undefined;
   return { maven, wrapper };
 }
 

--- a/lib/modules/manager/maven-wrapper/types.ts
+++ b/lib/modules/manager/maven-wrapper/types.ts
@@ -1,5 +1,5 @@
 export interface Version {
-  url: string;
+  replaceString: string;
   version: string;
 }
 


### PR DESCRIPTION
## Changes

Add ability to extract [Maven Wrapper](https://docs.renovatebot.com/modules/manager/maven-wrapper/) version from new `wrapperVersion` property, in _addition_ to existing `wrapperUrl` property.

Specifically:
- Generalised the extracted text from `url` to `replaceString` to match how it's used elsewhere
- Added _additional_ regex to match/extract `wrapperVersion`, used when parsing for a version
- Added a new unit test to cover this scenario

## Context

Renovate _currently_ detects the Maven Wrapper version using the `wrapperUrl` property.

This property was removed in https://github.com/apache/maven-wrapper/pull/114 (`3.3.0`), and replaced with a new `wrapperVersion` property in https://github.com/apache/maven-wrapper/pull/135 (`3.3.1`).

Renovate does not support `wrapperVersion` property and is unable to identify / upgrade these newer versions.

This directly addresses https://github.com/renovatebot/renovate/discussions/31696.

A related discussion is at https://github.com/renovatebot/renovate/discussions/28648 - but note that Maven Wrapper `3.3.0` specifically has _neither_ a `wrapperUrl`, nor a `wrapperVersion` and is **not handled** by this pull request, and further development is required. Earlier / later versions are supported.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository