### PR TITLE
fix(manager/npm): support modern pnpm overrides syntax

### DIFF
--- a/lib/modules/manager/npm/__fixtures__/inputs/02.json
+++ b/lib/modules/manager/npm/__fixtures__/inputs/02.json
@@ -13,6 +13,11 @@
     "@babel/core": "7.0.0",
     "config": "1.21.0"
   },
+  "pnpm": {
+    "overrides": {
+      "express>cookie": "0.7.0"
+    }
+  },
   "homepage": "https://keylocation.sg",
   "keywords": [
     "Key Location",

--- a/lib/modules/manager/npm/extract/common/package-file.ts
+++ b/lib/modules/manager/npm/extract/common/package-file.ts
@@ -84,19 +84,26 @@ export function extractPackageJson(
               ),
             );
           } else if (depType === 'pnpm' && depName === 'overrides') {
+            // pnpm overrides
+            // https://pnpm.io/package_json#pnpmoverrides
             for (const [overridesKey, overridesVal] of Object.entries(
               val as unknown as NpmPackageDependency,
             )) {
               if (is.string(overridesVal)) {
+                // Newer flat syntax: `parent>parent>child`
+                const packageName = overridesKey.split('>').pop()!;
                 dep = {
                   depName: overridesKey,
+                  packageName,
                   depType: 'pnpm.overrides',
-                  ...extractDependency(depName, overridesKey, overridesVal),
+                  ...extractDependency(depName, packageName, overridesVal),
                 };
                 setNodeCommitTopic(dep);
+                // TODO: Is this expected? It's always 'overrides'.
                 dep.prettyDepType = depTypes[depName];
                 deps.push(dep);
               } else if (is.object(overridesVal)) {
+                // Older nested object syntax: `parent: { parent: { child: version } }`
                 deps.push(
                   ...extractOverrideDepsRec(
                     [overridesKey],

--- a/lib/modules/manager/npm/extract/index.spec.ts
+++ b/lib/modules/manager/npm/extract/index.spec.ts
@@ -1052,6 +1052,14 @@ describe('modules/manager/npm/extract/index', () => {
               depType: 'dependencies',
               prettyDepType: 'dependency',
             },
+            {
+              currentValue: '0.7.0',
+              datasource: 'npm',
+              depName: 'express>cookie',
+              packageName: 'cookie',
+              depType: 'pnpm.overrides',
+              prettyDepType: 'overrides',
+            },
           ],
           extractedConstraints: {},
           managerData: {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Support modern  pnpm overrides:

```json
{
  "pnpm": {
    "overrides": {
      "express>cookie": "0.7.0"
    }   
  }
}
```
<!-- Describe what behavior is changed by this PR. -->

## Context
- https://pnpm.io/package_json#pnpmoverrides
- https://github.com/renovate-reproductions/npm-pnpm-nested-overrides/pull/3
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
