### PR TITLE
fix(circleci): parsing of inline orb definitions

### DIFF
--- a/lib/modules/manager/circleci/extract.spec.ts
+++ b/lib/modules/manager/circleci/extract.spec.ts
@@ -249,5 +249,65 @@ describe('modules/manager/circleci/extract', () => {
         },
       ]);
     });
+
+    it('extracts orb definitions', () => {
+      const res = extractPackageFile(codeBlock`
+      version: 2.1
+
+      orbs:
+        myorb:
+          orbs:
+            python: circleci/python@2.1.1
+
+          executors:
+            python:
+              docker:
+                - image: cimg/python:3.9
+
+          jobs:
+            test_image:
+              docker:
+                - image: cimg/python:3.7
+              steps:
+                - checkout
+
+      workflows:
+        Test:
+          jobs:
+            - myorb/test_image`);
+
+      expect(res).toEqual({
+        deps: [
+          {
+            currentValue: '2.1.1',
+            datasource: 'orb',
+            depName: 'python',
+            depType: 'orb',
+            packageName: 'circleci/python',
+            versioning: 'npm',
+          },
+          {
+            autoReplaceStringTemplate:
+              '{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}',
+            currentDigest: undefined,
+            currentValue: '3.9',
+            datasource: 'docker',
+            depName: 'cimg/python',
+            depType: 'docker',
+            replaceString: 'cimg/python:3.9',
+          },
+          {
+            autoReplaceStringTemplate:
+              '{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}',
+            currentDigest: undefined,
+            currentValue: '3.7',
+            datasource: 'docker',
+            depName: 'cimg/python',
+            depType: 'docker',
+            replaceString: 'cimg/python:3.7',
+          },
+        ],
+      });
+    });
   });
 });

--- a/lib/modules/manager/circleci/schema.ts
+++ b/lib/modules/manager/circleci/schema.ts
@@ -4,14 +4,31 @@ export const CircleCiDocker = z.object({
   image: z.string(),
 });
 
-export type CircleCiJob = z.infer<typeof CircleCiJob>;
 export const CircleCiJob = z.object({
   docker: z.array(CircleCiDocker).optional(),
 });
+export type CircleCiJob = z.infer<typeof CircleCiJob>;
+
+const baseOrb = z.object({
+  executors: z.record(z.string(), CircleCiJob).optional(),
+  jobs: z.record(z.string(), CircleCiJob).optional(),
+});
+
+type Orb = z.infer<typeof baseOrb> & {
+  orbs?: Record<string, string | Orb>;
+};
+
+export const CircleCiOrb: z.ZodType<Orb> = baseOrb.extend({
+  orbs: z.lazy(() =>
+    z.record(z.string(), z.union([z.string(), CircleCiOrb])).optional(),
+  ),
+});
+export type CircleCiOrb = z.infer<typeof CircleCiOrb>;
 
 export const CircleCiFile = z.object({
   aliases: z.array(CircleCiDocker).optional(),
   executors: z.record(z.string(), CircleCiJob).optional(),
   jobs: z.record(z.string(), CircleCiJob).optional(),
-  orbs: z.record(z.string()).optional(),
+  orbs: z.record(z.string(), z.union([z.string(), CircleCiOrb])).optional(),
 });
+export type CircleCiFile = z.infer<typeof CircleCiFile>;


### PR DESCRIPTION
## Changes

https://github.com/renovatebot/renovate/pull/30142 changed how CircleCI config parsing worked, but didn't take into account inline orb definitions.

## Context

The `config5.yml` fixture is a valid CircleCI config:
```
$ circleci config validate lib/modules/manager/circleci/__fixtures__/config5.yml
Config file at lib/modules/manager/circleci/__fixtures__/config5.yml is valid.
```

However, we lost the ability to parse out inline orb definitions which can include orb references and images.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
