### PR TITLE
chore: update discussion request-help template

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/request-help.yml
+++ b/.github/DISCUSSION_TEMPLATE/request-help.yml
@@ -1,20 +1,11 @@
 body:
   - type: dropdown
-    id: question-type
-    attributes:
-      label: What would you like help with?
-      options:
-        - 'I would like help with my configuration'
-        - 'I think I found a bug'
-        - 'Other'
-
-  - type: dropdown
     id: how-are-you-running-renovate
     attributes:
       label: How are you running Renovate?
       options:
-        - 'Mend Renovate hosted app on github.com'
-        - 'Self-hosted'
+        - 'A Mend.io-hosted app'
+        - 'Self-hosted Renovate'
 
   - type: input
     id: self-hosted-version
@@ -29,7 +20,7 @@ body:
       label: Please tell us more about your question or problem
       description: |
         Remember to [follow these guidelines](https://github.com/renovatebot/renovate/blob/main/docs/development/help-us-help-you.md) for maximum effectiveness.
-        It may help to include a [minimal reproduction](https://github.com/renovatebot/renovate/blob/main/docs/development/minimal-reproductions.md) as well.
+        Include a [minimal reproduction](https://github.com/renovatebot/renovate/blob/main/docs/development/minimal-reproductions.md) if you think you found a bug.
     validations:
       required: true
 

--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -376,56 +376,6 @@
 
     Thanks, the Renovate team
 
-'auto:bug-to-idea':
-  comment: >
-    Hi there,
-
-
-    A maintainer reviewed the information, and decided that this is not a bug. To avoid confusing others, we will close this Discussion. Please keep reading as there is good news too!
-
-
-    The good news is that the maintainer likes your idea, in general. Please create a new [Suggest an Idea](https://github.com/renovatebot/renovate/discussions/new?category=suggest-an-idea) Discussion. Feel free to copy/paste what you need from this Discussion. Please focus on the feature request: explain what Renovate should do, and how Renovate can know when/what to do. We may convert that Discussion to an Issue when it is ready. Note that you will still have to wait for a maintainer, or someone else, to do the work needed for your feature.
-
-
-    Why are we closing your Discussion? For us, bug reports are about things that are not working as intended, or things that are not working as described in the docs. What you found may be bad behavior, but we do not think it is a bug.
-
-
-    For more details, please read [our development docs about bug handling](https://github.com/renovatebot/renovate/blob/main/docs/development/bug-handling.md).
-
-
-    Thanks, the Renovate team
-
-'auto:bug-invalid':
-  comment: >
-    Hi there,
-
-
-    A maintainer decided this is not a bug, and behaving as designed. The maintainer will explain why this behavior is correct. To avoid confusing future readers, we will close this Discussion.
-
-
-    We want Bug-type Discussions to be about things that we rate as bugs. For more details, please read [our development docs about bug handling](https://github.com/renovatebot/renovate/blob/main/docs/development/bug-handling.md).
-
-
-    If this bug report makes you think of an idea for a new feature, or how to improve a current feature, feel free to create a new [Suggest an Idea](https://github.com/renovatebot/renovate/discussions/new?category=suggest-an-idea) Discussion.
-
-
-    Thanks, the Renovate team
-  close: true
-  close-reason: 'outdated'
-
-'auto:bug-converted':
-  comment: >
-    Hi there,
-
-
-    A maintainer confirmed this is a bug, and converted this Discussion to an Issue. If you have more thoughts/info about the bug, please post them in the Issue.
-
-
-    We will close this Discussion, as we want new info to go in the Issue.
-
-
-    Thanks, the Renovate team
-
 'auto:idea-rewrite':
   comment: >
     Hi there,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Drop the option of "I found a bug" and instead have a generic request help section instead. Removed associated label actions  too.

## Context

Users are terrible at judging what a bug is.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
