### PR TITLE
feat(manager/copier): propagate Git auth env vars

### DIFF
--- a/lib/modules/manager/copier/artifacts.spec.ts
+++ b/lib/modules/manager/copier/artifacts.spec.ts
@@ -1,7 +1,7 @@
 import { mockDeep } from 'jest-mock-extended';
 import { join } from 'upath';
 import { mockExecAll } from '../../../../test/exec-util';
-import { fs, git, mocked, partial } from '../../../../test/util';
+import { fs, git, hostRules, mocked, partial } from '../../../../test/util';
 import { GlobalConfig } from '../../../config/global';
 import type { RepoGlobalConfig } from '../../../config/types';
 import { logger } from '../../../logger';
@@ -40,6 +40,7 @@ const adminConfig: RepoGlobalConfig = {
 describe('modules/manager/copier/artifacts', () => {
   beforeEach(() => {
     GlobalConfig.set(adminConfig);
+    hostRules.clear();
 
     // Mock git repo status
     git.getRepoStatus.mockResolvedValue(
@@ -120,6 +121,56 @@ describe('modules/manager/copier/artifacts', () => {
           cmd: 'copier update --skip-answered --defaults --answers-file .copier-answers.yml --vcs-ref 1.1.0',
           options: {
             cwd: '/tmp/github/some/repo',
+          },
+        },
+      ]);
+    });
+
+    it('propagates Git environment from hostRules', async () => {
+      const execSnapshots = mockExecAll();
+
+      hostRules.add({
+        hostType: 'github',
+        matchHost: 'github.com',
+        token: 'abc123',
+      });
+      hostRules.add({
+        hostType: 'git-tags',
+        matchHost: 'gittags.com',
+        username: 'git-tags-user',
+        password: 'git-tags-password',
+      });
+
+      await updateArtifacts({
+        packageFileName: '.copier-answers.yml',
+        updatedDeps: upgrades,
+        newPackageFileContent: '',
+        config: {},
+      });
+
+      expect(execSnapshots).toMatchObject([
+        {
+          cmd: 'copier update --skip-answered --defaults --answers-file .copier-answers.yml --vcs-ref 1.1.0',
+          options: {
+            cwd: '/tmp/github/some/repo',
+            env: {
+              GIT_CONFIG_COUNT: '6',
+              GIT_CONFIG_KEY_0: 'url.https://ssh:abc123@github.com/.insteadOf',
+              GIT_CONFIG_KEY_1: 'url.https://git:abc123@github.com/.insteadOf',
+              GIT_CONFIG_KEY_2: 'url.https://abc123@github.com/.insteadOf',
+              GIT_CONFIG_KEY_3:
+                'url.https://git-tags-user:git-tags-password@gittags.com/.insteadOf',
+              GIT_CONFIG_KEY_4:
+                'url.https://git-tags-user:git-tags-password@gittags.com/.insteadOf',
+              GIT_CONFIG_KEY_5:
+                'url.https://git-tags-user:git-tags-password@gittags.com/.insteadOf',
+              GIT_CONFIG_VALUE_0: 'ssh://git@github.com/',
+              GIT_CONFIG_VALUE_1: 'git@github.com:',
+              GIT_CONFIG_VALUE_2: 'https://github.com/',
+              GIT_CONFIG_VALUE_3: 'ssh://git@gittags.com/',
+              GIT_CONFIG_VALUE_4: 'git@gittags.com:',
+              GIT_CONFIG_VALUE_5: 'https://gittags.com/',
+            },
           },
         },
       ]);

--- a/lib/modules/manager/copier/artifacts.ts
+++ b/lib/modules/manager/copier/artifacts.ts
@@ -6,6 +6,7 @@ import { exec } from '../../../util/exec';
 import type { ExecOptions } from '../../../util/exec/types';
 import { readLocalFile } from '../../../util/fs';
 import { getRepoStatus } from '../../../util/git';
+import { getGitEnvironmentVariables } from '../../../util/git/auth';
 import type {
   UpdateArtifact,
   UpdateArtifactsConfig,
@@ -72,10 +73,12 @@ export async function updateArtifacts({
   }
 
   const command = buildCommand(config, packageFileName, newVersion);
+  const gitEnv = getGitEnvironmentVariables(['git-tags']);
   const execOptions: ExecOptions = {
     cwdFile: packageFileName,
     docker: {},
     userConfiguredEnv: config.env,
+    extraEnv: gitEnv,
     toolConstraints: [
       {
         toolName: 'python',

--- a/lib/modules/manager/copier/readme.md
+++ b/lib/modules/manager/copier/readme.md
@@ -5,3 +5,20 @@ Enabling this behavior must be allowed in the [self-hosted configuration](../../
 Actually enable it in the [configuration](../../../configuration-options.md) by setting `ignoreScripts` to `false`.
 
 If you need to change the versioning format, read the [versioning](../../versioning/index.md) documentation to learn more.
+
+### Private Modules Authentication
+
+Before running the `copier` command to update from the template, Renovate exports `git` [`insteadOf`](https://git-scm.com/docs/git-config#Documentation/git-config.txt-urlltbasegtinsteadOf) directives in environment variables.
+
+Renovate uses this logic before it updates the template copy:
+
+The token from the `hostRules` entry matching `hostType=github` and `matchHost=api.github.com` is added as the default authentication for `github.com`.
+For those running against `github.com`, this token will be the default platform token.
+
+Next, all `hostRules` with both a token or username/password and `matchHost` will be fetched, except for any `github.com` one from above.
+
+Rules from this list are converted to environment variable directives if they match _any_ of these characteristics:
+
+- No `hostType` is defined, or
+- `hostType` is `git-tags`, or
+- `hostType` is a platform (`github`, `gitlab`, `azure`, etc.)


### PR DESCRIPTION
## Changes

Propagate Git authentication variables to calls for the `copier` CLI.

## Context

At the moment, Copier isn't able to update from templates hosted in private repositories. Renovate properly detects those updates and creates update PRs but when `copier` is executed to apply the update it makes its own `git` calls and fails to authenticate with private Git repos, resulting in a failure
<details>
<summary>failure log</summary>

```
Command failed: copier update --skip-answered --defaults --answers-file .copier-answers.yml --vcs-ref v1.0.5
Traceback (most recent call last):
  File "/opt/containerbase/tools/copier/9.3.1/3.13.0/bin/copier", line 8, in <module>
    sys.exit(copier_app_run())
             ~~~~~~~~~~~~~~^^
  File "/opt/containerbase/tools/copier/9.3.1/3.13.0/lib/python3.13/site-packages/plumbum/cli/application.py", line 640, in run
    inst, retcode = subapp.run(argv, exit=False)
                    ~~~~~~~~~~^^^^^^^^^^^^^^^^^^
  File "/opt/containerbase/tools/copier/9.3.1/3.13.0/lib/python3.13/site-packages/plumbum/cli/application.py", line 635, in run
    retcode = inst.main(*tailargs)
  File "/opt/containerbase/tools/copier/9.3.1/3.13.0/lib/python3.13/site-packages/copier/cli.py", line 425, in main
    return _handle_exceptions(inner)
  File "/opt/containerbase/tools/copier/9.3.1/3.13.0/lib/python3.13/site-packages/copier/cli.py", line 70, in _handle_exceptions
    method()
    ~~~~~~^^
  File "/opt/containerbase/tools/copier/9.3.1/3.13.0/lib/python3.13/site-packages/copier/cli.py", line 415, in inner
    with self._worker(
         ~~~~~~~~~~~~^
        dst_path=destination_path,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<4 lines>...
        overwrite=True,
        ^^^^^^^^^^^^^^^
    ) as worker:
    ^
  File "/opt/containerbase/tools/copier/9.3.1/3.13.0/lib/python3.13/site-packages/copier/main.py", line 228, in __exit__
    raise value
  File "/opt/containerbase/tools/copier/9.3.1/3.13.0/lib/python3.13/site-packages/copier/cli.py", line 423, in inner
    worker.run_update()
    ~~~~~~~~~~~~~~~~~^^
  File "/opt/containerbase/tools/copier/9.3.1/3.13.0/lib/python3.13/site-packages/copier/main.py", line 857, in run_update
    self._check_unsafe("update")
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/opt/containerbase/tools/copier/9.3.1/3.13.0/lib/python3.13/site-packages/copier/main.py", line 242, in _check_unsafe
    if self.template.jinja_extensions:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/containerbase/tools/python/3.13.0/lib/python3.13/functools.py", line 1037, in __get__
    val = self.func(instance)
  File "/opt/containerbase/tools/copier/9.3.1/3.13.0/lib/python3.13/site-packages/copier/template.py", line 338, in jinja_extensions
    return tuple(self.config_data.get("jinja_extensions", ()))
                 ^^^^^^^^^^^^^^^^
  File "/opt/containerbase/tools/python/3.13.0/lib/python3.13/functools.py", line 1037, in __get__
    val = self.func(instance)
  File "/opt/containerbase/tools/copier/9.3.1/3.13.0/lib/python3.13/site-packages/copier/template.py", line 300, in config_data
    result = filter_config(self._raw_config)[0]
                           ^^^^^^^^^^^^^^^^
  File "/opt/containerbase/tools/python/3.13.0/lib/python3.13/functools.py", line 1037, in __get__
    val = self.func(instance)
  File "/opt/containerbase/tools/copier/9.3.1/3.13.0/lib/python3.13/site-packages/copier/template.py", line 257, in _raw_config
    for p in self.local_abspath.glob("copier.*")
             ^^^^^^^^^^^^^^^^^^
  File "/opt/containerbase/tools/python/3.13.0/lib/python3.13/functools.py", line 1037, in __get__
    val = self.func(instance)
  File "/opt/containerbase/tools/copier/9.3.1/3.13.0/lib/python3.13/site-packages/copier/template.py", line 556, in local_abspath
    result = Path(clone(self.url_expanded, self.ref))
                  ~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/containerbase/tools/copier/9.3.1/3.13.0/lib/python3.13/site-packages/copier/vcs.py", line 182, in clone
    _clone()
    ~~~~~~^^
  File "/opt/containerbase/tools/copier/9.3.1/3.13.0/lib/python3.13/site-packages/plumbum/commands/base.py", line 115, in __call__
    return self.run(args, **kwargs)[1]
           ~~~~~~~~^^^^^^^^^^^^^^^^
  File "/opt/containerbase/tools/copier/9.3.1/3.13.0/lib/python3.13/site-packages/plumbum/commands/base.py", line 254, in run
    return p.run()
           ~~~~~^^
  File "/opt/containerbase/tools/copier/9.3.1/3.13.0/lib/python3.13/site-packages/plumbum/commands/base.py", line 217, in runner
    return run_proc(p, retcode, timeout)
  File "/opt/containerbase/tools/copier/9.3.1/3.13.0/lib/python3.13/site-packages/plumbum/commands/processes.py", line 330, in run_proc
    return _check_process(proc, retcode, timeout, stdout, stderr)
  File "/opt/containerbase/tools/copier/9.3.1/3.13.0/lib/python3.13/site-packages/plumbum/commands/processes.py", line 19, in _check_process
    proc.verify(retcode, timeout, stdout, stderr)
    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/containerbase/tools/copier/9.3.1/3.13.0/lib/python3.13/site-packages/plumbum/machines/base.py", line 29, in verify
    raise ProcessExecutionError(
        getattr(self, "argv", None), self.returncode, stdout, stderr
    )
plumbum.commands.processes.ProcessExecutionError: Unexpected exit code: 128
Command line: | /usr/bin/git clone --no-checkout https://github.com/GreyTeardrop/private-copier-template.git /tmp/copier.vcs.clone.z922swsv --filter=blob:none
Stderr:       | Cloning into '/tmp/copier.vcs.clone.z922swsv'...
              | fatal: could not read Username for 'https://github.com': No such device or address
```
</details>

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The https://github.com/GreyTeardrop/copier-renovate-experiment repo contains test results - https://github.com/GreyTeardrop/copier-renovate-experiment/pull/7 as created by stock Renovate GitHub app and https://github.com/GreyTeardrop/copier-renovate-experiment/pull/6 as created by Renovate with this patch.