### PR TITLE
fix(yaml): allow filtering of invalid multidoc

### DIFF
--- a/lib/util/yaml.ts
+++ b/lib/util/yaml.ts
@@ -63,18 +63,18 @@ export function parseYaml<ResT = unknown>(
 
   const results: ResT[] = [];
   for (const rawDocument of rawDocuments) {
-    const document = rawDocument.toJS({ maxAliasCount: 10000 });
-
     const errors = rawDocument.errors;
     // handle YAML parse errors
     if (errors?.length) {
       const error = new AggregateError(errors, 'Failed to parse YAML file');
       if (options?.failureBehaviour === 'filter') {
-        logger.debug({ error, document }, 'Failed to parse YAML');
+        logger.debug(`Failed to parse YAML file: ${error.message}`);
         continue;
       }
       throw error;
     }
+
+    const document = rawDocument.toJS({ maxAliasCount: 10000 });
 
     // skip schema validation if no schema is provided
     if (!schema) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Fixes yaml parsing logic so that `.toJS()` isn't called on invalid documents.

## Context

Works around problem found in #31902 (probably a better long term solution is needed through, particularly for single docs which will still throw).

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
