### PR TITLE
fix(platform/github): catch errors addLabels()

### DIFF
--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -3410,6 +3410,24 @@ describe('modules/platform/github/index', () => {
         `Deleting label old_label from #1234`,
       );
     });
+
+    describe('addLabels', () => {
+      it('warns if adding labels failed', async () => {
+        const scope = httpMock.scope(githubApiHost);
+        scope.post('/repos/undefined/issues/2/labels').reply(400, {
+          message: 'Failed to add labels',
+        });
+        await expect(github.addLabels(2, ['fail'])).toResolve();
+        expect(logger.logger.warn).toHaveBeenCalledWith(
+          {
+            err: expect.any(Object),
+            issueNo: 2,
+            labels: ['fail'],
+          },
+          'Error while adding labels. Skipping',
+        );
+      });
+    });
   });
 
   describe('reattemptPlatformAutomerge(number, platformPrOptions)', () => {

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -1489,11 +1489,18 @@ async function addLabels(
   labels: string[] | null | undefined,
 ): Promise<void> {
   logger.debug(`Adding labels '${labels?.join(', ')}' to #${issueNo}`);
-  const repository = config.parentRepo ?? config.repository;
-  if (is.array(labels) && labels.length) {
-    await githubApi.postJson(`repos/${repository}/issues/${issueNo}/labels`, {
-      body: labels,
-    });
+  try {
+    const repository = config.parentRepo ?? config.repository;
+    if (is.array(labels) && labels.length) {
+      await githubApi.postJson(`repos/${repository}/issues/${issueNo}/labels`, {
+        body: labels,
+      });
+    }
+  } catch (err) {
+    logger.warn(
+      { err, issueNo, labels },
+      'Error while adding labels. Skipping',
+    );
   }
 }
 

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -1484,7 +1484,7 @@ export async function addReviewers(
   }
 }
 
-async function addLabels(
+export async function addLabels(
   issueNo: number,
   labels: string[] | null | undefined,
 ): Promise<void> {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Add try/catch block to the `addLabels()` function
<!-- Describe what behavior is changed by this PR. -->

## Context
Closes: https://github.com/renovatebot/renovate/issues/31091

Due errors from this function not being handled correctly, the error was bring passed onto the `github.createPr()` function which then resulted in incorrect debug logs. It also affected addition of assignees.
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository https://github.com/Rahul-renovate-testing/repro-31091/pull/1 (assginees added but label is not as it exceeds maxCharLimit)

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
