### PR TITLE
refactor(github): Use matching refs search instead of HEAD requests

### DIFF
--- a/lib/modules/platform/github/branch.spec.ts
+++ b/lib/modules/platform/github/branch.spec.ts
@@ -5,10 +5,8 @@ describe('modules/platform/github/branch', () => {
   it('should return true if the branch exists', async () => {
     httpMock
       .scope('https://api.github.com')
-      .head('/repos/my/repo/git/refs/heads/renovate/foobar/')
-      .reply(404)
-      .head('/repos/my/repo/git/refs/heads/renovate/foobar')
-      .reply(200, { ref: 'renovate/foobar' });
+      .get('/repos/my/repo/git/matching-refs/heads/renovate/foobar')
+      .reply(200, [{ ref: 'refs/heads/renovate/foobar' }]);
 
     const result = await remoteBranchExists('my/repo', 'renovate/foobar');
 
@@ -18,10 +16,8 @@ describe('modules/platform/github/branch', () => {
   it('should return false if the branch does not exist', async () => {
     httpMock
       .scope('https://api.github.com')
-      .head('/repos/my/repo/git/refs/heads/renovate/foobar/')
-      .reply(404)
-      .head('/repos/my/repo/git/refs/heads/renovate/foobar')
-      .reply(404);
+      .get('/repos/my/repo/git/matching-refs/heads/renovate/foobar')
+      .reply(200, []);
 
     const result = await remoteBranchExists('my/repo', 'renovate/foobar');
 
@@ -31,8 +27,12 @@ describe('modules/platform/github/branch', () => {
   it('should throw an error for nested branches', async () => {
     httpMock
       .scope('https://api.github.com')
-      .head('/repos/my/repo/git/refs/heads/renovate/foobar/')
-      .reply(200);
+      .get('/repos/my/repo/git/matching-refs/heads/renovate/foobar')
+      .reply(200, [
+        { ref: 'refs/heads/renovate/foobar/branch-1' },
+        { ref: 'refs/heads/renovate/foobar/branch-2' },
+        { ref: 'refs/heads/renovate/foobar/branch-3' },
+      ]);
 
     await expect(
       remoteBranchExists('my/repo', 'renovate/foobar'),
@@ -44,8 +44,8 @@ describe('modules/platform/github/branch', () => {
   it('should throw an error if the request fails for any other reason', async () => {
     httpMock
       .scope('https://api.github.com')
-      .head('/repos/my/repo/git/refs/heads/renovate/foobar/')
-      .reply(500, { message: 'Something went wrong' });
+      .get('/repos/my/repo/git/matching-refs/heads/renovate/foobar')
+      .reply(500);
 
     await expect(
       remoteBranchExists('my/repo', 'renovate/foobar'),


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes



## Context

- It could help with #30644

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
