### PR TITLE
fix(lib/data): remove incorrect changelog for psycopg2

### DIFF
--- a/lib/data/changelog-urls.json
+++ b/lib/data/changelog-urls.json
@@ -16,8 +16,6 @@
     "lxml": "https://git.launchpad.net/lxml/plain/CHANGES.txt",
     "mypy": "https://mypy-lang.blogspot.com/",
     "phonenumbers": "https://github.com/daviddrysdale/python-phonenumbers/blob/dev/python/HISTORY.md",
-    "psycopg2": "https://initd.org/psycopg/articles/tag/release/",
-    "psycopg2-binary": "https://initd.org/psycopg/articles/tag/release/",
     "pycountry": "https://github.com/flyingcircusio/pycountry/blob/master/HISTORY.txt",
     "django-debug-toolbar": "https://django-debug-toolbar.readthedocs.io/en/latest/changes.html",
     "requests": "https://github.com/psf/requests/blob/master/HISTORY.md",


### PR DESCRIPTION


<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Renovate pull requests for `psycopg2` and `psycopg2-binary` link to a dead changelog: remove the incorrect internal data.

## Context

The correct changelog location is https://www.psycopg.org/docs/news.html
Changelog was added in https://github.com/psycopg/psycopg2/commit/bfdffc2c5723c18f30dddef81789237578dada6a 
Changelog can be seen in the pypi metadata: https://pypi.org/project/psycopg2/

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
