### PR TITLE
feat(presets): add `pep621` manager support to `:semanticPrefixFixDepsChoreOthers` preset

### DIFF
--- a/lib/config/presets/__snapshots__/index.spec.ts.snap
+++ b/lib/config/presets/__snapshots__/index.spec.ts.snap
@@ -83,6 +83,16 @@ exports[`config/presets/index resolvePreset migrates automerge in presets 1`] = 
       "semanticCommitType": "fix",
     },
     {
+      "matchDepTypes": [
+        "project.dependencies",
+        "project.optional-dependencies",
+      ],
+      "matchManagers": [
+        "pep621",
+      ],
+      "semanticCommitType": "fix",
+    },
+    {
       "matchPackageNames": [
         "*",
       ],

--- a/lib/config/presets/internal/default.ts
+++ b/lib/config/presets/internal/default.ts
@@ -574,6 +574,14 @@ export const presets: Record<string, Preset> = {
         ],
         semanticCommitType: 'fix',
       },
+      {
+        matchDepTypes: [
+          'project.dependencies',
+          'project.optional-dependencies',
+        ],
+        matchManagers: ['pep621'],
+        semanticCommitType: 'fix',
+      },
     ],
   },
   separateMajorReleases: {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

I've added a package rule to the `:semanticPrefixFixDepsChoreOthers` preset that sets the semantic commit type `fix` for PEP 621 runtime dependencies. In contrast to several other package managers, which use `dependencies` as the `depType` for runtime dependencies, PEP 621 uses `project.dependencies` and `project.optional-dependencies`, hence the semantic commit type `fix` wasn't used for PEP 621 runtime dependency updates prior to this PR.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

I've migrated a project to [`uv`](https://github.com/astral-sh/uv), which conforms with PEP 621, and noticed that the `:semanticPrefixFixDepsChoreOthers` preset included in the `config:recommended` preset doesn't work correctly (`chore` is used also for runtime dependency manifest updates).

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

The relevant documentation is auto-generated.

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

I tested the changes by configuring the package rules manually in a test project.

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
