### PR TITLE
fix(gerrit): improve commit message vs pr title workaround

### DIFF
--- a/lib/modules/platform/gerrit/client.spec.ts
+++ b/lib/modules/platform/gerrit/client.spec.ts
@@ -208,39 +208,6 @@ describe('modules/platform/gerrit/client', () => {
     });
   });
 
-  describe('setCommitMessage()', () => {
-    it('setCommitMessage', async () => {
-      const change = partial<GerritChange>({});
-      httpMock
-        .scope(gerritEndpointUrl)
-        .put('/a/changes/123456/message', { message: 'new message' })
-        .reply(200, gerritRestResponse(change), jsonResultHeader);
-      await expect(client.setCommitMessage(123456, 'new message')).toResolve();
-    });
-  });
-
-  describe('updateChangeSubject', () => {
-    it('updateChangeSubject - success', async () => {
-      const change = partial<GerritChange>({});
-      const newSubject = 'new subject';
-      const previousSubject = 'some subject';
-      const previousBody = `some body\n\nChange-Id: some-change-id\n`;
-      httpMock
-        .scope(gerritEndpointUrl)
-        .put('/a/changes/123456/message', {
-          message: `${newSubject}\n\n${previousBody}`,
-        })
-        .reply(200, gerritRestResponse(change), jsonResultHeader);
-      await expect(
-        client.updateChangeSubject(
-          123456,
-          `${previousSubject}\n\n${previousBody}`,
-          'new subject',
-        ),
-      ).toResolve();
-    });
-  });
-
   describe('getMessages()', () => {
     it('no messages', async () => {
       httpMock

--- a/lib/modules/platform/gerrit/client.ts
+++ b/lib/modules/platform/gerrit/client.ts
@@ -98,25 +98,6 @@ class GerritClient {
     return change.body;
   }
 
-  async setCommitMessage(changeNumber: number, message: string): Promise<void> {
-    await this.gerritHttp.putJson(`a/changes/${changeNumber}/message`, {
-      body: { message },
-    });
-  }
-
-  async updateChangeSubject(
-    number: number,
-    currentMessage: string,
-    newSubject: string,
-  ): Promise<void> {
-    // Replace first line of the commit message with the new subject
-    const newMessage = currentMessage.replace(
-      new RegExp(`^.*$`, 'm'),
-      newSubject,
-    );
-    await this.setCommitMessage(number, newMessage);
-  }
-
   async getMessages(changeNumber: number): Promise<GerritChangeMessageInfo[]> {
     const messages = await this.gerritHttp.getJson<GerritChangeMessageInfo[]>(
       `a/changes/${changeNumber}/messages`,

--- a/lib/modules/platform/gerrit/index.spec.ts
+++ b/lib/modules/platform/gerrit/index.spec.ts
@@ -187,29 +187,6 @@ describe('modules/platform/gerrit/index', () => {
       gerrit.writeToConfig({ labels: {} });
     });
 
-    it('updatePr() - new prTitle => copy to commit msg', async () => {
-      const oldSubject = 'old title';
-      const oldMessage = `${oldSubject}\n\nsome body\n\nChange-Id: ...`;
-      const change = partial<GerritChange>({
-        subject: oldSubject,
-        current_revision: 'some-revision',
-        revisions: {
-          'some-revision': partial<GerritRevisionInfo>({
-            commit: {
-              message: oldMessage,
-            },
-          }),
-        },
-      });
-      clientMock.getChange.mockResolvedValueOnce(change);
-      await gerrit.updatePr({ number: 123456, prTitle: 'new title' });
-      expect(clientMock.updateChangeSubject).toHaveBeenCalledWith(
-        123456,
-        oldMessage,
-        'new title',
-      );
-    });
-
     it('updatePr() - auto approve enabled', async () => {
       const change = partial<GerritChange>({
         current_revision: 'some-revision',
@@ -332,7 +309,7 @@ describe('modules/platform/gerrit/index', () => {
       ]);
     });
 
-    it('createPr() - update body/title WITHOUT approve', async () => {
+    it('createPr() - update body WITHOUT approve', async () => {
       const pr = await gerrit.createPr({
         sourceBranch: 'source',
         targetBranch: 'target',
@@ -349,11 +326,6 @@ describe('modules/platform/gerrit/index', () => {
         TAG_PULL_REQUEST_BODY,
       );
       expect(clientMock.approveChange).not.toHaveBeenCalled();
-      expect(clientMock.updateChangeSubject).toHaveBeenCalledWith(
-        123456,
-        message,
-        'title',
-      );
     });
 
     it('createPr() - update body and approve', async () => {
@@ -373,7 +345,6 @@ describe('modules/platform/gerrit/index', () => {
         TAG_PULL_REQUEST_BODY,
       );
       expect(clientMock.approveChange).toHaveBeenCalledWith(123456);
-      expect(clientMock.setCommitMessage).not.toHaveBeenCalled();
     });
   });
 

--- a/lib/modules/platform/gerrit/index.ts
+++ b/lib/modules/platform/gerrit/index.ts
@@ -153,14 +153,6 @@ export async function getPr(number: number): Promise<Pr | null> {
 
 export async function updatePr(prConfig: UpdatePrConfig): Promise<void> {
   logger.debug(`updatePr(${prConfig.number}, ${prConfig.prTitle})`);
-  const change = await client.getChange(prConfig.number);
-  if (change.subject !== prConfig.prTitle) {
-    await client.updateChangeSubject(
-      prConfig.number,
-      change.revisions[change.current_revision].commit.message,
-      prConfig.prTitle,
-    );
-  }
   if (prConfig.prBody) {
     await client.addMessageIfNotAlreadyExists(
       prConfig.number,
@@ -196,14 +188,6 @@ export async function createPr(prConfig: CreatePRConfig): Promise<Pr | null> {
   if (pr === undefined) {
     throw new Error(
       `the change should be created automatically from previous push to refs/for/${prConfig.sourceBranch}`,
-    );
-  }
-  //Workaround for "Known Problems.1"
-  if (pr.subject !== prConfig.prTitle) {
-    await client.updateChangeSubject(
-      pr._number,
-      pr.revisions[pr.current_revision].commit.message,
-      prConfig.prTitle,
     );
   }
   await client.addMessageIfNotAlreadyExists(

--- a/lib/modules/platform/gerrit/readme.md
+++ b/lib/modules/platform/gerrit/readme.md
@@ -61,15 +61,3 @@ For example, if you want to use the [Merge Confidence](../../../merge-confidence
 
 - Creating issues (not a Gerrit concept)
 - Dependency Dashboard (needs issues first)
-
-## Known problems
-
-### PR title is different from first commit message
-
-Sometimes the PR title passed to the Gerrit platform code is different from the first line of the commit message.
-For example:
-
-- Commit-Message=`Update keycloak.version to v21`
-- Pull-Request-Title=`Update keycloak.version to v21 (major)`
-
-In this case the Gerrit-Platform implementation tries to detect this and change the commit-message in a second patch-set.

--- a/lib/modules/platform/gerrit/scm.spec.ts
+++ b/lib/modules/platform/gerrit/scm.spec.ts
@@ -266,6 +266,7 @@ describe('modules/platform/gerrit/scm', () => {
           baseBranch: 'main',
           message: 'commit msg',
           files: [],
+          prTitle: 'pr title',
         }),
       ).resolves.toBeNull();
       expect(clientMock.findChanges).toHaveBeenCalledWith(
@@ -294,6 +295,7 @@ describe('modules/platform/gerrit/scm', () => {
           baseBranch: 'main',
           message: 'commit msg',
           files: [],
+          prTitle: 'pr title',
         }),
       ).toBe('commitSha');
       expect(git.prepareCommit).toHaveBeenCalledWith({
@@ -301,11 +303,12 @@ describe('modules/platform/gerrit/scm', () => {
         branchName: 'renovate/dependency-1.x',
         files: [],
         message: [
-          'commit msg',
+          'pr title',
           expect.stringMatching(
             /^Renovate-Branch: renovate\/dependency-1\.x\nChange-Id: I[a-z0-9]{40}$/,
           ),
         ],
+        prTitle: 'pr title',
         force: true,
       });
       expect(git.pushCommit).toHaveBeenCalledWith({
@@ -338,6 +341,7 @@ describe('modules/platform/gerrit/scm', () => {
           baseBranch: 'main',
           message: ['commit msg'],
           files: [],
+          prTitle: 'pr title',
         }),
       ).toBeNull();
       expect(git.prepareCommit).toHaveBeenCalledWith({
@@ -345,9 +349,10 @@ describe('modules/platform/gerrit/scm', () => {
         branchName: 'renovate/dependency-1.x',
         files: [],
         message: [
-          'commit msg',
+          'pr title',
           'Renovate-Branch: renovate/dependency-1.x\nChange-Id: ...',
         ],
+        prTitle: 'pr title',
         force: true,
       });
       expect(git.fetchRevSpec).toHaveBeenCalledWith('refs/changes/1/2');
@@ -379,6 +384,7 @@ describe('modules/platform/gerrit/scm', () => {
           baseBranch: 'main',
           message: 'commit msg',
           files: [],
+          prTitle: 'pr title',
         }),
       ).toBe('commitSha');
       expect(git.prepareCommit).toHaveBeenCalledWith({
@@ -386,9 +392,10 @@ describe('modules/platform/gerrit/scm', () => {
         branchName: 'renovate/dependency-1.x',
         files: [],
         message: [
-          'commit msg',
+          'pr title',
           'Renovate-Branch: renovate/dependency-1.x\nChange-Id: ...',
         ],
+        prTitle: 'pr title',
         force: true,
       });
       expect(git.fetchRevSpec).toHaveBeenCalledWith('refs/changes/1/2');

--- a/lib/modules/platform/gerrit/scm.ts
+++ b/lib/modules/platform/gerrit/scm.ts
@@ -105,10 +105,18 @@ export class GerritScm extends DefaultGitScm {
       .then((res) => res.pop());
 
     let hasChanges = true;
-    const origMsg =
+    const message =
       typeof commit.message === 'string' ? [commit.message] : commit.message;
+
+    // In Gerrit, the change subject/title is the first line of the commit message
+    if (commit.prTitle) {
+      const firstMessageLines = message[0].split('\n');
+      firstMessageLines[0] = commit.prTitle;
+      message[0] = firstMessageLines.join('\n');
+    }
+
     commit.message = [
-      ...origMsg,
+      ...message,
       `Renovate-Branch: ${commit.branchName}\nChange-Id: ${existingChange?.change_id ?? generateChangeId()}`,
     ];
     const commitResult = await git.prepareCommit({ ...commit, force: true });

--- a/lib/util/git/types.ts
+++ b/lib/util/git/types.ts
@@ -83,6 +83,8 @@ export interface CommitFilesConfig {
   message: string | string[];
   force?: boolean;
   platformCommit?: PlatformCommitOptions;
+  /** Only needed by Gerrit platform */
+  prTitle?: string;
 }
 
 export interface PushFilesConfig {

--- a/lib/workers/repository/update/branch/commit.ts
+++ b/lib/workers/repository/update/branch/commit.ts
@@ -60,5 +60,7 @@ export function commitFilesToBranch(
     message: config.commitMessage!,
     force: !!config.forceCommit,
     platformCommit: config.platformCommit,
+    // Only needed by Gerrit platform
+    prTitle: config.prTitle,
   });
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This improves the workaround for the Gerrit change title mismatch issue.

The previous approach had big downsides:

1. It would create new patchsets every time the commit message title did not match with the prTitle
   - Creating new patchsets means triggerring unecessary CI jobs, which depending on the project, might be expensive
   - Increases the list of iterations of a change. Some Gerrit deployments will limit the amount of iterations a change can have and if the limit is reached, the change is doomed and needs to be recreated, which requires manual intervention.

   Image:

   <img src="https://github.com/user-attachments/assets/a4f93ca1-61e7-4b8d-822c-8d1850a3cb38" alt="description" width="300"/>

2. If Renovate for whatever reason fails before updating the commit message to match the PR title, it would mean that the change would be forgot by Renovate forever, and Renovate would attempt to create a new one next time. Also, if this happens and someone closes the change (to ignore future updates), Renovate will also never realize that the change was closed and will keep trying to create a new one.
   - Although it seems rare, it has happened several times with my Renovate deployment. I spent several hours to figure out this was the root cause.

The new approach will always ensure the commit is created or recreated with the proper title. In this case, none of the downsides above will happen. Also, it cleans the code a little, removing gimmicks no longer necessary.

I understand this fix touches a bit of code outside of the Gerrit platform, but I believe it is better enough to at least justify it being merged (when compared to the current approach). If a better approach is found in the future, we can always refactor it.

With this fix, I also believe that the user doesn't even need to be aware of how this is handled. Previously, maybe the user would notice the **second patchset** and thus the documentation would explain this behavior. Now, the user will never notice this behavior to begin with. Obviously, I'm open to suggestions.

<!-- Describe what behavior is changed by this PR. -->

## Context

See above.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
