### PR TITLE
feat(pep621): add support for `dependency-groups` (PEP 735)

### DIFF
--- a/lib/modules/manager/pep621/__fixtures__/pyproject_with_pdm.toml
+++ b/lib/modules/manager/pep621/__fixtures__/pyproject_with_pdm.toml
@@ -25,6 +25,11 @@ pytest = [
   "pytest-mock",
 ]
 
+[dependency-groups]
+typing = ["mypy==1.13.0", "types-requests"]
+coverage = ["pytest-cov==5.0.0"]
+all = [{include-group = "typing"}, {include-group = "coverage"}, "click==8.1.7"]
+
 [tool.pdm.dev-dependencies]
 test = [
   "pdm[pytest]",

--- a/lib/modules/manager/pep621/extract.spec.ts
+++ b/lib/modules/manager/pep621/extract.spec.ts
@@ -147,6 +147,47 @@ describe('modules/manager/pep621/extract', () => {
         },
       ]);
 
+      const dependenciesFromDependencyGroups = result?.deps.filter(
+        (dep) => dep.depType === 'dependency-groups',
+      );
+      expect(dependenciesFromDependencyGroups).toEqual([
+        {
+          packageName: 'mypy',
+          datasource: 'pypi',
+          depType: 'dependency-groups',
+          currentValue: '==1.13.0',
+          currentVersion: '1.13.0',
+          depName: 'mypy',
+          managerData: { depGroup: 'typing' },
+        },
+        {
+          packageName: 'types-requests',
+          datasource: 'pypi',
+          depType: 'dependency-groups',
+          skipReason: 'unspecified-version',
+          depName: 'types-requests',
+          managerData: { depGroup: 'typing' },
+        },
+        {
+          packageName: 'pytest-cov',
+          datasource: 'pypi',
+          depType: 'dependency-groups',
+          currentValue: '==5.0.0',
+          currentVersion: '5.0.0',
+          depName: 'pytest-cov',
+          managerData: { depGroup: 'coverage' },
+        },
+        {
+          packageName: 'click',
+          datasource: 'pypi',
+          depType: 'dependency-groups',
+          currentValue: '==8.1.7',
+          currentVersion: '8.1.7',
+          depName: 'click',
+          managerData: { depGroup: 'all' },
+        },
+      ]);
+
       const pdmDevDependencies = result?.deps.filter(
         (dep) => dep.depType === 'tool.pdm.dev-dependencies',
       );

--- a/lib/modules/manager/pep621/extract.ts
+++ b/lib/modules/manager/pep621/extract.ts
@@ -39,6 +39,12 @@ export async function extractPackageFile(
   );
   deps.push(
     ...parseDependencyGroupRecord(
+      depTypes.dependencyGroups,
+      def['dependency-groups'],
+    ),
+  );
+  deps.push(
+    ...parseDependencyGroupRecord(
       depTypes.optionalDependencies,
       def.project?.['optional-dependencies'],
     ),

--- a/lib/modules/manager/pep621/readme.md
+++ b/lib/modules/manager/pep621/readme.md
@@ -10,6 +10,7 @@ Available `depType`s:
 
 - `project.dependencies`
 - `project.optional-dependencies`
+- `dependency-groups`
 - `build-system.requires`
 - `tool.pdm.dev-dependencies`
 - `tool.uv.dev-dependencies`

--- a/lib/modules/manager/pep621/schema.ts
+++ b/lib/modules/manager/pep621/schema.ts
@@ -1,4 +1,3 @@
-import is from '@sindresorhus/is';
 import { z } from 'zod';
 import { LooseArray, LooseRecord, Toml } from '../../../util/schema-utils';
 

--- a/lib/modules/manager/pep621/schema.ts
+++ b/lib/modules/manager/pep621/schema.ts
@@ -88,7 +88,7 @@ export const PyProjectSchema = z.object({
     .record(
       z.string(),
       // Skip non-string entries, like `{include-group = "typing"}`, as they are not dependencies.
-      LooseArray(z.string())
+      LooseArray(z.string()),
     )
     .optional(),
   tool: z

--- a/lib/modules/manager/pep621/schema.ts
+++ b/lib/modules/manager/pep621/schema.ts
@@ -87,10 +87,8 @@ export const PyProjectSchema = z.object({
   'dependency-groups': z
     .record(
       z.string(),
-      z
-        .array(z.union([z.string(), z.object({})]))
-        // Skip non-string entries, like `{include-group = "typing"}`, as they are not dependencies.
-        .transform((deps) => deps.filter(is.string)),
+      // Skip non-string entries, like `{include-group = "typing"}`, as they are not dependencies.
+      LooseArray(z.string())
     )
     .optional(),
   tool: z

--- a/lib/modules/manager/pep621/schema.ts
+++ b/lib/modules/manager/pep621/schema.ts
@@ -1,3 +1,4 @@
+import is from '@sindresorhus/is';
 import { z } from 'zod';
 import { LooseArray, LooseRecord, Toml } from '../../../util/schema-utils';
 
@@ -82,6 +83,15 @@ export const PyProjectSchema = z.object({
       requires: DependencyListSchema,
       'build-backend': z.string().optional(),
     })
+    .optional(),
+  'dependency-groups': z
+    .record(
+      z.string(),
+      z
+        .array(z.union([z.string(), z.object({})]))
+        // Skip non-string entries, like `{include-group = "typing"}`, as they are not dependencies.
+        .transform((deps) => deps.filter(is.string)),
+    )
     .optional(),
   tool: z
     .object({

--- a/lib/modules/manager/pep621/utils.ts
+++ b/lib/modules/manager/pep621/utils.ts
@@ -16,6 +16,7 @@ const pep508Regex = regEx(
 export const depTypes = {
   dependencies: 'project.dependencies',
   optionalDependencies: 'project.optional-dependencies',
+  dependencyGroups: 'dependency-groups',
   pdmDevDependencies: 'tool.pdm.dev-dependencies',
   uvDevDependencies: 'tool.uv.dev-dependencies',
   uvSources: 'tool.uv.sources',


### PR DESCRIPTION
Closes #32147.

## Changes

Add support for Python `dependency-groups`, which recently got accepted as part of [PEP 735](https://peps.python.org/pep-0735/).

## Context

As mentioned in the linked discussion, not all tools that support PEP 621 for defining project dependencies support `dependency-groups` (so far, only uv does AFAIK), but since the feature would only be used by users of tools that support it, it should not be problematic to assume that all tools support it already.

But if you feel like we should take a more defensive approach and only parse dependencies for tools that explicitly support it, happy to update the PR.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

Tested over https://github.com/mkniewallner/renovate-uv-dependency-groups.

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
