### PR TITLE
fix(manager/poetry): set `sourceName` only if defined

### DIFF
--- a/lib/modules/manager/poetry/__snapshots__/extract.spec.ts.snap
+++ b/lib/modules/manager/poetry/__snapshots__/extract.spec.ts.snap
@@ -359,7 +359,6 @@ exports[`modules/manager/poetry/extract extractPackageFile() extracts multiple d
       "depType": "dependencies",
       "managerData": {
         "nestedVersion": true,
-        "sourceName": undefined,
       },
       "versioning": "poetry",
     },
@@ -370,7 +369,6 @@ exports[`modules/manager/poetry/extract extractPackageFile() extracts multiple d
       "depType": "dependencies",
       "managerData": {
         "nestedVersion": true,
-        "sourceName": undefined,
       },
       "versioning": "poetry",
     },

--- a/lib/modules/manager/poetry/extract.spec.ts
+++ b/lib/modules/manager/poetry/extract.spec.ts
@@ -481,11 +481,17 @@ describe('modules/manager/poetry/extract', () => {
             depName: 'typer',
             currentValue: '^0.9.0',
             registryUrls: ['https://pypi.org/pypi/'],
+            managerData: {
+              sourceName: 'pypi',
+            },
           },
           {
             depName: 'requests-cache',
             currentValue: '^1.1.0',
             registryUrls: ['https://example.com'],
+            managerData: {
+              sourceName: 'artifactory',
+            },
           },
         ]);
       });

--- a/lib/modules/manager/poetry/schema.ts
+++ b/lib/modules/manager/poetry/schema.ts
@@ -96,7 +96,10 @@ const PoetryPypiDependency = z.union([
 
       return {
         datasource: PypiDatasource.id,
-        managerData: { nestedVersion: true, sourceName: source?.toLowerCase() },
+        managerData: {
+          nestedVersion: true,
+          ...(source ? { sourceName: source.toLowerCase() } : {}),
+        },
         currentValue,
       };
     }),


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This is a minor internal fix that sets the `managerData.sourceName` property only if the `source` attribute in a dependency specification is set. Before, the property was always set, and it was set to `undefined` when the `source` attribute in a dependency specification was provided.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

See https://github.com/renovatebot/renovate/pull/32096#discussion_r1817769695 for the suggested change by @secustor.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->