### PR TITLE
refactor(rebaseWhen): small refactor for rebaseWhen value setter

### DIFF
--- a/lib/workers/repository/update/branch/reuse.ts
+++ b/lib/workers/repository/update/branch/reuse.ts
@@ -37,34 +37,10 @@ export async function shouldReuseExistingBranch(
     return result;
   }
   logger.debug(`Branch already exists`);
-  if (result.rebaseWhen === 'auto') {
-    if (result.automerge === true) {
-      logger.debug(
-        'Converting rebaseWhen=auto to rebaseWhen=behind-base-branch because automerge=true',
-      );
-      result.rebaseWhen = 'behind-base-branch';
-    } else if (await platform.getBranchForceRebase?.(result.baseBranch)) {
-      logger.debug(
-        'Converting rebaseWhen=auto to rebaseWhen=behind-base-branch because platform is configured to require up-to-date branches',
-      );
-      result.rebaseWhen = 'behind-base-branch';
-    } else if (await shouldKeepUpdated(result, baseBranch, branchName)) {
-      logger.debug(
-        'Converting rebaseWhen=auto to rebaseWhen=behind-base-branch because keep-updated label is set',
-      );
-      result.rebaseWhen = 'behind-base-branch';
-    }
-  }
-  if (result.rebaseWhen === 'auto') {
-    logger.debug(
-      'Converting rebaseWhen=auto to rebaseWhen=conflicted because no rule for converting to rebaseWhen=behind-base-branch applies',
-    );
-    result.rebaseWhen = 'conflicted';
-  }
-  if (
-    result.rebaseWhen === 'behind-base-branch' ||
-    (await shouldKeepUpdated(result, baseBranch, branchName))
-  ) {
+  const keepUpdated = await shouldKeepUpdated(result, baseBranch, branchName);
+  await determineRebaseWhenValue(result, keepUpdated);
+
+  if (result.rebaseWhen === 'behind-base-branch' || keepUpdated) {
     if (await scm.isBranchBehindBase(branchName, baseBranch)) {
       logger.debug(`Branch is behind base branch and needs rebasing`);
       // We can rebase the branch only if no PR or PR can be rebased
@@ -91,10 +67,7 @@ export async function shouldReuseExistingBranch(
 
     if ((await scm.isBranchModified(branchName, baseBranch)) === false) {
       logger.debug(`Branch is not mergeable and needs rebasing`);
-      if (
-        result.rebaseWhen === 'never' &&
-        !(await shouldKeepUpdated(result, baseBranch, branchName))
-      ) {
+      if (result.rebaseWhen === 'never' && !keepUpdated) {
         logger.debug('Rebasing disabled by config');
         result.reuseExistingBranch = true;
         result.isModified = false;
@@ -135,4 +108,38 @@ export async function shouldReuseExistingBranch(
   result.reuseExistingBranch = true;
   result.isModified = false;
   return result;
+}
+
+/**
+ * This method updates rebaseWhen value when it's set to auto(default)
+ *
+ * @param result BranchConfig
+ * @param keepUpdated boolean
+ */
+async function determineRebaseWhenValue(
+  result: BranchConfig,
+  keepUpdated: boolean,
+): Promise<void> {
+  // Helper function for logging and assigning
+  const setRebaseWhen = (value: string, reason: string): void => {
+    logger.debug(
+      `Converting rebaseWhen=${result.rebaseWhen} to rebaseWhen=${value} because ${reason}`,
+    );
+    result.rebaseWhen = value;
+  };
+
+  if (result.rebaseWhen === 'auto') {
+    if (result.automerge === true) {
+      setRebaseWhen('behind-base-branch', 'automerge=true');
+    } else if (await platform.getBranchForceRebase?.(result.baseBranch)) {
+      setRebaseWhen(
+        'behind-base-branch',
+        'platform is configured to require up-to-date branches',
+      );
+    } else if (keepUpdated) {
+      setRebaseWhen('behind-base-branch', 'keep-updated label is set');
+    } else {
+      setRebaseWhen('conflicted', 'no rule for behind-base-branch applies');
+    }
+  }
 }

--- a/lib/workers/repository/update/branch/reuse.ts
+++ b/lib/workers/repository/update/branch/reuse.ts
@@ -120,26 +120,24 @@ async function determineRebaseWhenValue(
   result: BranchConfig,
   keepUpdated: boolean,
 ): Promise<void> {
-  // Helper function for logging and assigning
-  const setRebaseWhen = (value: string, reason: string): void => {
-    logger.debug(
-      `Converting rebaseWhen=${result.rebaseWhen} to rebaseWhen=${value} because ${reason}`,
-    );
-    result.rebaseWhen = value;
-  };
-
   if (result.rebaseWhen === 'auto') {
+    let reason;
+
+    let newValue = 'behind-base-branch';
     if (result.automerge === true) {
-      setRebaseWhen('behind-base-branch', 'automerge=true');
+      reason = 'automerge=true';
     } else if (await platform.getBranchForceRebase?.(result.baseBranch)) {
-      setRebaseWhen(
-        'behind-base-branch',
-        'platform is configured to require up-to-date branches',
-      );
+      reason = 'platform is configured to require up-to-date branches';
     } else if (keepUpdated) {
-      setRebaseWhen('behind-base-branch', 'keep-updated label is set');
+      reason = 'keep-updated label is set';
     } else {
-      setRebaseWhen('conflicted', 'no rule for behind-base-branch applies');
+      newValue = 'conflicted';
+      reason = 'no rule for behind-base-branch applies';
     }
+
+    logger.debug(
+      `Converting rebaseWhen=${result.rebaseWhen} to rebaseWhen=${newValue} because ${reason}`,
+    );
+    result.rebaseWhen = newValue;
   }
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

refactor rebaseWhen to be more readable and maintainable
<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
