### PR TITLE
test(manager/uv): move source skip test to `extract`

### DIFF
--- a/lib/modules/manager/pep621/extract.spec.ts
+++ b/lib/modules/manager/pep621/extract.spec.ts
@@ -1,6 +1,8 @@
 import { codeBlock } from 'common-tags';
 import { Fixtures } from '../../../../test/fixtures';
 import { fs } from '../../../../test/util';
+import { GitRefsDatasource } from '../../datasource/git-refs';
+import { depTypes } from './utils';
 import { extractPackageFile } from '.';
 
 jest.mock('../../../util/fs');
@@ -322,6 +324,65 @@ describe('modules/manager/pep621/extract', () => {
             'https://pypi.org/pypi/',
             'https://private-site.org/pypi/simple',
           ],
+        },
+      ]);
+    });
+
+    it('should skip dependencies with unsupported uv sources', async () => {
+      const result = await extractPackageFile(
+        codeBlock`
+        [project]
+        dependencies = [
+          "dep1",
+          "dep2",
+          "dep3",
+          "dep4",
+          "dep5",
+          "dep6",
+          "dep7",
+        ]
+
+        [tool.uv.sources]
+        dep2 = { git = "https://github.com/foo/bar" }
+        dep3 = { path = "/local-dep.whl" }
+        dep4 = { url = "https://example.com" }
+        dep5 = { workspace = true }
+        `,
+        'pyproject.toml',
+      );
+
+      expect(result?.deps).toMatchObject([
+        {
+          depName: 'dep1',
+        },
+        {
+          depName: 'dep2',
+          depType: depTypes.uvSources,
+          datasource: GitRefsDatasource.id,
+          packageName: 'https://github.com/foo/bar',
+          currentValue: undefined,
+          skipReason: 'unspecified-version',
+        },
+        {
+          depName: 'dep3',
+          depType: depTypes.uvSources,
+          skipReason: 'path-dependency',
+        },
+        {
+          depName: 'dep4',
+          depType: depTypes.uvSources,
+          skipReason: 'unsupported-url',
+        },
+        {
+          depName: 'dep5',
+          depType: depTypes.uvSources,
+          skipReason: 'inherited-dependency',
+        },
+        {
+          depName: 'dep6',
+        },
+        {
+          depName: 'dep7',
         },
       ]);
     });

--- a/lib/modules/manager/pep621/processors/uv.spec.ts
+++ b/lib/modules/manager/pep621/processors/uv.spec.ts
@@ -66,69 +66,6 @@ describe('modules/manager/pep621/processors/uv', () => {
         },
       ]);
     });
-
-    it('skips dependencies with unsupported sources', () => {
-      const pyproject = {
-        tool: {
-          uv: {
-            sources: {
-              dep2: { git: 'https://github.com/foo/bar' },
-              dep3: { path: '/local-dep.whl' },
-              dep4: { url: 'https://example.com' },
-              dep5: { workspace: true },
-            },
-          },
-        },
-      } as const;
-      const dependencies = [
-        {},
-        { depName: 'dep1' },
-        { depName: 'dep2' },
-        { depName: 'dep3' },
-        { depName: 'dep4' },
-        { depName: 'dep5' },
-        { depName: 'dep6' },
-        { depName: 'dep7' },
-      ];
-
-      const result = processor.process(pyproject, dependencies);
-
-      expect(result).toEqual([
-        {},
-        {
-          depName: 'dep1',
-        },
-        {
-          depName: 'dep2',
-          depType: depTypes.uvSources,
-          datasource: GitRefsDatasource.id,
-          packageName: 'https://github.com/foo/bar',
-          currentValue: undefined,
-          skipReason: 'unspecified-version',
-        },
-        {
-          depName: 'dep3',
-          depType: depTypes.uvSources,
-          skipReason: 'path-dependency',
-        },
-        {
-          depName: 'dep4',
-          depType: depTypes.uvSources,
-          skipReason: 'unsupported-url',
-        },
-        {
-          depName: 'dep5',
-          depType: depTypes.uvSources,
-          skipReason: 'inherited-dependency',
-        },
-        {
-          depName: 'dep6',
-        },
-        {
-          depName: 'dep7',
-        },
-      ]);
-    });
   });
 
   it('applies git sources', () => {

--- a/lib/modules/manager/pep621/processors/uv.ts
+++ b/lib/modules/manager/pep621/processors/uv.ts
@@ -46,6 +46,7 @@ export class UvProcessor implements PyProjectProcessor {
     // Skip sources that do not make sense to handle (e.g. path).
     if (uv.sources) {
       for (const dep of deps) {
+        // istanbul ignore if
         if (!dep.depName) {
           continue;
         }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Extracted from https://github.com/renovatebot/renovate/pull/31297.

## Context

I was the one that initially added the test in `uv.spec.ts`, but working on https://github.com/renovatebot/renovate/pull/31297 showed that the test is not enough to cover new cases, as calling `processor.process` happens after the source normalisation is done. So moving the test to `extract.spect.ts` allows testing more cases related to how the schema is parsed and transformed.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
