### PR TITLE
fix: Fix timestamps for `internalChecksFilter` checks

### DIFF
--- a/lib/workers/repository/process/lookup/filter-checks.ts
+++ b/lib/workers/repository/process/lookup/filter-checks.ts
@@ -64,20 +64,21 @@ export async function filterInternalChecks(
       }
       candidateRelease = updatedCandidateRelease;
 
-      const { version, releaseTimestamp } = candidateRelease;
-
       // Now check for a minimumReleaseAge config
       const { minimumConfidence, minimumReleaseAge, updateType } =
         releaseConfig;
-      if (is.nonEmptyString(minimumReleaseAge) && releaseTimestamp) {
+      if (
+        is.nonEmptyString(minimumReleaseAge) &&
+        candidateRelease.releaseTimestamp
+      ) {
         if (
-          getElapsedMs(releaseTimestamp) <
+          getElapsedMs(candidateRelease.releaseTimestamp) <
           coerceNumber(toMs(minimumReleaseAge), 0)
         ) {
           // Skip it if it doesn't pass checks
           logger.trace(
             { depName, check: 'minimumReleaseAge' },
-            `Release ${version} is pending status checks`,
+            `Release ${candidateRelease.version} is pending status checks`,
           );
           pendingReleases.unshift(candidateRelease);
           continue;
@@ -91,14 +92,14 @@ export async function filterInternalChecks(
             datasource!,
             depName!,
             currentVersion!,
-            version,
+            candidateRelease.version,
             updateType!,
           )) ?? 'neutral';
         // TODO #22198
         if (!satisfiesConfidenceLevel(confidenceLevel, minimumConfidence!)) {
           logger.trace(
             { depName, check: 'minimumConfidence' },
-            `Release ${version} is pending status checks`,
+            `Release ${candidateRelease.version} is pending status checks`,
           );
           pendingReleases.unshift(candidateRelease);
           continue;

--- a/lib/workers/repository/process/lookup/filter-checks.ts
+++ b/lib/workers/repository/process/lookup/filter-checks.ts
@@ -64,14 +64,11 @@ export async function filterInternalChecks(
       }
       candidateRelease = updatedCandidateRelease;
 
+      const { version, releaseTimestamp } = candidateRelease;
+
       // Now check for a minimumReleaseAge config
-      const {
-        minimumConfidence,
-        minimumReleaseAge,
-        releaseTimestamp,
-        version: newVersion,
-        updateType,
-      } = releaseConfig;
+      const { minimumConfidence, minimumReleaseAge, updateType } =
+        releaseConfig;
       if (is.nonEmptyString(minimumReleaseAge) && releaseTimestamp) {
         if (
           getElapsedMs(releaseTimestamp) <
@@ -80,7 +77,7 @@ export async function filterInternalChecks(
           // Skip it if it doesn't pass checks
           logger.trace(
             { depName, check: 'minimumReleaseAge' },
-            `Release ${candidateRelease.version} is pending status checks`,
+            `Release ${version} is pending status checks`,
           );
           pendingReleases.unshift(candidateRelease);
           continue;
@@ -94,14 +91,14 @@ export async function filterInternalChecks(
             datasource!,
             depName!,
             currentVersion!,
-            newVersion,
+            version,
             updateType!,
           )) ?? 'neutral';
         // TODO #22198
         if (!satisfiesConfidenceLevel(confidenceLevel, minimumConfidence!)) {
           logger.trace(
             { depName, check: 'minimumConfidence' },
-            `Release ${candidateRelease.version} is pending status checks`,
+            `Release ${version} is pending status checks`,
           );
           pendingReleases.unshift(candidateRelease);
           continue;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Use `releaseTimestamp` from the post-processed release item rather than from config object

## Context

- Closes: #32177

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
