### PR TITLE
feat(versioning): allow versionings to provide isSame and use to detect majors

### DIFF
--- a/lib/modules/versioning/generic.spec.ts
+++ b/lib/modules/versioning/generic.spec.ts
@@ -68,6 +68,7 @@ describe('modules/versioning/generic', () => {
         'getPatch',
         'isCompatible',
         'isGreaterThan',
+        'isSame',
         'isSingleVersion',
         'isStable',
         'isValid',
@@ -182,6 +183,15 @@ describe('modules/versioning/generic', () => {
       expect(
         api.getSatisfyingVersion(['1.1.1', '2.2.2', '3.3.3'], '1.2.3'),
       ).toBeNull();
+    });
+
+    it('isSame', () => {
+      expect(api.isSame('major', '4.5.6', '4.6.0')).toBe(true);
+      expect(api.isSame('major', '4.5.6', '5.0.0')).toBe(false);
+      expect(api.isSame('minor', '4.5.6', '5.5.0')).toBe(true);
+      expect(api.isSame('minor', '4.5.6', '4.6.0')).toBe(false);
+      expect(api.isSame('patch', '4.5.6', '5.5.6')).toBe(true);
+      expect(api.isSame('patch', '4.5.6', '4.6.0')).toBe(false);
     });
   });
 });

--- a/lib/modules/versioning/generic.ts
+++ b/lib/modules/versioning/generic.ts
@@ -149,4 +149,14 @@ export abstract class GenericVersioningApi<
   matches(version: string, range: string): boolean {
     return this.equals(version, range);
   }
+
+  isSame(type: 'major'|'minor'|'patch', a: string, b: string): boolean {
+    if (type === 'major') {
+      return this.getMajor(a)! === this.getMajor(b)!;
+    } else if (type === 'minor') {
+      return this.getMinor(a)! === this.getMinor(b)!;
+    } else {
+      return this.getPatch(a)! === this.getPatch(b)!;
+    }
+  }
 }

--- a/lib/modules/versioning/generic.ts
+++ b/lib/modules/versioning/generic.ts
@@ -150,7 +150,7 @@ export abstract class GenericVersioningApi<
     return this.equals(version, range);
   }
 
-  isSame(type: 'major'|'minor'|'patch', a: string, b: string): boolean {
+  isSame(type: 'major' | 'minor' | 'patch', a: string, b: string): boolean {
     if (type === 'major') {
       return this.getMajor(a)! === this.getMajor(b)!;
     }

--- a/lib/modules/versioning/generic.ts
+++ b/lib/modules/versioning/generic.ts
@@ -153,10 +153,10 @@ export abstract class GenericVersioningApi<
   isSame(type: 'major'|'minor'|'patch', a: string, b: string): boolean {
     if (type === 'major') {
       return this.getMajor(a)! === this.getMajor(b)!;
-    } else if (type === 'minor') {
-      return this.getMinor(a)! === this.getMinor(b)!;
-    } else {
-      return this.getPatch(a)! === this.getPatch(b)!;
     }
+    if (type === 'minor') {
+      return this.getMinor(a)! === this.getMinor(b)!;
+    }
+    return this.getPatch(a)! === this.getPatch(b)!;
   }
 }

--- a/lib/modules/versioning/index.spec.ts
+++ b/lib/modules/versioning/index.spec.ts
@@ -86,6 +86,7 @@ describe('modules/versioning/index', () => {
       'toString',
       'valueOf',
       'subset',
+      'isSame',
     ];
     const npmApi = Object.keys(allVersioning.get(semverVersioning.id))
       .filter((val) => !optionalFunctions.includes(val))

--- a/lib/modules/versioning/types.ts
+++ b/lib/modules/versioning/types.ts
@@ -134,7 +134,7 @@ export interface VersioningApi {
    * Check whether the `type` in the `a` and `b` version numbers match.
    * Both `a` and `b` must pass `isVersion`.
    */
-  isSame?(type: 'major'|'minor'|'patch', a: string, b: string): boolean;
+  isSame?(type: 'major' | 'minor' | 'patch', a: string, b: string): boolean;
 }
 
 export interface VersioningApiConstructor {

--- a/lib/modules/versioning/types.ts
+++ b/lib/modules/versioning/types.ts
@@ -129,6 +129,12 @@ export interface VersioningApi {
    * Return whether unstable-to-unstable upgrades within the same major version are allowed.
    */
   allowUnstableMajorUpgrades?: boolean;
+
+  /**
+   * Check whether the `type` in the `a` and `b` version numbers match.
+   * Both `a` and `b` must pass `isVersion`.
+   */
+  isSame?(type: 'major'|'minor'|'patch', a: string, b: string): boolean;
 }
 
 export interface VersioningApiConstructor {

--- a/lib/workers/repository/process/lookup/update-type.ts
+++ b/lib/workers/repository/process/lookup/update-type.ts
@@ -15,6 +15,12 @@ export function getUpdateType(
   newVersion: string,
 ): UpdateType {
   if (
+    versioningApi.isSame &&
+    !versioningApi.isSame('major', newVersion, currentVersion)
+  ) {
+    return 'major';
+  }
+  if (
     versioningApi.getMajor(newVersion)! >
     versioningApi.getMajor(currentVersion)!
   ) {


### PR DESCRIPTION
This allows versioning to implement it's own `isSame` operation. This is useful
for e.g. versioning schemas like e.g. [PVP](https://pvp.haskell.org/) where the
major component has multiple numbers, and we need to distinguish `1.1` from
`1.10`.

## Changes

This PR is preparatory work and there are no intended user-visible changes.

## Context

See discussion at:

* https://github.com/renovatebot/renovate/discussions/31663

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
