### PR TITLE
fix(rebaseWhen): text in PR for new branches with automerge=true

### DIFF
--- a/lib/workers/repository/update/branch/reuse.spec.ts
+++ b/lib/workers/repository/update/branch/reuse.spec.ts
@@ -262,5 +262,15 @@ describe('workers/repository/update/branch/reuse', () => {
       expect(config.rebaseWhen).toBe('auto');
       expect(result.rebaseWhen).toBe('conflicted');
     });
+
+    it('converts rebaseWhen=auto to behind-base-branch if automerge is true AND branch is new', async () => {
+      config.rebaseWhen = 'auto';
+      config.automerge = true;
+      scm.branchExists.mockResolvedValueOnce(false);
+      scm.isBranchBehindBase.mockResolvedValueOnce(false);
+      const result = await shouldReuseExistingBranch(config);
+      expect(config.rebaseWhen).toBe('auto');
+      expect(result.rebaseWhen).toBe('behind-base-branch');
+    });
   });
 });

--- a/lib/workers/repository/update/branch/reuse.ts
+++ b/lib/workers/repository/update/branch/reuse.ts
@@ -31,14 +31,16 @@ export async function shouldReuseExistingBranch(
 ): Promise<BranchConfig> {
   const { baseBranch, branchName } = config;
   const result: BranchConfig = { ...config, reuseExistingBranch: false };
+
+  const keepUpdated = await shouldKeepUpdated(result, baseBranch, branchName);
+  await determineRebaseWhenValue(result, keepUpdated);
+
   // Check if branch exists
   if (!(await scm.branchExists(branchName))) {
     logger.debug(`Branch needs creating`);
     return result;
   }
   logger.debug(`Branch already exists`);
-  const keepUpdated = await shouldKeepUpdated(result, baseBranch, branchName);
-  await determineRebaseWhenValue(result, keepUpdated);
 
   if (result.rebaseWhen === 'behind-base-branch' || keepUpdated) {
     if (await scm.isBranchBehindBase(branchName, baseBranch)) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

update the rebaseWhen value even when branches needs creating.

changes are just moving the transform rebaseWhen function above few rows.
<!-- Describe what behavior is changed by this PR. -->

## Context

in case 
`automerge=true` 
the PR text results in:
🚦 Automerge: Enabled.
♻ Rebasing: Whenever PR becomes conflicted, or you tick the rebase/retry checkbox.

This is not what the documentation says,
 after investigating it appears to be only a text issue,
  as when rebasing an existing PR the rebasing is handled.

after fix result: 
🚦 Automerge: Enabled.
♻ Rebasing: Whenever PR is behind base branch, or you tick the rebase/retry checkbox.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
