### PR TITLE
refactor(manager): extract `applyGitSource`

### DIFF
--- a/lib/modules/manager/pep621/processors/uv.ts
+++ b/lib/modules/manager/pep621/processors/uv.ts
@@ -22,7 +22,7 @@ import type {
   UpdateArtifactsResult,
   Upgrade,
 } from '../../types';
-import { type PyProject, type UvGitSource, UvLockfileSchema } from '../schema';
+import { type PyProject, UvLockfileSchema } from '../schema';
 import { depTypes, parseDependencyList } from '../utils';
 import type { PyProjectProcessor } from './types';
 
@@ -63,7 +63,13 @@ export class UvProcessor implements PyProjectProcessor {
           } else if ('workspace' in depSource) {
             dep.skipReason = 'inherited-dependency';
           } else {
-            applyGitSource(dep, depSource);
+            applyGitSource(
+              dep,
+              depSource.git,
+              depSource.rev,
+              depSource.tag,
+              depSource.branch,
+            );
           }
         }
       }
@@ -183,8 +189,13 @@ export class UvProcessor implements PyProjectProcessor {
   }
 }
 
-function applyGitSource(dep: PackageDependency, depSource: UvGitSource): void {
-  const { git, rev, tag, branch } = depSource;
+function applyGitSource(
+  dep: PackageDependency,
+  git: string,
+  rev: string | undefined,
+  tag: string | undefined,
+  branch: string | undefined,
+): void {
   if (tag) {
     const platform = detectPlatform(git);
     if (platform === 'github' || platform === 'gitlab') {

--- a/lib/modules/manager/util.spec.ts
+++ b/lib/modules/manager/util.spec.ts
@@ -1,0 +1,100 @@
+import { GitRefsDatasource } from '../datasource/git-refs';
+import { GitTagsDatasource } from '../datasource/git-tags';
+import { GithubTagsDatasource } from '../datasource/github-tags';
+import { GitlabTagsDatasource } from '../datasource/gitlab-tags';
+import { type PackageDependency } from './types';
+import { applyGitSource } from './util';
+
+describe('modules/manager/util', () => {
+  it('applies GitHub source for tag', () => {
+    const dependency: PackageDependency = {};
+    const git = 'https://github.com/foo/bar';
+    const tag = 'v1.2.3';
+
+    applyGitSource(dependency, git, undefined, tag, undefined);
+
+    expect(dependency).toStrictEqual({
+      datasource: GithubTagsDatasource.id,
+      registryUrls: ['https://github.com'],
+      packageName: 'foo/bar',
+      currentValue: tag,
+      skipReason: undefined,
+    });
+  });
+
+  it('applies GitLab source for tag', () => {
+    const dependency: PackageDependency = {};
+    const git = 'https://gitlab.com/foo/bar';
+    const tag = 'v1.2.3';
+
+    applyGitSource(dependency, git, undefined, tag, undefined);
+
+    expect(dependency).toStrictEqual({
+      datasource: GitlabTagsDatasource.id,
+      registryUrls: ['https://gitlab.com'],
+      packageName: 'foo/bar',
+      currentValue: tag,
+      skipReason: undefined,
+    });
+  });
+
+  it('applies other git source for tag', () => {
+    const dependency: PackageDependency = {};
+    const git = 'https://a-git-source.com/foo/bar';
+    const tag = 'v1.2.3';
+
+    applyGitSource(dependency, git, undefined, tag, undefined);
+
+    expect(dependency).toStrictEqual({
+      datasource: GitTagsDatasource.id,
+      packageName: git,
+      currentValue: tag,
+      skipReason: undefined,
+    });
+  });
+
+  it('applies git source for rev', () => {
+    const dependency: PackageDependency = {};
+    const git = 'https://github.com/foo/bar';
+    const rev = 'abc1234';
+
+    applyGitSource(dependency, git, rev, undefined, undefined);
+
+    expect(dependency).toStrictEqual({
+      datasource: GitRefsDatasource.id,
+      packageName: git,
+      currentDigest: rev,
+      replaceString: rev,
+      skipReason: undefined,
+    });
+  });
+
+  it('skips git source for branch', () => {
+    const dependency: PackageDependency = {};
+    const git = 'https://github.com/foo/bar';
+    const branch = 'main';
+
+    applyGitSource(dependency, git, undefined, undefined, branch);
+
+    expect(dependency).toStrictEqual({
+      datasource: GitRefsDatasource.id,
+      packageName: git,
+      currentValue: branch,
+      skipReason: 'git-dependency',
+    });
+  });
+
+  it('skips git source for git only', () => {
+    const dependency: PackageDependency = {};
+    const git = 'https://github.com/foo/bar';
+
+    applyGitSource(dependency, git, undefined, undefined, undefined);
+
+    expect(dependency).toStrictEqual({
+      datasource: GitRefsDatasource.id,
+      packageName: git,
+      currentValue: undefined,
+      skipReason: 'unspecified-version',
+    });
+  });
+});

--- a/lib/modules/manager/util.ts
+++ b/lib/modules/manager/util.ts
@@ -1,0 +1,44 @@
+import { detectPlatform } from '../../util/common';
+import { parseGitUrl } from '../../util/git/url';
+import { GitRefsDatasource } from '../datasource/git-refs';
+import { GitTagsDatasource } from '../datasource/git-tags';
+import { GithubTagsDatasource } from '../datasource/github-tags';
+import { GitlabTagsDatasource } from '../datasource/gitlab-tags';
+import type { PackageDependency } from './types';
+
+export function applyGitSource(
+  dep: PackageDependency,
+  git: string,
+  rev: string | undefined,
+  tag: string | undefined,
+  branch: string | undefined,
+): void {
+  if (tag) {
+    const platform = detectPlatform(git);
+    if (platform === 'github' || platform === 'gitlab') {
+      dep.datasource =
+        platform === 'github'
+          ? GithubTagsDatasource.id
+          : GitlabTagsDatasource.id;
+      const { protocol, source, full_name } = parseGitUrl(git);
+      dep.registryUrls = [`${protocol}://${source}`];
+      dep.packageName = full_name;
+    } else {
+      dep.datasource = GitTagsDatasource.id;
+      dep.packageName = git;
+    }
+    dep.currentValue = tag;
+    dep.skipReason = undefined;
+  } else if (rev) {
+    dep.datasource = GitRefsDatasource.id;
+    dep.packageName = git;
+    dep.currentDigest = rev;
+    dep.replaceString = rev;
+    dep.skipReason = undefined;
+  } else {
+    dep.datasource = GitRefsDatasource.id;
+    dep.packageName = git;
+    dep.currentValue = branch;
+    dep.skipReason = branch ? 'git-dependency' : 'unspecified-version';
+  }
+}


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Move `applyGitSource` to a shared module.

## Context

This makes it possible to reuse it for `cargo` manager in https://github.com/renovatebot/renovate/pull/32235, alongside `uv` one.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
