### PR TITLE
feat(presets): add `poetry` manager support to `:semanticPrefixFixDepsChoreOthers` preset

### DIFF
--- a/lib/config/presets/__snapshots__/index.spec.ts.snap
+++ b/lib/config/presets/__snapshots__/index.spec.ts.snap
@@ -93,6 +93,16 @@ exports[`config/presets/index resolvePreset migrates automerge in presets 1`] = 
       "semanticCommitType": "fix",
     },
     {
+      "matchDepTypes": [
+        "dependencies",
+        "extras",
+      ],
+      "matchManagers": [
+        "poetry",
+      ],
+      "semanticCommitType": "fix",
+    },
+    {
       "matchPackageNames": [
         "*",
       ],

--- a/lib/config/presets/internal/default.ts
+++ b/lib/config/presets/internal/default.ts
@@ -582,6 +582,11 @@ export const presets: Record<string, Preset> = {
         matchManagers: ['pep621'],
         semanticCommitType: 'fix',
       },
+      {
+        matchDepTypes: ['dependencies', 'extras'],
+        matchManagers: ['poetry'],
+        semanticCommitType: 'fix',
+      },
     ],
   },
   separateMajorReleases: {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

I've added a package rule to the `:semanticPrefixFixDepsChoreOthers` preset that sets the semantic commit type `fix` for Poetry runtime dependencies (particularly, optional dependencies aka "extras"). I decided to add a new package rule with

```
matchDepTypes: ['dependencies, 'extras']
```

to the preset, although the second package rule in the preset already generically matches the `depType: 'dependencies'`, to have a self-contained package rule for Poetry. Alternatively, I could have added the `'extras'` to the `matchDepTypes` array of the second package rule

```diff
-matchDepTypes: ['dependencies', 'require'],
+matchDepTypes: ['dependencies', 'require', 'extras'],
```

but I felt that Poetry's `depType: 'extras'` is too specific to be added to this generic rule. Please feel free to prefer the alternative over the current implementation if you disagree with me.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

I noticed that PRs updating optional dependencies while using the preset `:semanticPrefixFixDepsChoreOthers` used the commit type `chore` and not `fix` since #32096 had been merged. Before #32095, optional dependencies were assigned an incorrect `depType` value (`'dependencies'` instead of `'extras'`). Prior to this PR, the preset `:semanticPrefixFixDepsChoreOthers` didn't include a package rule with `matchDepTypes` containing the value `'extras'`.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

Snapshots were updated and look correct.

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
