### PR TITLE
test(datasource/go): Remove go-source header from gitlab fixtures

### DIFF
--- a/lib/modules/datasource/go/__fixtures__/go-get-gitlab-ee-private-subgroup-api.html
+++ b/lib/modules/datasource/go/__fixtures__/go-get-gitlab-ee-private-subgroup-api.html
@@ -3,8 +3,6 @@
 <head>
   <meta name="go-import"
     content="my.custom.domain/group/subgroup-api/myrepo git https://my.custom.domain/group/subgroup-api/myrepo.git" />
-  <meta name="go-source"
-    content="my.custom.domain/group/subgroup-api/myrepo https://my.custom.domain/group/subgroup-api/myrepo https://my.custom.domain/group/subgroup-api/myrepo/-/tree/master{/dir} https://my.custom.domain/group/subgroup-api/myrepo/-/blob/master{/dir}/{file}#L{line}" />
 </head>
 
 <body>go get https://my.custom.domain/group/subgroup-api/myrepo</body>

--- a/lib/modules/datasource/go/__fixtures__/go-get-gitlab-ee-private-subgroup.html
+++ b/lib/modules/datasource/go/__fixtures__/go-get-gitlab-ee-private-subgroup.html
@@ -1,8 +1,6 @@
 <html>
 <head>
 	<meta name="go-import" content="my.custom.domain/golang/subgroup git https://my.custom.domain/golang/subgroup.git" />
-	<meta name="go-source"
-		content="my.custom.domain/golang/subgroup https://my.custom.domain/golang/subgroup https://my.custom.domain/golang/subgroup/-/tree/master{/dir} https://my.custom.domain/golang/subgroup/-/blob/master{/dir}/{file}#L{line}" />
 </head>
 
 <body>go get https://my.custom.domain/golang/subgroup</body>

--- a/lib/modules/datasource/go/__fixtures__/go-get-gitlab-ee-subgroup.html
+++ b/lib/modules/datasource/go/__fixtures__/go-get-gitlab-ee-subgroup.html
@@ -1,8 +1,6 @@
 <html>
 <head>
 	<meta name="go-import" content="my.custom.domain/golang/subgroup/myrepo git https://my.custom.domain/golang/subgroup/myrepo.git" />
-	<meta name="go-source"
-		content="my.custom.domain/golang/subgroup/myrepo https://my.custom.domain/golang/subgroup/myrepo https://my.custom.domain/golang/subgroup/myrepo/-/tree/master{/dir} https://my.custom.domain/golang/subgroup/myrepo/-/blob/master{/dir}/{file}#L{line}" />
 </head>
 
 <body>go get https://my.custom.domain/golang/subgroup/myrepo</body>

--- a/lib/modules/datasource/go/__fixtures__/go-get-gitlab-ee.html
+++ b/lib/modules/datasource/go/__fixtures__/go-get-gitlab-ee.html
@@ -1,8 +1,6 @@
 <html>
 <head>
 	<meta name="go-import" content="my.custom.domain/golang/myrepo git https://my.custom.domain/golang/myrepo.git" />
-	<meta name="go-source"
-		content="my.custom.domain/golang/myrepo https://my.custom.domain/golang/myrepo https://my.custom.domain/golang/myrepo/-/tree/master{/dir} https://my.custom.domain/golang/myrepo/-/blob/master{/dir}/{file}#L{line}" />
 </head>
 
 <body>go get https://my.custom.domain/golang/myrepo</body>

--- a/lib/modules/datasource/go/__fixtures__/go-get-gitlab.html
+++ b/lib/modules/datasource/go/__fixtures__/go-get-gitlab.html
@@ -3,7 +3,6 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="go-import" content="gitlab.com/group/subgroup git https://gitlab.com/group/subgroup/repo">
-<meta name="go-source" content="gitlab.com/group/subgroup https://gitlab.com/group/subgroup https://gitlab.com/group/subgroup/-/tree/master{/dir} https://gitlab.com/group/subgroup/-/blob/master{/dir}/{file}#L{line}">
 </head>
 <body>
 go get https://gitlab.com/group/subgroup

--- a/lib/modules/datasource/go/__fixtures__/go-get-submodule-gitlab.html
+++ b/lib/modules/datasource/go/__fixtures__/go-get-submodule-gitlab.html
@@ -2,7 +2,6 @@
 <html>
     <head>
         <meta name="go-import" content="gitlab.com/example/module git https://gitlab.com/example/module.git">
-        <meta name="go-source" content="gitlab.com/example/module https://gitlab.com/example/module https://gitlab.com/example/module/-/tree/master{/dir} https://gitlab.com/example/module/-/blob/master{/dir}/{file}#L{line}">
     </head>
     <body>go get https://gitlab.com/example/module</body>
 </html>


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

This pull requests removes the `go-source` header for all GitLab `go-get` fixtures.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

In https://gitlab.com/gitlab-org/gitlab/-/merge_requests/161162 GitLab removed the `go-source` header from its `go-get` endpoint responses:
> So, the go-source meta tag has been completely removed from the response.

That change has been deployed to gitlab.com and released for self-managed customers since GitLab v17.4.2 (or GitLab v17.5) almost a month ago: https://about.gitlab.com/releases/2024/10/09/patch-release-gitlab-17-4-2-released/

To ensure that the fixtures represent the actual responses, the `go-source` headers should be removed.

The new behavior can be tested against gitlab.com or any up-to-date self-hosted instance. Here are two examples:
```bash
$ curl https://gitlab.com/gitlab-org/gitlab?go-get=1
<html><head><meta name="go-import" content="gitlab.com/gitlab-org/gitlab git https://gitlab.com/gitlab-org/gitlab.git"></head><body>go get gitlab.com/gitlab-org/gitlab</body></html>

$ curl https://git.dev.local/development/go-sdk?go-get=1
<html><head><meta name="go-import" content="git.dev.local/development/go-sdk git https://git.dev.local/development/go-sdk.git"></head><body>go get git.dev.local/development/go-sdk</body></html>
```

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
