### PR TITLE
fix(datasource/maven): Maven Central has no index.html

### DIFF
--- a/lib/modules/datasource/maven/index.spec.ts
+++ b/lib/modules/datasource/maven/index.spec.ts
@@ -63,9 +63,9 @@ function mockGenericPackage(opts: MockOpts = {}) {
   }
 
   if (html) {
-    scope.get(`/${packagePath}/index.html`).reply(200, html);
+    scope.get(`/${packagePath}/`).reply(200, html);
   } else if (html === null) {
-    scope.get(`/${packagePath}/index.html`).reply(404);
+    scope.get(`/${packagePath}/`).reply(404);
   }
 
   if (pom) {
@@ -129,7 +129,7 @@ describe('modules/datasource/maven/index', () => {
   it('returns null when metadata is not found', async () => {
     httpMock
       .scope(baseUrl)
-      .get('/org/example/package/index.html')
+      .get('/org/example/package/')
       .reply(404)
       .get('/org/example/package/maven-metadata.xml')
       .reply(404);

--- a/lib/modules/datasource/maven/index.ts
+++ b/lib/modules/datasource/maven/index.ts
@@ -143,7 +143,7 @@ export class MavenDatasource extends Datasource {
       workingReleaseMap = {};
       let retryEarlier = false;
       try {
-        const indexUrl = getMavenUrl(dependency, repoUrl, 'index.html');
+        const indexUrl = getMavenUrl(dependency, repoUrl, '');
         const res = await downloadHttpProtocol(this.http, indexUrl);
         if (res) {
           for (const line of res.body.split(newlineRegex)) {
@@ -171,7 +171,7 @@ export class MavenDatasource extends Datasource {
         retryEarlier = true;
         logger.debug(
           { dependency, err },
-          'Failed to get releases from index.html',
+          'Failed to get releases from package index page',
         );
       }
       const cacheTTL = retryEarlier

--- a/lib/modules/datasource/sbt-package/index.spec.ts
+++ b/lib/modules/datasource/sbt-package/index.spec.ts
@@ -76,7 +76,7 @@ describe('modules/datasource/sbt-package/index', () => {
         .reply(404, '')
         .get('/maven2/com/example/empty/maven-metadata.xml')
         .reply(404)
-        .get('/maven2/com/example/empty/index.html')
+        .get('/maven2/com/example/empty/')
         .reply(404);
 
       const res = await getPkgReleases({


### PR DESCRIPTION
Fixes the current misbehaviour of the maven datasource requesting index.html at the package-level, whereas the intended html page is served for the folder. Maven Central always responds HTTP 404 when requested for index.html

## Changes

Change the maven datasource from requesting the non-existent `<package-root-folder>/index.html` to the proper `<package-root-folder>` to obtain the intended HTML-directory-listing of versions and their timestamps.

Updates the related testcases accordingly.

## Context

As indicated in my remark on [discussion 25461](https://github.com/renovatebot/renovate/discussions/25461#discussioncomment-11123646) the first remark made in the opening post, that index.html is non-existent was never addressed and still existent in the codebase of renovate resulting in every attempt for getting releases from Maven Central running into HTTP 404 errors.

Following up on the response given this is the PR that would resolve that issue.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [X] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
