### PR TITLE
feat(bitbucket): Add more logging to the PR cache

### DIFF
--- a/lib/modules/platform/bitbucket/index.ts
+++ b/lib/modules/platform/bitbucket/index.ts
@@ -283,7 +283,7 @@ function matchesState(state: string, desiredState: string): boolean {
 }
 
 export async function getPrList(): Promise<Pr[]> {
-  logger.debug('getPrList()');
+  logger.trace('getPrList()');
   return await BitbucketPrCache.getPrs(
     bitbucketHttp,
     config.repository,

--- a/lib/modules/platform/bitbucket/pr-cache.ts
+++ b/lib/modules/platform/bitbucket/pr-cache.ts
@@ -23,8 +23,15 @@ export class BitbucketPrCache {
     let pullRequestCache = repoCache.platform.bitbucket.pullRequestsCache as
       | BitbucketPrCacheData
       | undefined;
-    if (!pullRequestCache || pullRequestCache.author !== author) {
+    if (!pullRequestCache) {
       logger.debug('Initializing new PR cache at repository cache');
+      pullRequestCache = {
+        items: {},
+        updated_on: null,
+        author,
+      };
+    } else if (pullRequestCache.author !== author) {
+      logger.debug('Resetting PR cache because authors do not match');
       pullRequestCache = {
         items: {},
         updated_on: null,

--- a/lib/modules/platform/bitbucket/pr-cache.ts
+++ b/lib/modules/platform/bitbucket/pr-cache.ts
@@ -24,6 +24,7 @@ export class BitbucketPrCache {
       | BitbucketPrCacheData
       | undefined;
     if (!pullRequestCache || pullRequestCache.author !== author) {
+      logger.debug('Initializing new PR cache at repository cache');
       pullRequestCache = {
         items: {},
         updated_on: null,
@@ -66,6 +67,7 @@ export class BitbucketPrCache {
   }
 
   private addPr(pr: Pr): void {
+    logger.debug(`Adding PR #${pr.number} to the PR cache`);
     this.cache.items[pr.number] = pr;
   }
 
@@ -135,7 +137,13 @@ export class BitbucketPrCache {
       cacheProvider: repoCacheProvider,
     };
     const res = await http.getJson<PagedResult<PrResponse>>(url, opts);
-    this.reconcile(res.body.values);
+
+    const items = res.body.values;
+    logger.debug(`Fetched ${items.length} PRs to sync with cache`);
+
+    this.reconcile(items);
+
+    logger.debug(`Total PRs cached: ${Object.values(this.cache.items).length}`);
     return this;
   }
 }

--- a/lib/modules/platform/bitbucket/pr-cache.ts
+++ b/lib/modules/platform/bitbucket/pr-cache.ts
@@ -8,6 +8,7 @@ import { repoCacheProvider } from '../../../util/http/cache/repository-http-cach
 import type { Pr } from '../types';
 import type { BitbucketPrCacheData, PagedResult, PrResponse } from './types';
 import { prFieldsFilter, prInfo, prStates } from './utils';
+import { clone } from '../../../util/clone';
 
 export class BitbucketPrCache {
   private cache: BitbucketPrCacheData;
@@ -150,7 +151,16 @@ export class BitbucketPrCache {
 
     this.reconcile(items);
 
+    const oldCache = clone(this.cache.items);
     logger.debug(`Total PRs cached: ${Object.values(this.cache.items).length}`);
+    logger.trace(
+      {
+        items,
+        oldCache,
+        newCache: this.cache.items,
+      },
+      `Re`,
+    );
     return this;
   }
 }

--- a/lib/modules/platform/bitbucket/pr-cache.ts
+++ b/lib/modules/platform/bitbucket/pr-cache.ts
@@ -148,10 +148,10 @@ export class BitbucketPrCache {
 
     const items = res.body.values;
     logger.debug(`Fetched ${items.length} PRs to sync with cache`);
+    const oldCache = clone(this.cache.items);
 
     this.reconcile(items);
 
-    const oldCache = clone(this.cache.items);
     logger.debug(`Total PRs cached: ${Object.values(this.cache.items).length}`);
     logger.trace(
       {

--- a/lib/modules/platform/bitbucket/pr-cache.ts
+++ b/lib/modules/platform/bitbucket/pr-cache.ts
@@ -159,7 +159,7 @@ export class BitbucketPrCache {
         oldCache,
         newCache: this.cache.items,
       },
-      `Re`,
+      `PR cache sync finished`,
     );
     return this;
   }

--- a/lib/modules/platform/bitbucket/pr-cache.ts
+++ b/lib/modules/platform/bitbucket/pr-cache.ts
@@ -3,12 +3,12 @@ import { DateTime } from 'luxon';
 import { logger } from '../../../logger';
 import * as memCache from '../../../util/cache/memory';
 import { getCache } from '../../../util/cache/repository';
+import { clone } from '../../../util/clone';
 import type { BitbucketHttp } from '../../../util/http/bitbucket';
 import { repoCacheProvider } from '../../../util/http/cache/repository-http-cache-provider';
 import type { Pr } from '../types';
 import type { BitbucketPrCacheData, PagedResult, PrResponse } from './types';
 import { prFieldsFilter, prInfo, prStates } from './utils';
-import { clone } from '../../../util/clone';
 
 export class BitbucketPrCache {
   private cache: BitbucketPrCacheData;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

- Closes #32329
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
