### PR TITLE
docs: document hostRule needed for some self-hosted Gitea instances

### DIFF
--- a/lib/modules/platform/gitea/readme.md
+++ b/lib/modules/platform/gitea/readme.md
@@ -28,6 +28,21 @@ The PAT should have these permissions:
 
 If you use Gitea packages, add the `read:packages` scope.
 
+For Gitea instances configured with a base URL that differs from the Renovate `endpoint` (for example, where Gitea is configured with an externally accessible base URL, but Renovate is configured to access the Gitea instance locally.), Renovate may attempt to access repositories using the base URL.  In this case it may be necessary to configure a `hostRule` to use the PAT configured above for host authentication. (see [hostRules](https://docs.renovatebot.com/configuration-options/#hostrules))
+
+An example of a hostRule for an external domain with a token:
+
+```json
+{
+  "hostRules": [
+    {
+      "matchHost": "git.custom.org",
+      "token": "<some-token>"
+    }
+  ]
+}
+```
+
 ## Unsupported platform features/concepts
 
 - **Adding reviewers to PRs not supported**: Gitea versions older than `v1.14.0` do not have the required API.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Document the need for an additional hostRule for some self-hosted Gitea configurations.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

- #32311 

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
