### PR TITLE
feat(pep621): set Git insteadOf directives when updating pdm/uv locks

### DIFF
--- a/lib/modules/manager/pep621/processors/pdm.ts
+++ b/lib/modules/manager/pep621/processors/pdm.ts
@@ -5,6 +5,7 @@ import { logger } from '../../../../logger';
 import { exec } from '../../../../util/exec';
 import type { ExecOptions, ToolConstraint } from '../../../../util/exec/types';
 import { getSiblingFileName, readLocalFile } from '../../../../util/fs';
+import { getGitEnvironmentVariables } from '../../../../util/git/auth';
 import { Result } from '../../../../util/result';
 import { PypiDatasource } from '../../../datasource/pypi';
 import type {
@@ -116,8 +117,12 @@ export class PdmProcessor implements PyProjectProcessor {
         constraint: config.constraints?.pdm,
       };
 
+      const extraEnv = {
+        ...getGitEnvironmentVariables(['pep621']),
+      };
       const execOptions: ExecOptions = {
         cwdFile: packageFileName,
+        extraEnv,
         docker: {},
         userConfiguredEnv: config.env,
         toolConstraints: [pythonConstraint, pdmConstraint],

--- a/lib/modules/manager/pep621/processors/uv.spec.ts
+++ b/lib/modules/manager/pep621/processors/uv.spec.ts
@@ -356,6 +356,13 @@ describe('modules/manager/pep621/processors/uv', () => {
           cmd: 'uv lock --upgrade-package dep1 --upgrade-package dep2 --upgrade-package dep3 --upgrade-package dep4',
           options: {
             env: {
+              GIT_CONFIG_COUNT: '3',
+              GIT_CONFIG_KEY_0: 'url.https://user:pass@example.com/.insteadOf',
+              GIT_CONFIG_KEY_1: 'url.https://user:pass@example.com/.insteadOf',
+              GIT_CONFIG_KEY_2: 'url.https://user:pass@example.com/.insteadOf',
+              GIT_CONFIG_VALUE_0: 'ssh://git@example.com/',
+              GIT_CONFIG_VALUE_1: 'git@example.com:',
+              GIT_CONFIG_VALUE_2: 'https://example.com/',
               UV_EXTRA_INDEX_URL:
                 'https://foobar.com/ https://user:pass@example.com/',
             },

--- a/lib/modules/manager/pep621/processors/uv.ts
+++ b/lib/modules/manager/pep621/processors/uv.ts
@@ -6,6 +6,7 @@ import type { HostRule } from '../../../../types';
 import { exec } from '../../../../util/exec';
 import type { ExecOptions, ToolConstraint } from '../../../../util/exec/types';
 import { getSiblingFileName, readLocalFile } from '../../../../util/fs';
+import { getGitEnvironmentVariables } from '../../../../util/git/auth';
 import { find } from '../../../../util/host-rules';
 import { Result } from '../../../../util/result';
 import { parseUrl } from '../../../../util/url';
@@ -129,6 +130,7 @@ export class UvProcessor implements PyProjectProcessor {
       };
 
       const extraEnv = {
+        ...getGitEnvironmentVariables(['pep621']),
         ...getUvExtraIndexUrl(updateArtifact.updatedDeps),
       };
       const execOptions: ExecOptions = {

--- a/lib/modules/manager/pep621/readme.md
+++ b/lib/modules/manager/pep621/readme.md
@@ -16,3 +16,20 @@ Available `depType`s:
 - `tool.uv.dev-dependencies`
 - `tool.uv.sources`
 - `tool.hatch.envs.<env-name>`
+
+### Private Modules Authentication
+
+Before running the `pdm` or `uv` commands to update the `pdm.lock` or `uv.lock` respectively, Renovate exports `git` [`insteadOf`](https://git-scm.com/docs/git-config#Documentation/git-config.txt-urlltbasegtinsteadOf) directives in environment variables.
+
+Renovate uses this logic before it updates any "artifacts":
+
+The token from the `hostRules` entry matching `hostType=github` and `matchHost=api.github.com` is added as the default authentication for `github.com`.
+For those running against `github.com`, this token will be the default platform token.
+
+Next, all `hostRules` with both a token or username/password and `matchHost` will be fetched, except for any `github.com` one from above.
+
+Rules from this list are converted to environment variable directives if they match _any_ of these characteristics:
+
+- No `hostType` is defined, or
+- `hostType` is `pep621`, or
+- `hostType` is a platform (`github`, `gitlab`, `azure`, etc.)


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Set Git `insteadOf` directives (e.g. `https://` instead of `ssh://`) when updating pdm/uv locks

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

Same as `poetry`:

https://github.com/renovatebot/renovate/blob/714ecb017d3d6c799c4c7101006b238c39e0db0d/lib/modules/manager/poetry/artifacts.ts#L196

I need it for `uv`, but did `pdm` at the same time.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
