### PR TITLE
fix(worker/autodiscover): retain repo order on filtering

### DIFF
--- a/lib/workers/global/autodiscover.spec.ts
+++ b/lib/workers/global/autodiscover.spec.ts
@@ -167,9 +167,11 @@ describe('workers/global/autodiscover', () => {
     hostRules.find = jest.fn(() => ({
       token: 'abc',
     }));
+    // retains order
     const expectedRepositories = [
-      'another-project/repo',
       'department/dev/aProject',
+      'another-project/repo',
+      'department/dev/bProject',
     ];
     ghApi.getRepos = jest.fn(() =>
       Promise.resolve([

--- a/lib/workers/global/autodiscover.ts
+++ b/lib/workers/global/autodiscover.ts
@@ -51,6 +51,10 @@ export async function autodiscoverRepositories(
   }
 
   logger.debug(`Autodiscovered ${discovered.length} repositories`);
+  logger.trace(
+    { length: discovered.length, repositories: discovered },
+    `Autodiscovered repositories`,
+  );
 
   if (autodiscoverFilter) {
     logger.debug({ autodiscoverFilter }, 'Applying autodiscoverFilter');
@@ -116,5 +120,5 @@ export function applyFilters(repos: string[], filters: string[]): string[] {
       matched.add(repository);
     }
   }
-  return [...matched];
+  return repos.filter((repository) => matched.has(repository));
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Currently the repos are sorted by the matched filters which discards any server side filtering.
<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
