### PR TITLE
refactor(bazel-module): consolidate kv parsing logic

### DIFF
--- a/lib/modules/manager/bazel-module/parser/common.ts
+++ b/lib/modules/manager/bazel-module/parser/common.ts
@@ -1,0 +1,29 @@
+import { query as q } from 'good-enough-parser';
+import { regEx } from '../../../../util/regex';
+import type { Ctx } from '../context';
+import * as starlark from '../starlark';
+
+const booleanValuesRegex = regEx(`^${starlark.booleanStringValues.join('|')}$`);
+
+/**
+ * Matches key-value pairs:
+ * - `name = "foobar"`
+ * - `name = True`
+ * - `name = ["string"]`
+ **/
+export const kvParams = q
+  .sym<Ctx>((ctx, token) => ctx.startAttribute(token.value))
+  .op('=')
+  .alt(
+    q.str((ctx, token) => ctx.addString(token.value)),
+    q.sym<Ctx>(booleanValuesRegex, (ctx, token) => ctx.addBoolean(token.value)),
+    q.tree({
+      type: 'wrapped-tree',
+      maxDepth: 1,
+      startsWith: '[',
+      endsWith: ']',
+      postHandler: (ctx) => ctx.endArray(),
+      preHandler: (ctx) => ctx.startArray(),
+      search: q.many(q.str<Ctx>((ctx, token) => ctx.addString(token.value))),
+    }),
+  );

--- a/lib/modules/manager/bazel-module/parser/index.spec.ts
+++ b/lib/modules/manager/bazel-module/parser/index.spec.ts
@@ -66,6 +66,10 @@ describe('modules/manager/bazel-module/parser/index', () => {
           {
             rule: fragments.string('git_override'),
             module_name: fragments.string('rules_foo'),
+            patches: fragments.array(
+              [fragments.string('//:rules_foo.patch')],
+              true,
+            ),
             commit: fragments.string(
               '6a2c2e22849b3e6b33d5ea9aa72222d4803a986a',
             ),
@@ -102,6 +106,10 @@ describe('modules/manager/bazel-module/parser/index', () => {
           {
             rule: fragments.string('archive_override'),
             module_name: fragments.string('rules_foo'),
+            urls: fragments.array(
+              [fragments.string('https://example.com/archive.tar.gz')],
+              true,
+            ),
           },
           true,
         ),

--- a/lib/modules/manager/bazel-module/parser/maven.ts
+++ b/lib/modules/manager/bazel-module/parser/maven.ts
@@ -10,6 +10,7 @@ import {
   StringArrayFragmentSchema,
   StringFragmentSchema,
 } from '../fragments';
+import { kvParams } from './common';
 
 const artifactMethod = 'artifact';
 const installMethod = 'install';
@@ -114,22 +115,6 @@ export function fillRegistryUrls(
 
   return result;
 }
-
-const kvParams = q
-  .sym<Ctx>((ctx, token) => ctx.startAttribute(token.value))
-  .op('=')
-  .alt(
-    q.str((ctx, token) => ctx.addString(token.value)),
-    q.tree({
-      type: 'wrapped-tree',
-      maxDepth: 1,
-      startsWith: '[',
-      endsWith: ']',
-      postHandler: (ctx) => ctx.endArray(),
-      preHandler: (ctx) => ctx.startArray(),
-      search: q.many(q.str<Ctx>((ctx, token) => ctx.addString(token.value))),
-    }),
-  );
 
 export const mavenRules = q
   .sym<Ctx>(mavenVariableRegex, (ctx, token) => {

--- a/lib/modules/manager/bazel-module/parser/module.ts
+++ b/lib/modules/manager/bazel-module/parser/module.ts
@@ -1,9 +1,8 @@
 import { query as q } from 'good-enough-parser';
 import { regEx } from '../../../../util/regex';
 import type { Ctx } from '../context';
-import * as starlark from '../starlark';
+import { kvParams } from './common';
 
-const booleanValuesRegex = regEx(`^${starlark.booleanStringValues.join('|')}$`);
 const supportedRules = [
   'archive_override',
   'bazel_dep',
@@ -12,19 +11,6 @@ const supportedRules = [
   'single_version_override',
 ];
 const supportedRulesRegex = regEx(`^${supportedRules.join('|')}$`);
-
-/**
- * Matches key-value pairs:
- * - `name = "foobar"`
- * - `name = True`
- **/
-const kvParams = q
-  .sym<Ctx>((ctx, token) => ctx.startAttribute(token.value))
-  .op('=')
-  .alt(
-    q.str((ctx, token) => ctx.addString(token.value)),
-    q.sym<Ctx>(booleanValuesRegex, (ctx, token) => ctx.addBoolean(token.value)),
-  );
 
 export const moduleRules = q
   .sym<Ctx>(supportedRulesRegex, (ctx, token) => ctx.startRule(token.value))


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Move key value parsing logic into a common module. There are already 2 usages of it and a subsequent change (#32453) will introduce another one.

This causes some spurious test changes, where more of the input can be parsed now.

## Context

Split out from #32453 to ultimately achieve #31895.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
