### PR TITLE
docs(faq): update Renovate version in example

### DIFF
--- a/docs/usage/faq.md
+++ b/docs/usage/faq.md
@@ -51,7 +51,7 @@ Follow these steps to see which version the Mend Renovate app is on:
    ```
    INFO: Repository started
    {
-     "renovateVersion": "38.120.1"
+     "renovateVersion": "39.11.5"
    }
    ```
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Update the `renovateVersion` in the log output example

## Context

The hosted app now uses Renovate v39. This means it's time to update the FAQ (again). 🙃 

The plan is to automate updating the `renovateVersion` version in the FAQ. See:

- https://github.com/renovatebot/.github/issues/596

For reference, here's my PR from three weeks ago:

- #32054

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
