### PR TITLE
docs: release notes for Renovate v39

### DIFF
--- a/docs/usage/release-notes-for-major-versions.md
+++ b/docs/usage/release-notes-for-major-versions.md
@@ -25,7 +25,7 @@ All our Docker images now set the Docker user ID to `12021`, the old ID was `100
 After updating your Renovate Docker image to the new v39 release, you must:
 
 - Delete your old Docker cache, _or_
-- Cut and paste the permissions from the old ID into the new user ID
+- Ensure the new user ID has write permissions to any existing cache
 
 #### Updated version of Python, and new default behavior for the `-full` Docker image
 

--- a/docs/usage/release-notes-for-major-versions.md
+++ b/docs/usage/release-notes-for-major-versions.md
@@ -32,7 +32,7 @@ After updating your Renovate Docker image to the new v39 release, you must:
 On top of the changes listed above, the `-full` image now:
 
 - Uses Python 3.13
-- Defaults to [`binarySource=global`](https://docs.renovatebot.com/self-hosted-configuration/#binarysource) (note: this was previously the case in v36 onwards but regressed sometime in v38)
+- Defaults to [`binarySource=global`](self-hosted-configuration.md#binarysource) (note: this was previously the case in v36 onwards but regressed sometime in v38)
 
 If you want to keep the old behavior, where Renovate dynamically installs the needed tools: set the environment variable `RENOVATE_BINARY_SOURCE` to `"install"`.
 

--- a/docs/usage/release-notes-for-major-versions.md
+++ b/docs/usage/release-notes-for-major-versions.md
@@ -13,10 +13,10 @@ You also don't have to scroll to the bottom of the page to find the latest relea
 
 #### New tools for all Docker images
 
-All our Docker images now:
+All our Docker images now use:
 
-- Use Node.js v22 as base, was Node.js v20
-- Use Ubuntu 24.04 as base, was 20.04
+- Node.js v22 as base, was Node.js v20
+- Ubuntu 24.04 as base, was 20.04
 
 #### New Docker user ID for all Docker images
 

--- a/docs/usage/release-notes-for-major-versions.md
+++ b/docs/usage/release-notes-for-major-versions.md
@@ -36,10 +36,6 @@ On top of the changes listed above, the `-full` image now:
 
 If you want to keep the old behavior, where Renovate dynamically installs the needed tools: set the environment variable `RENOVATE_BINARY_SOURCE` to `"install"`.
 
-Question do we need to update the `binarySource` docs?
-It still says:
-
-> Starting in v36, Renovate's default Docker image (previously referred to as the "slim" image) uses `binarySource=install` while the "full" Docker image uses `binarySource=global`. If you are running Renovate in an environment where runtime download and install of tools is not possible then you should use the "full" image.
 
 #### Renovate tries squash merges first when automerging on GitHub
 

--- a/docs/usage/release-notes-for-major-versions.md
+++ b/docs/usage/release-notes-for-major-versions.md
@@ -19,8 +19,8 @@ Renovate Docker images now use Node.js v22 as base, this was Node.js v20.
 
 Renovate's "sidecar" images now:
 
- - Use Ubuntu 24.04 as base, this was 20.04
- - Set the user ID to `12021`, this was `1001`
+- Use Ubuntu 24.04 as base, this was 20.04
+- Set the user ID to `12021`, this was `1001`
 
 ##### Full images
 

--- a/docs/usage/release-notes-for-major-versions.md
+++ b/docs/usage/release-notes-for-major-versions.md
@@ -11,29 +11,42 @@ You also don't have to scroll to the bottom of the page to find the latest relea
 
 ### Breaking changes for 39
 
-General:
+#### New tools and config for Renovate's Docker images
 
-- Renovate Docker images use Node.js v22 as base, was Node.js v20
-- **deps:** Renovate sidecar images will now default to use:
-   - Ubuntu 24.04, this was 20.04
-   - User ID `12021`, this was `1001`
-- **deps:** The Renovate full image uses Ubuntu 24.04, Python 3.13 and Node v22
-- **Dockerfile:** Renovate -full images now use `binarySource=global`. Set `RENOVATE_BINARY_SOURCE=install` to revert to dynamic tool installation.
+Renovate Docker images now use Node.js v22 as base, this was Node.js v20.
 
-Specific:
+##### Sidecar images
 
-- **github:** Renovate prefers squash merges over other kinds of merges in GitHub. Only applies if you allow squash merges in your GitHub config for the repository.
-- **branchNameStrict:** Branch names with multiple forward slashes (`/`) will change if `branchNameStrict=true`
+Renovate's "sidecar" images now:
+
+ - Use Ubuntu 24.04 as base, this was 20.04
+ - Set the user ID to `12021`, this was `1001`
+
+##### Full images
+
+Renovate's `-full` images now uses:
+
+- Ubuntu 24.04
+- Python 3.13
+- Node.js v22
+
+The Renovate `-full` image defaults to [`binarySource=global`](https://docs.renovatebot.com/self-hosted-configuration/#binarysource).
+If you want to keep the old behavior, where Renovate dynamically installs the needed tools: set the environment variable `RENOVATE_BINARY_SOURCE` to `"install"`.
+
+Question do we need to update the `binarySource` docs?
+It still says:
+
+> Starting in v36, Renovate's default Docker image (previously referred to as the "slim" image) uses `binarySource=install` while the "full" Docker image uses `binarySource=global`. If you are running Renovate in an environment where runtime download and install of tools is not possible then you should use the "full" image.
+
+#### Prefer squash merges for automerges on GitHub
+
+When automerging, Renovate tries the "squash merge" method first.
+
+#### Branch names with multiple slashes
+
+Branch names with multiple forward slashes (`/`) will change if `branchNameStrict=true`.
 
 ### Commentary for 39
-
-#### Major version updates
-
-We updated our images to use new major versions of Node.js, Python and Ubuntu.
-
-#### Why we we change branch names with multiple slashes
-
-Explain why this was changed here.
 
 #### Prefer squash merge for automerges to allow signed commits on GitHub
 
@@ -48,6 +61,10 @@ Read the [GitHub Docs, Signature verification for rebase and merge](https://docs
 
 Note from HonkingGoose to maintainers, the [GitHub Docs, signature verification for bots](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#signature-verification-for-bots) have more info about signing commits as bot author.
 I don't know if we already do this, or if the method is better than relying on a specific kind of merge type?
+
+#### Why we we change branch names with multiple slashes
+
+Explain why this was changed here.
 
 ### Link to release notes for 39
 

--- a/docs/usage/release-notes-for-major-versions.md
+++ b/docs/usage/release-notes-for-major-versions.md
@@ -36,7 +36,6 @@ On top of the changes listed above, the `-full` image now:
 
 If you want to keep the old behavior, where Renovate dynamically installs the needed tools: set the environment variable `RENOVATE_BINARY_SOURCE` to `"install"`.
 
-
 #### Renovate tries squash merges first when automerging on GitHub
 
 Due to technical reasons, GitHub will only sign commits coming from a squash merge.

--- a/docs/usage/release-notes-for-major-versions.md
+++ b/docs/usage/release-notes-for-major-versions.md
@@ -50,25 +50,22 @@ If you want to allow squash merges on your GitHub repository, follow the steps i
 #### Branch names with multiple slashes
 
 Branch names with multiple forward slashes (`/`) will change if `branchNameStrict=true`.
-
-Suggest a "old behavior" example.
-
-Suggest a "new behavior" example.
+Previously there were cases where special characters could still enter branch names despite `branchNameStrict=true` being set.
+This has now been corrected, which can result in some branch name changes because any forward slashes will be converted to hyphens.
 
 ### Commentary for 39
 
 #### Technical reasons for trying the squash merge first on GitHub
 
-Insert Renovate maintainer details here.
+Renovate has changed its GitHub merge preference to "squash" because this way results in signed commits, while "rebase" merges do not.
 
 Read the [GitHub Docs, Signature verification for rebase and merge](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#signature-verification-for-rebase-and-merge) to learn more about commit signing.
 
-Note from HonkingGoose to maintainers, the [GitHub Docs, signature verification for bots](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#signature-verification-for-bots) have more info about signing commits as bot author.
-I don't know if we already do this, or if the method is better than relying on a specific kind of merge type?
 
 #### Why we change branch names with multiple slashes
 
-Explain why this was changed here.
+Branches with slashes are undesirable and this was a bug.
+We are changing it in a major release out of politeness so that you know to expect some branch name changes if you have `branchNameStrict` enabled.
 
 ### Link to release notes for 39
 

--- a/docs/usage/release-notes-for-major-versions.md
+++ b/docs/usage/release-notes-for-major-versions.md
@@ -11,26 +11,29 @@ You also don't have to scroll to the bottom of the page to find the latest relea
 
 ### Breaking changes for 39
 
-#### New tools and config for Renovate's Docker images
+#### New tools for all Docker images
 
-Renovate Docker images now use Node.js v22 as base, this was Node.js v20.
+All our Docker images now:
 
-##### Sidecar images
+- Use Node.js v22 as base, was Node.js v20
+- Use Ubuntu 24.04 as base, was 20.04
 
-Renovate's "sidecar" images now:
+#### New Docker user ID for all Docker images
 
-- Use Ubuntu 24.04 as base, this was 20.04
-- Set the user ID to `12021`, this was `1001`
+All our Docker images now set the Docker user ID to `12021`, the old ID was `1001`.
 
-##### Full images
+After updating your Renovate Docker image to the new v39 release, you must:
 
-Renovate's `-full` images now uses:
+- Delete your old Docker cache, _or_
+- Cut and paste the permissions from the old ID into the new user ID
 
-- Ubuntu 24.04
-- Python 3.13
-- Node.js v22
+#### Updated version of Python, and new default behavior for the `-full` Docker image
 
-The Renovate `-full` image defaults to [`binarySource=global`](https://docs.renovatebot.com/self-hosted-configuration/#binarysource).
+On top of the changes listed above, the `-full` image now:
+
+- Uses Python 3.13
+- Defaults to [`binarySource=global`](https://docs.renovatebot.com/self-hosted-configuration/#binarysource).
+
 If you want to keep the old behavior, where Renovate dynamically installs the needed tools: set the environment variable `RENOVATE_BINARY_SOURCE` to `"install"`.
 
 Question do we need to update the `binarySource` docs?
@@ -38,31 +41,37 @@ It still says:
 
 > Starting in v36, Renovate's default Docker image (previously referred to as the "slim" image) uses `binarySource=install` while the "full" Docker image uses `binarySource=global`. If you are running Renovate in an environment where runtime download and install of tools is not possible then you should use the "full" image.
 
-#### Prefer squash merges for automerges on GitHub
+#### Renovate tries squash merges first when automerging on GitHub
 
-When automerging, Renovate tries the "squash merge" method first.
+Due to technical reasons, GitHub will only sign commits coming from a squash merge.
+To help those who want Renovate to sign its commits, Renovate now tries the squash merge first.
+
+Of course, Renovate only uses the merge method(s) that you allow in your GitHub repository config.
+
+##### How you can allow squash merges on your GitHub repository
+
+If you want to allow squash merges on your GitHub repository, follow the steps in the [GitHub Docs, configuring commit squashing for pull requests](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/configuring-commit-squashing-for-pull-requests).
 
 #### Branch names with multiple slashes
 
 Branch names with multiple forward slashes (`/`) will change if `branchNameStrict=true`.
 
+Suggest a "old behavior" example.
+
+Suggest a "new behavior" example.
+
 ### Commentary for 39
 
-#### Prefer squash merge for automerges to allow signed commits on GitHub
+#### Technical reasons for trying the squash merge first on GitHub
 
-This info is for the GitHub platform only.
+Insert Renovate maintainer details here.
 
-When you sign your commits on GitHub, you'll want Renovate's commits to be signed too.
-If Renovate automerges its PRs with the **Rebase and Merge** option, then GitHub can't sign the commits.
-But GitHub can sign squash-merged commits for Renovate.
-This is why we changed the default behavior to try the squash merge first.
-
-Read the [GitHub Docs, Signature verification for rebase and merge](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#signature-verification-for-rebase-and-merge) to learn more.
+Read the [GitHub Docs, Signature verification for rebase and merge](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#signature-verification-for-rebase-and-merge) to learn more about commit signing.
 
 Note from HonkingGoose to maintainers, the [GitHub Docs, signature verification for bots](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#signature-verification-for-bots) have more info about signing commits as bot author.
 I don't know if we already do this, or if the method is better than relying on a specific kind of merge type?
 
-#### Why we we change branch names with multiple slashes
+#### Why we change branch names with multiple slashes
 
 Explain why this was changed here.
 

--- a/docs/usage/release-notes-for-major-versions.md
+++ b/docs/usage/release-notes-for-major-versions.md
@@ -32,7 +32,7 @@ After updating your Renovate Docker image to the new v39 release, you must:
 On top of the changes listed above, the `-full` image now:
 
 - Uses Python 3.13
-- Defaults to [`binarySource=global`](https://docs.renovatebot.com/self-hosted-configuration/#binarysource) (note: this was previously the case in v36 onwards but regressed sometime in v38).
+- Defaults to [`binarySource=global`](https://docs.renovatebot.com/self-hosted-configuration/#binarysource) (note: this was previously the case in v36 onwards but regressed sometime in v38)
 
 If you want to keep the old behavior, where Renovate dynamically installs the needed tools: set the environment variable `RENOVATE_BINARY_SOURCE` to `"install"`.
 
@@ -49,9 +49,10 @@ If you want to allow squash merges on your GitHub repository, follow the steps i
 
 #### Branch names with multiple slashes
 
-Branch names with multiple forward slashes (`/`) will change if `branchNameStrict=true`.
-Previously there were cases where special characters could still enter branch names despite `branchNameStrict=true` being set.
-This has now been corrected, which can result in some branch name changes because any forward slashes will be converted to hyphens.
+If you set `branchNameStrict=true`, then branch names with multiple forward slashes (`/`) will change.
+
+The problem was that even if you set `branchNameStrict=true`, in some cases special characters could still end up in Renovate's branch names.
+We fixed this problem, by letting Renovate convert multiple forward slashes (`/`) to hyphens (`-`) in its branch names, if `branchNameStrict=true`.
 
 ### Commentary for 39
 
@@ -61,11 +62,11 @@ Renovate has changed its GitHub merge preference to "squash" because this way re
 
 Read the [GitHub Docs, Signature verification for rebase and merge](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#signature-verification-for-rebase-and-merge) to learn more about commit signing.
 
-
 #### Why we change branch names with multiple slashes
 
-Branches with slashes are undesirable and this was a bug.
-We are changing it in a major release out of politeness so that you know to expect some branch name changes if you have `branchNameStrict` enabled.
+Branches with mutiple slashes (`/`) are not wanted, this was a bug.
+We are changing it in a major release out of politeness to all our users.
+If you enabled `branchNameStrict`, you can expect some branch names to change.
 
 ### Link to release notes for 39
 

--- a/docs/usage/release-notes-for-major-versions.md
+++ b/docs/usage/release-notes-for-major-versions.md
@@ -32,7 +32,7 @@ After updating your Renovate Docker image to the new v39 release, you must:
 On top of the changes listed above, the `-full` image now:
 
 - Uses Python 3.13
-- Defaults to [`binarySource=global`](https://docs.renovatebot.com/self-hosted-configuration/#binarysource).
+- Defaults to [`binarySource=global`](https://docs.renovatebot.com/self-hosted-configuration/#binarysource) (note: this was previously the case in v36 onwards but regressed sometime in v38).
 
 If you want to keep the old behavior, where Renovate dynamically installs the needed tools: set the environment variable `RENOVATE_BINARY_SOURCE` to `"install"`.
 

--- a/docs/usage/release-notes-for-major-versions.md
+++ b/docs/usage/release-notes-for-major-versions.md
@@ -7,6 +7,52 @@ The most recent versions are always at the top of the page.
 This is because recent versions may revert changes made in an older version.
 You also don't have to scroll to the bottom of the page to find the latest release notes.
 
+## Version 39
+
+### Breaking changes for 39
+
+General:
+
+- Renovate Docker images use Node.js v22 as base, was Node.js v20
+- **deps:** Renovate sidecar images will now default to use:
+   - Ubuntu 24.04, this was 20.04
+   - User ID `12021`, this was `1001`
+- **deps:** The Renovate full image uses Ubuntu 24.04, Python 3.13 and Node v22
+- **Dockerfile:** Renovate -full images now use `binarySource=global`. Set `RENOVATE_BINARY_SOURCE=install` to revert to dynamic tool installation.
+
+Specific:
+
+- **github:** Renovate prefers squash merges over other kinds of merges in GitHub. Only applies if you allow squash merges in your GitHub config for the repository.
+- **branchNameStrict:** Branch names with multiple forward slashes (`/`) will change if `branchNameStrict=true`
+
+### Commentary for 39
+
+#### Major version updates
+
+We updated our images to use new major versions of Node.js, Python and Ubuntu.
+
+#### Why we we change branch names with multiple slashes
+
+Explain why this was changed here.
+
+#### Prefer squash merge for automerges to allow signed commits on GitHub
+
+This info is for the GitHub platform only.
+
+When you sign your commits on GitHub, you'll want Renovate's commits to be signed too.
+If Renovate automerges its PRs with the **Rebase and Merge** option, then GitHub can't sign the commits.
+But GitHub can sign squash-merged commits for Renovate.
+This is why we changed the default behavior to try the squash merge first.
+
+Read the [GitHub Docs, Signature verification for rebase and merge](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#signature-verification-for-rebase-and-merge) to learn more.
+
+Note from HonkingGoose to maintainers, the [GitHub Docs, signature verification for bots](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#signature-verification-for-bots) have more info about signing commits as bot author.
+I don't know if we already do this, or if the method is better than relying on a specific kind of merge type?
+
+### Link to release notes for 39
+
+[Release notes for `v39` on GitHub](https://github.com/renovatebot/renovate/releases/tag/39.0.0).
+
 ## Version 38
 
 ### Breaking changes for 38

--- a/tools/mkdocs/mkdocs.yml
+++ b/tools/mkdocs/mkdocs.yml
@@ -59,7 +59,7 @@ theme:
   # The custom_dir points to the overrides folder, this folder has the code for our announcement bar.
   # The easiest way to disable the announcement bar is to comment out the custom_dir: overrides entry in this mkdocs.yml file.
   # https://squidfunk.github.io/mkdocs-material/customization/#setup-and-theme-structure
-  # custom_dir: overrides
+  custom_dir: overrides
 
   logo: 'assets/images/logo.png'
   favicon: 'assets/images/logo.png'

--- a/tools/mkdocs/overrides/main.html
+++ b/tools/mkdocs/overrides/main.html
@@ -6,6 +6,6 @@
 
 {% block announce %}
 <p>
-  We released Renovate <code>v38</code>. Read the <a href="https://docs.renovatebot.com/release-notes-for-major-versions/">Release notes for major versions of Renovate</a> to learn what's changed.
+  We released Renovate <code>v39</code>. Read the <a href="https://docs.renovatebot.com/release-notes-for-major-versions/">Release notes for major versions of Renovate</a> to learn what's changed.
 </p>
 {% endblock %}


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Write release notes for Renovate v39, based on [the `39.0.0` release notes on GitHub](https://github.com/renovatebot/renovate/releases/tag/39.0.0)
  - Group similar parts
  - Add headings
  - Use lists
  - Explain why we made certain changes
- Enable announcement bar feature in the MkDocs config file
- Update the announcement bar text, so it mentions `v39`
- Explain how a user can allow squash merges on their GitHub repo, and link to the GitHub Docs

## Context

The hosted app now uses Renovate v39. So we should put nice release notes in the docs. 😄 

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
