### PR TITLE
fix(hex/mix): stop suffixing versions with `== ` by default

### DIFF
--- a/lib/modules/versioning/hex/index.ts
+++ b/lib/modules/versioning/hex/index.ts
@@ -100,9 +100,6 @@ function getNewValue({
     } else {
       newSemver = newSemver.replace(regEx(/~\s*(\d+\.\d+\.\d)/), '~> $1');
     }
-    if (npm.isVersion(newSemver)) {
-      newSemver = `== ${newSemver}`;
-    }
   }
   return newSemver;
 }


### PR DESCRIPTION
## Changes

Semantic versions (not ranges) in `mix.exs` files stop getting suffixed with `== `, by default.

## Context

https://github.com/renovatebot/renovate/commit/0c06a23a3f5130299a564aea7909c7c2d8cae804#diff-5050def58eaa9d548349c16252d28f932eb05401d5981e867392517f18c18847R80 introduced `== ` as an always-present suffix to `hex` versions (Hex and Git alike). The problem that comes with this (up until now we'd been updating our PRs "by hand") is that e.g. a dependency like `{:k_lib, git: "git@github.com:k/k_lib.git", tag: "v0.0.1"}` gets updated to `{:k_lib, git: "git@github.com:k/k_lib.git", tag: "== v0.0.2"}` which is not valid Mix syntax.

I was looking at the code and trying to do this optionally but I can't seem to find (does it exist?) a proper option... if I could pass something from `mix` to `hex` then I could use that to optionally add the `== `, keeping previous behaviour but allowing for the bug fix.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository