### PR TITLE
fix: Handle `extractVersion` with release post-processing

### DIFF
--- a/lib/modules/datasource/common.spec.ts
+++ b/lib/modules/datasource/common.spec.ts
@@ -103,7 +103,10 @@ describe('modules/datasource/common', () => {
       };
       const res = applyExtractVersion(releaseResult, '^v(?<version>.+)$');
       expect(res).toEqual({
-        releases: [{ version: '1.0.0' }, { version: '2.0.0' }],
+        releases: [
+          { version: '1.0.0', versionOrig: 'v1.0.0' },
+          { version: '2.0.0', versionOrig: 'v2.0.0' },
+        ],
       });
     });
 
@@ -113,7 +116,7 @@ describe('modules/datasource/common', () => {
       };
       const result = applyExtractVersion(releaseResult, '^v(?<version>.+)$');
       expect(result).toEqual({
-        releases: [{ version: '1.0.0' }],
+        releases: [{ version: '1.0.0', versionOrig: 'v1.0.0' }],
       });
     });
   });

--- a/lib/modules/datasource/common.ts
+++ b/lib/modules/datasource/common.ts
@@ -110,6 +110,7 @@ export function applyExtractVersion(
       return null;
     }
 
+    release.versionOrig = release.version;
     release.version = version;
     return release;
   });

--- a/lib/modules/datasource/maven/index.ts
+++ b/lib/modules/datasource/maven/index.ts
@@ -252,8 +252,9 @@ export class MavenDatasource extends Datasource {
     namespace: `datasource-maven`,
     key: (
       { registryUrl, packageName }: PostprocessReleaseConfig,
-      { version }: Release,
-    ) => `postprocessRelease:${registryUrl}:${packageName}:${version}`,
+      { version, versionOrig }: Release,
+    ) =>
+      `postprocessRelease:${registryUrl}:${packageName}:${versionOrig ?? version}`,
     ttlMinutes: 24 * 60,
   })
   override async postprocessRelease(
@@ -268,7 +269,7 @@ export class MavenDatasource extends Datasource {
 
     const pomUrl = await createUrlForDependencyPom(
       this.http,
-      release.version,
+      release.versionOrig ?? release.version,
       dependency,
       registryUrl,
     );

--- a/lib/modules/datasource/postprocess-release.spec.ts
+++ b/lib/modules/datasource/postprocess-release.spec.ts
@@ -124,31 +124,6 @@ describe('modules/datasource/postprocess-release', () => {
     expect(release).toBeNull();
   });
 
-  it('preserves rejected release when `extractVersion` was set', async () => {
-    const releaseOrig: Release = { version: '1.2.3' };
-
-    class SomeDatasource extends DummyDatasource {
-      override postprocessRelease(
-        _config: PostprocessReleaseConfig,
-        _release: Release,
-      ): Promise<PostprocessReleaseResult> {
-        return Promise.resolve('reject');
-      }
-    }
-    getDatasourceFor.mockReturnValueOnce(new SomeDatasource());
-
-    const release = await postprocessRelease(
-      {
-        datasource: 'some-datasource',
-        packageName: 'some-package',
-        extractVersion: '^(?<version>\\d+)$',
-      },
-      releaseOrig,
-    );
-
-    expect(release).toBe(releaseOrig);
-  });
-
   it('falls back when error was thrown', async () => {
     const releaseOrig: Release = { version: '1.2.3' };
 

--- a/lib/modules/datasource/postprocess-release.ts
+++ b/lib/modules/datasource/postprocess-release.ts
@@ -49,22 +49,14 @@ export async function postprocessRelease(
     );
 
     if (result === 'reject') {
-      if (config.extractVersion) {
-        logger.debug(
-          {
-            datasource,
-            packageName,
-            registryUrl,
-            version: release.version,
-            extractVersion: config.extractVersion,
-          },
-          'Rejected release combined with `extractVersion`: preserving the release',
-        );
-        return release;
-      }
-
       logger.debug(
-        { datasource, packageName, registryUrl, version: release.version },
+        {
+          datasource,
+          packageName,
+          registryUrl,
+          version: release.version,
+          versionOrig: release.versionOrig,
+        },
         'Rejected release',
       );
       return null;

--- a/lib/modules/datasource/types.ts
+++ b/lib/modules/datasource/types.ts
@@ -61,6 +61,8 @@ export interface Release {
   isStable?: boolean;
   releaseTimestamp?: string | null;
   version: string;
+  /** The original value to which `extractVersion` was applied */
+  versionOrig?: string;
   newDigest?: string | undefined;
   constraints?: Record<string, string[]>;
   dependencies?: Record<string, string>;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

- Closes: #32266
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
