### PR TITLE
fix(git): fix gpg commit signing (#32483)

### DIFF
--- a/lib/util/git/private-key.spec.ts
+++ b/lib/util/git/private-key.spec.ts
@@ -35,7 +35,7 @@ describe('util/git/private-key', () => {
       exec.exec.calledWith(any()).mockResolvedValue({ stdout: '', stderr: '' });
       exec.exec
         .calledWith(
-          `gpg --import ${upath.join(os.tmpdir() + '/git-private-gpg.key')}`,
+          `gpg --batch --no-tty --import ${upath.join(os.tmpdir() + '/git-private-gpg.key')}`,
         )
         .mockRejectedValueOnce({
           stderr: `something wrong`,
@@ -50,7 +50,7 @@ describe('util/git/private-key', () => {
       exec.exec.calledWith(any()).mockResolvedValue({ stdout: '', stderr: '' });
       exec.exec
         .calledWith(
-          `gpg --import ${upath.join(os.tmpdir() + '/git-private-gpg.key')}`,
+          `gpg --batch --no-tty --import ${upath.join(os.tmpdir() + '/git-private-gpg.key')}`,
         )
         .mockResolvedValueOnce({
           stderr: `gpg: key ${publicKey}: secret key imported\nfoo\n`,

--- a/lib/util/git/private-key.ts
+++ b/lib/util/git/private-key.ts
@@ -64,7 +64,9 @@ class GPGKey extends PrivateKey {
   protected async importKey(): Promise<string | undefined> {
     const keyFileName = upath.join(os.tmpdir() + '/git-private-gpg.key');
     await fs.outputFile(keyFileName, this.key);
-    const { stdout, stderr } = await exec(`gpg --batch --no-tty --import ${keyFileName}`);
+    const { stdout, stderr } = await exec(
+      `gpg --batch --no-tty --import ${keyFileName}`,
+    );
     logger.debug({ stdout, stderr }, 'Private key import result');
     await fs.remove(keyFileName);
     return `${stdout}${stderr}`

--- a/lib/util/git/private-key.ts
+++ b/lib/util/git/private-key.ts
@@ -64,7 +64,7 @@ class GPGKey extends PrivateKey {
   protected async importKey(): Promise<string | undefined> {
     const keyFileName = upath.join(os.tmpdir() + '/git-private-gpg.key');
     await fs.outputFile(keyFileName, this.key);
-    const { stdout, stderr } = await exec(`gpg --import ${keyFileName}`);
+    const { stdout, stderr } = await exec(`gpg --batch --no-tty --import ${keyFileName}`);
     logger.debug({ stdout, stderr }, 'Private key import result');
     await fs.remove(keyFileName);
     return `${stdout}${stderr}`

--- a/lib/util/git/private-key.ts
+++ b/lib/util/git/private-key.ts
@@ -65,6 +65,7 @@ class GPGKey extends PrivateKey {
     const keyFileName = upath.join(os.tmpdir() + '/git-private-gpg.key');
     await fs.outputFile(keyFileName, this.key);
     const { stdout, stderr } = await exec(
+      // --batch --no-tty flags allow Renovate to skip warnings about unsupported algorithms in the key
       `gpg --batch --no-tty --import ${keyFileName}`,
     );
     logger.debug({ stdout, stderr }, 'Private key import result');


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

After upgrading to Renovate 39, committing using GPG keys began failing with the error message `cannot open '/dev/tty': No such device or address`.

This change adds the `--no-tty` and `--batch` commands to the `gpg` import of the private key.
These flags are described in the manpage as:
> --no-tty
>   Make sure that the TTY (terminal) is never used for any output. This option is needed in some cases because GnuPG sometimes prints warnings to the TTY even if --batch is used. 
> --batch
>   Use batch mode. Never ask, do not allow interactive commands. --no-batch disables this option. Note that even with a filename given on the command line, gpg might still need to read from STDIN (in particular if gpg figures that the input is a detached signature and no data file has been specified). Thus if you do not want to feed data via STDIN, you should connect STDIN to /dev/null. It is highly recommended to use this option along with the options --status-fd and --with-colons for any unattended use of gpg. Should not be used in an option file.

I am not sure that `--batch` is strictly necessary to fix this issue, but it does seem to be recommended in this usage.

## Context

This references discussion #32483.

I have not been able to build renovate here to test these exact changes.  I did however override the `gpg` command in the docker image to insert the 2 flags into the command, and this did solve the issue.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
