### PR TITLE
fix: ensure packageFiles isn't null during dependency extraction

### DIFF
--- a/lib/workers/repository/process/index.ts
+++ b/lib/workers/repository/process/index.ts
@@ -119,7 +119,7 @@ export async function extractDependencies(
   let res: ExtractResult = {
     branches: [],
     branchList: [],
-    packageFiles: null!,
+    packageFiles: {},
   };
   if (GlobalConfig.get('platform') !== 'local' && config.baseBranches?.length) {
     config.baseBranches = unfoldBaseBranches(
@@ -146,7 +146,10 @@ export async function extractDependencies(
         const baseBranchRes = await lookup(baseBranchConfig, packageFiles);
         res.branches = res.branches.concat(baseBranchRes?.branches);
         res.branchList = res.branchList.concat(baseBranchRes?.branchList);
-        res.packageFiles = res.packageFiles || baseBranchRes?.packageFiles; // Use the first branch
+        if (!res.packageFiles || !Object.keys(res.packageFiles).length) {
+          // Use the first branch
+          res.packageFiles = baseBranchRes?.packageFiles;
+        }
       }
     }
     removeMeta(['baseBranch']);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Addresses an edge case where `fetchDependencyVulnerabilities` ([here](https://github.com/renovatebot/renovate/blob/9b45b6b1529a53653ae1256cc2703529d7ba681e/lib/workers/repository/process/vulnerabilities.ts#L108)) is called with an unexpected `packageFiles` null object. This only occurs if the renovate config includes  `dependencyDashboardOSVVulnerabilitySummary` and is run on a non-existing base branch.

Reproduction repo: https://github.com/renovate-demo/32558

```
"err": {
   "message": "Cannot convert undefined or null to object",
   "stack": "TypeError: Cannot convert undefined or null to object
     at Function.keys (<anonymous>)
     at Vulnerabilities.fetchDependencyVulnerabilities (renovate/lib/workers/repository/process/vulnerabilities.ts:110:29)
     at Vulnerabilities.fetchVulnerabilities (renovate/lib/workers/repository/process/vulnerabilities.ts:99:31)
     at getDashboardMarkdownVulnerabilities (renovate/lib/workers/repository/dependency-dashboard.ts:588:54)
     at async ensureDependencyDashboard (renovate/lib/workers/repository/dependency-dashboard.ts:500:16)
     at async Object.renovateRepository (renovate/lib/workers/repository/index.ts:106:9)
     at async attributes.repository (renovate/lib/workers/global/index.ts:202:11)
     at async start (renovate/lib/workers/global/index.ts:187:7)
     at async renovate/lib/renovate.ts:19:22"
}
```

The root cause is in `extractDependencies` where `packageFiles` is forcefully set to `null`:
https://github.com/renovatebot/renovate/blob/9b45b6b1529a53653ae1256cc2703529d7ba681e/lib/workers/repository/process/index.ts#L122

so that it then can be reset to the first existing base branch:
https://github.com/renovatebot/renovate/blob/9b45b6b1529a53653ae1256cc2703529d7ba681e/lib/workers/repository/process/index.ts#L149

If none of the provided base branches is existing, `res.packageFiles` remains a null object, leading to the above mentioned error.

The proposed fix initializes `res.packageFiles` with `{}` so that it corresponds to the `ExtractResult` interface ([here](https://github.com/renovatebot/renovate/blob/9b45b6b1529a53653ae1256cc2703529d7ba681e/lib/workers/repository/process/extract-update.ts#L21-L25)) and applies an emptiness check to find if `res.packageFiles` should be updated.

I can't think of any potential side effects of this change, since no calling method would expect `packageFiles` to be null anyway. Only `ensureOnboardingPr` considers `packageFiles` to be null but throughout its execution asserts `packageFiles!`, so I think this is some legacy that might benefit from refactoring:
https://github.com/renovatebot/renovate/blob/9b45b6b1529a53653ae1256cc2703529d7ba681e/lib/workers/repository/onboarding/pr/index.ts#L33-L35


## Context

- https://github.com/renovatebot/renovate/discussions/32558

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
