### PR TITLE
feat(poetry): support GCloud credentials for Google Artifact Registry when locking

### DIFF
--- a/lib/modules/manager/poetry/__fixtures__/pyproject.10.toml
+++ b/lib/modules/manager/poetry/__fixtures__/pyproject.10.toml
@@ -20,6 +20,10 @@ name = "five"
 name = "some-gar-repo"
 url = "https://someregion-python.pkg.dev/some-project/some-repo/simple/"
 
+[[tool.poetry.source]]
+name = "invalid-url"
+url = "invalid-url"
+
 [build-system]
 requires = ["poetry_core>=1.0", "wheel"]
 build-backend = "poetry.masonry.api"

--- a/lib/modules/manager/poetry/__fixtures__/pyproject.10.toml
+++ b/lib/modules/manager/poetry/__fixtures__/pyproject.10.toml
@@ -17,10 +17,6 @@ url = "last.url"
 name = "five"
 
 [[tool.poetry.source]]
-name = "some-gar-repo"
-url = "https://someregion-python.pkg.dev/some-project/some-repo/simple/"
-
-[[tool.poetry.source]]
 name = "invalid-url"
 url = "invalid-url"
 

--- a/lib/modules/manager/poetry/__fixtures__/pyproject.10.toml
+++ b/lib/modules/manager/poetry/__fixtures__/pyproject.10.toml
@@ -16,6 +16,10 @@ url = "last.url"
 [[tool.poetry.source]]
 name = "five"
 
+[[tool.poetry.source]]
+name = "some-gar-repo"
+url = "https://someregion-python.pkg.dev/some-project/some-repo/simple/"
+
 [build-system]
 requires = ["poetry_core>=1.0", "wheel"]
 build-backend = "poetry.masonry.api"

--- a/lib/modules/manager/poetry/__fixtures__/pyproject.13.toml
+++ b/lib/modules/manager/poetry/__fixtures__/pyproject.13.toml
@@ -1,0 +1,7 @@
+[[tool.poetry.source]]
+name = "some-gar-repo"
+url = "https://someregion-python.pkg.dev/some-project/some-repo/simple/"
+
+[build-system]
+requires = ["poetry_core>=1.0", "wheel"]
+build-backend = "poetry.masonry.api"

--- a/lib/modules/manager/poetry/__fixtures__/pyproject.13.toml
+++ b/lib/modules/manager/poetry/__fixtures__/pyproject.13.toml
@@ -1,7 +1,0 @@
-[[tool.poetry.source]]
-name = "some-gar-repo"
-url = "https://someregion-python.pkg.dev/some-project/some-repo/simple/"
-
-[build-system]
-requires = ["poetry_core>=1.0", "wheel"]
-build-backend = "poetry.masonry.api"

--- a/lib/modules/manager/poetry/artifacts.spec.ts
+++ b/lib/modules/manager/poetry/artifacts.spec.ts
@@ -206,7 +206,7 @@ describe('modules/manager/poetry/artifacts', () => {
           },
         },
       ]);
-      expect(hostRules.find.mock.calls).toHaveLength(7);
+      expect(hostRules.find.mock.calls).toHaveLength(9);
       expect(execSnapshots).toMatchObject([
         {
           cmd: 'poetry update --lock --no-interaction dep1',
@@ -269,7 +269,7 @@ describe('modules/manager/poetry/artifacts', () => {
           },
         },
       ]);
-      expect(hostRules.find.mock.calls).toHaveLength(7);
+      expect(hostRules.find.mock.calls).toHaveLength(9);
       expect(execSnapshots).toMatchObject([
         {
           cmd: 'poetry update --lock --no-interaction dep1',

--- a/lib/modules/manager/poetry/artifacts.spec.ts
+++ b/lib/modules/manager/poetry/artifacts.spec.ts
@@ -16,7 +16,14 @@ import { updateArtifacts } from '.';
 
 const pyproject1toml = Fixtures.get('pyproject.1.toml');
 const pyproject10toml = Fixtures.get('pyproject.10.toml');
-const pyproject13toml = Fixtures.get('pyproject.13.toml');
+const pyproject13toml = `[[tool.poetry.source]]
+name = "some-gar-repo"
+url = "https://someregion-python.pkg.dev/some-project/some-repo/simple/"
+
+[build-system]
+requires = ["poetry_core>=1.0", "wheel"]
+build-backend = "poetry.masonry.api"
+`;
 
 jest.mock('../../../util/exec/env');
 jest.mock('../../../util/fs');

--- a/lib/modules/manager/poetry/artifacts.ts
+++ b/lib/modules/manager/poetry/artifacts.ts
@@ -138,7 +138,7 @@ async function getMatchingHostRule(url: string | undefined): Promise<HostRule> {
         password: accessToken,
       };
     }
-    logger.once.debug(`Could not get Google access token (url=${url)`);
+    logger.once.debug(`Could not get Google access token (url=${url})`);
   }
 
   return {};

--- a/lib/modules/manager/poetry/artifacts.ts
+++ b/lib/modules/manager/poetry/artifacts.ts
@@ -126,7 +126,7 @@ async function getMatchingHostRule(url: string | undefined): Promise<HostRule> {
 
   const parsedUrl = parseUrl(url);
   if (!parsedUrl) {
-    logger.once.debug({ url }, 'Failed to parse URL');
+    logger.once.debug(`Failed to parse URL ${url}`);
     return {};
   }
 
@@ -138,7 +138,7 @@ async function getMatchingHostRule(url: string | undefined): Promise<HostRule> {
         password: accessToken,
       };
     }
-    logger.once.debug({ url }, 'Could not get Google access token');
+    logger.once.debug(`Could not get Google access token (url=${url)`);
   }
 
   return {};


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Detect Google Artifact Registry URL and pass GCloud Oauth credentials via `POETRY_HTTP_BASIC_*` environment variables when running `poetry lock`

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

Similar to #32545 for uv

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
