### PR TITLE
docs(rust): hostType should be "crate" instead of "cargo"

### DIFF
--- a/docs/usage/rust.md
+++ b/docs/usage/rust.md
@@ -34,7 +34,7 @@ Read the [Rust environment variables docs](https://doc.rust-lang.org/cargo/refer
 You as user can set authentication for private crates by adding a `hostRules` configuration to your `renovate.json` file.
 
 All token `hostRules` with a `hostType` (e.g. `github`, `gitlab`, `bitbucket`, etc.) and host rules without a `hostType` will be automatically setup for authentication.
-You can also configure a `hostRules` that's only for Cargo authentication (e.g. `hostType: 'cargo'`).
+You can also configure a `hostRules` that's only for Cargo authentication (e.g. `hostType: 'crate'`).
 
 ```js title="Example of authentication for a private GitHub and Cargo registry:"
 module.exports = {
@@ -47,7 +47,7 @@ module.exports = {
     {
       matchHost: 'someGitHost.enterprise.com',
       token: process.env.CARGO_GIT_TOKEN,
-      hostType: 'cargo',
+      hostType: 'crate',
     },
   ],
 };


### PR DESCRIPTION
This PR splits https://github.com/renovatebot/renovate/pull/32393 into smaller parts.


<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Replace `cargo` with `crate` in private registry usage document

<!-- Describe what behavior is changed by this PR. -->

## Context

`hostType` should be either platform or datasource. For Rust crate, datasource is not `cargo`, but `crate`.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
