### PR TITLE
fix(docker-image): ensure base & cache dir at build time

### DIFF
--- a/lib/util/cache/repository/common.ts
+++ b/lib/util/cache/repository/common.ts
@@ -1,6 +1,6 @@
-// Increment this whenever there could be incompatibilities between old and new cache structure
 import upath from 'upath';
 
+// Increment this whenever there could be incompatibilities between old and new cache structure
 export const CACHE_REVISION = 13;
 
 export function getLocalCacheFileName(

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -97,7 +97,7 @@ RUN ln -sf /usr/local/renovate/node /bin/node
 
 # ensure default base and cache directories exist.
 RUN mkdir -p /tmp/renovate/cache && \
-    chmod -R 775 /tmp/renovate/cache
+    chmod -R 775 /tmp/renovate
 
 # test
 RUN set -ex; \

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -96,8 +96,8 @@ COPY --link --from=build --chown=root:root /usr/local/renovate/ /usr/local/renov
 RUN ln -sf /usr/local/renovate/node /bin/node
 
 # ensure default base and cache directories exist.
-RUN mkdir -p /tmp/renovate /tmp/renovate/cache && \
-    chmod 775 /tmp/renovate /tmp/renovate/cache
+RUN mkdir -p /tmp/renovate/cache && \
+    chmod -R 775 /tmp/renovate/cache
 
 # test
 RUN set -ex; \

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -95,6 +95,10 @@ COPY --link --from=build --chown=root:root /usr/local/renovate/ /usr/local/renov
 # make our node binary available as last in path
 RUN ln -sf /usr/local/renovate/node /bin/node
 
+# ensure default base and cache directories exist.
+RUN mkdir -p /tmp/renovate /tmp/renovate/cache && \
+    chmod 775 /tmp/renovate /tmp/renovate/cache
+
 # test
 RUN set -ex; \
   renovate --version; \


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Create the default base and cache directories at docker image build time.
This will allow bind mounting cache assets without breaking the expected Renovate directory permissions at runtime.

This assumes that the ubuntu user is part of the root group, which is currently the case.

<!-- Describe what behavior is changed by this PR. -->

## Context
- #32444
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
