### PR TITLE
feat(bundler): add inline source support

### DIFF
--- a/lib/modules/manager/bundler/extract.spec.ts
+++ b/lib/modules/manager/bundler/extract.spec.ts
@@ -170,21 +170,27 @@ describe('modules/manager/bundler/extract', () => {
 
   it('parses inline source in Gemfile', async () => {
     const sourceInlineGemfile = codeBlock`
-      gem "some_internal_gem", source: 'https://gems.foo.com'
-      gem 'another_internal_gem', "~> 1", source: 'https://gems.bar.com'
+      baz = 'https://gems.baz.com'
+      gem "inline_source_gem", source: 'https://gems.foo.com'
+      gem 'inline_source_gem_with_version', "~> 1", source: 'https://gems.bar.com'
+      gem 'inline_source_gem_with_variable_source', source: baz
       `;
     fs.readLocalFile.mockResolvedValueOnce(sourceInlineGemfile);
     const res = await extractPackageFile(sourceInlineGemfile, 'Gemfile');
     expect(res).toMatchObject({
       deps: [
         {
-          depName: 'some_internal_gem',
+          depName: 'inline_source_gem',
           registryUrls: ['https://gems.foo.com'],
         },
         {
-          depName: 'another_internal_gem',
+          depName: 'inline_source_gem_with_version',
           currentValue: '"~> 1"',
           registryUrls: ['https://gems.bar.com'],
+        },
+        {
+          depName: 'inline_source_gem_with_variable_source',
+          registryUrls: ['https://gems.baz.com'],
         },
       ],
     });

--- a/lib/modules/manager/bundler/extract.spec.ts
+++ b/lib/modules/manager/bundler/extract.spec.ts
@@ -145,8 +145,6 @@ describe('modules/manager/bundler/extract', () => {
 
   it('parses source variable in Gemfile', async () => {
     const sourceVariableGemfile = codeBlock`
-      source "https://rubygems.org"
-      ruby '~> 1.5.3'
       foo = 'https://gems.foo.com'
       bar = 'https://gems.bar.com'
 
@@ -159,12 +157,36 @@ describe('modules/manager/bundler/extract', () => {
 
     fs.readLocalFile.mockResolvedValueOnce(sourceVariableGemfile);
     const res = await extractPackageFile(sourceVariableGemfile, 'Gemfile');
-    expect(res?.deps).toHaveLength(2);
-    expect(res?.registryUrls).toHaveLength(2);
-    expect(res?.registryUrls?.[1]).toBe('https://gems.foo.com');
-    expect(res?.deps[1]).toMatchObject({
-      depName: 'some_internal_gem',
-      registryUrls: ['https://gems.bar.com'],
+    expect(res).toMatchObject({
+      registryUrls: ['https://gems.foo.com'],
+      deps: [
+        {
+          depName: 'some_internal_gem',
+          registryUrls: ['https://gems.bar.com'],
+        },
+      ],
+    });
+  });
+
+  it('parses inline source in Gemfile', async () => {
+    const sourceInlineGemfile = codeBlock`
+      gem "some_internal_gem", source: 'https://gems.foo.com'
+      gem 'another_internal_gem', "~> 1", source: 'https://gems.bar.com'
+      `;
+    fs.readLocalFile.mockResolvedValueOnce(sourceInlineGemfile);
+    const res = await extractPackageFile(sourceInlineGemfile, 'Gemfile');
+    expect(res).toMatchObject({
+      deps: [
+        {
+          depName: 'some_internal_gem',
+          registryUrls: ['https://gems.foo.com'],
+        },
+        {
+          depName: 'another_internal_gem',
+          currentValue: '"~> 1"',
+          registryUrls: ['https://gems.bar.com'],
+        },
+      ],
     });
   });
 });

--- a/lib/modules/manager/bundler/extract.ts
+++ b/lib/modules/manager/bundler/extract.ts
@@ -137,6 +137,14 @@ export async function extractPackageFile(
         const currentValue = gemMatch.groups.currentValue;
         dep.currentValue = currentValue;
       }
+      if (gemMatch.groups?.registryUrl) {
+        const registryUrl = gemMatch.groups.registryUrl;
+        dep.registryUrls = [registryUrl];
+      }
+      if (gemMatch.groups?.sourceName) {
+        const registryUrl = variables[gemMatch.groups.sourceName];
+        dep.registryUrls = [registryUrl];
+      }
       dep.datasource = RubygemsDatasource.id;
       res.deps.push(dep);
     }


### PR DESCRIPTION
## Changes

Here I'm adding support for "inline source" declaration, that is when a user declare a one-off source for a specific gem.

## Context

While working on supporting variables, it appears that inline sources were not supported. 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
