### PR TITLE
fix(gradle): Strip `/.` prefix when searching for `gradlew`

### DIFF
--- a/lib/modules/manager/gradle/artifacts.ts
+++ b/lib/modules/manager/gradle/artifacts.ts
@@ -153,7 +153,7 @@ export async function updateArtifacts({
 
   const gradlewName = gradleWrapperFileName();
   const gradlewFile = await findUpLocal(
-    gradlewName.replace(new regEx(`^\\./`), ''),
+    gradlewName.replace(regEx(`^\\./`), ''),
     dirname(packageFileName),
   );
   if (!gradlewFile) {

--- a/lib/modules/manager/gradle/artifacts.ts
+++ b/lib/modules/manager/gradle/artifacts.ts
@@ -153,7 +153,7 @@ export async function updateArtifacts({
 
   const gradlewName = gradleWrapperFileName();
   const gradlewFile = await findUpLocal(
-    gradlewName.replace(new RegExp(`^\\./`), ''),
+    gradlewName.replace(new regEx(`^\\./`), ''),
     dirname(packageFileName),
   );
   if (!gradlewFile) {

--- a/lib/modules/manager/gradle/artifacts.ts
+++ b/lib/modules/manager/gradle/artifacts.ts
@@ -152,7 +152,10 @@ export async function updateArtifacts({
   }
 
   const gradlewName = gradleWrapperFileName();
-  const gradlewFile = await findUpLocal(gradlewName, dirname(packageFileName));
+  const gradlewFile = await findUpLocal(
+    gradlewName.replace(new RegExp(`^\\./`), ''),
+    dirname(packageFileName),
+  );
   if (!gradlewFile) {
     logger.debug(
       'Found Gradle dependency lockfiles but no gradlew - aborting update',


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

`gradleWrapperFileName` returns `./gradlew` when not running on Windows. `findUpLocal` returns unexpected results due to the `./` prefix, therefore strip the `./` prefix when calling `findUpLocal`.

## Context

This change fixes an issue where Renovate debug logs [`Found Gradle dependency lockfiles but no gradlew - aborting update`](https://github.com/renovatebot/renovate/blob/46194117afc160863d70ec0430b25e167f341bd1/lib/modules/manager/gradle/artifacts.ts#L158) even when `gradlew` exists, resulting in gradle lockfiles not being updated as expected.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [X] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
