### PR TITLE
feat(datasource/maven): Introduce option to assume that looked up maven data is specification compliant

### DIFF
--- a/docs/usage/self-hosted-experimental.md
+++ b/docs/usage/self-hosted-experimental.md
@@ -73,6 +73,14 @@ See [issue 8660](https://github.com/renovatebot/renovate/issues/8660) for backgr
 
 Skip initializing `RE2` for regular expressions and instead use Node-native `RegExp` instead.
 
+## `RENOVATE_X_MAVEN_LOOKUP_ASSUME_SPECIFICATION_COMPLIANT`
+
+If set to any value, Renovate assumes that the looked up [Maven Metadata](https://maven.apache.org/repositories/metadata.html) conforms to specification.
+Enabling this will:
+
+- not use the HTML index page for lookup
+- not check if looked up `.pom` files exist
+
 ## `RENOVATE_X_NUGET_DOWNLOAD_NUPKGS`
 
 If set to any value, Renovate will download `nupkg` files for determining package metadata.

--- a/lib/modules/datasource/maven/index.ts
+++ b/lib/modules/datasource/maven/index.ts
@@ -129,7 +129,10 @@ export class MavenDatasource extends Datasource {
     dependency: MavenDependency,
     repoUrl: string,
   ): Promise<ReleaseMap> {
-    if (!repoUrl.startsWith(MAVEN_REPO)) {
+    if (
+      process.env.RENOVATE_X_MAVEN_LOOKUP_ASSUME_SPECIFICATION_COMPLIANT ||
+      !repoUrl.startsWith(MAVEN_REPO)
+    ) {
       return inputReleaseMap;
     }
 
@@ -261,7 +264,11 @@ export class MavenDatasource extends Datasource {
     { packageName, registryUrl }: PostprocessReleaseConfig,
     release: Release,
   ): Promise<PostprocessReleaseResult> {
-    if (!packageName || !registryUrl) {
+    if (
+      process.env.RENOVATE_X_MAVEN_LOOKUP_ASSUME_SPECIFICATION_COMPLIANT ||
+      !packageName ||
+      !registryUrl
+    ) {
       return release;
     }
 


### PR DESCRIPTION
## Changes

The current maven datasource lookup is not conform with the Maven standards and was only introduced because a few people used misconfigured maven repositories.

This PR introduces an experimental option ``RENOVATE_X_MAVEN_LOOKUP_ASSUME_SPECIFICATION_COMPLIANT``.
If this is set, Renovate assumes that the looked up [Maven Metadata](https://maven.apache.org/repositories/metadata.html) conforms to specification and will skip some checks and requests.

## Context

Fixes #27768

In the future it might be desirable to make this the default.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

