### PR TITLE
fix(datasource/maven): make cache key extractedVersion specific

### DIFF
--- a/lib/modules/datasource/maven/index.spec.ts
+++ b/lib/modules/datasource/maven/index.spec.ts
@@ -711,6 +711,21 @@ describe('modules/datasource/maven/index', () => {
       expect(res).toBe(releaseOrig);
     });
 
+    it('returns original value for 200 response with versionOrig', async () => {
+      httpMock
+        .scope(MAVEN_REPO)
+        .head('/foo/bar/1.2.3/bar-1.2.3.pom')
+        .reply(200);
+      const releaseOrig: Release = { version: '1.2', versionOrig: '1.2.3' };
+
+      const res = await postprocessRelease(
+        { datasource, packageName: 'foo:bar', registryUrl: MAVEN_REPO },
+        releaseOrig,
+      );
+
+      expect(res).toBe(releaseOrig);
+    });
+
     it('returns original value for invalid configs', async () => {
       const releaseOrig: Release = { version: '1.2.3' };
       expect(

--- a/lib/modules/datasource/maven/index.ts
+++ b/lib/modules/datasource/maven/index.ts
@@ -254,7 +254,7 @@ export class MavenDatasource extends Datasource {
       { registryUrl, packageName }: PostprocessReleaseConfig,
       { version, versionOrig }: Release,
     ) =>
-      `postprocessRelease:${registryUrl}:${packageName}:${versionOrig ?? version}${versionOrig ? `:${version}` : ''}`,
+      `postprocessRelease:${registryUrl}:${packageName}:${versionOrig ? `${versionOrig}:${version}` : `${version}`}`,
     ttlMinutes: 24 * 60,
   })
   override async postprocessRelease(

--- a/lib/modules/datasource/maven/index.ts
+++ b/lib/modules/datasource/maven/index.ts
@@ -254,7 +254,7 @@ export class MavenDatasource extends Datasource {
       { registryUrl, packageName }: PostprocessReleaseConfig,
       { version, versionOrig }: Release,
     ) =>
-      `postprocessRelease:${registryUrl}:${packageName}:${versionOrig ?? version}`,
+      `postprocessRelease:${registryUrl}:${packageName}:${versionOrig ?? version}${versionOrig ? `:${version}` : ''}`,
     ttlMinutes: 24 * 60,
   })
   override async postprocessRelease(


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

I think I found a small regression with https://github.com/renovatebot/renovate/pull/32540 with one of our internal package from an internal maven registry.
It seem that if you use both the full version and extracted version of a dependency (e.g. `1.2.3-internal-5` & `1.2.3`) there is a high chance (not on every run) that Renovate will use the same value for both updates (50/50 chance if it is the extracted one or the full one).
My gut feeling is this is some caching & race-condition.

After making the cache key dependent on both version and versionOrig in  https://github.com/renovatebot/renovate/pull/32540/files#diff-e51e63b36811d835c0f1a07638208603e43d5b223bf45b073b56cc8de7dccf10R257 I could no longer reproduce it with our internal repository

I wasn’t able to reproduce it yet with a public package (which is weird again), but will then make sure to open a discussion/issue. (This is my current testing PR, which for whatever reason behaves correctly: https://github.com/Shegox/spring-boot-pom/pull/2).

## Context

This PR adds as an additional cache key the (extracted) version. While this will create a few more cache entries (and cache misses) it will ensure that we include both `version` and `versionOrig` (if available) in the cache key to ensure no mixup.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
