### PR TITLE
fix: Revert "fix(bitbucket): source link root path"

### DIFF
--- a/lib/modules/platform/bitbucket/index.spec.ts
+++ b/lib/modules/platform/bitbucket/index.spec.ts
@@ -1656,14 +1656,6 @@ describe('modules/platform/bitbucket/index', () => {
 
       expect(bitbucket.massageMarkdown(prBody)).toMatchSnapshot();
     });
-
-    it('converts source links', () => {
-      const prBody = '[source](https://bitbucket.org/foo/bar/tree/HEAD)';
-
-      expect(bitbucket.massageMarkdown(prBody)).toBe(
-        '[source](https://bitbucket.org/foo/bar/src/HEAD)',
-      );
-    });
   });
 
   describe('updatePr()', () => {

--- a/lib/modules/platform/bitbucket/index.ts
+++ b/lib/modules/platform/bitbucket/index.ts
@@ -583,7 +583,6 @@ export function massageMarkdown(input: string): string {
     .replace(regEx(/<\/?(details|blockquote)>/g), '')
     .replace(regEx(`\n---\n\n.*?<!-- rebase-check -->.*?\n`), '')
     .replace(regEx(/\]\(\.\.\/pull\//g), '](../../pull-requests/')
-    .replace(regEx(/\/tree\/HEAD/g), '/src/HEAD')
     .replace(regEx(/<!--renovate-(?:debug|config-hash):.*?-->/g), '');
 }
 


### PR DESCRIPTION
Reverts renovatebot/renovate#32676

Was approved / auto-merged prematurely. 

massageMarkdown is not a suitable alternate since this is not massaging a platforms PR body.  Instead, it is constructing the correct source link for the package depending on its host.  As such, i'll re-raise my original implementation