### PR TITLE
refactor: Error type narrowing for `Result` class

### DIFF
--- a/lib/util/result.spec.ts
+++ b/lib/util/result.spec.ts
@@ -240,9 +240,8 @@ describe('util/result', () => {
       });
 
       it('converts error to Result', () => {
-        const result = Result.err<string>('oops').catch(() =>
-          Result.ok<number>(42),
-        );
+        const error: Result<number, string> = Result.err<string>('oops');
+        const result = error.catch((_err) => Result.ok<number>(42));
         expect(result).toEqual(Result.ok(42));
       });
 
@@ -600,15 +599,15 @@ describe('util/result', () => {
 
     describe('Catch', () => {
       it('converts error to AsyncResult', async () => {
-        const result = await Result.err<string>('oops').catch(() =>
-          AsyncResult.ok(42),
-        );
+        const error: Result<number, string> = Result.err<string>('oops');
+        const result = await error.catch(() => AsyncResult.ok(42));
         expect(result).toEqual(Result.ok(42));
       });
 
       it('converts error to Promise', async () => {
         const fallback = Promise.resolve(Result.ok(42));
-        const result = await Result.err<string>('oops').catch(() => fallback);
+        const error: Result<number, string> = Result.err<string>('oops');
+        const result = await error.catch(() => fallback);
         expect(result).toEqual(Result.ok(42));
       });
 
@@ -619,9 +618,9 @@ describe('util/result', () => {
       });
 
       it('converts AsyncResult error to Result', async () => {
-        const result = await AsyncResult.err<string>('oops').catch(() =>
-          AsyncResult.ok<number>(42),
-        );
+        const error: AsyncResult<number, string> =
+          AsyncResult.err<string>('oops');
+        const result = await error.catch(() => AsyncResult.ok<number>(42));
         expect(result).toEqual(Result.ok(42));
       });
     });

--- a/lib/util/result.ts
+++ b/lib/util/result.ts
@@ -480,28 +480,23 @@ export class Result<T extends Val, E extends Val = Error> {
   }
 
   catch<U extends Val = T, EE extends Val = E>(
-    fn: (err: E) => Result<U, E | EE>,
-  ): Result<T | U, E | EE>;
+    fn: (err: E) => Result<U, EE>,
+  ): Result<T | U, EE>;
   catch<U extends Val = T, EE extends Val = E>(
-    fn: (err: E) => AsyncResult<U, E | EE>,
-  ): AsyncResult<T | U, E | EE>;
+    fn: (err: E) => AsyncResult<U, EE>,
+  ): AsyncResult<T | U, EE>;
   catch<U extends Val = T, EE extends Val = E>(
-    fn: (err: E) => Promise<Result<U, E | EE>>,
-  ): AsyncResult<T | U, E | EE>;
+    fn: (err: E) => Promise<Result<U, EE>>,
+  ): AsyncResult<T | U, EE>;
   catch<U extends Val = T, EE extends Val = E>(
-    fn: (
-      err: E,
-    ) =>
-      | Result<U, E | EE>
-      | AsyncResult<U, E | EE>
-      | Promise<Result<U, E | EE>>,
-  ): Result<T | U, E | EE> | AsyncResult<T | U, E | EE> {
+    fn: (err: E) => Result<U, EE> | AsyncResult<U, EE> | Promise<Result<U, EE>>,
+  ): Result<T | U, EE> | AsyncResult<T | U, EE> {
     if (this.res.ok) {
-      return this;
+      return this as never;
     }
 
     if (this.res._uncaught) {
-      return this;
+      return this as never;
     }
 
     try {
@@ -833,25 +828,23 @@ export class AsyncResult<T extends Val, E extends Val>
   }
 
   catch<U extends Val = T, EE extends Val = E>(
-    fn: (err: NonNullable<E>) => Result<U, E | EE>,
-  ): AsyncResult<T | U, E | EE>;
+    fn: (err: NonNullable<E>) => Result<U, EE>,
+  ): AsyncResult<T | U, EE>;
   catch<U extends Val = T, EE extends Val = E>(
-    fn: (err: NonNullable<E>) => AsyncResult<U, E | EE>,
-  ): AsyncResult<T | U, E | EE>;
+    fn: (err: NonNullable<E>) => AsyncResult<U, EE>,
+  ): AsyncResult<T | U, EE>;
   catch<U extends Val = T, EE extends Val = E>(
-    fn: (err: NonNullable<E>) => Promise<Result<U, E | EE>>,
-  ): AsyncResult<T | U, E | EE>;
+    fn: (err: NonNullable<E>) => Promise<Result<U, EE>>,
+  ): AsyncResult<T | U, EE>;
   catch<U extends Val = T, EE extends Val = E>(
     fn: (
       err: NonNullable<E>,
-    ) =>
-      | Result<U, E | EE>
-      | AsyncResult<U, E | EE>
-      | Promise<Result<U, E | EE>>,
-  ): AsyncResult<T | U, E | EE> {
-    const caughtAsyncResult = this.asyncResult.then((result) =>
-      // eslint-disable-next-line promise/no-nesting
-      result.catch(fn as never),
+    ) => Result<U, EE> | AsyncResult<U, EE> | Promise<Result<U, EE>>,
+  ): AsyncResult<T | U, EE> {
+    const caughtAsyncResult: Promise<Result<T, EE>> = this.asyncResult.then(
+      (result) =>
+        // eslint-disable-next-line promise/no-nesting
+        result.catch(fn as never),
     );
     return AsyncResult.wrap(caughtAsyncResult);
   }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

When dealing with errors via `.catch(...)`, it's useful to be able to narrow error domain while possibly extending the result domain, instead of always preserving original error type.

When the original error domain should be preserved or extended, it could be done by explicit typing.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
