### PR TITLE
refactor(maven): Unify resource fetching utility functions

### DIFF
--- a/lib/modules/datasource/clojure/index.spec.ts
+++ b/lib/modules/datasource/clojure/index.spec.ts
@@ -229,8 +229,8 @@ describe('modules/datasource/clojure/index', () => {
     mockGenericPackage({ pom });
 
     httpMock
-      .scope('https://repo.maven.apache.org')
-      .get('/maven2/org/example/package/maven-metadata.xml')
+      .scope('https://repo.maven.apache.org/maven2')
+      .get('/org/example/package/maven-metadata.xml')
       .reply(200, '###');
 
     const { sourceUrl } = (await get())!;

--- a/lib/modules/datasource/maven/s3.spec.ts
+++ b/lib/modules/datasource/maven/s3.spec.ts
@@ -89,7 +89,7 @@ describe('modules/datasource/maven/s3', () => {
           {
             failedUrl: 's3://repobucket/org/example/package/maven-metadata.xml',
           },
-          'Dependency lookup authorization failed. Please correct AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY env vars',
+          'Maven S3 lookup error: credentials provider error, check "AWS_ACCESS_KEY_ID" and "AWS_SECRET_ACCESS_KEY" variables',
         );
       });
 
@@ -108,7 +108,7 @@ describe('modules/datasource/maven/s3', () => {
           {
             failedUrl: 's3://repobucket/org/example/package/maven-metadata.xml',
           },
-          'Dependency lookup failed. Please a correct AWS_REGION env var',
+          'Maven S3 lookup error: missing region, check "AWS_REGION" variable',
         );
       });
 
@@ -127,7 +127,7 @@ describe('modules/datasource/maven/s3', () => {
           {
             failedUrl: 's3://repobucket/org/example/package/maven-metadata.xml',
           },
-          'S3 url not found',
+          'Maven S3 lookup error: object not found',
         );
       });
 
@@ -146,7 +146,7 @@ describe('modules/datasource/maven/s3', () => {
           {
             failedUrl: 's3://repobucket/org/example/package/maven-metadata.xml',
           },
-          'S3 url not found',
+          'Maven S3 lookup error: object not found',
         );
       });
 
@@ -163,10 +163,10 @@ describe('modules/datasource/maven/s3', () => {
         expect(res).toBeNull();
         expect(logger.debug).toHaveBeenCalledWith(
           {
+            err: expect.objectContaining({ message: 'Unknown error' }),
             failedUrl: 's3://repobucket/org/example/package/maven-metadata.xml',
-            message: 'Unknown error',
           },
-          'Unknown S3 download error',
+          'Maven S3 lookup error: unknown error',
         );
       });
 
@@ -178,9 +178,6 @@ describe('modules/datasource/maven/s3', () => {
           })
           .resolvesOnce({});
         expect(await get('org.example:package', baseUrlS3)).toBeNull();
-        expect(logger.debug).toHaveBeenCalledWith(
-          "Expecting Readable response type got 'undefined' type instead",
-        );
       });
     });
   });

--- a/lib/modules/datasource/maven/types.ts
+++ b/lib/modules/datasource/maven/types.ts
@@ -1,5 +1,5 @@
-import type { XmlDocument } from 'xmldoc';
-import type { Release } from '../types';
+import type { Result } from '../../../util/result';
+import type { Release, ReleaseResult } from '../types';
 
 export interface MavenDependency {
   display: string;
@@ -8,11 +8,36 @@ export interface MavenDependency {
   dependencyUrl: string;
 }
 
-export interface MavenXml {
-  isCacheable?: boolean;
-  xml?: XmlDocument;
-}
-
 export type ReleaseMap = Record<string, Release | null>;
 
-export type HttpResourceCheckResult = 'found' | 'not-found' | 'error' | Date;
+export type DependencyInfo = Pick<
+  ReleaseResult,
+  'homepage' | 'sourceUrl' | 'packageScope'
+>;
+
+export interface MavenFetchSuccess<T = string> {
+  isCacheable?: boolean;
+  lastModified?: string;
+  data: T;
+}
+
+export type MavenFetchError =
+  | { type: 'invalid-url' }
+  | { type: 'host-disabled' }
+  | { type: 'not-found' }
+  | { type: 'host-error' }
+  | { type: 'permission-issue' }
+  | { type: 'temporary-error' }
+  | { type: 'maven-central-temporary-error'; err: Error }
+  | { type: 'connection-error' }
+  | { type: 'unsupported-host' }
+  | { type: 'unsupported-format' }
+  | { type: 'unsupported-protocol' }
+  | { type: 'credentials-error' }
+  | { type: 'missing-aws-region' }
+  | { type: 'unknown'; err: Error };
+
+export type MavenFetchResult<T = string> = Result<
+  MavenFetchSuccess<T>,
+  MavenFetchError
+>;

--- a/lib/modules/datasource/maven/util.ts
+++ b/lib/modules/datasource/maven/util.ts
@@ -1,6 +1,5 @@
 import { Readable } from 'node:stream';
-import { GetObjectCommand, HeadObjectCommand } from '@aws-sdk/client-s3';
-import { DateTime } from 'luxon';
+import { GetObjectCommand } from '@aws-sdk/client-s3';
 import { XmlDocument } from 'xmldoc';
 import { HOST_DISABLED } from '../../../constants/error-messages';
 import { logger } from '../../../logger';
@@ -9,18 +8,17 @@ import { type Http, HttpError } from '../../../util/http';
 import type { HttpOptions, HttpResponse } from '../../../util/http/types';
 import { regEx } from '../../../util/regex';
 import { Result } from '../../../util/result';
-import type { S3UrlParts } from '../../../util/s3';
 import { getS3Client, parseS3Url } from '../../../util/s3';
 import { streamToString } from '../../../util/streams';
 import { ensureTrailingSlash, parseUrl } from '../../../util/url';
 import { normalizeDate } from '../metadata';
-import type { ReleaseResult } from '../types';
 import { getGoogleAuthToken } from '../util';
 import { MAVEN_REPO } from './common';
-import type {
-  HttpResourceCheckResult,
-  MavenDependency,
-  MavenXml,
+import {
+  type DependencyInfo,
+  type MavenDependency,
+  type MavenFetchResult,
+  type MavenFetchSuccess,
 } from './types';
 
 function getHost(url: string): string | null {
@@ -69,121 +67,195 @@ export async function downloadHttpProtocol(
   http: Http,
   pkgUrl: URL | string,
   opts: HttpOptions = {},
-): Promise<HttpResponse | null> {
+): Promise<MavenFetchResult> {
   const url = pkgUrl.toString();
-  const res = await Result.wrap(http.get(url, opts))
-    .onError((err) => {
+  const fetchResult = await Result.wrap<HttpResponse, Error>(
+    http.get(url, opts),
+  )
+    .transform((res): MavenFetchSuccess<string> => {
+      const result: MavenFetchSuccess<string> = { data: res.body };
+
+      if (!res.authorization) {
+        result.isCacheable = true;
+      }
+
+      const lastModified = normalizeDate(res?.headers?.['last-modified']);
+      if (lastModified) {
+        result.lastModified = lastModified;
+      }
+
+      return result;
+    })
+    .catch((err): MavenFetchResult => {
       // istanbul ignore next: never happens, needs for type narrowing
       if (!(err instanceof HttpError)) {
-        return;
+        return Result.err({ type: 'unknown', err });
       }
 
       const failedUrl = url;
       if (err.message === HOST_DISABLED) {
         logger.trace({ failedUrl }, 'Host disabled');
-        return;
+        return Result.err({ type: 'host-disabled' });
       }
 
       if (isNotFoundError(err)) {
         logger.trace({ failedUrl }, `Url not found`);
-        return;
+        return Result.err({ type: 'not-found' });
       }
 
       if (isHostError(err)) {
         logger.debug(`Cannot connect to host ${failedUrl}`);
-        return;
+        return Result.err({ type: 'host-error' });
       }
 
       if (isPermissionsIssue(err)) {
         logger.debug(
           `Dependency lookup unauthorized. Please add authentication with a hostRule for ${failedUrl}`,
         );
-        return;
+        return Result.err({ type: 'permission-issue' });
       }
 
       if (isTemporaryError(err)) {
         logger.debug({ failedUrl, err }, 'Temporary error');
-        return;
+        if (getHost(url) === getHost(MAVEN_REPO)) {
+          return Result.err({ type: 'maven-central-temporary-error', err });
+        } else {
+          return Result.err({ type: 'temporary-error' });
+        }
       }
 
       if (isConnectionError(err)) {
         logger.debug(`Connection refused to maven registry ${failedUrl}`);
-        return;
+        return Result.err({ type: 'connection-error' });
       }
 
       if (isUnsupportedHostError(err)) {
         logger.debug(`Unsupported host ${failedUrl}`);
-        return;
+        return Result.err({ type: 'unsupported-host' });
       }
 
       logger.info({ failedUrl, err }, 'Unknown HTTP download error');
-    })
-    .catch((err): Result<HttpResponse | 'silent-error', ExternalHostError> => {
-      if (
-        err instanceof HttpError &&
-        isTemporaryError(err) &&
-        getHost(url) === getHost(MAVEN_REPO)
-      ) {
-        return Result.err(new ExternalHostError(err));
-      }
+      return Result.err({ type: 'unknown', err });
+    });
 
-      return Result.ok('silent-error');
-    })
-    .unwrapOrThrow();
-
-  if (res === 'silent-error') {
-    return null;
+  const { err } = fetchResult.unwrap();
+  if (err?.type === 'maven-central-temporary-error') {
+    throw new ExternalHostError(err.err);
   }
 
-  return res;
+  return fetchResult;
+}
+
+export async function downloadHttpContent(
+  http: Http,
+  pkgUrl: URL | string,
+  opts: HttpOptions = {},
+): Promise<string | null> {
+  const fetchResult = await downloadHttpProtocol(http, pkgUrl, opts);
+  return fetchResult.transform(({ data }) => data).unwrapOrNull();
 }
 
 function isS3NotFound(err: Error): boolean {
   return err.message === 'NotFound' || err.message === 'NoSuchKey';
 }
 
-export async function downloadS3Protocol(pkgUrl: URL): Promise<string | null> {
+export async function downloadS3Protocol(
+  pkgUrl: URL,
+): Promise<MavenFetchResult> {
   logger.trace({ url: pkgUrl.toString() }, `Attempting to load S3 dependency`);
-  try {
-    const s3Url = parseS3Url(pkgUrl);
-    if (s3Url === null) {
-      return null;
-    }
-    const { Body: res } = await getS3Client().send(new GetObjectCommand(s3Url));
-    if (res instanceof Readable) {
-      return streamToString(res);
-    }
-    logger.debug(
-      `Expecting Readable response type got '${typeof res}' type instead`,
-    );
-  } catch (err) {
-    const failedUrl = pkgUrl.toString();
-    if (err.name === 'CredentialsProviderError') {
-      logger.debug(
-        { failedUrl },
-        'Dependency lookup authorization failed. Please correct AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY env vars',
-      );
-    } else if (err.message === 'Region is missing') {
-      logger.debug(
-        { failedUrl },
-        'Dependency lookup failed. Please a correct AWS_REGION env var',
-      );
-    } else if (isS3NotFound(err)) {
-      logger.trace({ failedUrl }, `S3 url not found`);
-    } else {
-      logger.debug(
-        { failedUrl, message: err.message },
-        'Unknown S3 download error',
-      );
-    }
+
+  const s3Url = parseS3Url(pkgUrl);
+  if (!s3Url) {
+    return Result.err({ type: 'invalid-url' });
   }
-  return null;
+
+  return await Result.wrap(() => {
+    const command = new GetObjectCommand(s3Url);
+    const client = getS3Client();
+    return client.send(command);
+  })
+    .transform(
+      async ({
+        Body,
+        LastModified,
+        DeleteMarker,
+      }): Promise<MavenFetchResult> => {
+        if (DeleteMarker) {
+          return Result.err({ type: 'not-found' });
+        }
+
+        if (!(Body instanceof Readable)) {
+          return Result.err({ type: 'unsupported-format' });
+        }
+
+        const data = await streamToString(Body);
+        const result: MavenFetchSuccess = { data };
+
+        const lastModified = normalizeDate(LastModified);
+        if (lastModified) {
+          result.lastModified = lastModified;
+        }
+
+        return Result.ok(result);
+      },
+    )
+    .catch((err): MavenFetchResult => {
+      if (!(err instanceof Error)) {
+        return Result.err(err);
+      }
+
+      if (err.name === 'CredentialsProviderError') {
+        return Result.err({ type: 'credentials-error' });
+      }
+
+      if (err.message === 'Region is missing') {
+        return Result.err({ type: 'missing-aws-region' });
+      }
+
+      if (isS3NotFound(err)) {
+        return Result.err({ type: 'not-found' });
+      }
+
+      return Result.err({ type: 'unknown', err });
+    })
+    .onError((err) => {
+      const failedUrl = pkgUrl.toString();
+
+      if (err.type === 'credentials-error') {
+        logger.debug(
+          { failedUrl },
+          'Maven S3 lookup error: credentials provider error, check "AWS_ACCESS_KEY_ID" and "AWS_SECRET_ACCESS_KEY" variables',
+        );
+        return;
+      }
+
+      if (err.type === 'missing-aws-region') {
+        logger.debug(
+          { failedUrl },
+          'Maven S3 lookup error: missing region, check "AWS_REGION" variable',
+        );
+        return;
+      }
+
+      if (err.type === 'not-found') {
+        logger.trace({ failedUrl }, 'Maven S3 lookup error: object not found');
+        return;
+      }
+
+      if (err.type === 'unknown') {
+        logger.debug(
+          { failedUrl, err: err.err },
+          'Maven S3 lookup error: unknown error',
+        );
+        return;
+      }
+    });
 }
 
 export async function downloadArtifactRegistryProtocol(
   http: Http,
   pkgUrl: URL,
-): Promise<HttpResponse | null> {
+): Promise<MavenFetchResult> {
   const opts: HttpOptions = {};
   const host = pkgUrl.host;
   const path = pkgUrl.pathname;
@@ -201,93 +273,7 @@ export async function downloadArtifactRegistryProtocol(
 
   const url = pkgUrl.toString().replace('artifactregistry:', 'https:');
 
-  return downloadHttpProtocol(http, url, opts);
-}
-
-async function checkHttpResource(
-  http: Http,
-  pkgUrl: URL,
-): Promise<HttpResourceCheckResult> {
-  try {
-    const res = await http.head(pkgUrl.toString());
-    const timestamp = res?.headers?.['last-modified'];
-    if (timestamp) {
-      const isoTimestamp = normalizeDate(timestamp);
-      if (isoTimestamp) {
-        const releaseDate = DateTime.fromISO(isoTimestamp, {
-          zone: 'UTC',
-        }).toJSDate();
-        return releaseDate;
-      }
-    }
-    return 'found';
-  } catch (err) {
-    if (isNotFoundError(err)) {
-      return 'not-found';
-    }
-
-    const failedUrl = pkgUrl.toString();
-    logger.debug(
-      { failedUrl, statusCode: err.statusCode },
-      `Can't check HTTP resource existence`,
-    );
-    return 'error';
-  }
-}
-
-export async function checkS3Resource(
-  s3Url: S3UrlParts,
-): Promise<HttpResourceCheckResult> {
-  try {
-    const response = await getS3Client().send(new HeadObjectCommand(s3Url));
-    if (response.DeleteMarker) {
-      return 'not-found';
-    }
-    if (response.LastModified) {
-      return response.LastModified;
-    }
-    return 'found';
-  } catch (err) {
-    if (isS3NotFound(err)) {
-      return 'not-found';
-    } else {
-      logger.debug(
-        {
-          bucket: s3Url.Bucket,
-          key: s3Url.Key,
-          name: err.name,
-          message: err.message,
-        },
-        `Can't check S3 resource existence`,
-      );
-    }
-    return 'error';
-  }
-}
-
-export async function checkResource(
-  http: Http,
-  pkgUrl: URL | string,
-): Promise<HttpResourceCheckResult> {
-  const parsedUrl = typeof pkgUrl === 'string' ? parseUrl(pkgUrl) : pkgUrl;
-  if (parsedUrl === null) {
-    return 'error';
-  }
-
-  const s3Url = parseS3Url(parsedUrl);
-  if (s3Url) {
-    return await checkS3Resource(s3Url);
-  }
-
-  if (parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:') {
-    return await checkHttpResource(http, parsedUrl);
-  }
-
-  logger.debug(
-    { url: pkgUrl.toString() },
-    `Unsupported Maven protocol in check resource`,
-  );
-  return 'not-found';
+  return await downloadHttpProtocol(http, url, opts);
 }
 
 function containsPlaceholder(str: string): boolean {
@@ -305,46 +291,51 @@ export function getMavenUrl(
   );
 }
 
+export async function downloadMaven(
+  http: Http,
+  url: URL | string,
+): Promise<MavenFetchResult> {
+  const pkgUrl = url instanceof URL ? url : parseUrl(url);
+  if (!pkgUrl) {
+    return Result.err({ type: 'invalid-url' });
+  }
+
+  const protocol = pkgUrl.protocol.slice(0, -1);
+
+  let result: MavenFetchResult = Result.err({ type: 'unsupported-protocol' });
+
+  if (protocol === 'http' || protocol === 'https') {
+    result = await downloadHttpProtocol(http, pkgUrl);
+  }
+
+  if (protocol === 'artifactregistry') {
+    result = await downloadArtifactRegistryProtocol(http, pkgUrl);
+  }
+
+  if (protocol === 's3') {
+    result = await downloadS3Protocol(pkgUrl);
+  }
+
+  return result.onError((err) => {
+    if (err.type === 'unsupported-protocol') {
+      logger.debug(
+        { url: pkgUrl.toString() },
+        `Maven lookup error: unsupported protocol (${protocol})`,
+      );
+    }
+  });
+}
+
 export async function downloadMavenXml(
   http: Http,
-  pkgUrl: URL,
-): Promise<MavenXml> {
-  const protocol = pkgUrl.protocol;
-
-  if (protocol === 'http:' || protocol === 'https:') {
-    const res = await downloadHttpProtocol(http, pkgUrl);
-    const body = res?.body;
-    if (body) {
-      return {
-        xml: new XmlDocument(body),
-        isCacheable: !res.authorization,
-      };
-    }
-  }
-
-  if (protocol === 'artifactregistry:') {
-    const res = await downloadArtifactRegistryProtocol(http, pkgUrl);
-    const body = res?.body;
-    if (body) {
-      return {
-        xml: new XmlDocument(body),
-        isCacheable: !res.authorization,
-      };
-    }
-  }
-
-  if (protocol === 's3:') {
-    const res = await downloadS3Protocol(pkgUrl);
-    if (res) {
-      return { xml: new XmlDocument(res) };
-    }
-  }
-
-  logger.debug(
-    { url: pkgUrl.toString() },
-    `Content is not found for Maven url`,
-  );
-  return {};
+  url: URL | string,
+): Promise<MavenFetchResult<XmlDocument>> {
+  const rawResult = await downloadMaven(http, url);
+  const xmlResult = rawResult.transform((result) => ({
+    ...result,
+    data: new XmlDocument(result.data),
+  }));
+  return xmlResult;
 }
 
 export function getDependencyParts(packageName: string): MavenDependency {
@@ -396,13 +387,14 @@ async function getSnapshotFullVersion(
     `${version}/maven-metadata.xml`,
   );
 
-  const { xml: mavenMetadata } = await downloadMavenXml(http, metadataUrl);
-  // istanbul ignore if: hard to test
-  if (!mavenMetadata) {
-    return null;
-  }
+  const metadataXmlResult = await downloadMavenXml(http, metadataUrl);
 
-  return extractSnapshotVersion(mavenMetadata);
+  return metadataXmlResult
+    .transform(({ data }) => {
+      const nullErr = { type: 'snapshot-extract-error' };
+      return Result.wrapNullable(extractSnapshotVersion(data), nullErr);
+    })
+    .unwrapOrNull();
 }
 
 function isSnapshotVersion(version: string): boolean {
@@ -445,8 +437,7 @@ export async function getDependencyInfo(
   repoUrl: string,
   version: string,
   recursionLimit = 5,
-): Promise<Partial<ReleaseResult>> {
-  const result: Partial<ReleaseResult> = {};
+): Promise<DependencyInfo> {
   const path = await createUrlForDependencyPom(
     http,
     version,
@@ -455,64 +446,71 @@ export async function getDependencyInfo(
   );
 
   const pomUrl = getMavenUrl(dependency, repoUrl, path);
-  const { xml: pomContent } = await downloadMavenXml(http, pomUrl);
-  // istanbul ignore if
-  if (!pomContent) {
-    return result;
-  }
+  const pomXmlResult = await downloadMavenXml(http, pomUrl);
+  const dependencyInfoResult = await pomXmlResult.transform(
+    async ({ data: pomContent }) => {
+      const result: DependencyInfo = {};
 
-  const homepage = pomContent.valueWithPath('url');
-  if (homepage && !containsPlaceholder(homepage)) {
-    result.homepage = homepage;
-  }
-
-  const sourceUrl = pomContent.valueWithPath('scm.url');
-  if (sourceUrl && !containsPlaceholder(sourceUrl)) {
-    result.sourceUrl = sourceUrl
-      .replace(regEx(/^scm:/), '')
-      .replace(regEx(/^git:/), '')
-      .replace(regEx(/^git@github.com:/), 'https://github.com/')
-      .replace(regEx(/^git@github.com\//), 'https://github.com/');
-
-    if (result.sourceUrl.startsWith('//')) {
-      // most likely the result of us stripping scm:, git: etc
-      // going with prepending https: here which should result in potential information retrival
-      result.sourceUrl = `https:${result.sourceUrl}`;
-    }
-  }
-
-  const groupId = pomContent.valueWithPath('groupId');
-  if (groupId) {
-    result.packageScope = groupId;
-  }
-
-  const parent = pomContent.childNamed('parent');
-  if (recursionLimit > 0 && parent && (!result.sourceUrl || !result.homepage)) {
-    // if we found a parent and are missing some information
-    // trying to get the scm/homepage information from it
-    const [parentGroupId, parentArtifactId, parentVersion] = [
-      'groupId',
-      'artifactId',
-      'version',
-    ].map((k) => parent.valueWithPath(k)?.replace(/\s+/g, ''));
-    if (parentGroupId && parentArtifactId && parentVersion) {
-      const parentDisplayId = `${parentGroupId}:${parentArtifactId}`;
-      const parentDependency = getDependencyParts(parentDisplayId);
-      const parentInformation = await getDependencyInfo(
-        http,
-        parentDependency,
-        repoUrl,
-        parentVersion,
-        recursionLimit - 1,
-      );
-      if (!result.sourceUrl && parentInformation.sourceUrl) {
-        result.sourceUrl = parentInformation.sourceUrl;
+      const homepage = pomContent.valueWithPath('url');
+      if (homepage && !containsPlaceholder(homepage)) {
+        result.homepage = homepage;
       }
-      if (!result.homepage && parentInformation.homepage) {
-        result.homepage = parentInformation.homepage;
-      }
-    }
-  }
 
-  return result;
+      const sourceUrl = pomContent.valueWithPath('scm.url');
+      if (sourceUrl && !containsPlaceholder(sourceUrl)) {
+        result.sourceUrl = sourceUrl
+          .replace(regEx(/^scm:/), '')
+          .replace(regEx(/^git:/), '')
+          .replace(regEx(/^git@github.com:/), 'https://github.com/')
+          .replace(regEx(/^git@github.com\//), 'https://github.com/');
+
+        if (result.sourceUrl.startsWith('//')) {
+          // most likely the result of us stripping scm:, git: etc
+          // going with prepending https: here which should result in potential information retrival
+          result.sourceUrl = `https:${result.sourceUrl}`;
+        }
+      }
+
+      const groupId = pomContent.valueWithPath('groupId');
+      if (groupId) {
+        result.packageScope = groupId;
+      }
+
+      const parent = pomContent.childNamed('parent');
+      if (
+        recursionLimit > 0 &&
+        parent &&
+        (!result.sourceUrl || !result.homepage)
+      ) {
+        // if we found a parent and are missing some information
+        // trying to get the scm/homepage information from it
+        const [parentGroupId, parentArtifactId, parentVersion] = [
+          'groupId',
+          'artifactId',
+          'version',
+        ].map((k) => parent.valueWithPath(k)?.replace(/\s+/g, ''));
+        if (parentGroupId && parentArtifactId && parentVersion) {
+          const parentDisplayId = `${parentGroupId}:${parentArtifactId}`;
+          const parentDependency = getDependencyParts(parentDisplayId);
+          const parentInformation = await getDependencyInfo(
+            http,
+            parentDependency,
+            repoUrl,
+            parentVersion,
+            recursionLimit - 1,
+          );
+          if (!result.sourceUrl && parentInformation.sourceUrl) {
+            result.sourceUrl = parentInformation.sourceUrl;
+          }
+          if (!result.homepage && parentInformation.homepage) {
+            result.homepage = parentInformation.homepage;
+          }
+        }
+      }
+
+      return result;
+    },
+  );
+
+  return dependencyInfoResult.unwrapOrElse({});
 }

--- a/lib/modules/datasource/maven/util.ts
+++ b/lib/modules/datasource/maven/util.ts
@@ -296,6 +296,7 @@ export async function downloadMaven(
   url: URL | string,
 ): Promise<MavenFetchResult> {
   const pkgUrl = url instanceof URL ? url : parseUrl(url);
+  // istanbul ignore if
   if (!pkgUrl) {
     return Result.err({ type: 'invalid-url' });
   }

--- a/lib/modules/datasource/sbt-package/index.spec.ts
+++ b/lib/modules/datasource/sbt-package/index.spec.ts
@@ -70,8 +70,6 @@ describe('modules/datasource/sbt-package/index', () => {
             <a href="empty_but_invalid/">???</a>
           `,
         )
-        .get('/maven2/com/example/empty/')
-        .reply(200, '')
         .get('/maven2/com/example/empty_but_invalid/')
         .reply(404, '')
         .get('/maven2/com/example/empty/maven-metadata.xml')


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

When fetching package info, Renovate fetches two POM-files:
- one for the latest version, in order to obtain actual `homepage` and `sourceUrl`
- another one for the release selected as the new versio, in order to obtain `releaseTimestamp` or reject this release if POM doesn't exist

In most cases, these files are same, so we may leverage caching to avoid extra HTTP calls. This PR contains the prior work before this objective could be achieved.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
