### PR TITLE
feat(manager/dockerfile): add support for Dockerfile `RUN --mount=from`

### DIFF
--- a/lib/modules/manager/dockerfile/extract.spec.ts
+++ b/lib/modules/manager/dockerfile/extract.spec.ts
@@ -32,6 +32,37 @@ describe('modules/manager/dockerfile/extract', () => {
       ]);
     });
 
+    it('handles run --mount=from', () => {
+      const res = extractPackageFile(
+        'RUN --mount=from=ghcr.io/astral-sh/uv,source=/uv,target=/bin/uv uv pip install numpy\n' +
+        'RUN --mount=type=cache,from=example.com/cache/image,target=/root/.cache pip install numpy\n',
+        '',
+        {}
+      )?.deps;
+      expect(res).toEqual([
+        {
+          autoReplaceStringTemplate:
+            '{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}',
+          currentDigest: undefined,
+          currentValue: undefined,
+          datasource: 'docker',
+          depName: 'ghcr.io/astral-sh/uv',
+          depType: 'stage',
+          replaceString: 'ghcr.io/astral-sh/uv',
+        },
+        {
+          autoReplaceStringTemplate:
+            '{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}',
+          currentDigest: undefined,
+          currentValue: undefined,
+          datasource: 'docker',
+          depName: 'example.com/cache/image',
+          depType: 'final',
+          replaceString: 'example.com/cache/image',
+        }
+      ]);
+    });
+
     it('is case insensitive', () => {
       const res = extractPackageFile('From node\n', '', {})?.deps;
       expect(res).toEqual([

--- a/lib/modules/manager/dockerfile/extract.spec.ts
+++ b/lib/modules/manager/dockerfile/extract.spec.ts
@@ -34,8 +34,11 @@ describe('modules/manager/dockerfile/extract', () => {
 
     it('handles run --mount=from', () => {
       const res = extractPackageFile(
-        'RUN --mount=from=ghcr.io/astral-sh/uv,source=/uv,target=/bin/uv uv pip install numpy\n' +
-          'RUN --mount=type=cache,from=example.com/cache/image,target=/root/.cache pip install numpy\n',
+        'FROM scratch as build\n' +
+          'FROM scratch as final\n' +
+          'RUN --mount=from=ghcr.io/astral-sh/uv,source=/uv,target=/bin/uv uv pip install numpy\n' +
+          'RUN --mount=type=cache,from=example.com/cache/image,target=/root/.cache pip install numpy\n' +
+          'RUN --mount=type=bind,from=build,source=/project/dist/lib.whl,target=/dist/lib.whl pip install /dist/lib.whl\n',
         '',
         {},
       )?.deps;

--- a/lib/modules/manager/dockerfile/extract.spec.ts
+++ b/lib/modules/manager/dockerfile/extract.spec.ts
@@ -35,9 +35,9 @@ describe('modules/manager/dockerfile/extract', () => {
     it('handles run --mount=from', () => {
       const res = extractPackageFile(
         'RUN --mount=from=ghcr.io/astral-sh/uv,source=/uv,target=/bin/uv uv pip install numpy\n' +
-        'RUN --mount=type=cache,from=example.com/cache/image,target=/root/.cache pip install numpy\n',
+          'RUN --mount=type=cache,from=example.com/cache/image,target=/root/.cache pip install numpy\n',
         '',
-        {}
+        {},
       )?.deps;
       expect(res).toEqual([
         {
@@ -59,7 +59,7 @@ describe('modules/manager/dockerfile/extract', () => {
           depName: 'example.com/cache/image',
           depType: 'final',
           replaceString: 'example.com/cache/image',
-        }
+        },
       ]);
     });
 

--- a/lib/modules/manager/dockerfile/extract.ts
+++ b/lib/modules/manager/dockerfile/extract.ts
@@ -424,8 +424,8 @@ export function extractPackageFile(
 
     const runMountFromRegex = regEx(
       '^[ \\t]*RUN(?:' +
-      escapeChar +
-      '[ \\t]*\\r?\\n| |\\t|#.*?\\r?\\n|--[a-z]+(?:=[a-zA-Z0-9_.:-]+?)?)+--mount=(?:\\S*=\\S*,)*from=(?<image>[^, ]+)',
+        escapeChar +
+        '[ \\t]*\\r?\\n| |\\t|#.*?\\r?\\n|--[a-z]+(?:=[a-zA-Z0-9_.:-]+?)?)+--mount=(?:\\S*=\\S*,)*from=(?<image>[^, ]+)',
       'im',
     );
     const runMountFromMatch = instruction.match(runMountFromRegex);

--- a/lib/modules/manager/dockerfile/extract.ts
+++ b/lib/modules/manager/dockerfile/extract.ts
@@ -422,7 +422,7 @@ export function extractPackageFile(
       }
     }
 
-    const runMountFromRegex = new RegExp(
+    const runMountFromRegex = regEx(
       '^[ \\t]*RUN(?:' +
       escapeChar +
       '[ \\t]*\\r?\\n| |\\t|#.*?\\r?\\n|--[a-z]+(?:=[a-zA-Z0-9_.:-]+?)?)+--mount=(?:\\S*=\\S*,)*from=(?<image>[^, ]+)',

--- a/lib/modules/manager/dockerfile/extract.ts
+++ b/lib/modules/manager/dockerfile/extract.ts
@@ -422,6 +422,41 @@ export function extractPackageFile(
       }
     }
 
+    const runMountFromRegex = new RegExp(
+      '^[ \\t]*RUN(?:' +
+      escapeChar +
+      '[ \\t]*\\r?\\n| |\\t|#.*?\\r?\\n|--[a-z]+(?:=[a-zA-Z0-9_.:-]+?)?)+--mount=(?:\\S*=\\S*,)*from=(?<image>[^, ]+)',
+      'im',
+    );
+    const runMountFromMatch = instruction.match(runMountFromRegex);
+    if (runMountFromMatch?.groups?.image) {
+      if (stageNames.includes(runMountFromMatch.groups.image)) {
+        logger.debug(
+          { image: runMountFromMatch.groups.image },
+          'Skipping alias RUN --mount=from',
+        );
+      } else {
+        const dep = getDep(
+          runMountFromMatch.groups.image,
+          true,
+          config.registryAliases,
+        );
+        const lineNumberRanges: number[][] = [
+          [lineNumberInstrStart, lineNumber],
+        ];
+        processDepForAutoReplace(dep, lineNumberRanges, lines, lineFeed);
+        logger.debug(
+          {
+            depName: dep.depName,
+            currentValue: dep.currentValue,
+            currentDigest: dep.currentDigest,
+          },
+          'Dockerfile RUN --mount=from',
+        );
+        deps.push(dep);
+      }
+    }
+
     lineNumber += 1;
   }
 

--- a/lib/modules/manager/dockerfile/readme.md
+++ b/lib/modules/manager/dockerfile/readme.md
@@ -38,7 +38,6 @@ FROM node:20.9.0
 COPY --from alpine:3.19.4 /bin/sh /usr/local/sh
 ```
 
-
 #### `RUN --mount` support
 
 Images referenced in `RUN --mount` directives are also supported.
@@ -48,7 +47,6 @@ FROM python:3.12
 RUN --mount=from=ghcr.io/astral-sh/uv:0.5,source=/uv,target=/bin/uv \
     uv venv
 ```
-
 
 #### `syntax` support
 

--- a/lib/modules/manager/dockerfile/readme.md
+++ b/lib/modules/manager/dockerfile/readme.md
@@ -4,6 +4,7 @@ This manager extracts image references in a `Dockerfile` and/or `Containerfile` 
 
 - [`FROM`](https://docs.docker.com/reference/dockerfile/#from) images
 - [`COPY --from`](https://docs.docker.com/reference/dockerfile/#copy---from) images
+- [`RUN --mount`](https://docs.docker.com/reference/dockerfile/#run---mount) images
 - [`syntax`](https://docs.docker.com/reference/dockerfile/#syntax) images
 
 #### `FROM` support
@@ -36,6 +37,18 @@ Renovate can update images referenced in `COPY --from` directives.
 FROM node:20.9.0
 COPY --from alpine:3.19.4 /bin/sh /usr/local/sh
 ```
+
+
+#### `RUN --mount` support
+
+Images referenced in `RUN --mount` directives are also supported.
+
+```dockerfile
+FROM python:3.12
+RUN --mount=from=ghcr.io/astral-sh/uv:0.5,source=/uv,target=/bin/uv \
+    uv venv
+```
+
 
 #### `syntax` support
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This add support for updating a docker image mount during a RUN step in a Dockerfile. I used the handling for `COPY --from` as an example.

## Context

See for all syntax supported by docker: https://docs.docker.com/reference/dockerfile/#run---mount

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
