### PR TITLE
fix(manager/kustomize): fix parsing kustomize resource URLs with additional query parameters

### DIFF
--- a/lib/modules/manager/kustomize/extract.spec.ts
+++ b/lib/modules/manager/kustomize/extract.spec.ts
@@ -61,6 +61,12 @@ describe('modules/manager/kustomize/extract', () => {
       expect(res).toBeNull();
     });
 
+    it('should return null for an http base without ref/version', () => {
+      const base = 'https://github.com/user/test-repo.git';
+      const res = extractResource(`${base}?timeout=10s`);
+      expect(res).toBeNull();
+    });
+
     it('should extract out the version of an http base', () => {
       const base = 'https://github.com/user/test-repo.git';
       const version = 'v1.0.0';

--- a/lib/modules/manager/kustomize/extract.spec.ts
+++ b/lib/modules/manager/kustomize/extract.spec.ts
@@ -164,7 +164,7 @@ describe('modules/manager/kustomize/extract', () => {
       expect(pkg).toEqual(sample);
     });
 
-    it('should extract out the version of an http base from version param', () => {
+    it('should extract out the version of an http base from first version param', () => {
       const base = 'https://github.com/user/test-repo.git';
       const version = 'v1.0.0';
       const sample = {
@@ -173,7 +173,20 @@ describe('modules/manager/kustomize/extract', () => {
         depName: 'user/test-repo',
       };
 
-      const pkg = extractResource(`${base}?version=${version}`);
+      const pkg = extractResource(`${base}?version=${version}&version=v0`);
+      expect(pkg).toEqual(sample);
+    });
+
+    it('should extract out the version of an http base from first ref param', () => {
+      const base = 'https://github.com/user/test-repo.git';
+      const version = 'v1.0.0';
+      const sample = {
+        currentValue: version,
+        datasource: GithubTagsDatasource.id,
+        depName: 'user/test-repo',
+      };
+
+      const pkg = extractResource(`${base}?ref=${version}&ref=v0`);
       expect(pkg).toEqual(sample);
     });
   });

--- a/lib/modules/manager/kustomize/extract.spec.ts
+++ b/lib/modules/manager/kustomize/extract.spec.ts
@@ -148,6 +148,34 @@ describe('modules/manager/kustomize/extract', () => {
       const pkg = extractResource(`${base}?ref=${version}`);
       expect(pkg).toEqual(sample);
     });
+
+    it('should extract out the version of an http base with additional params', () => {
+      const base = 'https://github.com/user/test-repo.git';
+      const version = 'v1.0.0';
+      const sample = {
+        currentValue: version,
+        datasource: GithubTagsDatasource.id,
+        depName: 'user/test-repo',
+      };
+
+      const pkg = extractResource(
+        `${base}?timeout=120&ref=${version}&submodules=false&version=v1`,
+      );
+      expect(pkg).toEqual(sample);
+    });
+
+    it('should extract out the version of an http base from version param', () => {
+      const base = 'https://github.com/user/test-repo.git';
+      const version = 'v1.0.0';
+      const sample = {
+        currentValue: version,
+        datasource: GithubTagsDatasource.id,
+        depName: 'user/test-repo',
+      };
+
+      const pkg = extractResource(`${base}?version=${version}`);
+      expect(pkg).toEqual(sample);
+    });
   });
 
   describe('extractHelmChart', () => {

--- a/lib/modules/manager/kustomize/extract.ts
+++ b/lib/modules/manager/kustomize/extract.ts
@@ -1,4 +1,4 @@
-import querystring from 'querystring';
+import querystring from 'node:querystring';
 import is from '@sindresorhus/is';
 import { logger } from '../../../logger';
 import { coerceArray } from '../../../util/array';

--- a/lib/modules/manager/kustomize/extract.ts
+++ b/lib/modules/manager/kustomize/extract.ts
@@ -1,3 +1,4 @@
+import querystring from 'querystring';
 import is from '@sindresorhus/is';
 import { logger } from '../../../logger';
 import { coerceArray } from '../../../util/array';
@@ -18,19 +19,19 @@ import type { HelmChart, Image, Kustomize } from './types';
 // URL specifications should follow the hashicorp URL format
 // https://github.com/hashicorp/go-getter#url-format
 const gitUrl = regEx(
-  /^(?:git::)?(?<url>(?:(?:(?:http|https|ssh):\/\/)?(?:.*@)?)?(?<path>(?:[^:/\s]+(?::[0-9]+)?[:/])?(?<project>[^/\s]+\/[^/\s]+)))(?<subdir>[^?\s]*)\?ref=(?<currentValue>.+)$/,
+  /^(?:git::)?(?<url>(?:(?:(?:http|https|ssh):\/\/)?(?:.*@)?)?(?<path>(?:[^:/\s]+(?::[0-9]+)?[:/])?(?<project>[^/\s]+\/[^/\s]+)))(?<subdir>[^?\s]*)\?(?<queryString>.+)$/,
 );
 // regex to match URLs with ".git" delimiter
 const dotGitRegex = regEx(
-  /^(?:git::)?(?<url>(?:(?:(?:http|https|ssh):\/\/)?(?:.*@)?)?(?<path>(?:[^:/\s]+(?::[0-9]+)?[:/])?(?<project>[^?\s]*(\.git))))(?<subdir>[^?\s]*)\?ref=(?<currentValue>.+)$/,
+  /^(?:git::)?(?<url>(?:(?:(?:http|https|ssh):\/\/)?(?:.*@)?)?(?<path>(?:[^:/\s]+(?::[0-9]+)?[:/])?(?<project>[^?\s]*(\.git))))(?<subdir>[^?\s]*)\?(?<queryString>.+)$/,
 );
 // regex to match URLs with "_git" delimiter
 const underscoreGitRegex = regEx(
-  /^(?:git::)?(?<url>(?:(?:(?:http|https|ssh):\/\/)?(?:.*@)?)?(?<path>(?:[^:/\s]+(?::[0-9]+)?[:/])?(?<project>[^?\s]*)(_git\/[^/\s]+)))(?<subdir>[^?\s]*)\?ref=(?<currentValue>.+)$/,
+  /^(?:git::)?(?<url>(?:(?:(?:http|https|ssh):\/\/)?(?:.*@)?)?(?<path>(?:[^:/\s]+(?::[0-9]+)?[:/])?(?<project>[^?\s]*)(_git\/[^/\s]+)))(?<subdir>[^?\s]*)\?(?<queryString>.+)$/,
 );
 // regex to match URLs having an extra "//"
 const gitUrlWithPath = regEx(
-  /^(?:git::)?(?<url>(?:(?:(?:http|https|ssh):\/\/)?(?:.*@)?)?(?<path>(?:[^:/\s]+(?::[0-9]+)?[:/])(?<project>[^?\s]+)))(?:\/\/)(?<subdir>[^?\s]+)\?ref=(?<currentValue>.+)$/,
+  /^(?:git::)?(?<url>(?:(?:(?:http|https|ssh):\/\/)?(?:.*@)?)?(?<path>(?:[^:/\s]+(?::[0-9]+)?[:/])(?<project>[^?\s]+)))(?:\/\/)(?<subdir>[^?\s]+)\?(?<queryString>.+)$/,
 );
 
 export function extractResource(base: string): PackageDependency | null {
@@ -50,10 +51,17 @@ export function extractResource(base: string): PackageDependency | null {
     return null;
   }
 
-  const { path } = match.groups;
+  const { path, queryString } = match.groups;
+  const params = querystring.parse(queryString);
+  const refParam = Array.isArray(params.ref) ? params.ref[0] : params.ref;
+  const versionParam = Array.isArray(params.version)
+    ? params.version[0]
+    : params.version;
+  const currentValue = refParam ?? versionParam;
+
   if (regEx(/(?:github\.com)(:|\/)/).test(path)) {
     return {
-      currentValue: match.groups.currentValue,
+      currentValue,
       datasource: GithubTagsDatasource.id,
       depName: match.groups.project.replace('.git', ''),
     };
@@ -63,7 +71,7 @@ export function extractResource(base: string): PackageDependency | null {
     datasource: GitTagsDatasource.id,
     depName: path.replace('.git', ''),
     packageName: match.groups.url,
-    currentValue: match.groups.currentValue,
+    currentValue,
   };
 }
 

--- a/lib/modules/manager/kustomize/extract.ts
+++ b/lib/modules/manager/kustomize/extract.ts
@@ -58,6 +58,9 @@ export function extractResource(base: string): PackageDependency | null {
     ? params.version[0]
     : params.version;
   const currentValue = refParam ?? versionParam;
+  if (!currentValue) {
+    return null;
+  }
 
   if (regEx(/(?:github\.com)(:|\/)/).test(path)) {
     return {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Fix extracting of resource version when there's additional query parameters present, eg:

```
https://github.com/argoproj/argo-cd/manifests/cluster-install?ref=v2.13.0&timeout=90s
```

Would currently generate the following change:

| Package | Type | Update | Change |
|---|---|---|---|
| [argoproj/argo-cd](https://redirect.github.com/argoproj/argo-cd) | Kustomization | patch | `v2.13.0&timeout=90s` -> `v2.13.1` |

Which would remove the configured timeout of 90s by accident.

## Context

Kustomize allows the following query string parameter in it's [remote resource URLs](https://github.com/kubernetes-sigs/kustomize/blob/master/examples/remoteBuild.md):

- ref
- version
- timeout
- submodules

This PR makes renovate aware of these options and allows to correctly extract the current version in case more parameters are being used by the end-user.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
