### PR TITLE
feat(manager/pep621): add support for uv index configuration

### DIFF
--- a/lib/modules/manager/pep621/processors/uv.spec.ts
+++ b/lib/modules/manager/pep621/processors/uv.spec.ts
@@ -157,7 +157,7 @@ describe('modules/manager/pep621/processors/uv', () => {
           sources: {
             dep1: { index: 'foo' },
             dep2: { index: 'bar' },
-            dep3: { non_existent_future_source: {} },
+            dep3: { non_existent_future_source: {} } as any,
           },
           index: [
             {

--- a/lib/modules/manager/pep621/processors/uv.spec.ts
+++ b/lib/modules/manager/pep621/processors/uv.spec.ts
@@ -214,17 +214,13 @@ describe('modules/manager/pep621/processors/uv', () => {
       },
       {
         depName: 'dep3',
-        registryUrls: [
-          'https://baz.com/simple',
-          'https://pypi.org/pypi/'
-        ],
+        registryUrls: ['https://baz.com/simple', 'https://pypi.org/pypi/'],
         packageName: 'dep3',
       },
     ]);
   });
 
-
-it('override implicit default index', () => {
+  it('override implicit default index', () => {
     const pyproject = {
       tool: {
         uv: {
@@ -256,22 +252,18 @@ it('override implicit default index', () => {
     expect(result).toEqual([
       {
         depName: 'dep1',
-        registryUrls: [
-          'https://foo.com/simple',
-        ],
+        registryUrls: ['https://foo.com/simple'],
         packageName: 'dep1',
       },
       {
         depName: 'dep2',
-        registryUrls: [
-          'https://foo.com/simple',
-        ],
+        registryUrls: ['https://foo.com/simple'],
         packageName: 'dep2',
       },
     ]);
   });
 
-it('override explicit default index', () => {
+  it('override explicit default index', () => {
     const pyproject = {
       tool: {
         uv: {
@@ -307,9 +299,7 @@ it('override explicit default index', () => {
       {
         depName: 'dep1',
         depType: depTypes.uvSources,
-        registryUrls: [
-          'https://foo.com/simple',
-        ],
+        registryUrls: ['https://foo.com/simple'],
         packageName: 'dep1',
       },
       {
@@ -532,9 +522,7 @@ it('override explicit default index', () => {
           packageName: 'dep6',
           depType: depTypes.dependencies,
           datasource: PypiDatasource.id,
-          registryUrls: [
-            'https://pinned.com/simple',
-          ],
+          registryUrls: ['https://pinned.com/simple'],
         },
       ];
       const result = await processor.updateArtifacts(
@@ -548,16 +536,18 @@ it('override explicit default index', () => {
           tool: {
             uv: {
               sources: {
-                dep6: {index : 'pinned-index'},
+                dep6: { index: 'pinned-index' },
               },
-              index: [{
-                name: 'pinned-index',
-                url: 'https://pinned.com/simple',
-                default: false,
-                explicit: true,
-              }]
-            }
-          }
+              index: [
+                {
+                  name: 'pinned-index',
+                  url: 'https://pinned.com/simple',
+                  default: false,
+                  explicit: true,
+                },
+              ],
+            },
+          },
         },
       );
       expect(result).toEqual([
@@ -583,8 +573,8 @@ it('override explicit default index', () => {
               GIT_CONFIG_VALUE_2: 'https://example.com/',
               UV_EXTRA_INDEX_URL:
                 'https://foobar.com/ https://user:pass@example.com/ https://oauth2accesstoken:some-token@someregion-python.pkg.dev/some-project/some-repo/',
-              UV_INDEX_PINNED_INDEX_USERNAME: "user",
-              UV_INDEX_PINNED_INDEX_PASSWORD: "pass",
+              UV_INDEX_PINNED_INDEX_USERNAME: 'user',
+              UV_INDEX_PINNED_INDEX_PASSWORD: 'pass',
             },
           },
         },

--- a/lib/modules/manager/pep621/processors/uv.spec.ts
+++ b/lib/modules/manager/pep621/processors/uv.spec.ts
@@ -157,6 +157,7 @@ describe('modules/manager/pep621/processors/uv', () => {
           sources: {
             dep1: { index: 'foo' },
             dep2: { index: 'bar' },
+            dep3: { non_existent_future_source: {} },
           },
           index: [
             {
@@ -195,6 +196,10 @@ describe('modules/manager/pep621/processors/uv', () => {
         depName: 'dep3',
         packageName: 'dep3',
       },
+      {
+        depName: 'dep4',
+        packageName: 'dep4',
+      },
     ];
 
     const result = processor.process(pyproject, dependencies);
@@ -214,8 +219,14 @@ describe('modules/manager/pep621/processors/uv', () => {
       },
       {
         depName: 'dep3',
-        registryUrls: ['https://baz.com/simple', 'https://pypi.org/pypi/'],
+        depType: depTypes.uvSources,
         packageName: 'dep3',
+        skipReason: 'unknown-registry',
+      },
+      {
+        depName: 'dep4',
+        registryUrls: ['https://baz.com/simple', 'https://pypi.org/pypi/'],
+        packageName: 'dep4',
       },
     ]);
   });

--- a/lib/modules/manager/pep621/processors/uv.spec.ts
+++ b/lib/modules/manager/pep621/processors/uv.spec.ts
@@ -150,6 +150,176 @@ describe('modules/manager/pep621/processors/uv', () => {
     ]);
   });
 
+  it('pinned to non-default index', () => {
+    const pyproject = {
+      tool: {
+        uv: {
+          sources: {
+            dep1: { index: 'foo' },
+            dep2: { index: 'bar' },
+          },
+          index: [
+            {
+              name: 'foo',
+              url: 'https://foo.com/simple',
+              default: false,
+              explicit: true,
+            },
+            {
+              name: 'bar',
+              url: 'https://bar.com/simple',
+              default: false,
+              explicit: true,
+            },
+            {
+              name: 'baz',
+              url: 'https://baz.com/simple',
+              default: false,
+              explicit: false,
+            },
+          ],
+        },
+      },
+    };
+
+    const dependencies = [
+      {
+        depName: 'dep1',
+        packageName: 'dep1',
+      },
+      {
+        depName: 'dep2',
+        packageName: 'dep2',
+      },
+      {
+        depName: 'dep3',
+        packageName: 'dep3',
+      },
+    ];
+
+    const result = processor.process(pyproject, dependencies);
+
+    expect(result).toEqual([
+      {
+        depName: 'dep1',
+        depType: depTypes.uvSources,
+        registryUrls: ['https://foo.com/simple'],
+        packageName: 'dep1',
+      },
+      {
+        depName: 'dep2',
+        depType: depTypes.uvSources,
+        registryUrls: ['https://bar.com/simple'],
+        packageName: 'dep2',
+      },
+      {
+        depName: 'dep3',
+        registryUrls: [
+          'https://baz.com/simple',
+          'https://pypi.org/pypi/'
+        ],
+        packageName: 'dep3',
+      },
+    ]);
+  });
+
+
+it('override implicit default index', () => {
+    const pyproject = {
+      tool: {
+        uv: {
+          index: [
+            {
+              name: 'foo',
+              url: 'https://foo.com/simple',
+              default: true,
+              explicit: false,
+            },
+          ],
+        },
+      },
+    };
+
+    const dependencies = [
+      {
+        depName: 'dep1',
+        packageName: 'dep1',
+      },
+      {
+        depName: 'dep2',
+        packageName: 'dep2',
+      },
+    ];
+
+    const result = processor.process(pyproject, dependencies);
+
+    expect(result).toEqual([
+      {
+        depName: 'dep1',
+        registryUrls: [
+          'https://foo.com/simple',
+        ],
+        packageName: 'dep1',
+      },
+      {
+        depName: 'dep2',
+        registryUrls: [
+          'https://foo.com/simple',
+        ],
+        packageName: 'dep2',
+      },
+    ]);
+  });
+
+it('override explicit default index', () => {
+    const pyproject = {
+      tool: {
+        uv: {
+          sources: {
+            dep1: { index: 'foo' },
+          },
+          index: [
+            {
+              name: 'foo',
+              url: 'https://foo.com/simple',
+              default: true,
+              explicit: true,
+            },
+          ],
+        },
+      },
+    };
+
+    const dependencies = [
+      {
+        depName: 'dep1',
+        packageName: 'dep1',
+      },
+      {
+        depName: 'dep2',
+        packageName: 'dep2',
+      },
+    ];
+
+    const result = processor.process(pyproject, dependencies);
+
+    expect(result).toEqual([
+      {
+        depName: 'dep1',
+        depType: depTypes.uvSources,
+        registryUrls: [
+          'https://foo.com/simple',
+        ],
+        packageName: 'dep1',
+      },
+      {
+        depName: 'dep2',
+        registryUrls: [],
+        packageName: 'dep2',
+      },
+    ]);
+  });
+
   describe('updateArtifacts()', () => {
     it('returns null if there is no lock file', async () => {
       fs.getSiblingFileName.mockReturnValueOnce('uv.lock');
@@ -303,6 +473,11 @@ describe('modules/manager/pep621/processors/uv', () => {
         username: 'user',
         password: 'pass',
       });
+      hostRules.add({
+        matchHost: 'https://pinned.com/simple',
+        username: 'user',
+        password: 'pass',
+      });
       googleAuth.mockImplementationOnce(
         jest.fn().mockImplementationOnce(() => ({
           getAccessToken: jest.fn().mockResolvedValue('some-token'),
@@ -353,6 +528,14 @@ describe('modules/manager/pep621/processors/uv', () => {
             'https://someregion-python.pkg.dev/some-project/some-repo/',
           ],
         },
+        {
+          packageName: 'dep6',
+          depType: depTypes.dependencies,
+          datasource: PypiDatasource.id,
+          registryUrls: [
+            'https://pinned.com/simple',
+          ],
+        },
       ];
       const result = await processor.updateArtifacts(
         {
@@ -361,7 +544,21 @@ describe('modules/manager/pep621/processors/uv', () => {
           config: {},
           updatedDeps,
         },
-        {},
+        {
+          tool: {
+            uv: {
+              sources: {
+                dep6: {index : 'pinned-index'},
+              },
+              index: [{
+                name: 'pinned-index',
+                url: 'https://pinned.com/simple',
+                default: false,
+                explicit: true,
+              }]
+            }
+          }
+        },
       );
       expect(result).toEqual([
         {
@@ -374,10 +571,10 @@ describe('modules/manager/pep621/processors/uv', () => {
       ]);
       expect(execSnapshots).toMatchObject([
         {
-          cmd: 'uv lock --upgrade-package dep1 --upgrade-package dep2 --upgrade-package dep3 --upgrade-package dep4 --upgrade-package dep5',
+          cmd: 'uv lock --upgrade-package dep1 --upgrade-package dep2 --upgrade-package dep3 --upgrade-package dep4 --upgrade-package dep5 --upgrade-package dep6',
           options: {
             env: {
-              GIT_CONFIG_COUNT: '3',
+              GIT_CONFIG_COUNT: '6',
               GIT_CONFIG_KEY_0: 'url.https://user:pass@example.com/.insteadOf',
               GIT_CONFIG_KEY_1: 'url.https://user:pass@example.com/.insteadOf',
               GIT_CONFIG_KEY_2: 'url.https://user:pass@example.com/.insteadOf',
@@ -386,6 +583,8 @@ describe('modules/manager/pep621/processors/uv', () => {
               GIT_CONFIG_VALUE_2: 'https://example.com/',
               UV_EXTRA_INDEX_URL:
                 'https://foobar.com/ https://user:pass@example.com/ https://oauth2accesstoken:some-token@someregion-python.pkg.dev/some-project/some-repo/',
+              UV_INDEX_PINNED_INDEX_USERNAME: "user",
+              UV_INDEX_PINNED_INDEX_PASSWORD: "pass",
             },
           },
         },

--- a/lib/modules/manager/pep621/processors/uv.ts
+++ b/lib/modules/manager/pep621/processors/uv.ts
@@ -64,6 +64,7 @@ export class UvProcessor implements PyProjectProcessor {
         if (depSource) {
           // Dependency is pinned to a specific source.
           dep.depType = depTypes.uvSources;
+          /* istanbul ignore else  */
           if ('index' in depSource) {
             const index = uv.index?.find(
               ({ name }) => name === depSource.index,

--- a/lib/modules/manager/pep621/processors/uv.ts
+++ b/lib/modules/manager/pep621/processors/uv.ts
@@ -103,7 +103,7 @@ export class UvProcessor implements PyProjectProcessor {
             // If there are implicit indexes, check them first and fall back
             // to the default.
             dep.registryUrls = implicitIndexUrls.concat(
-              dep.registryUrls ?? new PypiDatasource().defaultRegistryUrls,
+              dep.registryUrls ?? PypiDatasource.defaultURL,
             );
           }
         }

--- a/lib/modules/manager/pep621/processors/uv.ts
+++ b/lib/modules/manager/pep621/processors/uv.ts
@@ -38,7 +38,7 @@ export class UvProcessor implements PyProjectProcessor {
     const defaultIndex = uv.index?.find(
       (index) => index.default && !index.explicit,
     );
-    const implicitIndexes = uv.index
+    const implicitIndexUrls = uv.index
       ?.filter((index) => !index.explicit && index.name !== defaultIndex?.name)
       ?.map(({ url }) => url);
 
@@ -51,7 +51,7 @@ export class UvProcessor implements PyProjectProcessor {
 
     // https://docs.astral.sh/uv/concepts/dependencies/#dependency-sources
     // Skip sources that do not make sense to handle (e.g. path).
-    if (uv.sources || defaultIndex || implicitIndexes) {
+    if (uv.sources || defaultIndex || implicitIndexUrls) {
       for (const dep of deps) {
         // istanbul ignore if
         if (!dep.packageName) {
@@ -99,11 +99,11 @@ export class UvProcessor implements PyProjectProcessor {
             dep.registryUrls = [defaultIndex.url];
           }
 
-          if (implicitIndexes) {
+          if (implicitIndexUrls) {
             // If there are implicit indexes, check them first and fall back
             // to the default.
-            dep.registryUrls = implicitIndexes.concat(
-              dep.registryUrls ?? 'https://pypi.org/pypi/',
+            dep.registryUrls = implicitIndexUrls.concat(
+              dep.registryUrls ?? new PypiDatasource().defaultRegistryUrls,
             );
           }
         }

--- a/lib/modules/manager/pep621/processors/uv.ts
+++ b/lib/modules/manager/pep621/processors/uv.ts
@@ -32,8 +32,12 @@ export class UvProcessor implements PyProjectProcessor {
       return deps;
     }
 
-    const hasExplicitDefault = uv.index?.some((index) => index.default && index.explicit);
-    const defaultIndex = uv.index?.find((index) => index.default && !index.explicit);
+    const hasExplicitDefault = uv.index?.some(
+      (index) => index.default && index.explicit,
+    );
+    const defaultIndex = uv.index?.find(
+      (index) => index.default && !index.explicit,
+    );
     const implicitIndexes = uv.index
       ?.filter((index) => !index.explicit && index.name !== defaultIndex?.name)
       ?.map(({ url }) => url);
@@ -99,7 +103,7 @@ export class UvProcessor implements PyProjectProcessor {
             // If there are implicit indexes, check them first and fall back
             // to the default.
             dep.registryUrls = implicitIndexes.concat(
-              dep.registryUrls ?? 'https://pypi.org/pypi/'
+              dep.registryUrls ?? 'https://pypi.org/pypi/',
             );
           }
         }

--- a/lib/modules/manager/pep621/processors/uv.ts
+++ b/lib/modules/manager/pep621/processors/uv.ts
@@ -53,13 +53,14 @@ export class UvProcessor implements PyProjectProcessor {
         const depSource = uv.sources[dep.packageName];
         if (depSource) {
           dep.depType = depTypes.uvSources;
-          if ('url' in depSource) {
-            dep.skipReason = 'unsupported-url';
-          } else if ('path' in depSource) {
-            dep.skipReason = 'path-dependency';
-          } else if ('workspace' in depSource) {
-            dep.skipReason = 'inherited-dependency';
-          } else {
+          if ('index' in depSource) {
+            const index = uv.index?.find(
+              ({ name }) => name === depSource.index,
+            );
+            if (index) {
+              dep.registryUrls = [index.url];
+            }
+          } else if ('git' in depSource) {
             applyGitSource(
               dep,
               depSource.git,
@@ -67,6 +68,14 @@ export class UvProcessor implements PyProjectProcessor {
               depSource.tag,
               depSource.branch,
             );
+          } else if ('url' in depSource) {
+            dep.skipReason = 'unsupported-url';
+          } else if ('path' in depSource) {
+            dep.skipReason = 'path-dependency';
+          } else if ('workspace' in depSource) {
+            dep.skipReason = 'inherited-dependency';
+          } else {
+            dep.skipReason = 'unknown-registry';
           }
         }
       }
@@ -132,7 +141,8 @@ export class UvProcessor implements PyProjectProcessor {
 
       const extraEnv = {
         ...getGitEnvironmentVariables(['pep621']),
-        ...(await getUvExtraIndexUrl(updateArtifact.updatedDeps)),
+        ...(await getUvExtraIndexUrl(project, updateArtifact.updatedDeps)),
+        ...(await getUvIndexCredentials(project)),
       };
       const execOptions: ExecOptions = {
         cwdFile: packageFileName,
@@ -217,11 +227,41 @@ function getMatchingHostRule(url: string | undefined): HostRule {
   return find({ hostType: PypiDatasource.id, url });
 }
 
-async function getUvExtraIndexUrl(deps: Upgrade[]): Promise<NodeJS.ProcessEnv> {
+async function getUsernamePassword(
+  url: URL,
+): Promise<{ username?: string; password?: string }> {
+  const rule = getMatchingHostRule(url.toString());
+  if (rule.username || rule.password) {
+    return rule;
+  }
+
+  if (url.hostname.endsWith('.pkg.dev')) {
+    const accessToken = await getGoogleAuthTokenRaw();
+    if (accessToken) {
+      return {
+        username: 'oauth2accesstoken',
+        password: accessToken,
+      };
+    } else {
+      logger.once.debug({ url }, 'Could not get Google access token');
+    }
+  }
+
+  return {};
+}
+
+async function getUvExtraIndexUrl(
+  project: PyProject,
+  deps: Upgrade[],
+): Promise<NodeJS.ProcessEnv> {
   const pyPiRegistryUrls = deps
     .filter((dep) => dep.datasource === PypiDatasource.id)
-    .map((dep) => dep.registryUrls)
-    .flat();
+    .filter((dep) => {
+      // Remove dependencies that are pinned to a specific index
+      const sources = project.tool?.uv?.sources;
+      return !sources || !(dep.packageName! in sources);
+    })
+    .flatMap((dep) => dep.registryUrls);
   const registryUrls = new Set(pyPiRegistryUrls);
   const extraIndexUrls: string[] = [];
 
@@ -231,21 +271,13 @@ async function getUvExtraIndexUrl(deps: Upgrade[]): Promise<NodeJS.ProcessEnv> {
       continue;
     }
 
-    const rule = getMatchingHostRule(parsedUrl.toString());
-    if (rule.username || rule.password) {
-      if (rule.username) {
-        parsedUrl.username = rule.username;
+    const { username, password } = await getUsernamePassword(parsedUrl);
+    if (username || password) {
+      if (username) {
+        parsedUrl.username = username;
       }
-      if (rule.password) {
-        parsedUrl.password = rule.password;
-      }
-    } else if (parsedUrl.hostname.endsWith('.pkg.dev')) {
-      const accessToken = await getGoogleAuthTokenRaw();
-      if (accessToken) {
-        parsedUrl.username = 'oauth2accesstoken';
-        parsedUrl.password = accessToken;
-      } else {
-        logger.once.debug({ registryUrl }, 'Could not get Google access token');
+      if (password) {
+        parsedUrl.password = password;
       }
     }
 
@@ -255,4 +287,38 @@ async function getUvExtraIndexUrl(deps: Upgrade[]): Promise<NodeJS.ProcessEnv> {
   return {
     UV_EXTRA_INDEX_URL: extraIndexUrls.join(' '),
   };
+}
+
+async function getUvIndexCredentials(
+  project: PyProject,
+): Promise<NodeJS.ProcessEnv> {
+  const uv_indexes = project.tool?.uv?.index;
+
+  if (is.nullOrUndefined(uv_indexes)) {
+    return {};
+  }
+
+  const entries = [];
+
+  for (const { name, url } of uv_indexes) {
+    const parsedUrl = parseUrl(url);
+    // istanbul ignore if
+    if (!parsedUrl) {
+      continue;
+    }
+
+    const { username, password } = await getUsernamePassword(parsedUrl);
+
+    const NAME = name.toUpperCase().replace(/[^A-Z0-9]/g, '_');
+
+    if (username) {
+      entries.push([`UV_INDEX_${NAME}_USERNAME`, username]);
+    }
+
+    if (password) {
+      entries.push([`UV_INDEX_${NAME}_PASSWORD`, password]);
+    }
+  }
+
+  return Object.fromEntries(entries);
 }

--- a/lib/modules/manager/pep621/processors/uv.ts
+++ b/lib/modules/manager/pep621/processors/uv.ts
@@ -64,7 +64,6 @@ export class UvProcessor implements PyProjectProcessor {
         if (depSource) {
           // Dependency is pinned to a specific source.
           dep.depType = depTypes.uvSources;
-          /* istanbul ignore else  */
           if ('index' in depSource) {
             const index = uv.index?.find(
               ({ name }) => name === depSource.index,

--- a/lib/modules/manager/pep621/schema.ts
+++ b/lib/modules/manager/pep621/schema.ts
@@ -36,6 +36,10 @@ const HatchSchema = z.object({
     .optional(),
 });
 
+const UvIndexSource = z.object({
+  index: z.string(),
+});
+
 const UvGitSource = z.object({
   git: z.string(),
   rev: z.string().optional(),
@@ -58,6 +62,7 @@ const UvWorkspaceSource = z.object({
 
 // https://docs.astral.sh/uv/concepts/dependencies/#dependency-sources
 const UvSource = z.union([
+  UvIndexSource,
   UvGitSource,
   UvUrlSource,
   UvPathSource,
@@ -71,6 +76,16 @@ const UvSchema = z.object({
     z.string().transform((source) => normalizePythonDepName(source)),
     UvSource,
   ).optional(),
+  index: z
+    .array(
+      z.object({
+        name: z.string(),
+        url: z.string(),
+        default: z.boolean().default(false),
+        explicit: z.boolean().default(false),
+      }),
+    )
+    .optional(),
 });
 
 export const PyProjectSchema = z.object({


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Add support for `tool.uv.index` configurations and pinning dependencies to them.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

fixes #32265 

- https://docs.astral.sh/uv/configuration/indexes/
- https://docs.astral.sh/uv/concepts/projects/dependencies/#index

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
