### PR TITLE
docs(gradle): add a section about Gradle plugin support

### DIFF
--- a/docs/usage/java.md
+++ b/docs/usage/java.md
@@ -48,16 +48,15 @@ Renovate does not support:
 
 ### Gradle Plugin Support
 
-Renovate can also update [Gradle plugins](https://docs.gradle.org/current/userguide/plugins.html). It supports the
-`id(<pluginId>)` syntax as well as the `kotlin(<kotlinPluginId>)` shortcut for `id(org.jetbrains.kotlin.<kotlinPluginId>)`.
+Renovate can also update [Gradle plugins](https://docs.gradle.org/current/userguide/plugins.html).
+It supports the `id(<pluginId>)` syntax as well as the `kotlin(<kotlinPluginId>)` shortcut for `id(org.jetbrains.kotlin.<kotlinPluginId>)`.
 
 For specifying `packageRules` it is important to know how `depName` and `packageName` are defined for a Gradle plugin:
 
 - The `depName` field is equal to `<pluginId>`
 - The `packageName` field is equal to `<pluginId>:<pluginId>.gradle.plugin`
 
-This is a direct consequence of the [Plugin Marker Artifact](https://docs.gradle.org/current/userguide/plugins.html#sec:plugin_markers)
-naming convention.
+This is a direct consequence of the [Plugin Marker Artifact](https://docs.gradle.org/current/userguide/plugins.html#sec:plugin_markers) naming convention.
 
 ## Gradle Wrapper
 

--- a/docs/usage/java.md
+++ b/docs/usage/java.md
@@ -46,6 +46,19 @@ Renovate does not support:
 - Catalogs with custom names that do not end in `.toml`
 - Catalogs outside the `gradle` folder whose names do not end in `.versions.toml` (unless overridden via [`fileMatch`](./configuration-options.md#filematch) configuration)
 
+### Gradle Plugin Support
+
+Renovate can also update [Gradle plugins](https://docs.gradle.org/current/userguide/plugins.html). It supports the
+`id(<pluginId>)` syntax as well as the `kotlin(<kotlinPluginId>)` shortcut for `id(org.jetbrains.kotlin.<kotlinPluginId>)`.
+
+For specifying `packageRules` it is important to know how `depName` and `packageName` are defined for a Gradle plugin:
+
+- The `depName` field is equal to `<pluginId>`
+- The `packageName` field is equal to `<pluginId>:<pluginId>.gradle.plugin`
+
+This is a direct consequence of the [Plugin Marker Artifact](https://docs.gradle.org/current/userguide/plugins.html#sec:plugin_markers)
+naming convention.
+
 ## Gradle Wrapper
 
 Renovate can update the [Gradle Wrapper](https://docs.gradle.org/current/userguide/gradle_wrapper.html) of a project.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Add some information about Gradle plugin support.

<!-- Describe what behavior is changed by this PR. -->

## Context

It wasn't really obvious to me which value I need to use in `matchPackageNames` for Gradle plugins. So I thought I might document my findings in a prominent place to help others. I'm no native speaker, so feel free to give me any feedback about the spelling or wording.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
