### PR TITLE
feat(manager/flux): Allow OCI media type used by `flux push artifact` to enable Release Notes lookup

### DIFF
--- a/lib/modules/datasource/docker/schema.spec.ts
+++ b/lib/modules/datasource/docker/schema.spec.ts
@@ -152,6 +152,60 @@ describe('modules/datasource/docker/schema', () => {
     });
   });
 
+  it('parses OCI flux artifact', () => {
+    const manifest = {
+      schemaVersion: 2,
+      mediaType: 'application/vnd.oci.image.manifest.v1+json',
+      config: {
+        mediaType: 'application/vnd.cncf.flux.config.v1+json',
+        digest:
+          'sha256:7cd37ea18409c76d241ad0d4ed484e206275be3535782be144ae257d54dd8d50',
+        size: 233,
+      },
+      layers: [
+        {
+          mediaType: 'application/vnd.cncf.flux.content.v1.tar+gzip',
+          digest:
+            'sha256:243a01363756cd6bc04243680d4c9aeac274523f298f9525823db9ae7e188a3c',
+          size: 1113,
+        },
+      ],
+      annotations: {
+        'org.opencontainers.image.source':
+          'https://github.com/renovatebot/renovate',
+      },
+    };
+    expect(OciImageManifest.parse(manifest)).toMatchObject({
+      schemaVersion: 2,
+      mediaType: 'application/vnd.oci.image.manifest.v1+json',
+      config: {
+        mediaType: 'application/vnd.cncf.flux.config.v1+json',
+        digest:
+          'sha256:7cd37ea18409c76d241ad0d4ed484e206275be3535782be144ae257d54dd8d50',
+        size: 233,
+      },
+      annotations: {
+        'org.opencontainers.image.source':
+          'https://github.com/renovatebot/renovate',
+      },
+    });
+
+    expect(Manifest.parse(manifest)).toMatchObject({
+      schemaVersion: 2,
+      mediaType: 'application/vnd.oci.image.manifest.v1+json',
+      config: {
+        mediaType: 'application/vnd.cncf.flux.config.v1+json',
+        digest:
+          'sha256:7cd37ea18409c76d241ad0d4ed484e206275be3535782be144ae257d54dd8d50',
+        size: 233,
+      },
+      annotations: {
+        'org.opencontainers.image.source':
+          'https://github.com/renovatebot/renovate',
+      },
+    });
+  });
+
   it('parses distribution manifest', () => {
     const manifest = {
       schemaVersion: 2,

--- a/lib/modules/datasource/docker/schema.ts
+++ b/lib/modules/datasource/docker/schema.ts
@@ -69,6 +69,7 @@ export const OciImageManifest = ManifestObject.extend({
       'application/vnd.cncf.helm.config.v1+json',
       'application/vnd.devcontainers',
       'application/vnd.oci.empty.v1+json',
+      'application/vnd.cncf.flux.config.v1+json',
     ]),
   }),
   annotations: z.record(z.string()).nullish(),


### PR DESCRIPTION
## Changes

Adds an additional OCIManifest config media type `application/vnd.cncf.flux.config.v1+json`, which is used by [`flux push artifact`](https://fluxcd.io/flux/cmd/flux_push_artifact/). Without this, renovate fails to lookup the manifest and in turn cannot fetch information like the `sourceUrl` that is set in the manifest annotation.

## Context

`flux push artifact` can be used to push `Kustomize` manifests to an OCI registry, where they can be pulled with the `OCIRepository` CustomResourceDefinition. Renovate supports updating these references, but does not provide any release notes in the PR. With this change it can.

<details>
<summary> Error without this change</summary>

```
DEBUG: Invalid manifest response (repository=maboehm/test-renovate-flux-oci)
       "registry": "https://ghcr.io",
       "dockerRepository": "stefanprodan/manifests/podinfo",
       "tag": "latest",
       "body": "{\"schemaVersion\":2,\"mediaType\":\"application/vnd.oci.image.manifest.v1+json\",\"config\":{\"mediaType\":\"application/vnd.cncf.flux.config.v1+json\",\"size\":233,\"digest\":\"sha256:7cd37ea18409c76d241ad0d4ed484e206275be3535782be144ae257d54dd8d50\"},\"layers\":[{\"mediaType\":\"application/vnd.cncf.flux.content.v1.tar+gzip\",\"size\":1113,\"digest\":\"sha256:243a01363756cd6bc04243680d4c9aeac274523f298f9525823db9ae7e188a3c\"}],\"annotations\":{\"org.opencontainers.image.created\":\"2024-10-08T09:02:04Z\",\"org.opencontainers.image.revision\":\"6.7.1/6b7aab8a10d6ee8b895b0a5048f4ab0966ed29ff\",\"org.opencontainers.image.source\":\"https://github.com/stefanprodan/podinfo\"}}",
       "headers": {
         "content-length": "639",
         "content-type": "application/vnd.oci.image.manifest.v1+json",
         "docker-content-digest": "sha256:efff1a4f48b85359f2a1440e29e64a6da105b45303c2c00e8f1e3da39354707c",
         "docker-distribution-api-version": "registry/2.0",
         "etag": "\"sha256:efff1a4f48b85359f2a1440e29e64a6da105b45303c2c00e8f1e3da39354707c\"",
         "date": "Thu, 28 Nov 2024 13:07:48 GMT",
         "x-github-request-id": "B562:43F83:D9AA3A:DDEB42:67486B24"
       },
       "err": {
         "message": "Schema error",
         "stack": "ZodError: Schema error\n    at Object.get error [as error] (/workspaces/renovate/node_modules/.pnpm/zod@3.23.8/node_modules/zod/lib/types.js:55:31)\n    at DockerDatasource.getManifest (/workspaces/renovate/lib/modules/datasource/docker/index.ts:308:23)\n    at processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at async DockerDatasource.getLabels (/workspaces/renovate/lib/modules/datasource/docker/index.ts:478:24)\n    at async /workspaces/renovate/lib/util/cache/package/decorator.ts:134:20\n    at async DockerDatasource.getReleases (/workspaces/renovate/lib/modules/datasource/docker/index.ts:1106:20)\n    at async getRegistryReleases (/workspaces/renovate/lib/modules/datasource/index.ts:85:15)\n    at async fetchReleases (/workspaces/renovate/lib/modules/datasource/index.ts:318:15)\n    at async lookupUpdates (/workspaces/renovate/lib/workers/repository/process/lookup/index.ts:140:56)\n    at async Function.wrap (/workspaces/renovate/lib/util/stats.ts:38:20)\n    at async fetchDepUpdates (/workspaces/renovate/lib/workers/repository/process/fetch.ts:58:42)\n    at async /workspaces/renovate/lib/workers/repository/process/fetch.ts:104:23\n    at async /workspaces/renovate/node_modules/.pnpm/p-map@4.0.0/node_modules/p-map/index.js:57:22",
         "issues": {
           "config": {
             "mediaType": "Invalid enum value. Expected 'application/vnd.oci.image.config.v1+json' | 'application/vnd.cncf.helm.config.v1+json' | 'application/vnd.devcontainers' | 'application/vnd.oci.empty.v1+json', received 'application/vnd.cncf.flux.config.v1+json'"
           }
         }
       }
```
</details>

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

This example repo and PR was created to demonstrate this: The PR was created with the latest version of renovate, and then updated with a run that included these changes. https://github.com/maboehm/test-renovate-flux-oci/pull/1