### PR TITLE
refactor: Rename `unwrapOrElse` to `unwrapOr` for `Result` utility

### DIFF
--- a/lib/modules/datasource/rubygems/common.ts
+++ b/lib/modules/datasource/rubygems/common.ts
@@ -39,6 +39,6 @@ export function getV1Releases(
   return http.getJsonSafe(versionsUrl, GemVersions).transform((releaseResult) =>
     getV1Metadata(http, registryUrl, packageName)
       .transform((metadata) => assignMetadata(releaseResult, metadata))
-      .unwrapOrElse(releaseResult),
+      .unwrapOr(releaseResult),
   );
 }

--- a/lib/modules/manager/pep621/processors/pdm.ts
+++ b/lib/modules/manager/pep621/processors/pdm.ts
@@ -77,7 +77,7 @@ export class PdmProcessor implements PyProjectProcessor {
       const lockFileMapping = Result.parse(
         lockFileContent,
         PdmLockfileSchema.transform(({ lock }) => lock),
-      ).unwrapOrElse({});
+      ).unwrapOr({});
 
       for (const dep of deps) {
         const packageName = dep.packageName;

--- a/lib/modules/manager/poetry/extract.ts
+++ b/lib/modules/manager/poetry/extract.ts
@@ -30,7 +30,7 @@ export async function extractPackageFile(
   const lockfileMapping = Result.parse(
     lockContents,
     Lockfile.transform(({ lock }) => lock),
-  ).unwrapOrElse({});
+  ).unwrapOr({});
 
   let pythonVersion: string | undefined;
   filterMap(res.deps, (dep) => {

--- a/lib/modules/manager/poetry/update-locked.ts
+++ b/lib/modules/manager/poetry/update-locked.ts
@@ -20,5 +20,5 @@ export function updateLockedDependency(
           ? { status: 'already-updated' }
           : { status: 'unsupported' },
     )
-    .unwrapOrElse({ status: 'unsupported' });
+    .unwrapOr({ status: 'unsupported' });
 }

--- a/lib/util/result.spec.ts
+++ b/lib/util/result.spec.ts
@@ -124,22 +124,22 @@ describe('util/result', () => {
 
       it('skips fallback for successful value', () => {
         const res: Result<number> = Result.ok(42);
-        expect(res.unwrapOrElse(-1)).toBe(42);
+        expect(res.unwrapOr(-1)).toBe(42);
       });
 
       it('uses fallback for error value', () => {
         const res: Result<number, string> = Result.err('oops');
-        expect(res.unwrapOrElse(42)).toBe(42);
+        expect(res.unwrapOr(42)).toBe(42);
       });
 
-      it('unwrapOrElse throws uncaught transform error', () => {
+      it('unwrapOr throws uncaught transform error', () => {
         const res = Result.ok(42);
         expect(() =>
           res
             .transform(() => {
               throw 'oops';
             })
-            .unwrapOrElse(0),
+            .unwrapOr(0),
         ).toThrow('oops');
       });
 
@@ -408,12 +408,12 @@ describe('util/result', () => {
 
       it('skips fallback for successful AsyncResult', async () => {
         const res = Result.wrap(Promise.resolve(42));
-        await expect(res.unwrapOrElse(0)).resolves.toBe(42);
+        await expect(res.unwrapOr(0)).resolves.toBe(42);
       });
 
       it('uses fallback for error AsyncResult', async () => {
         const res = Result.wrap(Promise.reject('oops'));
-        await expect(res.unwrapOrElse(42)).resolves.toBe(42);
+        await expect(res.unwrapOr(42)).resolves.toBe(42);
       });
 
       it('returns ok-value for unwrapOrThrow', async () => {

--- a/lib/util/result.ts
+++ b/lib/util/result.ts
@@ -337,12 +337,12 @@ export class Result<T extends Val, E extends Val = Error> {
    *
    *   ```ts
    *
-   *   const value = Result.err('bar').unwrapOrElse('foo');
+   *   const value = Result.err('bar').unwrapOr('foo');
    *   expect(val).toBe('foo');
    *
    *   ```
    */
-  unwrapOrElse(fallback: T): T {
+  unwrapOr(fallback: T): T {
     if (this.res.ok) {
       return this.res.val;
     }
@@ -706,14 +706,14 @@ export class AsyncResult<T extends Val, E extends Val>
    *
    *   ```ts
    *
-   *   const val = await Result.wrap(readFile('foo.txt')).unwrapOrElse('bar');
+   *   const val = await Result.wrap(readFile('foo.txt')).unwrapOr('bar');
    *   expect(val).toBe('bar');
    *   expect(err).toBeUndefined();
    *
    *   ```
    */
-  unwrapOrElse(fallback: T): Promise<T> {
-    return this.asyncResult.then<T>((res) => res.unwrapOrElse(fallback));
+  unwrapOr(fallback: T): Promise<T> {
+    return this.asyncResult.then<T>((res) => res.unwrapOr(fallback));
   }
 
   /**


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
