### PR TITLE
fix(datasource/conan): updated default url

### DIFF
--- a/lib/modules/datasource/conan/common.ts
+++ b/lib/modules/datasource/conan/common.ts
@@ -1,7 +1,7 @@
 import { regEx } from '../../../util/regex';
 import type { ConanPackage } from './types';
 
-export const defaultRegistryUrl = 'https://center.conan.io/';
+export const defaultRegistryUrl = 'https://center2.conan.io/';
 
 export const datasource = 'conan';
 

--- a/lib/modules/datasource/conan/index.spec.ts
+++ b/lib/modules/datasource/conan/index.spec.ts
@@ -191,7 +191,7 @@ describe('modules/datasource/conan/index', () => {
           packageName: 'poco/1.2@_/_',
         }),
       ).toEqual({
-        registryUrl: 'https://center.conan.io',
+        registryUrl: 'https://center2.conan.io',
         releases: [
           {
             version: '1.8.1',


### PR DESCRIPTION
the old url will not receive updates, see here[0] for more infos

[0] https://blog.conan.io/2024/09/30/Conan-Center-will-stop-receiving-updates-for-Conan-1.html

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

update the url for conancenter, the old url will not receive updates, see here[0] for more infos

[0] https://blog.conan.io/2024/09/30/Conan-Center-will-stop-receiving-updates-for-Conan-1.html

## Context

see above

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
