### PR TITLE
fix(gerrit): `getBranchStatus` not returning `red` for failed checks

### DIFF
--- a/lib/modules/platform/gerrit/client.ts
+++ b/lib/modules/platform/gerrit/client.ts
@@ -18,7 +18,7 @@ const QUOTES_REGEX = regEx('"', 'g');
 class GerritClient {
   private requestDetails = [
     'SUBMITTABLE', //include the submittable field in ChangeInfo, which can be used to tell if the change is reviewed and ready for submit.
-    'CHECK', // include potential problems with the change.
+    'CHECK', // include potential consistency problems with the change (not related to labels)
     'MESSAGES',
     'DETAILED_ACCOUNTS',
     'LABELS',

--- a/lib/modules/platform/gerrit/index.ts
+++ b/lib/modules/platform/gerrit/index.ts
@@ -258,6 +258,13 @@ export async function getBranchStatus(
     if (hasProblems) {
       return 'red';
     }
+    const hasBlockingLabels =
+      changes.filter((change) =>
+        Object.values(change.labels ?? {}).some((label) => label.blocking),
+      ).length > 0;
+    if (hasBlockingLabels) {
+      return 'red';
+    }
   }
   return 'yellow';
 }
@@ -284,11 +291,12 @@ export async function getBranchStatusCheck(
     if (change) {
       const labelRes = change.labels?.[context];
       if (labelRes) {
-        if (labelRes.approved) {
-          return 'green';
-        }
+        // Check for rejected first, as a label could have both rejected and approved
         if (labelRes.rejected) {
           return 'red';
+        }
+        if (labelRes.approved) {
+          return 'green';
         }
       }
     }

--- a/lib/modules/platform/gerrit/types.ts
+++ b/lib/modules/platform/gerrit/types.ts
@@ -77,6 +77,8 @@ export interface GerritChangeMessageInfo {
 export interface GerritLabelInfo {
   approved?: GerritAccountInfo;
   rejected?: GerritAccountInfo;
+  /** If true, the label blocks submit operation. If not set, the default is false. */
+  blocking?: boolean;
 }
 
 export interface GerritActionInfo {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Fix `getBranchStatus` not returning `red` in case of failed CI checks.

The previous implementation was relying on the presence of `problems`, which is improper, given `problems` will only be set if the change has some Gerrit internal inconsistency, completely unrelated to CI checks ([ref](https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#problem-info)).

This fixes the issue where reviewers were never being added to a change with auto-merge enabled but failed CI checks. But potentially fixes other issues as well.

This change also fixes a minor issue with `getBranchStatusCheck`, where it considers a check `green` in case both an approved and rejected result is return. In my opinion, rejected should have higher importance in this case and thus turn the status check into `red`.

<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

I self-host Renovate with Gerrit and realized this issue after noticing that the reviewers were not being added to auto-merge changes with failed CI checks.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
