### PR TITLE
feat(gerrit): Reduce email notifications

### DIFF
--- a/lib/modules/platform/gerrit/client.spec.ts
+++ b/lib/modules/platform/gerrit/client.spec.ts
@@ -243,6 +243,7 @@ describe('modules/platform/gerrit/client', () => {
         .post('/a/changes/123456/revisions/current/review', {
           message: 'message',
           tag: 'tag',
+          notify: 'NONE',
         })
         .reply(200, gerritRestResponse([]), jsonResultHeader);
       await expect(client.addMessage(123456, 'message', 'tag')).toResolve();
@@ -253,6 +254,7 @@ describe('modules/platform/gerrit/client', () => {
         .scope(gerritEndpointUrl)
         .post('/a/changes/123456/revisions/current/review', {
           message: 'message',
+          notify: 'NONE',
         })
         .reply(200, gerritRestResponse([]), jsonResultHeader);
       await expect(client.addMessage(123456, 'message')).toResolve();
@@ -265,6 +267,7 @@ describe('modules/platform/gerrit/client', () => {
         .scope(gerritEndpointUrl)
         .post('/a/changes/123456/revisions/current/review', {
           message: okMessage,
+          notify: 'NONE',
         })
         .reply(200, gerritRestResponse([]), jsonResultHeader);
       await expect(client.addMessage(123456, tooBigMessage)).toResolve();
@@ -311,6 +314,7 @@ describe('modules/platform/gerrit/client', () => {
         .post('/a/changes/123456/revisions/current/review', {
           message: 'new trimmed message',
           tag: 'TAG',
+          notify: 'NONE',
         })
         .reply(200, gerritRestResponse([]), jsonResultHeader);
 
@@ -347,6 +351,7 @@ describe('modules/platform/gerrit/client', () => {
         .scope(gerritEndpointUrl)
         .post('/a/changes/123456/revisions/current/review', {
           labels: { 'Code-Review': 2 },
+          notify: 'NONE',
         })
         .reply(200, gerritRestResponse([]), jsonResultHeader);
       await expect(client.setLabel(123456, 'Code-Review', +2)).toResolve();
@@ -357,11 +362,12 @@ describe('modules/platform/gerrit/client', () => {
     it('add', async () => {
       httpMock
         .scope(gerritEndpointUrl)
-        .post('/a/changes/123456/reviewers', {
-          reviewer: 'username',
+        .post('/a/changes/123456/revisions/current/review', {
+          reviewers: [{ reviewer: 'user1' }, { reviewer: 'user2' }],
+          notify: 'OWNER_REVIEWERS',
         })
         .reply(200, gerritRestResponse([]), jsonResultHeader);
-      await expect(client.addReviewer(123456, 'username')).toResolve();
+      await expect(client.addReviewers(123456, ['user1', 'user2'])).toResolve();
     });
   });
 
@@ -421,6 +427,7 @@ describe('modules/platform/gerrit/client', () => {
         .scope(gerritEndpointUrl)
         .post('/a/changes/123456/revisions/current/review', {
           labels: { 'Code-Review': +2 },
+          notify: 'NONE',
         })
         .reply(200, gerritRestResponse(''), jsonResultHeader);
       await expect(client.approveChange(123456)).toResolve();

--- a/lib/modules/platform/gerrit/client.ts
+++ b/lib/modules/platform/gerrit/client.ts
@@ -114,7 +114,7 @@ class GerritClient {
     const message = this.normalizeMessage(fullMessage);
     await this.gerritHttp.postJson(
       `a/changes/${changeNumber}/revisions/current/review`,
-      { body: { message, tag } },
+      { body: { message, tag, notify: 'NONE' } },
     );
   }
 
@@ -149,18 +149,25 @@ class GerritClient {
   ): Promise<void> {
     await this.gerritHttp.postJson(
       `a/changes/${changeNumber}/revisions/current/review`,
-      { body: { labels: { [label]: value } } },
+      { body: { labels: { [label]: value }, notify: 'NONE' } },
     );
   }
 
-  async addReviewer(changeNumber: number, reviewer: string): Promise<void> {
-    await this.gerritHttp.postJson(`a/changes/${changeNumber}/reviewers`, {
-      body: { reviewer },
-    });
+  async addReviewers(changeNumber: number, reviewers: string[]): Promise<void> {
+    await this.gerritHttp.postJson(
+      `a/changes/${changeNumber}/revisions/current/review`,
+      {
+        body: {
+          reviewers: reviewers.map((r) => ({ reviewer: r })),
+          notify: 'OWNER_REVIEWERS', // Avoids notifying cc's
+        },
+      },
+    );
   }
 
   async addAssignee(changeNumber: number, assignee: string): Promise<void> {
     await this.gerritHttp.putJson<GerritAccountInfo>(
+      // TODO: refactor this as this API removed in Gerrit 3.8
       `a/changes/${changeNumber}/assignee`,
       {
         body: { assignee },

--- a/lib/modules/platform/gerrit/index.spec.ts
+++ b/lib/modules/platform/gerrit/index.spec.ts
@@ -610,17 +610,11 @@ describe('modules/platform/gerrit/index', () => {
       await expect(
         gerrit.addReviewers(123456, ['user1', 'user2']),
       ).resolves.toBeUndefined();
-      expect(clientMock.addReviewer).toHaveBeenCalledTimes(2);
-      expect(clientMock.addReviewer).toHaveBeenNthCalledWith(
-        1,
-        123456,
+      expect(clientMock.addReviewers).toHaveBeenCalledTimes(1);
+      expect(clientMock.addReviewers).toHaveBeenCalledWith(123456, [
         'user1',
-      );
-      expect(clientMock.addReviewer).toHaveBeenNthCalledWith(
-        2,
-        123456,
         'user2',
-      );
+      ]);
     });
   });
 

--- a/lib/modules/platform/gerrit/index.ts
+++ b/lib/modules/platform/gerrit/index.ts
@@ -340,9 +340,7 @@ export async function addReviewers(
   number: number,
   reviewers: string[],
 ): Promise<void> {
-  for (const reviewer of reviewers) {
-    await client.addReviewer(number, reviewer);
-  }
+  await client.addReviewers(number, reviewers);
 }
 
 /**

--- a/lib/modules/platform/gerrit/scm.spec.ts
+++ b/lib/modules/platform/gerrit/scm.spec.ts
@@ -314,7 +314,7 @@ describe('modules/platform/gerrit/scm', () => {
       expect(git.pushCommit).toHaveBeenCalledWith({
         files: [],
         sourceRef: 'renovate/dependency-1.x',
-        targetRef: 'refs/for/main',
+        targetRef: 'refs/for/main%notify=NONE',
       });
     });
 
@@ -402,7 +402,7 @@ describe('modules/platform/gerrit/scm', () => {
       expect(git.pushCommit).toHaveBeenCalledWith({
         files: [],
         sourceRef: 'renovate/dependency-1.x',
-        targetRef: 'refs/for/main',
+        targetRef: 'refs/for/main%notify=NONE',
       });
       expect(clientMock.wasApprovedBy).toHaveBeenCalledWith(
         existingChange,

--- a/lib/modules/platform/gerrit/scm.ts
+++ b/lib/modules/platform/gerrit/scm.ts
@@ -131,7 +131,7 @@ export class GerritScm extends DefaultGitScm {
       if (hasChanges || commit.force) {
         const pushResult = await git.pushCommit({
           sourceRef: commit.branchName,
-          targetRef: `refs/for/${commit.baseBranch!}`,
+          targetRef: `refs/for/${commit.baseBranch!}%notify=NONE`,
           files: commit.files,
         });
         if (pushResult) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This PR will reduce the number of email notifications sent as result of some Renovate operation when using the Gerrit platform.

Here are the operations that will no longer send email notifications:

- When rebasing a change (i.e. pushing a new patchset)
- When auto-approving (not auto-merging) a change (i.e. voting with Code-Review +2)
- When posting a comment/message (e.g. when posting pr body)

Here are the operations that will still send email notifications:

- When adding someone as a reviewer of a change

  However this operation was refactored to avoid calling one Gerrit API for each reviewer, instead it calls the API once with all reviewers. This also means that the email notification will be sent only once, instead of one email per reviewer.

Unrelated, but this PR also adds a comment about an API that was removed by Gerrit 3.8 (`/assignee`). It doesn't fix the problem but at least makes us aware of it.

<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
