### PR TITLE
feat(presets): add TanStack/form monorepo

### DIFF
--- a/lib/data/monorepo.json
+++ b/lib/data/monorepo.json
@@ -505,6 +505,7 @@
     "swashbuckle-aspnetcore": "https://github.com/domaindrivendev/Swashbuckle.AspNetCore",
     "system.io.abstractions": "https://github.com/System-IO-Abstractions/System.IO.Abstractions/",
     "tamagui": "https://github.com/tamagui/tamagui",
+    "tanstack-form": "https://github.com/TanStack/form",
     "tanstack-query": "https://github.com/TanStack/query",
     "tanstack-router": "https://github.com/TanStack/router",
     "tanstack-table": "https://github.com/TanStack/table",


### PR DESCRIPTION
## Changes

Adds TanStack Form to the List of Monorepos:

- https://tanstack.com/form
- https://github.com/tanstack/form

## Context

Currently updates of packages in this monorepo are presented as separate updates even with `group:monorepos` configured:

Example: 
```
* [ ] Update dependency @tanstack/react-form to ^0.39.0
* [ ] Update dependency @tanstack/zod-form-adapter to ^0.39.0
```

This is an nx-monorepo and the packages can be found here: https://github.com/TanStack/form/tree/main/packages

These should be grouped like this:
```
* [] Update tanstack-form monorepo to ^0.39.0
```

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository