### PR TITLE
feat(presets): add vaddin/hilla monorepo

### DIFF
--- a/lib/data/monorepo.json
+++ b/lib/data/monorepo.json
@@ -540,7 +540,7 @@
     "unhead": "https://github.com/unjs/unhead",
     "unocss": "https://github.com/unocss/unocss",
     "uppy": "https://github.com/transloadit/uppy",
-    "vaadinHilla": "https://github.com/vaadin/hilla",
+    "vaadin-hilla": "https://github.com/vaadin/hilla",
     "vaadinWebComponents": "https://github.com/vaadin/web-components",
     "visx": "https://github.com/airbnb/visx",
     "vitest": "https://github.com/vitest-dev/vitest",

--- a/lib/data/monorepo.json
+++ b/lib/data/monorepo.json
@@ -540,6 +540,7 @@
     "unhead": "https://github.com/unjs/unhead",
     "unocss": "https://github.com/unocss/unocss",
     "uppy": "https://github.com/transloadit/uppy",
+    "vaadinHilla": "https://github.com/vaadin/hilla",
     "vaadinWebComponents": "https://github.com/vaadin/web-components",
     "visx": "https://github.com/airbnb/visx",
     "vitest": "https://github.com/vitest-dev/vitest",


### PR DESCRIPTION
## Changes

Adds Vaadin/Hilla to the List of Monorepos:

- https://github.com/vaadin/hilla

## Context

Currently updates of packages in this monorepo are presented as separate updates even with `group:monorepos` configured.

This is an nx-monorepo and the packages can be found here: https://github.com/vaadin/hilla/tree/main/packages

❗ there is a mix of "typescript" and "java" dependencies

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository