### PR TITLE
feat(replacements): framer-motion to motion

### DIFF
--- a/lib/data/replacements.json
+++ b/lib/data/replacements.json
@@ -16,6 +16,7 @@
       "replacements:eslint-plugin-vitest-to-scoped",
       "replacements:fakerjs-to-scoped",
       "replacements:fastify-to-scoped",
+      "replacements:framer-motion-to-motion",
       "replacements:hapi-to-scoped",
       "replacements:jade-to-pug",
       "replacements:joi-to-scoped",
@@ -667,6 +668,18 @@
         "matchPackageNames": ["fastify-zipkin"],
         "replacementName": "@fastify/zipkin",
         "replacementVersion": "3.0.0"
+      }
+    ]
+  },
+  "framer-motion-to-motion": {
+    "description": "`framer-motion` and Motion One have merged under the package name `motion`, though `framer-motion` is still being published. `motion` is now the recommended name.",
+    "packageRules": [
+      {
+        "matchCurrentVersion": ">=11.11.12",
+        "matchDatasources": ["npm"],
+        "matchPackageNames": ["framer-motion"],
+        "replacementName": "motion",
+        "replacementVersion": "11.11.12"
       }
     ]
   },


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Created a replacement rule for `framer-motion` with its continuation package `motion`.

## Context

The package has been published as `motion` since version 11.11.12 following the merger between Framer Motion and Motion One.

Proof:
* Package documentation: https://www.npmjs.com/package/motion
* Official announcement: https://motion.dev/blog/framer-motion-is-now-independent-introducing-motion

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
