### PR TITLE
feat: apply `ignorePresets` when resolving the `globalExtends` array

### DIFF
--- a/lib/workers/global/index.ts
+++ b/lib/workers/global/index.ts
@@ -96,10 +96,11 @@ export async function validatePresets(config: AllConfig): Promise<void> {
 
 export async function resolveGlobalExtends(
   globalExtends: string[],
+  ignorePresets?: string[],
 ): Promise<AllConfig> {
   try {
     // Make a "fake" config to pass to resolveConfigPresets and resolve globalPresets
-    const config = { extends: globalExtends };
+    const config = { extends: globalExtends, ignorePresets };
     const resolvedConfig = await resolveConfigPresets(config);
     return resolvedConfig;
   } catch (err) {
@@ -133,10 +134,13 @@ export async function start(): Promise<number> {
     await instrument('config', async () => {
       // read global config from file, env and cli args
       config = await getGlobalConfig();
-      if (config?.globalExtends) {
+      if (is.nonEmptyArray(config?.globalExtends)) {
         // resolve global presets immediately
         config = mergeChildConfig(
-          await resolveGlobalExtends(config.globalExtends),
+          await resolveGlobalExtends(
+            config.globalExtends,
+            config.ignorePresets,
+          ),
           config,
         );
       }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Respect self hosted `ignorePresets` config option when resolving the `globalExtends` array.
<!-- Describe what behavior is changed by this PR. -->

## Context
- https://github.com/renovatebot/renovate/discussions/32596#discussioncomment-11318670
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
