### PR TITLE
docs: list uv.lock as supported by lockFileMaintenance.

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2246,6 +2246,7 @@ Supported lock files:
 - `pubspec.lock`
 - `pyproject.toml`
 - `requirements.txt`
+- `uv.lock`
 - `yarn.lock`
 
 Support for new lock files may be added via feature request.


### PR DESCRIPTION
## Changes

Indicate that `uv.lock` is actually supported by the `lockFileMaintenance` option of repository configuration.

## Context

This PR is a follow-up of [this discussion](https://github.com/renovatebot/renovate/discussions/32833)

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
