### PR TITLE
fix(bundler): gracefully ignore internal packages

### DIFF
--- a/lib/modules/manager/bundler/extract.spec.ts
+++ b/lib/modules/manager/bundler/extract.spec.ts
@@ -275,4 +275,25 @@ describe('modules/manager/bundler/extract', () => {
       ],
     });
   });
+
+  it('skips local gems in Gemfile', async () => {
+    const pathGemfile = codeBlock`
+      gem 'foo', path: 'vendor/foo'
+      gem 'bar'
+    `;
+
+    fs.readLocalFile.mockResolvedValueOnce(pathGemfile);
+    const res = await extractPackageFile(pathGemfile, 'Gemfile');
+    expect(res).toMatchObject({
+      deps: [
+        {
+          depName: 'foo',
+          skipReason: 'internal-package',
+        },
+        {
+          depName: 'bar',
+        },
+      ],
+    });
+  });
 });

--- a/lib/modules/manager/bundler/extract.ts
+++ b/lib/modules/manager/bundler/extract.ts
@@ -25,6 +25,7 @@ const sourceMatchRegex = regEx(
 const gitRefsMatchRegex = regEx(
   `((git:\\s*['"](?<gitUrl>[^'"]+)['"])|(\\s*,\\s*github:\\s*['"](?<repoName>[^'"]+)['"]))(\\s*,\\s*branch:\\s*['"](?<branchName>[^'"]+)['"])?(\\s*,\\s*ref:\\s*['"](?<refName>[^'"]+)['"])?(\\s*,\\s*tag:\\s*['"](?<tagName>[^'"]+)['"])?`,
 );
+const pathMatchRegex = regEx(`path:\\s*['"](?<path>[^'"]+)['"]`);
 
 export async function extractPackageFile(
   content: string,
@@ -147,6 +148,11 @@ export async function extractPackageFile(
       if (gemMatch.currentValue) {
         const currentValue = gemMatch.currentValue;
         dep.currentValue = currentValue;
+      }
+
+      const pathMatch = pathMatchRegex.exec(line)?.groups;
+      if (pathMatch) {
+        dep.skipReason = 'internal-package';
       }
 
       const sourceMatch = sourceMatchRegex.exec(line)?.groups;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

With this change, Renovate will now consider gems declared with a `path` to be local and skip them with reason `internal-package`.

Relates to https://github.com/renovatebot/renovate/discussions/32749

## Context

Bundler support was missing this part and the skip reason was not correct.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
