### PR TITLE
fix(presets): use regex to match versions for :automergeStableNonMajor preset

### DIFF
--- a/lib/config/presets/internal/default.ts
+++ b/lib/config/presets/internal/default.ts
@@ -96,7 +96,7 @@ export const presets: Record<string, Preset> = {
     packageRules: [
       {
         automerge: true,
-        matchCurrentVersion: '>= 1.0.0',
+        matchCurrentVersion: '!/^0/"',
         matchUpdateTypes: ['minor', 'patch'],
       },
     ],

--- a/lib/config/presets/internal/default.ts
+++ b/lib/config/presets/internal/default.ts
@@ -96,7 +96,7 @@ export const presets: Record<string, Preset> = {
     packageRules: [
       {
         automerge: true,
-        matchCurrentVersion: '!/^0/"',
+        matchCurrentVersion: '!/^0/',
         matchUpdateTypes: ['minor', 'patch'],
       },
     ],


### PR DESCRIPTION
## Changes

The `:automergeStableNonMajor` preset now uses a regex for matchCurrentVersion, so it can be used for e.g. semver and python versioning.

## Context

As [discussed here](https://github.com/renovatebot/renovate/discussions/32735), not all versionings support ranges, so to match versions ">= 1.0.0" it's safer to use a regex.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
