### PR TITLE
fix(bundler): fix inline source variable parsing

### DIFF
--- a/lib/modules/manager/bundler/extract.spec.ts
+++ b/lib/modules/manager/bundler/extract.spec.ts
@@ -175,6 +175,7 @@ describe('modules/manager/bundler/extract', () => {
       gem "inline_source_gem", source: 'https://gems.foo.com'
       gem 'inline_source_gem_with_version', "~> 1", source: 'https://gems.bar.com'
       gem 'inline_source_gem_with_variable_source', source: baz
+      gem 'inline_source_gem_with_variable_source_and_require_after', source: baz, require: %w[inline_source_gem]
       gem "inline_source_gem_with_require_after", source: 'https://gems.foo.com', require: %w[inline_source_gem]
       gem "inline_source_gem_with_require_before", require: %w[inline_source_gem], source: 'https://gems.foo.com'
       gem "inline_source_gem_with_group_before", group: :production, source: 'https://gems.foo.com'
@@ -197,6 +198,10 @@ describe('modules/manager/bundler/extract', () => {
         },
         {
           depName: 'inline_source_gem_with_variable_source',
+          registryUrls: ['https://gems.baz.com'],
+        },
+        {
+          depName: 'inline_source_gem_with_variable_source_and_require_after',
           registryUrls: ['https://gems.baz.com'],
         },
         {

--- a/lib/modules/manager/bundler/extract.ts
+++ b/lib/modules/manager/bundler/extract.ts
@@ -20,7 +20,7 @@ const gemMatchRegex = regEx(
   `^\\s*gem\\s+(['"])(?<depName>[^'"]+)(['"])(\\s*,\\s*(?<currentValue>(['"])[^'"]+['"](\\s*,\\s*['"][^'"]+['"])?))?`,
 );
 const sourceMatchRegex = regEx(
-  `source:\\s*(['"](?<registryUrl>[^'"]+)['"]|(?<sourceName>\\w+))?`,
+  `source:\\s*((?:['"](?<registryUrl>[^'"]+)['"])|(?<sourceName>\\w+))?`,
 );
 const gitRefsMatchRegex = regEx(
   `((git:\\s*['"](?<gitUrl>[^'"]+)['"])|(\\s*,\\s*github:\\s*['"](?<repoName>[^'"]+)['"]))(\\s*,\\s*branch:\\s*['"](?<branchName>[^'"]+)['"])?(\\s*,\\s*ref:\\s*['"](?<refName>[^'"]+)['"])?(\\s*,\\s*tag:\\s*['"](?<tagName>[^'"]+)['"])?`,

--- a/lib/modules/manager/bundler/extract.ts
+++ b/lib/modules/manager/bundler/extract.ts
@@ -20,7 +20,7 @@ const gemMatchRegex = regEx(
   `^\\s*gem\\s+(['"])(?<depName>[^'"]+)(['"])(\\s*,\\s*(?<currentValue>(['"])[^'"]+['"](\\s*,\\s*['"][^'"]+['"])?))?`,
 );
 const sourceMatchRegex = regEx(
-  `source:\\s*(['"](?<registryUrl>[^'"]+)['"]|(?<sourceName>[^'"]+))?`,
+  `source:\\s*(['"](?<registryUrl>[^'"]+)['"]|(?<sourceName>\\w+))?`,
 );
 const gitRefsMatchRegex = regEx(
   `((git:\\s*['"](?<gitUrl>[^'"]+)['"])|(\\s*,\\s*github:\\s*['"](?<repoName>[^'"]+)['"]))(\\s*,\\s*branch:\\s*['"](?<branchName>[^'"]+)['"])?(\\s*,\\s*ref:\\s*['"](?<refName>[^'"]+)['"])?(\\s*,\\s*tag:\\s*['"](?<tagName>[^'"]+)['"])?`,


### PR DESCRIPTION
## Changes

Improve ineline source variable parsing. Before this change, renovate was wrongly capturing basically every character after `source: `.

## Context

Original implementation was missing a test. We had, as users, this use case in our codebase, and decided to propose a fix.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
