### PR TITLE
fix(pep621): handle dependency-groups (PEP 735) in pdm lockfile updates

### DIFF
--- a/lib/modules/manager/pep621/processors/pdm.spec.ts
+++ b/lib/modules/manager/pep621/processors/pdm.spec.ts
@@ -173,6 +173,11 @@ describe('modules/manager/pep621/processors/pdm', () => {
           managerData: { depGroup: 'group3' },
         },
         { packageName: 'dep9', depType: depTypes.buildSystemRequires },
+        {
+          packageName: 'dep10',
+          depType: depTypes.dependencyGroups,
+          managerData: { depGroup: 'dev' },
+        },
       ];
       const result = await processor.updateArtifacts(
         {
@@ -205,6 +210,9 @@ describe('modules/manager/pep621/processors/pdm', () => {
         {
           cmd: 'pdm update --no-sync --update-eager -dG group3 dep7 dep8',
         },
+        {
+          cmd: 'pdm update --no-sync --update-eager -dG dev dep10',
+        },
       ]);
     });
 
@@ -232,6 +240,10 @@ describe('modules/manager/pep621/processors/pdm', () => {
           packageName: 'dep5',
           depType: depTypes.pdmDevDependencies,
         },
+        {
+          packageName: 'dep10',
+          depType: depTypes.dependencyGroups,
+        },
       ];
       const result = await processor.updateArtifacts(
         {
@@ -244,7 +256,7 @@ describe('modules/manager/pep621/processors/pdm', () => {
       );
       expect(result).toBeNull();
       expect(execSnapshots).toEqual([]);
-      expect(logger.once.warn).toHaveBeenCalledTimes(2);
+      expect(logger.once.warn).toHaveBeenCalledTimes(3);
     });
 
     it('return update on lockfileMaintenance', async () => {

--- a/lib/modules/manager/pep621/processors/pdm.ts
+++ b/lib/modules/manager/pep621/processors/pdm.ts
@@ -193,6 +193,7 @@ function generateCMDs(updatedDeps: Upgrade<Pep621ManagerData>[]): string[] {
         );
         break;
       }
+      case depTypes.dependencyGroups:
       case depTypes.pdmDevDependencies: {
         if (is.nullOrUndefined(dep.managerData?.depGroup)) {
           logger.once.warn(


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

pdm 2.20.0 added support for `dependency-groups` (PEP 735) but so far they were not handled correctly during lockfile updates. This PR adds the needed `depGroup` for updates to succeed.

<!-- Describe what behavior is changed by this PR. -->

## Context

- Closes https://github.com/renovatebot/renovate/discussions/32940
- Related to https://github.com/renovatebot/renovate/pull/32148

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

Test repo: https://github.com/renovate-demo/32940-pep621-buildsystem-requires-reproduction/pull/1

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
