### PR TITLE
fix(hex): Relax case in typing of schema

### DIFF
--- a/lib/modules/datasource/hex/__fixtures__/private_package.json
+++ b/lib/modules/datasource/hex/__fixtures__/private_package.json
@@ -19,7 +19,9 @@
     "licenses": [
       "MIT"
     ],
-    "links": {},
+    "links": {
+      "GitHub": "https://github.com/renovate_test/private_package"
+    },
     "maintainers": []
   },
   "name": "private_package",

--- a/lib/modules/datasource/hex/__snapshots__/index.spec.ts.snap
+++ b/lib/modules/datasource/hex/__snapshots__/index.spec.ts.snap
@@ -104,6 +104,7 @@ exports[`modules/datasource/hex/index getReleases processes a private repo with 
       "version": "0.1.1",
     },
   ],
+  "sourceUrl": "https://github.com/renovate_test/private_package",
 }
 `;
 

--- a/lib/modules/datasource/hex/index.spec.ts
+++ b/lib/modules/datasource/hex/index.spec.ts
@@ -168,6 +168,7 @@ describe('modules/datasource/hex/index', () => {
 
       expect(result).toEqual({
         homepage: 'https://hex.pm/packages/renovate_test/private_package',
+        sourceUrl: 'https://github.com/renovate_test/private_package',
         registryUrl: 'https://hex.pm',
         releases: [
           { releaseTimestamp: '2021-08-04T15:26:26.500Z', version: '0.1.0' },

--- a/lib/modules/datasource/hex/schema.ts
+++ b/lib/modules/datasource/hex/schema.ts
@@ -8,11 +8,21 @@ export const HexRelease = z
     html_url: z.string().optional(),
     meta: z
       .object({
-        links: z.record(z.unknown()).transform(links => Object.fromEntries(
-          Object.entries(links).map(([key, value]) => [key.toLowerCase(), value]),
-        )).pipe(z.object({
-          github: z.string(),
-        })),
+        links: z
+          .record(z.unknown())
+          .transform((links) =>
+            Object.fromEntries(
+              Object.entries(links).map(([key, value]) => [
+                key.toLowerCase(),
+                value,
+              ]),
+            ),
+          )
+          .pipe(
+            z.object({
+              github: z.string(),
+            }),
+          ),
       })
       .nullable()
       .catch(null),
@@ -58,6 +68,6 @@ export const HexRelease = z
     if (hexResponse.meta?.links?.github) {
       releaseResult.sourceUrl = hexResponse.meta.links.github;
     }
-    
+
     return releaseResult;
   });

--- a/lib/modules/datasource/hex/schema.ts
+++ b/lib/modules/datasource/hex/schema.ts
@@ -58,15 +58,15 @@ export const HexRelease = z
       ? normalizeKeys(hexResponse.meta.links)
       : undefined;
 
-      if (normalizedLinks?.github) {
-        releaseResult.sourceUrl = normalizedLinks.github;
-      }
+    if (normalizedLinks?.github) {
+      releaseResult.sourceUrl = normalizedLinks.github;
+    }
 
     return releaseResult;
   });
 
-  function normalizeKeys(obj: Record<string, any>): Record<string, any> {
-    return Object.fromEntries(
-      Object.entries(obj).map(([key, value]) => [key.toLowerCase(), value]),
-    );
-  }
+function normalizeKeys(obj: Record<string, any>): Record<string, any> {
+  return Object.fromEntries(
+    Object.entries(obj).map(([key, value]) => [key.toLowerCase(), value]),
+  );
+}

--- a/lib/modules/datasource/hex/schema.ts
+++ b/lib/modules/datasource/hex/schema.ts
@@ -8,10 +8,11 @@ export const HexRelease = z
     html_url: z.string().optional(),
     meta: z
       .object({
-        links: z.union([
-          z.object({ Github: z.string() }),
-          z.object({ GitHub: z.string() }),
-        ]),
+        links: z.record(z.unknown()).transform(links => Object.fromEntries(
+          Object.entries(links).map(([key, value]) => [key.toLowerCase(), value]),
+        )).pipe(z.object({
+          github: z.string(),
+        })),
       })
       .nullable()
       .catch(null),
@@ -54,19 +55,9 @@ export const HexRelease = z
       releaseResult.homepage = hexResponse.html_url;
     }
 
-    const normalizedLinks = hexResponse.meta?.links
-      ? normalizeKeys(hexResponse.meta.links)
-      : undefined;
-
-    if (normalizedLinks?.github) {
-      releaseResult.sourceUrl = normalizedLinks.github;
+    if (hexResponse.meta?.links?.github) {
+      releaseResult.sourceUrl = hexResponse.meta.links.github;
     }
-
+    
     return releaseResult;
   });
-
-function normalizeKeys(obj: Record<string, any>): Record<string, any> {
-  return Object.fromEntries(
-    Object.entries(obj).map(([key, value]) => [key.toLowerCase(), value]),
-  );
-}

--- a/lib/modules/datasource/hex/schema.ts
+++ b/lib/modules/datasource/hex/schema.ts
@@ -8,9 +8,10 @@ export const HexRelease = z
     html_url: z.string().optional(),
     meta: z
       .object({
-        links: z.object({
-          Github: z.string(),
-        }),
+        links: z.union([
+          z.object({ Github: z.string() }),
+          z.object({ GitHub: z.string() }),
+        ]),
       })
       .nullable()
       .catch(null),
@@ -53,9 +54,19 @@ export const HexRelease = z
       releaseResult.homepage = hexResponse.html_url;
     }
 
-    if (hexResponse.meta?.links?.Github) {
-      releaseResult.sourceUrl = hexResponse.meta.links.Github;
-    }
+    const normalizedLinks = hexResponse.meta?.links
+      ? normalizeKeys(hexResponse.meta.links)
+      : undefined;
+
+      if (normalizedLinks?.github) {
+        releaseResult.sourceUrl = normalizedLinks.github;
+      }
 
     return releaseResult;
   });
+
+  function normalizeKeys(obj: Record<string, any>): Record<string, any> {
+    return Object.fromEntries(
+      Object.entries(obj).map(([key, value]) => [key.toLowerCase(), value]),
+    );
+  }

--- a/lib/modules/datasource/hex/schema.ts
+++ b/lib/modules/datasource/hex/schema.ts
@@ -9,7 +9,7 @@ export const HexRelease = z
     meta: z
       .object({
         links: z
-          .record(z.unknown())
+          .record(z.string())
           .transform((links) =>
             Object.fromEntries(
               Object.entries(links).map(([key, value]) => [


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

In hex datasource schema, change the meta.links to accept either `Github` or `GitHub`

## Context
https://github.com/renovatebot/renovate/discussions/29993#discussioncomment-9944037

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
