### PR TITLE
refactor: Rename manager result type to `MaybePromise`

### DIFF
--- a/lib/modules/manager/custom/regex/index.ts
+++ b/lib/modules/manager/custom/regex/index.ts
@@ -2,9 +2,9 @@ import is from '@sindresorhus/is';
 import type { Category } from '../../../../constants';
 import type {
   ExtractConfig,
+  MaybePromise,
   PackageDependency,
   PackageFileContent,
-  Result,
 } from '../../types';
 import { handleAny, handleCombination, handleRecursive } from './strategies';
 import type { RegexManagerConfig, RegexManagerTemplates } from './types';
@@ -22,7 +22,7 @@ export function extractPackageFile(
   content: string,
   packageFile: string,
   config: ExtractConfig,
-): Result<PackageFileContent | null> {
+): MaybePromise<PackageFileContent | null> {
   let deps: PackageDependency[];
   switch (config.matchStringsStrategy) {
     default:

--- a/lib/modules/manager/index.ts
+++ b/lib/modules/manager/index.ts
@@ -6,10 +6,10 @@ import type {
   ExtractConfig,
   GlobalManagerConfig,
   ManagerApi,
+  MaybePromise,
   PackageFile,
   PackageFileContent,
   RangeConfig,
-  Result,
 } from './types';
 export { hashMap } from './fingerprint.generated';
 
@@ -65,7 +65,7 @@ export function extractPackageFile(
   content: string,
   fileName: string,
   config: ExtractConfig,
-): Result<PackageFileContent | null> {
+): MaybePromise<PackageFileContent | null> {
   const m = managers.get(manager)! ?? customManagers.get(manager)!;
   if (!m) {
     return null;

--- a/lib/modules/manager/setup-cfg/extract.ts
+++ b/lib/modules/manager/setup-cfg/extract.ts
@@ -4,7 +4,11 @@ import { logger } from '../../../logger';
 import { newlineRegex, regEx } from '../../../util/regex';
 import { PypiDatasource } from '../../datasource/pypi';
 import { normalizePythonDepName } from '../../datasource/pypi/common';
-import type { PackageDependency, PackageFileContent, Result } from '../types';
+import type {
+  MaybePromise,
+  PackageDependency,
+  PackageFileContent,
+} from '../types';
 
 function getSectionName(str: string): string {
   const [, sectionName] = regEx(/^\[\s*([^\s]+)\s*]\s*$/).exec(str) ?? [];
@@ -89,7 +93,7 @@ function parseDep(
 
 export function extractPackageFile(
   content: string,
-): Result<PackageFileContent | null> {
+): MaybePromise<PackageFileContent | null> {
   logger.trace('setup-cfg.extractPackageFile()');
 
   let sectionName: string | null = null;

--- a/lib/modules/manager/types.ts
+++ b/lib/modules/manager/types.ts
@@ -11,7 +11,7 @@ import type { FileChange } from '../../util/git/types';
 import type { MergeConfidence } from '../../util/merge-confidence/types';
 import type { CustomExtractConfig } from './custom/types';
 
-export type Result<T> = T | Promise<T>;
+export type MaybePromise<T> = T | Promise<T>;
 
 export interface ManagerData<T> {
   managerData?: T;
@@ -258,34 +258,34 @@ export interface ManagerApi extends ModuleApi {
     currentValue: string,
     bumpVersion: ReleaseType,
     packageFile: string,
-  ): Result<BumpPackageVersionResult>;
+  ): MaybePromise<BumpPackageVersionResult>;
 
-  detectGlobalConfig?(): Result<GlobalManagerConfig>;
+  detectGlobalConfig?(): MaybePromise<GlobalManagerConfig>;
 
   extractAllPackageFiles?(
     config: ExtractConfig,
     files: string[],
-  ): Result<PackageFile[] | null>;
+  ): MaybePromise<PackageFile[] | null>;
 
   extractPackageFile?(
     content: string,
     packageFile?: string,
     config?: ExtractConfig,
-  ): Result<PackageFileContent | null>;
+  ): MaybePromise<PackageFileContent | null>;
 
   getRangeStrategy?(config: RangeConfig): RangeStrategy;
 
   updateArtifacts?(
     updateArtifact: UpdateArtifact,
-  ): Result<UpdateArtifactsResult[] | null>;
+  ): MaybePromise<UpdateArtifactsResult[] | null>;
 
   updateDependency?(
     updateDependencyConfig: UpdateDependencyConfig,
-  ): Result<string | null>;
+  ): MaybePromise<string | null>;
 
   updateLockedDependency?(
     config: UpdateLockedConfig,
-  ): Result<UpdateLockedResult>;
+  ): MaybePromise<UpdateLockedResult>;
 }
 
 // TODO: name and properties used by npm manager


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
