### PR TITLE
fix(platform/azure): Add current project id as sourceRepositoryId to azure getPrList

### DIFF
--- a/lib/modules/platform/azure/index.ts
+++ b/lib/modules/platform/azure/index.ts
@@ -259,7 +259,11 @@ export async function getPrList(): Promise<AzurePr[]> {
     do {
       fetchedPrs = await azureApiGit.getPullRequests(
         config.repoId,
-        { status: 4 },
+        {
+          status: 4,
+          // fetch only prs directly created on the repo and not by forks
+          sourceRepositoryId: config.project,
+        },
         config.project,
         0,
         skip,


### PR DESCRIPTION
... to avoid that the bot needs read permissions to all PR source repositories

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This PR adds a second `searchCriteria` to the Azure getPrList call. The added `searchCriteria` is the `sourceRepositoryId` with the id of the current project. This has the effect that only pull requests are returned, which have their sources in branches of the current project or in other words no pull requests from forks are returned.

## Context

This PR tries to solve the problem that the user account associated with "Renovate-Git-Token" requires read access to any source repository from which pull requests are created. 
Without the read access currently the getPrList call fails and an exception like this is reported:

```plain
"err": {
             "message": "Cannot read properties of null (reading 'length')",
             "stack": "TypeError: Cannot read properties of null (reading 'length')\n    at Proxy.getPrList (/home/AzDevOps/work/1/s/node_modules/renovate/lib/modules/platform/azure/index.ts:270:25)\n    at processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at finalizeRepo (/home/AzDevOps/work/1/s/node_modules/renovate/lib/workers/repository/finalize/index.ts:25:18)\n    at Object.renovateRepository (/home/AzDevOps/work/1/s/node_modules/renovate/lib/workers/repository/index.ts:113:7)\n    at attributes.repository (/home/AzDevOps/work/1/s/node_modules/renovate/lib/workers/global/index.ts:206:11)\n    at start (/home/AzDevOps/work/1/s/node_modules/renovate/lib/workers/global/index.ts:191:7)\n    at /home/AzDevOps/work/1/s/node_modules/renovate/lib/renovate.ts:19:22"
           },
```

I'm not sure if the restriction to PRs only from the current repository has unwanted sideeffects.
Maybe the PR can be changed to be a solution strategie if the fetching of all PRs fails?
Is there a requirement for renovate to see all available PRs including forks?


## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
