### PR TITLE
docs: remove app secrets deprecation date

### DIFF
--- a/docs/usage/mend-hosted/credentials.md
+++ b/docs/usage/mend-hosted/credentials.md
@@ -9,7 +9,7 @@ If you self-host, you can skip reading this page.
 
 ## :warning: Migrate secrets in your Renovate config file :warning:
 
-The Mend-hosted cloud app will stop reading secrets from the Renovate config file in your repository on 01-Oct-2024.
+Use of encrypted secrets in the Mend Renovate cloud apps has been deprecated and soon the apps will stop reading secrets from the Renovate config file in your repository.
 You must migrate any secrets you currently keep in the Renovate config file, and put them in the app settings page on [developer.mend.io](https://developer.mend.io).
 To add secrets you must have admin-level rights.
 

--- a/docs/usage/mend-hosted/credentials.md
+++ b/docs/usage/mend-hosted/credentials.md
@@ -4,6 +4,7 @@ The information on this page is for the Mend-hosted cloud apps:
 
 - Renovate App on GitHub
 - Mend App on Bitbucket
+- Mend App on Azure DevOps
 
 If you self-host, you can skip reading this page.
 


### PR DESCRIPTION
## Changes

Updated docs to remove the date regarding app secrets deprecation in Mend-hosted Credentials page.

## Context

Extra time has been given for app secrets migration. Hard deadline no longer documented

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository