### PR TITLE
docs(nuget): add info about nested nuget ignorePaths

### DIFF
--- a/docs/usage/nuget.md
+++ b/docs/usage/nuget.md
@@ -132,7 +132,8 @@ If you use Azure DevOps:
 
 ## Ignoring package files when using presets
 
-Because `nuget` manager has a dedicated `ignorePaths` entry in the `:ignoreModulesAndTests` preset, if you're using any presets that extend it (like `config:recommended`), you need to put your `ignorePaths` inside the `nuget` section for it to be merged. For example:
+Because `nuget` manager has a dedicated `ignorePaths` entry in the `:ignoreModulesAndTests` preset, if you're using any presets that extend it (like `config:recommended`), you need to put your `ignorePaths` inside the `nuget` section for it to be merged.
+For example:
 
 ```json
 {
@@ -144,7 +145,7 @@ Because `nuget` manager has a dedicated `ignorePaths` entry in the `:ignoreModul
 }
 ```
 
-Otherwise, your entries will be ignored.
+Otherwise, all `nuget.ignorePaths` values in `:ignoreModulesAndTests` will override values you put inside `ignorePaths` at the top-level config.
 
 ## Future work
 

--- a/docs/usage/nuget.md
+++ b/docs/usage/nuget.md
@@ -130,6 +130,22 @@ If you use Azure DevOps:
     The username of the PAT must match the username of the _user of the PAT_.
     The generated `nuget.config` forces the basic authentication, which cannot be overridden externally!
 
+## Ignoring package files when using presets
+
+Because `nuget` manager has a dedicated `ignorePaths` entry in the `:ignoreModulesAndTests` preset, if you're using any presets that extend it (like `config:recommended`), you need to put your `ignorePaths` inside the `nuget` section for it to be merged. For example:
+
+```json
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "nuget": {
+    "ignorePaths": ["IgnoreThisPackage/**"]
+  }
+}
+```
+
+Otherwise, your entries will be ignored.
+
 ## Future work
 
 We welcome contributions or feature requests to support more patterns or use cases.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Added info about the need to use nested ignorePaths for nuget when using config presets.

## Context

Motivated by confusion and lack of documentation which made me think this was a bug.
See: https://github.com/renovatebot/renovate/discussions/33017

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
