### PR TITLE
fix(presets): typo in utoipa monorepo

### DIFF
--- a/lib/data/monorepo.json
+++ b/lib/data/monorepo.json
@@ -546,7 +546,7 @@
     "unhead": "https://github.com/unjs/unhead",
     "unocss": "https://github.com/unocss/unocss",
     "uppy": "https://github.com/transloadit/uppy",
-    "utopia": "https://github.com/juhaku/utoipa",
+    "utoipa": "https://github.com/juhaku/utoipa",
     "vaadin-hilla": "https://github.com/vaadin/hilla",
     "vaadinWebComponents": "https://github.com/vaadin/web-components",
     "visx": "https://github.com/airbnb/visx",


### PR DESCRIPTION
## Changes

Fix a typo in the name of the utoipa monorepo.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [X] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
