### PR TITLE
refactor(manager/custom): reorganize and update utility functions

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -771,9 +771,8 @@ Example:
       "customType": "regex",
       "fileMatch": ["values.yaml$"],
       "matchStrings": [
-        "image:\\s+(?<depName>my\\.old\\.registry/aRepository/andImage):(?<currentValue>[^\\s]+)"
-      ],
-      "datasource": "docker"
+        "ENV .*?_VERSION=(?<currentValue>.*) # (?<datasource>.*?)/(?<depName>.*?)\\s"
+      ]
     }
   ]
 }

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -769,9 +769,11 @@ Example:
   "customManagers": [
     {
       "customType": "regex",
+      "fileMatch": ["values.yaml$"],
       "matchStrings": [
-        "ENV .*?_VERSION=(?<currentValue>.*) # (?<datasource>.*?)/(?<depName>.*?)\\s"
-      ]
+        "image:\\s+(?<depName>my\\.old\\.registry/aRepository/andImage):(?<currentValue>[^\\s]+)"
+      ],
+      "datasource": "docker"
     }
   ]
 }

--- a/lib/modules/manager/custom/regex/index.ts
+++ b/lib/modules/manager/custom/regex/index.ts
@@ -6,9 +6,9 @@ import type {
   PackageFileContent,
   Result,
 } from '../../types';
+import { validMatchFields } from '../utils';
 import { handleAny, handleCombination, handleRecursive } from './strategies';
 import type { RegexManagerConfig, RegexManagerTemplates } from './types';
-import { validMatchFields } from './utils';
 
 export const categories: Category[] = ['custom'];
 

--- a/lib/modules/manager/custom/regex/strategies.ts
+++ b/lib/modules/manager/custom/regex/strategies.ts
@@ -1,11 +1,10 @@
 import is from '@sindresorhus/is';
-import { logger } from '../../../../logger';
 import { regEx } from '../../../../util/regex';
 import type { PackageDependency } from '../../types';
+import { checkIsValidDependency } from '../utils';
 import type { RecursionParameter, RegexManagerConfig } from './types';
 import {
   createDependency,
-  isValidDependency,
   mergeExtractionTemplate,
   mergeGroups,
   regexMatchAll,
@@ -32,7 +31,7 @@ export function handleAny(
     )
     .filter(is.truthy)
     .filter((dep: PackageDependency) =>
-      checkIsValidDependency(dep, packageFile),
+      checkIsValidDependency(dep, packageFile, 'regex'),
     );
 }
 
@@ -61,7 +60,7 @@ export function handleCombination(
   return [createDependency(extraction, config)]
     .filter(is.truthy)
     .filter((dep: PackageDependency) =>
-      checkIsValidDependency(dep, packageFile),
+      checkIsValidDependency(dep, packageFile, 'regex'),
     );
 }
 
@@ -84,7 +83,7 @@ export function handleRecursive(
   })
     .filter(is.truthy)
     .filter((dep: PackageDependency) =>
-      checkIsValidDependency(dep, packageFile),
+      checkIsValidDependency(dep, packageFile, 'regex'),
     );
 }
 
@@ -115,24 +114,4 @@ function processRecursive(parameters: RecursionParameter): PackageDependency[] {
       combinedGroups: mergeGroups(combinedGroups, match.groups ?? {}),
     });
   });
-}
-
-function checkIsValidDependency(
-  dep: PackageDependency,
-  packageFile: string,
-): boolean {
-  const isValid = isValidDependency(dep);
-  if (!isValid) {
-    const meta = {
-      packageDependency: dep,
-      packageFile,
-    };
-    logger.trace(
-      meta,
-      'Discovered a package dependency by matching regex, but it did not pass validation. Discarding',
-    );
-    return isValid;
-  }
-
-  return isValid;
 }

--- a/lib/modules/manager/custom/regex/utils.ts
+++ b/lib/modules/manager/custom/regex/utils.ts
@@ -4,26 +4,13 @@ import { migrateDatasource } from '../../../../config/migrations/custom/datasour
 import { logger } from '../../../../logger';
 import * as template from '../../../../util/template';
 import type { PackageDependency } from '../../types';
+import type { ValidMatchFields } from '../utils';
+import { validMatchFields } from '../utils';
 import type {
   ExtractionTemplate,
   RegexManagerConfig,
   RegexManagerTemplates,
 } from './types';
-
-export const validMatchFields = [
-  'depName',
-  'packageName',
-  'currentValue',
-  'currentDigest',
-  'datasource',
-  'versioning',
-  'extractVersion',
-  'registryUrl',
-  'depType',
-  'indentation',
-] as const;
-
-type ValidMatchFields = (typeof validMatchFields)[number];
 
 function updateDependency(
   dependency: PackageDependency,
@@ -118,19 +105,4 @@ export function mergeExtractionTemplate(
     groups: mergeGroups(base.groups, addition.groups),
     replaceString: addition.replaceString ?? base.replaceString,
   };
-}
-
-export function isValidDependency({
-  depName,
-  currentValue,
-  currentDigest,
-  packageName,
-}: PackageDependency): boolean {
-  // check if all the fields are set
-  return (
-    (is.nonEmptyStringAndNotWhitespace(depName) ||
-      is.nonEmptyStringAndNotWhitespace(packageName)) &&
-    (is.nonEmptyStringAndNotWhitespace(currentDigest) ||
-      is.nonEmptyStringAndNotWhitespace(currentValue))
-  );
 }

--- a/lib/modules/manager/custom/utils.ts
+++ b/lib/modules/manager/custom/utils.ts
@@ -1,0 +1,57 @@
+import is from '@sindresorhus/is';
+import { logger } from '../../../logger';
+import type { PackageDependency } from '../types';
+
+export const validMatchFields = [
+  'depName',
+  'packageName',
+  'currentValue',
+  'currentDigest',
+  'datasource',
+  'versioning',
+  'extractVersion',
+  'registryUrl',
+  'depType',
+  'indentation',
+] as const;
+
+export type ValidMatchFields = (typeof validMatchFields)[number];
+
+function isValidDependency({
+  depName,
+  currentValue,
+  currentDigest,
+  packageName,
+  datasource,
+}: PackageDependency): boolean {
+  // check if all the fields are set
+  return (
+    (is.nonEmptyStringAndNotWhitespace(depName) ||
+      is.nonEmptyStringAndNotWhitespace(packageName)) &&
+    (is.nonEmptyStringAndNotWhitespace(currentDigest) ||
+      is.nonEmptyStringAndNotWhitespace(currentValue)) &&
+    is.nonEmptyStringAndNotWhitespace(datasource)
+  );
+}
+
+export function checkIsValidDependency(
+  dep: PackageDependency,
+  packageFile: string,
+  manager: string,
+): boolean {
+  const isValid = isValidDependency(dep);
+  if (!isValid) {
+    const meta = {
+      packageDependency: dep,
+      packageFile,
+      manager,
+    };
+    logger.trace(
+      meta,
+      'Discovered a package dependency, but it did not pass validation. Discarding',
+    );
+    return isValid;
+  }
+
+  return isValid;
+}

--- a/lib/modules/manager/custom/utils.ts
+++ b/lib/modules/manager/custom/utils.ts
@@ -17,7 +17,7 @@ export const validMatchFields = [
 
 export type ValidMatchFields = (typeof validMatchFields)[number];
 
-function isValidDependency({
+export function isValidDependency({
   depName,
   currentValue,
   currentDigest,

--- a/lib/modules/manager/devcontainer/extract.ts
+++ b/lib/modules/manager/devcontainer/extract.ts
@@ -1,5 +1,5 @@
 import { logger } from '../../../logger';
-import { isValidDependency } from '../custom/regex/utils';
+import { isValidDependency } from '../custom/utils';
 import { getDep as getDockerDep } from '../dockerfile/extract';
 import type {
   ExtractConfig,

--- a/lib/workers/repository/extract/extract-fingerprint-config.ts
+++ b/lib/workers/repository/extract/extract-fingerprint-config.ts
@@ -3,8 +3,8 @@ import type { RenovateConfig } from '../../../config/types';
 import { getEnabledManagersList } from '../../../modules/manager';
 import { isCustomManager } from '../../../modules/manager/custom';
 import type { RegexManagerTemplates } from '../../../modules/manager/custom/regex/types';
-import { validMatchFields } from '../../../modules/manager/custom/regex/utils';
 import type { CustomExtractConfig } from '../../../modules/manager/custom/types';
+import { validMatchFields } from '../../../modules/manager/custom/utils';
 import type { WorkerExtractConfig } from '../../types';
 
 export interface FingerprintExtractConfig {

--- a/lib/workers/repository/update/branch/auto-replace.spec.ts
+++ b/lib/workers/repository/update/branch/auto-replace.spec.ts
@@ -218,6 +218,7 @@ describe('workers/repository/update/branch/auto-replace', () => {
       upgrade.packageFile = '.gitlab-ci.yml';
       upgrade.autoReplaceStringTemplate =
         "'{{{depName}}}'\nref: {{{newValue}}}";
+      upgrade.datasourceTemplate = 'docker';
       upgrade.matchStringsStrategy = 'combination';
 
       // If the new "name" is not added to the matchStrings, the regex matcher fails to extract from `newContent` as
@@ -237,7 +238,7 @@ describe('workers/repository/update/branch/auto-replace', () => {
       );
     });
 
-    it('fails with oldversion in depname', async () => {
+    it('fails with oldversion in depName', async () => {
       const yml =
         'image: "1111111111.dkr.ecr.us-east-1.amazonaws.com/my-repository:1"\n\n';
       upgrade.manager = 'regex';
@@ -252,6 +253,7 @@ describe('workers/repository/update/branch/auto-replace', () => {
       upgrade.matchStrings = [
         'image:\\s*\\\'?\\"?(?<depName>[^:]+):(?<currentValue>[^\\s\\\'\\"]+)\\\'?\\"?\\s*',
       ];
+      upgrade.datasourceTemplate = 'docker';
       const res = doAutoReplace(upgrade, yml, reuseExistingBranch);
       await expect(res).rejects.toThrow(WORKER_FILE_UPDATE_FAILED);
     });
@@ -316,6 +318,7 @@ describe('workers/repository/update/branch/auto-replace', () => {
       upgrade.matchStrings = [
         'image:\\s*\\\'?\\"?(?<depName>[^:]+):(?<currentValue>[^\\s\\\'\\"]+)\\\'?\\"?\\s*',
       ];
+      upgrade.datasourceTemplate = 'docker';
       const res = await doAutoReplace(upgrade, yml, reuseExistingBranch);
       expect(res).toBe(yml);
     });
@@ -1190,6 +1193,7 @@ describe('workers/repository/update/branch/auto-replace', () => {
       upgrade.matchStrings = [
         'image:\\s*?\\\'?\\"?(?<depName>[^:\\\'\\"]+):(?<currentValue>[^@\\\'\\"]+)@?(?<currentDigest>[^\\s\\\'\\"]+)?\\"?\\\'?\\s*',
       ];
+      upgrade.datasourceTemplate = 'docker';
       const res = await doAutoReplace(upgrade, yml, reuseExistingBranch);
       expect(res).toBe('image: "some.other.url.com/some-new-repo:3.16"');
     });
@@ -1213,6 +1217,7 @@ describe('workers/repository/update/branch/auto-replace', () => {
       upgrade.matchStrings = [
         'image:\\s*[\\\'\\"]?(?<depName>[^:]+):(?<currentValue>[^@]+)?@?(?<currentDigest>[^\\s\\\'\\"]+)?[\\\'\\"]?\\s*',
       ];
+      upgrade.datasourceTemplate = 'docker';
       const res = await doAutoReplace(upgrade, yml, reuseExistingBranch);
       expect(res).toBe(
         'image: "some.other.url.com/some-new-repo:3.16@sha256:p0o9i8u7z6t5r4e3w2q1"',


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- Move the fns and constants which can be used by all the custom managers in a separate `utils` in the custom folder.
- Fix example in the `customManagers` section in the docs
- Make `datasource` field mandatory in the `isValidDependency` fn
- And one typo fix
<!-- Describe what behavior is changed by this PR. -->

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
