### PR TITLE
docs(commitMessage): add example/clarification

### DIFF
--- a/docs/usage/configuration-templates.md
+++ b/docs/usage/configuration-templates.md
@@ -58,6 +58,25 @@ It can be empty in some cases, like if the action/topic doesn't change a package
 `commitBody` is used if you wish to add multi-line commit messages, such as for the `Signed-off-by` fields, or adding `[skip-ci]`, etc.
 It is appended to the generated `commitMessage`, separated by a newline.
 
+If you configuration uses [groups](https://docs.renovatebot.com/configuration-options/#group) you need to put the above configuration options under the `group` property and might also need to
+enable [`prTitleStrict`](https://docs.renovatebot.com/configuration-options/#prtitlestrict).
+Example:
+```json
+{
+  "matchDatasources": ["npm"],
+  "matchPackageNames": ["*"],
+  "matchUpdateTypes": ["major"],
+  "groupName": "frontend_major",
+  "prTitleStrict": true,
+  "group": {
+    "commitMessagePrefix": "[RENOVATE]",
+    "commitMessageTopic": "FE major dependencies",
+    "commitMessageExtra": "",
+    "commitMessageSuffix": ""
+  }
+}
+```
+
 ## PR Title
 
 Because commit messages match with the PR title, the PR title template defaults to `null` and inherits/copies the value from `commitMessage`.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Clarify commit message customization functionality in certain cases.

## Context

Issue originally reported in https://github.com/renovatebot/renovate/discussions/32872

## Documentation (please check one with an [x])

- [x ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository