### PR TITLE
feat: raise error when encrypted + no privateKey

### DIFF
--- a/docs/usage/self-hosted-experimental.md
+++ b/docs/usage/self-hosted-experimental.md
@@ -39,6 +39,10 @@ This includes the following:
 
 If set to any value, Renovate will stop using the Docker Hub API (`https://hub.docker.com`) to fetch tags and instead use the normal Docker API for images pulled from `https://index.docker.io`.
 
+## `RENOVATE_X_ENCRYPTED_STRICT`
+
+If set to `"true"`, a config error Issue will be raised in case repository config contains `encrypted` objects without any `privateKey` defined.
+
 ## `RENOVATE_X_EXEC_GPID_HANDLE`
 
 If set, Renovate will terminate the whole process group of a terminated child process spawned by Renovate.

--- a/lib/config/decrypt.spec.ts
+++ b/lib/config/decrypt.spec.ts
@@ -12,6 +12,7 @@ describe('config/decrypt', () => {
     beforeEach(() => {
       config = {};
       GlobalConfig.reset();
+      delete process.env.RENOVATE_X_ENCRYPTED_STRICT;
     });
 
     it('returns empty with no privateKey', async () => {
@@ -29,6 +30,15 @@ describe('config/decrypt', () => {
       expect(logger.logger.once.warn).toHaveBeenCalledWith('text');
       expect(res.encrypted).toBeUndefined();
       expect(res.a).toBeUndefined();
+    });
+
+    it('throws exception if encrypted found but no privateKey', async () => {
+      config.encrypted = { a: '1' };
+      process.env.RENOVATE_X_ENCRYPTED_STRICT = 'true';
+
+      await expect(decryptConfig(config, repository)).rejects.toThrow(
+        'config-validation',
+      );
     });
   });
 });

--- a/lib/config/decrypt.ts
+++ b/lib/config/decrypt.ts
@@ -1,4 +1,5 @@
 import is from '@sindresorhus/is';
+import { CONFIG_VALIDATION } from '../constants/error-messages';
 import { logger } from '../logger';
 import { regEx } from '../util/regex';
 import { addSecretForSanitizing } from '../util/sanitize';
@@ -173,7 +174,15 @@ export async function decryptConfig(
           }
         }
       } else {
-        logger.error('Found encrypted data but no privateKey');
+        if (process.env.RENOVATE_X_ENCRYPTED_STRICT === 'true') {
+          const error = new Error(CONFIG_VALIDATION);
+          error.validationSource = 'config';
+          error.validationError = 'Encrypted config unsupported';
+          error.validationMessage = `This config contains an encrypted object at location \`$.${key}\` but no privateKey is configured. To support encrypted config, the Renovate administrator must configure a \`privateKey\` in Global Configuration.`;
+          throw error;
+        } else {
+          logger.error('Found encrypted data but no privateKey');
+        }
       }
       delete decryptedConfig.encrypted;
     } else if (is.array(val)) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds new option `RENOVATE_X_ENCRYPTED_STRICT` which raises a config exception if `encrypted` is used without `privateKey`.

## Context

To be used by the Mend hosted app, probably made default behavior in future.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

https://github.com/renovate-reproductions/encrypted1/issues/2

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
