### PR TITLE
fix(config/presets): ensure groups have packageRules

### DIFF
--- a/lib/config/presets/internal/group.spec.ts
+++ b/lib/config/presets/internal/group.spec.ts
@@ -1,0 +1,14 @@
+import { presets } from './group';
+
+const exceptions = new Set(['monorepos', 'recommended']);
+
+describe('config/presets/internal/group', () => {
+  it('presets should have right name', () => {
+    // Check that each preset contains a `packageRules` key, except exceptions
+    for (const name of Object.keys(presets).filter(
+      (name) => !exceptions.has(name),
+    )) {
+      expect(presets[name]).toHaveProperty('packageRules');
+    }
+  });
+});

--- a/lib/config/presets/internal/group.spec.ts
+++ b/lib/config/presets/internal/group.spec.ts
@@ -6,6 +6,7 @@ describe('config/presets/internal/group', () => {
   const presetNames = Object.keys(presets).filter(
     (name) => !exceptions.has(name),
   );
+
   it.each(presetNames)('group:%s contains packageRules', (name: string) => {
     expect(presets[name]).toHaveProperty('packageRules');
   });

--- a/lib/config/presets/internal/group.spec.ts
+++ b/lib/config/presets/internal/group.spec.ts
@@ -3,12 +3,10 @@ import { presets } from './group';
 const exceptions = new Set(['monorepos', 'recommended']);
 
 describe('config/presets/internal/group', () => {
-  it('presets should have right name', () => {
-    // Check that each preset contains a `packageRules` key, except exceptions
-    for (const name of Object.keys(presets).filter(
-      (name) => !exceptions.has(name),
-    )) {
-      expect(presets[name]).toHaveProperty('packageRules');
-    }
+  const presetNames = Object.keys(presets).filter(
+    (name) => !exceptions.has(name),
+  );
+  it.each(presetNames)('group:%s contains packageRules', (name: string) => {
+    expect(presets[name]).toHaveProperty('packageRules');
   });
 });

--- a/lib/config/presets/internal/group.ts
+++ b/lib/config/presets/internal/group.ts
@@ -111,14 +111,19 @@ const staticGroups = {
   },
   fusionjs: {
     description: 'Group Fusion.js packages together.',
-    matchPackageNames: [
-      'fusion-cli',
-      'fusion-core',
-      'fusion-test-utils',
-      'fusion-tokens',
-      'fusion-plugin-**',
-      'fusion-react**',
-      'fusion-apollo**',
+    packageRules: [
+      {
+        groupName: 'Fusion.js packages',
+        matchPackageNames: [
+          'fusion-cli',
+          'fusion-core',
+          'fusion-test-utils',
+          'fusion-tokens',
+          'fusion-plugin-**',
+          'fusion-react**',
+          'fusion-apollo**',
+        ],
+      },
     ],
   },
   githubArtifactActions: {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Fixes `group:fusionjs` and adds a test

## Context

Closes #33087

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
