### PR TITLE
feat(preset): add LinkifyJS monorepo

### DIFF
--- a/lib/data/monorepo.json
+++ b/lib/data/monorepo.json
@@ -360,6 +360,7 @@
     "lerna-lite": "https://github.com/lerna-lite/lerna-lite",
     "lexical": "https://github.com/facebook/lexical",
     "linguijs": "https://github.com/lingui/js-lingui",
+    "linkifyjs": "https://github.com/nfrasser/linkifyjs",
     "log4j2": "https://github.com/apache/logging-log4j2",
     "logback": "https://github.com/qos-ch/logback",
     "loopback": [


### PR DESCRIPTION
## Changes

Add https://github.com/nfrasser/linkifyjs monorepo preset.

## Context

https://github.com/nfrasser/linkifyjs is the source for linkifyjs and many linkify-* nodejs packages; and they share the same versions.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository