### PR TITLE
fix(gitea): use configured endpoint in PR cache

### DIFF
--- a/lib/modules/platform/gitea/pr-cache.ts
+++ b/lib/modules/platform/gitea/pr-cache.ts
@@ -115,13 +115,16 @@ export class GiteaPrCache {
   }
 
   private async sync(http: GiteaHttp): Promise<GiteaPrCache> {
-    const query = getQueryString({
+    const urlPath = `${API_PATH}/repos/${this.repo}/pulls`;
+    const queryParams = {
       state: 'all',
       sort: 'recentupdate',
-    });
+    };
 
+    let page: number = 1;
+    const query = getQueryString(queryParams);
     let url: string | undefined =
-      `${API_PATH}/repos/${this.repo}/pulls?${query}`;
+      `${urlPath}?${query}`;
 
     while (url) {
       const res: HttpResponse<PR[]> = await http.getJson<PR[]>(url, {
@@ -134,7 +137,12 @@ export class GiteaPrCache {
         break;
       }
 
-      url = parseLinkHeader(res.headers.link)?.next?.url;
+      page += 1;
+      const query = getQueryString({
+        ...queryParams,
+        page
+      });
+      url = `${urlPath}?${query}`;
     }
 
     return this;

--- a/lib/modules/platform/gitea/pr-cache.ts
+++ b/lib/modules/platform/gitea/pr-cache.ts
@@ -133,7 +133,8 @@ export class GiteaPrCache {
       });
 
       const needNextPage = this.reconcile(res.body);
-      if (!needNextPage) {
+      const nextUrl: string | undefined = parseLinkHeader(res.headers.link)?.next?.url;
+      if (!needNextPage || res.body.length === 0 || nextUrl === undefined) {
         break;
       }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Ensure that gitea PR cache uses the endpoint configured by the user

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

As detailed in issue https://github.com/renovatebot/renovate/discussions/32825, renovate paginates using the url returned by gitea, which may change the endpoint. This causes authentication failures since tokens are not attached to the request or a network error if the returned url is not accesible from within the network. Also a gitea instance configured with a `http` public url would remove transport encryption even if renovate was configured with a `https` endpoint.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
