### PR TITLE
fix(config-migration): skip migration of package.json

### DIFF
--- a/lib/workers/repository/config-migration/index.spec.ts
+++ b/lib/workers/repository/config-migration/index.spec.ts
@@ -46,6 +46,19 @@ describe('workers/repository/config-migration/index', () => {
     expect(ensureConfigMigrationPr).toHaveBeenCalledTimes(0);
   });
 
+  it('skips pr creation if config found in package.json', async () => {
+    const branchList: string[] = [];
+    mockedFunction(MigratedDataFactory.getAsync).mockResolvedValue({
+      content,
+      indent: partial<Indent>(),
+      filename: 'package.json',
+    });
+    const res = await configMigration(config, branchList);
+    expect(res).toMatchObject({ result: 'no-migration' });
+    expect(checkConfigMigrationBranch).toHaveBeenCalledTimes(0);
+    expect(ensureConfigMigrationPr).toHaveBeenCalledTimes(0);
+  });
+
   it('creates migration pr if needed', async () => {
     const branchList: string[] = [];
     mockedFunction(checkConfigMigrationBranch).mockResolvedValue({

--- a/lib/workers/repository/config-migration/index.ts
+++ b/lib/workers/repository/config-migration/index.ts
@@ -27,6 +27,14 @@ export async function configMigration(
     return { result: 'no-migration' };
   }
 
+  if (migratedConfigData.filename === 'package.json') {
+    logger.debug(
+      ' Using package.json for Renovate config is deprecated - please use a dedicated configuration file instead. Skipping config migration.',
+    );
+    MigratedDataFactory.reset();
+    return { result: 'no-migration' };
+  }
+
   const res = await checkConfigMigrationBranch(config, migratedConfigData);
 
   // migration needed but not demanded by user


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
1. If config is present in `package.json` and migration is need:
 Prev: Add checkbox on dependency dashboard and if the user checks it create a migration PR (faulty PR)
 Now: No checkbox on dashboard instead a warning message is shown there asking the user to migrate to a dedicated config file 
 
 2. If config is present in `package.json` and migration is needed and a faulty pr exists
 After this PR is merged, such open PRs will be closed and warning will be added on dashboard asking user to migrate to a dedicated config file
 
<!-- Describe what behavior is changed by this PR. -->

## Context
- Closes: https://github.com/renovatebot/renovate/issues/33116
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository [pt1-repro ](https://github.com/Rahul-renovate-testing/repro-33078-1/issues/2) [pt2-repro](https://github.com/Rahul-renovate-testing/repro-33078-2)

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
