### PR TITLE
docs(config): remove deprecation date from secrets migration

### DIFF
--- a/docs/usage/mend-hosted/migrating-secrets.md
+++ b/docs/usage/mend-hosted/migrating-secrets.md
@@ -8,7 +8,7 @@ They can be referenced from the Renovate config files inside the repo using `{{ 
 
 ## Old method
 
-This method will is deprecated:
+This method is deprecated:
 
 ```json title="Put encrypted secret in Renovate config"
 {

--- a/docs/usage/mend-hosted/migrating-secrets.md
+++ b/docs/usage/mend-hosted/migrating-secrets.md
@@ -8,7 +8,7 @@ They can be referenced from the Renovate config files inside the repo using `{{ 
 
 ## Old method
 
-This method will stop working on 01-Oct-2024:
+This method will is deprecated:
 
 ```json title="Put encrypted secret in Renovate config"
 {
@@ -25,7 +25,7 @@ This method will stop working on 01-Oct-2024:
 
 ## New method
 
-This is the new method, that you should start using:
+This is the new method that you should start using:
 
 ```json title="Reference the app secret in the Renovate config"
 {


### PR DESCRIPTION
## Changes

Removed date of deprecation for encrypted secrets from Migrating Secrets docs page in Mend-hosted Apps section.

## Context

Deprecation date has been extended, and hence removed from the Migrating Secrets page.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository