### PR TITLE
feat(datasource/github-runners): deprecate Ubuntu 20.04

### DIFF
--- a/lib/modules/datasource/github-runners/index.spec.ts
+++ b/lib/modules/datasource/github-runners/index.spec.ts
@@ -13,7 +13,7 @@ describe('modules/datasource/github-runners/index', () => {
         releases: [
           { version: '16.04', isDeprecated: true },
           { version: '18.04', isDeprecated: true },
-          { version: '20.04' },
+          { version: '20.04', isDeprecated: true },
           { version: '22.04' },
           { version: '24.04' },
         ],

--- a/lib/modules/datasource/github-runners/index.ts
+++ b/lib/modules/datasource/github-runners/index.ts
@@ -19,7 +19,7 @@ export class GithubRunnersDatasource extends Datasource {
     ubuntu: [
       { version: '24.04' },
       { version: '22.04' },
-      { version: '20.04' },
+      { version: '20.04', isDeprecated: true },
       { version: '18.04', isDeprecated: true },
       { version: '16.04', isDeprecated: true },
     ],


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Deprecate Ubuntu 20.04 github-runner image datasource

## Context

The GitHub Blog tells users to start updating away from 20.04:

- [GitHub blog, Ubuntu 20 image is closing down](https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#ubuntu-20-image-is-closing-down)

But the [`actions/runner-images/` repository README.md](https://github.com/actions/runner-images/blob/5c8a14c94ce4ce691feb225859daa030c5ff896f/README.md#available-images) lists the Ubuntu 20.04 image as stable, and maintained.

I would like to depcrate the image _now_, to match the advice given in the GitHub Blog post.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
