### PR TITLE
feat(manager/helmfile): allow forward slashes in OCI chart names

### DIFF
--- a/lib/modules/manager/helmfile/extract.spec.ts
+++ b/lib/modules/manager/helmfile/extract.spec.ts
@@ -363,6 +363,36 @@ describe('modules/manager/helmfile/extract', () => {
       });
     });
 
+    it('allows OCI chart names containing forward slashes', async () => {
+      const content = `
+      repositories:
+        - name: oci-repo
+          url: ghcr.io/example/oci-repo
+          oci: true
+      releases:
+        - name: nested-example
+          version: 1.2.3
+          chart: oci://ghcr.io/example/nested/path/chart
+      `;
+      const fileName = 'helmfile.yaml';
+      const result = await extractPackageFile(content, fileName, {
+        registryAliases: {
+          stable: 'https://charts.helm.sh/stable',
+        },
+      });
+      expect(result).toMatchObject({
+        datasource: 'helm',
+        deps: [
+          {
+            currentValue: '1.2.3',
+            depName: 'path/chart',
+            datasource: 'docker',
+            packageName: 'ghcr.io/example/nested/path/chart',
+          },
+        ],
+      });
+    });
+
     it('parses a chart with an oci repository with ---', async () => {
       const content = codeBlock`
       repositories:

--- a/lib/modules/manager/helmfile/extract.spec.ts
+++ b/lib/modules/manager/helmfile/extract.spec.ts
@@ -372,7 +372,7 @@ describe('modules/manager/helmfile/extract', () => {
       releases:
         - name: nested-example
           version: 1.2.3
-          chart: oci://ghcr.io/example/nested/path/chart
+          chart: oci-repo/nested/path/chart
       `;
       const fileName = 'helmfile.yaml';
       const result = await extractPackageFile(content, fileName, {
@@ -385,9 +385,9 @@ describe('modules/manager/helmfile/extract', () => {
         deps: [
           {
             currentValue: '1.2.3',
-            depName: 'path/chart',
+            depName: 'nested/path/chart',
             datasource: 'docker',
-            packageName: 'ghcr.io/example/nested/path/chart',
+            packageName: 'ghcr.io/example/oci-repo/nested/path/chart',
           },
         ],
       });

--- a/lib/modules/manager/helmfile/extract.spec.ts
+++ b/lib/modules/manager/helmfile/extract.spec.ts
@@ -375,11 +375,7 @@ describe('modules/manager/helmfile/extract', () => {
           chart: oci-repo/nested/path/chart
       `;
       const fileName = 'helmfile.yaml';
-      const result = await extractPackageFile(content, fileName, {
-        registryAliases: {
-          stable: 'https://charts.helm.sh/stable',
-        },
-      });
+      const result = await extractPackageFile(content, fileName, {});
       expect(result).toMatchObject({
         datasource: 'helm',
         deps: [

--- a/lib/modules/manager/helmfile/extract.ts
+++ b/lib/modules/manager/helmfile/extract.ts
@@ -18,7 +18,7 @@ import {
   localChartHasKustomizationsYaml,
 } from './utils';
 
-const isValidChartName = (name: string | undefined, oci: boolean): boolean {
+const isValidChartName = (name: string | undefined, oci: boolean): boolean => {
   if (oci) {
     return !!name && !regEx(/[!@#$%^&*(),.?":{}|<>A-Z]/).test(name);
   } else {

--- a/lib/modules/manager/helmfile/extract.ts
+++ b/lib/modules/manager/helmfile/extract.ts
@@ -123,7 +123,7 @@ export async function extractPackageFile(
 
       // By definition on helm the chart name should be lowercase letter + number + -
       // However helmfile support templating of that field
-      if (!isValidChartName(res.depName, isOCIRegistry(dep.chart) || registryData[repoName]?.oci)) {
+      if (!isValidChartName(res.depName, isOCIRegistry(dep.chart) || (registryData[repoName]?.oci ?? false))) {
         res.skipReason = 'unsupported-chart-type';
       }
 

--- a/lib/modules/manager/helmfile/extract.ts
+++ b/lib/modules/manager/helmfile/extract.ts
@@ -24,7 +24,7 @@ const isValidChartName = (name: string | undefined, oci: boolean): boolean => {
   } else {
     return !!name && !regEx(/[!@#$%^&*(),.?":{}/|<>A-Z]/).test(name);
   }
-}
+};
 
 function isLocalPath(possiblePath: string): boolean {
   return ['./', '../', '/'].some((localPrefix) =>
@@ -123,7 +123,12 @@ export async function extractPackageFile(
 
       // By definition on helm the chart name should be lowercase letter + number + -
       // However helmfile support templating of that field
-      if (!isValidChartName(res.depName, isOCIRegistry(dep.chart) || (registryData[repoName]?.oci ?? false))) {
+      if (
+        !isValidChartName(
+          res.depName,
+          isOCIRegistry(dep.chart) || (registryData[repoName]?.oci ?? false),
+        )
+      ) {
         res.skipReason = 'unsupported-chart-type';
       }
 

--- a/lib/modules/manager/helmfile/extract.ts
+++ b/lib/modules/manager/helmfile/extract.ts
@@ -18,7 +18,7 @@ import {
   localChartHasKustomizationsYaml,
 } from './utils';
 
-const isValidChartName = (name: string | undefined, oci: boolean): boolean => {
+function isValidChartName(name: string | undefined, oci: boolean): boolean {
   if (oci) {
     return !!name && !regEx(/[!@#$%^&*(),.?":{}|<>A-Z]/).test(name);
   } else {

--- a/lib/modules/manager/helmfile/extract.ts
+++ b/lib/modules/manager/helmfile/extract.ts
@@ -18,8 +18,13 @@ import {
   localChartHasKustomizationsYaml,
 } from './utils';
 
-const isValidChartName = (name: string | undefined): boolean =>
-  !!name && !regEx(/[!@#$%^&*(),.?":{}/|<>A-Z]/).test(name);
+const isValidChartName = (name: string | undefined, oci: boolean): boolean {
+  if (oci) {
+    return !!name && !regEx(/[!@#$%^&*(),.?":{}|<>A-Z]/).test(name);
+  } else {
+    return !!name && !regEx(/[!@#$%^&*(),.?":{}/|<>A-Z]/).test(name);
+  }
+}
 
 function isLocalPath(possiblePath: string): boolean {
   return ['./', '../', '/'].some((localPrefix) =>
@@ -118,7 +123,7 @@ export async function extractPackageFile(
 
       // By definition on helm the chart name should be lowercase letter + number + -
       // However helmfile support templating of that field
-      if (!isValidChartName(res.depName)) {
+      if (!isValidChartName(res.depName, isOCIRegistry(dep.chart) || registryData[repoName]?.oci)) {
         res.skipReason = 'unsupported-chart-type';
       }
 

--- a/lib/modules/manager/helmfile/extract.ts
+++ b/lib/modules/manager/helmfile/extract.ts
@@ -24,7 +24,7 @@ function isValidChartName(name: string | undefined, oci: boolean): boolean {
   } else {
     return !!name && !regEx(/[!@#$%^&*(),.?":{}/|<>A-Z]/).test(name);
   }
-};
+}
 
 function isLocalPath(possiblePath: string): boolean {
   return ['./', '../', '/'].some((localPrefix) =>


### PR DESCRIPTION
## Changes



The helmfile manager now properly handles OCI chart names that contain forward slashes. Previously, the validation would reject chart names with slashes even for OCI repositories. This change modifies the isValidChartName function to use different validation rules for OCI vs non-OCI charts.

Added test coverage to verify the new behavior works correctly.

## Context

Issue was described in [discussion][1].

[1]: https://github.com/renovatebot/renovate/discussions/26207

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [X] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

