### PR TITLE
fix(cache): add extract revision, stop deleting skipReason

### DIFF
--- a/lib/util/cache/repository/types.ts
+++ b/lib/util/cache/repository/types.ts
@@ -8,6 +8,7 @@ import type { RepoInitConfig } from '../../../workers/repository/init/types';
 import type { PrBlockedBy } from '../../../workers/types';
 
 export interface BaseBranchCache {
+  revision?: number;
   sha: string; // branch commit sha
   configHash: string; // object hash of config
   extractionFingerprints: Record<string, string | undefined>; // matching manager fingerprints

--- a/lib/workers/repository/process/extract-update.spec.ts
+++ b/lib/workers/repository/process/extract-update.spec.ts
@@ -6,7 +6,13 @@ import { fingerprint } from '../../../util/fingerprint';
 import type { LongCommitSha } from '../../../util/git/types';
 import { generateFingerprintConfig } from '../extract/extract-fingerprint-config';
 import * as _branchify from '../updates/branchify';
-import { extract, isCacheExtractValid, lookup, update } from './extract-update';
+import {
+  EXTRACT_CACHE_REVISION,
+  extract,
+  isCacheExtractValid,
+  lookup,
+  update,
+} from './extract-update';
 
 const createVulnerabilitiesMock = jest.fn();
 
@@ -97,6 +103,7 @@ describe('workers/repository/process/extract-update', () => {
       repositoryCache.getCache.mockReturnValueOnce({
         scan: {
           master: {
+            revision: EXTRACT_CACHE_REVISION,
             sha: '123test',
             configHash: fingerprint(generateFingerprintConfig(config)),
             extractionFingerprints: {},
@@ -150,6 +157,7 @@ describe('workers/repository/process/extract-update', () => {
 
     beforeEach(() => {
       cachedExtract = {
+        revision: EXTRACT_CACHE_REVISION,
         sha: 'sha',
         configHash: undefined as never,
         extractionFingerprints: {},
@@ -160,6 +168,18 @@ describe('workers/repository/process/extract-update', () => {
     it('undefined cache', () => {
       expect(isCacheExtractValid('sha', 'hash', undefined)).toBe(false);
       expect(logger.logger.debug).toHaveBeenCalledTimes(0);
+    });
+
+    it('returns false if no revision', () => {
+      delete cachedExtract.revision;
+      expect(isCacheExtractValid('sha', 'hash', cachedExtract)).toBe(false);
+      expect(logger.logger.debug).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns false if revision mismatch', () => {
+      cachedExtract.revision = -1;
+      expect(isCacheExtractValid('sha', 'hash', cachedExtract)).toBe(false);
+      expect(logger.logger.debug).toHaveBeenCalledTimes(1);
     });
 
     it('partial cache', () => {

--- a/lib/workers/repository/process/extract-update.ts
+++ b/lib/workers/repository/process/extract-update.ts
@@ -18,6 +18,7 @@ import { Vulnerabilities } from './vulnerabilities';
 import type { WriteUpdateResult } from './write';
 import { writeUpdates } from './write';
 
+// Increment this if needing to cache bust ALL extract caches
 export const EXTRACT_CACHE_REVISION = 1;
 
 export interface ExtractResult {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Removes problematic `skipReason` removal (it's unreliable, and I want to reduce complexity in this PR), and adds an extract cache revision to "cache bust" all extract caches due to this mistake.

## Context

- closes #33171

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
