### PR TITLE
feat(bun): Add support for updating text-format lockfile when package.json changes

### DIFF
--- a/lib/modules/manager/bun/artifacts.spec.ts
+++ b/lib/modules/manager/bun/artifacts.spec.ts
@@ -41,7 +41,7 @@ describe('modules/manager/bun/artifacts', () => {
       expect(await updateArtifacts(updateArtifact)).toBeNull();
     });
 
-    describe("when using .lockb lockfile format", () => {
+    describe('when using .lockb lockfile format', () => {
       it('skips if cannot read lock file', async () => {
         updateArtifact.updatedDeps = [
           { manager: 'bun', lockFiles: ['bun.lockb'] },
@@ -135,7 +135,7 @@ describe('modules/manager/bun/artifacts', () => {
       });
     });
 
-    describe("when using .lock lockfile format", () => {
+    describe('when using .lock lockfile format', () => {
       it('skips if cannot read lock file', async () => {
         updateArtifact.updatedDeps = [
           { manager: 'bun', lockFiles: ['bun.lock'] },
@@ -227,12 +227,12 @@ describe('modules/manager/bun/artifacts', () => {
           { artifactError: { lockFile: 'bun.lock', stderr: 'nope' } },
         ]);
       });
-    })
+    });
   });
 
   describe('bun command execution', () => {
     it('check install options with configs', async () => {
-      const lockfileFormats = ["bun.lockb", "bun.lock"];
+      const lockfileFormats = ['bun.lockb', 'bun.lock'];
       const testCases = [
         {
           allowScripts: undefined,

--- a/lib/modules/manager/bun/artifacts.spec.ts
+++ b/lib/modules/manager/bun/artifacts.spec.ts
@@ -41,101 +41,198 @@ describe('modules/manager/bun/artifacts', () => {
       expect(await updateArtifacts(updateArtifact)).toBeNull();
     });
 
-    it('skips if cannot read lock file', async () => {
-      updateArtifact.updatedDeps = [
-        { manager: 'bun', lockFiles: ['bun.lockb'] },
-      ];
-      expect(await updateArtifacts(updateArtifact)).toBeNull();
-    });
-
-    it('returns null if lock content unchanged', async () => {
-      updateArtifact.updatedDeps = [
-        { manager: 'bun', lockFiles: ['bun.lockb'] },
-      ];
-      const oldLock = Buffer.from('old');
-      fs.readFile.mockResolvedValueOnce(oldLock as never);
-      fs.readFile.mockResolvedValueOnce(oldLock as never);
-      expect(await updateArtifacts(updateArtifact)).toBeNull();
-    });
-
-    it('returns updated lock content', async () => {
-      updateArtifact.updatedDeps = [
-        { manager: 'bun', lockFiles: ['bun.lockb'] },
-      ];
-      const oldLock = Buffer.from('old');
-      fs.readFile.mockResolvedValueOnce(oldLock as never);
-      const newLock = Buffer.from('new');
-      fs.readFile.mockResolvedValueOnce(newLock as never);
-      expect(await updateArtifacts(updateArtifact)).toEqual([
-        {
-          file: {
-            path: 'bun.lockb',
-            type: 'addition',
-            contents: newLock,
-          },
-        },
-      ]);
-    });
-
-    it('supports lockFileMaintenance', async () => {
-      updateArtifact.updatedDeps = [
-        { manager: 'bun', lockFiles: ['bun.lockb'] },
-      ];
-      updateArtifact.config.updateType = 'lockFileMaintenance';
-      const oldLock = Buffer.from('old');
-      fs.readFile.mockResolvedValueOnce(oldLock as never);
-      const newLock = Buffer.from('new');
-      fs.readFile.mockResolvedValueOnce(newLock as never);
-      expect(await updateArtifacts(updateArtifact)).toEqual([
-        {
-          file: {
-            path: 'bun.lockb',
-            type: 'addition',
-            contents: newLock,
-          },
-        },
-      ]);
-    });
-
-    it('handles temporary error', async () => {
-      const execError = new ExecError(TEMPORARY_ERROR, {
-        cmd: '',
-        stdout: '',
-        stderr: '',
-        options: { encoding: 'utf8' },
+    describe("when using .lockb lockfile format", () => {
+      it('skips if cannot read lock file', async () => {
+        updateArtifact.updatedDeps = [
+          { manager: 'bun', lockFiles: ['bun.lockb'] },
+        ];
+        expect(await updateArtifacts(updateArtifact)).toBeNull();
       });
-      updateArtifact.updatedDeps = [
-        { manager: 'bun', lockFiles: ['bun.lockb'] },
-      ];
-      const oldLock = Buffer.from('old');
-      fs.readFile.mockResolvedValueOnce(oldLock as never);
-      exec.mockRejectedValueOnce(execError);
-      await expect(updateArtifacts(updateArtifact)).rejects.toThrow(
-        TEMPORARY_ERROR,
-      );
+
+      it('returns null if lock content unchanged', async () => {
+        updateArtifact.updatedDeps = [
+          { manager: 'bun', lockFiles: ['bun.lockb'] },
+        ];
+        const oldLock = Buffer.from('old');
+        fs.readFile.mockResolvedValueOnce(oldLock as never);
+        fs.readFile.mockResolvedValueOnce(oldLock as never);
+        expect(await updateArtifacts(updateArtifact)).toBeNull();
+      });
+
+      it('returns updated lock content', async () => {
+        updateArtifact.updatedDeps = [
+          { manager: 'bun', lockFiles: ['bun.lockb'] },
+        ];
+        const oldLock = Buffer.from('old');
+        fs.readFile.mockResolvedValueOnce(oldLock as never);
+        const newLock = Buffer.from('new');
+        fs.readFile.mockResolvedValueOnce(newLock as never);
+        expect(await updateArtifacts(updateArtifact)).toEqual([
+          {
+            file: {
+              path: 'bun.lockb',
+              type: 'addition',
+              contents: newLock,
+            },
+          },
+        ]);
+      });
+
+      it('supports lockFileMaintenance', async () => {
+        updateArtifact.updatedDeps = [
+          { manager: 'bun', lockFiles: ['bun.lockb'] },
+        ];
+        updateArtifact.config.updateType = 'lockFileMaintenance';
+        const oldLock = Buffer.from('old');
+        fs.readFile.mockResolvedValueOnce(oldLock as never);
+        const newLock = Buffer.from('new');
+        fs.readFile.mockResolvedValueOnce(newLock as never);
+        expect(await updateArtifacts(updateArtifact)).toEqual([
+          {
+            file: {
+              path: 'bun.lockb',
+              type: 'addition',
+              contents: newLock,
+            },
+          },
+        ]);
+      });
+
+      it('handles temporary error', async () => {
+        const execError = new ExecError(TEMPORARY_ERROR, {
+          cmd: '',
+          stdout: '',
+          stderr: '',
+          options: { encoding: 'utf8' },
+        });
+        updateArtifact.updatedDeps = [
+          { manager: 'bun', lockFiles: ['bun.lockb'] },
+        ];
+        const oldLock = Buffer.from('old');
+        fs.readFile.mockResolvedValueOnce(oldLock as never);
+        exec.mockRejectedValueOnce(execError);
+        await expect(updateArtifacts(updateArtifact)).rejects.toThrow(
+          TEMPORARY_ERROR,
+        );
+      });
+
+      it('handles full error', async () => {
+        const execError = new ExecError('nope', {
+          cmd: '',
+          stdout: '',
+          stderr: '',
+          options: { encoding: 'utf8' },
+        });
+        updateArtifact.updatedDeps = [
+          { manager: 'bun', lockFiles: ['bun.lockb'] },
+        ];
+        const oldLock = Buffer.from('old');
+        fs.readFile.mockResolvedValueOnce(oldLock as never);
+        exec.mockRejectedValueOnce(execError);
+        expect(await updateArtifacts(updateArtifact)).toEqual([
+          { artifactError: { lockFile: 'bun.lockb', stderr: 'nope' } },
+        ]);
+      });
     });
 
-    it('handles full error', async () => {
-      const execError = new ExecError('nope', {
-        cmd: '',
-        stdout: '',
-        stderr: '',
-        options: { encoding: 'utf8' },
+    describe("when using .lock lockfile format", () => {
+      it('skips if cannot read lock file', async () => {
+        updateArtifact.updatedDeps = [
+          { manager: 'bun', lockFiles: ['bun.lock'] },
+        ];
+        expect(await updateArtifacts(updateArtifact)).toBeNull();
       });
-      updateArtifact.updatedDeps = [
-        { manager: 'bun', lockFiles: ['bun.lockb'] },
-      ];
-      const oldLock = Buffer.from('old');
-      fs.readFile.mockResolvedValueOnce(oldLock as never);
-      exec.mockRejectedValueOnce(execError);
-      expect(await updateArtifacts(updateArtifact)).toEqual([
-        { artifactError: { lockFile: 'bun.lockb', stderr: 'nope' } },
-      ]);
-    });
+
+      it('returns null if lock content unchanged', async () => {
+        updateArtifact.updatedDeps = [
+          { manager: 'bun', lockFiles: ['bun.lock'] },
+        ];
+        const oldLock = Buffer.from('old');
+        fs.readFile.mockResolvedValueOnce(oldLock as never);
+        fs.readFile.mockResolvedValueOnce(oldLock as never);
+        expect(await updateArtifacts(updateArtifact)).toBeNull();
+      });
+
+      it('returns updated lock content', async () => {
+        updateArtifact.updatedDeps = [
+          { manager: 'bun', lockFiles: ['bun.lock'] },
+        ];
+        const oldLock = Buffer.from('old');
+        fs.readFile.mockResolvedValueOnce(oldLock as never);
+        const newLock = Buffer.from('new');
+        fs.readFile.mockResolvedValueOnce(newLock as never);
+        expect(await updateArtifacts(updateArtifact)).toEqual([
+          {
+            file: {
+              path: 'bun.lock',
+              type: 'addition',
+              contents: newLock,
+            },
+          },
+        ]);
+      });
+
+      it('supports lockFileMaintenance', async () => {
+        updateArtifact.updatedDeps = [
+          { manager: 'bun', lockFiles: ['bun.lock'] },
+        ];
+        updateArtifact.config.updateType = 'lockFileMaintenance';
+        const oldLock = Buffer.from('old');
+        fs.readFile.mockResolvedValueOnce(oldLock as never);
+        const newLock = Buffer.from('new');
+        fs.readFile.mockResolvedValueOnce(newLock as never);
+        expect(await updateArtifacts(updateArtifact)).toEqual([
+          {
+            file: {
+              path: 'bun.lock',
+              type: 'addition',
+              contents: newLock,
+            },
+          },
+        ]);
+      });
+
+      it('handles temporary error', async () => {
+        const execError = new ExecError(TEMPORARY_ERROR, {
+          cmd: '',
+          stdout: '',
+          stderr: '',
+          options: { encoding: 'utf8' },
+        });
+        updateArtifact.updatedDeps = [
+          { manager: 'bun', lockFiles: ['bun.lock'] },
+        ];
+        const oldLock = Buffer.from('old');
+        fs.readFile.mockResolvedValueOnce(oldLock as never);
+        exec.mockRejectedValueOnce(execError);
+        await expect(updateArtifacts(updateArtifact)).rejects.toThrow(
+          TEMPORARY_ERROR,
+        );
+      });
+
+      it('handles full error', async () => {
+        const execError = new ExecError('nope', {
+          cmd: '',
+          stdout: '',
+          stderr: '',
+          options: { encoding: 'utf8' },
+        });
+        updateArtifact.updatedDeps = [
+          { manager: 'bun', lockFiles: ['bun.lock'] },
+        ];
+        const oldLock = Buffer.from('old');
+        fs.readFile.mockResolvedValueOnce(oldLock as never);
+        exec.mockRejectedValueOnce(execError);
+        expect(await updateArtifacts(updateArtifact)).toEqual([
+          { artifactError: { lockFile: 'bun.lock', stderr: 'nope' } },
+        ]);
+      });
+    })
   });
 
   describe('bun command execution', () => {
     it('check install options with configs', async () => {
+      const lockfileFormats = ["bun.lockb", "bun.lock"];
       const testCases = [
         {
           allowScripts: undefined,
@@ -184,38 +281,40 @@ describe('modules/manager/bun/artifacts', () => {
         },
       ];
 
-      for (const testCase of testCases) {
-        GlobalConfig.set({
-          ...globalConfig,
-          allowScripts: testCase.allowScripts,
-        });
-        const updateArtifact: UpdateArtifact = {
-          config: { ignoreScripts: testCase.ignoreScripts },
-          newPackageFileContent: '',
-          packageFileName: '',
-          updatedDeps: [{ manager: 'bun', lockFiles: ['bun.lockb'] }],
-        };
+      for (const lockFile of lockfileFormats) {
+        for (const testCase of testCases) {
+          GlobalConfig.set({
+            ...globalConfig,
+            allowScripts: testCase.allowScripts,
+          });
+          const updateArtifact: UpdateArtifact = {
+            config: { ignoreScripts: testCase.ignoreScripts },
+            newPackageFileContent: '',
+            packageFileName: '',
+            updatedDeps: [{ manager: 'bun', lockFiles: [lockFile] }],
+          };
 
-        const oldLock = Buffer.from('old');
-        fs.readFile.mockResolvedValueOnce(oldLock as never);
-        const newLock = Buffer.from('new');
-        fs.readFile.mockResolvedValueOnce(newLock as never);
+          const oldLock = Buffer.from('old');
+          fs.readFile.mockResolvedValueOnce(oldLock as never);
+          const newLock = Buffer.from('new');
+          fs.readFile.mockResolvedValueOnce(newLock as never);
 
-        await updateArtifacts(updateArtifact);
+          await updateArtifacts(updateArtifact);
 
-        expect(exec).toHaveBeenCalledWith(testCase.expectedCmd, {
-          cwdFile: '',
-          docker: {},
-          toolConstraints: [
-            {
-              toolName: 'bun',
-            },
-          ],
-          userConfiguredEnv: undefined,
-        });
+          expect(exec).toHaveBeenCalledWith(testCase.expectedCmd, {
+            cwdFile: '',
+            docker: {},
+            toolConstraints: [
+              {
+                toolName: 'bun',
+              },
+            ],
+            userConfiguredEnv: undefined,
+          });
 
-        exec.mockClear();
-        GlobalConfig.reset();
+          exec.mockClear();
+          GlobalConfig.reset();
+        }
       }
     });
   });

--- a/lib/modules/manager/bun/extract.spec.ts
+++ b/lib/modules/manager/bun/extract.spec.ts
@@ -9,7 +9,7 @@ describe('modules/manager/bun/extract', () => {
       expect(await extractAllPackageFiles({}, ['package.json'])).toEqual([]);
     });
 
-    describe("when using the .lockb lockfile format", () => {
+    describe('when using the .lockb lockfile format', () => {
       it('ignores missing package.json file', async () => {
         expect(await extractAllPackageFiles({}, ['bun.lockb'])).toEqual([]);
       });
@@ -67,7 +67,7 @@ describe('modules/manager/bun/extract', () => {
       });
     });
 
-    describe("when using the .lock lockfile format", () => {
+    describe('when using the .lock lockfile format', () => {
       it('ignores missing package.json file', async () => {
         expect(await extractAllPackageFiles({}, ['bun.lock'])).toEqual([]);
       });

--- a/lib/modules/manager/bun/extract.spec.ts
+++ b/lib/modules/manager/bun/extract.spec.ts
@@ -9,60 +9,120 @@ describe('modules/manager/bun/extract', () => {
       expect(await extractAllPackageFiles({}, ['package.json'])).toEqual([]);
     });
 
-    it('ignores missing package.json file', async () => {
-      expect(await extractAllPackageFiles({}, ['bun.lockb'])).toEqual([]);
-    });
+    describe("when using the .lockb lockfile format", () => {
+      it('ignores missing package.json file', async () => {
+        expect(await extractAllPackageFiles({}, ['bun.lockb'])).toEqual([]);
+      });
 
-    it('ignores invalid package.json file', async () => {
-      (fs.readLocalFile as jest.Mock).mockResolvedValueOnce('invalid');
-      expect(await extractAllPackageFiles({}, ['bun.lockb'])).toEqual([]);
-    });
+      it('ignores invalid package.json file', async () => {
+        (fs.readLocalFile as jest.Mock).mockResolvedValueOnce('invalid');
+        expect(await extractAllPackageFiles({}, ['bun.lockb'])).toEqual([]);
+      });
 
-    it('handles null response', async () => {
-      fs.getSiblingFileName.mockReturnValueOnce('package.json');
-      fs.readLocalFile.mockResolvedValueOnce(
-        // This package.json returns null from the extractor
-        JSON.stringify({
-          _id: 1,
-          _args: 1,
-          _from: 1,
-        }),
-      );
-      expect(await extractAllPackageFiles({}, ['bun.lockb'])).toEqual([]);
-    });
+      it('handles null response', async () => {
+        fs.getSiblingFileName.mockReturnValueOnce('package.json');
+        fs.readLocalFile.mockResolvedValueOnce(
+          // This package.json returns null from the extractor
+          JSON.stringify({
+            _id: 1,
+            _args: 1,
+            _from: 1,
+          }),
+        );
+        expect(await extractAllPackageFiles({}, ['bun.lockb'])).toEqual([]);
+      });
 
-    it('parses valid package.json file', async () => {
-      fs.getSiblingFileName.mockReturnValueOnce('package.json');
-      fs.readLocalFile.mockResolvedValueOnce(
-        JSON.stringify({
-          name: 'test',
-          version: '0.0.1',
-          dependencies: {
-            dep1: '1.0.0',
-          },
-        }),
-      );
-      expect(await extractAllPackageFiles({}, ['bun.lockb'])).toMatchObject([
-        {
-          deps: [
-            {
-              currentValue: '1.0.0',
-              datasource: 'npm',
-              depName: 'dep1',
-              depType: 'dependencies',
-              prettyDepType: 'dependency',
+      it('parses valid package.json file', async () => {
+        fs.getSiblingFileName.mockReturnValueOnce('package.json');
+        fs.readLocalFile.mockResolvedValueOnce(
+          JSON.stringify({
+            name: 'test',
+            version: '0.0.1',
+            dependencies: {
+              dep1: '1.0.0',
             },
-          ],
-          extractedConstraints: {},
-          lockFiles: ['bun.lockb'],
-          managerData: {
-            hasPackageManager: false,
-            packageJsonName: 'test',
+          }),
+        );
+        expect(await extractAllPackageFiles({}, ['bun.lockb'])).toMatchObject([
+          {
+            deps: [
+              {
+                currentValue: '1.0.0',
+                datasource: 'npm',
+                depName: 'dep1',
+                depType: 'dependencies',
+                prettyDepType: 'dependency',
+              },
+            ],
+            extractedConstraints: {},
+            lockFiles: ['bun.lockb'],
+            managerData: {
+              hasPackageManager: false,
+              packageJsonName: 'test',
+            },
+            packageFile: 'package.json',
+            packageFileVersion: '0.0.1',
           },
-          packageFile: 'package.json',
-          packageFileVersion: '0.0.1',
-        },
-      ]);
+        ]);
+      });
+    });
+
+    describe("when using the .lock lockfile format", () => {
+      it('ignores missing package.json file', async () => {
+        expect(await extractAllPackageFiles({}, ['bun.lock'])).toEqual([]);
+      });
+
+      it('ignores invalid package.json file', async () => {
+        (fs.readLocalFile as jest.Mock).mockResolvedValueOnce('invalid');
+        expect(await extractAllPackageFiles({}, ['bun.lock'])).toEqual([]);
+      });
+
+      it('handles null response', async () => {
+        fs.getSiblingFileName.mockReturnValueOnce('package.json');
+        fs.readLocalFile.mockResolvedValueOnce(
+          // This package.json returns null from the extractor
+          JSON.stringify({
+            _id: 1,
+            _args: 1,
+            _from: 1,
+          }),
+        );
+        expect(await extractAllPackageFiles({}, ['bun.lock'])).toEqual([]);
+      });
+
+      it('parses valid package.json file', async () => {
+        fs.getSiblingFileName.mockReturnValueOnce('package.json');
+        fs.readLocalFile.mockResolvedValueOnce(
+          JSON.stringify({
+            name: 'test',
+            version: '0.0.1',
+            dependencies: {
+              dep1: '1.0.0',
+            },
+          }),
+        );
+        expect(await extractAllPackageFiles({}, ['bun.lock'])).toMatchObject([
+          {
+            deps: [
+              {
+                currentValue: '1.0.0',
+                datasource: 'npm',
+                depName: 'dep1',
+                depType: 'dependencies',
+                prettyDepType: 'dependency',
+              },
+            ],
+            extractedConstraints: {},
+            lockFiles: ['bun.lock'],
+            managerData: {
+              hasPackageManager: false,
+              packageJsonName: 'test',
+            },
+            packageFile: 'package.json',
+            packageFileVersion: '0.0.1',
+          },
+        ]);
+      });
     });
   });
 });

--- a/lib/modules/manager/bun/extract.ts
+++ b/lib/modules/manager/bun/extract.ts
@@ -18,7 +18,12 @@ export async function extractAllPackageFiles(
 ): Promise<PackageFile[]> {
   const packageFiles: PackageFile<NpmManagerData>[] = [];
   for (const matchedFile of matchedFiles) {
-    if (!(matchesFileName(matchedFile, 'bun.lockb') || matchesFileName(matchedFile, 'bun.lock'))) {
+    if (
+      !(
+        matchesFileName(matchedFile, 'bun.lockb') ||
+        matchesFileName(matchedFile, 'bun.lock')
+      )
+    ) {
       logger.warn({ matchedFile }, 'Invalid bun lockfile match');
       continue;
     }

--- a/lib/modules/manager/bun/extract.ts
+++ b/lib/modules/manager/bun/extract.ts
@@ -18,7 +18,7 @@ export async function extractAllPackageFiles(
 ): Promise<PackageFile[]> {
   const packageFiles: PackageFile<NpmManagerData>[] = [];
   for (const matchedFile of matchedFiles) {
-    if (!matchesFileName(matchedFile, 'bun.lockb')) {
+    if (!(matchesFileName(matchedFile, 'bun.lockb') || matchesFileName(matchedFile, 'bun.lock'))) {
       logger.warn({ matchedFile }, 'Invalid bun lockfile match');
       continue;
     }

--- a/lib/modules/manager/bun/index.ts
+++ b/lib/modules/manager/bun/index.ts
@@ -13,7 +13,7 @@ export const supersedesManagers = ['npm'];
 export const supportsLockFileMaintenance = true;
 
 export const defaultConfig = {
-  fileMatch: ['(^|/)bun\\.lockb$'],
+  fileMatch: ['(^|/)bun\\.lockb$', '(^|/)bun\\.lock$'],
   digest: {
     prBodyDefinitions: {
       Change:

--- a/lib/modules/manager/bun/index.ts
+++ b/lib/modules/manager/bun/index.ts
@@ -13,7 +13,7 @@ export const supersedesManagers = ['npm'];
 export const supportsLockFileMaintenance = true;
 
 export const defaultConfig = {
-  fileMatch: ['(^|/)bun\\.lockb$', '(^|/)bun\\.lock$'],
+  fileMatch: ['(^|/)bun\\.lockb?$'],
   digest: {
     prBodyDefinitions: {
       Change:


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Bun 1.2.x will introduce and switch by default to a text-format verison of the lockfile. Where currently they use a binary version named `bun.lockb`, this will become `bun.lock` and be plaintext:

https://bun.sh/blog/bun-lock-text-lockfile

This can be switched on by default in-advance since Bun 1.1.40 and so will appear in the wild as of now:

https://bun.sh/blog/bun-v1.1.40#new-install-savetextlockfile-in-bunfig-toml

This commit adds support for both lockfile formats by supporting by file-suffixes.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

As of Bun 1.1.40, this feature can be opted-in and Renovate no longer works for Bun without it.

As of Bun 1.2.x this feature will be on by default.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

The docs that would be affected are auto-generated ones

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

Tested and run on https://github.com/nathankleyn/bun-renovate-text-lockfile-test, where you can see a PR at which correctly detected and changed the new-style lockfile: https://github.com/nathankleyn/bun-renovate-text-lockfile-test/pull/2

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
