### PR TITLE
Introducing Renovate CLI Guru on Gurubase.io

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,6 +6,7 @@
 [![Build status](https://github.com/renovatebot/renovate/actions/workflows/build.yml/badge.svg)](https://github.com/renovatebot/renovate/actions/workflows/build.yml)
 ![Docker Pulls](https://img.shields.io/docker/pulls/renovate/renovate?color=turquoise)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/renovatebot/renovate/badge)](https://securityscorecards.dev/viewer/?uri=github.com/renovatebot/renovate)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Renovate%20CLI%20Guru-006BFF)](https://gurubase.io/g/renovate-cli)
 
 # What is the Mend Renovate CLI?
 


### PR DESCRIPTION
Hello team,

We are the maintainers of [Anteon](https://github.com/getanteon/anteon). Recently, we created Gurubase.io with the mission of building a centralized, open-source, tool-focused knowledge base. Each "guru" in Gurubase is equipped with custom knowledge to answer user questions based on data related to the respective tool.

We’re excited to let you know that [Renovate CLI Guru](https://gurubase.io/g/renovate-cli) has been manually added to Gurubase. Renovate CLI Guru uses the data from this repo and data from the [docs](https://docs.renovatebot.com/) to answer questions by leveraging the LLM.

This PR introduces the "Renovate CLI Guru", showcasing that Renovate CLI now has an AI assistant available to help users with their questions. We’d love to hear your feedback on this contribution.

You also have the option to maintain the "Renovate CLI Guru" by following the instructions in the [Gurubase Repo](https://github.com/getanteon/gurubase?tab=readme-ov-file#how-to-claim-a-guru) and to add an ASK AI widget to the Renovate CLI documentation website as detailed [here](https://github.com/getanteon/gurubase?tab=readme-ov-file#widget).

If you’d prefer us to disable Renovate CLI Guru in Gurubase, just let us know that's totally fine.
