### PR TITLE
chore: Add k8s.io/component-helpers to group:kubernetes

### DIFF
--- a/lib/config/presets/internal/group.ts
+++ b/lib/config/presets/internal/group.ts
@@ -316,9 +316,10 @@ const staticGroups = {
           'k8s.io/cluster-bootstrap**',
           'k8s.io/code-generator**',
           'k8s.io/component-base**',
+          'k8s.io/component-helpers**',
           'k8s.io/controller-manager**',
           'k8s.io/cri-api**',
-          // 'k8s.io/csi-api', has not go.mod set up and does not follow the versioning of other repos
+          // 'k8s.io/csi-api', has no go.mod set up and does not follow the versioning of other repos
           'k8s.io/csi-translation-lib**',
           'k8s.io/kube-aggregator**',
           'k8s.io/kube-controller-manager**',


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

This PR adds the Go package [`k8s.io/component-helpers`](https://pkg.go.dev/k8s.io/component-helpers) to the preset [`group:kubernetes`](https://docs.renovatebot.com/presets-group/#groupkubernetes).

### Motivation

We're using the preset `config:recommended` which includes `group:kubernetes`.
Renovate opened the following PRs:
* https://github.com/gardener/gardener/pull/11018
* https://github.com/gardener/gardener/pull/11019

I want to group these through `group:kubernetes`.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

As I understand it, the documentation for [`group:kubernetes`](https://docs.renovatebot.com/presets-group/#groupkubernetes) is automatically updated using the definition of the config preset.

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
