### PR TITLE
feat(preset): Fix axis2 monorepo group

### DIFF
--- a/lib/data/monorepo.json
+++ b/lib/data/monorepo.json
@@ -598,6 +598,7 @@
     "apache-poi": "/^org.apache.poi:/",
     "aws-java-sdk": "/^com.amazonaws:aws-java-sdk-/",
     "aws-java-sdk-v2": "/^software.amazon.awssdk:/",
+    "axis2": "/^org.apache.axis2:/",
     "babel6": "/^babel6$/",
     "clarity": ["/^@cds//", "/^@clr//"],
     "embroider": "/^@embroider//",

--- a/lib/data/monorepo.json
+++ b/lib/data/monorepo.json
@@ -55,10 +55,6 @@
       "https://github.com/awslabs/aws-sdk-rust"
     ],
     "awsappsync": "https://github.com/awslabs/aws-mobile-appsync-sdk-js",
-    "axis2": [
-      "https://gitbox.apache.org/repos/asf?p=axis-axis2-java-core.git;a=summary",
-      "https://github.com/apache/axis-axis2-java-core"
-    ],
     "azure-functions-dotnet-worker": "https://github.com/Azure/azure-functions-dotnet-worker",
     "azure azure-libraries-for-net": "https://github.com/Azure/azure-libraries-for-net",
     "azure azure-sdk-for-net": "https://github.com/Azure/azure-sdk-for-net",


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- axis2:mex and axis2:addressing were still getting updated separately, regardless of the axis2 grouping (as it was done by source url).

- For this reason, axis2 was refactored to be grouped by group id instead of source url.

- mex and addressing are contained within modules: https://repo1.maven.org/maven2/org/apache/axis2/axis2/1.8.2/axis2-1.8.2.pom

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
