### PR TITLE
chore: `debug-logs` label action

### DIFF
--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -100,16 +100,6 @@
     </details>
 
 
-    ### Insufficient logs
-
-    <details><summary>Select me to read instructions</summary>
-
-
-    If you already gave us a log, and the Renovate team said it's not enough, then follow the instructions from the **No logs at all** section.
-
-    </details>
-
-
     ### Formatting your logs
 
     <details><summary>Select me to read instructions</summary>
@@ -134,6 +124,35 @@
 
     Good luck,
 
+
+    The Renovate team
+
+'auto:debug-logs':
+  comment: >
+    Hi there,
+
+    The logs you've provided are insufficient for troubleshooting. We specifically need **DEBUG** level logs to help diagnose your issue.
+
+    ### How to enable DEBUG logs
+
+    Add "logLevel": "debug" in your self-hosted configuration
+    Or
+    Add LOG_LEVEL=debug to your environment variables before invoking Renovate.
+
+
+    ### Sharing your DEBUG logs
+
+    Please format your logs using:
+
+        <details><summary>DEBUG logs</summary>
+
+        ```
+        Your DEBUG level logs here
+        ```
+
+        </details>
+
+    For large logs, please use [GitHub Gist](https://gist.github.com/) and share the link.
 
     The Renovate team
 

--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -135,9 +135,7 @@
 
     ### How to enable DEBUG logs
 
-    Add "logLevel": "debug" in your self-hosted configuration
-    Or
-    Add LOG_LEVEL=debug to your environment variables before invoking Renovate.
+    Add `LOG_LEVEL=debug` to your environment variables before invoking Renovate.
 
 
     ### Sharing your DEBUG logs


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Add a new `debug-logs` label action which requests the user to specifically share the debug logs.
Also, contains info onw how to get DEBUG logs and share them
<!-- Describe what behavior is changed by this PR. -->

## Context
- Ref: https://github.com/renovatebot/renovate/issues/27349
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
