### PR TITLE
feat(presets): include Astro adapters in astro monorepo

### DIFF
--- a/lib/data/monorepo.json
+++ b/lib/data/monorepo.json
@@ -31,7 +31,10 @@
     "aspnet extensions": "https://github.com/aspnet/Extensions",
     "aspnet-api-versioning": "https://github.com/Microsoft/aspnet-api-versioning",
     "aspnet-health-checks": "https://github.com/xabaril/AspNetCore.Diagnostics.HealthChecks",
-    "astro": "https://github.com/withastro/astro",
+    "astro": [
+      "https://github.com/withastro/astro",
+      "https://github.com/withastro/adapters"
+    ],
     "auto": "https://github.com/intuit/auto",
     "autofixture": "https://github.com/AutoFixture/AutoFixture",
     "automapper-dotnet": [


### PR DESCRIPTION
## Changes

This adds the missing Astro adapters monorepo packages to the `astro` group.

## Context

The `astro` group only include the core Astro monorepo. It is missing the Astro adapters monorepo, which includes packages like `@astrojs/node`, `@astrojs/cloudflare`, etc. These should be grouped together with Astro core dependencies.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
