### PR TITLE
fix(platform/github): use correct url to find pr when only using branch name

### DIFF
--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -2568,7 +2568,7 @@ describe('modules/platform/github/index', () => {
       const scope = httpMock.scope(githubApiHost);
       initRepoMock(scope, 'some/repo');
       scope
-        .get('/repos/some/repo/pulls?head=some/repo:branch&state=open')
+        .get('/repos/some/repo/pulls?head=some:branch&state=open')
         .reply(200, [
           {
             number: 1,
@@ -2598,7 +2598,7 @@ describe('modules/platform/github/index', () => {
       const scope = httpMock.scope(githubApiHost);
       initRepoMock(scope, 'some/repo');
       scope
-        .get('/repos/some/repo/pulls?head=some/repo:branch&state=open')
+        .get('/repos/some/repo/pulls?head=some:branch&state=open')
         .reply(200, []);
       await github.initRepo({ repository: 'some/repo' });
       const pr = await github.findPr({

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -855,9 +855,10 @@ export async function findPr({
 
   if (includeOtherAuthors) {
     const repo = config.parentRepo ?? config.repository;
+    const org = repo?.split('/')[0];
     // PR might have been created by anyone, so don't use the cached Renovate PR list
     const { body: prList } = await githubApi.getJson<GhRestPr[]>(
-      `repos/${repo}/pulls?head=${repo}:${branchName}&state=open`,
+      `repos/${repo}/pulls?head=${org}:${branchName}&state=open`,
       { cacheProvider: repoCacheProvider },
     );
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- reaplce `repo` with `org` in the url/endpoint used to find the pr when we use only branch name to find the pr
<!-- Describe what behavior is changed by this PR. -->

## Context
- The current url is incorrect, we should be using:
`https://api.github.com/repos/OWNER/REPO/pulls?head=OWNER:BRANCHNAME?state=open` ([ref](https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests))
instead of:
`https://api.github.com/repos/OWNER/REPO/pulls?head=OWNER/REPO:BRANCHNAME?state=open`

This bug was introduced in this PR: https://github.com/renovatebot/renovate/pull/25954/

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository
[Before ](https://github.com/Rahul-renovate-testing/repro-no-cmnt-hosted-app/pull/4) (no comment, because pr wasn't found even though it existed) (ran using the hosted app)
[After ](https://github.com/Rahul-renovate-testing/recon-pr-del-cmnt/pull/1) (comment added) (ran using self-hosted, afterv making changes)
<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
