### PR TITLE
refactor(gerrit): remove deprecated source branch as hashtags support

### DIFF
--- a/lib/modules/platform/gerrit/client.spec.ts
+++ b/lib/modules/platform/gerrit/client.spec.ts
@@ -102,7 +102,6 @@ describe('modules/platform/gerrit/client', () => {
         'footer:Renovate-Branch=dependency-xyz',
         { branchName: 'dependency-xyz' },
       ],
-      ['hashtag:sourceBranch-dependency-xyz', { branchName: 'dependency-xyz' }], // for backwards compatibility
       ['label:Code-Review=-2', { branchName: 'dependency-xyz', label: '-2' }],
       [
         'branch:otherTarget',

--- a/lib/modules/platform/gerrit/client.ts
+++ b/lib/modules/platform/gerrit/client.ts
@@ -233,16 +233,7 @@ class GerritClient {
     const filterState = mapPrStateToGerritFilter(searchConfig.state);
     const filters = ['owner:self', 'project:' + repository, filterState];
     if (searchConfig.branchName) {
-      filters.push(
-        ...[
-          '(',
-          `footer:Renovate-Branch=${searchConfig.branchName}`,
-          // for backwards compatibility
-          'OR',
-          `hashtag:sourceBranch-${searchConfig.branchName}`,
-          ')',
-        ],
-      );
+      filters.push(`footer:Renovate-Branch=${searchConfig.branchName}`);
     }
     if (searchConfig.targetBranch) {
       filters.push(`branch:${searchConfig.targetBranch}`);

--- a/lib/modules/platform/gerrit/readme.md
+++ b/lib/modules/platform/gerrit/readme.md
@@ -8,12 +8,6 @@ Support for Gerrit is currently _experimental_, meaning that it _might_ still ha
 
 Renovate stores its metadata in the _commit message footer_.
 
-Previously Renovate stored metadata in Gerrit's _hashtags_.
-To keep backwards compatibility, Renovate still reads metadata from hashtags.
-But Renovate _always_ puts its metadata in the _commit message footer_!
-When the Renovate maintainers mark Gerrit support as stable, the maintainers will remove the "read metadata from hashtags" feature.
-This means changes without metadata in the commit message footer will be "forgotten" by Renovate.
-
 ## Authentication
 
 <figure markdown>

--- a/lib/modules/platform/gerrit/types.ts
+++ b/lib/modules/platform/gerrit/types.ts
@@ -34,10 +34,6 @@ export type GerritReviewersType = 'REVIEWER' | 'CC' | 'REMOVED';
 
 export interface GerritChange {
   branch: string;
-  /**
-   * for backwards compatibility
-   */
-  hashtags?: string[];
   change_id: string;
   subject: string;
   status: GerritChangeStatus;

--- a/lib/modules/platform/gerrit/utils.spec.ts
+++ b/lib/modules/platform/gerrit/utils.spec.ts
@@ -184,47 +184,6 @@ describe('modules/platform/gerrit/utils', () => {
       });
       expect(utils.extractSourceBranch(change)).toBe('renovate/dependency-1.x');
     });
-
-    // for backwards compatibility
-    it('no commit message but with hashtags', () => {
-      const change = partial<GerritChange>({
-        hashtags: ['sourceBranch-renovate/dependency-1.x'],
-      });
-      expect(utils.extractSourceBranch(change)).toBe('renovate/dependency-1.x');
-    });
-
-    // for backwards compatibility
-    it('commit message with no footer but with hashtags', () => {
-      const change = partial<GerritChange>({
-        hashtags: ['sourceBranch-renovate/dependency-1.x'],
-        current_revision: 'abc',
-        revisions: {
-          abc: partial<GerritRevisionInfo>({
-            commit: {
-              message: 'some message...',
-            },
-          }),
-        },
-      });
-      expect(utils.extractSourceBranch(change)).toBe('renovate/dependency-1.x');
-    });
-
-    // for backwards compatibility
-    it('prefers the footer over the hashtags', () => {
-      const change = partial<GerritChange>({
-        hashtags: ['sourceBranch-renovate/dependency-1.x'],
-        current_revision: 'abc',
-        revisions: {
-          abc: partial<GerritRevisionInfo>({
-            commit: {
-              message:
-                'Some change\n\nRenovate-Branch: renovate/dependency-2.x\nChange-Id: ...',
-            },
-          }),
-        },
-      });
-      expect(utils.extractSourceBranch(change)).toBe('renovate/dependency-2.x');
-    });
   });
 
   describe('findPullRequestBody()', () => {

--- a/lib/modules/platform/gerrit/utils.ts
+++ b/lib/modules/platform/gerrit/utils.ts
@@ -101,11 +101,6 @@ export function extractSourceBranch(change: GerritChange): string | undefined {
     }
   }
 
-  // for backwards compatibility
-  sourceBranch ??= change.hashtags
-    ?.find((tag) => tag.startsWith('sourceBranch-'))
-    ?.replace('sourceBranch-', '');
-
   return sourceBranch ?? undefined;
 }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Removes the deprecated support for resolving source branches from hashtags in Gerrit.

<!-- Describe what behavior is changed by this PR. -->

## Context

This was deprecated almost a year ago in:

- https://github.com/renovatebot/renovate/pull/29802

By now, all changes should have been migrated already for whoever is using Renovate with Gerrit.

**However, the motivation for this change is that I'm preparing the ground to repurpose Gerrit hashtags to behave as PR labels, which should be a great addition for the Gerrit platform.**

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
