### PR TITLE
docs: Add example and fix typo for readme of regex versioning module

### DIFF
--- a/lib/modules/versioning/regex/readme.md
+++ b/lib/modules/versioning/regex/readme.md
@@ -49,8 +49,22 @@ Here is another example, this time for handling Bitnami Docker images, which use
   "packageRules": [
     {
       "matchDatasources": ["docker"],
-      "matchPackageNamees": ["bitnami/**", "docker.io/bitnami/**"],
+      "matchPackageNames": ["bitnami/**", "docker.io/bitnami/**"],
       "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(?:-(?<compatibility>.+)(?<build>\\d+)-r(?<revision>\\d+))?$"
+    }
+  ]
+}
+```
+
+Here is another example, this time for handling `ghcr.io/linuxserver/tautulli` Docker images, which use `major` and `build` indicators with string prefixes:
+
+```json
+{
+  "packageRules": [
+    {
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["ghcr.io/linuxserver/tautulli"],
+      "versioning": "regex:^v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-ls(?<build>.+)$"
     }
   ]
 }
@@ -63,7 +77,7 @@ Here is another example, this time for handling `ghcr.io/linuxserver/openssh-ser
   "packageRules": [
     {
       "matchDatasources": ["docker"],
-      "matchPackageNamees": ["ghcr.io/linuxserver/openssh-server"],
+      "matchPackageNames": ["ghcr.io/linuxserver/openssh-server"],
       "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)_p(?<patch>\\d+)-r(?<build>\\d)-ls(?<revision>.+)$"
     }
   ]


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
This adds an example for `linuxserver/tautulli` docker image to show that for the fourth version part (the `ls` number), the `build` capture group should be used. This differs from the current example of `linuxserver/openssh-server` which the `ls` number is the fifth version part so versioning should be used. Closes #33270. 

Also fixes typo in the doc (should be `matchPackageNames` instead of `matchPackageNamees`)

## Context

I have opened an discussion #33270 while attempting to adapting the `linuxserver/openssh-server` example for linuxserver/librespeed. Afterwards the maintainer replied that the `build` instead of `versioning` capture group should be used for the fourth versioning part (the `ls` number).

I think most linuxserver.io image tags follow semver plus build number (`x.y.z-lsnn`). `ghcr.io/linuxserver/openssh-server` is a particularly difficult case with the five capture groups. I think it is a good idea to add an additional example to show how to handle linuxserver.io image tags in the format of `x.y.z-lsnn`. I believe that this will let beginners to get started to use renovate with most linuxserver.io images. This will also clearly demonstrate that when only four version parts are needed, build instead of revision should be used for the fourth capture group.

I choose `tautulli` as an example as this is the fourth most pulled linuxserver image according to [their stats](https://fleet.linuxserver.io/). The version tag prefixed with `v` also further demonstrates a difference with `openssh-server`.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
