### PR TITLE
fix(github): remove deleted issue from issues cache

### DIFF
--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -1531,6 +1531,57 @@ describe('modules/platform/github/index', () => {
     });
   });
 
+  describe('getIssue()', () => {
+    it('returns null if issues disabled', async () => {
+      const scope = httpMock.scope(githubApiHost);
+      initRepoMock(scope, 'some/repo', { hasIssuesEnabled: false });
+      await github.initRepo({ repository: 'some/repo' });
+      const res = await github.getIssue(1);
+      expect(res).toBeNull();
+    });
+
+    it('returns issue', async () => {
+      const scope = httpMock.scope(githubApiHost);
+      initRepoMock(scope, 'some/repo');
+      const issue = {
+        number: 1,
+        state: 'open',
+        title: 'title-1',
+        body: 'body-1',
+      };
+      scope
+        .get('/repos/some/repo/issues/1')
+        .reply(200, { ...issue, updated_at: '2022-01-01T00:00:00Z' });
+      await github.initRepo({ repository: 'some/repo' });
+      const res = await github.getIssue(1);
+      expect(res).toMatchObject({
+        ...issue,
+        lastModified: '2022-01-01T00:00:00Z',
+      });
+    });
+
+    it('returns null if issue not found', async () => {
+      const scope = httpMock.scope(githubApiHost);
+      initRepoMock(scope, 'some/repo');
+      scope.get('/repos/some/repo/issues/1').reply(404);
+      await github.initRepo({ repository: 'some/repo' });
+      const res = await github.getIssue(1);
+      expect(res).toBeNull();
+    });
+
+    it('logs debug message if issue deleted', async () => {
+      const scope = httpMock.scope(githubApiHost);
+      initRepoMock(scope, 'some/repo');
+      scope.get('/repos/some/repo/issues/1').reply(410);
+      await github.initRepo({ repository: 'some/repo' });
+      const res = await github.getIssue(1);
+      expect(res).toBeNull();
+      expect(logger.logger.debug).toHaveBeenCalledWith(
+        'Issue #1 has been deleted',
+      );
+    });
+  });
+
   describe('findIssue()', () => {
     it('returns null if no issue', async () => {
       httpMock

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -1247,7 +1247,7 @@ export async function getIssue(number: number): Promise<Issue | null> {
     GithubIssueCache.updateIssue(issue);
     return issue;
   } catch (err) /* istanbul ignore next */ {
-    logger.debug({ err, number: number }, 'Error getting issue');
+    logger.debug({ err, number }, 'Error getting issue');
     // istanbul ignore if
     if (err.message === 'Response Code 410(Gone)') {
       logger.debug(`Issue #${number} has been deleted`);

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -1231,7 +1231,6 @@ export async function getIssueList(): Promise<Issue[]> {
 }
 
 export async function getIssue(number: number): Promise<Issue | null> {
-  // istanbul ignore if
   if (config.hasIssuesEnabled === false) {
     return null;
   }
@@ -1246,10 +1245,9 @@ export async function getIssue(number: number): Promise<Issue | null> {
     );
     GithubIssueCache.updateIssue(issue);
     return issue;
-  } catch (err) /* istanbul ignore next */ {
+  } catch (err) {
     logger.debug({ err, number }, 'Error getting issue');
-    // istanbul ignore if
-    if (err.message === 'Response Code 410(Gone)') {
+    if (err.response?.statusCode === 410) {
       logger.debug(`Issue #${number} has been deleted`);
       GithubIssueCache.deleteIssue(number);
     }

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -1247,7 +1247,12 @@ export async function getIssue(number: number): Promise<Issue | null> {
     GithubIssueCache.updateIssue(issue);
     return issue;
   } catch (err) /* istanbul ignore next */ {
-    logger.debug({ err, number }, 'Error getting issue');
+    logger.debug({ err, number: number }, 'Error getting issue');
+    // istanbul ignore if
+    if (err.message === 'Response Code 410(Gone)') {
+      logger.debug(`Issue #${number} has been deleted`);
+      GithubIssueCache.deleteIssue(number);
+    }
     return null;
   }
 }

--- a/lib/modules/platform/github/issue.spec.ts
+++ b/lib/modules/platform/github/issue.spec.ts
@@ -159,6 +159,32 @@ describe('modules/platform/github/issue', () => {
       });
     });
 
+    it('removes particular issue from the cache', () => {
+      cache.platform = {
+        github: {
+          issuesCache: {
+            '1': {
+              number: 1,
+              body: 'body-1',
+              state: 'open',
+              title: 'title-1',
+              lastModified: '2020-01-01T00:00:00.000Z',
+            },
+          },
+        },
+      };
+
+      GithubIssueCache.deleteIssue(1);
+
+      expect(cache).toEqual({
+        platform: {
+          github: {
+            issuesCache: {},
+          },
+        },
+      });
+    });
+
     it('reconciles cache', () => {
       cache.platform = {
         github: {

--- a/lib/modules/platform/github/issue.ts
+++ b/lib/modules/platform/github/issue.ts
@@ -85,6 +85,13 @@ export class GithubIssueCache {
     }
   }
 
+  static deleteIssue(number: number): void {
+    const cacheData = this.data;
+    if (cacheData) {
+      delete cacheData[number];
+    }
+  }
+
   /**
    * At the moment of repo initialization, repository cache is not available.
    * What we can do is to store issues for later reconciliation.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
1. `getIssue()`:  Detect deleted issues and remove them from the `GithubIssuesCache`
2. `GithubIssuesCache`:  Added a new method `deleteIssue` to the 
<!-- Describe what behavior is changed by this PR. -->

## Context
- Closes: https://github.com/renovatebot/renovate/issues/32267
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or https://github.com/Rahul-renovate-testing/repro-32267/issues 
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
