### PR TITLE
fix(yaml): handle when templates are used as Yaml keys

### DIFF
--- a/lib/modules/manager/docker-compose/__fixtures__/docker-compose.4.yml.j2
+++ b/lib/modules/manager/docker-compose/__fixtures__/docker-compose.4.yml.j2
@@ -1,0 +1,26 @@
+---
+version: "3"
+
+networks:
+  {{ network_name }}:
+    external: true
+  frontend:
+    external: true
+
+services:
+  web:
+    image: "node:42.0.0"
+    networks:
+      - {{ network_name }}
+      - frontend
+    ports:
+      - "80:8000"
+    deploy:
+      replicas: 2
+      update_config:
+        parallelism: 2
+        delay: 10s
+      placement:
+        {{ placement | indent(8) }}
+      restart_policy:
+        condition: on-failure

--- a/lib/modules/manager/docker-compose/extract.spec.ts
+++ b/lib/modules/manager/docker-compose/extract.spec.ts
@@ -6,6 +6,7 @@ const yamlFile1 = Fixtures.get('docker-compose.1.yml');
 const yamlFile3 = Fixtures.get('docker-compose.3.yml');
 const yamlFile3NoVersion = Fixtures.get('docker-compose.3-no-version.yml');
 const yamlFile3DefaultValue = Fixtures.get('docker-compose.3-default-val.yml');
+const yamlFile4Templated = Fixtures.get('docker-compose.4.yml.j2');
 
 describe('modules/manager/docker-compose/extract', () => {
   describe('extractPackageFile()', () => {
@@ -54,6 +55,23 @@ describe('modules/manager/docker-compose/extract', () => {
         ]
       `);
       expect(res?.deps).toHaveLength(1);
+    });
+
+    it('extracts can parse a templated yaml file', () => {
+      const res = extractPackageFile(yamlFile4Templated, '', {});
+      expect(res).toEqual({
+        deps: [
+          {
+            depName: 'node',
+            currentValue: '42.0.0',
+            currentDigest: undefined,
+            replaceString: 'node:42.0.0',
+            autoReplaceStringTemplate:
+              '{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}',
+            datasource: 'docker',
+          },
+        ],
+      });
     });
 
     it('extracts can parse yaml tags for version 3', () => {

--- a/lib/util/yaml.spec.ts
+++ b/lib/util/yaml.spec.ts
@@ -181,11 +181,11 @@ describe('util/yaml', () => {
       ).toEqual([
         {
           myObject: {
-            aString: "d1ddada",
+            aString: 'd1ddada',
           },
         },
         {
-          foo: "06de5ba",
+          foo: '06de5ba',
         },
       ]);
     });
@@ -291,18 +291,15 @@ services:
           { removeTemplates: true },
         ),
       ).toEqual({
-        "object": {
+        object: {
           // Hash for `{{value}}`
-          "string": "string",
-          "number": 42,
+          string: 'string',
+          number: 42,
           // Hash for `{{value}}`
-          "stringTemplated": "f00c233",
+          stringTemplated: 'f00c233',
           // Hash for `{{42}}`
-          "numberTemplated": "df35179",
-          "list": [
-            "f00c233",
-            "listEntry",
-          ],
+          numberTemplated: 'df35179',
+          list: ['f00c233', 'listEntry'],
         },
       });
     });
@@ -324,19 +321,19 @@ services:
           { removeTemplates: true },
         ),
       ).toEqual({
-        "object": {
-          "string": "string",
+        object: {
+          string: 'string',
           // Hash for `{{aKey}}`
-          "94fdf85": {
-            "string": "string",
-            "number": 12,
+          '94fdf85': {
+            string: 'string',
+            number: 12,
           },
           // Hash for `{{anotherKey}}`
-          "8904e7f": {
-            "string": "another string",
-            "number": 30,
+          '8904e7f': {
+            string: 'another string',
+            number: 30,
           },
-          "number": 42,
+          number: 42,
         },
       });
     });
@@ -357,13 +354,13 @@ services:
           { removeTemplates: true },
         ),
       ).toEqual({
-        "object": {
-          "string": "string",
-          "childObject": {
-            "key": "value",
+        object: {
+          string: 'string',
+          childObject: {
+            key: 'value',
           },
-          "anotherChildObject": null,
-          "number": 42,
+          anotherChildObject: null,
+          number: 42,
         },
       });
     });

--- a/lib/util/yaml.spec.ts
+++ b/lib/util/yaml.spec.ts
@@ -278,9 +278,9 @@ services:
         parseSingleYaml(
           codeBlock`
             object:
-              string: {{value}}
+              string: "string"
               number: 42
-              stringTemplated: {{\`value\`}}
+              stringTemplated: "{{value}}"
               numberTemplated: {{42}}
               list:
             {% if test.enabled %}
@@ -293,10 +293,10 @@ services:
       ).toEqual({
         "object": {
           // Hash for `{{value}}`
-          "string": "f00c233",
+          "string": "string",
           "number": 42,
-          // Hash for `{{\`value\`}}`
-          "stringTemplated": "7379d56",
+          // Hash for `{{value}}`
+          "stringTemplated": "f00c233",
           // Hash for `{{42}}`
           "numberTemplated": "df35179",
           "list": [

--- a/lib/util/yaml.ts
+++ b/lib/util/yaml.ts
@@ -143,26 +143,24 @@ export function dump(obj: any, opts?: DumpOptions): string {
 
 function getShortHash(data: any): string {
 
-  return crypto
-    .createHash('sha256')
-    .update(data)
-    .digest('hex')
-    .substring(0,7);
+  return crypto.createHash('sha256').update(data).digest('hex').substring(0,7);
 }
 
 function massageContent(content: string, options?: YamlOptions): string {
   if (options?.removeTemplates) {
-    return content
-      // NOTE: It seems safe to empty a line that only
-      // contains a Jinja2 tag entry.
-      .replace(regEx(/^(\s*)?{{.+?}}$/gm), '')
-      .replace(regEx(/{{`.+?`}}/gs), '')
-      // NOTE: In order to keep a proper Yaml syntax before
-      // the parsing, we're remplacing each of the remaining
-      // Jinja2 by a hash of the whole matched tag.
-      .replace(regEx(/{{.+?}}/g), getShortHash)
-      .replace(regEx(/{%`.+?`%}/gs), '')
-      .replace(regEx(/{%.+?%}/g), '');
+    return (
+      content
+        // NOTE: It seems safe to empty a line that only
+        // contains a Jinja2 tag entry.
+        .replace(regEx(/^(\s*)?{{.+?}}$/gm), '')
+        .replace(regEx(/{{`.+?`}}/gs), '')
+        // NOTE: In order to keep a proper Yaml syntax before
+        // the parsing, we're remplacing each of the remaining
+        // Jinja2 by a hash of the whole matched tag.
+        .replace(regEx(/{{.+?}}/g), getShortHash)
+        .replace(regEx(/{%`.+?`%}/gs), '')
+        .replace(regEx(/{%.+?%}/g), '')
+    );
   }
 
   return content;

--- a/lib/util/yaml.ts
+++ b/lib/util/yaml.ts
@@ -143,7 +143,7 @@ export function dump(obj: any, opts?: DumpOptions): string {
 
 function getShortHash(data: any): string {
 
-  return crypto.createHash('sha256').update(data).digest('hex').substring(0,7);
+  return crypto.createHash('sha256').update(data).digest('hex').substring(0, 7);
 }
 
 function massageContent(content: string, options?: YamlOptions): string {

--- a/lib/util/yaml.ts
+++ b/lib/util/yaml.ts
@@ -142,7 +142,6 @@ export function dump(obj: any, opts?: DumpOptions): string {
 }
 
 function getShortHash(data: any): string {
-
   return crypto.createHash('sha256').update(data).digest('hex').substring(0, 7);
 }
 

--- a/lib/util/yaml.ts
+++ b/lib/util/yaml.ts
@@ -156,6 +156,7 @@ function massageContent(content: string, options?: YamlOptions): string {
       // NOTE: It seems safe to empty a line that only
       // contains a Jinja2 tag entry.
       .replace(regEx(/^(\s*)?{{.+?}}$/gm), '')
+      .replace(regEx(/{{`.+?`}}/gs), '')
       // NOTE: In order to keep a proper Yaml syntax before
       // the parsing, we're remplacing each of the remaining
       // Jinja2 by a hash of the whole matched tag.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This add support for cases where templates are used as key in Yaml files.

## Context

See: https://github.com/renovatebot/renovate/discussions/18470#discussioncomment-11709294

For example, when having a `docker-compose.yaml.j2` file like the following:
```yaml
---
# {{ ansible_managed }}
version: "3.8"

networks:
  {{ network_name }}:
    external: true

services:
  app:
    image: "<NAME>@<HASH>"
    networks:
      - {{ network_name }}
    command: command
    deploy:
      mode: global
      placement:
        {{ placement | ansible.builtin.to_nice_yaml | indent(10) }}
      labels:
        - "name=value"
```

Renovate was failing with the following error:
```
DEBUG: docker-compose.extractPackageFile(<REDACTED>/docker-compose.yml.j2)
DEBUG: Parsing Docker Compose config YAML failed
{
  "err": {
    "message": "Schema error",
    "stack": "ZodError: Schema error\n    at Object.get error [as error] (/usr/local/renovate/node_modules/.pnpm/zod@3.24.1/node_modules/zod/lib/types.js:55:31)\n    at ZodUnion.parse (/usr/local/renovate/node_modules/.pnpm/zod@3.24.1/node_modules/zod/lib/types.js:131:22)\n    at parseSingleYaml (/usr/local/renovate/lib/util/yaml.ts:136:17)\n    at Object.extractPackageFile (/usr/local/renovate/lib/modules/manager/docker-compose/extract.ts:39:29)\n    at extractPackageFile (/usr/local/renovate/lib/modules/manager/index.ts:75:9)\n    at getManagerPackageFiles (/usr/local/renovate/lib/workers/repository/extract/manager-files.ts:58:43)\n    at /usr/local/renovate/lib/workers/repository/extract/index.ts:57:28\n    at async Promise.all (index 1)\n    at extractAllDependencies (/usr/local/renovate/lib/workers/repository/extract/index.ts:54:26)\n    at extract (/usr/local/renovate/lib/workers/repository/process/extract-update.ts:159:28)\n    at extractDependencies (/usr/local/renovate/lib/workers/repository/process/index.ts:158:26)\n    at Object.renovateRepository (/usr/local/renovate/lib/workers/repository/index.ts:71:9)\n    at attributes.repository (/usr/local/renovate/lib/workers/global/index.ts:206:11)\n    at start (/usr/local/renovate/lib/workers/global/index.ts:191:7)\n    at /usr/local/renovate/lib/renovate.ts:19:22",
    "issues": [
      "Expected object, received null",
      "Expected object, received null"
    ]
  }
  "packageFile": "<REDACTED>/docker-compose.yml.j2"
}
```

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
