### PR TITLE
feat(presets): Add `axum` monorepo

### DIFF
--- a/lib/data/monorepo.json
+++ b/lib/data/monorepo.json
@@ -55,6 +55,7 @@
       "https://github.com/awslabs/aws-sdk-rust"
     ],
     "awsappsync": "https://github.com/awslabs/aws-mobile-appsync-sdk-js",
+    "axum": "https://github.com/tokio-rs/axum",
     "azure-functions-dotnet-worker": "https://github.com/Azure/azure-functions-dotnet-worker",
     "azure azure-libraries-for-net": "https://github.com/Azure/azure-libraries-for-net",
     "azure azure-sdk-for-net": "https://github.com/Azure/azure-sdk-for-net",


### PR DESCRIPTION
## Changes

This PR adds a new monorepo group: `axum` (-> https://github.com/tokio-rs/axum/)

## Context

This should group https://github.com/rust-lang/crates.io/pull/10302 and https://github.com/rust-lang/crates.io/pull/10303 into a single pull request. `axum` is one of the most popular web frameworks for the Rust language.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
