### PR TITLE
fix(platform): ensure order for cached pr's on gitea and bitbucket

### DIFF
--- a/lib/modules/platform/bitbucket/pr-cache.spec.ts
+++ b/lib/modules/platform/bitbucket/pr-cache.spec.ts
@@ -166,8 +166,8 @@ describe('modules/platform/bitbucket/pr-cache', () => {
     );
 
     expect(res).toMatchObject([
-      { number: 1, title: 'title' },
       { number: 2, title: 'title' },
+      { number: 1, title: 'title' },
     ]);
     expect(cache).toEqual({
       httpCache: {},

--- a/lib/modules/platform/bitbucket/pr-cache.ts
+++ b/lib/modules/platform/bitbucket/pr-cache.ts
@@ -11,6 +11,7 @@ import type { BitbucketPrCacheData, PagedResult, PrResponse } from './types';
 import { prFieldsFilter, prInfo, prStates } from './utils';
 
 export class BitbucketPrCache {
+  private items: Pr[] = [];
   private cache: BitbucketPrCacheData;
 
   private constructor(
@@ -41,6 +42,7 @@ export class BitbucketPrCache {
     }
     repoCache.platform.bitbucket.pullRequestsCache = pullRequestCache;
     this.cache = pullRequestCache;
+    this.updateItems();
   }
 
   private static async init(
@@ -62,7 +64,7 @@ export class BitbucketPrCache {
   }
 
   private getPrs(): Pr[] {
-    return Object.values(this.cache.items);
+    return this.items;
   }
 
   static async getPrs(
@@ -77,6 +79,7 @@ export class BitbucketPrCache {
   private setPr(pr: Pr): void {
     logger.debug(`Adding PR #${pr.number} to the PR cache`);
     this.cache.items[pr.number] = pr;
+    this.updateItems();
   }
 
   static async setPr(
@@ -161,6 +164,16 @@ export class BitbucketPrCache {
       },
       `PR cache sync finished`,
     );
+
+    this.updateItems();
     return this;
+  }
+
+  /**
+   * Ensure the pr cache starts with the most recent PRs.
+   * JavaScript ensures that the cache is sorted by PR number.
+   */
+  private updateItems(): void {
+    this.items = Object.values(this.cache.items).reverse();
   }
 }

--- a/lib/modules/platform/gitea/index.spec.ts
+++ b/lib/modules/platform/gitea/index.spec.ts
@@ -1166,10 +1166,10 @@ describe('modules/platform/gitea/index', () => {
 
       const res = await gitea.getPrList();
       expect(res).toMatchObject([
-        { number: 1, title: 'Some PR' },
-        { number: 2, title: 'Other PR' },
-        { number: 3, title: 'Draft PR' },
         { number: 4, title: 'Merged PR' },
+        { number: 3, title: 'Draft PR' },
+        { number: 2, title: 'Other PR' },
+        { number: 1, title: 'Some PR' },
       ]);
     });
 
@@ -1209,10 +1209,10 @@ describe('modules/platform/gitea/index', () => {
       const res = await gitea.getPrList();
 
       expect(res).toMatchObject([
-        { number: 1, title: 'Some PR' },
-        { number: 2, title: 'Other PR' },
-        { number: 3, title: 'Draft PR' },
         { number: 4, title: 'Merged PR' },
+        { number: 3, title: 'Draft PR' },
+        { number: 2, title: 'Other PR' },
+        { number: 1, title: 'Some PR' },
       ]);
     });
 
@@ -1244,16 +1244,16 @@ describe('modules/platform/gitea/index', () => {
       await initFakeRepo(scope);
 
       const res1 = await gitea.getPrList();
-      expect(res1).toMatchObject([{ number: 1 }, { number: 2 }]);
+      expect(res1).toMatchObject([{ number: 2 }, { number: 1 }]);
 
       memCache.set('gitea-pr-cache-synced', false);
 
       const res2 = await gitea.getPrList();
       expect(res2).toMatchObject([
-        { number: 1 },
-        { number: 2 },
-        { number: 3 },
         { number: 4 },
+        { number: 3 },
+        { number: 2 },
+        { number: 1 },
       ]);
     });
   });

--- a/lib/modules/platform/gitea/pr-cache.ts
+++ b/lib/modules/platform/gitea/pr-cache.ts
@@ -11,6 +11,7 @@ import { API_PATH, toRenovatePR } from './utils';
 
 export class GiteaPrCache {
   private cache: GiteaPrCacheData;
+  private items: Pr[] = [];
 
   private constructor(
     private repo: string,
@@ -31,6 +32,7 @@ export class GiteaPrCache {
     }
     repoCache.platform.gitea.pullRequestsCache = pullRequestCache;
     this.cache = pullRequestCache;
+    this.updateItems();
   }
 
   static forceSync(): void {
@@ -54,7 +56,7 @@ export class GiteaPrCache {
   }
 
   private getPrs(): Pr[] {
-    return Object.values(this.cache.items);
+    return this.items;
   }
 
   static async getPrs(
@@ -68,6 +70,7 @@ export class GiteaPrCache {
 
   private setPr(item: Pr): void {
     this.cache.items[item.number] = item;
+    this.updateItems();
   }
 
   static async setPr(
@@ -137,6 +140,16 @@ export class GiteaPrCache {
       url = parseLinkHeader(res.headers.link)?.next?.url;
     }
 
+    this.updateItems();
+
     return this;
+  }
+
+  /**
+   * Ensure the pr cache starts with the most recent PRs.
+   * JavaScript ensures that the cache is sorted by PR number.
+   */
+  private updateItems(): void {
+    this.items = Object.values(this.cache.items).reverse();
   }
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Reverse the cached pr list, so renovate finds the most recent PR first.
<!-- Describe what behavior is changed by this PR. -->

## Context
Currently the cache returns pr's in accending order, so renovate always finds the oldest PR if multiple match.
So it opens new PR's event if a newer PR was already closed.
We do this sorting on github pr cache.

- closes #32672
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
