### PR TITLE
fix(npm): Include `@types/react-is` in "react monorepo" group

### DIFF
--- a/lib/config/presets/internal/group.ts
+++ b/lib/config/presets/internal/group.ts
@@ -451,7 +451,7 @@ const staticGroups = {
     packageRules: [
       {
         groupName: 'react monorepo',
-        matchPackageNames: ['@types/react', '@types/react-dom'],
+        matchPackageNames: ['@types/react', '@types/react-dom', '@types/react-is'],
       },
     ],
   },

--- a/lib/config/presets/internal/group.ts
+++ b/lib/config/presets/internal/group.ts
@@ -451,7 +451,11 @@ const staticGroups = {
     packageRules: [
       {
         groupName: 'react monorepo',
-        matchPackageNames: ['@types/react', '@types/react-dom', '@types/react-is'],
+        matchPackageNames: [
+          '@types/react',
+          '@types/react-dom',
+          '@types/react-is',
+        ],
       },
     ],
   },


### PR DESCRIPTION
## Changes

Include `@types/react-is` in "react monorepo" group

## Context

Discussion: https://github.com/renovatebot/renovate/discussions/33387

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

---

I think this PR will solve the issue, but I don't understand why this code doesn't take care of it:

https://github.com/renovatebot/renovate/blob/79b65486a14faa895458f88fccd25e786e6ae84d/lib/config/presets/internal/packages.ts#L136-L140

Or why this package rule isn't defined like:

```
matchPackageNames: ['@types/react**'],
```

There is some duplication here of React package names that I don't understand. I just tried to make the minimal change needed to fix the issue in this PR.