### PR TITLE
feat(bazel-module): Support `git_repository`

### DIFF
--- a/docs/usage/bazel.md
+++ b/docs/usage/bazel.md
@@ -145,6 +145,19 @@ archive_override(
 Renovate ignores [`multiple_version_override`](https://bazel.build/rules/lib/globals/module#multiple_version_override).
 `multiple_version_override` does not affect the processing of version updates for a module.
 
+### `git_repository`
+
+If Renovate finds a [`git_repository`](https://bazel.build/rules/lib/repo/git#git_repository), it evaluates the `commit` value at the specified `remote`.
+`remote` is limited to github repos: `https://github.com/<owner>/<repo>.git`
+
+```python
+git_repository(
+    name = "rules_foo",
+    remote = "https://github.com/fooexample/rules_foo.git",
+    commit = "8c94e11c2b05b6f25ced5f23cd07d0cfd36edc1a",
+)
+```
+
 ## Legacy `WORKSPACE` files
 
 Renovate extracts dependencies from the following repository rules:
@@ -160,7 +173,7 @@ Renovate extracts dependencies from the following repository rules:
 It also recognizes when these repository rule names are prefixed with an underscore.
 For example, `_http_archive` is treated the same as `http_archive`.
 
-### `git_repository`
+### `git_repository` (legacy)
 
 Renovate updates any `git_repository` declaration that has the following:
 

--- a/lib/modules/manager/bazel-module/extract.spec.ts
+++ b/lib/modules/manager/bazel-module/extract.spec.ts
@@ -392,5 +392,31 @@ describe('modules/manager/bazel-module/extract', () => {
         },
       ]);
     });
+
+    it('returns git_repository dependencies', async () => {
+      const input = codeBlock`
+        git_repository(
+            name = "rules_foo",
+            commit = "850cb49c8649e463b80ef7984e7c744279746170",
+            remote = "https://github.com/example/rules_foo.git",
+        )
+        `;
+      const result = await extractPackageFile(input, 'MODULE.bazel');
+      if (!result) {
+        throw new Error('Expected a result.');
+      }
+      expect(result.deps).toHaveLength(1);
+      expect(result.deps).toEqual(
+        expect.arrayContaining([
+          {
+            datasource: GithubTagsDatasource.id,
+            depType: 'git_repository',
+            depName: 'rules_foo',
+            currentDigest: '850cb49c8649e463b80ef7984e7c744279746170',
+            packageName: 'example/rules_foo',
+          },
+        ]),
+      );
+    });
   });
 });

--- a/lib/modules/manager/bazel-module/parser/index.spec.ts
+++ b/lib/modules/manager/bazel-module/parser/index.spec.ts
@@ -315,5 +315,37 @@ describe('modules/manager/bazel-module/parser/index', () => {
         ),
       ]);
     });
+
+    it('finds the git_repository', () => {
+      const input = codeBlock`
+        git_repository(
+          name = "rules_foo",
+          remote = "https://github.com/example/rules_foo.git",
+          commit = "6a2c2e22849b3e6b33d5ea9aa72222d4803a986a",
+          patches = ["//:rules_foo.patch"],
+          patch_strip = 1,
+        )
+      `;
+      const res = parse(input);
+      expect(res).toEqual([
+        fragments.record(
+          {
+            rule: fragments.string('git_repository'),
+            name: fragments.string('rules_foo'),
+            patches: fragments.array(
+              [fragments.string('//:rules_foo.patch')],
+              true,
+            ),
+            commit: fragments.string(
+              '6a2c2e22849b3e6b33d5ea9aa72222d4803a986a',
+            ),
+            remote: fragments.string(
+              'https://github.com/example/rules_foo.git',
+            ),
+          },
+          true,
+        ),
+      ]);
+    });
   });
 });

--- a/lib/modules/manager/bazel-module/parser/module.ts
+++ b/lib/modules/manager/bazel-module/parser/module.ts
@@ -9,6 +9,7 @@ const supportedRules = [
   'git_override',
   'local_path_override',
   'single_version_override',
+  'git_repository',
 ];
 const supportedRulesRegex = regEx(`^${supportedRules.join('|')}$`);
 


### PR DESCRIPTION
## Changes

This adds support for `git_repository` dependencies declared in `MODULE.bazel` files.

## Context

The legacy `WORKSPACE` bazel manager supports `git_repository` dependencies, but the bazel-module manger does not. The `WORKSPACE` system is officially deprecated and bzlmod is the on-by-default dependency management system for bazel. `MODULE.bazel` files allow for `git_repository` dependencies to be declared, but renovate is not updating them.

This implementation departs from the legacy `WORKSPACE` implementation of `git_repository` by preferring the use of `commit` over `tag`. Use of `tag` is considered a not recommended practice in bazel because it can lead to non-reproducible builds, and the bazel will emit a warning suggesting the conversion of a `tag` to a `commit`. This implementation instead follows the implementation of `git_override` and uses `commit`.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository
