### PR TITLE
feat(pre-commit): support python additional_dependencies

### DIFF
--- a/lib/modules/manager/pre-commit/__fixtures__/complex.pre-commit-config.yaml
+++ b/lib/modules/manager/pre-commit/__fixtures__/complex.pre-commit-config.yaml
@@ -13,11 +13,18 @@ repos:
     rev: 19.3b0
     hooks:
       - id: black
+        language: python
+        additional_dependencies:
+          - "request==1.1.1"
+          - "" # broken pypi package
   - repo: https://gitlab.com/psf/black
     # should also detect gitlab
     rev: 19.3b0
     hooks:
       - id: black
+        # missing language, not extracted
+        additional_dependencies:
+          - "urllib==24.9.0"
   - repo: http://gitlab.com/psf/black
     # should also detect http
     rev: 19.3b0
@@ -48,3 +55,7 @@ repos:
   - repo: some_invalid_url
     # case with invlalid url.
     rev: v1.0.0
+
+  # pre-commit meta hooks
+  - repo: meta
+    hooks: []

--- a/lib/modules/manager/pre-commit/__snapshots__/extract.spec.ts.snap
+++ b/lib/modules/manager/pre-commit/__snapshots__/extract.spec.ts.snap
@@ -11,6 +11,14 @@ exports[`modules/manager/pre-commit/extract extractPackageFile() extracts from c
       "packageName": "pre-commit/pre-commit-hooks",
     },
     {
+      "currentValue": "==1.1.1",
+      "currentVersion": "1.1.1",
+      "datasource": "pypi",
+      "depName": "request",
+      "depType": "pre-commit-python",
+      "packageName": "request",
+    },
+    {
       "currentValue": "19.3b0",
       "datasource": "github-tags",
       "depName": "psf/black",

--- a/lib/modules/manager/pre-commit/extract.spec.ts
+++ b/lib/modules/manager/pre-commit/extract.spec.ts
@@ -2,6 +2,7 @@ import { mockDeep } from 'jest-mock-extended';
 import { Fixtures } from '../../../../test/fixtures';
 import { mocked } from '../../../../test/util';
 import * as _hostRules from '../../../util/host-rules';
+import { PypiDatasource } from '../../datasource/pypi';
 import { extractPackageFile } from '.';
 
 jest.mock('../../../util/host-rules', () => mockDeep());
@@ -81,6 +82,14 @@ describe('modules/manager/pre-commit/extract', () => {
       expect(result).toMatchSnapshot({
         deps: [
           { depName: 'pre-commit/pre-commit-hooks', currentValue: 'v3.3.0' },
+          {
+            currentValue: '==1.1.1',
+            currentVersion: '1.1.1',
+            datasource: PypiDatasource.id,
+            depName: 'request',
+            depType: 'pre-commit-python',
+            packageName: 'request',
+          },
           { depName: 'psf/black', currentValue: '19.3b0' },
           { depName: 'psf/black', currentValue: '19.3b0' },
           { depName: 'psf/black', currentValue: '19.3b0' },

--- a/lib/modules/manager/pre-commit/extract.ts
+++ b/lib/modules/manager/pre-commit/extract.ts
@@ -7,6 +7,7 @@ import { regEx } from '../../../util/regex';
 import { parseSingleYaml } from '../../../util/yaml';
 import { GithubTagsDatasource } from '../../datasource/github-tags';
 import { GitlabTagsDatasource } from '../../datasource/gitlab-tags';
+import { pep508ToPackageDependency } from '../pep621/utils';
 import type { PackageDependency, PackageFileContent } from '../types';
 import {
   matchesPrecommitConfigHeuristic,
@@ -137,6 +138,23 @@ function findDependencies(precommitFile: PreCommitConfig): PackageDependency[] {
   }
   const packageDependencies: PackageDependency[] = [];
   precommitFile.repos.forEach((item) => {
+    // meta hooks is defined from pre-commit and doesn't support `additional_dependencies`
+    if (item.repo !== 'meta') {
+      item.hooks?.forEach((hook) => {
+        // normally language are not defined in yaml
+        // only support it when it's explicitly defined.
+        // this avoid to parse hooks from pre-commit-hooks.yaml from git repo
+        if (hook.language === 'python') {
+          hook.additional_dependencies?.map((req) => {
+            const dep = pep508ToPackageDependency('pre-commit-python', req);
+            if (dep) {
+              packageDependencies.push(dep);
+            }
+          });
+        }
+      });
+    }
+
     if (matchesPrecommitDependencyHeuristic(item)) {
       logger.trace(item, 'Matched pre-commit dependency spec');
       const repository = String(item.repo);

--- a/lib/modules/manager/pre-commit/readme.md
+++ b/lib/modules/manager/pre-commit/readme.md
@@ -26,3 +26,33 @@ To enable the `pre-commit` manager, add the following config:
 ```
 
 Alternatively, add `:enablePreCommit` to your `extends` array.
+
+### Additional Dependencies
+
+renovate has partial support for `additional_dependencies`, currently python only.
+
+for python hooks, you will need to **explicitly add language** to your hooks with `additional_dependencies`
+to let renovatebot know what kind of dependencies they are.
+
+For example, this work for `request`:
+
+```yaml
+- repo: https://github.com/psf/black
+  rev: 19.3b0
+  hooks:
+    - id: black
+      language: python
+      additional_dependencies:
+        - 'request==1.1.1'
+```
+
+this won't work:
+
+```yaml
+- repo: https://github.com/psf/black
+  rev: 19.3b0
+  hooks:
+    - id: black
+      additional_dependencies:
+        - 'request==1.1.1'
+```

--- a/lib/modules/manager/pre-commit/types.ts
+++ b/lib/modules/manager/pre-commit/types.ts
@@ -2,7 +2,13 @@ export interface PreCommitConfig {
   repos: PreCommitDependency[];
 }
 
+export interface PreCommitHook {
+  language?: string;
+  additional_dependencies?: Array<string>;
+}
+
 export interface PreCommitDependency {
   repo: string;
+  hooks?: Array<PreCommitHook>;
   rev: string;
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

partial support for https://github.com/renovatebot/renovate/issues/20780

## Changes

<!-- Describe what behavior is changed by this PR. -->

pre-commit hooks `additional_dependencies` are dynamic to many language, so we only support it if it's defined as `language: python`.

Normally hooks from repo doesn't need this, but add it also doesn't break anything and make our work must more easy so we do not need to do a extra http request and parse hooks from arbitrary repo in extracter.

support this kind of pre-commit config:
```yaml
  - repo: https://github.com/psf/black
    rev: 19.3b0
    hooks:
      - id: black
        language: python
        additional_dependencies:
          - "request==1.1.1"
```

and this won't work:
```yaml
  - repo: https://github.com/psf/black
    rev: 19.3b0
    hooks:
      - id: black
        additional_dependencies:
          - "request==1.1.1"
```

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

https://github.com/trim21/bencode-py/commit/ad08e6ec1360a99f1617d6f401507862da19d588
https://github.com/trim21/bencode-py/commit/47abeedc0a2e3e8df9699d016962367681bf0936

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
