### PR TITLE
fix(gradle): avoid heuristic matching of gradle feature variant capabilities

### DIFF
--- a/lib/modules/manager/gradle/parser.spec.ts
+++ b/lib/modules/manager/gradle/parser.spec.ts
@@ -759,12 +759,13 @@ describe('modules/manager/gradle/parser', () => {
 
   describe('heuristic dependency matching', () => {
     it.each`
-      input                                  | output
-      ${'("foo", "bar", "1.2.3")'}           | ${{ depName: 'foo:bar', currentValue: '1.2.3' }}
-      ${'("foo", "bar", "1.2.3", "4.5.6")'}  | ${null}
-      ${'(["foo", "bar", "1.2.3"])'}         | ${null}
-      ${'someMethod("foo", "bar", "1.2.3")'} | ${{ depName: 'foo:bar', currentValue: '1.2.3' }}
-      ${'listOf("foo", "bar", "baz")'}       | ${null}
+      input                                                                    | output
+      ${'("foo", "bar", "1.2.3")'}                                             | ${{ depName: 'foo:bar', currentValue: '1.2.3' }}
+      ${'("foo", "bar", "1.2.3", "4.5.6")'}                                    | ${null}
+      ${'(["foo", "bar", "1.2.3"])'}                                           | ${null}
+      ${'someMethod("foo", "bar", "1.2.3")'}                                   | ${{ depName: 'foo:bar', currentValue: '1.2.3' }}
+      ${'listOf("foo", "bar", "baz")'}                                         | ${null}
+      ${'java { registerFeature(foo) { capability("foo", "bar", "1.2.3") } }'} | ${null}
     `('$input', ({ input, output }) => {
       const { deps } = parseGradle(input);
       expect(deps).toMatchObject([output].filter(is.truthy));

--- a/lib/modules/manager/gradle/parser/dependencies.ts
+++ b/lib/modules/manager/gradle/parser/dependencies.ts
@@ -4,6 +4,7 @@ import type { Ctx } from '../types';
 import {
   GRADLE_PLUGINS,
   cleanupTempVars,
+  qDotOrBraceExpr,
   qTemplateString,
   qValueMatcher,
   storeInTokenMap,
@@ -204,4 +205,6 @@ export const qDependencies = q.alt(
   qKotlinShortNotationDependencies,
   qKotlinMapNotationDependencies,
   qImplicitGradlePlugin,
+  // avoid heuristic matching of gradle feature variant capabilities
+  qDotOrBraceExpr('java', q.sym<Ctx>('registerFeature').tree()),
 );


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds a dummy route to the gradle parser to prevent it from heuristically matching gradle feature variant capabilities as dependencies.

<!-- Describe what behavior is changed by this PR. -->

## Context

- Resolves https://github.com/renovatebot/renovate/discussions/33144

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

Test repo: https://github.com/renovate-demo/33144-gradle-features

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
