### PR TITLE
feat(preset): netflix dgs spring starters

### DIFF
--- a/lib/data/replacements.json
+++ b/lib/data/replacements.json
@@ -757,7 +757,7 @@
     "packageRules": [
       {
         "matchCurrentVersion": ">=9.2.2",
-        "matchDatasources": ["maven", "gradle"],
+        "matchDatasources": ["maven"],
         "matchPackageNames": [
           "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter",
           "com.netflix.graphql.dgs:graphql-dgs-webflux-starter"

--- a/lib/data/replacements.json
+++ b/lib/data/replacements.json
@@ -756,7 +756,7 @@
     "description": "`dgs-framework` migrated to new `spring-graphql` starters.",
     "packageRules": [
       {
-        "matchCurrentVersion": ">=9.2.2",
+        "matchCurrentVersion": "[9.2.2,)",
         "matchDatasources": ["maven"],
         "matchPackageNames": [
           "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter",

--- a/lib/data/replacements.json
+++ b/lib/data/replacements.json
@@ -23,6 +23,7 @@
       "replacements:k8s-registry-move",
       "replacements:mem-rename",
       "replacements:middie-to-scoped",
+      "replacements:netflix-dgs-spring-starters",
       "replacements:now-to-vercel",
       "replacements:npm-run-all-to-maintenance-fork",
       "replacements:opencost-registry-move",
@@ -748,6 +749,18 @@
         "matchPackageNames": ["middie"],
         "replacementName": "@fastify/middie",
         "replacementVersion": "8.0.0"
+      }
+    ]
+  },
+  "netflix-dgs-spring-starters": {
+    "description": "`dgs-framework` migrated to new `spring-graphql` starters.",
+    "packageRules": [
+      {
+        "matchCurrentVersion": ">=9.2.2",
+        "matchDatasources": ["maven", "gradle"],
+        "matchPackageNames": ["com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter", "com.netflix.graphql.dgs:graphql-dgs-webflux-starter"],
+        "replacementName": "com.netflix.graphql.dgs:dgs-starter",
+        "replacementVersion": "10.0.1"
       }
     ]
   },

--- a/lib/data/replacements.json
+++ b/lib/data/replacements.json
@@ -758,7 +758,10 @@
       {
         "matchCurrentVersion": ">=9.2.2",
         "matchDatasources": ["maven", "gradle"],
-        "matchPackageNames": ["com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter", "com.netflix.graphql.dgs:graphql-dgs-webflux-starter"],
+        "matchPackageNames": [
+          "com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter",
+          "com.netflix.graphql.dgs:graphql-dgs-webflux-starter"
+        ],
         "replacementName": "com.netflix.graphql.dgs:dgs-starter",
         "replacementVersion": "10.0.1"
       }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Add migration present for Netflix DGS Framework starters

<!-- Describe what behavior is changed by this PR. -->

## Context

See https://github.com/Netflix/dgs-framework/releases/tag/v10.0.0 release notes.  

From 10.x they consolidated a number of their starters 

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
