### PR TITLE
fix(manager/github-actions): preserve full depName

### DIFF
--- a/lib/modules/manager/github-actions/extract.spec.ts
+++ b/lib/modules/manager/github-actions/extract.spec.ts
@@ -467,7 +467,7 @@ describe('modules/manager/github-actions/extract', () => {
           build:
             steps:
               - name: "test1"
-                uses: https://github.com/actions/setup-node@56337c425554a6be30cdef71bf441f15be286854 # tag=v3.1.1
+                uses: https://github.com/actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # tag=v4.2.0
               - name: "test2"
                 uses: https://code.forgejo.org/actions/setup-node@56337c425554a6be30cdef71bf441f15be286854 # v3.1.1
               - name: "test3"
@@ -479,14 +479,18 @@ describe('modules/manager/github-actions/extract', () => {
       expect(res).toMatchObject({
         deps: [
           {
-            currentDigest: '56337c425554a6be30cdef71bf441f15be286854',
-            currentValue: 'v3.1.1',
+            depName: 'https://github.com/actions/cache',
+            packageName: 'actions/cache',
+            currentDigest: '1bd1e32a3bdc45362d1e726936510720a7c30a57',
+            currentValue: 'v4.2.0',
             replaceString:
-              'https://github.com/actions/setup-node@56337c425554a6be30cdef71bf441f15be286854 # tag=v3.1.1',
+              'https://github.com/actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # tag=v4.2.0',
             datasource: 'github-tags',
             registryUrls: ['https://github.com/'],
           },
           {
+            depName: 'https://code.forgejo.org/actions/setup-node',
+            packageName: 'actions/setup-node',
             currentDigest: '56337c425554a6be30cdef71bf441f15be286854',
             currentValue: 'v3.1.1',
             replaceString:


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Preserve the full dep name, so we can support replacements.
It's only relevant for Gitea / Forgejo. Github doesn't support those urls anyways.

It causes some open PR to be closed because of branch name changes, see sample repo below.
<!-- Describe what behavior is changed by this PR. -->

## Context
- https://github.com/renovate-reproductions/gh-actions-full-name/pulls
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
