### PR TITLE
fix(gradle): correct handling of heuristically matched dependency triples

### DIFF
--- a/lib/modules/manager/gradle/parser.spec.ts
+++ b/lib/modules/manager/gradle/parser.spec.ts
@@ -770,6 +770,17 @@ describe('modules/manager/gradle/parser', () => {
       const { deps } = parseGradle(input);
       expect(deps).toMatchObject([output].filter(is.truthy));
     });
+
+    it('handles 3 independent dependencies mismatched as groupId, artifactId, version', () => {
+      const { deps } = parseGradle(
+        'someConfig("foo:bar:1.2.3", "foo:baz:4.5.6", "foo:qux:7.8.9")',
+      );
+      expect(deps).toMatchObject([
+        { depName: 'foo:bar', currentValue: '1.2.3' },
+        { depName: 'foo:baz', currentValue: '4.5.6' },
+        { depName: 'foo:qux', currentValue: '7.8.9' },
+      ]);
+    });
   });
 
   describe('calculations', () => {

--- a/lib/modules/manager/gradle/parser/handlers.ts
+++ b/lib/modules/manager/gradle/parser/handlers.ts
@@ -6,7 +6,7 @@ import { regEx } from '../../../../util/regex';
 import type { PackageDependency } from '../../types';
 import type { parseGradle as parseGradleCallback } from '../parser';
 import type { Ctx, GradleManagerData } from '../types';
-import { parseDependencyString } from '../utils';
+import { isDependencyString, parseDependencyString } from '../utils';
 import {
   GRADLE_PLUGINS,
   REGISTRY_URLS,
@@ -166,6 +166,22 @@ export function handleLongFormDep(ctx: Ctx): Ctx {
   const artifactId = interpolateString(artifactIdTokens, ctx);
   const version = interpolateString(versionTokens, ctx);
   if (!groupId || !artifactId || !version) {
+    return ctx;
+  }
+
+  // Special handling: 3 independent dependencies mismatched as groupId, artifactId, version
+  if (
+    isDependencyString(groupId) &&
+    isDependencyString(artifactId) &&
+    isDependencyString(version)
+  ) {
+    ctx.tokenMap.templateStringTokens = groupIdTokens;
+    handleDepString(ctx);
+    ctx.tokenMap.templateStringTokens = artifactIdTokens;
+    handleDepString(ctx);
+    ctx.tokenMap.templateStringTokens = versionTokens;
+    handleDepString(ctx);
+
     return ctx;
   }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds special handling for an ambiguous parser match that occurs (only) when heuristically matching 3 string values in combination as `groupId`, `artifactId`, `version`.

During parsing it is difficult to find out whether `groupId`, `artifactId` and `version` are parts of exactly one complete dependency string or independent dependency strings. For example, `groupId` could occur as a simple string or as one or more concatenated variables. The approach taken here is to first interpolate and then decide how to treat the values.

<!-- Describe what behavior is changed by this PR. -->

## Context

- Closes https://github.com/renovatebot/renovate/issues/30234

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

Test repo: https://github.com/renovate-demo/30234-renovate-tt-gradle-reproducer/pulls

<details>
<summary>Extracted dependencies (repository=renovate-demo/30234-renovate-tt-gradle-reproducer)</summary>

```json
"packageFiles": {
 "gradle": [
   {
     "packageFile": "otherconfigs.gradle",
     "datasource": "maven",
     "deps": [
       {
         "depName": "org.wiremock:wiremock",
         "currentValue": "3.7.0",
         "managerData": {
           "fileReplacePosition": 93,
           "packageFile": "otherconfigs.gradle"
         },
         "fileReplacePosition": 93,
         "datasource": "maven",
         "registryUrls": [],
         "depType": "dependencies"
       },
       {
         "depName": "org.junit.jupiter:junit-jupiter-params",
         "currentValue": "5.6.3",
         "managerData": {
           "fileReplacePosition": 159,
           "packageFile": "otherconfigs.gradle"
         },
         "fileReplacePosition": 159,
         "datasource": "maven",
         "registryUrls": [],
         "depType": "dependencies"
       },
       {
         "depName": "jakarta.ws.rs:jakarta.ws.rs-api",
         "currentValue": "2.1.6",
         "managerData": {
           "fileReplacePosition": 212,
           "packageFile": "otherconfigs.gradle"
         },
         "fileReplacePosition": 212,
         "datasource": "maven",
         "registryUrls": [],
         "depType": "dependencies"
       }
     ]
   },
   {
     "packageFile": "thisdoeswork.gradle",
     "datasource": "maven",
     "deps": [
       {
         "depName": "jakarta.ws.rs:jakarta.ws.rs-api",
         "currentValue": "2.1.6",
         "managerData": {
           "fileReplacePosition": 118,
           "packageFile": "thisdoeswork.gradle"
         },
         "fileReplacePosition": 118,
         "datasource": "maven",
         "registryUrls": [],
         "depType": "dependencies"
       },
       {
         "depName": "org.wiremock:wiremock",
         "currentValue": "3.7.0",
         "managerData": {
           "fileReplacePosition": 175,
           "packageFile": "thisdoeswork.gradle"
         },
         "fileReplacePosition": 175,
         "datasource": "maven",
         "registryUrls": [],
         "depType": "dependencies"
       }
     ]
   },
   {
     "packageFile": "build.gradle",
     "datasource": "maven",
     "deps": [
       {
         "depName": "org.junit.jupiter:junit-jupiter-api",
         "currentValue": "5.6.2",
         "managerData": {
           "fileReplacePosition": 122,
           "packageFile": "build.gradle"
         },
         "fileReplacePosition": 122,
         "datasource": "maven",
         "registryUrls": [],
         "depType": "dependencies"
       },
       {
         "depName": "org.junit.jupiter:junit-jupiter-params",
         "currentValue": "5.6.3",
         "managerData": {
           "fileReplacePosition": 182,
           "packageFile": "build.gradle"
         },
         "fileReplacePosition": 182,
         "datasource": "maven",
         "registryUrls": [],
         "depType": "dependencies"
       },
       {
         "depName": "jakarta.ws.rs:jakarta.ws.rs-api",
         "currentValue": "2.1.6",
         "managerData": {
           "fileReplacePosition": 235,
           "packageFile": "build.gradle"
         },
         "fileReplacePosition": 235,
         "datasource": "maven",
         "registryUrls": [],
         "depType": "dependencies"
       },
       {
         "depName": "org.wiremock:wiremock",
         "currentValue": "3.7.0",
         "managerData": {
           "fileReplacePosition": 292,
           "packageFile": "build.gradle"
         },
         "fileReplacePosition": 292,
         "datasource": "maven",
         "registryUrls": [],
         "depType": "dependencies"
       }
     ]
   }
 ]
}
```
</details>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
