### PR TITLE
refactor(logger): remove templating from FATAL logs

### DIFF
--- a/lib/logger/utils.ts
+++ b/lib/logger/utils.ts
@@ -317,10 +317,7 @@ export function validateLogLevel(
       },
     ],
   });
-  logger.fatal(
-    { logLevel: logLevelToCheck },
-    'Invalid log level. terminating...',
-  );
+  logger.fatal({ logLevel: logLevelToCheck }, 'Invalid log level');
   process.exit(1);
 }
 

--- a/lib/logger/utils.ts
+++ b/lib/logger/utils.ts
@@ -317,7 +317,10 @@ export function validateLogLevel(
       },
     ],
   });
-  logger.fatal(`${logLevelToCheck} is not a valid log level. terminating...`);
+  logger.fatal(
+    { logLevel: logLevelToCheck },
+    'Invalid log level. terminating...',
+  );
   process.exit(1);
 }
 

--- a/lib/workers/global/config/parse/file.ts
+++ b/lib/workers/global/config/parse/file.ts
@@ -59,7 +59,7 @@ export async function getConfig(env: NodeJS.ProcessEnv): Promise<AllConfig> {
     config = await getParsedContent(configFile);
   } catch (err) {
     if (err instanceof SyntaxError || err instanceof TypeError) {
-      logger.fatal(`Could not parse config file \n ${err.stack!}`);
+      logger.fatal({ error: err.stack }, 'Could not parse config file');
       process.exit(1);
     } else if (err instanceof ReferenceError) {
       logger.fatal(

--- a/lib/workers/global/index.ts
+++ b/lib/workers/global/index.ts
@@ -221,9 +221,12 @@ export async function start(): Promise<number> {
     await exportStats(config);
   } catch (err) /* istanbul ignore next */ {
     if (err.message.startsWith('Init: ')) {
-      logger.fatal({ errorMessage: err.message.substring(6) }, 'Fatal error');
+      logger.fatal(
+        { errorMessage: err.message.substring(6) },
+        'Initialization error',
+      );
     } else {
-      logger.fatal({ err, errorMessage: err.message }, 'Fatal error');
+      logger.fatal({ err }, 'Unknown error');
     }
     if (!config!) {
       // return early if we can't parse config options

--- a/lib/workers/global/index.ts
+++ b/lib/workers/global/index.ts
@@ -221,9 +221,9 @@ export async function start(): Promise<number> {
     await exportStats(config);
   } catch (err) /* istanbul ignore next */ {
     if (err.message.startsWith('Init: ')) {
-      logger.fatal(err.message.substring(6));
+      logger.fatal({ errorMessage: err.message.substring(6) }, 'Fatal error');
     } else {
-      logger.fatal({ err }, `Fatal error: ${String(err.message)}`);
+      logger.fatal({ err, errorMessage: err.message }, 'Fatal error');
     }
     if (!config!) {
       // return early if we can't parse config options


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- remove templating from FATAL logs
<!-- Describe what behavior is changed by this PR. -->

## Context
- Ref: #33448 
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
