### PR TITLE
feat(presets): StyleX in Rust monorepo

### DIFF
--- a/lib/data/monorepo.json
+++ b/lib/data/monorepo.json
@@ -520,6 +520,7 @@
     "strapi": "https://github.com/strapi/strapi",
     "strum": "https://github.com/Peternator7/strum",
     "stryker-js": "https://github.com/stryker-mutator/stryker-js",
+    "stylexswc": "https://github.com/Dwlad90/stylex-swc-plugin",
     "surveyjs": "https://github.com/surveyjs/surveyjs",
     "swashbuckle-aspnetcore": "https://github.com/domaindrivendev/Swashbuckle.AspNetCore",
     "system.io.abstractions": "https://github.com/System-IO-Abstractions/System.IO.Abstractions/",

--- a/lib/data/monorepo.json
+++ b/lib/data/monorepo.json
@@ -520,7 +520,7 @@
     "strapi": "https://github.com/strapi/strapi",
     "strum": "https://github.com/Peternator7/strum",
     "stryker-js": "https://github.com/stryker-mutator/stryker-js",
-    "stylexswc": "https://github.com/Dwlad90/stylex-swc-plugin",
+    "stylex-swc": "https://github.com/Dwlad90/stylex-swc-plugin",
     "surveyjs": "https://github.com/surveyjs/surveyjs",
     "swashbuckle-aspnetcore": "https://github.com/domaindrivendev/Swashbuckle.AspNetCore",
     "system.io.abstractions": "https://github.com/System-IO-Abstractions/System.IO.Abstractions/",


### PR DESCRIPTION
## Changes

https://github.com/Dwlad90/stylex-swc-plugin is a monorepo that contains @stylexswc/* NPM packages.

https://www.npmjs.com/search?q=%40stylexswc%2F

## Context

It'd be nice if these updates were grouped:

<img width="589" alt="image" src="https://github.com/user-attachments/assets/00995812-c4c7-4f28-a09d-5ac10102df9e" />


## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
- [x] I have no idea how to test this change
