### PR TITLE
fix(gitea): sort commit status by id

### DIFF
--- a/lib/modules/platform/gitea/gitea-helper.spec.ts
+++ b/lib/modules/platform/gitea/gitea-helper.spec.ts
@@ -685,37 +685,41 @@ describe('modules/platform/gitea/gitea-helper', () => {
     });
 
     it('should properly determine worst commit status', async () => {
-      const statuses: {
-        status: CommitStatusType;
-        created_at: string;
+      const statuses: (Pick<CommitStatus, 'id' | 'status' | 'created_at'> & {
         expected: CommitStatusType;
-      }[] = [
+      })[] = [
         {
+          id: 122,
           status: 'unknown',
           created_at: '2020-03-25T01:00:00Z',
           expected: 'unknown',
         },
         {
+          id: 124,
           status: 'pending',
           created_at: '2020-03-25T03:00:00Z',
           expected: 'pending',
         },
         {
+          id: 125,
           status: 'warning',
           created_at: '2020-03-25T04:00:00Z',
           expected: 'warning',
         },
         {
+          id: 126,
           status: 'failure',
           created_at: '2020-03-25T05:00:00Z',
           expected: 'failure',
         },
         {
+          id: 123,
           status: 'success',
           created_at: '2020-03-25T02:00:00Z',
           expected: 'failure',
         },
         {
+          id: 127,
           status: 'success',
           created_at: '2020-03-25T06:00:00Z',
           expected: 'success',
@@ -726,13 +730,13 @@ describe('modules/platform/gitea/gitea-helper', () => {
         { ...mockCommitStatus, status: 'unknown' },
       ];
 
-      for (const statusElem of statuses) {
-        const { status, expected } = statusElem;
+      for (const { id, status, expected, created_at } of statuses) {
         // Add current status ot list of commit statuses, then mock the API to return the whole list
         commitStatuses.push({
           ...mockCommitStatus,
+          id,
           status,
-          created_at: statusElem.created_at,
+          created_at,
         });
         httpMock
           .scope(baseUrl)

--- a/lib/modules/platform/gitea/gitea-helper.ts
+++ b/lib/modules/platform/gitea/gitea-helper.ts
@@ -394,10 +394,7 @@ export const renovateToGiteaStatusMapping: Record<
 function filterStatus(data: CommitStatus[]): CommitStatus[] {
   const ret: Record<string, CommitStatus> = {};
   for (const i of data) {
-    if (
-      !ret[i.context] ||
-      new Date(ret[i.context].created_at) < new Date(i.created_at)
-    ) {
+    if (!ret[i.context] || ret[i.context].id < i.id) {
       ret[i.context] = i;
     }
   }

--- a/lib/modules/platform/gitea/gitea-helper.ts
+++ b/lib/modules/platform/gitea/gitea-helper.ts
@@ -415,13 +415,14 @@ export async function getCombinedCommitStatus(
   });
 
   let worstState = 0;
-  for (const cs of filterStatus(res.body)) {
+  const statuses = filterStatus(res.body);
+  for (const cs of statuses) {
     worstState = Math.max(worstState, commitStatusStates.indexOf(cs.status));
   }
 
   return {
     worstStatus: commitStatusStates[worstState],
-    statuses: res.body,
+    statuses,
   };
 }
 

--- a/lib/modules/platform/gitea/types.ts
+++ b/lib/modules/platform/gitea/types.ts
@@ -138,8 +138,8 @@ export interface CommitStatus {
   id: number;
   status: CommitStatusType;
   context: string;
-  description: string;
-  target_url: string;
+  description?: string;
+  target_url?: string;
   created_at: string;
 }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Sort commit status by id when computing worst status. They can have same time stamp.
Also return filtered status list, otherwise we can find wrong status.
<!-- Describe what behavior is changed by this PR. -->

## Context
- fixes #33613
- ref #33531
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
