### PR TITLE
fix(gitea): handle null PR as temporary error

### DIFF
--- a/lib/modules/platform/gitea/index.spec.ts
+++ b/lib/modules/platform/gitea/index.spec.ts
@@ -9,6 +9,7 @@ import {
   REPOSITORY_CHANGED,
   REPOSITORY_EMPTY,
   REPOSITORY_MIRRORED,
+  TEMPORARY_ERROR,
 } from '../../../constants/error-messages';
 import type { logger as _logger } from '../../../logger';
 import type * as _git from '../../../util/git';
@@ -1308,6 +1309,18 @@ describe('modules/platform/gitea/index', () => {
       const res = await gitea.getPr(42);
 
       expect(res).toBeNull();
+    });
+
+    it('should throw temporary error for null pull request', async () => {
+      const scope = httpMock
+        .scope('https://gitea.com/api/v1')
+        .get('/repos/some/repo/pulls')
+        .query({ state: 'all', sort: 'recentupdate' })
+        .reply(200, [null]); // TODO: 404 should be handled
+      await initFakePlatform(scope);
+      await initFakeRepo(scope);
+
+      await expect(gitea.getPr(42)).rejects.toThrow(TEMPORARY_ERROR);
     });
   });
 

--- a/lib/modules/platform/gitea/pr-cache.ts
+++ b/lib/modules/platform/gitea/pr-cache.ts
@@ -1,5 +1,7 @@
 import { dequal } from 'dequal';
 import { DateTime } from 'luxon';
+import { TEMPORARY_ERROR } from '../../../constants/error-messages';
+import { logger } from '../../../logger';
 import * as memCache from '../../../util/cache/memory';
 import { getCache } from '../../../util/cache/repository';
 import type { GiteaHttp } from '../../../util/http/gitea';
@@ -83,7 +85,7 @@ export class GiteaPrCache {
     prCache.setPr(item);
   }
 
-  private reconcile(rawItems: PR[]): boolean {
+  private reconcile(rawItems: (PR | null)[]): boolean {
     const { items } = this.cache;
     let { updated_at } = this.cache;
     const cacheTime = updated_at ? DateTime.fromISO(updated_at) : null;
@@ -91,6 +93,12 @@ export class GiteaPrCache {
     let needNextPage = true;
 
     for (const rawItem of rawItems) {
+      if (!rawItem) {
+        logger.warn('Gitea PR is empty, throwing temporary error');
+        // Gitea API sometimes returns empty PRs, so we throw a temporary error
+        // https://github.com/go-gitea/gitea/blob/fcd096231ac2deaefbca10a7db1b9b01f1da93d7/services/convert/pull.go#L34-L52
+        throw new Error(TEMPORARY_ERROR);
+      }
       const id = rawItem.number;
 
       const newItem = toRenovatePR(rawItem, this.author);
@@ -127,7 +135,8 @@ export class GiteaPrCache {
       `${API_PATH}/repos/${this.repo}/pulls?${query}`;
 
     while (url) {
-      const res: HttpResponse<PR[]> = await http.getJson<PR[]>(url, {
+      // TODO: use zod, typescript can't infer the type of the response #22198
+      const res: HttpResponse<(PR | null)[]> = await http.getJson(url, {
         memCache: false,
         paginate: false,
       });


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Better than getting `Cannot read properties of null (reading 'number')` in logs
<!-- Describe what behavior is changed by this PR. -->

## Context
See slack conversation
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
