### PR TITLE
fix(manager/haskell-cabal): Handle comments in Cabal file

### DIFF
--- a/lib/modules/manager/haskell-cabal/extract.spec.ts
+++ b/lib/modules/manager/haskell-cabal/extract.spec.ts
@@ -4,7 +4,16 @@ import {
   extractNamesAndRanges,
   findExtents,
   splitSingleDependency,
+  findDepends,
 } from './extract';
+
+const commentCabalFile = `build-depends:
+  -- leading
+ base,
+-- middle
+ other,
+ -- trailing
+ other2`;
 
 describe('modules/manager/haskell-cabal/extract', () => {
   describe('countPackageNameLength', () => {
@@ -89,6 +98,16 @@ describe('modules/manager/haskell-cabal/extract', () => {
         { currentValue: '', packageName: 'a', replaceString: 'a' },
         { currentValue: '', packageName: 'b', replaceString: 'b' },
       ]);
+    });
+  });
+
+  describe('findDepends()', () => {
+    it('strips comments', () => {
+      const res = findDepends(commentCabalFile + '\na: b');
+      expect(res).toEqual({
+        buildDependsContent: '\n base,\n other,\n other2',
+        lengthProcessed: commentCabalFile.length,
+      });
     });
   });
 });

--- a/lib/modules/manager/haskell-cabal/extract.spec.ts
+++ b/lib/modules/manager/haskell-cabal/extract.spec.ts
@@ -2,9 +2,9 @@ import {
   countPackageNameLength,
   countPrecedingIndentation,
   extractNamesAndRanges,
+  findDepends,
   findExtents,
   splitSingleDependency,
-  findDepends,
 } from './extract';
 
 const commentCabalFile = `build-depends:

--- a/lib/modules/manager/haskell-cabal/extract.ts
+++ b/lib/modules/manager/haskell-cabal/extract.ts
@@ -3,6 +3,7 @@ import { regEx } from '../../../util/regex';
 const buildDependsRegex = regEx(
   /(?<buildDependsFieldName>build-depends[ \t]*:)/i,
 );
+const commentRegex = regEx(/^[ \t]*--/);
 function isNonASCII(str: string): boolean {
   for (let i = 0; i < str.length; i++) {
     if (str.charCodeAt(i) > 127) {
@@ -86,6 +87,11 @@ export function findExtents(indent: number, content: string): number {
         break;
       }
       if (thisIndent < indent) {
+        if (content.slice(blockIdx - 1, blockIdx + 1) === '--') {
+          // not enough indention, but the line is a comment, so include it
+          mode = 'finding-newline';
+          continue;
+        }
         // go back to before the newline
         for (;;) {
           if (content[blockIdx--] === '\n') {
@@ -125,7 +131,8 @@ export function countPrecedingIndentation(
  *
  * @returns {{buildDependsContent: string, lengthProcessed: number}}
  *   buildDependsContent:
- *     the contents of the field, excluding the field name and the colon.
+ *     the contents of the field, excluding the field name and the colon,
+ *     and any comments within
  *
  *   lengthProcessed:
  *     points to after the end of the field. Note that the field does _not_
@@ -143,10 +150,19 @@ export function findDepends(
   const indent = countPrecedingIndentation(content, matchObj.index);
   const ourIdx: number =
     matchObj.index + matchObj.groups['buildDependsFieldName'].length;
-  const extent: number = findExtents(indent + 1, content.slice(ourIdx));
+  const extentLength: number = findExtents(indent + 1, content.slice(ourIdx));
+  const extent = content.slice(ourIdx, ourIdx + extentLength);
+  const lines = [];
+  // Windows-style line breaks are fine because
+  // carriage returns are before the line feed.
+  for (const maybeCommentLine of extent.split('\n')) {
+    if (!commentRegex.test(maybeCommentLine)) {
+      lines.push(maybeCommentLine);
+    }
+  }
   return {
-    buildDependsContent: content.slice(ourIdx, ourIdx + extent),
-    lengthProcessed: ourIdx + extent,
+    buildDependsContent: lines.join('\n'),
+    lengthProcessed: ourIdx + extentLength,
   };
 }
 


### PR DESCRIPTION
## Changes

The Haskell Cabal file parser doesn't handle comments.

This is an issue, since files are parsed incorrectly, and generated patches are invalid.

I simply forgot to implement this, and there were no comments inside the build-depends section in the Cabal regression suite corpus.

Before this PR, an unindented comment would be able to terminate the block, which is incorrect.

Before this PR, commas within the comments would be used to split the dependency listing, which is also incorrect.

After this PR, those issues are resolved.

## Context

* See this Renovate-generated commit, where a dependency is interpreted as including a following line, all the way up to it's final comma.
  * https://github.com/PostgREST/postgrest/pull/3861

* Issue reported by @wolfgangwalther in
  * https://github.com/renovatebot/renovate/pull/33142#issuecomment-2599803943

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [X] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
