### PR TITLE
fix(docs): correct documentation for fork processing

### DIFF
--- a/docs/usage/mend-hosted/hosted-apps-config.md
+++ b/docs/usage/mend-hosted/hosted-apps-config.md
@@ -74,12 +74,12 @@ This change causes Renovate to create an Onboarding PR, even if Renovate does no
 
 ## Fork Processing
 
-If an Organization installs Renovate with the "All repositories" option, then `forkProcessing` will remain set to its default value `false`.
+If an Organization installs Renovate with the "All repositories" option, then `forkProcessing` will remain set to its default value `disabled`.
 This means forked repositories are _not_ onboarded, Renovate ignores them.
-To change this behavior, push a `renovate.json` file to the repository with `"forkProcessing": true`.
+To change this behavior, push a `renovate.json` file to the repository with `"forkProcessing": "enabled"`.
 
 If an Organization installs Renovate with "Selected repositories", we assume the organization wants to onboard _all_ of the selected repositories, even forked repositories.
-Therefore we set `forkProcessing` to `true`.
+Therefore we set `forkProcessing` to "enabled".
 
 ## Inherited config
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
The section for "[Fork Processing](https://docs.renovatebot.com/mend-hosted/hosted-apps-config/#fork-processing)" from the documentation for the configuration of the hosted offer is out of date. This PR corrects that part of the documentation to bring it in line with [the reference for `forkProcessing`](https://docs.renovatebot.com/configuration-options/#forkprocessing).

![image](https://github.com/user-attachments/assets/033f46c3-d4f5-4917-a05e-753aa71aa1c4)

The documentation in question still uses boolean values that no longer work and are now incorrect.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [X] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [X] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
