### PR TITLE
docs: added list of valid namespace codes for the cacheTtlOverride config

### DIFF
--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -346,7 +346,7 @@ For example, to override the default TTL of 60 minutes for the `docker` datasour
 
 Valid codes for namespaces are as follows:
 
-- _test-namespace
+- \_test-namespace
 - changelog-bitbucket-notes@v2
 - changelog-bitbucket-release
 - changelog-gitea-notes@v2

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -346,90 +346,90 @@ For example, to override the default TTL of 60 minutes for the `docker` datasour
 
 Valid codes for namespaces are as follows:
 
-- \_test-namespace
-- changelog-bitbucket-notes@v2
-- changelog-bitbucket-release
-- changelog-gitea-notes@v2
-- changelog-gitea-release
-- changelog-github-notes@v2
-- changelog-github-release
-- changelog-gitlab-notes@v2
-- changelog-gitlab-release
-- datasource-artifactory
-- datasource-aws-machine-image
-- datasource-aws-rds
-- datasource-azure-bicep-resource
-- datasource-azure-pipelines-tasks
-- datasource-bazel
-- datasource-bitbucket-tags
-- datasource-bitrise
-- datasource-cdnjs
-- datasource-conan
-- datasource-conda
-- datasource-cpan
-- datasource-crate-metadata
-- datasource-crate
-- datasource-deb
-- datasource-deno
-- datasource-docker-architecture
-- datasource-docker-hub-cache
-- datasource-docker-digest
-- datasource-docker-hub-tags
-- datasource-docker-imageconfig
-- datasource-docker-labels
-- datasource-docker-releases-v2
-- datasource-docker-tags
-- datasource-dotnet-version
-- datasource-endoflife-date
-- datasource-galaxy-collection
-- datasource-galaxy
-- datasource-git-refs
-- datasource-git-tags
-- datasource-git
-- datasource-gitea-releases
-- datasource-gitea-tags
-- datasource-github-release-attachments
-- datasource-gitlab-packages
-- datasource-gitlab-releases
-- datasource-gitlab-tags
-- datasource-glasskube-packages
-- datasource-go-direct
-- datasource-go-proxy
-- datasource-go
-- datasource-golang-version
-- datasource-gradle-version
-- datasource-helm
-- datasource-hermit
-- datasource-hex
-- datasource-hexpm-bob
-- datasource-java-version
-- datasource-jenkins-plugins
-- datasource-maven
-- datasource-maven:head-requests-timeout
-- datasource-maven:head-requests
-- datasource-maven:metadata-xml
-- datasource-node-version
-- datasource-npm:data
-- datasource-nuget-v3
-- datasource-orb
-- datasource-packagist
-- datasource-pod
-- datasource-python-version
-- datasource-releases
-- datasource-repology
-- datasource-ruby-version
-- datasource-rubygems
-- datasource-sbt-package
-- datasource-terraform-module
-- datasource-terraform-provider
-- datasource-terraform
-- datasource-unity3d
-- github-releases-datasource-v2
-- github-tags-datasource-v2
-- merge-confidence
-- preset
-- terraform-provider-hash
-- url-sha256
+- `\_test-namespace`
+- `changelog-bitbucket-notes@v2`
+- `changelog-bitbucket-release`
+- `changelog-gitea-notes@v2`
+- `changelog-gitea-release`
+- `changelog-github-notes@v2`
+- `changelog-github-release`
+- `changelog-gitlab-notes@v2`
+- `changelog-gitlab-release`
+- `datasource-artifactory`
+- `datasource-aws-machine-image`
+- `datasource-aws-rds`
+- `datasource-azure-bicep-resource`
+- `datasource-azure-pipelines-tasks`
+- `datasource-bazel`
+- `datasource-bitbucket-tags`
+- `datasource-bitrise`
+- `datasource-cdnjs`
+- `datasource-conan`
+- `datasource-conda`
+- `datasource-cpan`
+- `datasource-crate-metadata`
+- `datasource-crate`
+- `datasource-deb`
+- `datasource-deno`
+- `datasource-docker-architecture`
+- `datasource-docker-hub-cache`
+- `datasource-docker-digest`
+- `datasource-docker-hub-tags`
+- `datasource-docker-imageconfig`
+- `datasource-docker-labels`
+- `datasource-docker-releases-v2`
+- `datasource-docker-tags`
+- `datasource-dotnet-version`
+- `datasource-endoflife-date`
+- `datasource-galaxy-collection`
+- `datasource-galaxy`
+- `datasource-git-refs`
+- `datasource-git-tags`
+- `datasource-git`
+- `datasource-gitea-releases`
+- `datasource-gitea-tags`
+- `datasource-github-release-attachments`
+- `datasource-gitlab-packages`
+- `datasource-gitlab-releases`
+- `datasource-gitlab-tags`
+- `datasource-glasskube-packages`
+- `datasource-go-direct`
+- `datasource-go-proxy`
+- `datasource-go`
+- `datasource-golang-version`
+- `datasource-gradle-version`
+- `datasource-helm`
+- `datasource-hermit`
+- `datasource-hex`
+- `datasource-hexpm-bob`
+- `datasource-java-version`
+- `datasource-jenkins-plugins`
+- `datasource-maven`
+- `datasource-maven:head-requests-timeout`
+- `datasource-maven:head-requests`
+- `datasource-maven:metadata-xml`
+- `datasource-node-version`
+- `datasource-npm:data`
+- `datasource-nuget-v3`
+- `datasource-orb`
+- `datasource-packagist`
+- `datasource-pod`
+- `datasource-python-version`
+- `datasource-releases`
+- `datasource-repology`
+- `datasource-ruby-version`
+- `datasource-rubygems`
+- `datasource-sbt-package`
+- `datasource-terraform-module`
+- `datasource-terraform-provider`
+- `datasource-terraform`
+- `datasource-unity3d`
+- `github-releases-datasource-v2`
+- `github-tags-datasource-v2`
+- `merge-confidence`
+- `preset`
+- `terraform-provider-hash`
+- `url-sha256`
 
 ## checkedBranches
 
@@ -457,14 +457,14 @@ This configuration will be applied after all other environment variables so you 
 
 If configuring secrets in to `customEnvVariables`, take this approach:
 
-```js
+```
 {
   secrets: {
-    SECRET_TOKEN: process.env.SECRET_TOKEN,
+    SECRET_TOKEN: process.env.SECRET_TOKEN
   },
   customEnvVariables: {
-    SECRET_TOKEN: '{{ secrets.SECRET_TOKEN }}',
-  },
+    SECRET_TOKEN: '{{ secrets.SECRET_TOKEN }}'
+  }
 }
 ```
 

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -456,14 +456,14 @@ This configuration will be applied after all other environment variables so you 
 
 If configuring secrets in to `customEnvVariables`, take this approach:
 
-```
+```js
 {
   secrets: {
-    SECRET_TOKEN: process.env.SECRET_TOKEN
+    SECRET_TOKEN: process.env.SECRET_TOKEN,
   },
   customEnvVariables: {
-    SECRET_TOKEN: '{{ secrets.SECRET_TOKEN }}'
-  }
+    SECRET_TOKEN: '{{ secrets.SECRET_TOKEN }}',
+  },
 }
 ```
 

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -346,7 +346,6 @@ For example, to override the default TTL of 60 minutes for the `docker` datasour
 
 Valid codes for namespaces are as follows:
 
-- `\_test-namespace`
 - `changelog-bitbucket-notes@v2`
 - `changelog-bitbucket-release`
 - `changelog-gitea-notes@v2`

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -344,6 +344,93 @@ For example, to override the default TTL of 60 minutes for the `docker` datasour
 }
 ```
 
+Valid codes for namespaces are as follows:
+
+- _test-namespace
+- changelog-bitbucket-notes@v2
+- changelog-bitbucket-release
+- changelog-gitea-notes@v2
+- changelog-gitea-release
+- changelog-github-notes@v2
+- changelog-github-release
+- changelog-gitlab-notes@v2
+- changelog-gitlab-release
+- datasource-artifactory
+- datasource-aws-machine-image
+- datasource-aws-rds
+- datasource-azure-bicep-resource
+- datasource-azure-pipelines-tasks
+- datasource-bazel
+- datasource-bitbucket-tags
+- datasource-bitrise
+- datasource-cdnjs
+- datasource-conan
+- datasource-conda
+- datasource-cpan
+- datasource-crate-metadata
+- datasource-crate
+- datasource-deb
+- datasource-deno
+- datasource-docker-architecture
+- datasource-docker-hub-cache
+- datasource-docker-digest
+- datasource-docker-hub-tags
+- datasource-docker-imageconfig
+- datasource-docker-labels
+- datasource-docker-releases-v2
+- datasource-docker-tags
+- datasource-dotnet-version
+- datasource-endoflife-date
+- datasource-galaxy-collection
+- datasource-galaxy
+- datasource-git-refs
+- datasource-git-tags
+- datasource-git
+- datasource-gitea-releases
+- datasource-gitea-tags
+- datasource-github-release-attachments
+- datasource-gitlab-packages
+- datasource-gitlab-releases
+- datasource-gitlab-tags
+- datasource-glasskube-packages
+- datasource-go-direct
+- datasource-go-proxy
+- datasource-go
+- datasource-golang-version
+- datasource-gradle-version
+- datasource-helm
+- datasource-hermit
+- datasource-hex
+- datasource-hexpm-bob
+- datasource-java-version
+- datasource-jenkins-plugins
+- datasource-maven
+- datasource-maven:head-requests-timeout
+- datasource-maven:head-requests
+- datasource-maven:metadata-xml
+- datasource-node-version
+- datasource-npm:data
+- datasource-nuget-v3
+- datasource-orb
+- datasource-packagist
+- datasource-pod
+- datasource-python-version
+- datasource-releases
+- datasource-repology
+- datasource-ruby-version
+- datasource-rubygems
+- datasource-sbt-package
+- datasource-terraform-module
+- datasource-terraform-provider
+- datasource-terraform
+- datasource-unity3d
+- github-releases-datasource-v2
+- github-tags-datasource-v2
+- merge-confidence
+- preset
+- terraform-provider-hash
+- url-sha256
+
 ## checkedBranches
 
 This array will allow you to set the names of the branches you want to rebase/create, as if you selected their checkboxes in the Dependency Dashboard issue.


### PR DESCRIPTION
## Changes

Added list of valid namespace codes for the _cacheTtlOverride_ configuration

## Context

To make it easier for users of the cacheTtlOverride option, the known list of namespace key codes has been added to the config page.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository