### PR TITLE
test(npm): use fs test utils in extract/pnpm.spec.ts

### DIFF
--- a/lib/modules/manager/npm/extract/pnpm.spec.ts
+++ b/lib/modules/manager/npm/extract/pnpm.spec.ts
@@ -97,6 +97,10 @@ describe('modules/manager/npm/extract/pnpm', () => {
         realFs.findLocalSiblingOrParent,
       );
       fs.getSiblingFileName.mockImplementation(realFs.getSiblingFileName);
+
+      // Falls through to reading from the fixture path defined in GlobalConfig
+      // at the top of this file
+      fs.readLocalFile.mockImplementation(realFs.readLocalFile);
     });
 
     it('uses pnpm workspaces', async () => {

--- a/lib/modules/manager/npm/extract/pnpm.spec.ts
+++ b/lib/modules/manager/npm/extract/pnpm.spec.ts
@@ -1,7 +1,6 @@
 import { Fixtures } from '../../../../../test/fixtures';
-import { getFixturePath, logger, partial } from '../../../../../test/util';
+import { fs, getFixturePath, logger, partial } from '../../../../../test/util';
 import { GlobalConfig } from '../../../../config/global';
-import * as fs from '../../../../util/fs';
 import * as yaml from '../../../../util/yaml';
 import type { PackageFile } from '../../types';
 import type { NpmManagerData } from '../types';
@@ -11,6 +10,8 @@ import {
   findPnpmWorkspace,
   getPnpmLock,
 } from './pnpm';
+
+jest.mock('../../../../util/fs');
 
 describe('modules/manager/npm/extract/pnpm', () => {
   beforeAll(() => {
@@ -23,9 +24,7 @@ describe('modules/manager/npm/extract/pnpm', () => {
 
   describe('.extractPnpmFilters()', () => {
     it('detects errors in pnpm-workspace.yml file structure', async () => {
-      jest
-        .spyOn(fs, 'readLocalFile')
-        .mockResolvedValueOnce('p!!!ckages:\n - "packages/*"');
+      fs.readLocalFile.mockResolvedValueOnce('p!!!ckages:\n - "packages/*"');
 
       const workSpaceFilePath = getFixturePath(
         'pnpm-monorepo/pnpm-workspace.yml',
@@ -60,7 +59,7 @@ describe('modules/manager/npm/extract/pnpm', () => {
 
   describe('.findPnpmWorkspace()', () => {
     it('detects missing pnpm-workspace.yaml', async () => {
-      jest.spyOn(fs, 'findLocalSiblingOrParent').mockResolvedValueOnce(null);
+      fs.findLocalSiblingOrParent.mockResolvedValueOnce(null);
 
       const packageFile = 'package.json';
       const res = await findPnpmWorkspace(packageFile);
@@ -72,10 +71,8 @@ describe('modules/manager/npm/extract/pnpm', () => {
     });
 
     it('detects missing pnpm-lock.yaml when pnpm-workspace.yaml was already found', async () => {
-      jest
-        .spyOn(fs, 'findLocalSiblingOrParent')
-        .mockResolvedValueOnce('pnpm-workspace.yaml');
-      jest.spyOn(fs, 'localPathExists').mockResolvedValueOnce(false);
+      fs.findLocalSiblingOrParent.mockResolvedValueOnce('pnpm-workspace.yaml');
+      fs.localPathExists.mockResolvedValueOnce(false);
 
       const packageFile = 'package.json';
       const res = await findPnpmWorkspace(packageFile);
@@ -91,7 +88,19 @@ describe('modules/manager/npm/extract/pnpm', () => {
   });
 
   describe('.detectPnpmWorkspaces()', () => {
+    beforeEach(() => {
+      const realFs = jest.requireActual<typeof fs>('../../../../util/fs');
+
+      // The real implementations of these functions are used for this block;
+      // they do static path manipulation.
+      fs.findLocalSiblingOrParent.mockImplementation(
+        realFs.findLocalSiblingOrParent,
+      );
+      fs.getSiblingFileName.mockImplementation(realFs.getSiblingFileName);
+    });
+
     it('uses pnpm workspaces', async () => {
+      fs.localPathExists.mockResolvedValue(true);
       const packageFiles = partial<PackageFile<NpmManagerData>>([
         {
           packageFile: 'package.json',
@@ -197,6 +206,7 @@ describe('modules/manager/npm/extract/pnpm', () => {
     });
 
     it('filters none matching packages', async () => {
+      fs.localPathExists.mockResolvedValue(true);
       const packageFiles = [
         {
           packageFile: 'package.json',
@@ -242,14 +252,14 @@ describe('modules/manager/npm/extract/pnpm', () => {
 
   describe('.getPnpmLock()', () => {
     it('returns empty if failed to parse', async () => {
-      jest.spyOn(fs, 'readLocalFile').mockResolvedValueOnce(undefined as never);
+      fs.readLocalFile.mockResolvedValueOnce(undefined as never);
       const res = await getPnpmLock('package.json');
       expect(res.lockedVersionsWithPath).toBeUndefined();
     });
 
     it('extracts version from monorepo', async () => {
       const plocktest1Lock = Fixtures.get('pnpm-monorepo/pnpm-lock.yaml', '..');
-      jest.spyOn(fs, 'readLocalFile').mockResolvedValueOnce(plocktest1Lock);
+      fs.readLocalFile.mockResolvedValueOnce(plocktest1Lock);
       const res = await getPnpmLock('package.json');
       expect(Object.keys(res.lockedVersionsWithPath!)).toHaveLength(11);
     });
@@ -259,13 +269,13 @@ describe('modules/manager/npm/extract/pnpm', () => {
         'lockfile-parsing/pnpm-lock.yaml',
         '..',
       );
-      jest.spyOn(fs, 'readLocalFile').mockResolvedValueOnce(plocktest1Lock);
+      fs.readLocalFile.mockResolvedValueOnce(plocktest1Lock);
       const res = await getPnpmLock('package.json');
       expect(Object.keys(res.lockedVersionsWithPath!)).toHaveLength(1);
     });
 
     it('returns empty if no deps', async () => {
-      jest.spyOn(fs, 'readLocalFile').mockResolvedValueOnce('{}');
+      fs.readLocalFile.mockResolvedValueOnce('{}');
       const res = await getPnpmLock('package.json');
       expect(res.lockedVersionsWithPath).toBeUndefined();
     });


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
This PR is split off from https://github.com/renovatebot/renovate/pull/33376, specifically the discussion at https://github.com/renovatebot/renovate/pull/33376#discussion_r1920385993. It changes tests in lib/modules/manager/npm/extract/pnpm.spec.ts to use the shared `fs` test utilities. cc @secustor ✉️ 

The `fs` test utilities are used by most test suites. This suite was an outlier, instead using `spyOn` as a way to implement partial mocks, letting other calls of the `fs` module fall through to the real implementation.

The test utilities assume that the whole `fs` module is mocked, so I made relevant changes to ensure that. A couple of tests were incidentally relying on the "real" implementation (primarily for path manipulation). For those, I explicitly passed the real version of the relevant functions to them. I think this still has some of the pitfalls of partial mocking, but it is more explicit about what is going on. The blast radius is also isolated to those couple of tests that are relying on this behaviour, instead of the whole suite.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->
Making these tests more consistent with other test suites, and paving the way for using the `fs` test utilities in https://github.com/renovatebot/renovate/pull/33376.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
