### PR TITLE
feat(datasource/hackage): Detect deprecation status

### DIFF
--- a/lib/modules/datasource/hackage/index.spec.ts
+++ b/lib/modules/datasource/hackage/index.spec.ts
@@ -33,11 +33,11 @@ describe('modules/datasource/hackage/index', () => {
       ).toBeNull();
     });
 
-    it('returns release for 200', async () => {
+    it('returns releases for 200', async () => {
       httpMock
         .scope(baseUrl)
         .get('/package/base.json')
-        .reply(200, { '4.20.0.1': 'normal' });
+        .reply(200, { '4.19.0.1': 'deprecated', '4.20.0.1': 'normal' });
       expect(
         await getPkgReleases({
           datasource: HackageDatasource.id,
@@ -46,6 +46,11 @@ describe('modules/datasource/hackage/index', () => {
       ).toEqual({
         registryUrl: baseUrl,
         releases: [
+          {
+            changelogUrl: baseUrl + 'package/base-4.19.0.1/changelog',
+            version: '4.19.0.1',
+            isDeprecated: true,
+          },
           {
             changelogUrl: baseUrl + 'package/base-4.20.0.1/changelog',
             version: '4.20.0.1',

--- a/lib/modules/datasource/hackage/index.spec.ts
+++ b/lib/modules/datasource/hackage/index.spec.ts
@@ -8,7 +8,7 @@ describe('modules/datasource/hackage/index', () => {
   describe('versionToRelease', () => {
     it('should make release with given version', () => {
       expect(
-        versionToRelease('3.1.0', 'base', 'http://localhost').version,
+        versionToRelease('3.1.0', 'base', 'http://localhost', false).version,
       ).toBe('3.1.0');
     });
   });
@@ -49,6 +49,7 @@ describe('modules/datasource/hackage/index', () => {
           {
             changelogUrl: baseUrl + 'package/base-4.20.0.1/changelog',
             version: '4.20.0.1',
+            isDeprecated: false,
           },
         ],
       });

--- a/lib/modules/datasource/hackage/index.ts
+++ b/lib/modules/datasource/hackage/index.ts
@@ -28,12 +28,14 @@ export class HackageDatasource extends Datasource {
       `${massagedPackageName}.json`,
     );
     const res = await this.http.getJson(url, HackagePackageMetadata);
-    const keys = Object.keys(res.body);
-    return {
-      releases: keys.map((version) =>
-        versionToRelease(version, packageName, registryUrl),
-      ),
-    };
+    const releases = [];
+    for (const [version, versionStatus] of Object.entries(res.body)) {
+      const isDeprecated = versionStatus === 'deprecated';
+      releases.push(
+        versionToRelease(version, packageName, registryUrl, isDeprecated),
+      );
+    }
+    return { releases };
   }
 }
 
@@ -41,6 +43,7 @@ export function versionToRelease(
   version: string,
   packageName: string,
   registryUrl: string,
+  isDeprecated: boolean,
 ): Release {
   return {
     version,
@@ -50,5 +53,6 @@ export function versionToRelease(
       `${packageName}-${version}`,
       'changelog',
     ),
+    isDeprecated,
   };
 }

--- a/lib/modules/datasource/hackage/schema.ts
+++ b/lib/modules/datasource/hackage/schema.ts
@@ -1,3 +1,8 @@
 import { z } from 'zod';
 
-export const HackagePackageMetadata = z.record(z.string());
+// See https://github.com/haskell/hackage-server
+// revision e885d36c
+// src/Distribution/Server/Features/PackageInfoJSON/State.hs line 160
+const VersionStatus = z.enum(['normal', 'deprecated', 'unpreferred']);
+
+export const HackagePackageMetadata = z.record(VersionStatus);


### PR DESCRIPTION
## Changes

During the recent addition of the Hackage datasource, I forgot that Renovate
and Hackage both have concepts of deprecated packages.

This PR implements support for deprecated versions, which isn't available
before this PR.

## Context

Renovate tried to upgrade my library to a deprecated version:

* https://github.com/ysangkok/haskell-tzdata/pull/13

You can see on [the Hackage API response](https://hackage.haskell.org/package/deepseq.json) that the version 1.6.0.0 is deprecated.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
