### PR TITLE
fix(config/inherited): apply secrets

### DIFF
--- a/lib/workers/repository/init/inherited.spec.ts
+++ b/lib/workers/repository/init/inherited.spec.ts
@@ -25,6 +25,7 @@ describe('workers/repository/init/inherited', () => {
       inheritConfigFileName: 'config.json',
       inheritConfigStrict: false,
     };
+    hostRules.clear();
   });
 
   it('should return the same config if repository or inheritConfig is not defined', async () => {
@@ -107,6 +108,30 @@ describe('workers/repository/init/inherited', () => {
       {
         matchHost: 'some-host-url',
         token: 'some-token',
+      },
+    ]);
+    expect(res.hostRules).toBeUndefined();
+  });
+
+  it('should apply secrets to inherited config', async () => {
+    platform.getRawFile.mockResolvedValue(
+      `{
+        "hostRules": [
+          {
+            "matchHost": "some-host-url",
+            "token": "{{ secrets.SECRET_TOKEN }}"
+          }
+        ]
+      }`,
+    );
+    const res = await mergeInheritedConfig({
+      ...config,
+      secrets: { SECRET_TOKEN: 'some-secret-token' },
+    });
+    expect(hostRules.getAll()).toMatchObject([
+      {
+        matchHost: 'some-host-url',
+        token: 'some-secret-token',
       },
     ]);
     expect(res.hostRules).toBeUndefined();

--- a/lib/workers/repository/init/inherited.ts
+++ b/lib/workers/repository/init/inherited.ts
@@ -3,6 +3,7 @@ import { dequal } from 'dequal';
 import { mergeChildConfig, removeGlobalConfig } from '../../../config';
 import { parseFileConfig } from '../../../config/parse';
 import { resolveConfigPresets } from '../../../config/presets';
+import { applySecretsToConfig } from '../../../config/secrets';
 import type { RenovateConfig } from '../../../config/types';
 import { validateConfig } from '../../../config/validation';
 import {
@@ -16,7 +17,6 @@ import * as hostRules from '../../../util/host-rules';
 import * as queue from '../../../util/http/queue';
 import * as throttle from '../../../util/http/throttle';
 import * as template from '../../../util/template';
-import { applySecretsToConfig } from '../../../config/secrets';
 
 export async function mergeInheritedConfig(
   config: RenovateConfig,

--- a/lib/workers/repository/init/inherited.ts
+++ b/lib/workers/repository/init/inherited.ts
@@ -16,6 +16,7 @@ import * as hostRules from '../../../util/host-rules';
 import * as queue from '../../../util/http/queue';
 import * as throttle from '../../../util/http/throttle';
 import * as template from '../../../util/template';
+import { applySecretsToConfig } from '../../../config/secrets';
 
 export async function mergeInheritedConfig(
   config: RenovateConfig,
@@ -105,6 +106,7 @@ export async function mergeInheritedConfig(
   }
 
   if (is.nullOrUndefined(filteredConfig.extends)) {
+    filteredConfig = applySecretsToConfig(filteredConfig, config.secrets ?? {});
     setInheritedHostRules(filteredConfig);
     return mergeChildConfig(config, filteredConfig);
   }
@@ -141,6 +143,7 @@ export async function mergeInheritedConfig(
     );
   }
 
+  filteredConfig = applySecretsToConfig(filteredConfig, config.secrets ?? {});
   setInheritedHostRules(filteredConfig);
   return mergeChildConfig(config, filteredConfig);
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- Apply secrets to inherited config before setting the host rules
<!-- Describe what behavior is changed by this PR. -->

## Context
- Ref: https://github.com/renovatebot/renovate/discussions/31461#discussioncomment-11912590
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository (tested locally)

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
