### PR TITLE
Update azuredevops docs

### DIFF
--- a/lib/modules/platform/azure/readme.md
+++ b/lib/modules/platform/azure/readme.md
@@ -98,6 +98,52 @@ module.exports = {
 
 For the `repositories` key, replace `YOUR-PROJECT/YOUR-REPO` with your Azure DevOps project and repository.
 
+### Using Azure DevOps internal API for pipeline tasks versions
+
+!!! info
+    Renovate bot is now using the set of APIs that azure provides to query the azure-pipelines tasks versions directly from the instance. ([PR #32966](https://github.com/renovatebot/renovate/pull/32966) and [Discussion #24820](https://github.com/renovatebot/renovate/discussions/24820))
+
+    To use it, you need to have in your config :
+
+      - `platform` = `azure`
+      - `endpoint` = `$(System.CollectionUri)` (an [azure predefined variable](https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml))
+      - `hostRules.hostType` = `azure-pipelines-tasks`
+
+An example configuration file, in `.json` format this time, would be :
+
+```json
+{
+  "platform": "azure",
+  "endpoint": "https://dev.azure.com/ORG_NAME",
+  "token": "process.env.RENOVATE_TOKEN",
+  "azure-pipelines": {
+    "enabled": true
+  },
+  "repositories": [
+    "PROJECT_NAME/REPO_NAME"
+  ],
+  "prHourlyLimit": 0,
+  "baseBranches": [
+    "main"
+  ],
+  "hostRules": [
+    {
+      "matchHost": "https://dev.azure.com/",
+      "hostType": "azure-pipelines-tasks",
+      "token": "process.env.RENOVATE_TOKEN"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchDatasources": [
+        "azure-pipelines-tasks"
+      ],
+      "extractVersion": "^(?<version>\\d+)"
+    }
+  ]
+}
+```
+
 ### Yarn users
 
 To do a successful `yarn install` you need to match the URL of the registry fully.

--- a/lib/modules/platform/azure/readme.md
+++ b/lib/modules/platform/azure/readme.md
@@ -51,6 +51,11 @@ steps:
       workingFile: .npmrc
 
   - bash: |
+      add-apt-repository ppa:git-core/ppa
+      apt update && apt install git -y
+    displayName: 'Install latest git version'
+
+  - bash: |
       git config --global user.email 'bot@renovateapp.com'
       git config --global user.name 'Renovate Bot'
       npx --userconfig .npmrc renovate

--- a/lib/modules/platform/azure/readme.md
+++ b/lib/modules/platform/azure/readme.md
@@ -62,7 +62,9 @@ steps:
     env:
       RENOVATE_PLATFORM: azure
       RENOVATE_ENDPOINT: $(System.CollectionUri)
+      RENOVATE_CONFIG_FILE: $(Build.SourcesDirectory)/renovate_bot_config.json
       RENOVATE_TOKEN: $(System.AccessToken)
+      LOG_LEVEL: debug
 ```
 
 ### Create a .npmrc file


### PR DESCRIPTION
## Changes

I wanted to add examples so that new users will benefit from the recent changes related to how renovate picks up tasks version using internal APIs when `azure-pipelines` is enabled in renovate configuration.

## Context

- #32966
- #24820

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- Using `pnpm docs:build` and `pnpm mkdocs serve` to preview the documentation changes.