### PR TITLE
docs(local-dev): add `pdm install` step

### DIFF
--- a/docs/development/local-development.md
+++ b/docs/development/local-development.md
@@ -177,6 +177,7 @@ If you're only working on the documentation files, you can use the `pnpm doc-fix
 ## Documentation
 
 We use [MkDocs](https://www.mkdocs.org) to generate the documentation.
+To install the required dependency, use `pdm install`.
 You can run `pnpm build:docs` to generate the docs.
 Then use `pnpm mkdocs serve` to preview the documentation locally.
 The docs will update automatically when you run `pnpm build:docs` again, no need to stop the `pnpm mkdocs serve` command.


### PR DESCRIPTION
Based on a discussion in #33729, it was missing from the local dev doc.

## Changes

I did not find it when trying on my own, I hope it helps future lads in search to contribute to docs.

## Context

- #33729

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required
