### PR TITLE
feat(bazel): set sourceUrl for Bazel modules

### DIFF
--- a/lib/modules/datasource/bazel/__fixtures__/metadata-no-yanked-versions.json
+++ b/lib/modules/datasource/bazel/__fixtures__/metadata-no-yanked-versions.json
@@ -1,4 +1,5 @@
 {
+    "homepage": "https://github.com/foo/bar",
     "versions": [
         "0.14.8",
         "0.14.9",

--- a/lib/modules/datasource/bazel/__fixtures__/metadata-with-yanked-versions.json
+++ b/lib/modules/datasource/bazel/__fixtures__/metadata-with-yanked-versions.json
@@ -1,4 +1,5 @@
 {
+    "homepage": "https://github.com/foo/bar",
     "versions": [
         "0.14.8",
         "0.14.9",

--- a/lib/modules/datasource/bazel/__fixtures__/metadata-with-yanked-versions.json
+++ b/lib/modules/datasource/bazel/__fixtures__/metadata-with-yanked-versions.json
@@ -1,5 +1,4 @@
 {
-    "homepage": "https://github.com/foo/bar",
     "versions": [
         "0.14.8",
         "0.14.9",

--- a/lib/modules/datasource/bazel/index.spec.ts
+++ b/lib/modules/datasource/bazel/index.spec.ts
@@ -58,6 +58,7 @@ describe('modules/datasource/bazel/index', () => {
           { version: '0.15.0' },
           { version: '0.16.0' },
         ],
+        sourceUrl: 'https://github.com/foo/bar',
       });
     });
 
@@ -76,6 +77,7 @@ describe('modules/datasource/bazel/index', () => {
           { version: '0.15.0', isDeprecated: true },
           { version: '0.16.0' },
         ],
+        sourceUrl: 'https://github.com/foo/bar',
       });
     });
   });

--- a/lib/modules/datasource/bazel/index.spec.ts
+++ b/lib/modules/datasource/bazel/index.spec.ts
@@ -77,7 +77,6 @@ describe('modules/datasource/bazel/index', () => {
           { version: '0.15.0', isDeprecated: true },
           { version: '0.16.0' },
         ],
-        sourceUrl: 'https://github.com/foo/bar',
       });
     });
   });

--- a/lib/modules/datasource/bazel/index.ts
+++ b/lib/modules/datasource/bazel/index.ts
@@ -57,7 +57,7 @@ export class BazelDatasource extends Datasource {
           }
           return release;
         });
-      result.sourceUrl = metadata.homepage;
+      if (metadata.homepage) result.sourceUrl = metadata.homepage;
     } catch (err) {
       // istanbul ignore else: not testable with nock
       if (err instanceof HttpError) {

--- a/lib/modules/datasource/bazel/index.ts
+++ b/lib/modules/datasource/bazel/index.ts
@@ -57,7 +57,9 @@ export class BazelDatasource extends Datasource {
           }
           return release;
         });
-      if (metadata.homepage) result.sourceUrl = metadata.homepage;
+      if (metadata.homepage) {
+        result.homepage = metadata.homepage;
+      }
     } catch (err) {
       // istanbul ignore else: not testable with nock
       if (err instanceof HttpError) {

--- a/lib/modules/datasource/bazel/index.ts
+++ b/lib/modules/datasource/bazel/index.ts
@@ -57,6 +57,7 @@ export class BazelDatasource extends Datasource {
           }
           return release;
         });
+      result.sourceUrl = metadata.homepage;
     } catch (err) {
       // istanbul ignore else: not testable with nock
       if (err instanceof HttpError) {

--- a/lib/modules/datasource/bazel/schema.ts
+++ b/lib/modules/datasource/bazel/schema.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 export const BazelModuleMetadata = z.object({
+  homepage: z.string().optional(),
   versions: z.array(z.string()),
   yanked_versions: z.record(z.string(), z.string()),
 });

--- a/lib/modules/datasource/bazel/schema.ts
+++ b/lib/modules/datasource/bazel/schema.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 export const BazelModuleMetadata = z.object({
-  homepage: z.string().optional(),
+  homepage: z.string().optional().nullable(),
   versions: z.array(z.string()),
   yanked_versions: z.record(z.string(), z.string()),
 });


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

This updates the Bazel datasource to read the [homepage attribute](https://github.com/bazelbuild/bazel-central-registry/blob/main/modules/abseil-cpp/metadata.json#L2) from the Bazel central registry and assign that to `sourceUrl`.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

I've made this change to get automatic changelogs for Bazel module PR:s.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
