### PR TITLE
feat(manager/pre-commit): parse 'ssh://git@' in pre-commit repo

### DIFF
--- a/lib/modules/manager/pre-commit/__fixtures__/complex.pre-commit-config.yaml
+++ b/lib/modules/manager/pre-commit/__fixtures__/complex.pre-commit-config.yaml
@@ -52,6 +52,11 @@ repos:
       - id: prettier
         exclude: ^notebooks
     rev: v2.1.2
+  - repo: ssh://git@github.com/pre-commit/pre-commit-hooks
+    # should allow explicit ssh protocol
+    hooks:
+    - id: check-merge-conflict
+    rev: v5.0.0
   - repo: some_invalid_url
     # case with invlalid url.
     rev: v1.0.0

--- a/lib/modules/manager/pre-commit/__snapshots__/extract.spec.ts.snap
+++ b/lib/modules/manager/pre-commit/__snapshots__/extract.spec.ts.snap
@@ -74,6 +74,13 @@ exports[`modules/manager/pre-commit/extract extractPackageFile() extracts from c
       "packageName": "prettier/pre-commit",
     },
     {
+      "currentValue": "v5.0.0",
+      "datasource": "github-tags",
+      "depName": "pre-commit/pre-commit-hooks",
+      "depType": "repository",
+      "packageName": "pre-commit/pre-commit-hooks",
+    },
+    {
       "currentValue": "v1.0.0",
       "datasource": undefined,
       "depName": undefined,

--- a/lib/modules/manager/pre-commit/extract.spec.ts
+++ b/lib/modules/manager/pre-commit/extract.spec.ts
@@ -105,6 +105,7 @@ describe('modules/manager/pre-commit/extract', () => {
           },
           { depName: 'prettier/pre-commit', currentValue: 'v2.1.2' },
           { depName: 'prettier/pre-commit', currentValue: 'v2.1.2' },
+          { depName: 'pre-commit/pre-commit-hooks', currentValue: 'v5.0.0' },
           { skipReason: 'invalid-url' },
         ],
       });

--- a/lib/modules/manager/pre-commit/extract.ts
+++ b/lib/modules/manager/pre-commit/extract.ts
@@ -96,6 +96,8 @@ function extractDependency(
     regEx('^git@(?<hostname>[^:]+):(?<depName>\\S*)'),
     // This split "git://github.com/pre-commit/pre-commit-hooks" -> "github.com" "pre-commit/pre-commit-hooks"
     regEx(/^git:\/\/(?<hostname>[^/]+)\/(?<depName>\S*)/),
+    // This splits "ssh://git@github.com/pre-commit/pre-commit-hooks" -> "github.com" "pre-commit/pre-commit-hooks"
+    regEx(/^ssh:\/\/git@(?<hostname>[^/]+)\/(?<depName>\S*)/),
   ];
   for (const urlMatcher of urlMatchers) {
     const match = urlMatcher.exec(repository);


### PR DESCRIPTION
It is possible to define a private hook repository with leading ssh:// protocol in pre-commit (as git:// does not necessarily use SSH), which is handled by pre-commit but not at renovate, this currently gives an invalid url.

This change adds a proper regex so renovate properly parses it.

## Changes

It is possible to define a private hook repository with leading ssh:// protocol in pre-commit (as git:// does not necessarily use SSH), which is handled by pre-commit but not at renovate, this currently gives an invalid url.

This change adds a proper regex so renovate properly parses it, extracting the hostname and depName from it


## Context

See discussion https://github.com/renovatebot/renovate/discussions/33849, I am currently explicitly stating the protocol 'ssh' for my private hook repo, which is not detected correctly.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository