### PR TITLE
feat(http): Return stale cache on revalidation errors

### DIFF
--- a/lib/util/http/cache/abstract-http-cache-provider.ts
+++ b/lib/util/http/cache/abstract-http-cache-provider.ts
@@ -39,7 +39,10 @@ export abstract class AbstractHttpCacheProvider implements HttpCacheProvider {
     }
   }
 
-  bypassServerResponse<T>(_url: string): Promise<HttpResponse<T> | null> {
+  bypassServer<T>(
+    _url: string,
+    _ignoreSoftTtl: boolean,
+  ): Promise<HttpResponse<T> | null> {
     return Promise.resolve(null);
   }
 

--- a/lib/util/http/cache/package-http-cache-provider.spec.ts
+++ b/lib/util/http/cache/package-http-cache-provider.spec.ts
@@ -109,4 +109,23 @@ describe('util/http/cache/package-http-cache-provider', () => {
       },
     });
   });
+
+  it('serves stale response during revalidation error', async () => {
+    mockTime('2024-06-15T00:15:00.000Z');
+    cache[url] = {
+      etag: 'etag-value',
+      lastModified: 'Fri, 15 Jun 2024 00:00:00 GMT',
+      httpResponse: { statusCode: 200, body: 'cached response' },
+      timestamp: '2024-06-15T00:00:00.000Z',
+    };
+    const cacheProvider = new PackageHttpCacheProvider({
+      namespace: '_test-namespace',
+    });
+    httpMock.scope(url).get('').reply(500);
+
+    const res = await http.get(url, { cacheProvider });
+
+    expect(res.body).toBe('cached response');
+    expect(packageCache.set).not.toHaveBeenCalled();
+  });
 });

--- a/lib/util/http/cache/package-http-cache-provider.ts
+++ b/lib/util/http/cache/package-http-cache-provider.ts
@@ -35,12 +35,17 @@ export class PackageHttpCacheProvider extends AbstractHttpCacheProvider {
     await set(this.namespace, url, data, this.hardTtlMinutes);
   }
 
-  override async bypassServerResponse<T>(
+  override async bypassServer<T>(
     url: string,
+    ignoreSoftTtl = false,
   ): Promise<HttpResponse<T> | null> {
     const cached = await this.get(url);
     if (!cached) {
       return null;
+    }
+
+    if (ignoreSoftTtl) {
+      return cached.httpResponse as HttpResponse<T>;
     }
 
     const cachedAt = DateTime.fromISO(cached.timestamp);

--- a/lib/util/http/cache/types.ts
+++ b/lib/util/http/cache/types.ts
@@ -6,7 +6,10 @@ export interface HttpCacheProvider {
     opts: T,
   ): Promise<void>;
 
-  bypassServerResponse<T>(url: string): Promise<HttpResponse<T> | null>;
+  bypassServer<T>(
+    url: string,
+    ignoreSoftTtl?: boolean,
+  ): Promise<HttpResponse<T> | null>;
 
   wrapServerResponse<T>(
     url: string,

--- a/lib/util/http/index.ts
+++ b/lib/util/http/index.ts
@@ -254,6 +254,10 @@ export class Http<Opts extends HttpOptions = HttpOptions> {
 
       const staleResponse = await cacheProvider?.bypassServer<T>(url, true);
       if (staleResponse) {
+        logger.debug(
+          { err },
+          `Request error: returning stale cache instead for ${url}`,
+        );
         return staleResponse;
       }
 

--- a/lib/util/http/index.ts
+++ b/lib/util/http/index.ts
@@ -181,8 +181,7 @@ export class Http<Opts extends HttpOptions = HttpOptions> {
     options.timeout ??= 60000;
 
     const { cacheProvider } = options;
-    const cachedResponse = await cacheProvider?.bypassServerResponse<T>(url);
-    // istanbul ignore if
+    const cachedResponse = await cacheProvider?.bypassServer<T>(url);
     if (cachedResponse) {
       return cachedResponse;
     }
@@ -252,6 +251,12 @@ export class Http<Opts extends HttpOptions = HttpOptions> {
       if (abortOnError && !abortIgnoreStatusCodes?.includes(err.statusCode)) {
         throw new ExternalHostError(err);
       }
+
+      const staleResponse = await cacheProvider?.bypassServer<T>(url, true);
+      if (staleResponse) {
+        return staleResponse;
+      }
+
       throw err;
     }
   }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

We could return cached result without hitting the server in 2 cases:
- The "soft TTL" is still valid
- The "softTTL" is expired, we hit the server for data fetch/revalidation, but it responded with error. Well, at least we could serve stale data from our cache.

This PR implements the second case.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
