### PR TITLE
feat(http): Stop caching GET responses in memory

### DIFF
--- a/lib/util/http/types.ts
+++ b/lib/util/http/types.ts
@@ -21,7 +21,6 @@ export type GotExtraOptions = {
   token?: string;
   hostType?: string;
   enabled?: boolean;
-  memCache?: boolean;
   noAuth?: boolean;
   context?: GotContextOptions;
 };
@@ -66,7 +65,6 @@ export interface HttpOptions {
   throwHttpErrors?: boolean;
 
   token?: string;
-  memCache?: boolean;
   cacheProvider?: HttpCacheProvider;
   readOnly?: boolean;
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Remove memory cache for GET requests during repository run.

Previously, all GET requests were cached in memory during repository runs. 
Since then, Renovate has evolved to use package/repository cache more efficiently. 
The memory cache is now redundant and unnecessarily consumes resources, 
as these requests are unlikely to be repeated during a single run.

To justify that, I created [the test repo](https://github.com/renovate-testing/test-mem-cache) with `package.json` stolen from Renovate.

This is the heap dump in `main` branch after dry-run:

<img width="197" alt="Google Chrome 2025-01-26 16 49 55" src="https://github.com/user-attachments/assets/8e65718b-cf89-4f61-9532-2165c172227a" />

This is the heap dump performed by the branch of this PR:

<img width="199" alt="Google Chrome 2025-01-26 16 50 15" src="https://github.com/user-attachments/assets/bd482410-2bce-44a4-bd30-6bf2cdc155db" />

- Another example is [Zed editor repo](https://github.com/zed-industries/zed): 300Mb vs 200Mb (lots of Rust deps)
- My Rubygems test repo: 350Mb vs 300Mb

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
