### PR TITLE
fix(gitea): platform automerge only fully works on Gitea v1.24 and Forgejo v10

### DIFF
--- a/lib/modules/platform/gitea/index.spec.ts
+++ b/lib/modules/platform/gitea/index.spec.ts
@@ -1679,7 +1679,7 @@ describe('modules/platform/gitea/index', () => {
         .reply(200, mockNewPR)
         .post('/repos/some/repo/pulls/42/merge')
         .reply(200);
-      await initFakePlatform(scope, '1.17.0');
+      await initFakePlatform(scope, '1.24.0');
       await initFakeRepo(scope);
 
       const res = await gitea.createPr({
@@ -1697,16 +1697,14 @@ describe('modules/platform/gitea/index', () => {
       expect(mergePR).toHaveBeenCalled();
     });
 
-    it('should use platform automerge on forgejo v7', async () => {
+    it('should not use platform automerge on forgejo v7', async () => {
       memCache.set('gitea-pr-cache-synced', true);
       const helper = await import('./gitea-helper');
       const mergePR = jest.spyOn(helper, 'mergePR');
       const scope = httpMock
         .scope('https://gitea.com/api/v1')
         .post('/repos/some/repo/pulls')
-        .reply(200, mockNewPR)
-        .post('/repos/some/repo/pulls/42/merge')
-        .reply(200);
+        .reply(200, mockNewPR);
       await initFakePlatform(scope, '7.0.0-dev-2136-f075579c95+gitea-1.22.0');
       await initFakeRepo(scope);
 
@@ -1722,19 +1720,17 @@ describe('modules/platform/gitea/index', () => {
         number: 42,
         title: 'pr-title',
       });
-      expect(mergePR).toHaveBeenCalled();
+      expect(mergePR).not.toHaveBeenCalled();
     });
 
-    it('should use platform automerge on forgejo v7 LTS', async () => {
+    it('should not use platform automerge on forgejo v7 LTS', async () => {
       memCache.set('gitea-pr-cache-synced', true);
       const helper = await import('./gitea-helper');
       const mergePR = jest.spyOn(helper, 'mergePR');
       const scope = httpMock
         .scope('https://gitea.com/api/v1')
         .post('/repos/some/repo/pulls')
-        .reply(200, mockNewPR)
-        .post('/repos/some/repo/pulls/42/merge')
-        .reply(200);
+        .reply(200, mockNewPR);
       await initFakePlatform(scope, '7.0.0+LTS-gitea-1.22.0');
       await initFakeRepo(scope);
 
@@ -1750,7 +1746,7 @@ describe('modules/platform/gitea/index', () => {
         number: 42,
         title: 'pr-title',
       });
-      expect(mergePR).toHaveBeenCalled();
+      expect(mergePR).not.toHaveBeenCalled();
     });
 
     it('continues on platform automerge error', async () => {
@@ -1761,7 +1757,7 @@ describe('modules/platform/gitea/index', () => {
         .reply(200, mockNewPR)
         .post('/repos/some/repo/pulls/42/merge')
         .replyWithError('unknown error');
-      await initFakePlatform(scope, '1.17.0');
+      await initFakePlatform(scope, '1.24.0');
       await initFakeRepo(scope);
 
       const res = await gitea.createPr({
@@ -1805,7 +1801,7 @@ describe('modules/platform/gitea/index', () => {
       });
       expect(logger.debug).toHaveBeenCalledWith(
         expect.objectContaining({ prNumber: 42 }),
-        'Gitea-native automerge: not supported on this version of Gitea. Use 1.17.0 or newer.',
+        'Gitea-native automerge: not supported on this version of Gitea. Use 1.24.0 or newer.',
       );
     });
 
@@ -1817,7 +1813,7 @@ describe('modules/platform/gitea/index', () => {
         .reply(200, mockNewPR)
         .post('/repos/some/repo/pulls/42/merge')
         .reply(200);
-      await initFakePlatform(scope, '1.17.0');
+      await initFakePlatform(scope, '10.0.0+gitea-1.22.0');
       await initFakeRepo(scope);
 
       const res = await gitea.createPr({
@@ -1856,7 +1852,7 @@ describe('modules/platform/gitea/index', () => {
             Do: prMergeStrategy,
             merge_when_checks_succeed: true,
           });
-        await initFakePlatform(scope, '1.17.0');
+        await initFakePlatform(scope, '1.24.0');
         await initFakeRepo(scope);
 
         const res = await gitea.createPr({

--- a/lib/modules/platform/gitea/index.ts
+++ b/lib/modules/platform/gitea/index.ts
@@ -214,9 +214,6 @@ const platform: Platform = {
       botUserName = user.username;
       defaults.version = await helper.getVersion({ token });
       if (defaults.version?.includes('gitea-')) {
-        defaults.version = defaults.version.substring(
-          defaults.version.indexOf('gitea-') + 6,
-        );
         defaults.isForgejo = true;
       }
     } catch (err) {
@@ -551,14 +548,18 @@ const platform: Platform = {
       });
 
       if (platformPrOptions?.usePlatformAutomerge) {
-        if (semver.gte(defaults.version, '1.17.0')) {
+        // Only Gitea v1.24.0+ and Forgejo v10.0.0+ support delete_branch_after_merge.
+        // This is required to not have undesired behavior when renovate finds existing branches on next run.
+        if (
+          semver.gte(defaults.version, defaults.isForgejo ? '10.0.0' : '1.24.0')
+        ) {
           try {
             await helper.mergePR(config.repository, gpr.number, {
               Do:
                 getMergeMethod(platformPrOptions?.automergeStrategy) ??
                 config.mergeMethod,
               merge_when_checks_succeed: true,
-              delete_branch_after_merge: true, // older Gitea / Forgejo versions will ignore this, so no version check needed
+              delete_branch_after_merge: true,
             });
 
             logger.debug(
@@ -574,7 +575,7 @@ const platform: Platform = {
         } else {
           logger.debug(
             { prNumber: gpr.number },
-            'Gitea-native automerge: not supported on this version of Gitea. Use 1.17.0 or newer.',
+            `Gitea-native automerge: not supported on this version of ${defaults.isForgejo ? 'Forgejo' : 'Gitea'}. Use ${defaults.isForgejo ? '10.0.0' : '1.24.0'} or newer.`,
           );
         }
       }

--- a/lib/modules/platform/gitea/index.ts
+++ b/lib/modules/platform/gitea/index.ts
@@ -558,6 +558,7 @@ const platform: Platform = {
                 getMergeMethod(platformPrOptions?.automergeStrategy) ??
                 config.mergeMethod,
               merge_when_checks_succeed: true,
+              delete_branch_after_merge: true, // older Gitea / Forgejo versions will ignore this, so no version check needed
             });
 
             logger.debug(

--- a/lib/modules/platform/gitea/readme.md
+++ b/lib/modules/platform/gitea/readme.md
@@ -31,9 +31,7 @@ If you use Gitea packages, add the `read:packages` scope.
 ## Unsupported platform features/concepts
 
 - **Adding reviewers to PRs not supported**: Gitea versions older than `v1.14.0` do not have the required API.
-- **`platformAutomerge` (`true` by default) for platform-native automerge not supported**: Gitea versions older than v1.17.0 do not have the required API.
-  ⚠️ This is only fully supported on Forgejo v10+ because only there branches are deleted after automerge.
-  Ensure to use another solution to automatically delete branches after platform automerge.
+- **`platformAutomerge` (`true` by default) for platform-native automerge not supported**: Gitea versions older than v1.24.0 and Forgejo versions older than v10.0.0 don't support required branch autodelete for automerge.
 - **Git upload filters**: If you're using a Gitea version older than `v1.16.0` then you must enable [clone filters](https://docs.gitea.io/en-us/clone-filters/).
 
 ## Features awaiting implementation

--- a/lib/modules/platform/gitea/readme.md
+++ b/lib/modules/platform/gitea/readme.md
@@ -32,6 +32,8 @@ If you use Gitea packages, add the `read:packages` scope.
 
 - **Adding reviewers to PRs not supported**: Gitea versions older than `v1.14.0` do not have the required API.
 - **`platformAutomerge` (`true` by default) for platform-native automerge not supported**: Gitea versions older than v1.17.0 do not have the required API.
+  ⚠️ This is only fully supported on Forgejo v10+ because only there branches are deleted after automerge.
+  Ensure to use another solution to automatically delete branches after platform automerge.
 - **Git upload filters**: If you're using a Gitea version older than `v1.16.0` then you must enable [clone filters](https://docs.gitea.io/en-us/clone-filters/).
 
 ## Features awaiting implementation

--- a/lib/modules/platform/gitea/types.ts
+++ b/lib/modules/platform/gitea/types.ts
@@ -199,6 +199,7 @@ export interface PRUpdateParams {
 export interface PRMergeParams {
   Do: PRMergeMethod;
   merge_when_checks_succeed?: boolean;
+  delete_branch_after_merge?: boolean;
 }
 
 export type CommentCreateParams = CommentUpdateParams;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Set `delete_branch_after_merge` when enabling automerge, so on Gitea v1.24+ and Forgejo v10+ branches are deleted after automerge.
They otherwise trigger new updates which should be blocked by release age. See linked repo for false pr.
<!-- Describe what behavior is changed by this PR. -->

## Context
- https://code.forgejo.org/renovate/renovate/commits/branch/main
- https://github.com/go-gitea/gitea/pull/32343
- https://codeberg.org/forgejo/forgejo/pulls/5689
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
