### PR TITLE
feat(presets): add `react-spectrum` monorepo

### DIFF
--- a/lib/data/monorepo.json
+++ b/lib/data/monorepo.json
@@ -485,6 +485,7 @@
     "react": "https://github.com/facebook/react",
     "react-admin": "https://github.com/marmelab/react-admin",
     "react-apollo": "https://github.com/apollographql/react-apollo",
+    "react-aria": "https://github.com/adobe/react-spectrum",
     "react-dnd": "https://github.com/react-dnd/react-dnd",
     "react-navigation": "https://github.com/react-navigation/react-navigation",
     "react-page": "https://github.com/react-page/react-page",

--- a/lib/data/monorepo.json
+++ b/lib/data/monorepo.json
@@ -485,7 +485,6 @@
     "react": "https://github.com/facebook/react",
     "react-admin": "https://github.com/marmelab/react-admin",
     "react-apollo": "https://github.com/apollographql/react-apollo",
-    "react-aria": "https://github.com/adobe/react-spectrum",
     "react-dnd": "https://github.com/react-dnd/react-dnd",
     "react-navigation": "https://github.com/react-navigation/react-navigation",
     "react-page": "https://github.com/react-page/react-page",
@@ -494,6 +493,7 @@
       "https://github.com/ReactTraining/react-router",
       "https://github.com/remix-run/react-router"
     ],
+    "react-spectrum": "https://github.com/adobe/react-spectrum",
     "reactivestack-cookies": "https://github.com/reactivestack/cookies",
     "reakit": "https://github.com/reakit/reakit",
     "redwood": "https://github.com/redwoodjs/redwood",


### PR DESCRIPTION
## Changes

Adds a `monorepo:react-spectrum` preset sourced from https://github.com/adobe/react-spectrum.

## Context

While using `group:monorepos`, we still get 2 separate bumps for:
- `Update dependency react-aria to v3.37.0`
- `Update dependency react-aria-components to v1.6.0`

Even though they have shared monorepo dependencies, and should ideally be bumped together.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
