### PR TITLE
chore: correctly update missing labels issue

### DIFF
--- a/tools/find-issues-with-missing-labels.sh
+++ b/tools/find-issues-with-missing-labels.sh
@@ -2,7 +2,6 @@
 
 # When the repository labels are changed (i.e dropped a label, added a label, etc), you should make the same change to the lists below.
 # For example, if the repository added a "type:task" type label, then add "-label:type:task" to the TYPE_LABELS_FILTER.
-TYPE_LABELS_FILTER='-label:type:bug -label:type:feature -label:type:docs -label:type:refactor -label:type:help'
 
 PRIORITY_LABELS_FILTER='-label:priority-1-critical -label:priority-2-high -label:priority-3-medium -label:priority-4-low'
 
@@ -14,7 +13,7 @@ REPO='renovatebot/renovate'
 
 ISSUE_TITLE="Issues with missing labels"
 
-for FILTER in "$TYPE_LABELS_FILTER" "$PRIORITY_LABELS_FILTER"; do
+for FILTER in "$PRIORITY_LABELS_FILTER"; do
   # Extract the label type from the filter
   LABEL_TYPE=$(echo "$FILTER" | cut -d ':' -f 2 | cut -d '-' -f 1)
 
@@ -40,6 +39,7 @@ done
 
 if [ "$HAS_ISSUES_MISSING_LABELS" = false ]; then
   echo "All checked issues have labels. Exiting the action."
+  ISSUE_BODY="$ISSUE_BODY All checked issues are correctly labeled.\n"
   exit 0
 fi
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- If all issues are correctly labeled, update the issue description with `All checked issues are correctly labeled.`
- Do not look for `type:` prefixed labels as we are replacing them with `issueType`
<!-- Describe what behavior is changed by this PR. -->

## Context
- Closes: #33701 
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or https://github.com/Rahul-renovate-testing/repro-33701/issues/4
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
