### PR TITLE
feat(http): Implement soft and hard TTL for all cache providers

### DIFF
--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -53,9 +53,7 @@ describe('modules/platform/github/index', () => {
       token: '123test',
     });
 
-    const repoCache = repository.getCache();
-    delete repoCache.platform;
-    delete process.env.RENOVATE_X_GITHUB_HOST_RULES;
+    repository.resetCache();
   });
 
   describe('initPlatform()', () => {

--- a/lib/util/http/cache/abstract-http-cache-provider.ts
+++ b/lib/util/http/cache/abstract-http-cache-provider.ts
@@ -23,10 +23,14 @@ export abstract class AbstractHttpCacheProvider implements HttpCacheProvider {
     return httpCache as HttpCache;
   }
 
-  async setCacheHeaders<T extends Pick<GotOptions, 'headers'>>(
+  async setCacheHeaders<T extends Pick<GotOptions, 'headers' | 'method'>>(
     url: string,
     opts: T,
   ): Promise<void> {
+    if (opts.method?.toLowerCase() !== 'get') {
+      return;
+    }
+
     const httpCache = await this.get(url);
     if (!httpCache) {
       return;

--- a/lib/util/http/cache/package-http-cache-provider.ts
+++ b/lib/util/http/cache/package-http-cache-provider.ts
@@ -1,9 +1,6 @@
-import { DateTime } from 'luxon';
 import { get, set } from '../../cache/package'; // Import the package cache functions
 import { resolveTtlValues } from '../../cache/package/ttl';
 import type { PackageCacheNamespace } from '../../cache/package/types';
-import { HttpCacheStats } from '../../stats';
-import type { HttpResponse } from '../types';
 import { AbstractHttpCacheProvider } from './abstract-http-cache-provider';
 import type { HttpCache } from './schema';
 
@@ -15,12 +12,14 @@ export interface PackageHttpCacheProviderOptions {
 export class PackageHttpCacheProvider extends AbstractHttpCacheProvider {
   private namespace: PackageCacheNamespace;
 
-  private softTtlMinutes: number;
-  private hardTtlMinutes: number;
+  protected override softTtlMinutes: number;
+  protected override hardTtlMinutes: number;
 
   constructor({ namespace, ttlMinutes = 15 }: PackageHttpCacheProviderOptions) {
     super();
+
     this.namespace = namespace;
+
     const { softTtlMinutes, hardTtlMinutes } = resolveTtlValues(
       this.namespace,
       ttlMinutes,
@@ -35,30 +34,5 @@ export class PackageHttpCacheProvider extends AbstractHttpCacheProvider {
 
   async persist(url: string, data: HttpCache): Promise<void> {
     await set(this.namespace, url, data, this.hardTtlMinutes);
-  }
-
-  override async bypassServer<T>(
-    url: string,
-    ignoreSoftTtl = false,
-  ): Promise<HttpResponse<T> | null> {
-    const cached = await this.get(url);
-    if (!cached) {
-      return null;
-    }
-
-    if (ignoreSoftTtl) {
-      return cached.httpResponse as HttpResponse<T>;
-    }
-
-    const cachedAt = DateTime.fromISO(cached.timestamp);
-    const deadline = cachedAt.plus({ minutes: this.softTtlMinutes });
-    const now = DateTime.now();
-    if (now >= deadline) {
-      HttpCacheStats.incLocalMisses(url);
-      return null;
-    }
-
-    HttpCacheStats.incLocalHits(url);
-    return cached.httpResponse as HttpResponse<T>;
   }
 }

--- a/lib/util/http/cache/repository-http-cache-provider.spec.ts
+++ b/lib/util/http/cache/repository-http-cache-provider.spec.ts
@@ -1,6 +1,5 @@
 import { Http } from '..';
 import * as httpMock from '../../../../test/http-mock';
-import { logger } from '../../../../test/util';
 import { resetCache } from '../../cache/repository';
 import { repoCacheProvider } from './repository-http-cache-provider';
 
@@ -57,19 +56,6 @@ describe('util/http/cache/repository-http-cache-provider', () => {
       body: { msg: 'Hello, world!' },
       authorization: false,
     });
-  });
-
-  it('reports if cache could not be persisted', async () => {
-    httpMock
-      .scope('https://example.com')
-      .get('/foo/bar')
-      .reply(200, { msg: 'Hello, world!' });
-
-    await http.getJsonUnchecked('https://example.com/foo/bar');
-
-    expect(logger.logger.debug).toHaveBeenCalledWith(
-      'http cache: failed to persist cache for https://example.com/foo/bar',
-    );
   });
 
   it('handles abrupt cache reset', async () => {

--- a/lib/util/http/cache/repository-http-cache-provider.ts
+++ b/lib/util/http/cache/repository-http-cache-provider.ts
@@ -3,6 +3,9 @@ import { AbstractHttpCacheProvider } from './abstract-http-cache-provider';
 import type { HttpCache } from './schema';
 
 export class RepositoryHttpCacheProvider extends AbstractHttpCacheProvider {
+  protected override softTtlMinutes = 0;
+  protected override hardTtlMinutes = 365 * 24 * 60;
+
   override load(url: string): Promise<unknown> {
     const cache = getCache();
     cache.httpCache ??= {};

--- a/lib/util/http/cache/repository-http-cache-provider.ts
+++ b/lib/util/http/cache/repository-http-cache-provider.ts
@@ -3,7 +3,7 @@ import { AbstractHttpCacheProvider } from './abstract-http-cache-provider';
 import type { HttpCache } from './schema';
 
 export class RepositoryHttpCacheProvider extends AbstractHttpCacheProvider {
-  protected override softTtlMinutes = 0;
+  protected override softTtlMinutes = 15;
   protected override hardTtlMinutes = 365 * 24 * 60;
 
   override load(url: string): Promise<unknown> {

--- a/lib/util/http/cache/schema.ts
+++ b/lib/util/http/cache/schema.ts
@@ -7,10 +7,6 @@ export const HttpCacheSchema = z
     httpResponse: z.unknown(),
     timestamp: z.string(),
   })
-  .refine(
-    ({ etag, lastModified }) => etag ?? lastModified,
-    'Cache object should have `etag` or `lastModified` fields',
-  )
   .nullable()
   .catch(null);
 export type HttpCache = z.infer<typeof HttpCacheSchema>;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Move TTL logic to abstract provider
- For repository cache, set soft ttl to zero, and hart TTL to 365 days
- For package cache, nothing changes
- Don't require cache to have at least one of `etag` or `lastModified`, now they're optional (useful for future memory cache implementation)

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
