### PR TITLE
fix(http): allow overwriting default Renovate headers

### DIFF
--- a/lib/util/http/host-rules.spec.ts
+++ b/lib/util/http/host-rules.spec.ts
@@ -543,4 +543,24 @@ describe('util/http/host-rules', () => {
       },
     });
   });
+
+  it('should replace existing headers with host rule headers', () => {
+    GlobalConfig.set({ allowedHeaders: ['Accept'] });
+    const hostRule = {
+      matchHost: 'https://domain.com/all-versions',
+      headers: {
+        'Accept': 'dummy',
+      },
+    };
+    let options = {
+      headers: {
+        'Accept': 'default'
+      }
+    };
+    expect(applyHostRule(url, options, hostRule)).toEqual({
+      headers: {
+        'Accept': 'dummy',
+      },
+    });
+  });
 });

--- a/lib/util/http/host-rules.spec.ts
+++ b/lib/util/http/host-rules.spec.ts
@@ -549,7 +549,7 @@ describe('util/http/host-rules', () => {
     const hostRule = {
       matchHost: 'https://domain.com/all-versions',
       headers: {
-        'Accept': 'dummy',
+        'Accept': 'replacement',
       },
     };
     let options = {
@@ -559,7 +559,7 @@ describe('util/http/host-rules', () => {
     };
     expect(applyHostRule(url, options, hostRule)).toEqual({
       headers: {
-        'Accept': 'dummy',
+        'Accept': 'replacement',
       },
     });
   });

--- a/lib/util/http/host-rules.spec.ts
+++ b/lib/util/http/host-rules.spec.ts
@@ -549,17 +549,17 @@ describe('util/http/host-rules', () => {
     const hostRule = {
       matchHost: 'https://domain.com/all-versions',
       headers: {
-        'Accept': 'replacement',
+        Accept: 'replacement',
       },
     };
-    let options = {
+    const options = {
       headers: {
-        'Accept': 'default'
-      }
+        Accept: 'default',
+      },
     };
     expect(applyHostRule(url, options, hostRule)).toEqual({
       headers: {
-        'Accept': 'replacement',
+        Accept: 'replacement',
       },
     });
   });

--- a/lib/util/http/host-rules.ts
+++ b/lib/util/http/host-rules.ts
@@ -176,8 +176,8 @@ export function applyHostRule<GotOptions extends HostRulesGotOptions>(
     }
 
     options.headers = {
-      ...filteredHeaders,
       ...options.headers,
+      ...filteredHeaders,
     };
   }
 


### PR DESCRIPTION
User specified headers should be able to overwrite the default headers.

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

The headers set by Renovate by default (`Accept` and `User-Agent` are the only ones I have observed) can now be overwritten if specified in `renovate.json` and allowed by `allowedHeaders`.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->
I encountered this issue when trying to retrieve the raw contents of a file from GitHub and needed to set the `"Accept": "application/vnd.github.v3.raw"` header for that purpose.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
