### PR TITLE
feat(logger): Add `withMeta` helper

### DIFF
--- a/lib/logger/index.spec.ts
+++ b/lib/logger/index.spec.ts
@@ -17,6 +17,7 @@ import {
   removeMeta,
   setContext,
   setMeta,
+  withMeta,
 } from '.';
 
 const initialContext = 'initial_context';
@@ -120,6 +121,43 @@ describe('logger/index', () => {
         '',
       );
       expect(bunyanDebugSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('withMeta adds and removes metadata correctly', () => {
+      const logMeta = { foo: 'foo' };
+      const tempMeta = { bar: 'bar' };
+
+      withMeta(tempMeta, () => {
+        logger.debug(logMeta, '');
+        expect(bunyanDebugSpy).toHaveBeenCalledWith(
+          { logContext: initialContext, ...tempMeta, ...logMeta },
+          '',
+        );
+      });
+
+      logger.debug(logMeta, '');
+      expect(bunyanDebugSpy).toHaveBeenCalledWith(
+        { logContext: initialContext, ...logMeta },
+        '',
+      );
+    });
+
+    it('withMeta handles cleanup when callback throws', () => {
+      const logMeta = { foo: 'foo' };
+      const tempMeta = { bar: 'bar' };
+
+      expect(() =>
+        withMeta(tempMeta, () => {
+          logger.debug(logMeta, '');
+          throw new Error('test error');
+        }),
+      ).toThrow('test error');
+
+      logger.debug(logMeta, '');
+      expect(bunyanDebugSpy).toHaveBeenCalledWith(
+        { logContext: initialContext, ...logMeta },
+        '',
+      );
     });
   });
 

--- a/lib/logger/index.ts
+++ b/lib/logger/index.ts
@@ -126,6 +126,15 @@ export function removeMeta(fields: string[]): void {
   loggerInternal.removeMeta(fields);
 }
 
+export function withMeta<T>(obj: Record<string, unknown>, cb: () => T): T {
+  setMeta(obj);
+  try {
+    return cb();
+  } finally {
+    removeMeta(Object.keys(obj));
+  }
+}
+
 export /* istanbul ignore next */ function addStream(
   stream: bunyan.Stream,
 ): void {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This helper enhances logging of Zod schema local failures.

The problem:
- When some part of data is invalid, we often want to continue the valid part, instead of failing the whole structure
- But we don't want the invalid part to fail silently
- We could log errors in `.catch(...)` calls, which solves the problem of granularity
- However, there is no way to provider additional context such as `packageFile` (for dependency extraction) or `url` (for HTTP requests)

The helper is meant to be used like this:
```typescript
withMeta({ url }, () => SomeSchema.parse(res.body))
```

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
