### PR TITLE
feat: Add `mjs` options to prettier

### DIFF
--- a/lib/workers/repository/config-migration/branch/migrated-data.ts
+++ b/lib/workers/repository/config-migration/branch/migrated-data.ts
@@ -32,8 +32,10 @@ const prettierConfigFilenames = new Set([
   '.prettierrc.json5',
   '.prettierrc.js',
   '.prettierrc.cjs',
+  '.prettierrc.mjs',
   'prettier.config.js',
   'prettier.config.cjs',
+  'prettier.config.mjs',
   '.prettierrc.toml',
 ]);
 


### PR DESCRIPTION
See here: https://prettier.io/docs/en/configuration.html

Now ESM modules are allowed for prettier config files

At the same time, it might make sense to use [prettier.resolveConfig](https://prettier.io/docs/en/api.html#prettierresolveconfigfileurlorpath--options), which returns `null` if no config is found. That way you don't need to keep matching prettier's interface ad-infinitum 

## Changes

Prettier allows mjs files.

## Context

Prettier now allows ESM configuration

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
