### PR TITLE
refactor(workers): move bump version to separate function

### DIFF
--- a/lib/workers/repository/update/branch/get-updated.ts
+++ b/lib/workers/repository/update/branch/get-updated.ts
@@ -241,7 +241,7 @@ export async function getUpdatedPackageFiles(
         );
         firstUpdate = false;
         if (res) {
-          res = await bumpPackageVersion(res, upgrade);
+          res = await applyManagerBumpPackageVersion(res, upgrade);
           if (res === packageFileContent) {
             logger.debug({ packageFile, depName }, 'No content changed');
           } else {
@@ -263,7 +263,7 @@ export async function getUpdatedPackageFiles(
         fileContent: packageFileContent!,
         upgrade,
       });
-      newContent = await bumpPackageVersion(newContent, upgrade);
+      newContent = await applyManagerBumpPackageVersion(newContent, upgrade);
       if (!newContent) {
         if (reuseExistingBranch) {
           logger.debug(
@@ -505,7 +505,7 @@ function processUpdateArtifactResults(
   }
 }
 
-async function bumpPackageVersion(
+async function applyManagerBumpPackageVersion(
   packageFileContent: string | null,
   upgrade: BranchUpgradeConfig,
 ): Promise<string | null> {

--- a/lib/workers/repository/update/branch/get-updated.ts
+++ b/lib/workers/repository/update/branch/get-updated.ts
@@ -14,7 +14,7 @@ import type {
 import { getFile } from '../../../../util/git';
 import type { FileAddition, FileChange } from '../../../../util/git/types';
 import { coerceString } from '../../../../util/string';
-import type { BranchConfig } from '../../../types';
+import type { BranchConfig, BranchUpgradeConfig } from '../../../types';
 import { doAutoReplace } from './auto-replace';
 
 export interface PackageFilesResult {
@@ -231,7 +231,6 @@ export async function getUpdatedPackageFiles(
         }
       }
     } else {
-      const bumpPackageVersion = get(manager, 'bumpPackageVersion');
       const updateDependency = get(manager, 'updateDependency');
       if (!updateDependency) {
         let res = await doAutoReplace(
@@ -242,19 +241,7 @@ export async function getUpdatedPackageFiles(
         );
         firstUpdate = false;
         if (res) {
-          if (
-            bumpPackageVersion &&
-            upgrade.bumpVersion &&
-            upgrade.packageFileVersion
-          ) {
-            const { bumpedContent } = await bumpPackageVersion(
-              res,
-              upgrade.packageFileVersion,
-              upgrade.bumpVersion,
-              packageFile,
-            );
-            res = bumpedContent;
-          }
+          res = await bumpPackageVersion(res, upgrade);
           if (res === packageFileContent) {
             logger.debug({ packageFile, depName }, 'No content changed');
           } else {
@@ -276,20 +263,7 @@ export async function getUpdatedPackageFiles(
         fileContent: packageFileContent!,
         upgrade,
       });
-      if (
-        newContent &&
-        bumpPackageVersion &&
-        upgrade.bumpVersion &&
-        upgrade.packageFileVersion
-      ) {
-        const { bumpedContent } = await bumpPackageVersion(
-          newContent,
-          upgrade.packageFileVersion,
-          upgrade.bumpVersion,
-          packageFile,
-        );
-        newContent = bumpedContent;
-      }
+      newContent = await bumpPackageVersion(newContent, upgrade);
       if (!newContent) {
         if (reuseExistingBranch) {
           logger.debug(
@@ -529,4 +503,28 @@ function processUpdateArtifactResults(
       }
     }
   }
+}
+
+async function bumpPackageVersion(
+  packageFileContent: string | null,
+  upgrade: BranchUpgradeConfig,
+): Promise<string | null> {
+  const bumpPackageVersion = get(upgrade.manager, 'bumpPackageVersion');
+  if (
+    !bumpPackageVersion ||
+    !packageFileContent ||
+    !upgrade.bumpVersion ||
+    !upgrade.packageFileVersion
+  ) {
+    return packageFileContent;
+  }
+
+  const result = await bumpPackageVersion(
+    packageFileContent,
+    upgrade.packageFileVersion,
+    upgrade.bumpVersion,
+    upgrade.packageFile!,
+  );
+
+  return result.bumpedContent;
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Small drive by refactor, while working on bumpVersions
<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

https://github.com/secustor/renovate-bump-versions/pull/3

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
