### PR TITLE
fix(lockfilemaintenance): ensure `isLockFileMaintenance` on grouping

### DIFF
--- a/lib/modules/manager/bun/artifacts.spec.ts
+++ b/lib/modules/manager/bun/artifacts.spec.ts
@@ -82,7 +82,7 @@ describe('modules/manager/bun/artifacts', () => {
         updateArtifact.updatedDeps = [
           { manager: 'bun', lockFiles: ['bun.lockb'] },
         ];
-        updateArtifact.config.updateType = 'lockFileMaintenance';
+        updateArtifact.config.isLockFileMaintenance = true;
         const oldLock = Buffer.from('old');
         fs.readFile.mockResolvedValueOnce(oldLock as never);
         const newLock = Buffer.from('new');
@@ -176,7 +176,7 @@ describe('modules/manager/bun/artifacts', () => {
         updateArtifact.updatedDeps = [
           { manager: 'bun', lockFiles: ['bun.lock'] },
         ];
-        updateArtifact.config.updateType = 'lockFileMaintenance';
+        updateArtifact.config.isLockFileMaintenance = true;
         const oldLock = Buffer.from('old');
         fs.readFile.mockResolvedValueOnce(oldLock as never);
         const newLock = Buffer.from('new');

--- a/lib/modules/manager/bun/artifacts.ts
+++ b/lib/modules/manager/bun/artifacts.ts
@@ -17,7 +17,7 @@ export async function updateArtifacts(
   const { packageFileName, updatedDeps, newPackageFileContent, config } =
     updateArtifact;
   logger.debug(`bun.updateArtifacts(${packageFileName})`);
-  const isLockFileMaintenance = config.updateType === 'lockFileMaintenance';
+  const { isLockFileMaintenance } = config;
 
   if (is.emptyArray(updatedDeps) && !isLockFileMaintenance) {
     logger.debug('No updated bun deps - returning null');

--- a/lib/modules/manager/cargo/artifacts.spec.ts
+++ b/lib/modules/manager/cargo/artifacts.spec.ts
@@ -412,7 +412,7 @@ describe('modules/manager/cargo/artifacts', () => {
         packageFileName: 'Cargo.toml',
         updatedDeps: [],
         newPackageFileContent: '{}',
-        config: { ...config, updateType: 'lockFileMaintenance' },
+        config: { ...config, isLockFileMaintenance: true },
       }),
     ).not.toBeNull();
     expect(execSnapshots).toMatchSnapshot();

--- a/lib/modules/manager/cargo/artifacts.ts
+++ b/lib/modules/manager/cargo/artifacts.ts
@@ -104,7 +104,7 @@ async function updateArtifactsImpl(
     return null;
   }
 
-  const isLockFileMaintenance = config.updateType === 'lockFileMaintenance';
+  const { isLockFileMaintenance } = config;
   if (!isLockFileMaintenance && !updatedDeps?.length) {
     logger.debug('No more dependencies to update');
     return [

--- a/lib/modules/manager/gleam/artifacts.spec.ts
+++ b/lib/modules/manager/gleam/artifacts.spec.ts
@@ -81,7 +81,7 @@ describe('modules/manager/gleam/artifacts', () => {
 
     it('supports lockFileMaintenance', async () => {
       updateArtifact.updatedDeps = [{ manager: 'gleam' }];
-      updateArtifact.config.updateType = 'lockFileMaintenance';
+      updateArtifact.config.isLockFileMaintenance = true;
       fs.readLocalFile.mockResolvedValueOnce('old');
       fs.readLocalFile.mockResolvedValueOnce('new');
       fs.getSiblingFileName.mockReturnValueOnce('manifest.toml');
@@ -98,7 +98,7 @@ describe('modules/manager/gleam/artifacts', () => {
 
     it('returns null if lockfile content unchanged', async () => {
       updateArtifact.updatedDeps = [{ manager: 'gleam' }];
-      updateArtifact.config.updateType = 'lockFileMaintenance';
+      updateArtifact.config.isLockFileMaintenance = true;
       fs.readLocalFile.mockResolvedValueOnce('old');
       fs.readLocalFile.mockResolvedValueOnce('old');
       fs.getSiblingFileName.mockReturnValueOnce('manifest.toml');

--- a/lib/modules/manager/gleam/artifacts.ts
+++ b/lib/modules/manager/gleam/artifacts.ts
@@ -17,7 +17,7 @@ export async function updateArtifacts(
   const { packageFileName, updatedDeps, newPackageFileContent, config } =
     updateArtifact;
   logger.debug(`gleam.updateArtifacts(${packageFileName})`);
-  const isLockFileMaintenance = config.updateType === 'lockFileMaintenance';
+  const { isLockFileMaintenance } = config;
 
   if (is.emptyArray(updatedDeps) && !isLockFileMaintenance) {
     logger.debug('No updated gleam deps - returning null');

--- a/lib/modules/manager/helmfile/artifacts.ts
+++ b/lib/modules/manager/helmfile/artifacts.ts
@@ -27,7 +27,7 @@ export async function updateArtifacts({
 }: UpdateArtifact): Promise<UpdateArtifactsResult[] | null> {
   logger.trace(`helmfile.updateArtifacts(${packageFileName})`);
 
-  const isLockFileMaintenance = config.updateType === 'lockFileMaintenance';
+  const { isLockFileMaintenance } = config;
   if (
     !isLockFileMaintenance &&
     (updatedDeps === undefined || updatedDeps.length < 1)

--- a/lib/modules/manager/helmv3/artifacts.spec.ts
+++ b/lib/modules/manager/helmv3/artifacts.spec.ts
@@ -155,7 +155,7 @@ describe('modules/manager/helmv3/artifacts', () => {
         packageFileName: 'Chart.yaml',
         updatedDeps: [],
         newPackageFileContent: chartFile,
-        config: { ...config, updateType: 'lockFileMaintenance' },
+        config: { ...config, isLockFileMaintenance: true },
       }),
     ).toMatchObject([
       {
@@ -589,7 +589,7 @@ describe('modules/manager/helmv3/artifacts', () => {
         newPackageFileContent: chartFile,
         config: {
           ...config,
-          updateType: 'lockFileMaintenance',
+          isLockFileMaintenance: true,
           registryAliases: { stable: 'the stable_url', repo1: 'the_repo1_url' },
         },
       }),
@@ -630,7 +630,7 @@ describe('modules/manager/helmv3/artifacts', () => {
         newPackageFileContent: chartFile,
         config: {
           ...config,
-          updateType: 'lockFileMaintenance',
+          isLockFileMaintenance: true,
           registryAliases: { stable: 'the_stable_url', repo1: 'the_repo1_url' },
         },
       }),
@@ -676,7 +676,7 @@ describe('modules/manager/helmv3/artifacts', () => {
         newPackageFileContent: chartFile,
         config: {
           ...config,
-          updateType: 'lockFileMaintenance',
+          isLockFileMaintenance: true,
           registryAliases: {
             stable: 'the_stable_url',
             oci: 'oci://registry.example.com/organization',
@@ -726,7 +726,7 @@ describe('modules/manager/helmv3/artifacts', () => {
         newPackageFileContent: chartFile,
         config: {
           ...config,
-          updateType: 'lockFileMaintenance',
+          isLockFileMaintenance: true,
           registryAliases: {},
         },
       }),
@@ -774,7 +774,7 @@ describe('modules/manager/helmv3/artifacts', () => {
         newPackageFileContent: chartFileECR,
         config: {
           ...config,
-          updateType: 'lockFileMaintenance',
+          isLockFileMaintenance: true,
           registryAliases: {},
         },
       }),
@@ -840,7 +840,7 @@ describe('modules/manager/helmv3/artifacts', () => {
         newPackageFileContent: chartFileECR,
         config: {
           ...config,
-          updateType: 'lockFileMaintenance',
+          isLockFileMaintenance: true,
           registryAliases: {},
         },
       }),
@@ -895,7 +895,7 @@ describe('modules/manager/helmv3/artifacts', () => {
         newPackageFileContent: chartFileECR,
         config: {
           ...config,
-          updateType: 'lockFileMaintenance',
+          isLockFileMaintenance: true,
           registryAliases: {},
         },
       }),
@@ -954,7 +954,7 @@ describe('modules/manager/helmv3/artifacts', () => {
         newPackageFileContent: chartFileECR,
         config: {
           ...config,
-          updateType: 'lockFileMaintenance',
+          isLockFileMaintenance: true,
           registryAliases: {},
         },
       }),
@@ -1009,7 +1009,7 @@ describe('modules/manager/helmv3/artifacts', () => {
         newPackageFileContent: chartFile,
         config: {
           ...config,
-          updateType: 'lockFileMaintenance',
+          isLockFileMaintenance: true,
           registryAliases: {
             repo1:
               'https://gitlab.com/api/v4/projects/xxxxxxx/packages/helm/stable',
@@ -1057,7 +1057,7 @@ describe('modules/manager/helmv3/artifacts', () => {
         newPackageFileContent: chartFileAlias,
         config: {
           ...config,
-          updateType: 'lockFileMaintenance',
+          isLockFileMaintenance: true,
           registryAliases: {
             jetstack: 'https://charts.jetstack.io',
           },

--- a/lib/modules/manager/helmv3/artifacts.ts
+++ b/lib/modules/manager/helmv3/artifacts.ts
@@ -93,7 +93,7 @@ export async function updateArtifacts({
 }: UpdateArtifact): Promise<UpdateArtifactsResult[] | null> {
   logger.debug(`helmv3.updateArtifacts(${packageFileName})`);
 
-  const isLockFileMaintenance = config.updateType === 'lockFileMaintenance';
+  const { isLockFileMaintenance } = config;
   const isUpdateOptionAddChartArchives = config.postUpdateOptions?.includes(
     'helmUpdateSubChartArchives',
   );

--- a/lib/modules/manager/npm/post-update/index.spec.ts
+++ b/lib/modules/manager/npm/post-update/index.spec.ts
@@ -587,7 +587,7 @@ describe('modules/manager/npm/post-update/index', () => {
             ...baseConfig,
             upgrades: [{ isLockfileUpdate: false }],
             reuseExistingBranch: true,
-            updateType: 'lockFileMaintenance',
+            isLockFileMaintenance: true,
             updateLockFiles: true,
           },
           additionalFiles,

--- a/lib/modules/manager/npm/post-update/index.ts
+++ b/lib/modules/manager/npm/post-update/index.ts
@@ -377,7 +377,7 @@ export async function getAdditionalFiles(
   }
   logger.debug('Getting updated lock files');
   if (
-    config.updateType === 'lockFileMaintenance' &&
+    config.isLockFileMaintenance &&
     config.reuseExistingBranch &&
     (await scm.branchExists(config.branchName))
   ) {

--- a/lib/modules/manager/pep621/processors/pdm.spec.ts
+++ b/lib/modules/manager/pep621/processors/pdm.spec.ts
@@ -279,7 +279,7 @@ describe('modules/manager/pep621/processors/pdm', () => {
           packageFileName: 'folder/pyproject.toml',
           newPackageFileContent: '',
           config: {
-            updateType: 'lockFileMaintenance',
+            isLockFileMaintenance: true,
           },
           updatedDeps: [],
         },
@@ -329,7 +329,7 @@ describe('modules/manager/pep621/processors/pdm', () => {
           packageFileName: 'folder/pyproject.toml',
           newPackageFileContent: '',
           config: {
-            updateType: 'lockFileMaintenance',
+            isLockFileMaintenance: true,
           },
           updatedDeps: [],
         },

--- a/lib/modules/manager/pep621/processors/pdm.ts
+++ b/lib/modules/manager/pep621/processors/pdm.ts
@@ -96,7 +96,7 @@ export class PdmProcessor implements PyProjectProcessor {
   ): Promise<UpdateArtifactsResult[] | null> {
     const { config, updatedDeps, packageFileName } = updateArtifact;
 
-    const isLockFileMaintenance = config.updateType === 'lockFileMaintenance';
+    const { isLockFileMaintenance } = config;
 
     // abort if no lockfile is defined
     const lockFileName = getSiblingFileName(packageFileName, 'pdm.lock');

--- a/lib/modules/manager/pep621/processors/uv.spec.ts
+++ b/lib/modules/manager/pep621/processors/uv.spec.ts
@@ -787,7 +787,7 @@ describe('modules/manager/pep621/processors/uv', () => {
           packageFileName: 'folder/pyproject.toml',
           newPackageFileContent: '',
           config: {
-            updateType: 'lockFileMaintenance',
+            isLockFileMaintenance: true,
           },
           updatedDeps: [],
         },

--- a/lib/modules/manager/pep621/processors/uv.ts
+++ b/lib/modules/manager/pep621/processors/uv.ts
@@ -147,7 +147,7 @@ export class UvProcessor implements PyProjectProcessor {
   ): Promise<UpdateArtifactsResult[] | null> {
     const { config, updatedDeps, packageFileName } = updateArtifact;
 
-    const isLockFileMaintenance = config.updateType === 'lockFileMaintenance';
+    const { isLockFileMaintenance } = config;
 
     // abort if no lockfile is defined
     const lockFileName = getSiblingFileName(packageFileName, 'uv.lock');

--- a/lib/modules/manager/poetry/artifacts.spec.ts
+++ b/lib/modules/manager/poetry/artifacts.spec.ts
@@ -676,7 +676,7 @@ describe('modules/manager/poetry/artifacts', () => {
           newPackageFileContent: '{}',
           config: {
             ...config,
-            updateType: 'lockFileMaintenance',
+            isLockFileMaintenance: true,
           },
         }),
       ).toEqual([

--- a/lib/modules/manager/poetry/artifacts.ts
+++ b/lib/modules/manager/poetry/artifacts.ts
@@ -172,7 +172,7 @@ export async function updateArtifacts({
   config,
 }: UpdateArtifact): Promise<UpdateArtifactsResult[] | null> {
   logger.debug(`poetry.updateArtifacts(${packageFileName})`);
-  const isLockFileMaintenance = config.updateType === 'lockFileMaintenance';
+  const { isLockFileMaintenance } = config;
 
   if (!is.nonEmptyArray(updatedDeps) && !isLockFileMaintenance) {
     logger.debug('No updated poetry deps - returning null');

--- a/lib/modules/manager/pub/artifacts.spec.ts
+++ b/lib/modules/manager/pub/artifacts.spec.ts
@@ -183,7 +183,7 @@ describe('modules/manager/pub/artifacts', () => {
         await pub.updateArtifacts({
           ...updateArtifact,
           newPackageFileContent: params.packageFileContent,
-          config: { ...config, updateType: 'lockFileMaintenance' },
+          config: { ...config, isLockFileMaintenance: true },
         }),
       ).toEqual([
         {

--- a/lib/modules/manager/pub/artifacts.ts
+++ b/lib/modules/manager/pub/artifacts.ts
@@ -22,7 +22,7 @@ export async function updateArtifacts({
   config,
 }: UpdateArtifact): Promise<UpdateArtifactsResult[] | null> {
   logger.debug(`pub.updateArtifacts(${packageFileName})`);
-  const isLockFileMaintenance = config.updateType === 'lockFileMaintenance';
+  const { isLockFileMaintenance } = config;
 
   if (is.emptyArray(updatedDeps) && !isLockFileMaintenance) {
     logger.debug('No updated pub deps - returning null');
@@ -101,7 +101,7 @@ export async function updateArtifacts({
 function getExecCommand(
   toolName: string,
   updatedDeps: Upgrade<Record<string, unknown>>[],
-  isLockFileMaintenance: boolean,
+  isLockFileMaintenance: boolean | undefined,
 ): string {
   if (isLockFileMaintenance) {
     return `${toolName} pub upgrade`;

--- a/lib/modules/manager/terraform/lockfile/index.spec.ts
+++ b/lib/modules/manager/terraform/lockfile/index.spec.ts
@@ -659,7 +659,7 @@ describe('modules/manager/terraform/lockfile/index', () => {
     ]);
 
     const localConfig: UpdateArtifactsConfig = {
-      updateType: 'lockFileMaintenance',
+      isLockFileMaintenance: true,
       ...config,
     };
 
@@ -769,7 +769,7 @@ describe('modules/manager/terraform/lockfile/index', () => {
     ]);
 
     const localConfig: UpdateArtifactsConfig = {
-      updateType: 'lockFileMaintenance',
+      isLockFileMaintenance: true,
       ...config,
     };
 
@@ -874,7 +874,7 @@ describe('modules/manager/terraform/lockfile/index', () => {
     ]);
 
     const localConfig: UpdateArtifactsConfig = {
-      updateType: 'lockFileMaintenance',
+      isLockFileMaintenance: true,
       ...config,
     };
     const result = await updateArtifacts({
@@ -944,7 +944,7 @@ describe('modules/manager/terraform/lockfile/index', () => {
     mockHash.mockResolvedValue(null);
 
     const localConfig: UpdateArtifactsConfig = {
-      updateType: 'lockFileMaintenance',
+      isLockFileMaintenance: true,
       ...config,
     };
 
@@ -980,7 +980,7 @@ describe('modules/manager/terraform/lockfile/index', () => {
 
   it('return null if experimental flag is not set', async () => {
     const localConfig: UpdateArtifactsConfig = {
-      updateType: 'lockFileMaintenance',
+      isLockFileMaintenance: true,
       ...config,
     };
     const result = await updateArtifacts({

--- a/lib/modules/manager/terraform/lockfile/index.ts
+++ b/lib/modules/manager/terraform/lockfile/index.ts
@@ -154,7 +154,7 @@ export async function updateArtifacts({
     }
 
     const updates: ProviderLockUpdate[] = [];
-    if (config.updateType === 'lockFileMaintenance') {
+    if (config.isLockFileMaintenance) {
       // update all locks in the file during maintenance --> only update version in constraints
       const maintenanceUpdates = await updateAllLocks(locks);
       updates.push(...maintenanceUpdates);

--- a/lib/modules/manager/terragrunt/artifacts.spec.ts
+++ b/lib/modules/manager/terragrunt/artifacts.spec.ts
@@ -38,7 +38,7 @@ describe('modules/manager/terragrunt/artifacts', () => {
 
   it('calls terraform updateArtifacts if the update type is lockfileMaintenance', async () => {
     const localConfig: UpdateArtifactsConfig = {
-      updateType: 'lockFileMaintenance',
+      isLockFileMaintenance: true,
       ...config,
     };
 

--- a/lib/modules/manager/terragrunt/artifacts.ts
+++ b/lib/modules/manager/terragrunt/artifacts.ts
@@ -5,7 +5,7 @@ import type { UpdateArtifact, UpdateArtifactsResult } from '../types';
 export async function updateArtifacts(
   artifact: UpdateArtifact,
 ): Promise<UpdateArtifactsResult[] | null> {
-  if (artifact.config.updateType !== 'lockFileMaintenance') {
+  if (!artifact.config.isLockFileMaintenance) {
     logger.debug(
       `UpdateType ${
         artifact.config.updateType as string

--- a/lib/modules/manager/types.ts
+++ b/lib/modules/manager/types.ts
@@ -315,4 +315,6 @@ export interface PostUpdateConfig<T = Record<string, any>>
   yarnLock?: string;
   branchName: string;
   reuseExistingBranch?: boolean;
+
+  isLockFileMaintenance?: boolean;
 }

--- a/lib/modules/manager/vendir/artifacts.spec.ts
+++ b/lib/modules/manager/vendir/artifacts.spec.ts
@@ -139,7 +139,7 @@ describe('modules/manager/vendir/artifacts', () => {
         packageFileName: 'vendir.yml',
         updatedDeps: [],
         newPackageFileContent: vendirFile,
-        config: { ...config, updateType: 'lockFileMaintenance' },
+        config: { ...config, isLockFileMaintenance: true },
       }),
     ).toEqual([
       {

--- a/lib/workers/repository/updates/generate.ts
+++ b/lib/workers/repository/updates/generate.ts
@@ -436,9 +436,23 @@ export function generateBranchConfig(
         .reduce((a, b) => a.concat(b), []),
     ),
   ];
+
   if (config.upgrades.some((upgrade) => upgrade.updateType === 'major')) {
     config.updateType = 'major';
   }
+
+  // explicit set `isLockFileMaintenance` for the branch for groups
+  if (config.upgrades.some((upgrade) => upgrade.isLockFileMaintenance)) {
+    config.isLockFileMaintenance = true;
+    // istanbul ignore if: not worth testing
+    if (config.upgrades.some((upgrade) => !upgrade.isLockFileMaintenance)) {
+      // TODO: warn?
+      logger.debug(
+        'Grouping lockfile maintenance with other update types is not supported',
+      );
+    }
+  }
+
   config.constraints = {};
   for (const upgrade of config.upgrades) {
     if (upgrade.constraints) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
ensure `isLockFileMaintenance` is `true` if grouping lockefile maintenance with other updates even it's not really supported.
<!-- Describe what behavior is changed by this PR. -->

## Context
- closes #32384
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
