### PR TITLE
docs: fix typos in documentation

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -724,7 +724,7 @@ The `matchStrings` must capture/extract the following three fields:
 - `depName` and / or `packageName`
 - `currentValue`
 
-Alteratively, you could also use corresponding templates (e.g. `depNameTemplate`) for these fields.
+Alternatively, you could also use corresponding templates (e.g. `depNameTemplate`) for these fields.
 But, we recommend you use only _one_ of these methods, or you'll get confused.
 
 Also, we recommend you explicitly set which `versioning` Renovate should use.
@@ -2487,7 +2487,7 @@ When in `silent` mode Renovate will:
 
 - _not_ create or update any Issue: even the Dependency Dashboard or Config Warning Issues will stay as-is
 - _not_ prune or close any existing Issues
-- _not_ create any Config Migration PRs, even if you explictly enabled Config Migration PRs in your Renovate config
+- _not_ create any Config Migration PRs, even if you explicitly enabled Config Migration PRs in your Renovate config
 
 ## npmToken
 

--- a/docs/usage/docker.md
+++ b/docs/usage/docker.md
@@ -501,7 +501,7 @@ hostRules: [
 One way to give Renovate the short-lived Google Access Token is to:
 
 1. Write a script that generates a `config.js` file, with the token, in your `gitlab-ci.yml` file
-1. Run the `config.js` creation scrip just before you start Renovate
+1. Run the `config.js` creation script just before you start Renovate
 
 For example:
 

--- a/docs/usage/getting-started/installing-onboarding.md
+++ b/docs/usage/getting-started/installing-onboarding.md
@@ -5,7 +5,7 @@
 Read the [Security and Permissions](../security-and-permissions.md) page to learn more about:
 
 - Renovate's security stance
-- What do if you need to use certificed software
+- What do if you need to use certificated software
 - The security/disclosure process
 - Permissions
 - Privacy

--- a/docs/usage/getting-started/installing-onboarding.md
+++ b/docs/usage/getting-started/installing-onboarding.md
@@ -5,7 +5,7 @@
 Read the [Security and Permissions](../security-and-permissions.md) page to learn more about:
 
 - Renovate's security stance
-- What do if you need to use certificated software
+- What do if you need to use certified software
 - The security/disclosure process
 - Permissions
 - Privacy

--- a/docs/usage/language-constraints-and-upgrading.md
+++ b/docs/usage/language-constraints-and-upgrading.md
@@ -68,7 +68,7 @@ In short, users who set `constraintsFiltering=strict` often do not understand ho
 
 ## Transitive constraint limitations
 
-Often a library sets language constraints (like the `engines` examples above), and then depend on libraries with _narrower_ contraints, like `"node": "^20.0.0"`.
+Often a library sets language constraints (like the `engines` examples above), and then depend on libraries with _narrower_ constraints, like `"node": "^20.0.0"`.
 In cases like these, Renovate "trusts" the declaration of the library and may create a update, even _with_ strict constraints filtering.
 
 For some package managers, like `npm`, this incompatibility will _not_ be detected or warned about (even during lock file generation), but this may not be a problem for your application.

--- a/docs/usage/python.md
+++ b/docs/usage/python.md
@@ -26,7 +26,7 @@ Legacy versions with the `===` prefix are ignored.
 ## Package name matching
 
 Your `matchPackageName` or `matchPackagePattern` rules will be matching against normalized names.
-So if you have specified package `some.package` or `ANOTHER_DEP` in your package files (`requirements.txt`, `pyproject.toml`), they will be treated as `some-package` and `another-dep` respecitvely.
+So if you have specified package `some.package` or `ANOTHER_DEP` in your package files (`requirements.txt`, `pyproject.toml`), they will be treated as `some-package` and `another-dep` respectively.
 Not only they will be case insensitive but will replace any amount `._-` to a single `-`.
 [Consult Python packaging documentation for the specification](https://packaging.python.org/en/latest/specifications/name-normalization/).
 

--- a/docs/usage/release-notes-for-major-versions.md
+++ b/docs/usage/release-notes-for-major-versions.md
@@ -64,7 +64,7 @@ Read the [GitHub Docs, Signature verification for rebase and merge](https://docs
 
 #### Why we change branch names with multiple slashes
 
-Branches with mutiple slashes (`/`) are not wanted, this was a bug.
+Branches with multiple slashes (`/`) are not wanted, this was a bug.
 We are changing it in a major release out of politeness to all our users.
 If you enabled `branchNameStrict`, you can expect some branch names to change.
 

--- a/docs/usage/string-pattern-matching.md
+++ b/docs/usage/string-pattern-matching.md
@@ -30,7 +30,7 @@ It is not valid to combine `*` with any other positive or negative match.
 }
 ```
 
-In the latter case, the `*` can be ommitted and achieve the same thing.
+In the latter case, the `*` can be omitted and achieve the same thing.
 
 ## Regex matching
 
@@ -47,7 +47,7 @@ To ignore case sensitivity you must set the `i` flag, see the regex patterns tab
 ### Renovate uses re2 syntax
 
 Renovate uses the [`re2` library](https://github.com/google/re2) for regex matching.
-`re2` is different from the full regex specification, because `re2` has a different sytax/support.
+`re2` is different from the full regex specification, because `re2` has a different syntax/support.
 
 For the full `re2` syntax, read [the `re2` syntax wiki page](https://github.com/google/re2/wiki/Syntax).
 

--- a/docs/usage/templates.md
+++ b/docs/usage/templates.md
@@ -130,7 +130,7 @@ Splits a string into an array of substrings.
 
 This example splits a package name by `-` and gets the second part:
 `{{ lookup (split packageName '-') 1 }}`
-An input of `foo-bar-test` therefor would return `bar`.
+An input of `foo-bar-test` therefore would return `bar`.
 
 ### stringToPrettyJSON
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Fix typos and spelling errors:

- "Alteratively" → "Alternatively"
- "explictly" → "explicitly"
- "certificed" → "certificated"
- "respecitvely" → "respectively"
- "mutiple" → "multiple"
- "sytax" → "syntax"
- "therefor" → "therefore"
- "ommitted" → "omitted"

## Context

Updating documentation for clarity and grammatical  accuracy.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
