### PR TITLE
feat(autoreplace): extended logging for autoreplace mismatches

### DIFF
--- a/lib/workers/repository/update/branch/auto-replace.ts
+++ b/lib/workers/repository/update/branch/auto-replace.ts
@@ -240,7 +240,7 @@ export async function doAutoReplace(
 
       const autoReplaceRegExpFlag = autoReplaceGlobalMatch ? 'g' : '';
       if (currentValue && newValue && currentValue !== newValue) {
-        if (newString.indexOf(currentValue) === -1) {
+        if (!newString.includes(currentValue)) {
           logger.debug(
             { stringToReplace: newString, currentValue, currentValueTemplate },
             'currentValue not found in string to replace',
@@ -252,7 +252,7 @@ export async function doAutoReplace(
         );
       }
       if (depName && newName && depName !== newName) {
-        if (newString.indexOf(depName) === -1) {
+        if (!newString.includes(depName)) {
           logger.debug(
             { stringToReplace: newString, depName, depNameTemplate },
             'depName not found in string to replace',
@@ -264,7 +264,7 @@ export async function doAutoReplace(
         );
       }
       if (currentDigest && newDigest && currentDigest !== newDigest) {
-        if (newString.indexOf(currentDigest) === -1) {
+        if (!newString.includes(currentDigest) {
           logger.debug(
             { stringToReplace: newString, currentDigest },
             'currentDigest not found in string to replace',
@@ -279,7 +279,7 @@ export async function doAutoReplace(
         newDigest &&
         currentDigestShort !== newDigest
       ) {
-        if (newString.indexOf(currentDigestShort) === -1) {
+        if (!newString.includes(currentDigestShort)) {
           logger.debug(
             { stringToReplace: newString, currentDigestShort },
             'currentDigestShort not found in string to replace',

--- a/lib/workers/repository/update/branch/auto-replace.ts
+++ b/lib/workers/repository/update/branch/auto-replace.ts
@@ -190,8 +190,10 @@ export async function doAutoReplace(
   const {
     packageFile,
     depName,
+    depNameTemplate,
     newName,
     currentValue,
+    currentValueTemplate,
     newValue,
     currentDigest,
     currentDigestShort,
@@ -237,24 +239,52 @@ export async function doAutoReplace(
       newString = replaceString!;
 
       const autoReplaceRegExpFlag = autoReplaceGlobalMatch ? 'g' : '';
-      if (currentValue && newValue) {
+      if (currentValue && newValue && currentValue !== newValue) {
+        if (newString.indexOf(currentValue) === -1) {
+          logger.debug(
+            { stringToReplace: newString, currentValue, currentValueTemplate },
+            'currentValue not found in string to replace',
+          );
+        }
         newString = newString.replace(
           regEx(escapeRegExp(currentValue), autoReplaceRegExpFlag),
           newValue,
         );
       }
-      if (depName && newName) {
+      if (depName && newName && depName !== newName) {
+        if (newString.indexOf(depName) === -1) {
+          logger.debug(
+            { stringToReplace: newString, depName, depNameTemplate },
+            'depName not found in string to replace',
+          );
+        }
         newString = newString.replace(
           regEx(escapeRegExp(depName), autoReplaceRegExpFlag),
           newName,
         );
       }
-      if (currentDigest && newDigest) {
+      if (currentDigest && newDigest && currentDigest !== newDigest) {
+        if (newString.indexOf(currentDigest) === -1) {
+          logger.debug(
+            { stringToReplace: newString, currentDigest },
+            'currentDigest not found in string to replace',
+          );
+        }
         newString = newString.replace(
           regEx(escapeRegExp(currentDigest), autoReplaceRegExpFlag),
           newDigest,
         );
-      } else if (currentDigestShort && newDigest) {
+      } else if (
+        currentDigestShort &&
+        newDigest &&
+        currentDigestShort !== newDigest
+      ) {
+        if (newString.indexOf(currentDigestShort) === -1) {
+          logger.debug(
+            { stringToReplace: newString, currentDigestShort },
+            'currentDigestShort not found in string to replace',
+          );
+        }
         newString = newString.replace(
           regEx(escapeRegExp(currentDigestShort), autoReplaceRegExpFlag),
           newDigest,

--- a/lib/workers/repository/update/branch/auto-replace.ts
+++ b/lib/workers/repository/update/branch/auto-replace.ts
@@ -264,7 +264,7 @@ export async function doAutoReplace(
         );
       }
       if (currentDigest && newDigest && currentDigest !== newDigest) {
-        if (!newString.includes(currentDigest) {
+        if (!newString.includes(currentDigest)) {
           logger.debug(
             { stringToReplace: newString, currentDigest },
             'currentDigest not found in string to replace',

--- a/lib/workers/types.ts
+++ b/lib/workers/types.ts
@@ -42,6 +42,8 @@ export interface BranchUpgradeConfig
   currentDigest?: string;
   currentDigestShort?: string;
   currentValue?: string;
+
+  currentValueTemplate?: string;
   depIndex?: number;
   depTypes?: string[];
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds extended logging to the autoreplace logic to help troubleshoot problems, especially from custom manager config mistakes.

## Context

#33821

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
