### PR TITLE
fix(nix): fix flake lock refresh

### DIFF
--- a/lib/modules/manager/nix/extract.spec.ts
+++ b/lib/modules/manager/nix/extract.spec.ts
@@ -128,6 +128,7 @@ describe('modules/manager/nix/extract', () => {
           currentValue: 'nixos-unstable',
           datasource: GitRefsDatasource.id,
           packageName: 'https://github.com/NixOS/nixpkgs',
+          replaceString: '9f4128e00b0ae8ec65918efeba59db998750ead6',
         },
       ],
     });

--- a/lib/modules/manager/nix/extract.ts
+++ b/lib/modules/manager/nix/extract.ts
@@ -95,6 +95,7 @@ export async function extractPackageFile(
           depName,
           currentValue: flakeOriginal.ref,
           currentDigest: flakeLocked.rev,
+          replaceString: flakeLocked.rev, // hack because renovate cannot check flake.lock file
           datasource: GitRefsDatasource.id,
           packageName: `https://${flakeOriginal.host ?? 'github.com'}/${flakeOriginal.owner}/${flakeOriginal.repo}`,
         });
@@ -104,6 +105,7 @@ export async function extractPackageFile(
           depName,
           currentValue: flakeOriginal.ref,
           currentDigest: flakeLocked.rev,
+          replaceString: flakeLocked.rev, // hack because renovate cannot check flake.lock file
           datasource: GitRefsDatasource.id,
           packageName: `https://${flakeOriginal.host ?? 'gitlab.com'}/${flakeOriginal.owner}/${flakeOriginal.repo}`,
         });
@@ -113,6 +115,7 @@ export async function extractPackageFile(
           depName,
           currentValue: flakeOriginal.ref,
           currentDigest: flakeLocked.rev,
+          replaceString: flakeLocked.rev, // hack because renovate cannot check flake.lock file
           datasource: GitRefsDatasource.id,
           packageName: flakeOriginal.url,
         });
@@ -122,6 +125,7 @@ export async function extractPackageFile(
           depName,
           currentValue: flakeOriginal.ref,
           currentDigest: flakeLocked.rev,
+          replaceString: flakeLocked.rev, // hack because renovate cannot check flake.lock file
           datasource: GitRefsDatasource.id,
           packageName: `https://${flakeOriginal.host ?? 'git.sr.ht'}/${flakeOriginal.owner}/${flakeOriginal.repo}`,
         });
@@ -131,6 +135,7 @@ export async function extractPackageFile(
           depName,
           currentValue: flakeLocked.ref,
           currentDigest: flakeLocked.rev,
+          replaceString: flakeLocked.rev, // hack because renovate cannot check flake.lock file
           datasource: GitRefsDatasource.id,
           // type tarball always contains this link
           packageName: flakeOriginal.url!.replace(


### PR DESCRIPTION
## Changes

This fixes a not fully tested change from #31921 which broke the new nix flake lock refresh for inputs named nixpkgs.

## Context

```
DEBUG: currentDigest not found in string to replace (repository=NuschtOS/ixx, branch=renovate/flake-inputs)
       "stringToReplace": "nixos-unstable",
       "currentDigest": "5df43628fdf08d642be8ba5b3625a6c70731c19c"
DEBUG: Starting search at index 55 (repository=NuschtOS/ixx, packageFile=flake.nix, branch=renovate/flake-inputs)
       "depName": "nixpkgs"
DEBUG: Found match at index 55 (repository=NuschtOS/ixx, packageFile=flake.nix, branch=renovate/flake-inputs)
       "depName": "nixpkgs"
DEBUG: Digest is not updated (repository=NuschtOS/ixx, packageFile=flake.nix, branch=renovate/flake-inputs)
       "depName": "nixpkgs",
       "manager": "nix",
       "expectedValue": "9d3ae807ebd2981d593cddd0080856873139aa40",
       "foundValue": "5df43628fdf08d642be8ba5b3625a6c70731c19c"
 WARN: Error updating branch: update failure (repository=NuschtOS/ixx, branch=renovate/flake-inputs)
DEBUG: syncBranchState() (repository=NuschtOS/ixx, branch=renovate/crates)
````

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
