### PR TITLE
fix(manager/jsonata): populate extract result with manager config fields

### DIFF
--- a/lib/config/presets/internal/custom-managers.ts
+++ b/lib/config/presets/internal/custom-managers.ts
@@ -6,13 +6,12 @@ export const presets: Record<string, Preset> = {
   biomeVersions: {
     customManagers: [
       {
-        customType: 'jsonata',
+        customType: 'regex',
         datasourceTemplate: 'npm',
         depNameTemplate: '@biomejs/biome',
-        fileFormat: 'json',
         fileMatch: ['(^|/)biome.jsonc?$'],
         matchStrings: [
-          '{"currentValue": $split($substringBefore($."$schema", "/schema.json"), "/")[-1]}',
+          '"https://biomejs.dev/schemas/(?<currentValue>[^"]+)/schema.json"',
         ],
       },
     ],

--- a/lib/config/presets/internal/custom-managers.ts
+++ b/lib/config/presets/internal/custom-managers.ts
@@ -6,12 +6,13 @@ export const presets: Record<string, Preset> = {
   biomeVersions: {
     customManagers: [
       {
-        customType: 'regex',
+        customType: 'jsonata',
         datasourceTemplate: 'npm',
         depNameTemplate: '@biomejs/biome',
+        fileFormat: 'json',
         fileMatch: ['(^|/)biome.jsonc?$'],
         matchStrings: [
-          '"https://biomejs.dev/schemas/(?<currentValue>[^"]+)/schema.json"',
+          '{"currentValue": $split($substringBefore($."$schema", "/schema.json"), "/")[-1]}',
         ],
       },
     ],

--- a/lib/modules/manager/custom/jsonata/index.spec.ts
+++ b/lib/modules/manager/custom/jsonata/index.spec.ts
@@ -67,6 +67,7 @@ describe('modules/manager/custom/jsonata/index', () => {
     const res = await extractPackageFile(json, 'unused', config);
 
     expect(res).toMatchObject({
+      ...config,
       deps: [
         {
           depName: 'foo',
@@ -119,6 +120,7 @@ describe('modules/manager/custom/jsonata/index', () => {
     const res = await extractPackageFile(json, 'unused', config);
 
     expect(res).toMatchObject({
+      ...config,
       deps: [
         {
           depName: 'foo',
@@ -190,6 +192,7 @@ describe('modules/manager/custom/jsonata/index', () => {
     const res = await extractPackageFile(json, 'unused', config);
 
     expect(res).toMatchObject({
+      ...config,
       deps: [
         {
           depName: 'foo',
@@ -313,6 +316,7 @@ describe('modules/manager/custom/jsonata/index', () => {
     };
     const res = await extractPackageFile('{}', 'unused', config);
     expect(res).toMatchObject({
+      ...config,
       deps: [
         {
           depName: 'foo',
@@ -325,6 +329,37 @@ describe('modules/manager/custom/jsonata/index', () => {
           datasource: 'npm',
         },
       ],
+    });
+  });
+
+  it('populates manager config and jsonata manager template fields in extract result', async () => {
+    const config = {
+      fileFormat: 'json',
+      matchStrings: [`{"depName": "foo"}`, `{"depName": "bar"}`],
+      currentValueTemplate: '1.0.0',
+      datasourceTemplate: 'npm',
+      // should be included present extract result as it is not valid jsonata manager template
+      // adding here for testing
+      autoReplaceStringTemplate: `{{{depName}}}:{{{newValue}}}`,
+    };
+    const res = await extractPackageFile('{}', 'unused', config);
+    expect(res).toMatchObject({
+      deps: [
+        {
+          depName: 'foo',
+          currentValue: '1.0.0',
+          datasource: 'npm',
+        },
+        {
+          depName: 'bar',
+          currentValue: '1.0.0',
+          datasource: 'npm',
+        },
+      ],
+      fileFormat: 'json',
+      matchStrings: [`{"depName": "foo"}`, `{"depName": "bar"}`],
+      currentValueTemplate: '1.0.0',
+      datasourceTemplate: 'npm',
     });
   });
 });

--- a/lib/modules/manager/custom/jsonata/index.ts
+++ b/lib/modules/manager/custom/jsonata/index.ts
@@ -43,28 +43,25 @@ export async function extractPackageFile(
     return null;
   }
 
-  let deps = await handleMatching(json, packageFile, config);
-
-  // filter all null values
-  deps = deps.filter(is.truthy);
-  if (deps.length) {
-    const res: PackageFileContent & JSONataManagerTemplates = {
-      deps,
-      matchStrings: config.matchStrings,
-      fileFormat: config.fileFormat,
-    };
-
-    // copy over templates for autoreplace
-    for (const field of validMatchFields.map(
-      (f) => `${f}Template` as keyof JSONataManagerTemplates,
-    )) {
-      if (config[field]) {
-        res[field] = config[field];
-      }
-    }
-
-    return res;
+  const deps = await handleMatching(json, packageFile, config);
+  if (!deps.length) {
+    return null;
   }
 
-  return null;
+  const res: PackageFileContent & JSONataManagerTemplates = {
+    deps,
+    matchStrings: config.matchStrings,
+    fileFormat: config.fileFormat,
+  };
+
+  // copy over templates for autoreplace
+  for (const field of validMatchFields.map(
+    (f) => `${f}Template` as keyof JSONataManagerTemplates,
+  )) {
+    if (config[field]) {
+      res[field] = config[field];
+    }
+  }
+
+  return res;
 }

--- a/lib/modules/manager/types.ts
+++ b/lib/modules/manager/types.ts
@@ -71,6 +71,7 @@ export interface PackageFileContent<T = Record<string, any>>
   skipInstalls?: boolean | null;
   matchStrings?: string[];
   matchStringsStrategy?: MatchStringsStrategy;
+  fileFormat?: string;
 }
 
 export interface PackageFile<T = Record<string, any>>


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- Populate the manager config fields necessary for extraction in the extract result
<!-- Describe what behavior is changed by this PR. -->

## Context
- These fields (especially `matchStrings` & `fileFormat` ) are necessary in the `confirmIfDepUpdated` function where we re-extract after updating the content in `doAutoReplace`. 

The test runs on the renovate repo passed without these fields after which I had removed them. But when I tried some other variations it failed. I think it was working before because the `fileFormat` had a default value `json`, which prevented the errors.
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
 https://github.com/Rahul-renovate-testing/migrate-cstm-preset-1
 https://github.com/Rahul-renovate-testing/renovate/pulls
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
