### PR TITLE
fix(gitea): allow overriding platform version

### DIFF
--- a/docs/usage/self-hosted-experimental.md
+++ b/docs/usage/self-hosted-experimental.md
@@ -99,7 +99,7 @@ If set to any value, Renovate will download `nupkg` files for determining packag
 
 ## `RENOVATE_X_PLATFORM_VERSION`
 
-Specify this string for Renovate to skip API checks and provide GitLab/Gitea/Bitbucket server version directly.
+Specify this string for Renovate to skip API checks and provide GitLab/Gitea and Forgejo/Bitbucket server version directly.
 Particularly useful with GitLab's `CI_JOB_TOKEN` to authenticate Renovate or to reduce API calls for Bitbucket.
 
 Read [platform details](modules/platform/gitlab/index.md) to learn why we need the server version on GitLab.

--- a/docs/usage/self-hosted-experimental.md
+++ b/docs/usage/self-hosted-experimental.md
@@ -99,7 +99,7 @@ If set to any value, Renovate will download `nupkg` files for determining packag
 
 ## `RENOVATE_X_PLATFORM_VERSION`
 
-Specify this string for Renovate to skip API checks and provide GitLab/Bitbucket server version directly.
+Specify this string for Renovate to skip API checks and provide GitLab/Gitea/Bitbucket server version directly.
 Particularly useful with GitLab's `CI_JOB_TOKEN` to authenticate Renovate or to reduce API calls for Bitbucket.
 
 Read [platform details](modules/platform/gitlab/index.md) to learn why we need the server version on GitLab.

--- a/lib/modules/platform/gitea/index.ts
+++ b/lib/modules/platform/gitea/index.ts
@@ -212,10 +212,18 @@ const platform: Platform = {
       gitAuthor = `${user.full_name ?? user.username} <${user.email}>`;
       botUserID = user.id;
       botUserName = user.username;
-      defaults.version = await helper.getVersion({ token });
+      // istanbul ignore if: experimental feature
+      if (semver.valid(process.env.RENOVATE_X_PLATFORM_VERSION)) {
+        defaults.version = process.env.RENOVATE_X_PLATFORM_VERSION!;
+      } else {
+        defaults.version = await helper.getVersion({ token });
+      }
       if (defaults.version?.includes('gitea-')) {
         defaults.isForgejo = true;
       }
+      logger.debug(
+        `${defaults.isForgejo ? 'Forgejo' : 'Gitea'} version: ${defaults.version}`,
+      );
     } catch (err) {
       logger.debug(
         { err },


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Useful if the platfrom version is somehow different to what renovate expects, like on codeberg.org
```sh
$ curl -s https://codeberg.org/api/v1/version | jq
{
  "version": "10.0.0-58-7e1df53+gitea-1.22.0"
}
```
<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
