### PR TITLE
fix(gitea): use endpoint for pr cache pagination

### DIFF
--- a/lib/modules/platform/gitea/index.spec.ts
+++ b/lib/modules/platform/gitea/index.spec.ts
@@ -1222,7 +1222,13 @@ describe('modules/platform/gitea/index', () => {
         .scope('https://gitea.com/api/v1')
         .get('/repos/some/repo/pulls')
         .query({ state: 'all', sort: 'recentupdate' })
-        .reply(200, mockPRs);
+        .reply(200, mockPRs.slice(0, 2), {
+          // test correct pagination handling, domain should be ignored
+          link: '<https://domain.test/api/v1/repos/some/repo/pulls?state=all&sort=recentupdate&page=2>; rel="next",<https://domain.test/api/v1/repos/some/repo/pulls?state=all&sort=recentupdate&page=4512>; rel="last"',
+        })
+        .get('/repos/some/repo/pulls')
+        .query({ state: 'all', sort: 'recentupdate', page: 2 })
+        .reply(200, mockPRs.slice(2));
       await initFakePlatform(scope);
       await initFakeRepo(scope);
 

--- a/lib/modules/platform/gitea/pr-cache.ts
+++ b/lib/modules/platform/gitea/pr-cache.ts
@@ -6,7 +6,7 @@ import * as memCache from '../../../util/cache/memory';
 import { getCache } from '../../../util/cache/repository';
 import type { GiteaHttp } from '../../../util/http/gitea';
 import type { HttpResponse } from '../../../util/http/types';
-import { getQueryString, parseLinkHeader } from '../../../util/url';
+import { getQueryString, parseLinkHeader, parseUrl } from '../../../util/url';
 import type { Pr } from '../types';
 import type { GiteaPrCacheData, PR } from './types';
 import { API_PATH, toRenovatePR } from './utils';
@@ -149,7 +149,8 @@ export class GiteaPrCache {
         break;
       }
 
-      url = parseLinkHeader(res.headers.link)?.next?.url;
+      const uri = parseUrl(parseLinkHeader(res.headers.link)?.next?.url);
+      url = uri ? `${uri?.pathname}${uri?.search}` : undefined;
     }
 
     this.updateItems();

--- a/lib/modules/platform/gitea/pr-cache.ts
+++ b/lib/modules/platform/gitea/pr-cache.ts
@@ -150,7 +150,7 @@ export class GiteaPrCache {
       }
 
       const uri = parseUrl(parseLinkHeader(res.headers.link)?.next?.url);
-      url = uri ? `${uri?.pathname}${uri?.search}` : undefined;
+      url = uri ? `${uri.pathname}${uri.search}` : undefined;
     }
 
     this.updateItems();


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Use configured endpoint in pr cache. The cache uses own pagination.
<!-- Describe what behavior is changed by this PR. -->

## Context
- closes #33121
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
