### PR TITLE
docs(jsonata): fix code block title for jsonata example

### DIFF
--- a/lib/modules/manager/custom/jsonata/readme.md
+++ b/lib/modules/manager/custom/jsonata/readme.md
@@ -67,7 +67,7 @@ When you configure a JSONata manager, use the following syntax:
 Overwrite the `<query>` placeholder text with your [JSONata](https://docs.jsonata.org/overview.html) query.
 The JSONata query transforms the content to a JSON object, similar to the this:
 
-```javascript dependencies information extracted usig jsonata query
+```javascript title="dependencies information extracted usig jsonata query"
 [
   {
     depName: 'some_dep',


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Sets the title property on the code block.

## Context

Rendering on the website is broken, seems to be because of the invalid format for the `title` 
https://docs.renovatebot.com/modules/manager/jsonata/
![image](https://github.com/user-attachments/assets/03be498e-98e8-4f9a-815a-6f11e8ac33b1)

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
