### PR TITLE
fix(datasource/dart-version): skip old svn revisions

### DIFF
--- a/lib/modules/datasource/dart-version/__fixtures__/beta.json
+++ b/lib/modules/datasource/dart-version/__fixtures__/beta.json
@@ -10,6 +10,8 @@
 		"channels/beta/release/2.19.0-255.2.beta/",
 		"channels/beta/release/2.19.0-374.1.beta/",
 		"channels/beta/release/2.19.0-374.2.beta/",
+    "channels/dev/release/30039/",
+    "channels/dev/release/30104/",
 		"channels/beta/release/latest/"
 	]
 }

--- a/lib/modules/datasource/dart-version/__fixtures__/stable.json
+++ b/lib/modules/datasource/dart-version/__fixtures__/stable.json
@@ -7,6 +7,8 @@
 		"channels/stable/release/2.18.0/",
 		"channels/stable/release/2.18.4/",
 		"channels/stable/release/2.18.5/",
+    "channels/stable/release/30036/",
+    "channels/stable/release/30107/",
 		"channels/stable/release/latest/"
 	]
 }

--- a/lib/modules/datasource/dart-version/index.ts
+++ b/lib/modules/datasource/dart-version/index.ts
@@ -5,6 +5,12 @@ import type { GetReleasesConfig, Release, ReleaseResult } from '../types';
 import type { DartResponse } from './types';
 
 export const stableVersionRegex = regEx(/^\d+\.\d+\.\d+$/);
+/**
+ * The server returns old svn versions which would need mapping to a version.
+ * They are very old, so we skip them instead.
+ * https://github.com/dart-lang/site-www/blob/7d4409c87bb6570b2d8870b20283f81f2b7e08fc/tool/get-dart/dart_sdk_archive/lib/src/svn_versions.dart#L2
+ */
+export const svnVersionRegex = regEx(/^\d+$/);
 
 export class DartVersionDatasource extends Datasource {
   static readonly id = 'dart-version';
@@ -65,6 +71,8 @@ export class DartVersionDatasource extends Datasource {
       .filter((version) => {
         if (
           version === 'latest' ||
+          // skip old svn versions
+          svnVersionRegex.test(version) ||
           // The API response contains a stable version being released as a non-stable
           // release. So we filter out these releases here.
           (channel !== 'stable' && stableVersionRegex.test(version))


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
The server returns old svn revisions as versions, they need manual mapping to version. We simply skip them instead, because they are very old ( `<1.11`)
<!-- Describe what behavior is changed by this PR. -->

## Context
- https://github.com/renovatebot/base-image/pull/1502
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
