### PR TITLE
fix: show fetchUpdates by manager/packageFile in debug log-level

### DIFF
--- a/lib/workers/repository/process/fetch.ts
+++ b/lib/workers/repository/process/fetch.ts
@@ -76,12 +76,19 @@ async function lookup(
   }
 
   return LookupStats.wrap(depConfig.datasource, async () => {
+    const { packageFile, manager } = packageFileConfig;
     return await Result.wrap(lookupUpdates(depConfig as LookupUpdateConfig))
       .onValue((dep) => {
-        logger.trace({ dep }, 'Dependency lookup success');
+        logger.trace(
+          { dep, packageFile, manager },
+          'Dependency lookup success',
+        );
       })
       .onError((err) => {
-        logger.trace({ err, depName }, 'Dependency lookup error');
+        logger.trace(
+          { err, depName, packageFile, manager },
+          'Dependency lookup error',
+        );
       })
       .catch((err): Result<UpdateResult, Error> => {
         if (
@@ -126,13 +133,16 @@ async function fetchManagerPackagerFileUpdates(
       return updates.unwrapOrThrow();
     },
   );
-  logger.trace(
+  logger.debug(
     { manager, packageFile, queueLength: queue.length },
     'fetchManagerPackagerFileUpdates starting with concurrency',
   );
 
   pFile.deps = await p.all(queue);
-  logger.trace({ packageFile }, 'fetchManagerPackagerFileUpdates finished');
+  logger.debug(
+    { manager, packageFile },
+    'fetchManagerPackagerFileUpdates finished',
+  );
 }
 
 async function fetchManagerUpdates(
@@ -145,12 +155,12 @@ async function fetchManagerUpdates(
     (pFile) => (): Promise<void> =>
       fetchManagerPackagerFileUpdates(config, managerConfig, pFile),
   );
-  logger.trace(
+  logger.debug(
     { manager, queueLength: queue.length },
     'fetchManagerUpdates starting',
   );
   await p.all(queue);
-  logger.trace({ manager }, 'fetchManagerUpdates finished');
+  logger.debug({ manager }, 'fetchManagerUpdates finished');
 }
 
 export async function fetchUpdates(


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Bump `fetchManagerUpdates` and `fetchManagerPackagerFileUpdates` starting/finished logs from debug to trace.

I am tempted to bump "Dependency lookup success/error" to debug level as well, but that might be too much, leaving it as trace for now.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

I have been trying to investigate a silent failure for a while now (https://github.com/renovatebot/renovate/discussions/30529#discussioncomment-12001755), it started months ago affecting 10-20% of the runs and now it affects 80-90% of them.

The trace log level is not usable as it requires a gargantuan amount of memory due the large objects logged. I think it will not be too verbose for the debug level, and will allow to collect better statistic on manager/packageFile able/unable to finish (I have been able to craft nifty SQL queries with [GCP Log Analytics](https://cloud.google.com/logging/docs/log-analytics#analytics)), and later I hope help narrow it down to a minimal reproduction. I built the image locally and ran it for a few hours, but I loose the continuously delivery of new release that could somehow provide a fix. I also want to empower others who may be experiencing the issue to better report any pattern they may observe (there are at least 4 upvotes on the discussion).

Open to alternative suggestions to troubleshoot this further. OTEL traces, system metrics (e.g. memory usage) have not been helpful so far, clearing the cache either. I tried to ["inspect"](https://nodejs.org/en/learn/getting-started/debugging) the node process (combination of `kubectl exec`, `kill -SIGUSR1` and `kubectl port-forward`, and Chrome browser), but I can't tell I know how to use this tool effectively.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
