### PR TITLE
fix(manager/custom): Revert "fix(manager/custom): Support range strategy with custom managers"

### DIFF
--- a/lib/modules/manager/index.spec.ts
+++ b/lib/modules/manager/index.spec.ts
@@ -170,7 +170,7 @@ describe('modules/manager/index', () => {
   });
 
   describe('getRangeStrategy', () => {
-    it('returns null for a unknown manager', () => {
+    it('returns null', () => {
       manager.getManagers().set('dummy', {
         defaultConfig: {},
         supportedDatasources: [],
@@ -178,37 +178,6 @@ describe('modules/manager/index', () => {
       expect(
         manager.getRangeStrategy({ manager: 'unknown', rangeStrategy: 'auto' }),
       ).toBeNull();
-    });
-
-    it('returns null for a undefined manager', () => {
-      manager.getManagers().set('dummy', {
-        defaultConfig: {},
-        supportedDatasources: [],
-      });
-      expect(manager.getRangeStrategy({ rangeStrategy: 'auto' })).toBeNull();
-    });
-
-    it('returns non-null for a custom manager', () => {
-      customManager.getCustomManagers().set('dummy', {
-        defaultConfig: {},
-        supportedDatasources: [],
-      });
-      expect(
-        manager.getRangeStrategy({ manager: 'dummy', rangeStrategy: 'auto' }),
-      ).not.toBeNull();
-    });
-
-    it('handles custom managers', () => {
-      customManager.getCustomManagers().set('dummy', {
-        defaultConfig: {},
-        supportedDatasources: [],
-        // For completeness. Custom managers are configured in json and can not
-        // provide a range strategy (yet) but the interface allows for it.
-        getRangeStrategy: () => 'bump',
-      });
-      expect(
-        manager.getRangeStrategy({ manager: 'dummy', rangeStrategy: 'auto' }),
-      ).toBe('bump');
     });
 
     it('returns non-null', () => {

--- a/lib/modules/manager/index.ts
+++ b/lib/modules/manager/index.ts
@@ -78,13 +78,10 @@ export function extractPackageFile(
 
 export function getRangeStrategy(config: RangeConfig): RangeStrategy | null {
   const { manager, rangeStrategy } = config;
-  if (!manager) {
+  if (!manager || !managers.has(manager)) {
     return null;
   }
-  const m = managers.get(manager) ?? customManagers.get(manager);
-  if (!m) {
-    return null;
-  }
+  const m = managers.get(manager)!;
   if (m.getRangeStrategy) {
     // Use manager's own function if it exists
     const managerRangeStrategy = m.getRangeStrategy(config);


### PR DESCRIPTION
Reverts renovatebot/renovate#33800

We've had multiple users now report a problem starting in this release, e.g. https://github.com/renovatebot/renovate/discussions/34054#discussioncomment-12086568