### PR TITLE
feat(platform/gitlab): use Notes API for automerge to support merge trains

### DIFF
--- a/docs/usage/faq.md
+++ b/docs/usage/faq.md
@@ -44,7 +44,6 @@ Some major platform features are not supported at all by Renovate.
 | --------------------------------------- | ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Jira issues                             | Bitbucket                                 | [#20568](https://github.com/renovatebot/renovate/issues/20568)                                                                                                                               |
 | Jira issues                             | Bitbucket Server                          | [#3796](https://github.com/renovatebot/renovate/issues/3796)                                                                                                                                 |
-| Merge trains                            | GitLab                                    | [#5573](https://github.com/renovatebot/renovate/issues/5573)                                                                                                                                 |
 | Configurable merge strategy and message | Only Bitbucket, Forgejo and Gitea for now | [#10867](https://github.com/renovatebot/renovate/issues/10867) [#10869](https://github.com/renovatebot/renovate/issues/10869) [#10870](https://github.com/renovatebot/renovate/issues/10870) |
 
 ## What is this `main` branch I see in the documentation?

--- a/lib/modules/platform/gitlab/index.spec.ts
+++ b/lib/modules/platform/gitlab/index.spec.ts
@@ -2143,7 +2143,7 @@ describe('modules/platform/gitlab/index', () => {
         .reply(200)
         .get('/api/v4/projects/undefined/merge_requests/12345')
         .reply(200)
-        .put('/api/v4/projects/undefined/merge_requests/12345/merge')
+        .post('/api/v4/projects/undefined/merge_requests/12345/notes')
         .reply(200);
       expect(
         await gitlab.createPr({
@@ -2187,65 +2187,7 @@ describe('modules/platform/gitlab/index', () => {
         .reply(200, reply_body)
         .get('/api/v4/projects/undefined/merge_requests/12345')
         .reply(200, reply_body)
-        .put('/api/v4/projects/undefined/merge_requests/12345/merge')
-        .reply(405, {})
-        .put('/api/v4/projects/undefined/merge_requests/12345/merge')
-        .reply(200, {});
-      process.env.RENOVATE_X_GITLAB_AUTO_MERGEABLE_CHECK_ATTEMPS = '3';
-      const pr = await gitlab.createPr({
-        sourceBranch: 'some-branch',
-        targetBranch: 'master',
-        prTitle: 'some-title',
-        prBody: 'the-body',
-        platformPrOptions: {
-          usePlatformAutomerge: true,
-        },
-      });
-      expect(pr).toMatchObject({
-        number: 12345,
-        sourceBranch: 'some-branch',
-        title: 'some title',
-      });
-      expect(logger.debug).toHaveBeenCalledWith(
-        'PR not yet in mergeable state. Retrying 1',
-      );
-      expect(logger.debug).toHaveBeenCalledWith(
-        'PR not yet in mergeable state. Retrying 2',
-      );
-      expect(logger.debug).toHaveBeenCalledWith(
-        'PR not yet in mergeable state. Retrying 3',
-      );
-      expect(timers.setTimeout.mock.calls).toMatchObject([
-        [100],
-        [400],
-        [900],
-        [100],
-      ]);
-    });
-
-    it('should parse detailed_merge_status attribute on >= 15.6', async () => {
-      await initPlatform('15.6.0-ee');
-      const reply_body = {
-        detailed_merge_status: 'pending',
-      };
-      httpMock
-        .scope(gitlabApiHost)
-        .post('/api/v4/projects/undefined/merge_requests')
-        .reply(200, {
-          id: 1,
-          iid: 12345,
-          title: 'some title',
-          source_branch: 'some-branch',
-          target_branch: 'master',
-          description: 'the-body',
-        })
-        .get('/api/v4/projects/undefined/merge_requests/12345')
-        .reply(200, reply_body)
-        .get('/api/v4/projects/undefined/merge_requests/12345')
-        .reply(200, reply_body)
-        .get('/api/v4/projects/undefined/merge_requests/12345')
-        .reply(200, reply_body)
-        .put('/api/v4/projects/undefined/merge_requests/12345/merge')
+        .post('/api/v4/projects/undefined/merge_requests/12345/notes')
         .reply(200, {});
       process.env.RENOVATE_X_GITLAB_AUTO_MERGEABLE_CHECK_ATTEMPS = '3';
       const pr = await gitlab.createPr({
@@ -2274,7 +2216,7 @@ describe('modules/platform/gitlab/index', () => {
       expect(timers.setTimeout.mock.calls).toMatchObject([[100], [400], [900]]);
     });
 
-    it('should retry auto merge creation on 405 method not allowed', async () => {
+    it('should parse detailed_merge_status attribute on >= 15.6', async () => {
       await initPlatform('15.6.0-ee');
       const reply_body = {
         detailed_merge_status: 'pending',
@@ -2296,11 +2238,7 @@ describe('modules/platform/gitlab/index', () => {
         .reply(200, reply_body)
         .get('/api/v4/projects/undefined/merge_requests/12345')
         .reply(200, reply_body)
-        .put('/api/v4/projects/undefined/merge_requests/12345/merge')
-        .reply(405, {})
-        .put('/api/v4/projects/undefined/merge_requests/12345/merge')
-        .reply(405, {})
-        .put('/api/v4/projects/undefined/merge_requests/12345/merge')
+        .post('/api/v4/projects/undefined/merge_requests/12345/notes')
         .reply(200, {});
       process.env.RENOVATE_X_GITLAB_AUTO_MERGEABLE_CHECK_ATTEMPS = '3';
       const pr = await gitlab.createPr({
@@ -2326,21 +2264,7 @@ describe('modules/platform/gitlab/index', () => {
       expect(logger.debug).toHaveBeenCalledWith(
         'PR not yet in mergeable state. Retrying 3',
       );
-      expect(logger.debug).toHaveBeenCalledWith(
-        expect.any(Object),
-        'Automerge on PR creation failed. Retrying 1',
-      );
-      expect(logger.debug).toHaveBeenCalledWith(
-        expect.any(Object),
-        'Automerge on PR creation failed. Retrying 2',
-      );
-      expect(timers.setTimeout.mock.calls).toMatchObject([
-        [100],
-        [400],
-        [900],
-        [100],
-        [400],
-      ]);
+      expect(timers.setTimeout.mock.calls).toMatchObject([[100], [400], [900]]);
     });
 
     it('should not retry if MR is mergeable and pipeline is running', async () => {
@@ -2364,7 +2288,7 @@ describe('modules/platform/gitlab/index', () => {
         })
         .get('/api/v4/projects/undefined/merge_requests/12345')
         .reply(200, reply_body)
-        .put('/api/v4/projects/undefined/merge_requests/12345/merge')
+        .post('/api/v4/projects/undefined/merge_requests/12345/notes')
         .reply(200, {});
       const pr = await gitlab.createPr({
         sourceBranch: 'some-branch',
@@ -2486,7 +2410,7 @@ describe('modules/platform/gitlab/index', () => {
             status: 'success',
           },
         })
-        .put('/api/v4/projects/undefined/merge_requests/12345/merge')
+        .post('/api/v4/projects/undefined/merge_requests/12345/notes')
         .reply(200)
         .get('/api/v4/projects/undefined/merge_requests/12345/approval_rules')
         .reply(200, [])
@@ -2580,7 +2504,7 @@ describe('modules/platform/gitlab/index', () => {
             status: 'success',
           },
         })
-        .put('/api/v4/projects/undefined/merge_requests/12345/merge')
+        .post('/api/v4/projects/undefined/merge_requests/12345/notes')
         .reply(200)
         .get('/api/v4/projects/undefined/merge_requests/12345/approval_rules')
         .reply(200, [
@@ -2638,7 +2562,7 @@ describe('modules/platform/gitlab/index', () => {
             status: 'success',
           },
         })
-        .put('/api/v4/projects/undefined/merge_requests/12345/merge')
+        .post('/api/v4/projects/undefined/merge_requests/12345/notes')
         .reply(200)
         .get('/api/v4/projects/undefined/merge_requests/12345/approval_rules')
         .reply(200, [
@@ -2707,7 +2631,7 @@ describe('modules/platform/gitlab/index', () => {
             status: 'success',
           },
         })
-        .put('/api/v4/projects/undefined/merge_requests/12345/merge')
+        .post('/api/v4/projects/undefined/merge_requests/12345/notes')
         .reply(200)
         .get('/api/v4/projects/undefined/merge_requests/12345/approval_rules')
         .reply(200, [
@@ -2786,7 +2710,7 @@ describe('modules/platform/gitlab/index', () => {
             status: 'success',
           },
         })
-        .put('/api/v4/projects/undefined/merge_requests/12345/merge')
+        .post('/api/v4/projects/undefined/merge_requests/12345/notes')
         .reply(200)
         .get('/api/v4/projects/undefined/merge_requests/12345/approval_rules')
         .reply(200, [
@@ -2836,7 +2760,7 @@ describe('modules/platform/gitlab/index', () => {
             status: 'success',
           },
         })
-        .put('/api/v4/projects/undefined/merge_requests/12345/merge')
+        .post('/api/v4/projects/undefined/merge_requests/12345/notes')
         .reply(200)
         .get('/api/v4/projects/undefined/merge_requests/12345/approval_rules')
         .reply(200, [])
@@ -3376,7 +3300,7 @@ describe('modules/platform/gitlab/index', () => {
             status: 'running',
           },
         })
-        .put('/api/v4/projects/undefined/merge_requests/12345/merge')
+        .post('/api/v4/projects/undefined/merge_requests/12345/notes')
         .reply(200);
 
       await expect(gitlab.reattemptPlatformAutomerge?.(pr)).toResolve();

--- a/lib/modules/platform/gitlab/index.ts
+++ b/lib/modules/platform/gitlab/index.ts
@@ -696,6 +696,11 @@ async function tryPrAutomerge(
         await setTimeout(mergeDelay * attempt ** 2); // exponential backoff
       }
 
+      // Use the /merge "quick action" to automerge, which will work for
+      // both merge trains or non-train merges
+      // Associated docs:
+      //  - https://docs.gitlab.com/api/notes/#create-new-merge-request-note
+      //  - https://docs.gitlab.com/user/project/quick_actions/
       await gitlabApi.postJson(
         `projects/${config.repository}/merge_requests/${pr}/notes`,
         {


### PR DESCRIPTION
closes https://github.com/renovatebot/renovate/issues/5573

Gitlab's /merge API does not support merge trains, but sending "/merge" over the MR comment (notes) API does work:
https://gitlab.com/gitlab-org/gitlab/-/issues/32665

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

When using automerge with Gitlab, renovate will now add MRs to merge trains. If not it will be merged as previously.

## Context

- https://github.com/renovatebot/renovate/issues/5573

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
