### PR TITLE
fix(datasource/bazel): make yanked_versions optional

### DIFF
--- a/lib/modules/datasource/bazel/index.ts
+++ b/lib/modules/datasource/bazel/index.ts
@@ -52,7 +52,7 @@ export class BazelDatasource extends Datasource {
         .sort(BzlmodVersion.defaultCompare)
         .map((bv) => {
           const release: Release = { version: bv.original };
-          if (is.truthy(metadata.yanked_versions[bv.original])) {
+          if (is.truthy(metadata.yanked_versions?.[bv.original])) {
             release.isDeprecated = true;
           }
           return release;

--- a/lib/modules/datasource/bazel/schema.ts
+++ b/lib/modules/datasource/bazel/schema.ts
@@ -3,5 +3,5 @@ import { z } from 'zod';
 export const BazelModuleMetadata = z.object({
   homepage: z.string().optional().nullable(),
   versions: z.array(z.string()),
-  yanked_versions: z.record(z.string(), z.string()),
+  yanked_versions: z.record(z.string(), z.string()).optional(),
 });


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Makes `yanked_versions` optional in zod schema for bazel datasource.

## Context

It seems at least one host does not return this, and we don't _need_ it anyway.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
