### PR TITLE
docs: Update "noisy" schedule examples to AWS SDK v3

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2559,14 +2559,14 @@ Here is an example if you want to group together all packages starting with `esl
 
 Note how the above uses `matchPackageNames` with a prefix pattern.
 
-Here's an example config to limit the "noisy" `aws-sdk` package to weekly updates:
+Here's an example config to limit the "noisy" AWS SDK packages to weekly updates:
 
 ```json
 {
   "packageRules": [
     {
-      "description": "Schedule aws-sdk updates on Sunday nights (9 PM - 12 AM)",
-      "matchPackageNames": ["aws-sdk"],
+      "description": "Schedule AWS SDK updates on Sunday nights (9 PM - 12 AM)",
+      "matchPackageNames": ["@aws-sdk/*"],
       "schedule": ["* 21-23 * * 0"]
     }
   ]

--- a/docs/usage/key-concepts/scheduling.md
+++ b/docs/usage/key-concepts/scheduling.md
@@ -113,14 +113,14 @@ These preset schedules only affect when Renovate bot checks for updates, and do 
 
 ### Schedule when to update specific dependencies
 
-The scheduling feature can be very useful for "noisy" packages that are updated frequently, such as `aws-sdk`.
+The scheduling feature can be very useful for "noisy" packages that are updated frequently, such as the AWS SDK.
 
-```json title="Restrict aws-sdk to weekly updates"
+```json title="Restrict AWS SDK to weekly updates"
 {
   "packageRules": [
     {
-      "description": "Schedule aws-sdk updates on Sunday nights (9 PM - 12 AM)",
-      "matchPackageNames": ["aws-sdk"],
+      "description": "Schedule AWS SDK updates on Sunday nights (9 PM - 12 AM)",
+      "matchPackageNames": ["@aws-sdk/*"],
       "schedule": ["* 21-23 * * 0"]
     }
   ]


### PR DESCRIPTION
## Changes

This PR updates the docs that reference the `aws-sdk` package to reference `@aws-sdk/*` instead.

## Context

The docs describe how to update "noisy" packages less frequently. The example given is `aws-sdk`. This is the name of the Node package for AWS SDK v2, which is deprecated. AWS SDK v3 is made up of individual packages for each service (e.g. `@aws-sdk/client-s3`).

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
