### PR TITLE
feat(bitbucket-server): add paginate http option

### DIFF
--- a/lib/util/http/bitbucket-server.spec.ts
+++ b/lib/util/http/bitbucket-server.spec.ts
@@ -1,5 +1,6 @@
 import * as httpMock from '../../../test/http-mock';
 import * as hostRules from '../host-rules';
+import { range } from '../range';
 import { BitbucketServerHttp, setBaseUrl } from './bitbucket-server';
 
 const baseUrl = 'https://git.example.com';
@@ -26,5 +27,88 @@ describe('util/http/bitbucket-server', () => {
     httpMock.scope(baseUrl).post('/some-url').reply(200, body);
     const res = await api.postJson('some-url');
     expect(res.body).toEqual(body);
+  });
+
+  it('invalid path', async () => {
+    setBaseUrl('some-in|valid-host');
+    const res = api.getJsonUnchecked('/some-url');
+    await expect(res).rejects.toThrow(
+      'Bitbucket Server: cannot parse path /some-url',
+    );
+  });
+
+  it('pagination: uses default limit if not configured', async () => {
+    const valuesPageOne = [...range(1, 100)];
+    const valuesPageTwo = [...range(101, 200)];
+    const valuesPageThree = [...range(201, 210)];
+
+    httpMock
+      .scope(baseUrl)
+      .get('/some-url?foo=bar&limit=100')
+      .reply(200, {
+        values: valuesPageOne,
+        size: 100,
+        isLastPage: false,
+        start: 0,
+        limit: 100,
+        nextPageStart: 100,
+      })
+      .get('/some-url?foo=bar&limit=100&start=100')
+      .reply(200, {
+        values: valuesPageTwo,
+        size: 100,
+        isLastPage: false,
+        start: 100,
+        limit: 100,
+        nextPageStart: 200,
+      })
+      .get('/some-url?foo=bar&limit=100&start=200')
+      .reply(200, {
+        values: valuesPageThree,
+        size: 10,
+        isLastPage: true,
+        start: 200,
+        limit: 100,
+      });
+
+    const res = await api.getJsonUnchecked('/some-url?foo=bar', {
+      paginate: true,
+    });
+    expect(res.body).toEqual([
+      ...valuesPageOne,
+      ...valuesPageTwo,
+      ...valuesPageThree,
+    ]);
+  });
+
+  it('pagination: uses configured limit', async () => {
+    const valuesPageOne = [...range(1, 50)];
+    const valuesPageTwo = [...range(51, 90)];
+
+    httpMock
+      .scope(baseUrl)
+      .get('/some-url?foo=bar&limit=50')
+      .reply(200, {
+        values: valuesPageOne,
+        size: 50,
+        isLastPage: false,
+        start: 0,
+        limit: 50,
+        nextPageStart: 50,
+      })
+      .get('/some-url?foo=bar&limit=50&start=50')
+      .reply(200, {
+        values: valuesPageTwo,
+        size: 40,
+        isLastPage: true,
+        start: 50,
+        limit: 50,
+      });
+
+    const res = await api.getJsonUnchecked('/some-url?foo=bar', {
+      paginate: true,
+      limit: 50,
+    });
+    expect(res.body).toEqual([...valuesPageOne, ...valuesPageTwo]);
   });
 });

--- a/lib/util/http/bitbucket-server.ts
+++ b/lib/util/http/bitbucket-server.ts
@@ -53,7 +53,7 @@ export class BitbucketServerHttp extends Http<BitbucketServerHttpOptions> {
     );
 
     if (opts.paginate && isPagedResult(result.body)) {
-      const collectedValues: T[] = [...result.body.values];
+      const collectedValues = [...result.body.values];
       let nextPageStart = result.body.nextPageStart;
 
       while (nextPageStart) {

--- a/lib/util/http/bitbucket-server.ts
+++ b/lib/util/http/bitbucket-server.ts
@@ -1,30 +1,79 @@
-import { resolveBaseUrl } from '../url';
+import is from '@sindresorhus/is';
+import { logger } from '../../logger';
+import { parseUrl, resolveBaseUrl } from '../url';
 import type { HttpOptions, HttpResponse, InternalHttpOptions } from './types';
 import { Http } from '.';
+
+const MAX_LIMIT = 100;
 
 let baseUrl: string;
 export const setBaseUrl = (url: string): void => {
   baseUrl = url;
 };
 
-export class BitbucketServerHttp extends Http {
+export interface BitbucketServerHttpOptions extends HttpOptions {
+  paginate?: boolean;
+  limit?: number;
+}
+
+interface PagedResult<T = unknown> {
+  nextPageStart?: number;
+  values: T[];
+}
+
+export class BitbucketServerHttp extends Http<BitbucketServerHttpOptions> {
   constructor(options?: HttpOptions) {
     super('bitbucket-server', options);
   }
 
-  protected override request<T>(
+  protected override async request<T>(
     path: string,
-    options?: InternalHttpOptions,
+    options?: InternalHttpOptions & BitbucketServerHttpOptions,
   ): Promise<HttpResponse<T>> {
-    const url = resolveBaseUrl(baseUrl, path);
-    const opts = {
-      baseUrl,
-      ...options,
-    };
+    const opts = { baseUrl, ...options };
     opts.headers = {
       ...opts.headers,
       'X-Atlassian-Token': 'no-check',
     };
-    return super.request<T>(url, opts);
+
+    const resolvedUrl = parseUrl(resolveBaseUrl(baseUrl, path));
+    if (!resolvedUrl) {
+      logger.error({ path }, 'Bitbucket Server: cannot parse path');
+      throw new Error(`Bitbucket Server: cannot parse path ${path}`);
+    }
+
+    if (opts.paginate) {
+      const limit = opts.limit ?? MAX_LIMIT;
+      resolvedUrl.searchParams.set('limit', limit.toString());
+    }
+
+    const result = await super.request<T | PagedResult<T>>(
+      resolvedUrl.toString(),
+      opts,
+    );
+
+    if (opts.paginate && isPagedResult(result.body)) {
+      const collectedValues: T[] = [...result.body.values];
+      let nextPageStart = result.body.nextPageStart;
+
+      while (nextPageStart) {
+        resolvedUrl.searchParams.set('start', nextPageStart.toString());
+
+        const nextResult = await super.request<PagedResult<T>>(
+          resolvedUrl.toString(),
+          opts,
+        );
+        collectedValues.push(...nextResult.body.values);
+        nextPageStart = nextResult.body.nextPageStart;
+      }
+
+      return { ...result, body: collectedValues as T };
+    }
+
+    return result as HttpResponse<T>;
   }
+}
+
+function isPagedResult(obj: unknown): obj is PagedResult {
+  return is.nonEmptyObject(obj) && is.array(obj.values);
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds a `paginate` http option for Bitbucket Server, analogous to what exists for other supported platforms. 
It doesn't change any existing request behavior. 

In a follow-up PR, I intend to replace all [utils.accumulateValues()](https://github.com/renovatebot/renovate/blob/dbabbdc5b3ee230eff277916c72f7c6bc75559c0/lib/modules/platform/bitbucket-server/utils.ts#L75) calls and then remove it.

I verified that it does what it should with tests on real repos and ensured it adheres to the [docs on paged APIs](https://docs.atlassian.com/bitbucket-server/rest/7.21.0/bitbucket-rest.html#paging-params).

<!-- Describe what behavior is changed by this PR. -->

## Context

- https://github.com/renovatebot/renovate/pull/22135
- https://github.com/renovatebot/renovate/issues/33290
- https://github.com/renovatebot/renovate/issues/3903

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
