### PR TITLE
feat(cache): Relax requirements for cacheable response headers

### DIFF
--- a/lib/modules/platform/bitbucket/pr-cache.spec.ts
+++ b/lib/modules/platform/bitbucket/pr-cache.spec.ts
@@ -74,7 +74,7 @@ describe('modules/platform/bitbucket/pr-cache', () => {
       },
     ]);
     expect(cache).toEqual({
-      httpCache: {},
+      httpCache: expect.toBeNonEmptyObject(),
       platform: {
         bitbucket: {
           pullRequestsCache: {
@@ -123,7 +123,7 @@ describe('modules/platform/bitbucket/pr-cache', () => {
       },
     ]);
     expect(cache).toEqual({
-      httpCache: {},
+      httpCache: expect.toBeNonEmptyObject(),
       platform: {
         bitbucket: {
           pullRequestsCache: {
@@ -170,7 +170,7 @@ describe('modules/platform/bitbucket/pr-cache', () => {
       { number: 1, title: 'title' },
     ]);
     expect(cache).toEqual({
-      httpCache: {},
+      httpCache: expect.toBeNonEmptyObject(),
       platform: {
         bitbucket: {
           pullRequestsCache: {

--- a/lib/util/http/cache/abstract-http-cache-provider.ts
+++ b/lib/util/http/cache/abstract-http-cache-provider.ts
@@ -65,15 +65,17 @@ export abstract class AbstractHttpCacheProvider implements HttpCacheProvider {
         httpResponse,
         timestamp,
       });
-      if (newHttpCache) {
-        logger.debug(
-          `http cache: saving ${url} (etag=${etag}, lastModified=${lastModified})`,
-        );
-        await this.persist(url, newHttpCache as HttpCache);
-      } else {
+
+      // istanbul ignore if: should never happen
+      if (!newHttpCache) {
         logger.debug(`http cache: failed to persist cache for ${url}`);
+        return resp;
       }
 
+      logger.debug(
+        `http cache: saving ${url} (etag=${etag}, lastModified=${lastModified})`,
+      );
+      await this.persist(url, newHttpCache as HttpCache);
       return resp;
     }
 

--- a/lib/util/http/cache/repository-http-cache-provider.spec.ts
+++ b/lib/util/http/cache/repository-http-cache-provider.spec.ts
@@ -1,6 +1,5 @@
 import { Http } from '..';
 import * as httpMock from '../../../../test/http-mock';
-import { logger } from '../../../../test/util';
 import { resetCache } from '../../cache/repository';
 import { repoCacheProvider } from './repository-http-cache-provider';
 

--- a/lib/util/http/cache/repository-http-cache-provider.spec.ts
+++ b/lib/util/http/cache/repository-http-cache-provider.spec.ts
@@ -59,19 +59,6 @@ describe('util/http/cache/repository-http-cache-provider', () => {
     });
   });
 
-  it('reports if cache could not be persisted', async () => {
-    httpMock
-      .scope('https://example.com')
-      .get('/foo/bar')
-      .reply(200, { msg: 'Hello, world!' });
-
-    await http.getJsonUnchecked('https://example.com/foo/bar');
-
-    expect(logger.logger.debug).toHaveBeenCalledWith(
-      'http cache: failed to persist cache for https://example.com/foo/bar',
-    );
-  });
-
   it('handles abrupt cache reset', async () => {
     const scope = httpMock.scope('https://example.com');
 

--- a/lib/util/http/cache/schema.ts
+++ b/lib/util/http/cache/schema.ts
@@ -7,10 +7,6 @@ export const HttpCacheSchema = z
     httpResponse: z.unknown(),
     timestamp: z.string(),
   })
-  .refine(
-    ({ etag, lastModified }) => etag ?? lastModified,
-    'Cache object should have `etag` or `lastModified` fields',
-  )
   .nullable()
   .catch(null);
 export type HttpCache = z.infer<typeof HttpCacheSchema>;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Upcoming memory provider implementation doesn't care about revalidation mechanics, so having either of `etag`/`last-modified` headers should be optional.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
