### PR TITLE
docs: clarify breaking changes to `GOSUMDB` in Renovate v38

### DIFF
--- a/docs/usage/release-notes-for-major-versions.md
+++ b/docs/usage/release-notes-for-major-versions.md
@@ -91,7 +91,7 @@ Specific:
 - **git:** check _all_ commits on the branch to decide if the branch was modified ([#28225](https://github.com/renovatebot/renovate/pull/28225))
 - **gitea:** use "bearer auth" instead of "token auth" to authenticate to the Gitea platform
 - **github:** if you run Renovate as a GitHub app then `platformCommit` is automatically enabled
-- **gomod:** the value of `GOSUMDB` has changed, which will now check signatures for modules. If you are using Renovate with private Go modules, you will need to set `GOPRIVATE`. For more details, see [Go's official documentation for working with private Go modules](https://golang.org/ref/mod#private-modules).
+- **gomod:** the value of `GOSUMDB` was previously set to `off`, meaning the Go toolchain would not validate signatures for modules. This has now been corrected, which may result in errors updating Go modules. In particular, if you are using Renovate with private Go modules, you will need to set `GOPRIVATE`. For more details, see [Go's official documentation for working with private Go modules](https://golang.org/ref/mod#private-modules).
 - **http:** remove `dnsCache`
 - **logging:** you must set file logging via env, not in `config.js`
 - **manager/pep621:** change `depName` for `pep621` dependencies. This causes the branch name for `pep621` updates to change, which in turn means Renovate may autoclose and re-open some `pep621` PRs. Also, Renovate may start grouping dependencies into a single PR.

--- a/docs/usage/release-notes-for-major-versions.md
+++ b/docs/usage/release-notes-for-major-versions.md
@@ -91,6 +91,7 @@ Specific:
 - **git:** check _all_ commits on the branch to decide if the branch was modified ([#28225](https://github.com/renovatebot/renovate/pull/28225))
 - **gitea:** use "bearer auth" instead of "token auth" to authenticate to the Gitea platform
 - **github:** if you run Renovate as a GitHub app then `platformCommit` is automatically enabled
+- **gomod:** the value of `GOSUMDB` has changed, which will now check signatures for modules. If you are using Renovate with private Go modules, you will need to set `GOPRIVATE`. For more details, see [Go's official documentation for working with private Go modules](https://golang.org/ref/mod#private-modules).
 - **http:** remove `dnsCache`
 - **logging:** you must set file logging via env, not in `config.js`
 - **manager/pep621:** change `depName` for `pep621` dependencies. This causes the branch name for `pep621` updates to change, which in turn means Renovate may autoclose and re-open some `pep621` PRs. Also, Renovate may start grouping dependencies into a single PR.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

As per discussions in [0], this can be an unexpected change for
consumers, who may start receiving errors when using private Go modules.

Although the change was via `containerbase`[1], we should call it out
here as a breaking change, as it does impact some users.

[0]: https://github.com/renovatebot/renovate/discussions/30627
[1]: https://github.com/containerbase/base/pull/2727

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
