### PR TITLE
test(bazel-module): test context failure cases with public interface

### DIFF
--- a/lib/modules/manager/bazel-module/context.spec.ts
+++ b/lib/modules/manager/bazel-module/context.spec.ts
@@ -119,39 +119,18 @@ describe('modules/manager/bazel-module/context', () => {
       });
     });
 
-    describe('.currentRule', () => {
-      it('returns the record fragment if it is current', () => {
-        const ctx = new Ctx().startRule('dummy');
-        expect(ctx.currentRule).toEqual(fragments.rule('dummy'));
-      });
-
-      it('throws if there is no current', () => {
-        const ctx = new Ctx();
-        expect(() => ctx.currentRule).toThrow(
-          new Error('Requested current, but no value.'),
-        );
-      });
-
-      it('throws if the current is not a rule fragment', () => {
-        const ctx = new Ctx().startArray();
-        expect(() => ctx.currentRule).toThrow(
-          new Error('Requested current rule, but does not exist.'),
-        );
-      });
+    it('throws on unbalanced endRule', () => {
+      const ctx = new Ctx().startRule('foo').startArray();
+      expect(() => ctx.endRule()).toThrow(
+        new Error('Requested current rule, but does not exist.'),
+      );
     });
 
-    describe('.currentArray', () => {
-      it('returns the array fragment if it is current', () => {
-        const ctx = new Ctx().startArray();
-        expect(ctx.currentArray).toEqual(fragments.array());
-      });
-
-      it('throws if the current is not an array fragment', () => {
-        const ctx = new Ctx().startRule('dummy');
-        expect(() => ctx.currentArray).toThrow(
-          new Error('Requested current array, but does not exist.'),
-        );
-      });
+    it('throws on unbalanced endArray', () => {
+      const ctx = new Ctx().startArray().startRule('dummy');
+      expect(() => ctx.endArray()).toThrow(
+        new Error('Requested current array, but does not exist.'),
+      );
     });
 
     it('throws if add an attribute without a parent', () => {

--- a/lib/modules/manager/bazel-module/context.spec.ts
+++ b/lib/modules/manager/bazel-module/context.spec.ts
@@ -119,6 +119,13 @@ describe('modules/manager/bazel-module/context', () => {
       });
     });
 
+    it('throws on missing current', () => {
+      const ctx = new Ctx()
+      expect(() => ctx.endRule()).toThrow(
+        new Error('Requested current, but no value.'),
+      );
+    });
+
     it('throws on unbalanced endRule', () => {
       const ctx = new Ctx().startRule('foo').startArray();
       expect(() => ctx.endRule()).toThrow(

--- a/lib/modules/manager/bazel-module/context.spec.ts
+++ b/lib/modules/manager/bazel-module/context.spec.ts
@@ -120,7 +120,7 @@ describe('modules/manager/bazel-module/context', () => {
     });
 
     it('throws on missing current', () => {
-      const ctx = new Ctx()
+      const ctx = new Ctx();
       expect(() => ctx.endRule()).toThrow(
         new Error('Requested current, but no value.'),
       );

--- a/lib/modules/manager/bazel-module/context.ts
+++ b/lib/modules/manager/bazel-module/context.ts
@@ -48,7 +48,8 @@ export class Ctx implements CtxCompatible {
     }
     return c;
   }
-  get currentRule(): RuleFragment {
+
+  private get currentRule(): RuleFragment {
     const current = this.current;
     if (current.type === 'rule') {
       return current;
@@ -56,7 +57,7 @@ export class Ctx implements CtxCompatible {
     throw new Error('Requested current rule, but does not exist.');
   }
 
-  get currentExtensionTag(): ExtensionTagFragment {
+  private get currentExtensionTag(): ExtensionTagFragment {
     const current = this.current;
     if (current.type === 'extensionTag') {
       return current;
@@ -64,7 +65,7 @@ export class Ctx implements CtxCompatible {
     throw new Error('Requested current extension tag, but does not exist.');
   }
 
-  get currentArray(): ArrayFragment {
+  private get currentArray(): ArrayFragment {
     const current = this.current;
     if (current.type === 'array') {
       return current;


### PR DESCRIPTION
## Changes

Ctx exposed some of it's internals merely for the purpose of testing. We adjust the tests to use the "real" public interface only.

## Context

Refactoring / simplification after #34154

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository