### PR TITLE
chore: find issue with missing `issueType`

### DIFF
--- a/tools/find-issues-with-missing-labels.sh
+++ b/tools/find-issues-with-missing-labels.sh
@@ -4,8 +4,10 @@
 # For example, if the repository added a "type:task" type label, then add "-label:type:task" to the TYPE_LABELS_FILTER.
 
 PRIORITY_LABELS_FILTER='-label:priority-1-critical -label:priority-2-high -label:priority-3-medium -label:priority-4-low'
+ISSUE_TYPE_FILTER='-type:Bug -type:Feature -type:Task'
 
 HAS_ISSUES_MISSING_LABELS=false
+HAS_ISSUES_MISSING_ISSUE_TYPE=false
 
 ISSUE_BODY="# Label check action\n"
 
@@ -13,49 +15,72 @@ REPO='renovatebot/renovate'
 
 ISSUE_TITLE="Issues with missing labels"
 
-for FILTER in "$PRIORITY_LABELS_FILTER"; do
-  # Extract the label type from the filter
-  LABEL_TYPE=$(echo "$FILTER" | cut -d ':' -f 2 | cut -d '-' -f 1)
+# Extract the label type from the filter
+LABEL_TYPE=$(echo "$PRIORITY_LABELS_FILTER" | cut -d ':' -f 2 | cut -d '-' -f 1)
 
-  # Fetch issues that match the filter
-  ISSUES_MISSING_LABEL=$(gh issue list --repo $REPO --limit 100000 -s open -S "$FILTER" --json "number,title") || { echo "Failed to fetch issues without $LABEL_TYPE labels"; exit 1; }
-  # Ignore the Issue from the "Find issues with missing labels" Action
-  ISSUES_MISSING_LABEL=$(echo "$ISSUES_MISSING_LABEL" | jq --arg title "$ISSUE_TITLE" 'map(select(.title != $title))')
+# Fetch issues that match the filter
+ISSUES_MISSING_LABEL=$(gh issue list --repo $REPO --limit 100000 -s open -S "$PRIORITY_LABELS_FILTER" --json "number,title") || { echo "Failed to fetch issues without $LABEL_TYPE labels"; exit 1; }
+# Ignore the Issue from the "Find issues with missing labels" Action
+ISSUES_MISSING_LABEL=$(echo "$ISSUES_MISSING_LABEL" | jq --arg title "$ISSUE_TITLE" 'map(select(.title != $title))')
 
-  if [ "$ISSUES_MISSING_LABEL" != "[]" ]; then
+if [ "$ISSUES_MISSING_LABEL" != "[]" ]; then
     HAS_ISSUES_MISSING_LABELS=true
-
+    
     # Create a list of issue numbers
     FORMATTED_OUTPUT=$(echo "$ISSUES_MISSING_LABEL" | jq -r '.[].number' | sed 's/^/- https:\/\/redirect.github.com\/renovatebot\/renovate\/issues\//')
-
+    
     # Count the issues and decide if the output should be singular or plural
     ISSUE_COUNT=$(echo "$ISSUES_MISSING_LABEL" | jq '. | length')
     ISSUE_SINGULAR_PLURAL=$(if [ "$ISSUE_COUNT" -eq 1 ]; then echo "issue"; else echo "issues"; fi)
-
+    
     # Append the "list of issues without labels" to the issue body
     ISSUE_BODY="$ISSUE_BODY## Found $ISSUE_COUNT $ISSUE_SINGULAR_PLURAL missing \`$LABEL_TYPE:\` labels:\n$FORMATTED_OUTPUT\n"
-  fi
-done
+fi
 
-if [ "$HAS_ISSUES_MISSING_LABELS" = false ]; then
-  echo "All checked issues have labels. Exiting the action."
-  ISSUE_BODY="$ISSUE_BODY All checked issues are correctly labeled.\n"
-  exit 0
+# Extract the issue type from the filter
+LABEL_TYPE=$(echo "$ISSUE_TYPE_FILTER" | cut -d ':' -f 2)
+
+# Fetch issues that match the filter
+ISSUES_MISSING_TYPE=$(gh issue list --repo $REPO --limit 100000 -s open -S "$ISSUE_TYPE_FILTER" --json "number,title") || { echo "Failed to fetch issues without $LABEL_TYPE"; exit 1; }
+# Ignore the Issue from the "Find issues with missing labels" Action
+ISSUES_MISSING_TYPE=$(echo "$ISSUES_MISSING_TYPE" | jq --arg title "$ISSUE_TITLE" 'map(select(.title != $title))')
+
+if [ "$ISSUES_MISSING_TYPE" != "[]" ]; then
+    HAS_ISSUES_MISSING_ISSUE_TYPE=true
+    
+    # Create a list of issue numbers
+    FORMATTED_OUTPUT=$(echo "$ISSUES_MISSING_TYPE" | jq -r '.[].number' | sed 's/^/- https:\/\/redirect.github.com\/renovatebot\/renovate\/issues\//')
+    
+    # Count the issues and decide if the output should be singular or plural
+    ISSUE_COUNT=$(echo "$ISSUES_MISSING_TYPE" | jq '. | length')
+    ISSUE_SINGULAR_PLURAL=$(if [ "$ISSUE_COUNT" -eq 1 ]; then echo "issue"; else echo "issues"; fi)
+    
+    # Append the "list of issues without labels" to the issue body
+    ISSUE_BODY="$ISSUE_BODY## Found $ISSUE_COUNT $ISSUE_SINGULAR_PLURAL missing issue type:\n$FORMATTED_OUTPUT\n"
+fi
+
+if [[ "$HAS_ISSUES_MISSING_LABELS" == "false" && "$HAS_ISSUES_MISSING_ISSUE_TYPE" == "false" ]]; then
+    echo "All checked issues have labels and type."
+    ISSUE_BODY="$ISSUE_BODY All checked issues are correctly labeled and have issue type.\n"
 fi
 
 LABEL_CHECK_ISSUE_EXISTS=$(gh search issues --repo $REPO --json "number,author,title" | jq --arg title "$ISSUE_TITLE" 'map(select(.title == $title and .author.type == "Bot"))') || { echo "Failed to fetch existing label check issue"; exit 1; }
 ISSUE_NUMBER=$(echo "$LABEL_CHECK_ISSUE_EXISTS" | jq -r '.[].number')
 
 if [ -z "$ISSUE_NUMBER" ]; then
-
-  # Create a new issue (with the list of issues in it).
-  gh issue create --repo $REPO --title "$ISSUE_TITLE" --body "$(echo -e "$ISSUE_BODY")" || { echo "Failed to create issue."; exit 1; }
+    
+    # Create a new issue (with the list of issues in it).
+    gh issue create --repo $REPO --title "$ISSUE_TITLE" --body "$(echo -e "$ISSUE_BODY")" || { echo "Failed to create issue."; exit 1; }
 else
-  # Edit the open issue, and update the list of issues.
-  gh issue edit "$ISSUE_NUMBER" --repo $REPO --title "$ISSUE_TITLE" --body "$(echo -e "$ISSUE_BODY")" || { echo "Failed to update issue."; exit 1; }
+    # Edit the open issue, and update the list of issues.
+    gh issue edit "$ISSUE_NUMBER" --repo $REPO --title "$ISSUE_TITLE" --body "$(echo -e "$ISSUE_BODY")" || { echo "Failed to update issue."; exit 1; }
+    
+    # Re-open the issue.
+    gh issue reopen "$ISSUE_NUMBER" --repo $REPO || { echo "Failed to reopen issue"; exit 1; }
+fi
 
-  # Re-open the issue.
-  gh issue reopen "$ISSUE_NUMBER" --repo $REPO || { echo "Failed to reopen issue"; exit 1; }
+if [[ "$HAS_ISSUES_MISSING_LABELS" == "false" && "$HAS_ISSUES_MISSING_ISSUE_TYPE" == "false" ]]; then
+    exit 0
 fi
 
 # Show the list of "issues with missing labels" in the logs.
@@ -65,4 +90,3 @@ echo -e "$ISSUE_BODY"
 echo "Found issues without labels. Please check the issue(s) listed above. Exiting the action."
 
 exit 1
-

--- a/tools/find-issues-with-missing-labels.sh
+++ b/tools/find-issues-with-missing-labels.sh
@@ -55,7 +55,7 @@ if [ "$ISSUES_MISSING_TYPE" != "[]" ]; then
     ISSUE_COUNT=$(echo "$ISSUES_MISSING_TYPE" | jq '. | length')
     ISSUE_SINGULAR_PLURAL=$(if [ "$ISSUE_COUNT" -eq 1 ]; then echo "issue"; else echo "issues"; fi)
     
-    # Append the "list of issues without labels" to the issue body
+    # Append the "list of issues without issye type" to the issue body
     ISSUE_BODY="$ISSUE_BODY## Found $ISSUE_COUNT $ISSUE_SINGULAR_PLURAL missing issue type:\n$FORMATTED_OUTPUT\n"
 fi
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- Looks for issues with missing `issueType` and adds them to the PR (`Issue with missing labels`)
<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or https://github.com/reno-test-rahul/repro-33701/issues/5
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
