### PR TITLE
feat(instrumentation/reporting): add libyear support

### DIFF
--- a/lib/instrumentation/reporting.ts
+++ b/lib/instrumentation/reporting.ts
@@ -14,6 +14,15 @@ const report: Report = {
   repositories: {},
 };
 
+/**
+ * Reset the report
+ * Should only be used for testing
+ */
+export function resetReport(): void {
+  report.problems = [];
+  report.repositories = {};
+}
+
 export function addBranchStats(
   config: RenovateConfig,
   branchesInformation: Partial<BranchCache>[],
@@ -37,6 +46,26 @@ export function addExtractionStats(
   coerceRepo(config.repository!);
   report.repositories[config.repository!].packageFiles =
     extractResult.packageFiles;
+}
+
+export function addLibYears(
+  config: RenovateConfig,
+  managerLibYears: Record<string, number>,
+  totalLibYears: number,
+  totalDepsCount: number,
+  outdatedDepsCount: number,
+): void {
+  if (is.nullOrUndefined(config.reportType)) {
+    return;
+  }
+
+  coerceRepo(config.repository!);
+  report.repositories[config.repository!].libYears = {
+    managerLibYears,
+    totalLibYears,
+    totalDepsCount,
+    outdatedDepsCount,
+  };
 }
 
 export function finalizeReport(): void {

--- a/lib/instrumentation/types.ts
+++ b/lib/instrumentation/types.ts
@@ -37,4 +37,12 @@ interface RepoReport {
   problems: BunyanRecord[];
   branches: Partial<BranchCache>[];
   packageFiles: Record<string, PackageFile[]>;
+  libYears?: LibYears;
+}
+
+export interface LibYears {
+  outdatedDepsCount: number;
+  totalDepsCount: number;
+  totalLibYears: number;
+  managerLibYears: Record<string, number>;
 }

--- a/lib/workers/repository/process/extract-update.ts
+++ b/lib/workers/repository/process/extract-update.ts
@@ -212,7 +212,7 @@ export async function lookup(
 ): Promise<ExtractResult> {
   await fetchVulnerabilities(config, packageFiles);
   await fetchUpdates(config, packageFiles);
-  calculateLibYears(packageFiles);
+  calculateLibYears(config, packageFiles);
   const { branches, branchList } = await branchifyUpgrades(
     config,
     packageFiles,

--- a/lib/workers/repository/process/libyear.spec.ts
+++ b/lib/workers/repository/process/libyear.spec.ts
@@ -1,12 +1,18 @@
+import type { RenovateConfig } from '../../../../test/util';
 import { logger } from '../../../../test/util';
+import { addLibYears } from '../../../instrumentation/reporting';
 import type { PackageFile } from '../../../modules/manager/types';
 import type { Timestamp } from '../../../util/timestamp';
 import { calculateLibYears } from './libyear';
 
+jest.mock('../../../instrumentation/reporting');
+
 describe('workers/repository/process/libyear', () => {
+  const config: RenovateConfig = {};
+
   describe('calculateLibYears', () => {
     it('returns early if no packageFiles', () => {
-      calculateLibYears(undefined);
+      calculateLibYears(config, undefined);
       expect(logger.logger.debug).not.toHaveBeenCalled();
     });
 
@@ -87,7 +93,7 @@ describe('workers/repository/process/libyear', () => {
           },
         ],
       };
-      calculateLibYears(packageFiles);
+      calculateLibYears(config, packageFiles);
       expect(logger.logger.debug).toHaveBeenCalledWith(
         'No currentVersionTimestamp for some/image',
       );
@@ -110,6 +116,18 @@ describe('workers/repository/process/libyear', () => {
           outdatedDepsCount: 4,
         },
         'Repository libYears',
+      );
+      expect(addLibYears).toHaveBeenCalledWith(
+        config,
+        {
+          bundler: 0.5027322404371585,
+          dockerfile: 0,
+          npm: 1,
+        },
+        // eslint-disable-next-line no-loss-of-precision
+        1.5027322404371585,
+        5,
+        4,
       );
     });
 
@@ -172,7 +190,7 @@ describe('workers/repository/process/libyear', () => {
           },
         ],
       };
-      calculateLibYears(packageFiles);
+      calculateLibYears(config, packageFiles);
       expect(logger.logger.debug).toHaveBeenCalledWith(
         {
           managerLibYears: {

--- a/lib/workers/repository/process/libyear.ts
+++ b/lib/workers/repository/process/libyear.ts
@@ -1,4 +1,6 @@
 import { DateTime } from 'luxon';
+import type { RenovateConfig } from '../../../config/types';
+import { addLibYears } from '../../../instrumentation/reporting';
 import { logger } from '../../../logger';
 import type { PackageFile } from '../../../modules/manager/types';
 
@@ -12,6 +14,7 @@ interface DepInfo {
   libYear?: number;
 }
 export function calculateLibYears(
+  config: RenovateConfig,
   packageFiles?: Record<string, PackageFile[]>,
 ): void {
   if (!packageFiles) {
@@ -70,14 +73,23 @@ export function calculateLibYears(
   }
 
   const [totalDepsCount, outdatedDepsCount, totalLibYears] = getCounts(allDeps);
+  const managerLibYears = getManagerLibYears(allDeps);
   logger.debug(
     {
-      managerLibYears: getManagerLibYears(allDeps),
+      managerLibYears,
       totalLibYears,
       totalDepsCount,
       outdatedDepsCount,
     },
     'Repository libYears',
+  );
+
+  addLibYears(
+    config,
+    managerLibYears,
+    totalLibYears,
+    totalDepsCount,
+    outdatedDepsCount,
   );
 }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Adds libyears to the reporting feature
<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
