### PR TITLE
fix(reconfigure): massage config prior to validation

### DIFF
--- a/lib/workers/repository/reconfigure/validate.spec.ts
+++ b/lib/workers/repository/reconfigure/validate.spec.ts
@@ -225,4 +225,24 @@ describe('workers/repository/reconfigure/validate', () => {
       state: 'green',
     });
   });
+
+  it('handles array fields which accept strings', async () => {
+    fs.readLocalFile.mockResolvedValueOnce(`
+        {
+          "packageRules": [
+            {
+              "description": "test",
+              "matchPackageNames": ["pkg"],
+              "enabled": false
+            }
+        }
+        `);
+    await validateReconfigureBranch(config);
+    expect(platform.setBranchStatus).toHaveBeenCalledWith({
+      branchName: 'prefix/reconfigure',
+      context: 'renovate/config-validation',
+      description: 'Validation Successful',
+      state: 'green',
+    });
+  });
 });

--- a/lib/workers/repository/reconfigure/validate.spec.ts
+++ b/lib/workers/repository/reconfigure/validate.spec.ts
@@ -235,6 +235,7 @@ describe('workers/repository/reconfigure/validate', () => {
               "matchPackageNames": ["pkg"],
               "enabled": false
             }
+          ]
         }
         `);
     await validateReconfigureBranch(config);

--- a/lib/workers/repository/reconfigure/validate.ts
+++ b/lib/workers/repository/reconfigure/validate.ts
@@ -1,5 +1,6 @@
 import is from '@sindresorhus/is';
 import JSON5 from 'json5';
+import { massageConfig } from '../../../config/massage';
 import type { RenovateConfig } from '../../../config/types';
 import { validateConfig } from '../../../config/validation';
 import { logger } from '../../../logger';
@@ -138,7 +139,8 @@ export async function validateReconfigureBranch(
   }
 
   // perform validation and provide a passing or failing check based on result
-  const validationResult = await validateConfig('repo', configFileParsed);
+  const massagedConfig = massageConfig(configFileParsed);
+  const validationResult = await validateConfig('repo', massagedConfig);
 
   // failing check
   if (validationResult.errors.length > 0) {


### PR DESCRIPTION
Fixes the following error, seen when validating MRs using the GitLab renovate-runner project:

    Configuration option 'packageRules[0].description' should be a list (Array)

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

Please forgive my lack of TypeScript-fu.

## Changes

Massages the configuration prior to validation of PRs with branches following the `{{branchPrefix}}reconfigure` pattern.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

There were ongoing discussions in https://github.com/renovatebot/renovate/discussions/28429 regarding validation errors seen for `description` fields that were passed as strings rather than arrays, which ought to be valid as per documentation.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
