### PR TITLE
fix(platform/gitlab): Revert "feat(platform/gitlab): use Notes API for automerge to support merge trains"

### DIFF
--- a/docs/usage/faq.md
+++ b/docs/usage/faq.md
@@ -44,6 +44,7 @@ Some major platform features are not supported at all by Renovate.
 | --------------------------------------- | ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Jira issues                             | Bitbucket                                 | [#20568](https://github.com/renovatebot/renovate/issues/20568)                                                                                                                               |
 | Jira issues                             | Bitbucket Server                          | [#3796](https://github.com/renovatebot/renovate/issues/3796)                                                                                                                                 |
+| Merge trains                            | GitLab                                    | [#5573](https://github.com/renovatebot/renovate/issues/5573)                                                                                                                                 |
 | Configurable merge strategy and message | Only Bitbucket, Forgejo and Gitea for now | [#10867](https://github.com/renovatebot/renovate/issues/10867) [#10869](https://github.com/renovatebot/renovate/issues/10869) [#10870](https://github.com/renovatebot/renovate/issues/10870) |
 
 ## What is this `main` branch I see in the documentation?

--- a/lib/modules/platform/gitlab/index.spec.ts
+++ b/lib/modules/platform/gitlab/index.spec.ts
@@ -2143,7 +2143,7 @@ describe('modules/platform/gitlab/index', () => {
         .reply(200)
         .get('/api/v4/projects/undefined/merge_requests/12345')
         .reply(200)
-        .post('/api/v4/projects/undefined/merge_requests/12345/notes')
+        .put('/api/v4/projects/undefined/merge_requests/12345/merge')
         .reply(200);
       expect(
         await gitlab.createPr({
@@ -2187,7 +2187,9 @@ describe('modules/platform/gitlab/index', () => {
         .reply(200, reply_body)
         .get('/api/v4/projects/undefined/merge_requests/12345')
         .reply(200, reply_body)
-        .post('/api/v4/projects/undefined/merge_requests/12345/notes')
+        .put('/api/v4/projects/undefined/merge_requests/12345/merge')
+        .reply(405, {})
+        .put('/api/v4/projects/undefined/merge_requests/12345/merge')
         .reply(200, {});
       process.env.RENOVATE_X_GITLAB_AUTO_MERGEABLE_CHECK_ATTEMPS = '3';
       const pr = await gitlab.createPr({
@@ -2213,7 +2215,12 @@ describe('modules/platform/gitlab/index', () => {
       expect(logger.debug).toHaveBeenCalledWith(
         'PR not yet in mergeable state. Retrying 3',
       );
-      expect(timers.setTimeout.mock.calls).toMatchObject([[100], [400], [900]]);
+      expect(timers.setTimeout.mock.calls).toMatchObject([
+        [100],
+        [400],
+        [900],
+        [100],
+      ]);
     });
 
     it('should parse detailed_merge_status attribute on >= 15.6', async () => {
@@ -2238,7 +2245,7 @@ describe('modules/platform/gitlab/index', () => {
         .reply(200, reply_body)
         .get('/api/v4/projects/undefined/merge_requests/12345')
         .reply(200, reply_body)
-        .post('/api/v4/projects/undefined/merge_requests/12345/notes')
+        .put('/api/v4/projects/undefined/merge_requests/12345/merge')
         .reply(200, {});
       process.env.RENOVATE_X_GITLAB_AUTO_MERGEABLE_CHECK_ATTEMPS = '3';
       const pr = await gitlab.createPr({
@@ -2267,6 +2274,75 @@ describe('modules/platform/gitlab/index', () => {
       expect(timers.setTimeout.mock.calls).toMatchObject([[100], [400], [900]]);
     });
 
+    it('should retry auto merge creation on 405 method not allowed', async () => {
+      await initPlatform('15.6.0-ee');
+      const reply_body = {
+        detailed_merge_status: 'pending',
+      };
+      httpMock
+        .scope(gitlabApiHost)
+        .post('/api/v4/projects/undefined/merge_requests')
+        .reply(200, {
+          id: 1,
+          iid: 12345,
+          title: 'some title',
+          source_branch: 'some-branch',
+          target_branch: 'master',
+          description: 'the-body',
+        })
+        .get('/api/v4/projects/undefined/merge_requests/12345')
+        .reply(200, reply_body)
+        .get('/api/v4/projects/undefined/merge_requests/12345')
+        .reply(200, reply_body)
+        .get('/api/v4/projects/undefined/merge_requests/12345')
+        .reply(200, reply_body)
+        .put('/api/v4/projects/undefined/merge_requests/12345/merge')
+        .reply(405, {})
+        .put('/api/v4/projects/undefined/merge_requests/12345/merge')
+        .reply(405, {})
+        .put('/api/v4/projects/undefined/merge_requests/12345/merge')
+        .reply(200, {});
+      process.env.RENOVATE_X_GITLAB_AUTO_MERGEABLE_CHECK_ATTEMPS = '3';
+      const pr = await gitlab.createPr({
+        sourceBranch: 'some-branch',
+        targetBranch: 'master',
+        prTitle: 'some-title',
+        prBody: 'the-body',
+        platformPrOptions: {
+          usePlatformAutomerge: true,
+        },
+      });
+      expect(pr).toMatchObject({
+        number: 12345,
+        sourceBranch: 'some-branch',
+        title: 'some title',
+      });
+      expect(logger.debug).toHaveBeenCalledWith(
+        'PR not yet in mergeable state. Retrying 1',
+      );
+      expect(logger.debug).toHaveBeenCalledWith(
+        'PR not yet in mergeable state. Retrying 2',
+      );
+      expect(logger.debug).toHaveBeenCalledWith(
+        'PR not yet in mergeable state. Retrying 3',
+      );
+      expect(logger.debug).toHaveBeenCalledWith(
+        expect.any(Object),
+        'Automerge on PR creation failed. Retrying 1',
+      );
+      expect(logger.debug).toHaveBeenCalledWith(
+        expect.any(Object),
+        'Automerge on PR creation failed. Retrying 2',
+      );
+      expect(timers.setTimeout.mock.calls).toMatchObject([
+        [100],
+        [400],
+        [900],
+        [100],
+        [400],
+      ]);
+    });
+
     it('should not retry if MR is mergeable and pipeline is running', async () => {
       await initPlatform('15.6.0-ee');
       const reply_body = {
@@ -2288,7 +2364,7 @@ describe('modules/platform/gitlab/index', () => {
         })
         .get('/api/v4/projects/undefined/merge_requests/12345')
         .reply(200, reply_body)
-        .post('/api/v4/projects/undefined/merge_requests/12345/notes')
+        .put('/api/v4/projects/undefined/merge_requests/12345/merge')
         .reply(200, {});
       const pr = await gitlab.createPr({
         sourceBranch: 'some-branch',
@@ -2410,7 +2486,7 @@ describe('modules/platform/gitlab/index', () => {
             status: 'success',
           },
         })
-        .post('/api/v4/projects/undefined/merge_requests/12345/notes')
+        .put('/api/v4/projects/undefined/merge_requests/12345/merge')
         .reply(200)
         .get('/api/v4/projects/undefined/merge_requests/12345/approval_rules')
         .reply(200, [])
@@ -2504,7 +2580,7 @@ describe('modules/platform/gitlab/index', () => {
             status: 'success',
           },
         })
-        .post('/api/v4/projects/undefined/merge_requests/12345/notes')
+        .put('/api/v4/projects/undefined/merge_requests/12345/merge')
         .reply(200)
         .get('/api/v4/projects/undefined/merge_requests/12345/approval_rules')
         .reply(200, [
@@ -2562,7 +2638,7 @@ describe('modules/platform/gitlab/index', () => {
             status: 'success',
           },
         })
-        .post('/api/v4/projects/undefined/merge_requests/12345/notes')
+        .put('/api/v4/projects/undefined/merge_requests/12345/merge')
         .reply(200)
         .get('/api/v4/projects/undefined/merge_requests/12345/approval_rules')
         .reply(200, [
@@ -2631,7 +2707,7 @@ describe('modules/platform/gitlab/index', () => {
             status: 'success',
           },
         })
-        .post('/api/v4/projects/undefined/merge_requests/12345/notes')
+        .put('/api/v4/projects/undefined/merge_requests/12345/merge')
         .reply(200)
         .get('/api/v4/projects/undefined/merge_requests/12345/approval_rules')
         .reply(200, [
@@ -2710,7 +2786,7 @@ describe('modules/platform/gitlab/index', () => {
             status: 'success',
           },
         })
-        .post('/api/v4/projects/undefined/merge_requests/12345/notes')
+        .put('/api/v4/projects/undefined/merge_requests/12345/merge')
         .reply(200)
         .get('/api/v4/projects/undefined/merge_requests/12345/approval_rules')
         .reply(200, [
@@ -2760,7 +2836,7 @@ describe('modules/platform/gitlab/index', () => {
             status: 'success',
           },
         })
-        .post('/api/v4/projects/undefined/merge_requests/12345/notes')
+        .put('/api/v4/projects/undefined/merge_requests/12345/merge')
         .reply(200)
         .get('/api/v4/projects/undefined/merge_requests/12345/approval_rules')
         .reply(200, [])
@@ -3300,7 +3376,7 @@ describe('modules/platform/gitlab/index', () => {
             status: 'running',
           },
         })
-        .post('/api/v4/projects/undefined/merge_requests/12345/notes')
+        .put('/api/v4/projects/undefined/merge_requests/12345/merge')
         .reply(200);
 
       await expect(gitlab.reattemptPlatformAutomerge?.(pr)).toResolve();

--- a/lib/modules/platform/gitlab/index.ts
+++ b/lib/modules/platform/gitlab/index.ts
@@ -658,8 +658,6 @@ async function tryPrAutomerge(
         250,
       );
 
-      let diffHeadSha = '';
-
       // Check for correct merge request status before setting `merge_when_pipeline_succeeds` to  `true`.
       for (let attempt = 1; attempt <= retryTimes; attempt += 1) {
         const { body } = await gitlabApi.getJsonUnchecked<{
@@ -668,13 +666,9 @@ async function tryPrAutomerge(
           pipeline: {
             status: string;
           };
-          sha: string;
         }>(`projects/${config.repository}/merge_requests/${pr}`, {
           memCache: false,
         });
-
-        diffHeadSha = body.sha;
-
         // detailed_merge_status is available with Gitlab >=15.6.0
         const use_detailed_merge_status = !!body.detailed_merge_status;
         const detailed_merge_status_check =
@@ -696,20 +690,28 @@ async function tryPrAutomerge(
         await setTimeout(mergeDelay * attempt ** 2); // exponential backoff
       }
 
-      // Use the /merge "quick action" to automerge, which will work for
-      // both merge trains or non-train merges
-      // Associated docs:
-      //  - https://docs.gitlab.com/api/notes/#create-new-merge-request-note
-      //  - https://docs.gitlab.com/user/project/quick_actions/
-      await gitlabApi.postJson(
-        `projects/${config.repository}/merge_requests/${pr}/notes`,
-        {
-          body: {
-            body: '/merge',
-            merge_request_diff_head_sha: diffHeadSha,
-          },
-        },
-      );
+      // Even if Gitlab returns a "merge-able" merge request status, enabling auto-merge sometimes
+      // returns a 405 Method Not Allowed. It seems to be a timing issue within Gitlab.
+      for (let attempt = 1; attempt <= retryTimes; attempt += 1) {
+        try {
+          await gitlabApi.putJson(
+            `projects/${config.repository}/merge_requests/${pr}/merge`,
+            {
+              body: {
+                should_remove_source_branch: true,
+                merge_when_pipeline_succeeds: true,
+              },
+            },
+          );
+          break;
+        } catch (err) {
+          logger.debug(
+            { err },
+            `Automerge on PR creation failed. Retrying ${attempt}`,
+          );
+        }
+        await setTimeout(mergeDelay * attempt ** 2); // exponential backoff
+      }
     }
   } catch (err) /* istanbul ignore next */ {
     logger.debug({ err }, 'Automerge on PR creation failed');


### PR DESCRIPTION
Reverts renovatebot/renovate#34102