### PR TITLE
feat(gitea/forgejo): set poster server filter for pr cache

### DIFF
--- a/lib/modules/platform/gitea/index.ts
+++ b/lib/modules/platform/gitea/index.ts
@@ -63,6 +63,7 @@ import {
 } from './utils';
 
 interface GiteaRepoConfig {
+  ignorePrAuthor: boolean;
   repository: string;
   mergeMethod: PRMergeMethod;
 
@@ -263,6 +264,7 @@ const platform: Platform = {
     cloneSubmodules,
     cloneSubmodulesFilter,
     gitUrl,
+    ignorePrAuthor,
   }: RepoParams): Promise<RepoResult> {
     let repo: Repo;
 
@@ -270,6 +272,7 @@ const platform: Platform = {
     config.repository = repository;
     config.cloneSubmodules = !!cloneSubmodules;
     config.cloneSubmodulesFilter = cloneSubmodulesFilter;
+    config.ignorePrAuthor = !!ignorePrAuthor;
 
     // Try to fetch information about repository
     try {
@@ -475,7 +478,12 @@ const platform: Platform = {
   },
 
   getPrList(): Promise<Pr[]> {
-    return GiteaPrCache.getPrs(giteaHttp, config.repository, botUserName);
+    return GiteaPrCache.getPrs(
+      giteaHttp,
+      config.repository,
+      config.ignorePrAuthor,
+      botUserName,
+    );
   },
 
   async getPr(number: number): Promise<Pr | null> {
@@ -491,7 +499,13 @@ const platform: Platform = {
 
       // Add pull request to cache for further lookups / queries
       if (pr) {
-        await GiteaPrCache.setPr(giteaHttp, config.repository, botUserName, pr);
+        await GiteaPrCache.setPr(
+          giteaHttp,
+          config.repository,
+          config.ignorePrAuthor,
+          botUserName,
+          pr,
+        );
       }
     }
 
@@ -593,7 +607,13 @@ const platform: Platform = {
         throw new Error('Can not parse newly created Pull Request');
       }
 
-      await GiteaPrCache.setPr(giteaHttp, config.repository, botUserName, pr);
+      await GiteaPrCache.setPr(
+        giteaHttp,
+        config.repository,
+        config.ignorePrAuthor,
+        botUserName,
+        pr,
+      );
       return pr;
     } catch (err) {
       // When the user manually deletes a branch from Renovate, the PR remains but is no longer linked to any branch. In
@@ -687,7 +707,13 @@ const platform: Platform = {
     );
     const pr = toRenovatePR(gpr, botUserName);
     if (pr) {
-      await GiteaPrCache.setPr(giteaHttp, config.repository, botUserName, pr);
+      await GiteaPrCache.setPr(
+        giteaHttp,
+        config.repository,
+        config.ignorePrAuthor,
+        botUserName,
+        pr,
+      );
     }
   },
 

--- a/lib/modules/platform/gitea/pr-cache.ts
+++ b/lib/modules/platform/gitea/pr-cache.ts
@@ -130,7 +130,7 @@ export class GiteaPrCache {
   }
 
   private async sync(http: GiteaHttp): Promise<GiteaPrCache> {
-    let query: string | undefined = getQueryString({
+    let query: string | null = getQueryString({
       state: 'all',
       sort: 'recentupdate',
       // Fetch 100 PRs on the first run to ensure we have the most recent PRs.
@@ -159,7 +159,7 @@ export class GiteaPrCache {
       }
 
       const uri = parseUrl(parseLinkHeader(res.headers.link)?.next?.url);
-      query = uri ? uri.search : undefined;
+      query = uri ? uri.search : null;
     }
 
     this.updateItems();

--- a/lib/modules/platform/gitea/pr-cache.ts
+++ b/lib/modules/platform/gitea/pr-cache.ts
@@ -17,6 +17,7 @@ export class GiteaPrCache {
 
   private constructor(
     private repo: string,
+    private readonly ignorePrAuthor: boolean,
     private author: string | null,
   ) {
     const repoCache = getCache();
@@ -44,9 +45,10 @@ export class GiteaPrCache {
   private static async init(
     http: GiteaHttp,
     repo: string,
+    ignorePrAuthor: boolean,
     author: string | null,
   ): Promise<GiteaPrCache> {
-    const res = new GiteaPrCache(repo, author);
+    const res = new GiteaPrCache(repo, ignorePrAuthor, author);
     const isSynced = memCache.get<true | undefined>('gitea-pr-cache-synced');
 
     if (!isSynced) {
@@ -64,9 +66,10 @@ export class GiteaPrCache {
   static async getPrs(
     http: GiteaHttp,
     repo: string,
+    ignorePrAuthor: boolean,
     author: string,
   ): Promise<Pr[]> {
-    const prCache = await GiteaPrCache.init(http, repo, author);
+    const prCache = await GiteaPrCache.init(http, repo, ignorePrAuthor, author);
     return prCache.getPrs();
   }
 
@@ -78,10 +81,11 @@ export class GiteaPrCache {
   static async setPr(
     http: GiteaHttp,
     repo: string,
+    ignorePrAuthor: boolean,
     author: string,
     item: Pr,
   ): Promise<void> {
-    const prCache = await GiteaPrCache.init(http, repo, author);
+    const prCache = await GiteaPrCache.init(http, repo, ignorePrAuthor, author);
     prCache.setPr(item);
   }
 
@@ -126,18 +130,23 @@ export class GiteaPrCache {
   }
 
   private async sync(http: GiteaHttp): Promise<GiteaPrCache> {
-    const query = getQueryString({
+    let query: string | undefined = getQueryString({
       state: 'all',
       sort: 'recentupdate',
+      // Fetch 100 PRs on the first run to ensure we have the most recent PRs.
+      // Gitea / Forgejo will cap appropriate (50 by default, see `MAX_RESPONSE_ITEMS`).
+      // https://docs.gitea.com/administration/config-cheat-sheet#api-api
+      // https://forgejo.org/docs/latest/admin/config-cheat-sheet/#api-api
+      limit: this.items.length ? 20 : 100,
+      // Supported since Gitea 1.23.0 and Forgejo v10.0.0.
+      // Will be ignoded by older instances.
+      ...(this.ignorePrAuthor ? {} : { poster: this.author }),
     });
 
-    let url: string | undefined =
-      `${API_PATH}/repos/${this.repo}/pulls?${query}`;
-
-    while (url) {
+    while (query) {
       // TODO: use zod, typescript can't infer the type of the response #22198
       const res: HttpResponse<(PR | null)[]> = await http.getJsonUnchecked(
-        url,
+        `${API_PATH}/repos/${this.repo}/pulls?${query}`,
         {
           memCache: false,
           paginate: false,
@@ -150,7 +159,7 @@ export class GiteaPrCache {
       }
 
       const uri = parseUrl(parseLinkHeader(res.headers.link)?.next?.url);
-      url = uri ? `${uri.pathname}${uri.search}` : undefined;
+      query = uri ? uri.search : undefined;
     }
 
     this.updateItems();


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- set poster server filter for pr cache
- optimize pr paging
- fix pr api path

<!-- Describe what behavior is changed by this PR. -->

## Context
- https://github.com/go-gitea/gitea/pull/32209
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
