### PR TITLE
test(bitbucket-server): Fix the tests performance

### DIFF
--- a/lib/modules/platform/bitbucket-server/index.spec.ts
+++ b/lib/modules/platform/bitbucket-server/index.spec.ts
@@ -1,17 +1,15 @@
 import is from '@sindresorhus/is';
 import { mockDeep } from 'jest-mock-extended';
 import * as httpMock from '../../../../test/http-mock';
-import { mocked } from '../../../../test/util';
+import { git, hostRules, logger } from '../../../../test/util';
 import {
   REPOSITORY_CHANGED,
   REPOSITORY_EMPTY,
   REPOSITORY_NOT_FOUND,
 } from '../../../constants/error-messages';
-import type { logger as _logger } from '../../../logger';
-import type * as _git from '../../../util/git';
 import type { LongCommitSha } from '../../../util/git/types';
 import { ensureTrailingSlash } from '../../../util/url';
-import type { Platform } from '../types';
+import * as bitbucket from '.';
 
 jest.mock('timers/promises');
 jest.mock('../../../util/git');
@@ -176,19 +174,12 @@ const scenarios = {
   'endpoint with path': new URL('https://stash.renovatebot.com/vcs'),
 };
 
-type HostRules = typeof import('../../../util/host-rules');
-
 describe('modules/platform/bitbucket-server/index', () => {
   Object.entries(scenarios).forEach(([scenarioName, url]) => {
     const urlHost = url.origin;
     const urlPath = url.pathname === '/' ? '' : url.pathname;
 
     describe(scenarioName, () => {
-      let bitbucket: Platform;
-
-      let hostRules: jest.Mocked<HostRules>;
-      let git: jest.Mocked<typeof _git>;
-      let logger: jest.Mocked<typeof _logger>;
       const username = 'abc';
       const password = '123';
       const userInfo = {
@@ -217,12 +208,6 @@ describe('modules/platform/bitbucket-server/index', () => {
       }
 
       beforeEach(async () => {
-        // reset module
-        jest.resetModules();
-        bitbucket = await import('.');
-        logger = mocked(await import('../../../logger')).logger;
-        hostRules = jest.requireMock('../../../util/host-rules');
-        git = jest.requireMock('../../../util/git');
         git.branchExists.mockReturnValue(true);
         git.isBranchBehindBase.mockResolvedValue(false);
         git.getBranchCommit.mockReturnValue(
@@ -312,7 +297,7 @@ describe('modules/platform/bitbucket-server/index', () => {
             username: 'abc',
             password: '123',
           });
-          expect(logger.debug).toHaveBeenCalledWith(
+          expect(logger.logger.debug).toHaveBeenCalledWith(
             expect.any(Object),
             'Error authenticating with Bitbucket. Check that your token includes "api" permissions',
           );
@@ -337,7 +322,7 @@ describe('modules/platform/bitbucket-server/index', () => {
           ).toEqual({
             endpoint: ensureTrailingSlash(url.href),
           });
-          expect(logger.debug).toHaveBeenCalledWith(
+          expect(logger.logger.debug).toHaveBeenCalledWith(
             expect.any(Object),
             'Failed to get user info, fallback gitAuthor will be used',
           );
@@ -708,12 +693,12 @@ describe('modules/platform/bitbucket-server/index', () => {
           httpMock
             .scope(urlHost)
             .get(
-              `${urlPath}/rest/api/1.0/projects/undefined/repos/undefined/settings/pull-requests`,
+              `${urlPath}/rest/api/1.0/projects/SOME/repos/repo/settings/pull-requests`,
             )
             .reply(200, {
               mergeConfig: null,
             });
-          const actual = await bitbucket.getBranchForceRebase!('main');
+          const actual = await bitbucket.getBranchForceRebase('main');
           expect(actual).toBeFalse();
         });
 
@@ -722,14 +707,14 @@ describe('modules/platform/bitbucket-server/index', () => {
           httpMock
             .scope(urlHost)
             .get(
-              `${urlPath}/rest/api/1.0/projects/undefined/repos/undefined/settings/pull-requests`,
+              `${urlPath}/rest/api/1.0/projects/SOME/repos/repo/settings/pull-requests`,
             )
             .reply(200, {
               mergeConfig: {
                 defaultStrategy: null,
               },
             });
-          const actual = await bitbucket.getBranchForceRebase!('main');
+          const actual = await bitbucket.getBranchForceRebase('main');
           expect(actual).toBeFalse();
         });
 
@@ -740,7 +725,7 @@ describe('modules/platform/bitbucket-server/index', () => {
             httpMock
               .scope(urlHost)
               .get(
-                `${urlPath}/rest/api/1.0/projects/undefined/repos/undefined/settings/pull-requests`,
+                `${urlPath}/rest/api/1.0/projects/SOME/repos/repo/settings/pull-requests`,
               )
               .reply(200, {
                 mergeConfig: {
@@ -749,7 +734,7 @@ describe('modules/platform/bitbucket-server/index', () => {
                   },
                 },
               });
-            const actual = await bitbucket.getBranchForceRebase!('main');
+            const actual = await bitbucket.getBranchForceRebase('main');
             expect(actual).toBeTrue();
           },
         );
@@ -761,7 +746,7 @@ describe('modules/platform/bitbucket-server/index', () => {
             httpMock
               .scope(urlHost)
               .get(
-                `${urlPath}/rest/api/1.0/projects/undefined/repos/undefined/settings/pull-requests`,
+                `${urlPath}/rest/api/1.0/projects/SOME/repos/repo/settings/pull-requests`,
               )
               .reply(200, {
                 mergeConfig: {
@@ -770,7 +755,7 @@ describe('modules/platform/bitbucket-server/index', () => {
                   },
                 },
               });
-            const actual = await bitbucket.getBranchForceRebase!('main');
+            const actual = await bitbucket.getBranchForceRebase('main');
             expect(actual).toBeFalse();
           },
         );
@@ -778,6 +763,7 @@ describe('modules/platform/bitbucket-server/index', () => {
 
       describe('addAssignees()', () => {
         it('does not throw', async () => {
+          await initRepo();
           expect(await bitbucket.addAssignees(3, ['some'])).toMatchSnapshot();
         });
       });
@@ -973,7 +959,7 @@ describe('modules/platform/bitbucket-server/index', () => {
           httpMock
             .scope(urlHost)
             .get(
-              `${urlPath}/rest/api/1.0/projects/undefined/repos/undefined/pull-requests/3/activities?limit=100`,
+              `${urlPath}/rest/api/1.0/projects/SOME/repos/repo/pull-requests/3/activities?limit=100`,
             )
             .reply(200);
           const res = await bitbucket.ensureComment({
@@ -1245,7 +1231,7 @@ describe('modules/platform/bitbucket-server/index', () => {
           httpMock
             .scope(urlHost)
             .get(
-              `${urlPath}/rest/api/1.0/projects/undefined/repos/undefined/pull-requests/5/activities?limit=100`,
+              `${urlPath}/rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/activities?limit=100`,
             )
             .reply(200, {
               isLastPage: false,
@@ -1264,7 +1250,7 @@ describe('modules/platform/bitbucket-server/index', () => {
               ],
             })
             .get(
-              `${urlPath}/rest/api/1.0/projects/undefined/repos/undefined/pull-requests/5/activities?limit=100&start=1`,
+              `${urlPath}/rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/activities?limit=100&start=1`,
             )
             .reply(200, {
               isLastPage: true,
@@ -2103,9 +2089,7 @@ Followed by some information.
               failed: 0,
             });
 
-          expect(await bitbucket.getBranchStatus('somebranch', true)).toBe(
-            'green',
-          );
+          expect(await bitbucket.getBranchStatus('somebranch')).toBe('green');
         });
 
         it('should be pending', async () => {
@@ -2120,9 +2104,7 @@ Followed by some information.
               failed: 0,
             });
 
-          expect(await bitbucket.getBranchStatus('somebranch', true)).toBe(
-            'yellow',
-          );
+          expect(await bitbucket.getBranchStatus('somebranch')).toBe('yellow');
 
           scope
             .get(
@@ -2134,9 +2116,7 @@ Followed by some information.
               failed: 0,
             });
 
-          expect(await bitbucket.getBranchStatus('somebranch', true)).toBe(
-            'yellow',
-          );
+          expect(await bitbucket.getBranchStatus('somebranch')).toBe('yellow');
         });
 
         it('should be failed', async () => {
@@ -2151,9 +2131,7 @@ Followed by some information.
               failed: 1,
             });
 
-          expect(await bitbucket.getBranchStatus('somebranch', true)).toBe(
-            'red',
-          );
+          expect(await bitbucket.getBranchStatus('somebranch')).toBe('red');
 
           scope
             .get(
@@ -2161,17 +2139,15 @@ Followed by some information.
             )
             .replyWithError('requst-failed');
 
-          expect(await bitbucket.getBranchStatus('somebranch', true)).toBe(
-            'red',
-          );
+          expect(await bitbucket.getBranchStatus('somebranch')).toBe('red');
         });
 
         it('throws repository-changed', async () => {
           git.branchExists.mockReturnValue(false);
           await initRepo();
-          await expect(
-            bitbucket.getBranchStatus('somebranch', true),
-          ).rejects.toThrow(REPOSITORY_CHANGED);
+          await expect(bitbucket.getBranchStatus('somebranch')).rejects.toThrow(
+            REPOSITORY_CHANGED,
+          );
         });
       });
 

--- a/lib/modules/platform/bitbucket-server/index.ts
+++ b/lib/modules/platform/bitbucket-server/index.ts
@@ -990,7 +990,7 @@ export async function updatePr({
   bitbucketInvalidReviewers,
   targetBranch,
 }: UpdatePrConfig & {
-  bitbucketInvalidReviewers: string[] | undefined;
+  bitbucketInvalidReviewers?: string[] | undefined;
 }): Promise<void> {
   const description = sanitize(rawDescription);
   logger.debug(`updatePr(${prNo}, title=${title})`);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

These are slowest tests in the `/lib/modules/platform/` directory, the main reason being `jest.resetModules()` usage.

This PR removes removes the module reset and fixes the downstream issues.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
