### PR TITLE
chore(docs): fix quote order on scheduling

### DIFF
--- a/docs/usage/key-concepts/scheduling.md
+++ b/docs/usage/key-concepts/scheduling.md
@@ -188,7 +188,7 @@ With Renovate's scheduling features you can "limit the noise" from frequently up
 Important tips for the `"schedule"` property:
 
 - Always use the array syntax `[]`, even if you only set a single schedule
-- Separate entries with a comma, like this: `["cron for schedule 1", "cron for schedule 2]"`
+- Separate entries with a comma, like this: `["cron for schedule 1", "cron for schedule 2"]`
 - Multiple entries in the `"schedule"` array are interpreted with the Boolean OR logic
 
 Read the [schedule config option](../configuration-options.md#schedule) documentation to learn more.


### PR DESCRIPTION
## Changes

Fix to docs where a code snipped has quotes in the wrong order.

## Context

Docs update.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository