### PR TITLE
feat(util): a AST based toml string replacer

### DIFF
--- a/lib/util/toml.spec.ts
+++ b/lib/util/toml.spec.ts
@@ -1,5 +1,6 @@
 import { codeBlock } from 'common-tags';
-import { parse as parseToml } from './toml';
+import { parseTOML } from 'toml-eslint-parser';
+import { getSingleValue, parse as parseToml, replaceString } from './toml';
 
 describe('util/toml', () => {
   it('works', () => {
@@ -27,5 +28,134 @@ describe('util/toml', () => {
     `;
 
     expect(() => parseToml(input)).toThrow(SyntaxError);
+  });
+
+  const rawToml = codeBlock`
+version = 'top level version'
+ext.version = "version of ext"
+
+[project]
+name = 'hello-world'
+rev = 3
+optional-deps = [
+  'dep 0',
+  'dep 1',
+]
+
+info = {}
+
+[project.ext]
+name = '1 ext'
+
+[dependencies]
+urllib2.version = 'version of urllib2'
+urllib2.build = '*py38*'
+
+'urllib3.ext' = 'version of urllib3.ext'
+urllib3 = { version = 'version of urllib3' }
+'requests' = "version of requests"
+"vc" = 'version of vc'
+
+[[packages]]
+name = '0'
+version = '0'
+
+[[packages]]
+name = '1'
+version = '1'
+`;
+
+  it('handle AST', () => {
+    const ast = parseTOML(rawToml);
+
+    const project = getSingleValue(ast, ['project']);
+    expect(project).toStrictEqual(undefined);
+
+    const optionalDeps = getSingleValue(ast, ['project', 'optional-deps']);
+    expect(optionalDeps).toStrictEqual(undefined);
+
+    const inlineArray = getSingleValue(ast, ['project', 'optional-deps', 1]);
+    expect(inlineArray?.value).toStrictEqual('dep 1');
+
+    const topLevelArray = getSingleValue(ast, ['packages', 1, 'version']);
+    expect(topLevelArray?.value).toStrictEqual('1');
+
+    const urllib2Version = getSingleValue(ast, [
+      'dependencies',
+      'urllib2',
+      'version',
+    ]);
+    expect(urllib2Version?.value).toStrictEqual('version of urllib2');
+
+    const topLevelVersion = getSingleValue(ast, ['version']);
+    expect(topLevelVersion?.value).toStrictEqual('top level version');
+
+    const topLevelExtVersion = getSingleValue(ast, ['ext', 'version']);
+    expect(topLevelExtVersion?.value).toStrictEqual('version of ext');
+
+    const vcVersion = getSingleValue(ast, ['dependencies', 'vc']);
+    expect(vcVersion?.value).toStrictEqual('version of vc');
+
+    const extensionNameAst = getSingleValue(ast, ['project', 'ext', 'name']);
+    expect(extensionNameAst?.value).toStrictEqual('1 ext');
+
+    const urllib3AST = getSingleValue(ast, [
+      'dependencies',
+      'urllib3',
+      'version',
+    ]);
+    expect(urllib3AST?.value).toStrictEqual('version of urllib3');
+
+    const urllib3ExtVersionAST = getSingleValue(ast, [
+      'dependencies',
+      'urllib3.ext',
+    ]);
+    expect(urllib3ExtVersionAST?.value).toStrictEqual('version of urllib3.ext');
+
+    const urllib2AST = getSingleValue(ast, [
+      'dependencies',
+      'urllib2',
+      'version',
+    ]);
+    expect(urllib2AST?.value).toStrictEqual('version of urllib2');
+
+    const projectRev = getSingleValue(ast, ['project', 'rev']);
+    expect(projectRev?.value).toStrictEqual(3);
+
+    expect(getSingleValue(ast, ['project'])).toBeUndefined();
+    expect(getSingleValue(ast, ['project', 'info'])).toBeUndefined();
+    expect(
+      getSingleValue(ast, ['project', 'info', 'not-exist']),
+    ).toBeUndefined();
+  });
+
+  it('replace string content', () => {
+    expect(replaceString(rawToml, ['project', 'name'], () => 'hello')).toBe(
+      rawToml.replace("name = 'hello-world'", "name = 'hello'"),
+    );
+
+    expect(
+      replaceString(
+        rawToml,
+        ['project', 'name'],
+        () => "string with a' single quote",
+      ),
+    ).toBe(
+      rawToml.replace(
+        "name = 'hello-world'",
+        `name = "string with a' single quote"`,
+      ),
+    );
+
+    expect(replaceString(rawToml, ['ext', 'version'], () => 'hello')).toBe(
+      rawToml.replace(
+        `ext.version = "version of ext"`,
+        `ext.version = "hello"`,
+      ),
+    );
+
+    expect(replaceString(rawToml, ['project', 'rev'], () => 'hello')).toBe(
+      rawToml,
+    );
   });
 });

--- a/lib/util/toml.spec.ts
+++ b/lib/util/toml.spec.ts
@@ -158,4 +158,8 @@ version = '1'
       rawToml,
     );
   });
+
+  it('should not replace table', () => {
+    expect(replaceString(rawToml, ['project'], () => 'hello')).toBe(rawToml);
+  });
 });

--- a/lib/util/toml.ts
+++ b/lib/util/toml.ts
@@ -1,6 +1,125 @@
-import { getStaticTOMLValue, parseTOML } from 'toml-eslint-parser';
+import is from '@sindresorhus/is';
+import { type AST, getStaticTOMLValue, parseTOML } from 'toml-eslint-parser';
 
 export function parse(input: string): unknown {
   const ast = parseTOML(input);
   return getStaticTOMLValue(ast);
+}
+
+function isKey(
+  ast: AST.TOMLKeyValue,
+  path: (string | number)[],
+): AST.TOMLValue | undefined {
+  if (ast.key.keys.length > path.length) {
+    return;
+  }
+
+  if (
+    ast.key.keys.every((key, index) => {
+      return (
+        (key.type === 'TOMLBare' && key.name === path[index]) ||
+        (key.type === 'TOMLQuoted' && key.value === path[index])
+      );
+    })
+  ) {
+    return getSingleValue(ast.value, path.slice(ast.key.keys.length));
+  }
+
+  return;
+}
+
+/**
+ * get a AST node presenting a single value (string/int/float)
+ * return undefined if the path point to a compose value (object/array)
+ */
+export function getSingleValue(
+  ast: AST.TOMLNode,
+  path: (string | number)[],
+): AST.TOMLValue | undefined {
+  if (path.length === 0) {
+    if (ast.type !== 'TOMLValue') {
+      return;
+    }
+    return ast;
+  }
+
+  if (ast.type === 'Program') {
+    return getSingleValue(ast.body[0], path);
+  }
+
+  if (ast.type === 'TOMLTopLevelTable') {
+    for (const body of ast.body) {
+      if (body.type === 'TOMLTable') {
+        // body.resolvedKey may be ['key'], ['key', 'subkey'] for object and [packages, number] for array
+        if (body.resolvedKey.length < path.length) {
+          if (body.resolvedKey.every((item, index) => item === path[index])) {
+            const restKey = path.slice(body.resolvedKey.length);
+            for (const item of body.body) {
+              const o = isKey(item, restKey);
+              if (o) {
+                return o;
+              }
+            }
+          }
+        }
+      } else if (body.type === 'TOMLKeyValue') {
+        const o = isKey(body, path);
+        if (o) {
+          return o;
+        }
+      }
+    }
+
+    return;
+  }
+
+  if (ast.type === 'TOMLTable' || ast.type === 'TOMLInlineTable') {
+    for (const item of ast.body) {
+      const o = isKey(item, path);
+      if (o) {
+        return o;
+      }
+    }
+
+    return;
+  }
+
+  if (ast.type === 'TOMLArray') {
+    if (is.number(path[0])) {
+      return getSingleValue(ast.elements[path[0]], path.slice(1));
+    }
+  }
+}
+
+/**
+ * Replace a string node at given object path in TOML, preserve toml whitespace style.
+ */
+export function replaceString(
+  toml: string,
+  path: (string | number)[],
+  updater: (currentValue: string) => string,
+): string {
+  const node = getSingleValue(parseTOML(toml), path);
+
+  if (!node) {
+    return toml;
+  }
+
+  if (node.kind !== 'string') {
+    return toml;
+  }
+
+  const newValue = updater(node.value);
+
+  let newStr: string;
+
+  if (node.style === 'basic') {
+    newStr = JSON.stringify(newValue);
+  } else if (newValue.includes("'")) {
+    newStr = JSON.stringify(newValue);
+  } else {
+    newStr = "'" + newValue + "'";
+  }
+
+  return toml.slice(0, node.range[0]) + newStr + toml.slice(node.range[1]);
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes


Add a new util to replace string value in toml based on AST to keey whitespace style.

It will be possible to replace a string value in toml based on object path.

for example:

```ts
import * as toml from './lib/util/toml';

const updated = toml.replaceString(
  `
[project]
dependencies = [
  'requests=1'
]
`,
  ['project', 'dependencies', 0],
  (currentSpec) => {
    return currentSpec.replace('=1', '=2');
  },
);


// OR

toml.replaceString(
  `
[project.dependencies]
requests = {version = '*'}
`,
  ['project', 'dependencies', 'requests', 'version'],
  () => {
    return '==0.2.7';
  },
);
```


I plan to use this in pixi manager like this:


```ts
import is from '@sindresorhus/is';
import { replaceString as replaceTomlString } from '../../../util/toml';
import type { UpdateDependencyConfig } from '../types';
import type { PixiManagerData } from './schema';

type PixiUpgrade = UpdateDependencyConfig<{path: (string|number)[]}>;

export function updateDependency({
  fileContent,
  upgrade,
}: PixiUpgrade): string | null {
  if (is.nullOrUndefined(upgrade.managerData)) {
    return fileContent;
  }

  return replaceTomlString(
    fileContent,
    upgrade.managerData.path,
    () => upgrade.newValue!,
  );
}
```

<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [X] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
