### PR TITLE
fix(changelogs): Pass depName to addReleaseNotes

### DIFF
--- a/lib/workers/repository/update/pr/changelog/__snapshots__/index.spec.ts.snap
+++ b/lib/workers/repository/update/pr/changelog/__snapshots__/index.spec.ts.snap
@@ -6,6 +6,7 @@ exports[`workers/repository/update/pr/changelog/index > getChangeLogJSON > filte
   "project": {
     "apiBaseUrl": "https://api.github.com/",
     "baseUrl": "https://github.com/",
+    "depName": undefined,
     "packageName": "@renovate/no",
     "repository": "chalk/chalk",
     "sourceDirectory": undefined,
@@ -65,6 +66,7 @@ exports[`workers/repository/update/pr/changelog/index > getChangeLogJSON > suppo
   "project": {
     "apiBaseUrl": "https://github-enterprise.example.com/api/v3/",
     "baseUrl": "https://github-enterprise.example.com/",
+    "depName": undefined,
     "packageName": "renovate",
     "repository": "chalk/chalk",
     "sourceDirectory": undefined,
@@ -124,6 +126,7 @@ exports[`workers/repository/update/pr/changelog/index > getChangeLogJSON > suppo
   "project": {
     "apiBaseUrl": "https://api.github.com/",
     "baseUrl": "https://github.com/",
+    "depName": undefined,
     "packageName": "renovate",
     "repository": "chalk/chalk",
     "sourceDirectory": undefined,
@@ -183,6 +186,7 @@ exports[`workers/repository/update/pr/changelog/index > getChangeLogJSON > suppo
   "project": {
     "apiBaseUrl": "https://github-enterprise.example.com/api/v3/",
     "baseUrl": "https://github-enterprise.example.com/",
+    "depName": undefined,
     "packageName": "renovate",
     "repository": "chalk/chalk",
     "sourceDirectory": undefined,
@@ -242,6 +246,7 @@ exports[`workers/repository/update/pr/changelog/index > getChangeLogJSON > suppo
   "project": {
     "apiBaseUrl": "https://api.github.com/",
     "baseUrl": "https://github.com/",
+    "depName": undefined,
     "packageName": "renovate",
     "repository": "chalk/chalk",
     "sourceDirectory": undefined,
@@ -301,6 +306,7 @@ exports[`workers/repository/update/pr/changelog/index > getChangeLogJSON > uses 
   "project": {
     "apiBaseUrl": "https://api.github.com/",
     "baseUrl": "https://github.com/",
+    "depName": undefined,
     "packageName": "renovate",
     "repository": "chalk/chalk",
     "sourceDirectory": undefined,
@@ -365,6 +371,7 @@ exports[`workers/repository/update/pr/changelog/index > getChangeLogJSON > works
   "project": {
     "apiBaseUrl": "https://api.github.com/",
     "baseUrl": "https://github.com/",
+    "depName": undefined,
     "packageName": "renovate",
     "repository": "chalk/chalk",
     "sourceDirectory": undefined,

--- a/lib/workers/repository/update/pr/changelog/github/__snapshots__/index.spec.ts.snap
+++ b/lib/workers/repository/update/pr/changelog/github/__snapshots__/index.spec.ts.snap
@@ -6,6 +6,7 @@ exports[`workers/repository/update/pr/changelog/github/index > getChangeLogJSON 
   "project": {
     "apiBaseUrl": "https://api.github.com/",
     "baseUrl": "https://github.com/",
+    "depName": undefined,
     "packageName": "@renovate/no",
     "repository": "chalk/chalk",
     "sourceDirectory": undefined,
@@ -65,6 +66,7 @@ exports[`workers/repository/update/pr/changelog/github/index > getChangeLogJSON 
   "project": {
     "apiBaseUrl": "https://github-enterprise.example.com/api/v3/",
     "baseUrl": "https://github-enterprise.example.com/",
+    "depName": undefined,
     "packageName": "renovate",
     "repository": "chalk/chalk",
     "sourceDirectory": undefined,
@@ -124,6 +126,7 @@ exports[`workers/repository/update/pr/changelog/github/index > getChangeLogJSON 
   "project": {
     "apiBaseUrl": "https://api.github.com/",
     "baseUrl": "https://github.com/",
+    "depName": undefined,
     "packageName": "renovate",
     "repository": "chalk/chalk",
     "sourceDirectory": undefined,
@@ -183,6 +186,7 @@ exports[`workers/repository/update/pr/changelog/github/index > getChangeLogJSON 
   "project": {
     "apiBaseUrl": "https://api.github.com/",
     "baseUrl": "https://github.com/",
+    "depName": undefined,
     "packageName": "renovate",
     "repository": "chalk/chalk",
     "sourceDirectory": undefined,
@@ -242,6 +246,7 @@ exports[`workers/repository/update/pr/changelog/github/index > getChangeLogJSON 
   "project": {
     "apiBaseUrl": "https://api.github.com/",
     "baseUrl": "https://github.com/",
+    "depName": undefined,
     "packageName": "renovate",
     "repository": "chalk/chalk",
     "sourceDirectory": undefined,
@@ -301,6 +306,7 @@ exports[`workers/repository/update/pr/changelog/github/index > getChangeLogJSON 
   "project": {
     "apiBaseUrl": "https://api.github.com/",
     "baseUrl": "https://github.com/",
+    "depName": undefined,
     "packageName": "renovate",
     "repository": "chalk/chalk",
     "sourceDirectory": undefined,

--- a/lib/workers/repository/update/pr/changelog/github/index.spec.ts
+++ b/lib/workers/repository/update/pr/changelog/github/index.spec.ts
@@ -100,6 +100,7 @@ describe('workers/repository/update/pr/changelog/github/index', () => {
         project: {
           apiBaseUrl: 'https://api.github.com/',
           baseUrl: 'https://github.com/',
+          depName: undefined,
           packageName: 'renovate',
           repository: 'chalk/chalk',
           sourceDirectory: undefined,
@@ -125,6 +126,7 @@ describe('workers/repository/update/pr/changelog/github/index', () => {
         project: {
           apiBaseUrl: 'https://api.github.com/',
           baseUrl: 'https://github.com/',
+          depName: undefined,
           packageName: 'renovate',
           repository: 'chalk/chalk',
           sourceDirectory: undefined,
@@ -151,6 +153,7 @@ describe('workers/repository/update/pr/changelog/github/index', () => {
         project: {
           apiBaseUrl: 'https://api.github.com/',
           baseUrl: 'https://github.com/',
+          depName: undefined,
           packageName: '@renovate/no',
           repository: 'chalk/chalk',
           sourceDirectory: undefined,
@@ -177,6 +180,7 @@ describe('workers/repository/update/pr/changelog/github/index', () => {
         project: {
           apiBaseUrl: 'https://api.github.com/',
           baseUrl: 'https://github.com/',
+          depName: undefined,
           packageName: 'renovate',
           repository: 'chalk/chalk',
           sourceDirectory: undefined,
@@ -264,6 +268,7 @@ describe('workers/repository/update/pr/changelog/github/index', () => {
         project: {
           apiBaseUrl: 'https://api.github.com/',
           baseUrl: 'https://github.com/',
+          depName: undefined,
           packageName: 'renovate',
           repository: 'chalk/chalk',
           sourceDirectory: undefined,
@@ -297,6 +302,7 @@ describe('workers/repository/update/pr/changelog/github/index', () => {
         project: {
           apiBaseUrl: 'https://github-enterprise.example.com/api/v3/',
           baseUrl: 'https://github-enterprise.example.com/',
+          depName: undefined,
           packageName: 'renovate',
           repository: 'chalk/chalk',
           sourceDirectory: undefined,
@@ -350,6 +356,7 @@ describe('workers/repository/update/pr/changelog/github/index', () => {
         project: {
           apiBaseUrl: 'https://api.github.com/',
           baseUrl: 'https://github.com/',
+          depName: undefined,
           type: 'github',
           repository: 'chalk/chalk',
           sourceUrl: 'https://github.com/chalk/chalk',

--- a/lib/workers/repository/update/pr/changelog/gitlab/__snapshots__/index.spec.ts.snap
+++ b/lib/workers/repository/update/pr/changelog/gitlab/__snapshots__/index.spec.ts.snap
@@ -6,6 +6,7 @@ exports[`workers/repository/update/pr/changelog/gitlab/index > getChangeLogJSON 
   "project": {
     "apiBaseUrl": "https://gitlab.com/api/v4/",
     "baseUrl": "https://gitlab.com/",
+    "depName": undefined,
     "packageName": "renovate",
     "repository": "meno/dropzone",
     "sourceDirectory": undefined,
@@ -55,6 +56,7 @@ exports[`workers/repository/update/pr/changelog/gitlab/index > getChangeLogJSON 
   "project": {
     "apiBaseUrl": "https://gitlab-enterprise.example.com/api/v4/",
     "baseUrl": "https://gitlab-enterprise.example.com/",
+    "depName": undefined,
     "packageName": "renovate",
     "repository": "meno/dropzone",
     "sourceDirectory": undefined,
@@ -104,6 +106,7 @@ exports[`workers/repository/update/pr/changelog/gitlab/index > getChangeLogJSON 
   "project": {
     "apiBaseUrl": "https://git.test.com/api/v4/",
     "baseUrl": "https://git.test.com/",
+    "depName": undefined,
     "packageName": "renovate",
     "repository": "meno/dropzone",
     "sourceDirectory": undefined,
@@ -153,6 +156,7 @@ exports[`workers/repository/update/pr/changelog/gitlab/index > getChangeLogJSON 
   "project": {
     "apiBaseUrl": "https://gitlab.com/api/v4/",
     "baseUrl": "https://gitlab.com/",
+    "depName": undefined,
     "packageName": "renovate",
     "repository": "meno/dropzone",
     "sourceDirectory": undefined,
@@ -222,6 +226,7 @@ exports[`workers/repository/update/pr/changelog/gitlab/index > getChangeLogJSON 
   "project": {
     "apiBaseUrl": "https://gitlab.com/api/v4/",
     "baseUrl": "https://gitlab.com/",
+    "depName": undefined,
     "packageName": "renovate",
     "repository": "meno/dropzone",
     "sourceDirectory": undefined,
@@ -271,6 +276,7 @@ exports[`workers/repository/update/pr/changelog/gitlab/index > getChangeLogJSON 
   "project": {
     "apiBaseUrl": "https://gitlab.com/api/v4/",
     "baseUrl": "https://gitlab.com/",
+    "depName": undefined,
     "packageName": "renovate",
     "repository": "meno/dropzone",
     "sourceDirectory": undefined,

--- a/lib/workers/repository/update/pr/changelog/gitlab/index.spec.ts
+++ b/lib/workers/repository/update/pr/changelog/gitlab/index.spec.ts
@@ -90,6 +90,7 @@ describe('workers/repository/update/pr/changelog/gitlab/index', () => {
         project: {
           apiBaseUrl: 'https://gitlab.com/api/v4/',
           baseUrl: 'https://gitlab.com/',
+          depName: undefined,
           packageName: 'renovate',
           repository: 'meno/dropzone',
           sourceDirectory: undefined,
@@ -132,6 +133,7 @@ describe('workers/repository/update/pr/changelog/gitlab/index', () => {
         project: {
           apiBaseUrl: 'https://gitlab.com/api/v4/',
           baseUrl: 'https://gitlab.com/',
+          depName: undefined,
           packageName: 'renovate',
           repository: 'meno/dropzone',
           sourceDirectory: undefined,
@@ -167,6 +169,7 @@ describe('workers/repository/update/pr/changelog/gitlab/index', () => {
         project: {
           apiBaseUrl: 'https://gitlab.com/api/v4/',
           baseUrl: 'https://gitlab.com/',
+          depName: undefined,
           packageName: 'renovate',
           repository: 'meno/dropzone',
           sourceDirectory: undefined,
@@ -202,6 +205,7 @@ describe('workers/repository/update/pr/changelog/gitlab/index', () => {
         project: {
           apiBaseUrl: 'https://gitlab.com/api/v4/',
           baseUrl: 'https://gitlab.com/',
+          depName: undefined,
           packageName: 'renovate',
           repository: 'meno/dropzone',
           sourceDirectory: undefined,

--- a/lib/workers/repository/update/pr/changelog/index.spec.ts
+++ b/lib/workers/repository/update/pr/changelog/index.spec.ts
@@ -122,6 +122,7 @@ describe('workers/repository/update/pr/changelog/index', () => {
         project: {
           apiBaseUrl: 'https://api.github.com/',
           baseUrl: 'https://github.com/',
+          depName: undefined,
           packageName: 'renovate',
           repository: 'chalk/chalk',
           sourceDirectory: undefined,
@@ -157,6 +158,7 @@ describe('workers/repository/update/pr/changelog/index', () => {
         project: {
           apiBaseUrl: 'https://api.github.com/',
           baseUrl: 'https://github.com/',
+          depName: undefined,
           packageName: 'renovate',
           repository: 'chalk/chalk',
           sourceDirectory: undefined,
@@ -216,6 +218,7 @@ describe('workers/repository/update/pr/changelog/index', () => {
         project: {
           apiBaseUrl: 'https://api.github.com/',
           baseUrl: 'https://github.com/',
+          depName: undefined,
           packageName: 'renovate',
           repository: 'chalk/chalk',
           sourceDirectory: undefined,
@@ -304,6 +307,7 @@ describe('workers/repository/update/pr/changelog/index', () => {
         project: {
           apiBaseUrl: 'https://api.github.com/',
           baseUrl: 'https://github.com/',
+          depName: undefined,
           packageName: 'renovate',
           repository: 'chalk/chalk',
           sourceDirectory: undefined,

--- a/lib/workers/repository/update/pr/changelog/source.ts
+++ b/lib/workers/repository/update/pr/changelog/source.ts
@@ -188,6 +188,7 @@ export abstract class ChangeLogSource {
         sourceUrl,
         sourceDirectory,
         packageName,
+        depName,
       },
       versions: changelogReleases,
     };


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This PR sets the `depName` on the `ChangeLogProject` that gets passed to the `addReleaseNotes` function.

## Context

When debugging why the changelog was not being added for one of my projects I noticed the following in my Renovate log lines:

```
DEBUG: getReleaseNotes(bjw-s/helm-charts, 3.7.2, ghcr.io/bjw-s/helm/app-template, undefined) (repository=bjw-s-labs/home-ops, branch=renovate/app-template-3.x)
```

In #30395 functionality was added to include `depName` in the release selection for changelogs, but it looks like the depName is not being forwarded to the functions that handle fetching the changelog, causing the `undefined` in the downstream `getReleaseNotes` function.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
