### PR TITLE
feat(config): support `.mjs` config files

### DIFF
--- a/lib/workers/global/config/parse/__fixtures__/config.mjs
+++ b/lib/workers/global/config/parse/__fixtures__/config.mjs
@@ -1,0 +1,3 @@
+export default {
+  token: 'abcdefg',
+};

--- a/lib/workers/global/config/parse/file.spec.ts
+++ b/lib/workers/global/config/parse/file.spec.ts
@@ -26,6 +26,7 @@ describe('workers/global/config/parse/file', () => {
     it.each([
       ['custom js config file', 'config.js'],
       ['custom js config file', 'config.cjs'],
+      ['custom js config file', 'config.mjs'],
       ['custom js config file exporting a Promise', 'config-promise.js'],
       ['custom js config file exporting a function', 'config-function.js'],
       // The next two are different syntactic ways of expressing the same thing
@@ -40,7 +41,7 @@ describe('workers/global/config/parse/file', () => {
       ['.renovaterc', '.renovaterc'],
       ['JSON5 config file', 'config.json5'],
       ['YAML config file', 'config.yaml'],
-    ])('parses %s', async (_fileType, filePath) => {
+    ])('parses %s > %s', async (_fileType, filePath) => {
       const configFile = upath.resolve(__dirname, './__fixtures__/', filePath);
       expect(
         await file.getConfig({ RENOVATE_CONFIG_FILE: configFile }),


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- Allow using `config.mjs`
- don't try to parse non-existing config
<!-- Describe what behavior is changed by this PR. -->

## Context
- https://github.com/visualon/docker-renovate/actions/runs/13667736967/job/38212221460#step:5:122
```
> [6/6] RUN install-tool renovate:
0.191 [03:18:02.764] INFO (1): Installing tool renovate@39.186.0...
32.70 FATAL: Could not parse config file
32.70        "error": "TypeError: File URL host must be \"localhost\" or empty on linux\n    at getPathFromURLPosix (node:internal/url:1486:11)\n    at fileURLToPath (node:internal/url:1510:63)\n    at finalizeResolution (node:internal/modules/esm/resolve:243:12)\n    at moduleResolve (node:internal/modules/esm/resolve:860:10)\n    at defaultResolve (node:internal/modules/esm/resolve:984:11)\n    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:685:12)\n    at ModuleLoader.#cachedDefaultResolve (node:internal/modules/esm/loader:634:25)\n    at ModuleLoader.resolve (node:internal/modules/esm/loader:617:38)\n    at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:273:38)\n    at onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:577:36)\n    at TracingChannel.tracePromise (node:diagnostics_channel:344:14)\n    at ModuleLoader.import (node:internal/modules/esm/loader:576:21)\n    at defaultImportModuleDynamicallyForScript (node:internal/modules/esm/utils:228:31)\n    at importModuleDynamicallyCallback (node:internal/modules/esm/utils:250:12)\n    at getParsedContent (/opt/containerbase/tools/renovate/39.186.0/22.14.0/node_modules/renovate/lib/workers/global/config/parse/file.ts:29:61)\n    at Object.getConfig (/opt/containerbase/tools/renovate/39.186.0/22.14.0/node_modules/renovate/lib/workers/global/config/parse/file.ts:59:20)\n    at parseConfigs (/opt/containerbase/tools/renovate/39.186.0/22.14.0/node_modules/renovate/lib/workers/global/config/parse/index.ts:24:39)\n    at getGlobalConfig (/opt/containerbase/tools/renovate/39.186.0/22.14.0/node_modules/renovate/lib/workers/global/index.ts:60:22)\n    at /opt/containerbase/tools/renovate/39.186.0/22.14.0/node_modules/renovate/lib/workers/global/index.ts:136:22\n    at /opt/containerbase/tools/renovate/39.186.0/22.14.0/node_modules/renovate/lib/instrumentation/index.ts:144:19"
34.28 [03:18:36.[126](https://github.com/visualon/docker-renovate/actions/runs/13667736967/job/38212221460#step:5:127)] ERROR (1): Command failed with exit code 1: renovate --version
34.28 [03:18:36.127] FATAL (1): Install tool renovate failed in 33.3s.
```
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
