### PR TITLE
fix(helmv3): non http alias in Helm

### DIFF
--- a/lib/modules/manager/helmv3/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/modules/manager/helmv3/__snapshots__/artifacts.spec.ts.snap
@@ -216,7 +216,7 @@ exports[`modules/manager/helmv3/artifacts > log into private registries and repo
     },
   },
   {
-    "cmd": "helm repo add stable the_stable_url --force-update",
+    "cmd": "helm repo add stable http://the_stable_url --force-update",
     "options": {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -493,10 +493,10 @@ exports[`modules/manager/helmv3/artifacts > returns updated Chart.lock with dock
 ]
 `;
 
-exports[`modules/manager/helmv3/artifacts > sets repositories from registryAliases 1`] = `
+exports[`modules/manager/helmv3/artifacts > sets repositories from registryAliases ignoring not well formed URI 1`] = `
 [
   {
-    "cmd": "helm repo add stable 'the stable_url' --force-update",
+    "cmd": "helm repo add stable http://the_stable_url --force-update",
     "options": {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -518,7 +518,7 @@ exports[`modules/manager/helmv3/artifacts > sets repositories from registryAlias
     },
   },
   {
-    "cmd": "helm repo add repo1 the_repo1_url --force-update",
+    "cmd": "helm repo add repo1 https://the_repo1_url --force-update",
     "options": {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -601,7 +601,7 @@ exports[`modules/manager/helmv3/artifacts > sets repositories from registryAlias
     },
   },
   {
-    "cmd": "docker run --rm --name=renovate_sidecar --label=renovate_child -v "/tmp/github/some/repo":"/tmp/github/some/repo" -v "/tmp/renovate/cache":"/tmp/renovate/cache" -e HELM_EXPERIMENTAL_OCI -e HELM_REGISTRY_CONFIG -e HELM_REPOSITORY_CONFIG -e HELM_REPOSITORY_CACHE -e CONTAINERBASE_CACHE_DIR -w "/tmp/github/some/repo" ghcr.io/containerbase/sidecar bash -l -c "install-tool helm v3.7.2 && helm repo add stable the_stable_url --force-update && helm repo add repo1 the_repo1_url --force-update && helm repo add repo-test https://gitlab.com/api/v4/projects/xxxxxxx/packages/helm/stable --force-update && helm dependency update ''"",
+    "cmd": "docker run --rm --name=renovate_sidecar --label=renovate_child -v "/tmp/github/some/repo":"/tmp/github/some/repo" -v "/tmp/renovate/cache":"/tmp/renovate/cache" -e HELM_EXPERIMENTAL_OCI -e HELM_REGISTRY_CONFIG -e HELM_REPOSITORY_CONFIG -e HELM_REPOSITORY_CACHE -e CONTAINERBASE_CACHE_DIR -w "/tmp/github/some/repo" ghcr.io/containerbase/sidecar bash -l -c "install-tool helm v3.7.2 && helm repo add stable http://the_stable_url --force-update && helm repo add repo1 https://the_repo1_url --force-update && helm repo add repo-test https://gitlab.com/api/v4/projects/xxxxxxx/packages/helm/stable --force-update && helm dependency update ''"",
     "options": {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",

--- a/lib/modules/manager/helmv3/artifacts.spec.ts
+++ b/lib/modules/manager/helmv3/artifacts.spec.ts
@@ -573,7 +573,7 @@ describe('modules/manager/helmv3/artifacts', () => {
     ]);
   });
 
-  it('sets repositories from registryAliases', async () => {
+  it('sets repositories from registryAliases ignoring not well formed URI', async () => {
     fs.privateCacheDir.mockReturnValue(
       '/tmp/renovate/cache/__renovate-private-cache',
     );
@@ -590,7 +590,11 @@ describe('modules/manager/helmv3/artifacts', () => {
         config: {
           ...config,
           isLockFileMaintenance: true,
-          registryAliases: { stable: 'the stable_url', repo1: 'the_repo1_url' },
+          registryAliases: {
+            stable: 'http://the_stable_url',
+            repo1: 'https://the_repo1_url',
+            $REGISTRY_ALIAS: 'my.registry.tld',
+          },
         },
       }),
     ).toMatchObject([
@@ -631,7 +635,11 @@ describe('modules/manager/helmv3/artifacts', () => {
         config: {
           ...config,
           isLockFileMaintenance: true,
-          registryAliases: { stable: 'the_stable_url', repo1: 'the_repo1_url' },
+          registryAliases: {
+            stable: 'http://the_stable_url',
+            repo1: 'https://the_repo1_url',
+            $REGISTRY_ALIAS: 'my.registry.tld',
+          },
         },
       }),
     ).toMatchObject([
@@ -678,7 +686,7 @@ describe('modules/manager/helmv3/artifacts', () => {
           ...config,
           isLockFileMaintenance: true,
           registryAliases: {
-            stable: 'the_stable_url',
+            stable: 'http://the_stable_url',
             oci: 'oci://registry.example.com/organization',
             repo1: 'https://the_repo1_url',
           },

--- a/lib/modules/manager/helmv3/utils.ts
+++ b/lib/modules/manager/helmv3/utils.ts
@@ -91,12 +91,14 @@ export function isAlias(repository: string): boolean {
 export function aliasRecordToRepositories(
   registryAliases: Record<string, string>,
 ): Repository[] {
-  return Object.entries(registryAliases).map(([alias, url]) => {
-    return {
-      name: alias,
-      repository: url,
-    };
-  });
+  return Object.entries(registryAliases)
+    .filter(([, url]) => url?.match(/^https?:\/\/.+/))
+    .map(([alias, url]) => {
+      return {
+        name: alias,
+        repository: url,
+      };
+    });
 }
 
 export function isFileInDir(dir: string, file: string): boolean {

--- a/lib/modules/manager/helmv3/utils.ts
+++ b/lib/modules/manager/helmv3/utils.ts
@@ -92,7 +92,7 @@ export function aliasRecordToRepositories(
   registryAliases: Record<string, string>,
 ): Repository[] {
   return Object.entries(registryAliases)
-    .filter(([, url]) => url?.match(/^https?:\/\/.+/))
+    .filter(([, url]) => /^(https?|oci):\/\/.+/.exec(url))
     .map(([alias, url]) => {
       return {
         name: alias,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
In Helm renovation, this issue keep only aliases containing an http URL which is a valid chart repository to avoid failing the `helm repo add` command

>  A chart repository is an HTTP server that ....

See [Helm doc](https://helm.sh/docs/topics/chart_repository/#create-a-chart-repository)

## Context

To resolve variables in dependencies, we add globally the configuration
```ts
    registryAliases: {
        // Required for GitLab CI component renovations (see https://github.com/renovatebot/renovate/discussions/27964)
        "$CI_SERVER_FQDN": process.env.CI_SERVER_FQDN,
        "$DOCKER_REGISTRY": process.env.DOCKER_REGISTRY,
        "${DOCKER_REGISTRY}": process.env.DOCKER_REGISTRY,
    },
```

But then, Helm renovations are failing with the following message
```
Command failed: helm repo add '$CI_SERVER_FQDN' gitlab.mycompany.tld --force-update
Error: could not find protocol handler for: 
```


<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ X ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ X ] No unit tests but ran on a real repository, or

