### PR TITLE
fix(global): import config file as url

### DIFF
--- a/lib/workers/global/config/parse/file.spec.ts
+++ b/lib/workers/global/config/parse/file.spec.ts
@@ -50,7 +50,9 @@ describe('workers/global/config/parse/file', () => {
 
     it('migrates', async () => {
       const configFile = upath.resolve(__dirname, './__fixtures__/config2.js');
-      const res = await file.getConfig({ RENOVATE_CONFIG_FILE: configFile });
+      // for coverage
+      const relativePath = upath.relative(process.cwd(), configFile);
+      const res = await file.getConfig({ RENOVATE_CONFIG_FILE: relativePath });
       expect(res).toMatchSnapshot();
       expect(res.rangeStrategy).toBe('bump');
     });

--- a/lib/workers/global/config/parse/file.ts
+++ b/lib/workers/global/config/parse/file.ts
@@ -1,3 +1,4 @@
+import { pathToFileURL } from 'url';
 import is from '@sindresorhus/is';
 import fs from 'fs-extra';
 import JSON5 from 'json5';
@@ -26,9 +27,12 @@ export async function getParsedContent(file: string): Promise<RenovateConfig> {
     case '.cjs':
     case '.mjs':
     case '.js': {
-      const tmpConfig = await import(
-        upath.isAbsolute(file) ? file : `${process.cwd()}/${file}`
-      );
+      const absoluteFilePath = upath.isAbsolute(file)
+        ? file
+        : `${process.cwd()}/${file}`;
+      // use file url paths to avoid issues with windows paths
+      // typescript does not support file URL for import
+      const tmpConfig = await import(pathToFileURL(absoluteFilePath).href);
       /* v8 ignore next: not testable */
       let config = tmpConfig.default ? tmpConfig.default : tmpConfig;
       // Allow the config to be a function


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Fixes `ERR_UNSUPPORTED_ESM_URL_SCHEME` on windows.
Tested real run on Linux and Windows.
<!-- Describe what behavior is changed by this PR. -->

## Context
- https://github.com/renovatebot/renovate/discussions/34622#discussioncomment-12395671
- https://github.com/nodejs/node/issues/31710
- https://github.com/jestjs/jest/pull/9558
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
