### PR TITLE
fix(yaml): less strictness on jinja2 regex

### DIFF
--- a/lib/util/yaml.ts
+++ b/lib/util/yaml.ts
@@ -168,7 +168,7 @@ export function dump(obj: any, opts?: DumpOptions): string {
 
 function massageContent(content: string, options?: YamlOptions): string {
   if (options?.removeTemplates) {
-    return stripTemplates(content.replace(regEx(/^\s+{{.+?}}:.+/gs), ''));
+    return stripTemplates(content);
   }
 
   return content;

--- a/lib/util/yaml.ts
+++ b/lib/util/yaml.ts
@@ -61,10 +61,10 @@ export function parseYaml<ResT = unknown>(
   content: string,
   options?: YamlOptionsMultiple<ResT>,
 ): ResT[] {
-  const messagedContent = messageContent(content, options);
+  const massagedContent = massageContent(content, options);
 
   const rawDocuments = parseAllDocuments(
-    messagedContent,
+    massagedContent,
     prepareParseOption(options),
   );
 
@@ -149,9 +149,9 @@ export function parseSingleYamlDocument(
   content: string,
   options?: YamlParseDocumentOptions,
 ): Document {
-  const messagedContent = messageContent(content, options);
+  const massagedContent = massageContent(content, options);
   const rawDocument = parseDocument(
-    messagedContent,
+    massagedContent,
     prepareParseOption(options),
   );
 
@@ -166,7 +166,7 @@ export function dump(obj: any, opts?: DumpOptions): string {
   return stringify(obj, opts);
 }
 
-function messageContent(content: string, options?: YamlOptions): string {
+function massageContent(content: string, options?: YamlOptions): string {
   if (options?.removeTemplates) {
     return stripTemplates(content.replace(regEx(/^\s+{{.+?}}:.+/gs), ''));
   }

--- a/lib/util/yaml.ts
+++ b/lib/util/yaml.ts
@@ -61,10 +61,10 @@ export function parseYaml<ResT = unknown>(
   content: string,
   options?: YamlOptionsMultiple<ResT>,
 ): ResT[] {
-  const massagedContent = massageContent(content, options);
+  const messagedContent = messageContent(content, options);
 
   const rawDocuments = parseAllDocuments(
-    massagedContent,
+    messagedContent,
     prepareParseOption(options),
   );
 
@@ -149,9 +149,9 @@ export function parseSingleYamlDocument(
   content: string,
   options?: YamlParseDocumentOptions,
 ): Document {
-  const massagedContent = massageContent(content, options);
+  const messagedContent = messageContent(content, options);
   const rawDocument = parseDocument(
-    massagedContent,
+    messagedContent,
     prepareParseOption(options),
   );
 
@@ -166,9 +166,9 @@ export function dump(obj: any, opts?: DumpOptions): string {
   return stringify(obj, opts);
 }
 
-function massageContent(content: string, options?: YamlOptions): string {
+function messageContent(content: string, options?: YamlOptions): string {
   if (options?.removeTemplates) {
-    return stripTemplates(content.replace(regEx(/\s+{{.+?}}:.+/gs), ''));
+    return stripTemplates(content.replace(regEx(/^\s+{{.+?}}:.+/gs), ''));
   }
 
   return content;


### PR DESCRIPTION
## Changes

Removing the regex pattern will allow parsing the file, without cutting almost whole file, in the following situations:

```yaml
networks:
  {{ custom_network }}:
    external: true

services:
  service_xpto:
    image: alpine:latest
    deploy:
      labels:
        {{ custom_key }}: {{ custom_value }}
        ...
```

## Context

- https://github.com/renovatebot/renovate/discussions/32967
- https://github.com/renovatebot/renovate/pull/33190

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository