### PR TITLE
fix: optimize type checks

### DIFF
--- a/lib/config/migrations/custom/rebase-stale-prs-migration.ts
+++ b/lib/config/migrations/custom/rebase-stale-prs-migration.ts
@@ -16,7 +16,7 @@ export class RebaseStalePrsMigration extends AbstractMigration {
         );
       }
 
-      if (is.null_(value)) {
+      if (null === value) {
         this.setSafely('rebaseWhen', 'auto');
       }
     }

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -677,7 +677,7 @@ export async function validateConfig(
                   });
                 }
                 if (
-                  !(is.string(statusCheckValue) || is.null_(statusCheckValue))
+                  !(is.string(statusCheckValue) || null === statusCheckValue)
                 ) {
                   errors.push({
                     topic: 'Configuration Error',

--- a/lib/modules/manager/bundler/artifacts.ts
+++ b/lib/modules/manager/bundler/artifacts.ts
@@ -85,7 +85,7 @@ export async function updateArtifacts(
     return null;
   }
 
-  const updatedDepNames = updatedDeps
+  const updatedDepNames: string[] = updatedDeps
     .map(({ depName }) => depName)
     .filter(is.nonEmptyStringAndNotWhitespace);
 

--- a/lib/modules/manager/mise/extract.ts
+++ b/lib/modules/manager/mise/extract.ts
@@ -45,7 +45,7 @@ function parseVersion(toolData: MiseToolSchema): string | null {
     // e.g. 'erlang = ["23.3", "24.0"]'
     return toolData.length ? toolData[0] : null; // Get the first version in the array
   }
-  if (is.nonEmptyString(toolData.version)) {
+  if (is.object(toolData) && is.nonEmptyString(toolData.version)) {
     // Handle the object case with a string version
     // e.g. 'python = { version = "3.11.2" }'
     return toolData.version;

--- a/lib/workers/repository/onboarding/pr/config-description.ts
+++ b/lib/workers/repository/onboarding/pr/config-description.ts
@@ -25,7 +25,9 @@ export function getScheduleDesc(config: RenovateConfig): string[] {
 function getDescriptionArray(config: RenovateConfig): string[] {
   logger.debug('getDescriptionArray()');
   logger.trace({ config });
-  const desc = is.nonEmptyArray(config.description) ? config.description : [];
+  const desc = is.array(config.description, is.string)
+    ? config.description
+    : [];
   return desc.concat(getScheduleDesc(config));
 }
 


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
preparation for `@sindresorhus/is` major upgrade
<!-- Describe what behavior is changed by this PR. -->

## Context
- `is.function_` and `is.null_` get trailing `_` removed
- `is.nonEmpty...` return stricter type.
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
