### PR TITLE
fix(bitbucket-server): use fallback gitAuthor if user info has empty email address

### DIFF
--- a/lib/modules/platform/bitbucket-server/index.ts
+++ b/lib/modules/platform/bitbucket-server/index.ts
@@ -161,6 +161,10 @@ export async function initPlatform({
         )
       ).body;
 
+      if (!emailAddress.length) {
+        throw new Error(`No email address configured for username ${username}`);
+      }
+
       platformConfig.gitAuthor = `${displayName} <${emailAddress}>`;
 
       logger.debug(`Detected gitAuthor: ${platformConfig.gitAuthor}`);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Fixes a platform init error that occurs when users have no email addresses assigned. From what I've seen, this can only happen with federated identities, otherwise email address is a mandatory field. 

With this change, the fallback gitAuthor is used, if `emailAddress` is empty.

<!-- Describe what behavior is changed by this PR. -->

## Context

- Closes https://github.com/renovatebot/renovate/issues/31175
- https://github.com/renovatebot/renovate/pull/29525

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
