### PR TITLE
chore(manager/custom): log when no dependencies for custom regex manager

### DIFF
--- a/lib/modules/manager/custom/regex/index.ts
+++ b/lib/modules/manager/custom/regex/index.ts
@@ -1,5 +1,6 @@
 import is from '@sindresorhus/is';
 import type { Category } from '../../../../constants';
+import { logger } from '../../../../logger';
 import type {
   ExtractConfig,
   MaybePromise,
@@ -9,7 +10,6 @@ import type {
 import { validMatchFields } from '../utils';
 import { handleAny, handleCombination, handleRecursive } from './strategies';
 import type { RegexManagerConfig, RegexManagerTemplates } from './types';
-import { logger } from '../../../../logger';
 
 export const categories: Category[] = ['custom'];
 

--- a/lib/modules/manager/custom/regex/index.ts
+++ b/lib/modules/manager/custom/regex/index.ts
@@ -9,6 +9,7 @@ import type {
 import { validMatchFields } from '../utils';
 import { handleAny, handleCombination, handleRecursive } from './strategies';
 import type { RegexManagerConfig, RegexManagerTemplates } from './types';
+import { logger } from '../../../../logger';
 
 export const categories: Category[] = ['custom'];
 
@@ -68,6 +69,10 @@ export function extractPackageFile(
     }
     return res;
   }
+  logger.debug(
+    { packageFile },
+    'No dependencies found in file for custom regex manager',
+  );
 
   return null;
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds a log message per-packageFile when custom regex managers don't match anything.

## Context

#34547

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
