### PR TITLE
refactor(gradle): unify handling of custom and predefined registry URLs

### DIFF
--- a/lib/modules/manager/gradle/parser/handlers.ts
+++ b/lib/modules/manager/gradle/parser/handlers.ts
@@ -1,8 +1,8 @@
-import URL from 'node:url';
 import upath from 'upath';
 import { logger } from '../../../../logger';
 import { getSiblingFileName } from '../../../../util/fs';
 import { regEx } from '../../../../util/regex';
+import { parseUrl } from '../../../../util/url';
 import type { PackageDependency } from '../../types';
 import type { parseGradle as parseGradleCallback } from '../parser';
 import type {
@@ -15,7 +15,6 @@ import { isDependencyString, parseDependencyString } from '../utils';
 import {
   GRADLE_PLUGINS,
   GRADLE_TEST_SUITES,
-  REGISTRY_URLS,
   findVariable,
   interpolateString,
   loadFromTokenMap,
@@ -337,19 +336,7 @@ function isPluginRegistry(ctx: Ctx): boolean {
   return false;
 }
 
-export function handlePredefinedRegistryUrl(ctx: Ctx): Ctx {
-  const registryName = loadFromTokenMap(ctx, 'registryUrl')[0].value;
-
-  ctx.registryUrls.push({
-    registryUrl: REGISTRY_URLS[registryName as keyof typeof REGISTRY_URLS],
-    scope: isPluginRegistry(ctx) ? 'plugin' : 'dep',
-    content: ctx.tmpRegistryContent,
-  });
-
-  return ctx;
-}
-
-export function handleCustomRegistryUrl(ctx: Ctx): Ctx {
+export function handleRegistryUrl(ctx: Ctx): Ctx {
   let localVariables = ctx.globalVars;
 
   if (ctx.tokenMap.name) {
@@ -373,17 +360,13 @@ export function handleCustomRegistryUrl(ctx: Ctx): Ctx {
   );
   if (registryUrl) {
     registryUrl = registryUrl.replace(regEx(/\\/g), '');
-    try {
-      const { host, protocol } = URL.parse(registryUrl);
-      if (host && protocol) {
-        ctx.registryUrls.push({
-          registryUrl,
-          scope: isPluginRegistry(ctx) ? 'plugin' : 'dep',
-          content: ctx.tmpRegistryContent,
-        });
-      }
-    } catch {
-      // no-op
+    const url = parseUrl(registryUrl);
+    if (url?.host && url.protocol) {
+      ctx.registryUrls.push({
+        registryUrl,
+        scope: isPluginRegistry(ctx) ? 'plugin' : 'dep',
+        content: ctx.tmpRegistryContent,
+      });
     }
   }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Simplifies the potential implementation of `exclusiveContent` by resolving URLs for predefined registries like `mavenCentral()` early during parsing. Any additional registry logic for `exlusiveContent` won't need to be added twice.
- Replaces the deprecated `URL.parse()` with `parseUrl()`.

<!-- Describe what behavior is changed by this PR. -->

## Context

- https://github.com/renovatebot/renovate/issues/14208

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
