### PR TITLE
fix(versioning/hex): Fix Hex range widening

### DIFF
--- a/lib/modules/versioning/hex/index.spec.ts
+++ b/lib/modules/versioning/hex/index.spec.ts
@@ -84,6 +84,8 @@ describe('modules/versioning/hex/index', () => {
     ${'>= 1.0.0 or <= 2.0.0'}  | ${'replace'}         | ${'1.2.3'}     | ${'2.0.7'} | ${'<= 2.0.7'}
     ${'>= 1.0.0 or <= 2.0.0'}  | ${'pin'}             | ${'1.2.3'}     | ${'2.0.7'} | ${'== 2.0.7'}
     ${'~> 0.4'}                | ${'replace'}         | ${'0.4.2'}     | ${'0.6.0'} | ${'~> 0.6'}
+    ${'~> 1.0'}                | ${'widen'}           | ${'1.0.0'}     | ${'2.0.0'} | ${'~> 1.0 or ~> 2.0'}
+    ${'~> 1.0.0'}              | ${'widen'}           | ${'1.0.0'}     | ${'2.0.0'} | ${'~> 1.0.0 or ~> 2.0.0'}
   `(
     'getNewValue("$currentValue", "$rangeStrategy", "$currentVersion", "$newVersion") === "$expected"',
     ({ currentValue, rangeStrategy, currentVersion, newVersion, expected }) => {

--- a/lib/modules/versioning/hex/index.ts
+++ b/lib/modules/versioning/hex/index.ts
@@ -89,16 +89,16 @@ function getNewValue({
 
     if (regEx(/~>\s*(\d+\.\d+\.\d+)$/).test(currentValue)) {
       newSemver = newSemver.replace(
-        regEx(/[\^~]\s*(\d+\.\d+\.\d+)/),
+        regEx(/[\^~]\s*(\d+\.\d+\.\d+)/g),
         (_str, p1: string) => `~> ${p1}`,
       );
     } else if (regEx(/~>\s*(\d+\.\d+)$/).test(currentValue)) {
       newSemver = newSemver.replace(
-        regEx(/\^\s*(\d+\.\d+)(\.\d+)?/),
+        regEx(/\^\s*(\d+\.\d+)(\.\d+)?/g),
         (_str, p1: string) => `~> ${p1}`,
       );
     } else {
-      newSemver = newSemver.replace(regEx(/~\s*(\d+\.\d+\.\d)/), '~> $1');
+      newSemver = newSemver.replace(regEx(/~\s*(\d+\.\d+\.\d)/g), '~> $1');
     }
     if (npm.isVersion(newSemver)) {
       newSemver = `== ${newSemver}`;

--- a/lib/modules/versioning/hex/readme.md
+++ b/lib/modules/versioning/hex/readme.md
@@ -1,1 +1,1 @@
-Hex versioning syntax is used for Elixir and Erlang hex dependencies. It is based on [Semantic Versioning 2.0](https://semver.org) and supports a subset of npm's range syntax.
+Hex versioning syntax is used for Elixir, Erlang and Gleam hex dependencies. It is based on [Semantic Versioning 2.0](https://semver.org) and supports a subset of npm's range syntax.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds the `/g` global flag to the regex's that convert npm ranges back into hex ranges.

Adds a new test case to better cover widening of ranges.

<!-- Describe what behavior is changed by this PR. -->

## Context

A Gleam user identified a test case where renovate's `widen` range strategy created a broken updated range. The test case is not specific to Gleam.

Failing PR: https://github.com/TanklesXL/glint/pull/75

Currently renovate produces these results:

Current Value: `~> 1.0`
Range Strategy: `widen`
Current Version: `1.0.0`
New Version: `2.0.0`
Expected: `~> 1.0 or ~> 2.0`
Got: `~> 1.0 or ^2.0.0`

After changing the regex's to act on all occurrences in the string, we get:

Current Value: `~> 1.0`
Range Strategy: `widen`
Current Version: `1.0.0`
New Version: `2.0.0`
Expected: `~> 1.0 or ~> 2.0`
Got: `~> 1.0 or ~> 2.0`

The Gleam Manager uses Hex Versioning, so the coverage I believe is Elixir, Erlang and Gleam. Existing test cases continue to pass after these changes, so I'm hoping for no negative impacts of this change. Let me know if I missed anything!

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
