### PR TITLE
refactor(gradle): make uri parsing reusable

### DIFF
--- a/lib/modules/manager/gradle/parser/common.spec.ts
+++ b/lib/modules/manager/gradle/parser/common.spec.ts
@@ -1,4 +1,5 @@
 import type { lexer } from 'good-enough-parser';
+import { lang } from 'good-enough-parser';
 import { partial } from '../../../../../test/util';
 import type { Ctx } from '../types';
 import {
@@ -9,6 +10,7 @@ import {
   interpolateString,
   loadFromTokenMap,
   prependNestingDepth,
+  qUri,
   reduceNestingDepth,
   storeInTokenMap,
   storeVarToken,
@@ -16,6 +18,7 @@ import {
 } from './common';
 
 describe('modules/manager/gradle/parser/common', () => {
+  const groovy = lang.createLang('groovy');
   let ctx: Ctx;
   const token = partial<lexer.Token>({ value: 'test' });
 
@@ -175,5 +178,19 @@ describe('modules/manager/gradle/parser/common', () => {
         ctx,
       ),
     ).toBeNull();
+  });
+
+  describe('qUri', () => {
+    it.each`
+      input                           | url
+      ${'"https://foo.bar/baz"'}      | ${'https://foo.bar/baz'}
+      ${'uri("https://foo.bar/baz")'} | ${'https://foo.bar/baz'}
+    `('$input', ({ input, url }) => {
+      const result = groovy.query(input, qUri, ctx);
+
+      expect(result).toMatchObject({
+        varTokens: [{ value: url }],
+      });
+    });
   });
 });

--- a/lib/modules/manager/gradle/parser/common.ts
+++ b/lib/modules/manager/gradle/parser/common.ts
@@ -301,6 +301,16 @@ export const qValueMatcher = qConcatExpr(
   qVariableAccessIdentifier,
 );
 
+// uri("https://foo.bar/baz")
+// "https://foo.bar/baz"
+export const qUri = q.alt(
+  q.sym<Ctx>('uri').tree({
+    maxDepth: 1,
+    search: qValueMatcher,
+  }),
+  qValueMatcher,
+);
+
 // import foo.bar
 // runtimeOnly("some:foo:${bar.bazVersion}")
 export const qKotlinImport = q

--- a/lib/modules/manager/gradle/parser/registry-urls.ts
+++ b/lib/modules/manager/gradle/parser/registry-urls.ts
@@ -9,6 +9,7 @@ import {
   cleanupTempVars,
   qArtifactId,
   qGroupId,
+  qUri,
   qValueMatcher,
   qVersion,
   storeInTokenMap,
@@ -83,15 +84,7 @@ const qRegistryContent = q.sym<Ctx>('content').tree({
 
 // uri("https://foo.bar/baz")
 // "https://foo.bar/baz"
-const qUri = q
-  .alt(
-    q.sym<Ctx>('uri').tree({
-      maxDepth: 1,
-      search: qValueMatcher,
-    }),
-    qValueMatcher,
-  )
-  .handler((ctx) => storeInTokenMap(ctx, 'registryUrl'));
+const qRegistryUrl = qUri.handler((ctx) => storeInTokenMap(ctx, 'registryUrl'));
 
 // mavenCentral()
 // mavenCentral { ... }
@@ -130,12 +123,12 @@ const qMavenArtifactRegistry = q.tree({
       .opt(q.op('='))
       .join(qValueMatcher)
       .handler((ctx) => storeInTokenMap(ctx, 'name')),
-    q.sym<Ctx>('url').opt(q.op('=')).join(qUri),
+    q.sym<Ctx>('url').opt(q.op('=')).join(qRegistryUrl),
     q.sym<Ctx>('setUrl').tree({
       maxDepth: 1,
       startsWith: '(',
       endsWith: ')',
-      search: q.begin<Ctx>().join(qUri).end(),
+      search: q.begin<Ctx>().join(qRegistryUrl).end(),
     }),
     qRegistryContent,
   ),
@@ -153,7 +146,11 @@ const qCustomRegistryUrl = q
         maxDepth: 1,
         startsWith: '(',
         endsWith: ')',
-        search: q.begin<Ctx>().opt(q.sym<Ctx>('url').op('=')).join(qUri).end(),
+        search: q
+          .begin<Ctx>()
+          .opt(q.sym<Ctx>('url').op('='))
+          .join(qRegistryUrl)
+          .end(),
       })
       .opt(qMavenArtifactRegistry),
     qMavenArtifactRegistry,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
Moves gradle uri parsing to common to make it reusable.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

I've got a first walking skeleton for #14208.
I would like to make some preparatory refactorings to make the feature PR concise.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
