### PR TITLE
fix(actions): add extractVersion to actions versions lookup

### DIFF
--- a/lib/modules/manager/github-actions/extract.spec.ts
+++ b/lib/modules/manager/github-actions/extract.spec.ts
@@ -664,6 +664,7 @@ describe('modules/manager/github-actions/extract', () => {
           currentValue: '16.x',
           datasource: 'github-releases',
           versioning: 'node',
+          extractVersion: '^(?<version>\\d+\\.\\d+\\.\\d+)(-\\d+)?$',
           depType: 'uses-with',
         },
         {
@@ -672,6 +673,7 @@ describe('modules/manager/github-actions/extract', () => {
           currentValue: '20.0.0',
           datasource: 'github-releases',
           versioning: 'node',
+          extractVersion: '^(?<version>\\d+\\.\\d+\\.\\d+)(-\\d+)?$',
           depType: 'uses-with',
         },
         {
@@ -680,6 +682,7 @@ describe('modules/manager/github-actions/extract', () => {
           currentValue: '1.23',
           datasource: 'github-releases',
           versioning: 'npm',
+          extractVersion: '^(?<version>\\d+\\.\\d+\\.\\d+)(-\\d+)?$',
           depType: 'uses-with',
         },
         {
@@ -688,6 +691,7 @@ describe('modules/manager/github-actions/extract', () => {
           currentValue: '>=3.8.0 <3.10.0',
           datasource: 'github-releases',
           versioning: 'npm',
+          extractVersion: '^(?<version>\\d+\\.\\d+\\.\\d+)(-\\d+)?$',
           depType: 'uses-with',
         },
         {
@@ -696,6 +700,7 @@ describe('modules/manager/github-actions/extract', () => {
           currentValue: 'latest',
           datasource: 'github-releases',
           versioning: 'node',
+          extractVersion: '^(?<version>\\d+\\.\\d+\\.\\d+)(-\\d+)?$',
           depType: 'uses-with',
         },
       ]);

--- a/lib/modules/manager/github-actions/extract.ts
+++ b/lib/modules/manager/github-actions/extract.ts
@@ -260,6 +260,7 @@ function extractWithYAMLParser(
               depName: action,
               packageName: `actions/${action}-versions`,
               ...actionData,
+              extractVersion: '^(?<version>\\d+\\.\\d+\\.\\d+)(-\\d+)?$', // Actions release tags are like 1.24.1-13667719799
               currentValue,
               depType: 'uses-with',
             });


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds extractVersions to actions to overcome strange tagging

## Context

https://github.com/actions/python-versions/tags

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
