### PR TITLE
fix(nuget): PackageSourceMapping: give the longest path precedence

### DIFF
--- a/lib/modules/manager/nuget/util.spec.ts
+++ b/lib/modules/manager/nuget/util.spec.ts
@@ -240,7 +240,11 @@ describe('modules/manager/nuget/util', () => {
         {
           name: 'contoso.com',
           url: 'https://contoso.com/packages/',
-          sourceMappedPackagePatterns: ['Contoso.*', 'NuGet.Common'],
+          sourceMappedPackagePatterns: [
+            'Contoso.*',
+            'NuGet.Common',
+            'AdventureWorks*',
+          ],
         },
         {
           name: 'contoso.test',
@@ -250,6 +254,7 @@ describe('modules/manager/nuget/util', () => {
             'Contoso.Test.*',
             'NuGet.*',
             'NuGet.Common*',
+            'AdventureWorks.Test.*',
           ],
         },
       ];
@@ -280,6 +285,16 @@ describe('modules/manager/nuget/util', () => {
         applyRegistries({ depName: 'Contoso.Test.SomePackage' }, registries),
       ).toEqual({
         depName: 'Contoso.Test.SomePackage',
+        registryUrls: ['https://contoso.test/packages/'],
+      });
+
+      expect(
+        applyRegistries(
+          { depName: 'AdventureWorks.Test.SomePackage' },
+          registries,
+        ),
+      ).toEqual({
+        depName: 'AdventureWorks.Test.SomePackage',
         registryUrls: ['https://contoso.test/packages/'],
       });
     });

--- a/lib/modules/manager/nuget/util.ts
+++ b/lib/modules/manager/nuget/util.ts
@@ -211,8 +211,8 @@ function sortPatterns(
     return -1;
   }
 
-  const aTrim = a[0].replace(/\*$/, '');
-  const bTrim = b[0].replace(/\*$/, '');
+  const aTrim = a[0].slice(0, -1);
+  const bTrim = b[0].slice(0, -1);
 
   return aTrim.localeCompare(bTrim) * -1;
 }

--- a/lib/modules/manager/nuget/util.ts
+++ b/lib/modules/manager/nuget/util.ts
@@ -197,6 +197,7 @@ export function applyRegistries(
  * Sorts patterns by specificity:
  * 1. Exact match patterns
  * 2. Wildcard match patterns
+ * The longest pattern has precedence.
  */
 function sortPatterns(
   a: [string, Registry[]],
@@ -210,7 +211,14 @@ function sortPatterns(
     return -1;
   }
 
-  return a[0].localeCompare(b[0]) * -1;
+  const aPathLength = (a[0].match(/\./g) ?? []).length;
+  const bPathLength = (b[0].match(/\./g) ?? []).length;
+
+  if (aPathLength === bPathLength) {
+    return a[0].localeCompare(b[0]) * -1;
+  }
+
+  return aPathLength < bPathLength ? 1 : -1;
 }
 
 export async function findGlobalJson(

--- a/lib/modules/manager/nuget/util.ts
+++ b/lib/modules/manager/nuget/util.ts
@@ -211,14 +211,10 @@ function sortPatterns(
     return -1;
   }
 
-  const aPathLength = (a[0].match(/\./g) ?? []).length;
-  const bPathLength = (b[0].match(/\./g) ?? []).length;
+  const aTrim = a[0].replace(/\*$/, '');
+  const bTrim = b[0].replace(/\*$/, '');
 
-  if (aPathLength === bPathLength) {
-    return a[0].localeCompare(b[0]) * -1;
-  }
-
-  return aPathLength < bPathLength ? 1 : -1;
+  return aTrim.localeCompare(bTrim) * -1;
 }
 
 export async function findGlobalJson(


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

NuGet PackageSourceMappings should give precedence to the longest path.
This is achieved by sorting the matching mappings. The order was defined by the localeCompare function. This failed for edge cases involving PackageSourceMappings with and without a period.

My change uses the path length defined by the number of periods to improve the sort order.

## Context

The PackageSourceMapping in our nuget.config caused the following warning:
```
 WARN: Package lookup failures (repository=groupname/reponame)
       "warnings": [
         "Failed to look up nuget package Package.Long.Name1",
         "Failed to look up nuget package Package.Even.Longer.Name2"
       ],
       "files": ["Directory.Packages.props"]
```

Debug logs showed 404 errors when trying to access the package. The wrong feed was used.
```
DEBUG: GET https://proget.internal/nuget/wrong-feed/v3/registrations-gz/package.long.name1/index.json = (code=ERR_NON_2XX_3XX_RESPONSE, statusCode=404 retryCount=0, duration=974) (repository=groupname/reponame)
DEBUG: Datasource 404 (repository=groupname/reponame)
       "datasource": "nuget",
       "packageName": "package.long.name1",
       "url": " https://proget.internal/nuget/wrong-feed/v3/registrations-gz/package.long.name1/index.json"
DEBUG: Failed to look up nuget package package.long.name1 (repository=groupname/reponame, packageFile=Directory.Packages.props, dependency=package.long.name1)
```

The nuget.config works correctly with `dotnet restore`. The rules should be valid, according to the documentation at https://learn.microsoft.com/en-us/nuget/consume-packages/package-source-mapping

The following is the relevant part of our nuget.config. Note that the pattern "Package*" in "wrong-feed" does not contain a period.
```
<?xml version="1.0" encoding="utf-8"?>
<configuration>
  <packageSources>
    <clear />
    <add key="wrong-feed" value="https://proget.internal/nuget/re-motion-debug/v3/index.json" />
    <add key="correct-feed" value="https://proget.internal/nuget/correct-feed/v3/index.json" />
    <add key="other-feed" value="https://proget.internal/nuget/other-feed/v3/index.json" />
  </packageSources>
  <packageSourceMapping>
    <!-- key value for <packageSource> should match key values from <packageSources> element -->
    <packageSource key="correct-feed">
      <package pattern="Package.Long.*" />
    </packageSource>
    <packageSource key="other-feed">
      <package pattern="Other.Things.*" />
      <package pattern="Some.Packages.*" />
    </packageSource>
    <packageSource key="wrong-feed">
      <package pattern="Package*" />
      <package pattern="Fork.Coypu*" />
    </packageSource>
  </packageSourceMapping>
</configuration>
```



I extended a test to see if I could reproduce the issue, then wrote a fix.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
