### PR TITLE
fix(gomod): Revert "fix(manager/gomod): perfer to use go version defined as toolchain to update artifacts"

### DIFF
--- a/lib/modules/manager/gomod/artifacts.spec.ts
+++ b/lib/modules/manager/gomod/artifacts.spec.ts
@@ -2120,86 +2120,6 @@ describe('modules/manager/gomod/artifacts', () => {
     expect(execSnapshots).toMatchObject(expectedResult);
   });
 
-  it('go.mod file contains go toolchain version', async () => {
-    GlobalConfig.set({ ...adminConfig, binarySource: 'install' });
-    fs.readLocalFile.mockResolvedValueOnce('Current go.sum');
-    fs.readLocalFile.mockResolvedValueOnce(null); // vendor modules filename
-    const execSnapshots = mockExecAll();
-    git.getRepoStatus.mockResolvedValueOnce(
-      partial<StatusResult>({
-        modified: ['go.sum'],
-      }),
-    );
-    fs.readLocalFile
-      .mockResolvedValueOnce('New go.sum')
-      .mockResolvedValueOnce('New go.mod');
-
-    const res = await gomod.updateArtifacts({
-      packageFileName: 'go.mod',
-      updatedDeps: [{ depName: 'golang.org/x/crypto', newVersion: '0.35.0' }],
-      newPackageFileContent: `someText\n\ngo 1.13\n\ntoolchain go1.23.6\n\n${gomod1}`,
-      config: {
-        updateType: 'minor',
-      },
-    });
-
-    expect(res).toEqual([
-      { file: { type: 'addition', path: 'go.sum', contents: 'New go.sum' } },
-      { file: { type: 'addition', path: 'go.mod', contents: 'New go.mod' } },
-    ]);
-
-    expect(execSnapshots).toMatchObject([
-      {
-        cmd: 'install-tool golang 1.23.6',
-      },
-      {
-        cmd: 'go get -d -t ./...',
-      },
-    ]);
-
-    expect(datasource.getPkgReleases).toBeCalledTimes(0);
-  });
-
-  it('go.mod file contains full go version without toolchain', async () => {
-    GlobalConfig.set({ ...adminConfig, binarySource: 'install' });
-    fs.readLocalFile.mockResolvedValueOnce('Current go.sum');
-    fs.readLocalFile.mockResolvedValueOnce(null); // vendor modules filename
-    const execSnapshots = mockExecAll();
-    git.getRepoStatus.mockResolvedValueOnce(
-      partial<StatusResult>({
-        modified: ['go.sum'],
-      }),
-    );
-    fs.readLocalFile
-      .mockResolvedValueOnce('New go.sum')
-      .mockResolvedValueOnce('New go.mod');
-
-    const res = await gomod.updateArtifacts({
-      packageFileName: 'go.mod',
-      updatedDeps: [{ depName: 'golang.org/x/crypto', newVersion: '0.35.0' }],
-      newPackageFileContent: `someText\n\ngo 1.23.5\n\n${gomod1}`,
-      config: {
-        updateType: 'minor',
-      },
-    });
-
-    expect(res).toEqual([
-      { file: { type: 'addition', path: 'go.sum', contents: 'New go.sum' } },
-      { file: { type: 'addition', path: 'go.mod', contents: 'New go.mod' } },
-    ]);
-
-    expect(execSnapshots).toMatchObject([
-      {
-        cmd: 'install-tool golang 1.23.5',
-      },
-      {
-        cmd: 'go get -d -t ./...',
-      },
-    ]);
-
-    expect(datasource.getPkgReleases).toBeCalledTimes(0);
-  });
-
   it('returns artifact notices', async () => {
     artifactsExtra.getExtraDepsNotice.mockReturnValue('some extra notice');
     GlobalConfig.set({ ...adminConfig, binarySource: 'docker' });
@@ -2223,7 +2143,7 @@ describe('modules/manager/gomod/artifacts', () => {
       updatedDeps: [
         { depName: 'github.com/google/go-github/v24', newVersion: 'v28.0.0' },
       ],
-      newPackageFileContent: `someText\n\ngo 1.17\n\n${gomod1}`,
+      newPackageFileContent: gomod1,
       config: {
         updateType: 'major',
         postUpdateOptions: ['gomodUpdateImportPaths'],

--- a/lib/modules/manager/gomod/artifacts.ts
+++ b/lib/modules/manager/gomod/artifacts.ts
@@ -444,32 +444,6 @@ export async function updateArtifacts({
 }
 
 function getGoConstraints(content: string): string | undefined {
-  // prefer toolchain directive when go.mod has one
-  const toolchainMatch = regEx(/^toolchain\s*go(?<gover>\d+\.\d+\.\d+)$/m).exec(
-    content,
-  );
-  const toolchainVer = toolchainMatch?.groups?.gover;
-  if (toolchainVer) {
-    logger.debug(
-      `Using go version ${toolchainVer} found in toolchain directive`,
-    );
-    return toolchainVer;
-  }
-
-  // If go.mod doesn't have toolchain directive and has a full go version spec,
-  // for example `go 1.23.6`, pick this version, this doesn't match major.minor version spec.
-  //
-  // This is because when go.mod have same version defined in go directive and toolchain directive,
-  // go will remove toolchain directive from go.mod.
-  //
-  // For example, go will rewrite `go 1.23.5\ntoolchain go1.23.5` to `go 1.23.5` by default,
-  // in this case, the go directive is the toolchain directive.
-  const goFullVersion = regEx(/^go\s*(?<gover>\d+\.\d+\.\d+)$/m).exec(content)
-    ?.groups?.gover;
-  if (goFullVersion) {
-    return goFullVersion;
-  }
-
   const re = regEx(/^go\s*(?<gover>\d+\.\d+)$/m);
   const match = re.exec(content);
   if (!match?.groups?.gover) {


### PR DESCRIPTION
Reverts renovatebot/renovate#34564