### PR TITLE
fix(versioning/docker): pure semver prerelease support

### DIFF
--- a/lib/modules/versioning/docker/index.ts
+++ b/lib/modules/versioning/docker/index.ts
@@ -25,7 +25,7 @@ class DockerVersioningApi extends GenericVersioningApi {
     }
 
     // Try to identify a pure semver prerelease first
-    const semver = this.parseSemverPrerelease(version);
+    const semver = parseSemverPrerelease(version);
     if (semver) {
       return {
         release: [semver.major, semver.minor, semver.patch],
@@ -107,7 +107,7 @@ class DockerVersioningApi extends GenericVersioningApi {
     }
 
     // Try to identify a pure semver prerelease first
-    if (this.parseSemverPrerelease(value)) {
+    if (parseSemverPrerelease(value)) {
       return value;
     }
 
@@ -117,22 +117,22 @@ class DockerVersioningApi extends GenericVersioningApi {
 
   // Allow upgrading from 1.2.3-4 to 1.2.4-5
   allowUnstableMajorUpgrades = true;
+}
 
-  private parseSemverPrerelease(version: string): SemVer | null {
-    const semver = parseSemver(version);
-    if (!semver) {
-      return null;
-    }
-    if (semver.prerelease.length === 0) {
-      return null;
-    }
-    // Only consider the likes of 1.2.3-4 and 1.2.3-beta.0 to avoid catching 1.2.3-alpine as prerelease
-    const last = semver.prerelease[semver.prerelease.length - 1];
-    if (typeof last === 'number') {
-      return semver;
-    }
+function parseSemverPrerelease(version: string): SemVer | null {
+  const semver = parseSemver(version);
+  if (!semver) {
     return null;
   }
+  if (semver.prerelease.length === 0) {
+    return null;
+  }
+  // Only consider the likes of 1.2.3-4 and 1.2.3-beta.0 to avoid catching 1.2.3-alpine as prerelease
+  const last = semver.prerelease[semver.prerelease.length - 1];
+  if (typeof last === 'number') {
+    return semver;
+  }
+  return null;
 }
 
 export const api: VersioningApi = new DockerVersioningApi();

--- a/lib/modules/versioning/docker/index.ts
+++ b/lib/modules/versioning/docker/index.ts
@@ -101,6 +101,23 @@ class DockerVersioningApi extends GenericVersioningApi {
     );
   }
 
+  valueToVersion(value: string): string {
+    if (!value) {
+      return value;
+    }
+
+    // Try to identify a pure semver prerelease first
+    if (this.parseSemverPrerelease(value)) {
+      return value;
+    }
+
+    // Remove any suffix after '-', e.g. '-alpine'
+    return value.split('-')[0];
+  }
+
+  // Allow upgrading from 1.2.3-4 to 1.2.4-5
+  allowUnstableMajorUpgrades = true;
+
   private parseSemverPrerelease(version: string): SemVer | null {
     const semver = parseSemver(version);
     if (!semver) {
@@ -115,20 +132,6 @@ class DockerVersioningApi extends GenericVersioningApi {
       return semver;
     }
     return null;
-  }
-
-  valueToVersion(value: string): string {
-    if (!value) {
-      return value;
-    }
-
-    // Try to identify a pure semver prerelease first
-    if (this.parseSemverPrerelease(value)) {
-      return value;
-    }
-
-    // Remove any suffix after '-', e.g. '-alpine'
-    return value.split('-')[0];
   }
 }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Fix support for pure semver prerelease versions in docker versioning.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

Docker images can be tagged with pure semver prerelease versions, e.g. `1.2.3-beta.1`. Renovate currently doesn't support this and disregards everything after the `-` in the tag.

Note that none of the existing tests were modified, only new test cases where added. This means the new code should not break any existing behavior.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
