### PR TITLE
feat(presets): add workaround for TJ actions

### DIFF
--- a/lib/config/presets/internal/workarounds.ts
+++ b/lib/config/presets/internal/workarounds.ts
@@ -25,6 +25,7 @@ export const presets: Record<string, Preset> = {
       'workarounds:rke2KubernetesVersioning',
       'workarounds:libericaJdkDockerVersioning',
       'workarounds:ubuntuDockerVersioning',
+      'workarounds:tjActionsChangedFiles',
     ],
     ignoreDeps: [], // Hack to improve onboarding PR description
   },
@@ -280,6 +281,17 @@ export const presets: Record<string, Preset> = {
           'redhat/**',
         ],
         versioning: 'redhat',
+      },
+    ],
+  },
+  tjActionsChangedFiles: {
+    description:
+      'Skip updating tj-actions/changed-files due to it being hacked',
+    packageRules: [
+      {
+        matchDatasources: ['github-actions'],
+        matchPackageNames: ['tj-actions/changed-files'],
+        enabled: false,
       },
     ],
   },

--- a/lib/config/presets/internal/workarounds.ts
+++ b/lib/config/presets/internal/workarounds.ts
@@ -289,9 +289,8 @@ export const presets: Record<string, Preset> = {
       'Skip updating tj-actions/changed-files due to it being hacked',
     packageRules: [
       {
-        matchDatasources: ['github-actions'],
-        matchPackageNames: ['tj-actions/changed-files'],
         enabled: false,
+        matchPackageNames: ['tj-actions/changed-files'],
       },
     ],
   },


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Disable updating tj-actions/changed-files

## Context

https://github.com/renovatebot/renovate/discussions/34824

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
