### PR TITLE
fix(logging): Use right setter for `withMeta`

### DIFF
--- a/lib/logger/index.spec.ts
+++ b/lib/logger/index.spec.ts
@@ -22,7 +22,7 @@ import {
 } from '.';
 import { partial } from '~test/util';
 
-const initialContext = 'initial_context';
+const logContext = 'initial_context';
 
 vi.unmock('.');
 vi.mock('nanoid', () => ({
@@ -39,10 +39,7 @@ describe('logger/index', () => {
   it('uses an auto-generated log context', () => {
     logger.debug('');
 
-    expect(bunyanDebugSpy).toHaveBeenCalledWith(
-      { logContext: initialContext },
-      '',
-    );
+    expect(bunyanDebugSpy).toHaveBeenCalledWith({ logContext }, '');
   });
 
   it('sets and gets context', () => {
@@ -70,95 +67,127 @@ describe('logger/index', () => {
 
   describe('meta functions', () => {
     beforeEach(() => {
-      setContext(initialContext);
+      setContext(logContext);
+      setMeta({});
     });
 
     it('sets meta', () => {
-      const logMeta = { foo: 'foo' };
-      const meta = { bar: 'bar' };
-      setMeta(meta);
+      setMeta({ foo: 'foo' });
+      setMeta({ bar: 'bar' });
 
-      logger.debug(logMeta, '');
+      logger.debug({ baz: 'baz' }, 'message');
 
       expect(bunyanDebugSpy).toHaveBeenCalledWith(
-        { logContext: initialContext, ...meta, ...logMeta },
-        '',
+        {
+          logContext,
+          // `foo` key was rewritten
+          bar: 'bar',
+          baz: 'baz',
+        },
+        'message',
       );
       expect(bunyanDebugSpy).toHaveBeenCalledTimes(1);
     });
 
     it('adds meta', () => {
-      const logMeta = { foo: 'foo' };
-      const meta = { bar: 'bar' };
-      addMeta(meta);
+      setMeta({ foo: 'foo' });
+      addMeta({ bar: 'bar' });
 
-      logger.debug(logMeta, '');
+      logger.debug({ baz: 'baz' }, 'message');
 
       expect(bunyanDebugSpy).toHaveBeenCalledWith(
-        { logContext: initialContext, ...meta, ...logMeta },
-        '',
+        {
+          logContext,
+          foo: 'foo',
+          bar: 'bar',
+          baz: 'baz',
+        },
+        'message',
       );
       expect(bunyanDebugSpy).toHaveBeenCalledTimes(1);
     });
 
     it('removes meta', () => {
-      const logMeta = { foo: 'foo' };
-      const meta = { bar: 'bar' };
-      setMeta(meta);
+      setMeta({
+        foo: 'foo',
+        bar: 'bar',
+      });
 
-      logger.debug(logMeta, '');
+      logger.debug({ baz: 'baz' }, 'message');
 
       expect(bunyanDebugSpy).toHaveBeenCalledWith(
-        { logContext: initialContext, ...meta, ...logMeta },
-        '',
+        {
+          logContext,
+          foo: 'foo',
+          bar: 'bar',
+          baz: 'baz',
+        },
+        'message',
       );
       expect(bunyanDebugSpy).toHaveBeenCalledTimes(1);
 
-      removeMeta(Object.keys(meta));
+      removeMeta(['bar']);
 
-      logger.debug(logMeta, '');
+      logger.debug({ baz: 'baz' }, 'message');
 
       expect(bunyanDebugSpy).toHaveBeenCalledWith(
-        { logContext: initialContext, ...logMeta },
-        '',
+        {
+          logContext,
+          foo: 'foo',
+          baz: 'baz',
+        },
+        'message',
       );
       expect(bunyanDebugSpy).toHaveBeenCalledTimes(2);
     });
 
     it('withMeta adds and removes metadata correctly', () => {
-      const logMeta = { foo: 'foo' };
-      const tempMeta = { bar: 'bar' };
+      setMeta({ foo: 'foo' });
 
-      withMeta(tempMeta, () => {
-        logger.debug(logMeta, '');
+      withMeta({ bar: 'bar' }, () => {
+        logger.debug({ baz: 'baz' }, 'message');
         expect(bunyanDebugSpy).toHaveBeenCalledWith(
-          { logContext: initialContext, ...tempMeta, ...logMeta },
-          '',
+          {
+            logContext,
+            foo: 'foo',
+            bar: 'bar',
+            baz: 'baz',
+          },
+          'message',
         );
       });
 
-      logger.debug(logMeta, '');
+      logger.debug({ baz: 'baz' }, 'message');
       expect(bunyanDebugSpy).toHaveBeenCalledWith(
-        { logContext: initialContext, ...logMeta },
-        '',
+        {
+          logContext,
+          foo: 'foo',
+          bar: 'bar',
+          baz: 'baz',
+        },
+        'message',
       );
     });
 
     it('withMeta handles cleanup when callback throws', () => {
-      const logMeta = { foo: 'foo' };
-      const tempMeta = { bar: 'bar' };
+      setMeta({ foo: 'foo' });
 
       expect(() =>
-        withMeta(tempMeta, () => {
-          logger.debug(logMeta, '');
+        withMeta({ bar: 'bar' }, () => {
+          logger.debug({ baz: 'baz' }, 'message');
           throw new Error('test error');
         }),
       ).toThrow('test error');
 
-      logger.debug(logMeta, '');
+      logger.debug({ baz: 'baz' }, 'message');
       expect(bunyanDebugSpy).toHaveBeenCalledWith(
-        { logContext: initialContext, ...logMeta },
-        '',
+        {
+          logContext,
+          foo: 'foo',
+          bar: 'bar',
+          baz: 'baz',
+        },
+        'message',
       );
     });
   });

--- a/lib/logger/index.ts
+++ b/lib/logger/index.ts
@@ -124,7 +124,7 @@ export function removeMeta(fields: string[]): void {
 }
 
 export function withMeta<T>(obj: Record<string, unknown>, cb: () => T): T {
-  setMeta(obj);
+  addMeta(obj);
   try {
     return cb();
   } finally {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

- Fixes bug introduced in #33978
- Ref: #34817
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
