### PR TITLE
fix(nix): urldecode gitlab subgroups

### DIFF
--- a/lib/modules/manager/nix/extract.spec.ts
+++ b/lib/modules/manager/nix/extract.spec.ts
@@ -602,4 +602,45 @@ describe('modules/manager/nix/extract', () => {
       ],
     });
   });
+
+  const flake12Lock = `{
+    "nodes": {
+      "subgroup-project": {
+        "locked": {
+          "lastModified": 1739792862,
+          "narHash": "sha256-n0MrSIZZknq2OqOYgNS0iMp2yVRekpBFGhrhsT7aXGg=",
+          "owner": "group%2Fsub-group",
+          "repo": "subgroup-project",
+          "rev": "24b560624f154c9e962d146217b2a964faaf2055",
+          "type": "gitlab"
+        },
+        "original": {
+          "owner": "group%2Fsub-group",
+          "repo": "subgroup-project",
+          "type": "gitlab"
+        }
+      },
+      "root": {
+        "inputs": {
+          "subgroup-project": "subgroup-project"
+        }
+      }
+    },
+    "root": "root",
+    "version": 7
+  }`;
+
+  it('uri decode gitlab subgroup', async () => {
+    fs.readLocalFile.mockResolvedValueOnce(flake12Lock);
+    expect(await extractPackageFile('', 'flake.nix')).toMatchObject({
+      deps: [
+        {
+          currentDigest: '24b560624f154c9e962d146217b2a964faaf2055',
+          datasource: 'git-refs',
+          depName: 'subgroup-project',
+          packageName: 'https://gitlab.com/group/sub-group/subgroup-project',
+        },
+      ],
+    });
+  });
 });

--- a/lib/modules/manager/nix/extract.ts
+++ b/lib/modules/manager/nix/extract.ts
@@ -105,7 +105,7 @@ export async function extractPackageFile(
           currentValue: flakeOriginal.ref,
           currentDigest: flakeLocked.rev,
           datasource: GitRefsDatasource.id,
-          packageName: `https://${flakeOriginal.host ?? 'gitlab.com'}/${flakeOriginal.owner}/${flakeOriginal.repo}`,
+          packageName: `https://${flakeOriginal.host ?? 'gitlab.com'}/${decodeURIComponent(flakeOriginal.owner!)}/${flakeOriginal.repo}`,
         });
         break;
       case 'git':


### PR DESCRIPTION
Do to a bug in nix one needs to uri encode the owner of a gitlab repository that resides in a subgroups, in this case the `/` as `%20F`. This however breaks the `git ls-remotes` which renovate runs to discover if the input can be updated.

This commit passes the owner attribute through `decodeURIComponent` to ensure that `git` is unware of this workaround on nixs side.

Nix PR: https://github.com/NixOS/nix/pull/9163


<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
