### PR TITLE
fix(manager/asdf): use releases instead of tags for skaffold

### DIFF
--- a/lib/modules/manager/asdf/extract.spec.ts
+++ b/lib/modules/manager/asdf/extract.spec.ts
@@ -697,7 +697,7 @@ dummy 1.2.3
           },
           {
             currentValue: '2.14.0',
-            datasource: 'github-tags',
+            datasource: 'github-releases',
             packageName: 'GoogleContainerTools/skaffold',
             depName: 'skaffold',
             extractVersion: '^v(?<version>\\S+)',

--- a/lib/modules/manager/asdf/upgradeable-tooling.ts
+++ b/lib/modules/manager/asdf/upgradeable-tooling.ts
@@ -726,7 +726,7 @@ export const upgradeableTooling: Record<string, ToolingDefinition> = {
   skaffold: {
     asdfPluginUrl: 'https://github.com/nklmilojevic/asdf-skaffold',
     config: {
-      datasource: GithubTagsDatasource.id,
+      datasource: GithubReleasesDatasource.id,
       packageName: 'GoogleContainerTools/skaffold',
       extractVersion: '^v(?<version>\\S+)',
     },


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Right now skaffold update PRs + mise are broken because `mise` tries to fetch a github release and for skaffold and likely many other tools, potentially those in https://github.com/renovatebot/renovate/pull/34703, there is a period of time where the tag exists but the release doesn't so renovate's PRs are broken.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
