### PR TITLE
docs: configuration-options.md: dynamic addLabels with depName

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -79,8 +79,7 @@ With the above config:
 - ESLint dependencies will have the label `linting`
 - All other dependencies will have the label `dependencies`
 
-If you want to have labels added dynamically, you can use
-[templates](./templates.md) such as `depName` for `addLabels`:
+If you want to use dynamic labels, you can use [templates](./templates.md) such as this example using `depName` for `addLabels`:
 
 ```json
 {

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -79,6 +79,15 @@ With the above config:
 - ESLint dependencies will have the label `linting`
 - All other dependencies will have the label `dependencies`
 
+If you want to have labels added dynamically, you can use
+[templates](./templates.md) such as `depName` for `addLabels`:
+
+```json
+{
+  "addLabels": ["{{depName}}"]
+}
+```
+
 <!-- prettier-ignore -->
 !!! note
     Keep your labels within the maximum character limit for your Git hosting platform.


### PR DESCRIPTION
## Changes

Add example for adding labels based on e.g. `depName` to have "dynamic" labels.

## Context

https://github.com/renovatebot/renovate/discussions/34936

## Documentation (please check one with an [x])

- [X] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [X] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

