### PR TITLE
fix(libyear): reduce log noise

### DIFF
--- a/lib/workers/repository/process/libyear.spec.ts
+++ b/lib/workers/repository/process/libyear.spec.ts
@@ -94,13 +94,13 @@ describe('workers/repository/process/libyear', () => {
         ],
       };
       calculateLibYears(config, packageFiles);
-      expect(logger.logger.debug).toHaveBeenCalledWith(
+      expect(logger.logger.once.debug).toHaveBeenCalledWith(
         'No currentVersionTimestamp for some/image',
       );
-      expect(logger.logger.debug).toHaveBeenCalledWith(
+      expect(logger.logger.once.debug).toHaveBeenCalledWith(
         'No releaseTimestamp for dep1 update to 3.0.0',
       );
-      expect(logger.logger.debug).toHaveBeenCalledWith(
+      expect(logger.logger.once.debug).toHaveBeenCalledWith(
         'No currentVersionTimestamp for dep3',
       );
       expect(logger.logger.debug).toHaveBeenCalledWith(

--- a/lib/workers/repository/process/libyear.ts
+++ b/lib/workers/repository/process/libyear.ts
@@ -39,7 +39,7 @@ export function calculateLibYears(
 
         depInfo.outdated = true;
         if (!dep.currentVersionTimestamp) {
-          logger.debug(`No currentVersionTimestamp for ${dep.depName}`);
+          logger.once.debug(`No currentVersionTimestamp for ${dep.depName}`);
           allDeps.push(depInfo);
           continue;
         }
@@ -50,7 +50,7 @@ export function calculateLibYears(
 
         for (const update of dep.updates) {
           if (!update.releaseTimestamp) {
-            logger.debug(
+            logger.once.debug(
               `No releaseTimestamp for ${dep.depName} update to ${update.newVersion}`,
             );
             continue;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Only log each libyear combination once to reduce log spam:

<!-- Describe what behavior is changed by this PR. -->

## Context
Sample log
```
DEBUG: Package releases lookups complete (repository=forgejo/forgejo, baseBranch=forgejo)
DEBUG: No currentVersionTimestamp for data.forgejo.org/oci/node (repository=forgejo/forgejo, baseBranch=forgejo)
DEBUG: No currentVersionTimestamp for data.forgejo.org/oci/node (repository=forgejo/forgejo, baseBranch=forgejo)
DEBUG: No currentVersionTimestamp for data.forgejo.org/oci/node (repository=forgejo/forgejo, baseBranch=forgejo)
DEBUG: No currentVersionTimestamp for data.forgejo.org/oci/node (repository=forgejo/forgejo, baseBranch=forgejo)
DEBUG: No currentVersionTimestamp for data.forgejo.org/oci/node (repository=forgejo/forgejo, baseBranch=forgejo)
DEBUG: No currentVersionTimestamp for data.forgejo.org/oci/node (repository=forgejo/forgejo, baseBranch=forgejo)
DEBUG: No currentVersionTimestamp for data.forgejo.org/oci/node (repository=forgejo/forgejo, baseBranch=forgejo)
DEBUG: No currentVersionTimestamp for data.forgejo.org/renovate/renovate (repository=forgejo/forgejo, baseBranch=forgejo)
DEBUG: No currentVersionTimestamp for data.forgejo.org/oci/node (repository=forgejo/forgejo, baseBranch=forgejo)
DEBUG: No currentVersionTimestamp for data.forgejo.org/oci/node (repository=forgejo/forgejo, baseBranch=forgejo)
DEBUG: No currentVersionTimestamp for data.forgejo.org/oci/node (repository=forgejo/forgejo, baseBranch=forgejo)
DEBUG: No currentVersionTimestamp for data.forgejo.org/oci/node (repository=forgejo/forgejo, baseBranch=forgejo)
DEBUG: No currentVersionTimestamp for data.forgejo.org/oci/node (repository=forgejo/forgejo, baseBranch=forgejo)
DEBUG: No currentVersionTimestamp for data.forgejo.org/oci/node (repository=forgejo/forgejo, baseBranch=forgejo)
DEBUG: No currentVersionTimestamp for data.forgejo.org/oci/node (repository=forgejo/forgejo, baseBranch=forgejo)
DEBUG: No currentVersionTimestamp for data.forgejo.org/oci/node (repository=forgejo/forgejo, baseBranch=forgejo)
DEBUG: No currentVersionTimestamp for github.com/42wim/sshsig (repository=forgejo/forgejo, baseBranch=forgejo)
DEBUG: No currentVersionTimestamp for github.com/go-ap/activitypub (repository=forgejo/forgejo, baseBranch=forgejo)
DEBUG: No currentVersionTimestamp for github.com/google/pprof (repository=forgejo/forgejo, baseBranch=forgejo)
DEBUG: No currentVersionTimestamp for github.com/lunny/vfsgen (repository=forgejo/forgejo, baseBranch=forgejo)
DEBUG: No currentVersionTimestamp for renovate (repository=forgejo/forgejo, baseBranch=forgejo)
DEBUG: Repository libYears (repository=forgejo/forgejo, baseBranch=forgejo)
       "managerLibYears": {
         "devcontainer": 0,
         "dockerfile": 0,
         "github-actions": 1.3659251331811264,
         "gomod": 12.137915868550262,
         "jsonnet-bundler": 0,
         "npm": 18.390201940234057,
         "poetry": 0.016455289193302892,
         "regex": 2.1719550109095[547](https://codeberg.org/forgejo/forgejo/actions/runs/65992#jobstep-2-547)
       },
       "totalLibYears": 34.0824532420683,
       "totalDepsCount": 427,
       "outdatedDepsCount": 66
```
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
