### PR TITLE
feat(scalafmt): parse version when enclosed in quotes

### DIFF
--- a/lib/modules/manager/scalafmt/extract.spec.ts
+++ b/lib/modules/manager/scalafmt/extract.spec.ts
@@ -22,6 +22,25 @@ describe('modules/manager/scalafmt/extract', () => {
       });
     });
 
+    it('extracts version correctly if enclosed in quotes', () => {
+      const scalafmtConf = codeBlock`
+      version = "3.8.0"
+    `;
+      const packages = extractPackageFile(scalafmtConf);
+      expect(packages).toMatchObject({
+        deps: [
+          {
+            datasource: 'github-releases',
+            packageName: 'scalameta/scalafmt',
+            depName: 'scalafmt',
+            currentValue: '3.8.0',
+            versioning: 'semver',
+            extractVersion: '^v(?<version>\\S+)',
+          },
+        ],
+      });
+    });
+
     it('ignore file if no version specified', () => {
       const scalafmtConf = codeBlock`
       maxColumn = 80

--- a/lib/modules/manager/scalafmt/extract.ts
+++ b/lib/modules/manager/scalafmt/extract.ts
@@ -4,7 +4,7 @@ import * as semverVersioning from '../../versioning/semver';
 import type { PackageDependency, PackageFileContent } from '../types';
 
 const scalafmtVersionRegex = regEx(
-  'version *= *(?<version>\\d+\\.\\d+\\.\\d+)',
+  'version *= *"?(?<version>\\d+\\.\\d+\\.\\d+)"?',
 );
 
 export function extractPackageFile(content: string): PackageFileContent | null {


### PR DESCRIPTION
## Changes

- Fixes https://github.com/renovatebot/renovate/issues/34998

## Context

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

