### PR TITLE
feat(presets): output presets in log level "debug"

### DIFF
--- a/lib/config/presets/index.ts
+++ b/lib/config/presets/index.ts
@@ -149,7 +149,7 @@ export async function getPreset(
   if (!presetConfig) {
     throw new Error(PRESET_DEP_NOT_FOUND);
   }
-  logger.trace({ presetConfig }, `Found preset ${preset}`);
+  logger.debug({ presetConfig }, `Found preset ${preset}`);
   if (params) {
     const argMapping: Record<string, string> = {};
     for (const [index, value] of params.entries()) {


### PR DESCRIPTION
## Changes
Output message `Found preset ...` on log level `debug` rather than `trace`.

## Context

See https://github.com/renovatebot/renovate/discussions/15621 for a discussion to access the renovate analysis result programatically.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
