### PR TITLE
docs(manager): mention other CI variables

### DIFF
--- a/lib/modules/manager/gitlabci/readme.md
+++ b/lib/modules/manager/gitlabci/readme.md
@@ -7,12 +7,14 @@ If you use Gitlab Dependency Proxy then you can use these predefined variables a
 - `CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX`
 - `CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX`
 
-If you use the predefined `CI_REGISTRY` variable make sure to configure its value via `registryAliases`:
+If you use predefined GitLab CI variables like `CI_REGISTRY` or `CI_SERVER_FQDN` make sure to configure their value via `registryAliases`:
 
 ```json
 {
   "registryAliases": {
-    "$CI_REGISTRY": "registry.example.com"
+    "$CI_REGISTRY": "registry.example.com",
+    "$CI_SERVER_FQDN": "gitlab.example.com",
+    "$CI_SERVER_HOST": "gitlab.example.com"
   }
 }
 ```


### PR DESCRIPTION
## Changes

Extends the docs to mention that other predefined CI variables might need to be configured in the registry aliases.

:hammer_and_pick: with :heart: by [Siemens](https://opensource.siemens.com/)

## Context

Noticed this while playing with GitLab CI components where [the GitLab docs suggest using the `$CI_SERVER_FQDN ` variable](https://docs.gitlab.com/ci/components/#use-a-component).

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

