### PR TITLE
fix(nuget): Optimize NuGet dependency resolution

### DIFF
--- a/lib/modules/manager/nuget/package-tree.ts
+++ b/lib/modules/manager/nuget/package-tree.ts
@@ -87,6 +87,11 @@ function recursivelyGetDependentPackageFiles(
   graph: Graph,
   deps: Map<string, boolean>,
 ): void {
+  if (deps.has(packageFileName)) {
+    // we have already visited this package file
+    return;
+  }
+
   const dependents = graph.adjacent(packageFileName);
 
   if (!dependents || dependents.size === 0) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

The`recursivelyGetDependentPackageFiles` function now checks against the files already in the Map, to avoid redundant traversal of already-visited package files.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

Renovate was experiencing performance bottlenecks during NuGet dependency updates, resulting in the program stalling for hours.
I traced the issue to the `recursivelyGetDependentPackageFiles` function, which can be optimized by adding a check against files we have already visted.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
