### PR TITLE
fix: log disabled updates count

### DIFF
--- a/lib/workers/repository/updates/flatten.ts
+++ b/lib/workers/repository/updates/flatten.ts
@@ -217,20 +217,13 @@ export async function flattenUpdates(
       update.semanticCommits = semanticCommits;
     }
   }
-  let filteredOutCount = 0;
   const filteredUpdates = updates
-    .filter((update) => {
-      if (update.enabled === false) {
-        filteredOutCount += 1;
-        return false;
-      }
-      return true;
-    })
+    .filter((update) => update.enabled !== false)
     .map(({ vulnerabilityAlerts, ...update }) => update)
     .map((update) => filterConfig(update, 'branch'));
-  if (filteredOutCount) {
+  if (filteredUpdates.length < updates.length) {
     logger.debug(
-      `Filtered out ${filteredOutCount} disabled update(s). ${filteredUpdates.length} update(s) remaining.`,
+      `Filtered out ${updates.length - filteredUpdates.length} disabled update(s). ${filteredUpdates.length} update(s) remaining.`,
     );
   }
   return filteredUpdates;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Checks explicitly for enabled=false plus adds logging of the filtered count

## Context

If a package rule disables a particular update, it doesn't seem to be reflected in the logs anywhere

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
