### PR TITLE
docs: add a note how to fix minimum release age with GAR's maven

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2447,7 +2447,7 @@ In those cases a feature request needs to be implemented.
     For `minimumReleaseAge` to work, the Maven source must return reliable `last-modified` headers.
 
     <!-- markdownlint-disable MD046 -->
-    If your custom maven source registry doesnt support `last-modified` header, like GAR (Google Artifact Registry's Maven implementation, then feasible option is to extend maven source registry url with https://repo1.maven.org/maven2 as the first item, then `currentVersionTimestamp` via `last-modified` will be taken from maven central for public dependencies.
+    If your custom Maven source registry does _not_ support the `last-modified` header, like GAR (Google Artifact Registry's Maven implementation) then you can extend the Maven source registry url with `https://repo1.maven.org/maven2` as the first item. Then the `currentVersionTimestamp` via `last-modified` will be taken from Maven central for public dependencies.
 
     ```json
     "registryUrls": [

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2447,7 +2447,7 @@ In those cases a feature request needs to be implemented.
     For `minimumReleaseAge` to work, the Maven source must return reliable `last-modified` headers.
 
     <!-- markdownlint-disable MD046 -->
-    If your custom Maven source registry does _not_ support the `last-modified` header, like GAR (Google Artifact Registry's Maven implementation) then you can extend the Maven source registry url with `https://repo1.maven.org/maven2` as the first item. Then the `currentVersionTimestamp` via `last-modified` will be taken from Maven central for public dependencies.
+    If your custom Maven source registry is **full proxy or pull-through** and does _not_ support the `last-modified` header, like GAR (Google Artifact Registry's Maven implementation) then you can extend the Maven source registry url with `https://repo1.maven.org/maven2` as the first item. Then the `currentVersionTimestamp` via `last-modified` will be taken from Maven central for public dependencies.
 
     ```json
     "registryUrls": [

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2447,14 +2447,15 @@ In those cases a feature request needs to be implemented.
     For `minimumReleaseAge` to work, the Maven source must return reliable `last-modified` headers.
 
     If your custom maven source registry doesnt support `last-modified` header, like GAR (Google Artifact Registry's Maven implementation, then feasible option is to extend maven source registry url with https://repo1.maven.org/maven2 as the first item, then `currentVersionTimestamp` via `last-modified` will be taken from maven central for public dependencies.
-
+    
+    <!-- markdownlint-disable MD046 -->
     ```json
     "registryUrls": [
       "https://repo1.maven.org/maven2",
       "https://europe-maven.pkg.dev/org-artifacts/maven-virtual"
     ],
     ```
-
+    <!-- markdownlint-enable MD046 -->
 
 
 <!-- prettier-ignore -->

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2448,7 +2448,7 @@ In those cases a feature request needs to be implemented.
 
     <!-- markdownlint-disable MD046 -->
     If your custom maven source registry doesnt support `last-modified` header, like GAR (Google Artifact Registry's Maven implementation, then feasible option is to extend maven source registry url with https://repo1.maven.org/maven2 as the first item, then `currentVersionTimestamp` via `last-modified` will be taken from maven central for public dependencies.
-    
+
     ```json
     "registryUrls": [
       "https://repo1.maven.org/maven2",

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2447,7 +2447,7 @@ In those cases a feature request needs to be implemented.
     For `minimumReleaseAge` to work, the Maven source must return reliable `last-modified` headers.
 
     <!-- markdownlint-disable MD046 -->
-    If your custom Maven source registry is **full proxy or pull-through** and does _not_ support the `last-modified` header, like GAR (Google Artifact Registry's Maven implementation) then you can extend the Maven source registry url with `https://repo1.maven.org/maven2` as the first item. Then the `currentVersionTimestamp` via `last-modified` will be taken from Maven central for public dependencies.
+    If your custom Maven source registry is **pull-through** and does _not_ support the `last-modified` header, like GAR (Google Artifact Registry's Maven implementation) then you can extend the Maven source registry url with `https://repo1.maven.org/maven2` as the first item. Then the `currentVersionTimestamp` via `last-modified` will be taken from Maven central for public dependencies.
 
     ```json
     "registryUrls": [

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2446,6 +2446,17 @@ In those cases a feature request needs to be implemented.
 !!! warning "Warning for Maven users"
     For `minimumReleaseAge` to work, the Maven source must return reliable `last-modified` headers.
 
+    If your custom maven source registry doesnt support `last-modified` header, like GAR (Google Artifact Registry's Maven implementation, then feasible option is to extend maven source registry url with https://repo1.maven.org/maven2 as the first item, then `currentVersionTimestamp` via `last-modified` will be taken from maven central for public dependencies.
+
+    ```json
+    "registryUrls": [
+      "https://repo1.maven.org/maven2",
+      "https://europe-maven.pkg.dev/org-artifacts/maven-virtual"
+    ],
+    ```
+
+
+
 <!-- prettier-ignore -->
 !!! note
     Configuring this option will add a `renovate/stability-days` option to the status checks.

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2446,9 +2446,9 @@ In those cases a feature request needs to be implemented.
 !!! warning "Warning for Maven users"
     For `minimumReleaseAge` to work, the Maven source must return reliable `last-modified` headers.
 
+    <!-- markdownlint-disable MD046 -->
     If your custom maven source registry doesnt support `last-modified` header, like GAR (Google Artifact Registry's Maven implementation, then feasible option is to extend maven source registry url with https://repo1.maven.org/maven2 as the first item, then `currentVersionTimestamp` via `last-modified` will be taken from maven central for public dependencies.
     
-    <!-- markdownlint-disable MD046 -->
     ```json
     "registryUrls": [
       "https://repo1.maven.org/maven2",
@@ -2456,7 +2456,6 @@ In those cases a feature request needs to be implemented.
     ],
     ```
     <!-- markdownlint-enable MD046 -->
-
 
 <!-- prettier-ignore -->
 !!! note


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

Earlier today I opened a discussion https://github.com/renovatebot/renovate/discussions/35017

> ### Tell us more.

> after tj-actions incident we decided reevaluate our stance on immediate bumping of dependencies and we want to introduce minimum release age requirement. We happen to use java and GAR and apparently GAR's maven implementation doesn't support `last-modified` header. Which renders minimum release age option less useful than we want it to be.
>
> We will be talking to GAR support shortly to find a way to remediate it, but I dont think we should have expectations to get it fixed in timely manner.
>
> We notice renovate having confidence badges and one of them is badge with age. And it appears to be internal to renovate database. Because in the logs `[org.junit.jupiter:junit-jupiter-api](https://junit.org/junit5/)@5.12.1` mentioned as `DEBUG: No currentVersionTimestamp for org.junit.jupiter:junit-jupiter-api` while at the same time featuring 11 days old on a age badge [![age](https://developer.mend.io/api/mc/badges/age/maven/org.junit.jupiter:junit-jupiter-api/5.12.1?slim=true)](https://docs.renovatebot.com/merge-confidence/).
>
> I understand minimum release age feature and merge confidence feature probably got developed independently and there is no intersection between them right now.
>
> Will it hurt to use merge confidence age information as a fallback source for `currentVersionTimestamp` if underlying registry misses to deliver such information itself? Obviously, this behavior can be behind another option.

After some thoughts we discovered that we can add maven central on before GAR's maven and it will make it work, which I documented in the discussion and then decided to contribute to documentation, so more people are aware of the workaround.


## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
