### PR TITLE
fix(host-rules): respect `hostRules.enabled=false` even when `noAuth=true`

### DIFF
--- a/lib/util/http/host-rules.spec.ts
+++ b/lib/util/http/host-rules.spec.ts
@@ -563,4 +563,19 @@ describe('util/http/host-rules', () => {
       },
     });
   });
+
+  it('enabled=false with noAuth', () => {
+    hostRules.add({
+      hostType: 'docker',
+      enabled: false,
+    });
+
+    const opts = { ...options, hostType: 'docker', noAuth: true };
+    const hostRule = findMatchingRule(url, opts);
+    expect(applyHostRule(url, opts, hostRule)).toEqual({
+      hostType: 'docker',
+      noAuth: true,
+      enabled: false,
+    });
+  });
 });

--- a/lib/util/http/host-rules.ts
+++ b/lib/util/http/host-rules.ts
@@ -122,7 +122,7 @@ export function applyHostRule<GotOptions extends HostRulesGotOptions>(
   options: GotOptions,
   hostRule: HostRule,
 ): GotOptions {
-  const { username, password, token, enabled, authType } = hostRule;
+  const { username, password, token, authType } = hostRule;
   const host = parseUrl(url)?.host;
   if (options.noAuth) {
     logger.trace({ url }, `Authorization disabled`);
@@ -143,8 +143,6 @@ export function applyHostRule<GotOptions extends HostRulesGotOptions>(
     logger.trace({ url }, `Applying Bearer authentication`);
     options.token = token;
     options.context = { ...options.context, authType };
-  } else if (enabled === false) {
-    options.enabled = false;
   } else {
     logger.once.debug(`hostRules: no authentication for ${host}`);
   }
@@ -155,6 +153,10 @@ export function applyHostRule<GotOptions extends HostRulesGotOptions>(
 
   if (hostRule.abortIgnoreStatusCodes) {
     options.abortIgnoreStatusCodes = hostRule.abortIgnoreStatusCodes;
+  }
+
+  if (hostRule.enabled === false) {
+    options.enabled = false;
   }
 
   if (hostRule.timeout) {

--- a/lib/util/http/host-rules.ts
+++ b/lib/util/http/host-rules.ts
@@ -122,6 +122,11 @@ export function applyHostRule<GotOptions extends HostRulesGotOptions>(
   options: GotOptions,
   hostRule: HostRule,
 ): GotOptions {
+  if (hostRule.enabled === false) {
+    options.enabled = false;
+    return options;
+  }
+
   const { username, password, token, authType } = hostRule;
   const host = parseUrl(url)?.host;
   if (options.noAuth) {
@@ -153,10 +158,6 @@ export function applyHostRule<GotOptions extends HostRulesGotOptions>(
 
   if (hostRule.abortIgnoreStatusCodes) {
     options.abortIgnoreStatusCodes = hostRule.abortIgnoreStatusCodes;
-  }
-
-  if (hostRule.enabled === false) {
-    options.enabled = false;
   }
 
   if (hostRule.timeout) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

* Previously, when `options.noAuth = true`, `hostRules.enabled = false` setting was not respected
* This caused problems in cases where access to certain hosts—such as index.docker.io—was meant to be blocked by disabling specific hostRules.
* This change ensures that `hostRules.enabled = false` is properly respected, even when `options.noAuth = true`.

The below screenshot is to show
* trying to access index.docker.io
* `hostRule.enabled = false`
* `options.noAuth = true`
* Thus else-if block (l.146) won't be executed
![image](https://github.com/user-attachments/assets/d2df7b24-2c8d-496c-9500-ed347f391a6c)


## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

https://github.com/yueki-work/renovate-issue-hostRules-disable/blob/main/renovate.json

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
