### PR TITLE
docs: add some information about docs site publishing

### DIFF
--- a/docs/development/docs-site.md
+++ b/docs/development/docs-site.md
@@ -2,6 +2,5 @@
 
 The [Renovate docs site](https://docs.renovatebot.com) is built from [a dedicated publishing repository](https://github.com/renovatebot/renovatebot.github.io) that pulls the source files from [this repository](../usage/).
 
-
 The publishing process is triggered automatically via Renovate updates.
 If you have submitted a documentation PR and your changes are not published within a day feel free to ping the maintainers.

--- a/docs/development/docs-site.md
+++ b/docs/development/docs-site.md
@@ -2,5 +2,6 @@
 
 The [Renovate docs site](https://docs.renovatebot.com) is built from [a dedicated publishing repository](https://github.com/renovatebot/renovatebot.github.io) that pulls the source files from [this repository](../usage/).
 
-The publishing process is triggered manually as needed.
+
+The publishing process is triggered automatically via Renovate updates.
 If you have submitted a documentation PR and your changes are not published within a day feel free to ping the maintainers.

--- a/docs/development/docs-site.md
+++ b/docs/development/docs-site.md
@@ -1,0 +1,6 @@
+# Docs site
+
+The [Renovate docs site](https://docs.renovatebot.com) is built from [a dedicated publishing repository](https://github.com/renovatebot/renovatebot.github.io) that pulls the source files from [this repository](../usage/).
+
+The publishing process is triggered manually as needed.
+If you have submitted a documentation PR and your changes are not published within a day feel free to ping the maintainers.


### PR DESCRIPTION
## Changes

Add some information about the publishing of the docs site.

## Context

I was wondering why https://github.com/renovatebot/renovate/pull/35016 is not visible on https://docs.renovatebot.com/modules/manager/gitlabci/ yet and could not find anything in the development docs.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

:hammer_and_pick: with :heart: by [Siemens](https://opensource.siemens.com/)
