### PR TITLE
fix(gerrit): memCache being used all the time

### DIFF
--- a/lib/modules/platform/bitbucket-server/index.ts
+++ b/lib/modules/platform/bitbucket-server/index.ts
@@ -340,9 +340,10 @@ export async function getPr(
     return null;
   }
 
-  const opts: HttpOptions = refreshCache
-    ? { memCache: false }
-    : { cacheProvider: memCacheProvider };
+  const opts: HttpOptions = { memCache: false };
+  if (!refreshCache) {
+    opts.cacheProvider = memCacheProvider;
+  }
 
   const res = await bitbucketServerHttp.getJsonUnchecked<BbsRestPr>(
     `./rest/api/1.0/projects/${config.projectKey}/repos/${config.repositorySlug}/pull-requests/${prNo}`,

--- a/lib/modules/platform/bitbucket-server/index.ts
+++ b/lib/modules/platform/bitbucket-server/index.ts
@@ -340,7 +340,10 @@ export async function getPr(
     return null;
   }
 
+  // Disables memCache (which is enabled by default) to be replaced by
+  // memCacheProvider.
   const opts: HttpOptions = { memCache: false };
+  // TODO: should refresh the cache rather than just ignore it
   if (!refreshCache) {
     opts.cacheProvider = memCacheProvider;
   }

--- a/lib/modules/platform/gerrit/client.ts
+++ b/lib/modules/platform/gerrit/client.ts
@@ -62,7 +62,7 @@ class GerritClient {
     findPRConfig: GerritFindPRConfig,
     refreshCache?: boolean,
   ): Promise<GerritChange[]> {
-    const opts: HttpOptions = {};
+    const opts: HttpOptions = { memCache: false };
     if (!refreshCache) {
       opts.cacheProvider = memCacheProvider;
     }

--- a/lib/modules/platform/gerrit/client.ts
+++ b/lib/modules/platform/gerrit/client.ts
@@ -62,7 +62,10 @@ class GerritClient {
     findPRConfig: GerritFindPRConfig,
     refreshCache?: boolean,
   ): Promise<GerritChange[]> {
+    // Disables memCache (which is enabled by default) to be replaced by
+    // memCacheProvider.
     const opts: HttpOptions = { memCache: false };
+    // TODO: should refresh the cache rather than just ignore it
     if (!refreshCache) {
       opts.cacheProvider = memCacheProvider;
     }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Fixes memCache being used all the time in Gerrit platform.

Turns out that `memCache` option when not specified is assumed to be `true` by default.

This PR will make sure to properly and explicitly set `memCache` to `false` always, and use `memCacheProvider` only in the situations where `memCache` was previously allowed.

Note it also aligns the implementation with BitBucket platform to make the code better understandable, but it doesn't change the behavior there.

<!-- Describe what behavior is changed by this PR. -->

## Context

This fixes a regression of https://github.com/renovatebot/renovate/pull/33901, as reported [here](https://github.com/renovatebot/renovate/pull/33901#issuecomment-2758897013).

Such regression was causing several severe issues which was rendering the whole platform unusable.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
