### PR TITLE
feat(gitea): find prs from other authors

### DIFF
--- a/lib/modules/platform/gitea/gitea-helper.spec.ts
+++ b/lib/modules/platform/gitea/gitea-helper.spec.ts
@@ -16,6 +16,7 @@ import {
   getIssue,
   getOrgLabels,
   getPR,
+  getPRByBranch,
   getRepo,
   getRepoContents,
   getRepoLabels,
@@ -417,6 +418,40 @@ describe('modules/platform/gitea/gitea-helper', () => {
 
       const res = await getPR(mockRepo.full_name, mockPR.number);
       expect(res).toEqual(mockPR);
+    });
+  });
+
+  describe('getPRByBranch', () => {
+    it('should call /api/v1/repos/[repo]/pulls/[base]/[head] endpoint', async () => {
+      httpMock
+        .scope(baseUrl)
+        .get(
+          `/repos/${mockRepo.full_name}/pulls/${mockPR.base!.ref}/${mockPR.head!.label}`,
+        )
+        .reply(200, mockPR);
+
+      const res = await getPRByBranch(
+        mockRepo.full_name,
+        mockPR.base!.ref,
+        mockPR.head!.label,
+      );
+      expect(res).toEqual(mockPR);
+    });
+
+    it('should return null if pr not found', async () => {
+      httpMock
+        .scope(baseUrl)
+        .get(
+          `/repos/${mockRepo.full_name}/pulls/${mockPR.base!.ref}/${mockPR.head!.label}`,
+        )
+        .reply(404);
+
+      const res = await getPRByBranch(
+        mockRepo.full_name,
+        mockPR.base!.ref,
+        mockPR.head!.label,
+      );
+      expect(res).toBeNull();
     });
   });
 

--- a/lib/modules/platform/gitea/gitea-helper.spec.ts
+++ b/lib/modules/platform/gitea/gitea-helper.spec.ts
@@ -46,7 +46,7 @@ import type {
   User,
 } from './types';
 import * as httpMock from '~test/http-mock';
-import { partial } from '~test/util';
+import { logger, partial } from '~test/util';
 
 describe('modules/platform/gitea/gitea-helper', () => {
   const giteaApiHost = 'https://gitea.renovatebot.com/';
@@ -452,6 +452,28 @@ describe('modules/platform/gitea/gitea-helper', () => {
         mockPR.head!.label,
       );
       expect(res).toBeNull();
+    });
+
+    it('should log error', async () => {
+      httpMock
+        .scope(baseUrl)
+        .get(
+          `/repos/${mockRepo.full_name}/pulls/${mockPR.base!.ref}/${mockPR.head!.label}`,
+        )
+        .reply(410);
+
+      const res = await getPRByBranch(
+        mockRepo.full_name,
+        mockPR.base!.ref,
+        mockPR.head!.label,
+      );
+      expect(res).toBeNull();
+      expect(logger.logger.debug).toHaveBeenCalledWith(
+        {
+          err: expect.any(Object),
+        },
+        'Error while fetching PR',
+      );
     });
   });
 

--- a/lib/modules/platform/gitea/gitea-helper.ts
+++ b/lib/modules/platform/gitea/gitea-helper.ts
@@ -1,3 +1,4 @@
+import { logger } from '../../../logger';
 import type { BranchStatus } from '../../../types';
 import type { GiteaHttpOptions } from '../../../util/http/gitea';
 import { GiteaHttp } from '../../../util/http/gitea';
@@ -193,7 +194,11 @@ export async function getPRByBranch(
   try {
     const res = await giteaHttp.getJsonUnchecked<PR>(url, options);
     return res.body;
-  } catch {
+  } catch (err) {
+    logger.trace({ err }, 'Error while fetching PR');
+    if (err.statusCode !== 404) {
+      logger.debug({ err }, 'Error while fetching PR');
+    }
     return null;
   }
 }

--- a/lib/modules/platform/gitea/gitea-helper.ts
+++ b/lib/modules/platform/gitea/gitea-helper.ts
@@ -183,6 +183,21 @@ export async function getPR(
   return res.body;
 }
 
+export async function getPRByBranch(
+  repoPath: string,
+  base: string,
+  head: string,
+  options?: GiteaHttpOptions,
+): Promise<PR | null> {
+  const url = `${API_PATH}/repos/${repoPath}/pulls/${base}/${head}`;
+  try {
+    const res = await giteaHttp.getJsonUnchecked<PR>(url, options);
+    return res.body;
+  } catch {
+    return null;
+  }
+}
+
 export async function requestPrReviewers(
   repoPath: string,
   idx: number,

--- a/lib/modules/platform/gitea/index.spec.ts
+++ b/lib/modules/platform/gitea/index.spec.ts
@@ -1468,6 +1468,61 @@ describe('modules/platform/gitea/index', () => {
 
       expect(res).toBeNull();
     });
+
+    it('finds pr from other authors using base and head', async () => {
+      const scope = httpMock
+        .scope('https://gitea.com/api/v1')
+        .get('/repos/some/repo/pulls/some-base-branch/some-head-branch')
+        .reply(200, {
+          number: 42,
+          state: 'open',
+          head: {
+            label: 'some-head-branch',
+            sha: mockCommitHash,
+            repo: partial<Repo>({ full_name: mockRepo.full_name }),
+          },
+          base: {
+            ref: 'some-base-branch',
+          },
+          title: 'from other author',
+          body: 'pr-body',
+          mergeable: true,
+          created_at: '2014-04-01T05:14:20Z',
+          updated_at: '2017-12-28T12:17:48Z',
+        });
+      await initFakePlatform(scope);
+      await initFakeRepo(scope);
+
+      const res = await gitea.findPr({
+        branchName: 'some-head-branch',
+        targetBranch: 'some-base-branch',
+        includeOtherAuthors: true,
+      });
+
+      expect(res).toMatchObject({
+        number: 42,
+        sourceBranch: 'some-head-branch',
+        targetBranch: 'some-base-branch',
+        title: 'from other author',
+      });
+    });
+
+    it('returns null if cannot find pr from other author', async () => {
+      const scope = httpMock
+        .scope('https://gitea.com/api/v1')
+        .get('/repos/some/repo/pulls/some-base-branch/some-head-branch')
+        .reply(404);
+      await initFakePlatform(scope);
+      await initFakeRepo(scope);
+
+      const res = await gitea.findPr({
+        branchName: 'some-head-branch',
+        targetBranch: 'some-base-branch',
+        includeOtherAuthors: true,
+      });
+
+      expect(res).toBeNull();
+    });
   });
 
   describe('createPr', () => {

--- a/lib/modules/platform/gitea/index.ts
+++ b/lib/modules/platform/gitea/index.ts
@@ -531,8 +531,22 @@ const platform: Platform = {
     prTitle: title,
     state = 'all',
     includeOtherAuthors,
+    targetBranch,
   }: FindPRConfig): Promise<Pr | null> {
     logger.debug(`findPr(${branchName}, ${title!}, ${state})`);
+    if (includeOtherAuthors && is.string(targetBranch)) {
+      // do not use pr cache as it only fetches prs created by the bot account
+      const pr = await helper.getPRByBranch(
+        config.repository,
+        targetBranch,
+        branchName,
+      );
+      if (!pr) {
+        return null;
+      }
+
+      return toRenovatePR(pr, null);
+    }
     const prList = await platform.getPrList();
     const pr = prList.find(
       (p) =>

--- a/lib/modules/platform/gitea/types.ts
+++ b/lib/modules/platform/gitea/types.ts
@@ -30,7 +30,7 @@ export interface PR {
   merged?: boolean;
   created_at: string;
   updated_at: string;
-  closed_at: string;
+  closed_at: string | null;
   diff_url: string;
   base?: {
     ref: string;

--- a/lib/workers/repository/reconfigure/validate.ts
+++ b/lib/workers/repository/reconfigure/validate.ts
@@ -153,6 +153,7 @@ export async function validateReconfigureBranch(
       branchName,
       state: 'open',
       includeOtherAuthors: true,
+      targetBranch: config.defaultBranch,
     });
 
     // add comment to reconfigure PR if it exists


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- Use the sourceBranch and targetBranch to find PRs from other authors using the [getPullRequestByBaseHead](https://docs.gitea.com/api/1.23/#tag/repository/operation/repoGetPullRequestByBaseHead) endpoint of Gitea API
<!-- Describe what behavior is changed by this PR. -->

## Context
- Useful to find reconfigure PRs
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository https://gitea.com/RahulGautamSingh/labels/pulls/7

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
