### PR TITLE
feat: Fetch `currentVersionTimestamp` via datasource postprocess

### DIFF
--- a/lib/modules/datasource/postprocess-release.spec.ts
+++ b/lib/modules/datasource/postprocess-release.spec.ts
@@ -27,7 +27,7 @@ describe('modules/datasource/postprocess-release', () => {
   it('returns original release for empty datasource field', async () => {
     const releaseOrig: Release = { version: '1.2.3' };
     const release = await postprocessRelease(
-      { packageName: 'some-package', registryUrl: 'https://example.com' },
+      { packageName: 'some-package' },
       releaseOrig,
     );
     expect(release).toBe(releaseOrig);
@@ -38,11 +38,7 @@ describe('modules/datasource/postprocess-release', () => {
     getDatasourceFor.mockReturnValueOnce(null);
 
     const release = await postprocessRelease(
-      {
-        datasource: 'some-datasource',
-        packageName: 'some-package',
-        registryUrls: ['https://example.com'],
-      },
+      { datasource: 'some-datasource', packageName: 'some-package' },
       releaseOrig,
     );
 
@@ -97,7 +93,11 @@ describe('modules/datasource/postprocess-release', () => {
     getDatasourceFor.mockReturnValueOnce(new SomeDatasource());
 
     const release = await postprocessRelease(
-      { datasource: 'some-datasource', packageName: 'some-package' },
+      {
+        datasource: 'some-datasource',
+        packageName: 'some-package',
+        registryUrl: 'https://example.com',
+      },
       releaseOrig,
     );
 
@@ -142,7 +142,11 @@ describe('modules/datasource/postprocess-release', () => {
     getDatasourceFor.mockReturnValueOnce(new SomeDatasource());
 
     const release = await postprocessRelease(
-      { datasource: 'some-datasource', packageName: 'some-package' },
+      {
+        datasource: 'some-datasource',
+        packageName: 'some-package',
+        registryUrls: ['https://example.com'],
+      },
       releaseOrig,
     );
 

--- a/lib/modules/datasource/postprocess-release.spec.ts
+++ b/lib/modules/datasource/postprocess-release.spec.ts
@@ -27,7 +27,7 @@ describe('modules/datasource/postprocess-release', () => {
   it('returns original release for empty datasource field', async () => {
     const releaseOrig: Release = { version: '1.2.3' };
     const release = await postprocessRelease(
-      { packageName: 'some-package' },
+      { packageName: 'some-package', registryUrl: 'https://example.com' },
       releaseOrig,
     );
     expect(release).toBe(releaseOrig);
@@ -38,7 +38,11 @@ describe('modules/datasource/postprocess-release', () => {
     getDatasourceFor.mockReturnValueOnce(null);
 
     const release = await postprocessRelease(
-      { datasource: 'some-datasource', packageName: 'some-package' },
+      {
+        datasource: 'some-datasource',
+        packageName: 'some-package',
+        registryUrls: ['https://example.com'],
+      },
       releaseOrig,
     );
 

--- a/lib/modules/datasource/postprocess-release.ts
+++ b/lib/modules/datasource/postprocess-release.ts
@@ -40,7 +40,7 @@ export async function postprocessRelease(
     return release;
   }
 
-  const registryUrl = config.registryUrl ?? null;
+  const registryUrl = config.registryUrl ?? config.registryUrls?.at(0) ?? null;
 
   try {
     const result = await ds.postprocessRelease(

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -323,7 +323,7 @@ export async function lookupUpdates(
       }
 
       res.currentVersion = currentVersion!;
-      const currentVersionTimestamp = getTimestamp(
+      const currentVersionTimestamp = await getTimestamp(
         config,
         allVersions,
         currentVersion,

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -19,6 +19,7 @@ import {
   getDatasourceFor,
   getDefaultVersioning,
 } from '../../../../modules/datasource/common';
+import { postprocessRelease } from '../../../../modules/datasource/postprocess-release';
 import { getRangeStrategy } from '../../../../modules/manager';
 import * as allVersioning from '../../../../modules/versioning';
 import { id as dockerVersioningId } from '../../../../modules/versioning/docker';
@@ -28,6 +29,7 @@ import { getElapsedDays } from '../../../../util/date';
 import { applyPackageRules } from '../../../../util/package-rules';
 import { regEx } from '../../../../util/regex';
 import { Result } from '../../../../util/result';
+import type { Timestamp } from '../../../../util/timestamp';
 import { getBucket } from './bucket';
 import { getCurrentVersion } from './current';
 import { filterVersions } from './filter';
@@ -40,16 +42,28 @@ import {
   isReplacementRulesConfigured,
 } from './utils';
 
-function getTimestamp(
+async function getTimestamp(
+  config: LookupUpdateConfig,
   versions: Release[],
   version: string,
   versioningApi: allVersioning.VersioningApi,
-): string | null | undefined {
-  return versions.find(
+): Promise<Timestamp | null | undefined> {
+  const currentRelease = versions.find(
     (v) =>
       versioningApi.isValid(v.version) &&
       versioningApi.equals(v.version, version),
-  )?.releaseTimestamp;
+  );
+
+  if (!currentRelease) {
+    return null;
+  }
+
+  if (currentRelease.releaseTimestamp) {
+    return currentRelease.releaseTimestamp;
+  }
+
+  const remoteRelease = await postprocessRelease(config, currentRelease);
+  return remoteRelease?.releaseTimestamp;
 }
 
 export async function lookupUpdates(
@@ -310,6 +324,7 @@ export async function lookupUpdates(
 
       res.currentVersion = currentVersion!;
       const currentVersionTimestamp = getTimestamp(
+        config,
         allVersions,
         currentVersion,
         versioningApi,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

For datasources that require 1+N requests for timestamp fetching, we use `postprocessRelease`.
With introduction of [libYear](https://libyear.com) calculation, the `releaseTimestamp` of the current version (i.e. extracted by manager) is also required.
This PR uses `postprocessRelease` to fetch such timestamps.

## Context

- Closes: #35032
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
