### PR TITLE
refactor: move `customEnvVariables` to util folder

### DIFF
--- a/lib/config/presets/index.spec.ts
+++ b/lib/config/presets/index.spec.ts
@@ -3,6 +3,7 @@ import { PLATFORM_RATE_LIMIT_EXCEEDED } from '../../constants/error-messages';
 import { ExternalHostError } from '../../types/errors/external-host-error';
 import * as memCache from '../../util/cache/memory';
 import * as _packageCache from '../../util/cache/package';
+import { setCustomEnv } from '../../util/env';
 import { GlobalConfig } from '../global';
 import type { RenovateConfig } from '../types';
 import * as _github from './github';
@@ -331,7 +332,7 @@ describe('config/presets/index', () => {
     });
 
     it('resolves self-hosted preset with templating', async () => {
-      GlobalConfig.set({ customEnvVariables: { GIT_REF: 'abc123' } });
+      setCustomEnv({ GIT_REF: 'abc123' });
       config.extends = ['local>username/preset-repo#{{ env.GIT_REF }}'];
       local.getPreset.mockImplementationOnce(({ tag }) =>
         tag === 'abc123'

--- a/lib/util/env.ts
+++ b/lib/util/env.ts
@@ -1,0 +1,9 @@
+let customEnv: Record<string, string> = {};
+
+export function setCustomEnv(envObj: Record<string, string>): void {
+  customEnv = envObj;
+}
+
+export function getCustomEnv(): Record<string, string> {
+  return customEnv;
+}

--- a/lib/util/exec/index.spec.ts
+++ b/lib/util/exec/index.spec.ts
@@ -2,6 +2,7 @@ import { mockDeep } from 'vitest-mock-extended';
 import { GlobalConfig } from '../../config/global';
 import type { RepoGlobalConfig } from '../../config/types';
 import { TEMPORARY_ERROR } from '../../constants/error-messages';
+import { setCustomEnv } from '../env';
 import * as dockerModule from './docker';
 import { getHermitEnvs } from './hermit';
 import type { ExecOptions, RawExecOptions, VolumeOption } from './types';
@@ -48,6 +49,7 @@ describe('util/exec/index', () => {
     vi.restoreAllMocks();
     processEnvOrig = process.env;
     GlobalConfig.reset();
+    setCustomEnv({});
   });
 
   afterEach(() => {
@@ -795,6 +797,7 @@ describe('util/exec/index', () => {
       return Promise.resolve({ stdout: '', stderr: '' });
     });
     GlobalConfig.set({ ...globalConfig, localDir: cwd, ...adminConfig });
+    setCustomEnv(adminConfig.customEnvVariables);
     if (hermitEnvs !== undefined) {
       getHermitEnvsMock.mockResolvedValue(hermitEnvs);
     }

--- a/lib/util/exec/index.ts
+++ b/lib/util/exec/index.ts
@@ -3,6 +3,7 @@ import upath from 'upath';
 import { GlobalConfig } from '../../config/global';
 import { TEMPORARY_ERROR } from '../../constants/error-messages';
 import { logger } from '../../logger';
+import { getCustomEnv } from '../env';
 import { rawExec } from './common';
 import { generateInstallCommands, isDynamicInstall } from './containerbase';
 import {
@@ -79,8 +80,8 @@ async function prepareRawExec(
 ): Promise<RawExecArguments> {
   const { docker } = opts;
   const preCommands = opts.preCommands ?? [];
-  const { customEnvVariables, containerbaseDir, binarySource } =
-    GlobalConfig.get();
+  const customEnvVariables = getCustomEnv();
+  const { containerbaseDir, binarySource } = GlobalConfig.get();
 
   if (binarySource === 'docker' || binarySource === 'install') {
     logger.debug(`Setting CONTAINERBASE_CACHE_DIR to ${containerbaseDir!}`);

--- a/lib/util/exec/utils.ts
+++ b/lib/util/exec/utils.ts
@@ -1,5 +1,5 @@
 import is from '@sindresorhus/is';
-import { GlobalConfig } from '../../config/global';
+import { getCustomEnv } from '../env';
 import { getChildProcessEnv } from './env';
 import type { ExecOptions } from './types';
 
@@ -8,7 +8,7 @@ export function getChildEnv({
   userConfiguredEnv,
   env: forcedEnv = {},
 }: ExecOptions): Record<string, string> {
-  const globalConfigEnv = GlobalConfig.get('customEnvVariables');
+  const globalConfigEnv = getCustomEnv();
 
   const inheritedKeys: string[] = [];
   for (const [key, val] of Object.entries(extraEnv ?? {})) {

--- a/lib/workers/global/config/parse/index.spec.ts
+++ b/lib/workers/global/config/parse/index.spec.ts
@@ -1,4 +1,5 @@
 import upath from 'upath';
+import { getCustomEnv } from '../../../../util/env';
 import { getParentDir, readSystemFile } from '../../../../util/fs';
 import getArgv from './__fixtures__/argv';
 import * as _hostRulesFromEnv from './host-rules-from-env';
@@ -61,6 +62,19 @@ describe('workers/global/config/parse/index', () => {
         ['force', null],
       ]);
       expect(parsedConfig).not.toContainKey('configFile');
+    });
+
+    it('sets customEnvVariables', async () => {
+      const env: NodeJS.ProcessEnv = {
+        ...defaultEnv,
+        RENOVATE_TOKEN: 'abc',
+        RENOVATE_CUSTOM_ENV_VARIABLES: '{"customKey": "customValue"}',
+      };
+      await configParser.parseConfigs(env, defaultArgv);
+      const customEnvVars = getCustomEnv();
+      expect(customEnvVars).toEqual({
+        customKey: 'customValue',
+      });
     });
 
     it('supports config.force', async () => {

--- a/lib/workers/global/config/parse/index.ts
+++ b/lib/workers/global/config/parse/index.ts
@@ -1,9 +1,11 @@
+import is from '@sindresorhus/is';
 import * as defaultsParser from '../../../../config/defaults';
 import type { AllConfig } from '../../../../config/types';
 import { mergeChildConfig } from '../../../../config/utils';
 import { logger, setContext } from '../../../../logger';
 import { detectAllGlobalConfig } from '../../../../modules/manager';
 import { coerceArray } from '../../../../util/array';
+import { setCustomEnv } from '../../../../util/env';
 import { readSystemFile } from '../../../../util/fs';
 import { addSecretForSanitizing } from '../../../../util/sanitize';
 import { ensureTrailingSlash } from '../../../../util/url';
@@ -105,6 +107,10 @@ export async function parseConfigs(
   if (!config.autodiscover && config.onboardingNoDeps !== 'disabled') {
     logger.debug('Enabling onboardingNoDeps while in non-autodiscover mode');
     config.onboardingNoDeps = 'enabled';
+  }
+
+  if (is.nonEmptyObject(config.customEnvVariables)) {
+    setCustomEnv(config.customEnvVariables);
   }
 
   return config;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- Create new file `env.ts` in the `lib/util` folder with these two functions: `setCustomEnv` & `getCustomEnv`
- Modify tests accordingly
<!-- Describe what behavior is changed by this PR. -->

## Context
- Closes: #35035 
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
