### PR TITLE
fix: prefer massaged URL when source URL isn't HTTP(S) to support changelogs for non Github sources

### DIFF
--- a/lib/modules/datasource/metadata.spec.ts
+++ b/lib/modules/datasource/metadata.spec.ts
@@ -1,4 +1,5 @@
 import type { Timestamp } from '../../util/timestamp';
+import { GitTagsDatasource } from './git-tags';
 import { HelmDatasource } from './helm';
 import { MavenDatasource } from './maven';
 import {
@@ -11,8 +12,17 @@ import { NpmDatasource } from './npm';
 import { PypiDatasource } from './pypi';
 import type { ReleaseResult } from './types';
 import { partial } from '~test/util';
+import { hostRules } from '~test/util';
 
 describe('modules/datasource/metadata', () => {
+  beforeEach(() => {
+    hostRules.clear();
+  });
+
+  afterEach(() => {
+    hostRules.clear();
+  });
+
   it('Should handle manualChangelogUrls', () => {
     const dep: ReleaseResult = {
       releases: [
@@ -119,6 +129,30 @@ describe('modules/datasource/metadata', () => {
       const dep: ReleaseResult = { sourceUrl, releases: [] };
       const datasource = HelmDatasource.id;
       const packageName = 'some-chart';
+
+      addMetaData(dep, datasource, packageName);
+      expect(dep).toMatchObject({
+        sourceUrl: expectedSourceUrl,
+      });
+    },
+  );
+
+  it.each`
+    sourceUrl                                      | expectedSourceUrl
+    ${'git@gitlab.com:group/sub-group/repo'}       | ${'https://gitlab.com/group/sub-group/repo'}
+    ${'git@gitlab.com:group/sub-group/repo.git'}   | ${'https://gitlab.com/group/sub-group/repo'}
+    ${'git@somehost.com:group/sub-group/repo.git'} | ${'https://somehost.com/group/sub-group/repo'}
+  `(
+    'Should fallback to massagedUrl for sourceUrl for non Github non HTTP(S) hosts: $sourceUrl -> $expectedSourceUrl',
+    ({ sourceUrl, expectedSourceUrl, expectedSourceDirectory }) => {
+      const dep: ReleaseResult = { sourceUrl, releases: [] };
+      const datasource = GitTagsDatasource.id;
+      const packageName = 'some-dep';
+
+      hostRules.add({
+        hostType: 'gitlab',
+        matchHost: 'somehost.com',
+      });
 
       addMetaData(dep, datasource, packageName);
       expect(dep).toMatchObject({

--- a/lib/modules/datasource/metadata.spec.ts
+++ b/lib/modules/datasource/metadata.spec.ts
@@ -11,8 +11,7 @@ import {
 import { NpmDatasource } from './npm';
 import { PypiDatasource } from './pypi';
 import type { ReleaseResult } from './types';
-import { partial } from '~test/util';
-import { hostRules } from '~test/util';
+import { hostRules, partial } from '~test/util';
 
 describe('modules/datasource/metadata', () => {
   beforeEach(() => {

--- a/lib/modules/datasource/metadata.ts
+++ b/lib/modules/datasource/metadata.ts
@@ -127,15 +127,21 @@ export function addMetaData(
   });
   extraBaseUrls.push('gitlab.com');
   if (dep.sourceUrl) {
+    // try massaging it
     const massagedUrl = massageUrl(dep.sourceUrl);
     if (is.emptyString(massagedUrl)) {
       delete dep.sourceUrl;
     } else {
-      // try massaging it
+      // parse from github-url-from-git only supports Github URLs as its name implies
       dep.sourceUrl =
         parse(massagedUrl, {
           extraBaseUrls,
         }) || dep.sourceUrl;
+      // prefer massaged URL to source URL if the latter does not start with http:// or https://
+      // (e.g. git@somehost.com). This allows to retrieve changelogs from git hosts other than Github
+      if (!isHttpUrl(dep.sourceUrl)) {
+        dep.sourceUrl = massagedUrl;
+      }
     }
   }
   if (shouldDeleteHomepage(dep.sourceUrl, dep.homepage)) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
This PR enables retrieving release notes from dependencies hosted on gitlab.com and self-hosted Gitlab instances.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

Without this PR, release notes from dependencies hosted on gitlab.com and self-hosted Gitlab instances are not retrieved as `sourceUrl` is left empty.

- #3323
- #27740

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
