### PR TITLE
fix(gomod): fix potential false-positive when matching tools

### DIFF
--- a/lib/modules/manager/gomod/extract.spec.ts
+++ b/lib/modules/manager/gomod/extract.spec.ts
@@ -232,6 +232,7 @@ describe('modules/manager/gomod/extract', () => {
           github.com/foo/bar v1.2.3
           github.com/foo/bar/sub1/sub2 v4.5.6 // indirect
           github.com/foo/bar/sub1 v7.8.9 // indirect
+          github.com/foo/bar/sub1/sub2/cmd/hell v10.11.12 // indirect
         )
         tool github.com/foo/bar/sub1/sub2/cmd/hello
       `;
@@ -259,6 +260,33 @@ describe('modules/manager/gomod/extract', () => {
           currentValue: 'v7.8.9',
           enabled: false,
           managerData: { lineNumber: 3, multiLine: true },
+        },
+        {
+          datasource: 'go',
+          depName: 'github.com/foo/bar/sub1/sub2/cmd/hell',
+          depType: 'indirect',
+          currentValue: 'v10.11.12',
+          enabled: false,
+          managerData: { lineNumber: 4, multiLine: true },
+        },
+      ],
+    });
+  });
+
+  it('extracts tool directives with exact match', () => {
+    const goMod = codeBlock`
+        require github.com/foo/bar v1.2.3 // indirect
+        tool github.com/foo/bar
+      `;
+    const res = extractPackageFile(goMod);
+    expect(res).toEqual({
+      deps: [
+        {
+          datasource: 'go',
+          depName: 'github.com/foo/bar',
+          depType: 'indirect',
+          currentValue: 'v1.2.3',
+          managerData: { lineNumber: 0 },
         },
       ],
     });

--- a/lib/modules/manager/gomod/extract.ts
+++ b/lib/modules/manager/gomod/extract.ts
@@ -7,11 +7,12 @@ function findMatchingModule(
   deps: PackageDependency[],
 ): PackageDependency | undefined {
   let bestMatch: PackageDependency | undefined;
+  const normalizedTool = tool.depName! + '/';
 
   // Find the longest matching prefix for the tool within the dependencies
   for (const dep of deps) {
     if (
-      tool.depName!.startsWith(dep.depName!) &&
+      normalizedTool.startsWith(dep.depName! + '/') &&
       dep.depName!.length > (bestMatch?.depName!.length ?? 0)
     ) {
       bestMatch = dep;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Avoid matching a module named `github.com/foo/bar/sub1/sub2/cmd/hell` with a tool named `github.com/foo/bar/sub1/sub2/cmd/hello` by appending trailing slashes before comparing

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

Follow up to #35078

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
