### PR TITLE
fix(datasource/deb): use only suite as parameter

### DIFF
--- a/lib/modules/datasource/deb/index.spec.ts
+++ b/lib/modules/datasource/deb/index.spec.ts
@@ -9,7 +9,7 @@ import { hashStream, toSha256 } from '../../../util/hash';
 import type { GetPkgReleasesConfig } from '../types';
 import { cacheSubDir } from './common';
 import * as fileUtils from './file';
-import { getBaseReleaseUrl } from './url';
+import { getBaseSuiteUrl } from './url';
 import { DebDatasource } from '.';
 import { Fixtures } from '~test/fixtures';
 import * as httpMock from '~test/http-mock';
@@ -517,7 +517,7 @@ function mockFetchInReleaseContent(
   const mockCall = httpMock
     .scope(debBaseUrl)
     .get(
-      getBaseReleaseUrl(getComponentUrl('', release, component, arch)) +
+      getBaseSuiteUrl(getComponentUrl('', release, component, arch)) +
         '/InRelease',
     );
 

--- a/lib/modules/datasource/deb/index.ts
+++ b/lib/modules/datasource/deb/index.ts
@@ -14,7 +14,7 @@ import { cacheSubDir, packageKeys, requiredPackageKeys } from './common';
 import { extract, getFileCreationTime } from './file';
 import { formatReleaseResult, releaseMetaInformationMatches } from './release';
 import type { PackageDescription } from './types';
-import { constructComponentUrls, getBaseReleaseUrl } from './url';
+import { constructComponentUrls, getBaseSuiteUrl } from './url';
 
 export class DebDatasource extends Datasource {
   static readonly id = 'deb';
@@ -47,8 +47,7 @@ export class DebDatasource extends Datasource {
    *
    * The following query parameters are required:
    * - components: comma separated list of components
-   * - suite: stable, oldstable or other alias for a release, either this or release must be given
-   * - release: buster, etc.
+   * - suite: stable, oldstable or other alias for a release, either this or release must be given like buster
    * - binaryArch: e.g. amd64 resolves to http://deb.debian.org/debian/dists/stable/non-free/binary-amd64/
    */
   override readonly defaultRegistryUrls = [
@@ -127,7 +126,7 @@ export class DebDatasource extends Datasource {
     compressedFile: string,
     lastDownloadTimestamp?: Date,
   ): Promise<boolean> {
-    const baseReleaseUrl = getBaseReleaseUrl(basePackageUrl);
+    const baseSuiteUrl = getBaseSuiteUrl(basePackageUrl);
     const packageUrl = joinUrlParts(basePackageUrl, `Packages.${compression}`);
     let needsToDownload = true;
 
@@ -153,11 +152,11 @@ export class DebDatasource extends Datasource {
     let inReleaseContent = '';
 
     try {
-      inReleaseContent = await this.fetchInReleaseFile(baseReleaseUrl);
+      inReleaseContent = await this.fetchInReleaseFile(baseSuiteUrl);
     } catch (error) {
       // This is expected to fail for Artifactory if GPG verification is not enabled
       logger.debug(
-        { url: baseReleaseUrl, err: error },
+        { url: baseSuiteUrl, err: error },
         'Could not fetch InRelease file',
       );
     }
@@ -167,7 +166,7 @@ export class DebDatasource extends Datasource {
       const expectedChecksum = parseChecksumsFromInRelease(
         inReleaseContent,
         // path to the Package.gz file
-        packageUrl.replace(`${baseReleaseUrl}/`, ''),
+        packageUrl.replace(`${baseSuiteUrl}/`, ''),
       );
       if (actualChecksum !== expectedChecksum) {
         await fs.rmCache(compressedFile);
@@ -179,9 +178,9 @@ export class DebDatasource extends Datasource {
   }
 
   /**
-   * Fetches the content of the InRelease file from the given base release URL.
+   * Fetches the content of the InRelease file from the given base suite URL.
    *
-   * @param baseReleaseUrl - The base URL of the release (e.g., 'https://deb.debian.org/debian/dists/bullseye').
+   * @param baseReleaseUrl - The base URL of the suite (e.g., 'https://deb.debian.org/debian/dists/bullseye').
    * @returns resolves to the content of the InRelease file.
    * @throws An error if the InRelease file could not be downloaded.
    */
@@ -236,7 +235,7 @@ export class DebDatasource extends Datasource {
   })
   async parseExtractedPackageIndex(
     extractedFile: string,
-    lastTimestamp: Date,
+    _lastTimestamp: Date,
   ): Promise<Record<string, PackageDescription[]>> {
     // read line by line to avoid high memory consumption as the extracted Packages
     // files can be multiple MBs in size

--- a/lib/modules/datasource/deb/readme.md
+++ b/lib/modules/datasource/deb/readme.md
@@ -13,9 +13,9 @@ To use a Debian repository with the datasource, you must set a properly formatte
 
 - `components`: Comma-separated list of repository components (e.g., `main,contrib,non-free`).
 - `binaryArch`: Architecture of the binary packages (e.g., `amd64`,`all`).
-- Either `suite` or `release`:
-  - `suite`: A rolling release alias like `stable`.
-  - `release`: A fixed release name such as `bullseye` or `buster`.
+- `suite`:
+  - A rolling release alias like `stable`.
+  - A fixed release name such as `bullseye` or `buster`.
 
 <!-- prettier-ignore -->
 !!! note
@@ -45,9 +45,9 @@ First you would set a custom manager in your `renovate.json` file for `Dockerfil
       "customType": "regex",
       "fileMatch": ["^Dockerfile$"],
       "matchStrings": [
-        "#\\s*renovate:\\s*?(release=(?<release>.*?))?\\s*depName=(?<depName>.*?)?\\sENV .*?_VERSION=\"(?<currentValue>.*)\""
+        "#\\s*renovate:\\s*?(suite=(?<suite>.*?))?\\s*depName=(?<depName>.*?)?\\sENV .*?_VERSION=\"(?<currentValue>.*)\""
       ],
-      "registryUrlTemplate": "https://deb.debian.org/debian?{{#if release }}release={{release}}{{else}}suite=stable{{/if}}&components=main,contrib,non-free&binaryArch=amd64",
+      "registryUrlTemplate": "https://deb.debian.org/debian?suite={#if suite }}{{suite}}{{else}}stable{{/if}}&components=main,contrib,non-free&binaryArch=amd64",
       "datasourceTemplate": "deb"
     }
   ]
@@ -59,7 +59,7 @@ Then you would put comments in your Dockerfile, to tell Renovate where to find t
 ```dockerfile
 FROM debian:bullseye
 
-# renovate: release=bullseye depName=gcc-11
+# renovate: suite=bullseye depName=gcc-11
 ENV GCC_VERSION="11.2.0-19"
 
 RUN apt-get update && \
@@ -101,8 +101,8 @@ The `debian` datasource supports these repository types:
 To use Artifactory, first configure the `deb` datasource by setting the `registryUrl`.
 
 ```title="Example of valid registryUrl format"
-https://<host>:<port>/artifactory/<repository-slug>?release=<release>&components=<components>&binaryArch=<binaryArch>
-https://artifactory.example.com:443/artifactory/debian?release=bookworm&components=main,contrib,non-free&binaryArch=amd64
+https://<host>:<port>/artifactory/<repository-slug>?suite=<suite>&components=<components>&binaryArch=<binaryArch>
+https://artifactory.example.com:443/artifactory/debian?suite=bookworm&components=main,contrib,non-free&binaryArch=amd64
 ```
 
 ### Authenticating to Artifactory

--- a/lib/modules/datasource/deb/url.spec.ts
+++ b/lib/modules/datasource/deb/url.spec.ts
@@ -1,4 +1,4 @@
-import { constructComponentUrls, getBaseReleaseUrl } from './url';
+import { constructComponentUrls, getBaseSuiteUrl } from './url';
 
 describe('modules/datasource/deb/url', () => {
   it('constructs URLs correctly from registry URL with suite', () => {
@@ -12,7 +12,7 @@ describe('modules/datasource/deb/url', () => {
     expect(componentUrls).toEqual(expectedUrls);
   });
 
-  it('constructs URLs correctly from registry URL with release', () => {
+  it('constructs URLs correctly from registry URL with deprecated release', () => {
     const registryUrl =
       'https://deb.debian.org/debian?release=bullseye&components=main,contrib&binaryArch=amd64';
     const expectedUrls = [
@@ -30,11 +30,11 @@ describe('modules/datasource/deb/url', () => {
     );
   });
 
-  it('returns the correct release url', () => {
+  it('returns the correct suite url', () => {
     const basePackageUrl =
       'https://deb.debian.org/debian/dists/bullseye/main/binary-amd64';
     const expectedUrl = 'https://deb.debian.org/debian/dists/bullseye';
 
-    expect(getBaseReleaseUrl(basePackageUrl)).toBe(expectedUrl);
+    expect(getBaseSuiteUrl(basePackageUrl)).toBe(expectedUrl);
   });
 });


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
`release` is redundant to `suite`, so we should only use the official name which is `suite`.
<!-- Describe what behavior is changed by this PR. -->

## Context
- https://github.com/renovatebot/renovate/pull/34902#discussion_r2006314616
- https://manpages.debian.org/testing/apt/sources.list.5.en.html
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
