### PR TITLE
fix(util): parse jsonc as jsonc

### DIFF
--- a/lib/util/common.spec.ts
+++ b/lib/util/common.spec.ts
@@ -27,6 +27,14 @@ const onlyJson5parsableString = `
   "isMarried": false,
 }
 `;
+const validJsoncString = `
+{
+  // This is a comment
+  "name": "John Doe",
+  "age": 30,
+  "city": "New York"
+}
+`;
 
 describe('util/common', () => {
   beforeEach(() => hostRules.clear());
@@ -106,7 +114,7 @@ describe('util/common', () => {
       expect(() => parseJson(invalidJsonString, 'renovate.json')).toThrow();
     });
 
-    it('catches and warns if content parsing faield with JSON.parse but not with JSON5.parse', () => {
+    it('catches and warns if content parsing failed with JSON.parse but not with JSON5.parse', () => {
       expect(parseJson(onlyJson5parsableString, 'renovate.json')).toEqual({
         name: 'Bob',
         age: 35,
@@ -117,6 +125,30 @@ describe('util/common', () => {
         { context: 'renovate.json' },
         'File contents are invalid JSON but parse using JSON5. Support for this will be removed in a future release so please change to a support .json5 file name or ensure correct JSON syntax.',
       );
+    });
+
+    it('does not warn if filename ends with .jsonc', () => {
+      parseJson(validJsoncString, 'renovate.jsonc');
+      expect(logger.logger.warn).not.toHaveBeenCalled();
+    });
+
+    it('does not warn if filename ends with .json5', () => {
+      parseJson(onlyJson5parsableString, 'renovate.json5');
+      expect(logger.logger.warn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('parseJsonc', () => {
+    it('returns parsed jsonc', () => {
+      expect(parseJson(validJsoncString, 'renovate.jsonc')).toEqual({
+        name: 'John Doe',
+        age: 30,
+        city: 'New York',
+      });
+    });
+
+    it('throws error for invalid jsonc', () => {
+      expect(() => parseJson(invalidJsonString, 'renovate.jsonc')).toThrow();
     });
   });
 });

--- a/lib/util/schema-utils.ts
+++ b/lib/util/schema-utils.ts
@@ -1,5 +1,4 @@
 import JSON5 from 'json5';
-import * as JSONC from 'jsonc-parser';
 import { DateTime } from 'luxon';
 import type { JsonArray, JsonValue } from 'type-fest';
 import {
@@ -11,6 +10,7 @@ import {
 } from 'zod';
 import { logger } from '../logger';
 import type { PackageDependency } from '../modules/manager/types';
+import { parseJsonc } from './common';
 import { parse as parseToml } from './toml';
 import type { YamlOptions } from './yaml';
 import { parseSingleYaml, parseYaml } from './yaml';
@@ -226,13 +226,12 @@ export const Json5 = z.string().transform((str, ctx): JsonValue => {
 });
 
 export const Jsonc = z.string().transform((str, ctx): JsonValue => {
-  const errors: JSONC.ParseError[] = [];
-  const value = JSONC.parse(str, errors, { allowTrailingComma: true });
-  if (errors.length === 0) {
-    return value;
+  try {
+    return parseJsonc(str);
+  } catch {
+    ctx.addIssue({ code: 'custom', message: 'Invalid JSONC' });
+    return z.NEVER;
   }
-  ctx.addIssue({ code: 'custom', message: 'Invalid JSONC' });
-  return z.NEVER;
 });
 
 export const UtcDate = z


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Parses `.jsonc` files using `jsonc-parser`, not with JSON5 fallback.

<!-- Describe what behavior is changed by this PR. -->

## Context

This avoids warnings: `File contents are invalid JSON but parse using JSON5`, while parsing JSONC files.
- #35176.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
