### PR TITLE
feat: allow user to pass git extra config

### DIFF
--- a/lib/util/git/auth.spec.ts
+++ b/lib/util/git/auth.spec.ts
@@ -113,11 +113,7 @@ describe('util/git/auth', () => {
       expect(
         getGitAuthenticatedEnvironmentVariables(
           'https://github.com/',
-          {
-            token: 'token1234',
-            hostType: 'github',
-            matchHost: 'github.com',
-          },
+          { token: 'token1234', hostType: 'github', matchHost: 'github.com' },
           { GIT_CONFIG_COUNT: '1' },
         ),
       ).toStrictEqual({
@@ -136,11 +132,7 @@ describe('util/git/auth', () => {
       expect(
         getGitAuthenticatedEnvironmentVariables(
           'https://github.com/',
-          {
-            token: 'token1234',
-            hostType: 'github',
-            matchHost: 'github.com',
-          },
+          { token: 'token1234', hostType: 'github', matchHost: 'github.com' },
           { GIT_CONFIG_COUNT: '1' },
         ),
       ).toStrictEqual({
@@ -177,11 +169,7 @@ describe('util/git/auth', () => {
       expect(
         getGitAuthenticatedEnvironmentVariables(
           'https://github.com/',
-          {
-            token: 'token1234',
-            hostType: 'github',
-            matchHost: 'github.com',
-          },
+          { token: 'token1234', hostType: 'github', matchHost: 'github.com' },
           { RANDOM_VARIABLE: 'random' },
         ),
       ).toStrictEqual({
@@ -260,15 +248,10 @@ describe('util/git/auth', () => {
       expect(
         getGitAuthenticatedEnvironmentVariables(
           'https://gitlab.com/',
-          {
-            hostType: 'gitlab',
-            matchHost: 'gitlab.com',
-          },
+          { hostType: 'gitlab', matchHost: 'gitlab.com' },
           { env: 'value' },
         ),
-      ).toStrictEqual({
-        env: 'value',
-      });
+      ).toStrictEqual({ env: 'value' });
     });
 
     it('returns url with token for http hosts', () => {
@@ -331,11 +314,7 @@ describe('util/git/auth', () => {
       expect(
         getGitAuthenticatedEnvironmentVariables(
           'https://github.com:89/org/repo.git',
-          {
-            token: 'token1234',
-            hostType: 'github',
-            matchHost: 'github.com',
-          },
+          { token: 'token1234', hostType: 'github', matchHost: 'github.com' },
         ),
       ).toStrictEqual({
         GIT_CONFIG_COUNT: '3',
@@ -369,6 +348,48 @@ describe('util/git/auth', () => {
         GIT_CONFIG_VALUE_0: 'ssh://git@git.mycompany.com:7999/',
         GIT_CONFIG_VALUE_1: 'ssh://git@git.mycompany.com:7999/',
         GIT_CONFIG_VALUE_2: 'https://git.mycompany.com/scm/',
+      });
+    });
+
+    it('returns extra git config', () => {
+      expect(
+        getGitAuthenticatedEnvironmentVariables(
+          'https://git.mycompany.com/',
+          {
+            token: 'token1234',
+            hostType: 'bitbucket-server',
+            matchHost: 'git.mycompany.com',
+          },
+          {
+            RENOVATE_GIT_EXTRA_CONFIG: JSON.stringify([
+              {
+                key: 'url.https://git.mycompany.com/scm/.insteadOf',
+                value: 'https://git.mycompany.com/scm/',
+              },
+              {
+                key: 'url.https://another.example.com/.insteadOf',
+                value: 'https://another.example.com/',
+              },
+            ]),
+          },
+        ),
+      ).toStrictEqual({
+        GIT_CONFIG_COUNT: '5',
+        GIT_CONFIG_KEY_0:
+          'url.https://ssh:token1234@git.mycompany.com/scm/.insteadOf',
+        GIT_CONFIG_KEY_1:
+          'url.https://git:token1234@git.mycompany.com/scm/.insteadOf',
+        GIT_CONFIG_KEY_2:
+          'url.https://token1234@git.mycompany.com/scm/.insteadOf',
+        GIT_CONFIG_KEY_3: 'url.https://git.mycompany.com/scm/.insteadOf',
+        GIT_CONFIG_KEY_4: 'url.https://another.example.com/.insteadOf',
+        GIT_CONFIG_VALUE_0: 'ssh://git@git.mycompany.com:7999/',
+        GIT_CONFIG_VALUE_1: 'ssh://git@git.mycompany.com:7999/',
+        GIT_CONFIG_VALUE_2: 'https://git.mycompany.com/scm/',
+        GIT_CONFIG_VALUE_3: 'https://git.mycompany.com/scm/',
+        GIT_CONFIG_VALUE_4: 'https://another.example.com/',
+        RENOVATE_GIT_EXTRA_CONFIG:
+          '[{"key":"url.https://git.mycompany.com/scm/.insteadOf","value":"https://git.mycompany.com/scm/"},{"key":"url.https://another.example.com/.insteadOf","value":"https://another.example.com/"}]',
       });
     });
   });

--- a/lib/util/git/auth.ts
+++ b/lib/util/git/auth.ts
@@ -42,9 +42,7 @@ export function getGitAuthenticatedEnvironmentVariables(
     gitConfigCount = parseInt(gitConfigCountEnvVariable, 10);
     if (Number.isNaN(gitConfigCount)) {
       logger.warn(
-        {
-          GIT_CONFIG_COUNT: process.env.GIT_CONFIG_COUNT,
-        },
+        { GIT_CONFIG_COUNT: process.env.GIT_CONFIG_COUNT },
         `Found GIT_CONFIG_COUNT env variable, but couldn't parse the value to an integer. Ignoring it.`,
       );
       gitConfigCount = 0;
@@ -71,9 +69,7 @@ export function getGitAuthenticatedEnvironmentVariables(
   // create a shallow copy of the environmentVariables as base so we don't modify the input parameter object
   // add the two new config key and value to the returnEnvironmentVariables object
   // increase the CONFIG_COUNT by one for each rule and add it to the object
-  const newEnvironmentVariables = {
-    ...environmentVariables,
-  };
+  const newEnvironmentVariables = { ...environmentVariables };
   for (const rule of authenticationRules) {
     newEnvironmentVariables[`GIT_CONFIG_KEY_${gitConfigCount}`] =
       `url.${rule.url}.insteadOf`;
@@ -81,6 +77,25 @@ export function getGitAuthenticatedEnvironmentVariables(
       rule.insteadOf;
     gitConfigCount++;
   }
+
+  // check if environmentVariables contains RENOVATE_GIT_EXTRA_CONFIG
+  const extraConfig = environmentVariables?.RENOVATE_GIT_EXTRA_CONFIG;
+  if (extraConfig) {
+    try {
+      const parsedExtraConfig = JSON.parse(extraConfig);
+      for (const { key, value } of parsedExtraConfig) {
+        newEnvironmentVariables[`GIT_CONFIG_KEY_${gitConfigCount}`] = key;
+        newEnvironmentVariables[`GIT_CONFIG_VALUE_${gitConfigCount}`] = value;
+        gitConfigCount++;
+      }
+    } catch (error) {
+      logger.warn(
+        { extraConfig },
+        `Failed to parse RENOVATE_GIT_EXTRA_CONFIG: ${error.message}`,
+      );
+    }
+  }
+
   newEnvironmentVariables.GIT_CONFIG_COUNT = gitConfigCount.toString();
 
   return newEnvironmentVariables;


### PR DESCRIPTION
# Changes

Add a way to pass extra git config to be stacked **after** host rules processing.

I'm not sure it's the "right" way to do so. Any help or feedback appreciated.

# Context

Before this change, any user env var are kept; but renovate-added one are taking precedence and thus "nulling" previous config that would target the same urls.

This is a simple attempt at allowing users to pass a JSON-formatted var to add arbitrary git config that would override Renovate ones.

Our specific use case: we want git operations to target a git CDN. Without this change, Renovate always bypass our config with hostrules-generated ones.

# Documentation (please check one with an [x])
- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)
I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository