### PR TITLE
fix(circleci): Ignore non-image alias items

### DIFF
--- a/lib/modules/manager/circleci/extract.ts
+++ b/lib/modules/manager/circleci/extract.ts
@@ -58,13 +58,11 @@ export function extractPackageFile(
 ): PackageFileContent | null {
   const deps: PackageDependency[] = [];
   try {
-    const parsed = parseSingleYaml(content, {
-      customSchema: CircleCiFile,
-    });
+    const parsed = CircleCiFile.parse(parseSingleYaml(content));
 
     deps.push(...extractDefinition(parsed, config));
 
-    for (const alias of coerceArray(parsed.aliases)) {
+    for (const alias of parsed.aliases) {
       deps.push({
         ...getDep(alias.image, true, config?.registryAliases),
         depType: 'docker',

--- a/lib/modules/manager/circleci/schema.ts
+++ b/lib/modules/manager/circleci/schema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { LooseArray } from '../../../util/schema-utils';
 
 export const CircleCiDocker = z.object({
   image: z.string(),
@@ -26,7 +27,7 @@ export const CircleCiOrb: z.ZodType<Orb> = baseOrb.extend({
 export type CircleCiOrb = z.infer<typeof CircleCiOrb>;
 
 export const CircleCiFile = z.object({
-  aliases: z.array(CircleCiDocker).optional(),
+  aliases: LooseArray(CircleCiDocker).catch([]),
   executors: z.record(z.string(), CircleCiJob).optional(),
   jobs: z.record(z.string(), CircleCiJob).optional(),
   orbs: z.record(z.string(), z.union([z.string(), CircleCiOrb])).optional(),


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Loose schema definition to accept `{ image: '...' }` items and ignore everything else under the `aliases` key.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
