### PR TITLE
feat(manager/composer): Add support for --with-all-dependencies (-W) (#32790)

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -564,6 +564,10 @@ Set to `null` (not recommended) to fully omit `--ignore-platform-reqs/--ignore-p
 This requires the Renovate image to be fully compatible with your Composer platform requirements in order for the Composer invocation to succeed, otherwise Renovate will fail to create the updated lock file.
 The Composer output should inform you about the reasons the update failed.
 
+## composerUpdateWithAllDependencies
+
+By default, Renovate will invoke `composer update` with the `--with-dependencies` option. Set this option to `true` in order to use `--with-all-dependencies` instead.
+
 ## confidential
 
 If enabled, all issues created by Renovate are set as confidential, even in a public repository.

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -535,6 +535,13 @@ const options: RenovateOptions[] = [
     default: [],
   },
   {
+    name: 'composerUpdateWithAllDependencies',
+    description:
+      'Configure use of `--with-all-dependencies` instead of the default `--with-dependencies` when running Composer update command.',
+    type: 'boolean',
+    default: false,
+  },
+  {
     name: 'goGetDirs',
     description: 'Directory pattern to run `go get` on.',
     type: 'array',

--- a/lib/modules/manager/composer/artifacts.spec.ts
+++ b/lib/modules/manager/composer/artifacts.spec.ts
@@ -1233,5 +1233,5 @@ describe('modules/manager/composer/artifacts', () => {
         options: { cwd: '/tmp/github/some/repo' },
       },
     ]);
-  })
+  });
 });

--- a/lib/modules/manager/composer/artifacts.spec.ts
+++ b/lib/modules/manager/composer/artifacts.spec.ts
@@ -1209,4 +1209,29 @@ describe('modules/manager/composer/artifacts', () => {
       },
     ]);
   });
+
+  it('uses --with-all-dependencies instead of --with-dependencies when composerUpdateWithAllDependencies is true', async () => {
+    fs.readLocalFile.mockResolvedValueOnce('{}');
+    const execSnapshots = mockExecAll();
+    fs.readLocalFile.mockResolvedValueOnce('{}');
+    git.getRepoStatus.mockResolvedValueOnce(repoStatus);
+
+    expect(
+      await composer.updateArtifacts({
+        packageFileName: 'composer.json',
+        updatedDeps: [{ depName: 'foo', newVersion: '1.1.0' }],
+        newPackageFileContent: '{}',
+        config: {
+          ...config,
+          composerUpdateWithAllDependencies: true,
+        },
+      }),
+    ).toBeNull();
+    expect(execSnapshots).toMatchObject([
+      {
+        cmd: 'composer update foo:1.1.0 --with-all-dependencies --ignore-platform-reqs --no-ansi --no-interaction --no-scripts --no-autoloader --no-plugins',
+        options: { cwd: '/tmp/github/some/repo' },
+      },
+    ]);
+  })
 });

--- a/lib/modules/manager/composer/artifacts.ts
+++ b/lib/modules/manager/composer/artifacts.ts
@@ -189,7 +189,10 @@ export async function updateArtifacts({
             .filter(is.string)
             .map((dep) => quote(dep))
             .join(' ')
-        ).trim() + (config.composerUpdateWithAllDependencies ? ' --with-all-dependencies' : ' --with-dependencies');
+        ).trim() +
+        (config.composerUpdateWithAllDependencies
+          ? ' --with-all-dependencies'
+          : ' --with-dependencies');
     }
     args += getComposerUpdateArguments(config, composerToolConstraint);
     logger.trace({ cmd, args }, 'composer command');

--- a/lib/modules/manager/composer/artifacts.ts
+++ b/lib/modules/manager/composer/artifacts.ts
@@ -189,7 +189,7 @@ export async function updateArtifacts({
             .filter(is.string)
             .map((dep) => quote(dep))
             .join(' ')
-        ).trim() + ' --with-dependencies';
+        ).trim() + (config.composerUpdateWithAllDependencies ? ' --with-all-dependencies' : ' --with-dependencies');
     }
     args += getComposerUpdateArguments(config, composerToolConstraint);
     logger.trace({ cmd, args }, 'composer command');

--- a/lib/modules/manager/types.ts
+++ b/lib/modules/manager/types.ts
@@ -35,6 +35,7 @@ export interface UpdateArtifactsConfig {
   isLockFileMaintenance?: boolean;
   constraints?: Record<string, string>;
   composerIgnorePlatformReqs?: string[];
+  composerUpdateWithAllDependencies?: boolean;
   goGetDirs?: string[];
   currentValue?: string;
   postUpdateOptions?: string[];


### PR DESCRIPTION
## Changes

This PR adds a repository configuration option (`composerUpdateWithAllDependencies`) in order to make `composer update` calls use the `--with-all-dependencies` instead of the default `--with-dependencies`.

## Context

- Closes #32790 

## Documentation

- [x] I have updated the documentation

## How I've tested my work

I have verified these changes via:

- [x] Both unit tests + ran on a real repository
