### PR TITLE
fix(workers/auto-replace): correctly handle prefix replacements

### DIFF
--- a/lib/workers/repository/update/branch/auto-replace.spec.ts
+++ b/lib/workers/repository/update/branch/auto-replace.spec.ts
@@ -757,6 +757,54 @@ describe('workers/repository/update/branch/auto-replace', () => {
       );
     });
 
+    it('updates with helm value image/repository prefix replacement', async () => {
+      const yml = codeBlock`
+        parser:
+          image:
+            repository: example.org/securecodebox/parser-nmap
+            tag: 3.14.3
+      `;
+      upgrade.manager = 'helm-values';
+      upgrade.depName = 'example.org/securecodebox/parser-nmap';
+      upgrade.replaceString = '3.14.3';
+      upgrade.currentValue = '3.14.3';
+      upgrade.depIndex = 0;
+      upgrade.updateType = 'replacement';
+      upgrade.newName = 'docker.example.org/securecodebox/parser-nmap';
+      upgrade.newValue = 'v5.1.0';
+      upgrade.packageFile = 'values.yml';
+      const res = await doAutoReplace(upgrade, yml, reuseExistingBranch);
+      expect(res).toBe(
+        yml
+          .replace(upgrade.depName, upgrade.newName)
+          .replace(upgrade.currentValue, upgrade.newValue),
+      );
+    });
+
+    it('updates with helm value image/repository version prefix replacement', async () => {
+      const yml = codeBlock`
+        parser:
+          image:
+            tag: 3.14.3
+            repository: docker.io/securecodebox/parser-nmap
+      `;
+      upgrade.manager = 'helm-values';
+      upgrade.depName = 'docker.io/securecodebox/parser-nmap';
+      upgrade.replaceString = '3.14.3';
+      upgrade.currentValue = '3.14.3';
+      upgrade.depIndex = 0;
+      upgrade.updateType = 'replacement';
+      upgrade.newName = 'iteratec/juice-balancer';
+      upgrade.newValue = 'v3.14.3';
+      upgrade.packageFile = 'values.yml';
+      const res = await doAutoReplace(upgrade, yml, reuseExistingBranch);
+      expect(res).toBe(
+        yml
+          .replace(upgrade.depName, upgrade.newName)
+          .replace(upgrade.currentValue, upgrade.newValue),
+      );
+    });
+
     it('updates with jenkins plugin replacement', async () => {
       const txt = 'script-security:1175\n';
       upgrade.manager = 'jenkins';

--- a/lib/workers/repository/update/branch/auto-replace.spec.ts
+++ b/lib/workers/repository/update/branch/auto-replace.spec.ts
@@ -757,6 +757,28 @@ describe('workers/repository/update/branch/auto-replace', () => {
       );
     });
 
+    it('updates with helm value image/repository wrong version', async () => {
+      const yml = codeBlock`
+        parser:
+          test: 3.14.3
+          image:
+              repository: docker.io/securecodebox/parser-nmap
+              tag: 2.14.3
+      `;
+      upgrade.manager = 'helm-values';
+      upgrade.depName = 'docker.io/securecodebox/parser-nmap';
+      upgrade.replaceString = '3.14.3';
+      upgrade.currentValue = '3.14.3';
+      upgrade.depIndex = 0;
+      upgrade.updateType = 'replacement';
+      upgrade.newName = 'iteratec/juice-balancer';
+      upgrade.newValue = 'v5.1.0';
+      upgrade.packageFile = 'values.yml';
+      await expect(
+        doAutoReplace(upgrade, yml, reuseExistingBranch),
+      ).rejects.toThrowError(WORKER_FILE_UPDATE_FAILED);
+    });
+
     it('updates with helm value image/repository prefix replacement', async () => {
       const yml = codeBlock`
         parser:

--- a/lib/workers/repository/update/branch/auto-replace.ts
+++ b/lib/workers/repository/update/branch/auto-replace.ts
@@ -134,6 +134,17 @@ function getDepsSignature(deps: PackageDependency[]): string {
     .join(',');
 }
 
+function firstIndexOf(
+  existingContent: string,
+  depName: string,
+  currentValue: string,
+  position = 0,
+): number {
+  const depIndex = existingContent.indexOf(depName, position);
+  const valIndex = existingContent.indexOf(currentValue, position);
+  return depIndex < valIndex ? depIndex : valIndex;
+}
+
 export async function checkBranchDepsMatchBaseDeps(
   upgrade: BranchUpgradeConfig,
   branchContent: string,
@@ -218,9 +229,7 @@ export async function doAutoReplace(
   logger.trace({ depName, replaceString }, 'autoReplace replaceString');
   let searchIndex: number;
   if (replaceWithoutReplaceString) {
-    const depIndex = existingContent.indexOf(depName!);
-    const valIndex = existingContent.indexOf(currentValue!);
-    searchIndex = depIndex < valIndex ? depIndex : valIndex;
+    searchIndex = firstIndexOf(existingContent, depName!, currentValue!);
   } else {
     searchIndex = existingContent.indexOf(replaceString!);
   }
@@ -317,8 +326,13 @@ export async function doAutoReplace(
             `Found depName at index ${searchIndex}`,
           );
           if (nameReplaced) {
-            startIndex += 1;
-            searchIndex = startIndex;
+            startIndex = firstIndexOf(
+              existingContent,
+              depName!,
+              currentValue!,
+              startIndex + 1,
+            );
+            searchIndex = startIndex - 1;
             await writeLocalFile(upgrade.packageFile!, existingContent);
             newContent = existingContent;
             nameReplaced = false;
@@ -329,6 +343,7 @@ export async function doAutoReplace(
           newContent = replaceAt(newContent, searchIndex, depName!, newName);
           await writeLocalFile(upgrade.packageFile!, newContent);
           nameReplaced = true;
+          searchIndex += newName.length - 1;
         } else if (
           newValue &&
           matchAt(newContent, searchIndex, currentValue!)
@@ -337,6 +352,20 @@ export async function doAutoReplace(
             { packageFile, currentValue },
             `Found currentValue at index ${searchIndex}`,
           );
+          if (valueReplaced) {
+            startIndex = firstIndexOf(
+              existingContent,
+              depName!,
+              currentValue!,
+              startIndex + 1,
+            );
+            searchIndex = startIndex - 1;
+            await writeLocalFile(upgrade.packageFile!, existingContent);
+            newContent = existingContent;
+            nameReplaced = false;
+            valueReplaced = false;
+            continue;
+          }
           // Now test if the result matches
           newContent = replaceAt(
             newContent,
@@ -346,11 +375,19 @@ export async function doAutoReplace(
           );
           await writeLocalFile(upgrade.packageFile!, newContent);
           valueReplaced = true;
+          searchIndex += newValue.length - 1;
         }
         if (nameReplaced && valueReplaced) {
           if (await confirmIfDepUpdated(upgrade, newContent)) {
             return newContent;
           }
+          startIndex = firstIndexOf(
+            existingContent,
+            depName!,
+            currentValue!,
+            startIndex + 1,
+          );
+          searchIndex = startIndex - 1;
           await writeLocalFile(upgrade.packageFile!, existingContent);
           newContent = existingContent;
           nameReplaced = false;

--- a/lib/workers/repository/update/branch/auto-replace.ts
+++ b/lib/workers/repository/update/branch/auto-replace.ts
@@ -142,7 +142,11 @@ function firstIndexOf(
 ): number {
   const depIndex = existingContent.indexOf(depName, position);
   const valIndex = existingContent.indexOf(currentValue, position);
-  return depIndex < valIndex ? depIndex : valIndex;
+  const index = depIndex < valIndex ? depIndex : valIndex;
+  if (index < 0) {
+    return position === 0 ? -1 : existingContent.length;
+  }
+  return index;
 }
 
 export async function checkBranchDepsMatchBaseDeps(


### PR DESCRIPTION
## Changes

This PR fixes at least one bug in auto replacement if the replacement adds a prefix (e.g. `example.org/foo` -> `docker.example.org/foo` or `1.2.3` -> `v1.2.3`).

Additionally the implementation is faster as it uses less iterations.

## Context

With the current implementation if the replacement (packageName or version) only adds a prefix, the replacement does not work and returns an error.
The additional tests are showing the issue.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
