### PR TITLE
fix(config): apply secrets to global config

### DIFF
--- a/lib/workers/global/config/parse/index.spec.ts
+++ b/lib/workers/global/config/parse/index.spec.ts
@@ -205,5 +205,28 @@ describe('workers/global/config/parse/index', () => {
       const parsedConfig = await configParser.parseConfigs(env, defaultArgv);
       expect(parsedConfig).toContainEntries([['onboardingNoDeps', 'enabled']]);
     });
+
+    it('apply secrets to global config', async () => {
+      vi.doMock('../../../../../config.js', () => ({
+        default: {
+          secrets: {
+            SECRET_TOKEN: 'secret_token',
+          },
+          customEnvVariables: {
+            TOKEN: '{{ secrets.SECRET_TOKEN }}',
+          },
+        },
+      }));
+      const env: NodeJS.ProcessEnv = {};
+      const parsedConfig = await configParser.parseConfigs(env, defaultArgv);
+      expect(parsedConfig).toMatchObject({
+        secrets: {
+          SECRET_TOKEN: 'secret_token',
+        },
+        customEnvVariables: {
+          TOKEN: 'secret_token',
+        },
+      });
+    });
   });
 });

--- a/lib/workers/global/config/parse/index.spec.ts
+++ b/lib/workers/global/config/parse/index.spec.ts
@@ -219,12 +219,20 @@ describe('workers/global/config/parse/index', () => {
       }));
       const env: NodeJS.ProcessEnv = {};
       const parsedConfig = await configParser.parseConfigs(env, defaultArgv);
-      expect(parsedConfig.secrets).toMatchObject({
-        SECRET_TOKEN: 'secret_token',
-      });
-      expect(parsedConfig.customEnvVariables).toMatchObject({
-        TOKEN: 'secret_token',
-      });
+      expect(parsedConfig).toContainEntries([
+        [
+          'secrets',
+          {
+            SECRET_TOKEN: 'secret_token',
+          },
+        ],
+        [
+          'customEnvVariables',
+          {
+            TOKEN: 'secret_token',
+          },
+        ],
+      ]);
     });
   });
 });

--- a/lib/workers/global/config/parse/index.spec.ts
+++ b/lib/workers/global/config/parse/index.spec.ts
@@ -208,31 +208,24 @@ describe('workers/global/config/parse/index', () => {
 
     it('apply secrets to global config', async () => {
       vi.doMock('../../../../../config.js', () => ({
-        default: {
-          secrets: {
-            SECRET_TOKEN: 'secret_token',
-          },
-          customEnvVariables: {
-            TOKEN: '{{ secrets.SECRET_TOKEN }}',
-          },
-        },
+        default: {},
       }));
-      const env: NodeJS.ProcessEnv = {};
+      const env: NodeJS.ProcessEnv = {
+        ...defaultEnv,
+        RENOVATE_SECRETS: '{"SECRET_TOKEN": "secret_token"}',
+        RENOVATE_CUSTOM_ENV_VARIABLES:
+          '{"TOKEN": "{{ secrets.SECRET_TOKEN }}"}',
+      };
       const parsedConfig = await configParser.parseConfigs(env, defaultArgv);
-      expect(parsedConfig).toContainEntries([
-        [
-          'secrets',
-          {
-            SECRET_TOKEN: 'secret_token',
-          },
-        ],
-        [
-          'customEnvVariables',
-          {
-            TOKEN: 'secret_token',
-          },
-        ],
-      ]);
+      expect(parsedConfig).toMatchObject({
+        secrets: {
+          SECRET_TOKEN: 'secret_token',
+        },
+
+        customEnvVariables: {
+          TOKEN: 'secret_token',
+        },
+      });
     });
   });
 });

--- a/lib/workers/global/config/parse/index.spec.ts
+++ b/lib/workers/global/config/parse/index.spec.ts
@@ -219,13 +219,11 @@ describe('workers/global/config/parse/index', () => {
       }));
       const env: NodeJS.ProcessEnv = {};
       const parsedConfig = await configParser.parseConfigs(env, defaultArgv);
-      expect(parsedConfig).toMatchObject({
-        secrets: {
-          SECRET_TOKEN: 'secret_token',
-        },
-        customEnvVariables: {
-          TOKEN: 'secret_token',
-        },
+      expect(parsedConfig.secrets).toMatchObject({
+        SECRET_TOKEN: 'secret_token',
+      });
+      expect(parsedConfig.customEnvVariables).toMatchObject({
+        TOKEN: 'secret_token',
       });
     });
   });

--- a/lib/workers/global/config/parse/index.ts
+++ b/lib/workers/global/config/parse/index.ts
@@ -117,6 +117,7 @@ export async function parseConfigs(
   for (const secret of Object.values(config.secrets ?? {})) {
     addSecretForSanitizing(secret, 'global');
   }
+
   if (is.nonEmptyObject(config.customEnvVariables)) {
     setCustomEnv(config.customEnvVariables);
   }

--- a/lib/workers/global/config/parse/index.ts
+++ b/lib/workers/global/config/parse/index.ts
@@ -115,7 +115,7 @@ export async function parseConfigs(
   if (is.nonEmptyObject(config.secrets)) {
     config = applySecretsToConfig(config, undefined, false);
     // add these secrets to the globalSecerets set so that they can be redacted from logs
-    for (const secret of Object.values(config.secrets ?? {})) {
+    for (const secret of Object.values(config.secrets!)) {
       addSecretForSanitizing(secret, 'global');
     }
   }

--- a/lib/workers/global/config/parse/index.ts
+++ b/lib/workers/global/config/parse/index.ts
@@ -1,5 +1,6 @@
 import is from '@sindresorhus/is';
 import * as defaultsParser from '../../../../config/defaults';
+import { applySecretsToConfig } from '../../../../config/secrets';
 import type { AllConfig } from '../../../../config/types';
 import { mergeChildConfig } from '../../../../config/utils';
 import { logger, setContext } from '../../../../logger';
@@ -109,6 +110,13 @@ export async function parseConfigs(
     config.onboardingNoDeps = 'enabled';
   }
 
+  // do not add these secrets to repoSecrets and,
+  //  do not delete the secrets object after applying on global config as it needs to be re-used for repo config
+  config = applySecretsToConfig(config, undefined, false);
+  // add these secrets to the globalSecerets set so that they can be redacted from logs
+  for (const secret of Object.values(config.secrets ?? {})) {
+    addSecretForSanitizing(secret, 'global');
+  }
   if (is.nonEmptyObject(config.customEnvVariables)) {
     setCustomEnv(config.customEnvVariables);
   }

--- a/lib/workers/global/config/parse/index.ts
+++ b/lib/workers/global/config/parse/index.ts
@@ -112,10 +112,12 @@ export async function parseConfigs(
 
   // do not add these secrets to repoSecrets and,
   //  do not delete the secrets object after applying on global config as it needs to be re-used for repo config
-  config = applySecretsToConfig(config, undefined, false);
-  // add these secrets to the globalSecerets set so that they can be redacted from logs
-  for (const secret of Object.values(config.secrets ?? {})) {
-    addSecretForSanitizing(secret, 'global');
+  if (is.nonEmptyObject(config.secrets)) {
+    config = applySecretsToConfig(config, undefined, false);
+    // add these secrets to the globalSecerets set so that they can be redacted from logs
+    for (const secret of Object.values(config.secrets ?? {})) {
+      addSecretForSanitizing(secret, 'global');
+    }
   }
 
   if (is.nonEmptyObject(config.customEnvVariables)) {

--- a/lib/workers/global/config/parse/index.ts
+++ b/lib/workers/global/config/parse/index.ts
@@ -114,7 +114,7 @@ export async function parseConfigs(
   //  do not delete the secrets object after applying on global config as it needs to be re-used for repo config
   if (is.nonEmptyObject(config.secrets)) {
     config = applySecretsToConfig(config, undefined, false);
-    // add these secrets to the globalSecerets set so that they can be redacted from logs
+    // adding these secrets to the globalSecrets set so that they can be redacted from logs
     for (const secret of Object.values(config.secrets!)) {
       addSecretForSanitizing(secret, 'global');
     }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- Apply secrets to global config 
- Make sure the secrets are added for sanitizing 
<!-- Describe what behavior is changed by this PR. -->

## Context
 - Closes: #35254 
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or (verified on [user provided reproduction](https://github.com/Rahul-renovate-testing/renovate-secret))
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
