### PR TITLE
feat(datasource/github-runners): mark Windows Server 2025 as stable

### DIFF
--- a/lib/modules/datasource/github-runners/index.spec.ts
+++ b/lib/modules/datasource/github-runners/index.spec.ts
@@ -60,7 +60,7 @@ describe('modules/datasource/github-runners/index', () => {
           { version: '2016', isDeprecated: true },
           { version: '2019' },
           { version: '2022' },
-          { version: '2025', isStable: false },
+          { version: '2025' },
         ],
         sourceUrl: 'https://github.com/actions/runner-images',
       });

--- a/lib/modules/datasource/github-runners/index.ts
+++ b/lib/modules/datasource/github-runners/index.ts
@@ -42,7 +42,7 @@ export class GithubRunnersDatasource extends Datasource {
       { version: '10.15', isDeprecated: true },
     ],
     windows: [
-      { version: '2025', isStable: false },
+      { version: '2025' },
       { version: '2022' },
       { version: '2019' },
       { version: '2016', isDeprecated: true },


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Mark Windows Server 2025 as stable, to match upstream document change

## Context

Upstream reference:

- https://github.com/actions/runner-images/pull/11954

Drive-by PR, not closing any issue with this.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
