### PR TITLE
fix(manager/helmfile): Allow replacements of oci:// charts

### DIFF
--- a/lib/modules/manager/helmfile/extract.spec.ts
+++ b/lib/modules/manager/helmfile/extract.spec.ts
@@ -339,7 +339,7 @@ describe('modules/manager/helmfile/extract', () => {
           stable: 'https://charts.helm.sh/stable',
         },
       });
-      expect(result).toMatchObject({
+      expect(result).toStrictEqual({
         datasource: 'helm',
         deps: [
           {
@@ -347,6 +347,7 @@ describe('modules/manager/helmfile/extract', () => {
             depName: 'example',
             datasource: 'docker',
             packageName: 'ghcr.io/example/oci-repo/example',
+            registryUrls: ['ghcr.io/example/oci-repo'],
           },
           {
             currentValue: '3.3.0',
@@ -355,9 +356,10 @@ describe('modules/manager/helmfile/extract', () => {
           },
           {
             currentValue: '0.4.2',
-            depName: 'url-example',
+            depName: 'ghcr.io/example/oci-repo/url-example',
             datasource: 'docker',
             packageName: 'ghcr.io/example/oci-repo/url-example',
+            registryUrls: [],
           },
         ],
       });
@@ -529,7 +531,7 @@ describe('modules/manager/helmfile/extract', () => {
           {
             currentValue: '0.4.2',
             datasource: 'docker',
-            depName: 'subgroup',
+            depName: 'gitlab.example.com:5000/group/subgroup',
             packageName: 'gitlab.example.com:5000/group/subgroup',
             registryUrls: [],
           },

--- a/lib/modules/manager/helmfile/extract.spec.ts
+++ b/lib/modules/manager/helmfile/extract.spec.ts
@@ -347,7 +347,6 @@ describe('modules/manager/helmfile/extract', () => {
             depName: 'example',
             datasource: 'docker',
             packageName: 'ghcr.io/example/oci-repo/example',
-            registryUrls: ['ghcr.io/example/oci-repo'],
           },
           {
             currentValue: '3.3.0',
@@ -359,7 +358,6 @@ describe('modules/manager/helmfile/extract', () => {
             depName: 'ghcr.io/example/oci-repo/url-example',
             datasource: 'docker',
             packageName: 'ghcr.io/example/oci-repo/url-example',
-            registryUrls: [],
           },
         ],
       });
@@ -533,7 +531,6 @@ describe('modules/manager/helmfile/extract', () => {
             datasource: 'docker',
             depName: 'gitlab.example.com:5000/group/subgroup',
             packageName: 'gitlab.example.com:5000/group/subgroup',
-            registryUrls: [],
           },
         ],
       });

--- a/lib/modules/manager/helmfile/extract.ts
+++ b/lib/modules/manager/helmfile/extract.ts
@@ -135,9 +135,9 @@ export async function extractPackageFile(
       if (
         !isValidChartName(
           isOCIRegistry(dep.chart)
-            ? res.depName?.slice(res.depName.lastIndexOf('/') + 1)
-            : res.depName,
-          isOCIRegistry(dep.chart) || (registryData[repoName!]?.oci ?? false),
+            ? depName.slice(depName.lastIndexOf('/') + 1)
+            : depName,
+          !!packageName,
         )
       ) {
         res.skipReason = 'unsupported-chart-type';


### PR DESCRIPTION
## Changes

Allow replacements of oci chart references in helmfile.

## Context

At the moment, it is not possible to do a replacement of a oci chart refence in a helmfile.yaml like the following:
```yaml
releases:
  name: example
  version: 1.2.3
  chart: oci://ghcr.io/example/oci-repo/url-example
```
This issue was found while testing #35265 against a repository.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository (see https://github.com/jonasrutishauser/renovate-35265-helmfile/pull/2)

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
