### PR TITLE
fix: also increase commits per run counter in dry-run mode

### DIFF
--- a/lib/workers/repository/update/branch/commit.ts
+++ b/lib/workers/repository/update/branch/commit.ts
@@ -7,6 +7,7 @@ import { scm } from '../../../../modules/platform/scm';
 import type { LongCommitSha } from '../../../../util/git/types';
 import { minimatch } from '../../../../util/minimatch';
 import { sanitize } from '../../../../util/sanitize';
+import { incLimitedValue } from '../../../global/limits';
 import type { BranchConfig } from '../../../types';
 
 export function commitFilesToBranch(
@@ -38,6 +39,7 @@ export function commitFilesToBranch(
   // istanbul ignore if
   if (GlobalConfig.get('dryRun')) {
     logger.info('DRY-RUN: Would commit files to branch ' + config.branchName);
+    incLimitedValue('Commits');
     return Promise.resolve(null);
   }
   // istanbul ignore if


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

This changes dry-run mode to also increase and therefore respect `prCommitsLimitPerRun` limit.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

I use Renovate in dry-run to test changes to real projects, and noticed it wasn't respecting the `prCommitsLimitPerRun` limit.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
