### PR TITLE
feat(preset): dont split params between quotes

### DIFF
--- a/lib/config/presets/parse.spec.ts
+++ b/lib/config/presets/parse.spec.ts
@@ -332,6 +332,18 @@ describe('config/presets/parse', () => {
       });
     });
 
+    it('returns scope with repo and params with quote and default', () => {
+      expect(
+        parsePreset('@somescope/somepackagename("param1, param2", param3)'),
+      ).toEqual({
+        repo: '@somescope/somepackagename',
+        params: ['param1, param2', 'param3'],
+        presetName: 'default',
+        presetPath: undefined,
+        presetSource: 'npm',
+      });
+    });
+
     it('returns scope with presetName', () => {
       expect(parsePreset('@somescope:somePresetName')).toEqual({
         repo: '@somescope/renovate-config',

--- a/lib/config/presets/parse.ts
+++ b/lib/config/presets/parse.ts
@@ -45,7 +45,8 @@ export function parsePreset(input: string): ParsedPreset {
   if (str.includes('(')) {
     params = str
       .slice(str.indexOf('(') + 1, -1)
-      .split(',')
+      .split(/,\s*(?=(?:(?:[^"]*"){2})*[^"]*$)/)
+      .map((elem) => elem.replace(/^\"+|\"+$/g, ''))
       .map((elem) => elem.trim());
     str = str.slice(0, str.indexOf('('));
   }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Don't split preset params inside quote.

The split regexp come from here: https://stackoverflow.com/questions/73121226/javascript-regex-split-a-string-by-commas-but-ignore-commas-within-double-quote
And the remove quote replace from here: https://stackoverflow.com/questions/26156292/trim-specific-character-from-a-string

## Context

we have preset args with comma:

    "defaultRegistryUrlTemplate": "https://www.somesite.com/query?code={{arg0}}"

We call this:  `mypreset("foo,bar")` so the defaultRegistryUrlTemplate will be: "https://www.somesite.com/query?code=foo,bar"

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
