### PR TITLE
refactor: move capitalize fn to `lib/util`

### DIFF
--- a/lib/util/string.spec.ts
+++ b/lib/util/string.spec.ts
@@ -1,4 +1,10 @@
-import { coerceString, looseEquals, replaceAt, stripTemplates } from './string';
+import {
+  capitalize,
+  coerceString,
+  looseEquals,
+  replaceAt,
+  stripTemplates,
+} from './string';
 
 describe('util/string', () => {
   describe('replaceAt', () => {
@@ -68,6 +74,13 @@ describe('util/string', () => {
       ${'{% entire text %}'}                                       | ${''}
     `('"$input" -> "$expected"', ({ input, expected }) => {
       expect(stripTemplates(input)).toBe(expected);
+    });
+  });
+
+  describe('capitalize', () => {
+    it('capitalizes', () => {
+      expect(capitalize('content')).toBe('Content');
+      expect(capitalize('Content')).toBe('Content');
     });
   });
 });

--- a/lib/util/string.ts
+++ b/lib/util/string.ts
@@ -168,3 +168,7 @@ export function stripTemplates(content: string): string {
 
   return result.join('');
 }
+
+export function capitalize(input: string): string {
+  return input[0].toUpperCase() + input.slice(1);
+}

--- a/test/other/validate-schemas.spec.ts
+++ b/test/other/validate-schemas.spec.ts
@@ -1,7 +1,7 @@
 import fs from 'fs-extra';
 import upath from 'upath';
 import { Json } from '../../lib/util/schema-utils';
-import { capitalize } from '../../tools/docs/utils';
+import { capitalize } from '../../lib/util/string';
 import * as Schemas from '../../tools/schemas/schema';
 
 describe('other/validate-schemas', () => {

--- a/tools/docs/utils.ts
+++ b/tools/docs/utils.ts
@@ -1,17 +1,13 @@
 import { logger } from '../../lib/logger';
 import type { ModuleApi } from '../../lib/types';
 import { regEx } from '../../lib/util/regex';
+import { capitalize } from '../../lib/util/string';
 import { readFile } from '../utils';
 
 const replaceStart =
   '<!-- Autogenerate in https://github.com/renovatebot/renovate -->';
 const replaceStop = '<!-- Autogenerate end -->';
 const goodUrlRegex = regEx(/\[(.+?)\]\((.+?)\)/);
-
-export function capitalize(input: string): string {
-  // console.log(input);
-  return input[0].toUpperCase() + input.slice(1);
-}
 
 export function formatName(input: string): string {
   return input.split('-').map(capitalize).join(' ');


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

The capitalize fn comes in handy in the `lib` directory code in the following PRs:
1. https://github.com/renovatebot/renovate/pull/33341
2. https://github.com/renovatebot/renovate/pull/35350

But, it currently sits in the `tools` directory and importing it from there breaks the CI builds.



<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
