### PR TITLE
feat(yaml): Improve YAML parser on Jinja2 templates

### DIFF
--- a/lib/util/yaml.spec.ts
+++ b/lib/util/yaml.spec.ts
@@ -207,12 +207,12 @@ describe('util/yaml', () => {
         {
           myObject: {
             aString: null,
-            anotherString: 'value'
+            anotherString: 'value',
           },
         },
         {
           foo: null,
-          bar: 'value:v2'
+          bar: 'value:v2',
         },
       ]);
     });
@@ -344,7 +344,7 @@ describe('util/yaml', () => {
           anotherString: 'value',
           myNestedObject: {
             aNestedString: null,
-            anotherNestedString: 'value:v2'
+            anotherNestedString: 'value:v2',
           },
         },
       });

--- a/lib/util/yaml.spec.ts
+++ b/lib/util/yaml.spec.ts
@@ -207,12 +207,12 @@ describe('util/yaml', () => {
         {
           myObject: {
             aString: null,
-            anotherString: "value"
+            anotherString: 'value'
           },
         },
         {
           foo: null,
-          bar: "value:v2"
+          bar: 'value:v2'
         },
       ]);
     });
@@ -341,10 +341,10 @@ describe('util/yaml', () => {
       ).toEqual({
         myObject: {
           aString: null,
-          anotherString: "value",
+          anotherString: 'value',
           myNestedObject: {
             aNestedString: null,
-            anotherNestedString: "value:v2"
+            anotherNestedString: 'value:v2'
           },
         },
       });

--- a/lib/util/yaml.spec.ts
+++ b/lib/util/yaml.spec.ts
@@ -189,6 +189,33 @@ describe('util/yaml', () => {
         },
       ]);
     });
+
+    it('should parse content with templates without quotes', () => {
+      expect(
+        parseYaml(
+          codeBlock`
+            myObject:
+              aString: {{ value }}
+              {{ prefixKey }}anotherString: value
+            ---
+            foo: {{ foo.bar }}
+            bar: value{{ value }}:v2
+          `,
+          { removeTemplates: true },
+        ),
+      ).toEqual([
+        {
+          myObject: {
+            aString: null,
+            anotherString: "value"
+          },
+        },
+        {
+          foo: null,
+          bar: "value:v2"
+        },
+      ]);
+    });
   });
 
   describe('load', () => {
@@ -291,6 +318,33 @@ describe('util/yaml', () => {
           aString: null,
           myNestedObject: {
             aNestedString: null,
+          },
+        },
+      });
+    });
+
+    it('should parse content with template without quotes', () => {
+      expect(
+        parseSingleYaml(
+          codeBlock`
+            myObject:
+              aString: {{value}}
+              {{prefixKey}}anotherString: value
+              {% if test.enabled %}
+              myNestedObject:
+                aNestedString: {{value}}
+                anotherNestedString: value{{value}}:v2
+              {% endif %}
+          `,
+          { removeTemplates: true },
+        ),
+      ).toEqual({
+        myObject: {
+          aString: null,
+          anotherString: "value",
+          myNestedObject: {
+            aNestedString: null,
+            anotherNestedString: "value:v2"
           },
         },
       });

--- a/lib/util/yaml.ts
+++ b/lib/util/yaml.ts
@@ -9,7 +9,6 @@ import type {
 import { parseAllDocuments, parseDocument, stringify } from 'yaml';
 import type { ZodType } from 'zod';
 import { logger } from '../logger';
-import { regEx } from './regex';
 import { stripTemplates } from './string';
 
 export interface YamlOptions<
@@ -168,7 +167,7 @@ export function dump(obj: any, opts?: DumpOptions): string {
 
 function massageContent(content: string, options?: YamlOptions): string {
   if (options?.removeTemplates) {
-    return stripTemplates(content.replace(regEx(/\s+{{.+?}}:.+/gs), ''));
+    return stripTemplates(content);
   }
 
   return content;


### PR DESCRIPTION
## Changes

- Added new tests that should fail at the moment, since the YAML Parser is not fixed, at first
![image](https://github.com/user-attachments/assets/433c9bce-2688-4c0d-aa0c-6398736701c1)

- Removing the regex pattern will allow parsing this example file, without replacing almost the whole file, in the following situations:

```yaml
networks: 
  {{ custom_network }}: 
    external: true

services:
  service_xpto: 
    hostname: {{ custom_value }}
    image: "{{ image }}:{{ version }}"
    deploy:
      labels: 
        label: {{ custom_value }}
        {{ prefix }}image:{{ custom_value }}
        ...
```

## Context

The workaround is to use double quotes, which does not make sense since Jinja does not need quotes to parse a template correctly.

Added new tests to cover the observed issue.

Without the regex pattern, the `docker-compose` manager works, and all images are correctly discovered and updated without any issues.

 - https://github.com/renovatebot/renovate/discussions/32967

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository
