### PR TITLE
fix(gerrit): hourly prs limit not being applied outside of execution

### DIFF
--- a/lib/modules/platform/gerrit/types.ts
+++ b/lib/modules/platform/gerrit/types.ts
@@ -37,6 +37,7 @@ export interface GerritChange {
   change_id: string;
   subject: string;
   status: GerritChangeStatus;
+  created: string;
   submittable?: boolean;
   _number: number;
   labels?: Record<string, GerritLabelInfo>;

--- a/lib/modules/platform/gerrit/utils.spec.ts
+++ b/lib/modules/platform/gerrit/utils.spec.ts
@@ -84,6 +84,7 @@ describe('modules/platform/gerrit/utils', () => {
         status: 'NEW',
         branch: 'main',
         subject: 'Fix for',
+        created: '2025-04-14 16:33:37.000000000',
         reviewers: {
           REVIEWER: [partial<GerritAccountInfo>({ username: 'username' })],
           REMOVED: [],
@@ -120,6 +121,7 @@ describe('modules/platform/gerrit/utils', () => {
         number: 123456,
         state: 'open',
         title: 'Fix for',
+        createdAt: '2025-04-14T16:33:37.000000000',
         sourceBranch: 'renovate/dependency-1.x',
         targetBranch: 'main',
         reviewers: ['username'],

--- a/lib/modules/platform/gerrit/utils.ts
+++ b/lib/modules/platform/gerrit/utils.ts
@@ -67,6 +67,7 @@ export function mapGerritChangeToPr(change: GerritChange): Pr {
     sourceBranch: extractSourceBranch(change) ?? change.branch,
     targetBranch: change.branch,
     title: change.subject,
+    createdAt: change.created?.replace(' ', 'T'),
     reviewers:
       change.reviewers?.REVIEWER?.filter(
         (reviewer) => typeof reviewer.username === 'string',


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

This fixes `prHourlyLimit` for Gerrit platform which was not being evaluated properly on initialization, meaning each execution would always start with an empty count of PRs created within the last hour.

Gerrit's `created` timestamp reference: https://gerrit-review.googlesource.com/Documentation/rest-api.html#timestamp

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

- Fixes https://github.com/renovatebot/renovate/discussions/35047#discussioncomment-12677501

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
