### PR TITLE
fix(nix): add `path` input type to Nix schema

### DIFF
--- a/lib/modules/manager/nix/extract.spec.ts
+++ b/lib/modules/manager/nix/extract.spec.ts
@@ -406,6 +406,36 @@ describe('modules/manager/nix/extract', () => {
 
   const flake10Lock = `{
     "nodes": {
+      "nixpkgs": {
+        "locked": {
+          "lastModified": 1687274257,
+          "narHash": "sha256-TutzPriQcZ8FghDhEolnHcYU2oHIG5XWF+/SUBNnAOE=",
+          "path": "/nix/store/22qgs3skscd9bmrxv9xv4q5d4wwm5ppx-source",
+          "rev": "2c9ecd1f0400076a4d6b2193ad468ff0a7e7fdc5",
+          "type": "path"
+        },
+        "original": {
+          "id": "nixpkgs",
+          "type": "indirect"
+        }
+      },
+      "root": {
+        "inputs": {
+          "nixpkgs": "nixpkgs"
+        }
+      }
+    },
+    "root": "root",
+    "version": 7
+  }`;
+
+  it('includes nixpkgs but using indirect type and path locked type that cannot be updated', async () => {
+    fs.readLocalFile.mockResolvedValueOnce(flake10Lock);
+    expect(await extractPackageFile('', 'flake.nix')).toBeNull();
+  });
+
+  const flake11Lock = `{
+    "nodes": {
       "flake-utils": {
         "inputs": {
           "systems": "systems"
@@ -487,7 +517,7 @@ describe('modules/manager/nix/extract', () => {
   }`;
 
   it('includes flake from GitHub Enterprise', async () => {
-    fs.readLocalFile.mockResolvedValueOnce(flake10Lock);
+    fs.readLocalFile.mockResolvedValueOnce(flake11Lock);
     expect(await extractPackageFile('', 'flake.nix')).toMatchObject({
       deps: [
         {
@@ -501,7 +531,7 @@ describe('modules/manager/nix/extract', () => {
     });
   });
 
-  const flake11Lock = `{
+  const flake12Lock = `{
     "nodes": {
       "data-mesher": {
         "inputs": {
@@ -590,7 +620,7 @@ describe('modules/manager/nix/extract', () => {
   }`;
 
   it('includes flake with tarball type', async () => {
-    fs.readLocalFile.mockResolvedValueOnce(flake11Lock);
+    fs.readLocalFile.mockResolvedValueOnce(flake12Lock);
     expect(await extractPackageFile('', 'flake.nix')).toMatchObject({
       deps: [
         {
@@ -603,7 +633,7 @@ describe('modules/manager/nix/extract', () => {
     });
   });
 
-  const flake12Lock = `{
+  const flake13Lock = `{
     "nodes": {
       "subgroup-project": {
         "locked": {
@@ -631,7 +661,7 @@ describe('modules/manager/nix/extract', () => {
   }`;
 
   it('uri decode gitlab subgroup', async () => {
-    fs.readLocalFile.mockResolvedValueOnce(flake12Lock);
+    fs.readLocalFile.mockResolvedValueOnce(flake13Lock);
     expect(await extractPackageFile('', 'flake.nix')).toMatchObject({
       deps: [
         {

--- a/lib/modules/manager/nix/schema.ts
+++ b/lib/modules/manager/nix/schema.ts
@@ -6,6 +6,7 @@ const InputType = z.enum([
   'github',
   'gitlab',
   'indirect',
+  'path',
   'sourcehut',
   'tarball',
 ]);


### PR DESCRIPTION
## Changes

Add `path` input type to the Nix schema and add a testcase.

## Context

When we are referring to an indirect original type, the locked type could be `path`.

Sample lock file: https://github.com/tharakadesilva/nixos-config/blob/main/flake.lock (search for `path` or `nixpkgs_4`).

This causes zod validation to fail as `path` is not a supported type. Here's what the error looks like:

<details><summary>Error</summary>

```
DEBUG: invalid flake.lock file
{
  "packageLockFile": "flake.lock"
  "error": {
    "message": "Schema error",
    "stack": "ZodError: Schema error\n    at Object.get error [as error] (/usr/local/renovate/node_modules/.pnpm/zod@3.24.2/node_modules/zod/lib/types.js:55:31)\n    at Object.extractPackageFile (/usr/local/renovate/lib/modules/manager/nix/extract.ts:43:49)\n    at getManagerPackageFiles (/usr/local/renovate/lib/workers/repository/extract/manager-files.ts:58:19)\n    at /usr/local/renovate/lib/workers/repository/extract/index.ts:57:28\n    at async Promise.all (index 1)\n    at extractAllDependencies (/usr/local/renovate/lib/workers/repository/extract/index.ts:54:26)\n    at extract (/usr/local/renovate/lib/workers/repository/process/extract-update.ts:160:28)\n    at extractDependencies (/usr/local/renovate/lib/workers/repository/process/index.ts:158:26)\n    at Object.renovateRepository (/usr/local/renovate/lib/workers/repository/index.ts:72:9)\n    at attributes.repository (/usr/local/renovate/lib/workers/global/index.ts:206:11)\n    at start (/usr/local/renovate/lib/workers/global/index.ts:191:7)\n    at /usr/local/renovate/lib/renovate.ts:19:22",
    "issues": {
      "nodes": {
        "nixpkgs_4": {
          "locked": {
            "type": "Invalid enum value. Expected 'git' | 'github' | 'gitlab' | 'indirect' | 'sourcehut' | 'tarball', received 'path'"
          }
        }
      }
    }
  }
}
```

</details> 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository