### PR TITLE
feat(prBody): Support templates in changelogUrl

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2738,6 +2738,19 @@ To read the changelogs you must use the link.
 }
 ```
 
+`changelogUrl` supports template compilation.
+
+```json title="Setting the changelog URL for the dummy package using a template"
+{
+  "packageRules": [
+    {
+      "matchPackageNames": ["dummy"],
+      "changelogUrl": "https://github.com/org/monorepo/blob/{{{sourceDirectory}}}/my-custom-changelog.txt"
+    }
+  ]
+}
+```
+
 <!-- prettier-ignore -->
 !!! note
     Renovate can fetch changelogs from Bitbucket, Bitbucket Server / Data Center, Gitea (Forgejo), GitHub and GitLab platforms only, and setting the URL to an unsupported host/platform type won't change that.

--- a/lib/workers/repository/update/pr/body/index.spec.ts
+++ b/lib/workers/repository/update/pr/body/index.spec.ts
@@ -174,6 +174,54 @@ describe('workers/repository/update/pr/body/index', () => {
       });
     });
 
+    it('templates changelogUrl', () => {
+      template.compile.mockImplementation((x) =>
+        x === '{{ testTemplate }}'
+          ? 'https://raw.githubusercontent.com/some/templated/CHANGELOG.md'
+          : x,
+      );
+
+      const upgrade = {
+        manager: 'some-manager',
+        branchName: 'some-branch',
+        dependencyUrl: 'https://github.com/foo/bar',
+        sourceUrl: 'https://github.com/foo/bar',
+        sourceDirectory: '/baz',
+        changelogUrl: '{{ testTemplate }}',
+        homepage: 'https://example.com',
+      };
+
+      getPrBody(
+        {
+          manager: 'some-manager',
+          baseBranch: 'base',
+          branchName: 'some-branch',
+          upgrades: [upgrade],
+        },
+        {
+          debugData: {
+            updatedInVer: '1.2.3',
+            createdInVer: '1.2.3',
+            targetBranch: 'base',
+          },
+        },
+        {},
+      );
+
+      expect(upgrade).toMatchObject({
+        branchName: 'some-branch',
+        changelogUrl: '{{ testTemplate }}',
+        depNameLinked:
+          '[undefined](https://example.com) ([source](https://github.com/foo/bar/tree/HEAD/baz), [changelog](https://raw.githubusercontent.com/some/templated/CHANGELOG.md))',
+        dependencyUrl: 'https://github.com/foo/bar',
+        homepage: 'https://example.com',
+        references:
+          '[homepage](https://example.com), [source](https://github.com/foo/bar/tree/HEAD/baz), [changelog](https://raw.githubusercontent.com/some/templated/CHANGELOG.md)',
+        sourceDirectory: '/baz',
+        sourceUrl: 'https://github.com/foo/bar',
+      });
+    });
+
     it('uses dependencyUrl as primary link', () => {
       const upgrade = {
         manager: 'some-manager',

--- a/lib/workers/repository/update/pr/body/index.spec.ts
+++ b/lib/workers/repository/update/pr/body/index.spec.ts
@@ -71,6 +71,8 @@ describe('workers/repository/update/pr/body/index', () => {
     });
 
     it('massages upgrades', () => {
+      template.compile.mockImplementation((x) => x);
+
       const upgrade = {
         manager: 'some-manager',
         branchName: 'some-branch',

--- a/lib/workers/repository/update/pr/body/index.ts
+++ b/lib/workers/repository/update/pr/body/index.ts
@@ -48,8 +48,11 @@ function massageUpdateMetadata(config: BranchConfig): void {
         `[source](${getFullSourceUrl(sourceUrl, sourceRootPath, sourceDirectory)})`,
       );
     }
-    if (changelogUrl) {
-      otherLinks.push(`[changelog](${changelogUrl})`);
+    const templatedChangelogUrl = changelogUrl
+      ? template.compile(changelogUrl, upgrade, true)
+      : undefined;
+    if (templatedChangelogUrl) {
+      otherLinks.push(`[changelog](${templatedChangelogUrl})`);
     }
     if (otherLinks.length) {
       depNameLinked += ` (${otherLinks.join(', ')})`;
@@ -64,8 +67,8 @@ function massageUpdateMetadata(config: BranchConfig): void {
         `[source](${getFullSourceUrl(sourceUrl, sourceRootPath, sourceDirectory)})`,
       );
     }
-    if (changelogUrl) {
-      references.push(`[changelog](${changelogUrl})`);
+    if (templatedChangelogUrl) {
+      references.push(`[changelog](${templatedChangelogUrl})`);
     }
     upgrade.references = references.join(', ');
   });


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
Support templates in the `changelogUrl` field by compiling that field during the `massageUpdateMetadata` step.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

- #31723 

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository
  - real repository on private GitLab instance 

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
