### PR TITLE
fix(devbox): nix is still required to update packages

### DIFF
--- a/lib/modules/manager/devbox/artifacts.ts
+++ b/lib/modules/manager/devbox/artifacts.ts
@@ -26,6 +26,7 @@ export async function updateArtifacts({
   const execOptions: ExecOptions = {
     cwdFile: packageFileName,
     toolConstraints: [
+      // we are required to install nix because devbox spawns nix commands internally
       {
         toolName: 'nix',
         constraint: constraints?.nix,

--- a/lib/modules/manager/devbox/artifacts.ts
+++ b/lib/modules/manager/devbox/artifacts.ts
@@ -27,6 +27,10 @@ export async function updateArtifacts({
     cwdFile: packageFileName,
     toolConstraints: [
       {
+        toolName: 'nix',
+        constraint: constraints?.nix,
+      },
+      {
         toolName: 'devbox',
         constraint: constraints?.devbox,
       },

--- a/lib/modules/manager/devbox/artifacts.ts
+++ b/lib/modules/manager/devbox/artifacts.ts
@@ -27,6 +27,8 @@ export async function updateArtifacts({
     cwdFile: packageFileName,
     toolConstraints: [
       // we are required to install nix because devbox spawns nix commands internally
+      // https://github.com/renovatebot/renovate/discussions/35382
+      // https://github.com/jetify-com/devbox/issues/2585
       {
         toolName: 'nix',
         constraint: constraints?.nix,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Devbox requires nix to be installed in order to update packages, this PR makes sure nix is installed as a constraint of devbox.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

- https://github.com/renovatebot/renovate/discussions/35382
- https://github.com/renovatebot/renovate/issues/27543
- https://github.com/jetify-com/devbox/issues/2585

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
