### PR TITLE
fix(worker): sort pr title numbers numerically

### DIFF
--- a/lib/workers/repository/process/sort.spec.ts
+++ b/lib/workers/repository/process/sort.spec.ts
@@ -15,7 +15,15 @@ describe('workers/repository/process/sort', () => {
         },
         {
           updateType: 'minor' as UpdateType,
-          prTitle: 'a minor update',
+          prTitle: 'a minor update 1.10',
+        },
+        {
+          updateType: 'minor' as UpdateType,
+          prTitle: 'a minor update 1.2',
+        },
+        {
+          updateType: 'minor' as UpdateType,
+          prTitle: 'a minor update 1.1',
         },
         {
           updateType: 'pin' as UpdateType,
@@ -31,7 +39,9 @@ describe('workers/repository/process/sort', () => {
         { prTitle: 'some other other pin', updateType: 'pin' },
         { prTitle: 'some other pin', updateType: 'pin' },
         { prTitle: 'some pin', updateType: 'pin' },
-        { prTitle: 'a minor update', updateType: 'minor' },
+        { prTitle: 'a minor update 1.1', updateType: 'minor' },
+        { prTitle: 'a minor update 1.2', updateType: 'minor' },
+        { prTitle: 'a minor update 1.10', updateType: 'minor' },
         { prTitle: 'some major update', updateType: 'major' },
       ]);
     });

--- a/lib/workers/repository/process/sort.ts
+++ b/lib/workers/repository/process/sort.ts
@@ -33,7 +33,7 @@ export function sortBranches(branches: Partial<BranchConfig>[]): void {
     }
     // TODO #22198
     // Sort by prTitle if updateType is the same
-    return a.prTitle! < b.prTitle! ? -1 : 1;
+    return a.prTitle!.localeCompare(b.prTitle!, undefined, { numeric: true });
   });
 }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
sort numbers in pr title numerically.
<!-- Describe what behavior is changed by this PR. -->

## Context
- closes #35269
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
