### PR TITLE
docs(nuget): document changelog fallback behaviour for partial V3 API server implementations

### DIFF
--- a/docs/usage/nuget.md
+++ b/docs/usage/nuget.md
@@ -70,7 +70,7 @@ All feeds are checked for dependency updates, and duplicate updates are merged i
     `registryUrls` set in other files are **not** passed to the NuGet commands.
 
 <!-- prettier-ignore -->
-!!! warning
+!!! note
     Some alternative feeds (e.g. Artifactory) do not implement the full set of [required NuGet resources](https://learn.microsoft.com/en-us/nuget/api/overview#resources-and-schema) for the V3 API. If the `PackageBaseAddress` resource does not exist, Renovate falls back to using the `projectUrl` from the catalog entry.
 
 ### Protocol versions

--- a/docs/usage/nuget.md
+++ b/docs/usage/nuget.md
@@ -69,6 +69,10 @@ All feeds are checked for dependency updates, and duplicate updates are merged i
     If your project has lockfile(s), for example a `package.lock.json` file, then you must set alternate feed settings in the `NuGet.config` file only.
     `registryUrls` set in other files are **not** passed to the NuGet commands.
 
+<!-- prettier-ignore -->
+!!! warning
+    Some alternative feeds (e.g. Artifactory) do not implement the full set of [required NuGet resources](https://learn.microsoft.com/en-us/nuget/api/overview#resources-and-schema) for the V3 API. If the `PackageBaseAddress` resource does not exist, Renovate falls back to using the `projectUrl` from the catalog entry.
+
 ### Protocol versions
 
 NuGet supports two protocol versions, `v2` and `v3`.

--- a/docs/usage/nuget.md
+++ b/docs/usage/nuget.md
@@ -71,7 +71,7 @@ All feeds are checked for dependency updates, and duplicate updates are merged i
 
 <!-- prettier-ignore -->
 !!! note
-    Some alternative feeds (e.g. Artifactory) do not implement the full set of [required NuGet resources](https://learn.microsoft.com/en-us/nuget/api/overview#resources-and-schema) for the V3 API. If the `PackageBaseAddress` resource does not exist, Renovate falls back to using the `projectUrl` from the catalog entry.
+    Some alternative feeds (e.g. Artifactory) do not implement the full set of [required NuGet resources](https://learn.microsoft.com/en-us/nuget/api/overview#resources-and-schema) for the V3 API. If the `PackageBaseAddress` resource does not exist, Renovate falls back to using the `projectUrl` from the dependency's catalog entry as the `sourceUrl` for the dependency, affecting [changelog detection](key-concepts/changelogs.md#how-renovate-detects-changelogs).
 
 ### Protocol versions
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Documenting the changelog fallback behaviour when Renovate interfaces with a partial Nuget V3 API implementation such as Artifactory.


## Context
I am in the process of migrating to Artifactory and ended up spending some time today diving into why changelogs stopped appearing in Renovate PRs when I switched my Nuget.org proxy to Artifactory, so wanted to add the note for future users.

I was considering adding a reference to https://docs.renovatebot.com/self-hosted-experimental/#renovate_x_nuget_download_nupkgs, but not sure that experimental, self-hosted only references should be added to this part of the documentation.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
