### PR TITLE
feat(datasource/github-runners): mark Windows Server 2019 as deprecated

### DIFF
--- a/lib/modules/datasource/github-runners/index.spec.ts
+++ b/lib/modules/datasource/github-runners/index.spec.ts
@@ -58,7 +58,7 @@ describe('modules/datasource/github-runners/index', () => {
       expect(res).toMatchObject({
         releases: [
           { version: '2016', isDeprecated: true },
-          { version: '2019' },
+          { version: '2019', isDeprecated: true },
           { version: '2022' },
           { version: '2025' },
         ],

--- a/lib/modules/datasource/github-runners/index.ts
+++ b/lib/modules/datasource/github-runners/index.ts
@@ -44,7 +44,7 @@ export class GithubRunnersDatasource extends Datasource {
     windows: [
       { version: '2025' },
       { version: '2022' },
-      { version: '2019' },
+      { version: '2019', isDeprecated: true },
       { version: '2016', isDeprecated: true },
     ],
   };

--- a/lib/modules/datasource/github-runners/readme.md
+++ b/lib/modules/datasource/github-runners/readme.md
@@ -1,7 +1,7 @@
 This datasource returns a list of all runners that are hosted by GitHub.
 The datasource is based on GitHub's [`runner-images`](https://github.com/actions/runner-images) and [`partner-runner-images`](https://github.com/actions/partner-runner-images) repositories.
 
-Examples: `windows-2022` / `ubuntu-24.04` / `macos-14`
+Examples: `windows-2025` / `ubuntu-24.04` / `macos-15`.
 
 ## Maintenance
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Update `readme.md` file, reference newest runner versions
- Mark Windows Server 2019 as deprecated

## Context

From the [GitHub Blog, Windows Server 2019 is closing down](https://github.blog/changelog/2025-04-15-upcoming-breaking-changes-and-releases-for-github-actions/#windows-server-2019-is-closing-down):

> We’re beginning the process of closing down the Windows server 2019 hosted runner image, following our [N-1 OS support policy](https://github.com/actions/runner-images?tab=readme-ov-file#software-and-image-support). This image will be fully retired by June 30, 2025. We recommend updating workflows use `windows-2022` or `windows-2025`.
> 
> To raise awareness of the upcoming removal, we’ll temporarily fail jobs using the `windows-2019` label starting in June 2025. The brownouts will occur on the following dates and times:
> 
> - June 3 13:00 – 21:00 UTC
> - June 10 13:00-21:00 UTC
> - June 17 13:00-21:00 UTC
> - June 24 13:00-21:00 UTC

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
