### PR TITLE
feat: captureGroups can be used in autoReplaceStringTemplate

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -781,6 +781,9 @@ This will lead to following update where `1.21-alpine` is the newest version of 
 image: my.new.registry/aRepository/andImage:1.21-alpine
 ```
 
+When a value from a capture group is required in the `autoReplaceStringTemplate`
+it can be accessed via `{{{ matchStringsCaptureGroups.<captureGroupName>}}}`.
+
 <!-- prettier-ignore -->
 !!! note
     Can only be used with the custom regex manager.

--- a/lib/modules/manager/custom/regex/utils.ts
+++ b/lib/modules/manager/custom/regex/utils.ts
@@ -66,6 +66,7 @@ export function createDependency(
     }
   }
   dependency.replaceString = replaceString;
+  dependency.matchStringsCaptureGroups = groups;
   return dependency;
 }
 

--- a/lib/modules/manager/types.ts
+++ b/lib/modules/manager/types.ts
@@ -164,6 +164,7 @@ export interface PackageDependency<T = Record<string, any>>
   isInternal?: boolean;
   variableName?: string;
   indentation?: string;
+  matchStringsCaptureGroups?: object;
 
   /**
    * override data source's default strategy.


### PR DESCRIPTION
## Changes

This change makes the values of the capture groups used in the `matchStrings` array available to later be used in the `autoReplaceStringTemplate` for regex managers.

This was not yet the case and there was already a discussion opened about this feature.

## Context

See discussion
 - https://github.com/renovatebot/renovate/discussions/30475

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository