### PR TITLE
feat(gradle): add support for exclusiveContent() repository definitions

### DIFF
--- a/lib/modules/manager/gradle/extract.ts
+++ b/lib/modules/manager/gradle/extract.ts
@@ -137,10 +137,18 @@ function getRegistryUrlsForDep(
 ): string[] {
   const scope = dep.depType === 'plugin' ? 'plugin' : 'dep';
 
-  const registryUrls = packageRegistries
-    .filter((item) => item.scope === scope)
-    .filter((item) => matchesContentDescriptor(dep, item.content))
-    .map((item) => item.registryUrl);
+  const matchingRegistries = packageRegistries.filter(
+    (item) =>
+      item.scope === scope && matchesContentDescriptor(dep, item.content),
+  );
+
+  const exclusiveRegistries = matchingRegistries.filter(
+    (item) => item.registryType === 'exclusive',
+  );
+
+  const registryUrls = (
+    exclusiveRegistries.length ? exclusiveRegistries : matchingRegistries
+  ).map((item) => item.registryUrl);
 
   if (!registryUrls.length && scope === 'plugin') {
     registryUrls.push(REGISTRY_URLS.gradlePluginPortal);

--- a/lib/modules/manager/gradle/parser/handlers.ts
+++ b/lib/modules/manager/gradle/parser/handlers.ts
@@ -336,6 +336,15 @@ function isPluginRegistry(ctx: Ctx): boolean {
   return false;
 }
 
+function isExclusiveRegistry(ctx: Ctx): boolean {
+  if (ctx.tokenMap.registryType) {
+    const registryType = loadFromTokenMap(ctx, 'registryType')[0].value;
+    return registryType === 'exclusiveContent';
+  }
+
+  return false;
+}
+
 export function handleRegistryUrl(ctx: Ctx): Ctx {
   let localVariables = ctx.globalVars;
 
@@ -364,6 +373,7 @@ export function handleRegistryUrl(ctx: Ctx): Ctx {
     if (url?.host && url.protocol) {
       ctx.registryUrls.push({
         registryUrl,
+        registryType: isExclusiveRegistry(ctx) ? 'exclusive' : 'regular',
         scope: isPluginRegistry(ctx) ? 'plugin' : 'dep',
         content: ctx.tmpRegistryContent,
       });

--- a/lib/modules/manager/gradle/types.ts
+++ b/lib/modules/manager/gradle/types.ts
@@ -80,6 +80,7 @@ export interface ContentDescriptorSpec {
 
 export interface PackageRegistry {
   registryUrl: string;
+  registryType: 'regular' | 'exclusive';
   scope: 'dep' | 'plugin';
   content?: ContentDescriptorSpec[];
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds support for `exclusiveContent` repo definitions for regular dependencies and within `pluginManagement` sections.

No change to existing behavior. The negative diff results from extracting the `.handler(...)` routines for `qPredefinedRegistries` and `qCustomUrl` into a shared `qRegistries` definition.

<!-- Describe what behavior is changed by this PR. -->

## Context

- Closes https://github.com/renovatebot/renovate/issues/14208
- Replaces https://github.com/renovatebot/renovate/pull/34722 - not needed
- Replaces https://github.com/renovatebot/renovate/pull/34771 - abandoned?!

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

Test repo: https://github.com/renovate-demo/14208-gradle-exclusive-content/pull/1

<details>

<summary>Extracted dependencies with correct registryUrl</summary>

```json
"config": {
 "gradle": [
   {
     "packageFile": "build.gradle",
     "datasource": "maven",
     "deps": [
       {
         "depName": "androidx.work:work-runtime",
         "currentValue": "2.5.0",
         "managerData": {
           "fileReplacePosition": 300,
           "packageFile": "build.gradle"
         },
         "fileReplacePosition": 300,
         "datasource": "maven",
         "registryUrls": ["https://dl.google.com/android/maven2/"],
         "depType": "dependencies",
         "updates": [
           {
             "bucket": "non-major",
             "newVersion": "2.10.0",
             "newValue": "2.10.0",
             "releaseTimestamp": "2024-10-30T17:02:36.000Z",
             "newVersionAgeInDays": 168,
             "newMajor": 2,
             "newMinor": 10,
             "newPatch": 0,
             "updateType": "minor",
             "libYears": 3.756721690953248,
             "branchName": "renovate/androidx.work-work-runtime-2.x"
           }
         ],
         "packageName": "androidx.work:work-runtime",
         "versioning": "gradle",
         "warnings": [],
         "sourceUrl": "https://cs.android.com/androidx/platform/frameworks/support",
         "registryUrl": "https://dl.google.com/android/maven2",
         "homepage": "https://developer.android.com/jetpack/androidx/releases/work#2.10.0",
         "packageScope": "androidx.work",
         "currentVersion": "2.5.0",
         "currentVersionTimestamp": "2021-01-27T18:00:00.000Z",
         "currentVersionAgeInDays": 1540,
         "isSingleVersion": true,
         "fixedVersion": "2.5.0"
       },
       {
         "depName": "com.google.protobuf:protobuf-java",
         "currentValue": "4.30.2",
         "managerData": {
           "fileReplacePosition": 361,
           "packageFile": "build.gradle"
         },
         "fileReplacePosition": 361,
         "datasource": "maven",
         "registryUrls": ["https://repo.maven.apache.org/maven2"],
         "depType": "dependencies",
         "updates": [],
         "packageName": "com.google.protobuf:protobuf-java",
         "versioning": "gradle",
         "warnings": [],
         "sourceUrl": "https://github.com/protocolbuffers/protobuf",
         "registryUrl": "https://repo.maven.apache.org/maven2",
         "homepage": "https://developers.google.com/protocol-buffers/",
         "currentVersion": "4.30.2",
         "currentVersionTimestamp": "2025-03-26T18:57:50.000Z",
         "currentVersionAgeInDays": 21,
         "fixedVersion": "4.30.2"
       }
     ]
   }
 ]
}

```

</details>


<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
