### PR TITLE
fix(repositoryCache): skip loading empty cache files

### DIFF
--- a/lib/util/cache/repository/impl/base.ts
+++ b/lib/util/cache/repository/impl/base.ts
@@ -58,6 +58,11 @@ export abstract class RepoCacheBase implements RepoCache {
         return;
       }
 
+      if (!is.nonEmptyString(oldCache)) {
+        logger.debug('RepoCacheBase.load() - cache file is empty - skipping');
+        return;
+      }
+
       const cacheV13 = RepoCacheV13.safeParse(oldCache);
       if (cacheV13.success) {
         await this.restore(cacheV13.data);

--- a/lib/util/cache/repository/impl/local.spec.ts
+++ b/lib/util/cache/repository/impl/local.spec.ts
@@ -61,6 +61,20 @@ describe('util/cache/repository/impl/local', () => {
     expect(localRepoCache.isModified()).toBeUndefined();
   });
 
+  it('should not load empty repository cache files', async () => {
+    fs.readCacheFile.mockResolvedValue('');
+    const localRepoCache = CacheFactory.get(
+      'some/repo',
+      '0123456789abcdef',
+      'local',
+    );
+    await localRepoCache.load(); // readCacheFile is mocked but has no return value set - therefore returns undefined
+    expect(logger.debug).toHaveBeenCalledWith(
+      'RepoCacheBase.load() - cache file is empty - skipping',
+    );
+    expect(localRepoCache.isModified()).toBeUndefined();
+  });
+
   it('skip when not found', async () => {
     const localRepoCache = CacheFactory.get(
       'some/repo',


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Skips loading empty repository cache files.
<!-- Describe what behavior is changed by this PR. -->

## Context
whenever a new repo is processed, its cache file is empty. this, in turn, causes Renovate to raise a warning in the dependency dashboard due to the cache file failing schema validation, which is expected for newly added scanned repos.


<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
