### PR TITLE
feat(presets): add `php-enqueue` monorepo

### DIFF
--- a/lib/data/monorepo.json
+++ b/lib/data/monorepo.json
@@ -471,6 +471,7 @@
     "parcel": "https://github.com/parcel-bundler/parcel",
     "payloadcms": "https://github.com/payloadcms/payload",
     "percy-cli": "https://github.com/percy/cli",
+    "php-enqueue": "https://github.com/php-enqueue",
     "picassojs": "https://github.com/qlik-oss/picasso.js",
     "pixijs": [
       "https://github.com/pixijs/pixi.js",

--- a/lib/data/monorepo.json
+++ b/lib/data/monorepo.json
@@ -625,7 +625,7 @@
     "ngrx": "https://github.com/ngrx/",
     "nx": "https://github.com/nrwl/nx",
     "octokit": "https://github.com/octokit/",
-    "php-enqueue": "https://github.com/php-enqueue",
+    "php-enqueue": "https://github.com/php-enqueue/",
     "semantic-release": "https://github.com/semantic-release/",
     "swc": "https://github.com/swc-project/",
     "twig": "https://github.com/twigphp/"

--- a/lib/data/monorepo.json
+++ b/lib/data/monorepo.json
@@ -471,7 +471,6 @@
     "parcel": "https://github.com/parcel-bundler/parcel",
     "payloadcms": "https://github.com/payloadcms/payload",
     "percy-cli": "https://github.com/percy/cli",
-    "php-enqueue": "https://github.com/php-enqueue",
     "picassojs": "https://github.com/qlik-oss/picasso.js",
     "pixijs": [
       "https://github.com/pixijs/pixi.js",
@@ -626,6 +625,7 @@
     "ngrx": "https://github.com/ngrx/",
     "nx": "https://github.com/nrwl/nx",
     "octokit": "https://github.com/octokit/",
+    "php-enqueue": "https://github.com/php-enqueue",
     "semantic-release": "https://github.com/semantic-release/",
     "swc": "https://github.com/swc-project/",
     "twig": "https://github.com/twigphp/"


### PR DESCRIPTION
## Changes

Groups the php-enqueue packages, which are mostly released together with the same tag, see https://packagist.org/?query=enqueue%2F

## Context

Renovate created 3 MRs for me updating 3 different enqueue  packages to 0.10.25.

I'm just not a 100% sure about naming. On GitHub all the packages live under `php-enqueue`, but they are released under `enqueue` to packagist. Using only enqueue felt like it might clash in the monorepo config potentially, so I ended up using the more specific `php-enqueue`. I don't have strong opinions about this though.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
