### PR TITLE
refactor: move utility fn

### DIFF
--- a/lib/workers/repository/reconfigure/utils.ts
+++ b/lib/workers/repository/reconfigure/utils.ts
@@ -1,3 +1,26 @@
+import is from '@sindresorhus/is';
+import { platform } from '../../../modules/platform';
+import type { BranchStatus } from '../../../types';
+
 export function getReconfigureBranchName(prefix: string): string {
   return `${prefix}reconfigure`;
+}
+
+export async function setBranchStatus(
+  branchName: string,
+  description: string,
+  state: BranchStatus,
+  context?: string | null,
+): Promise<void> {
+  if (!is.nonEmptyString(context)) {
+    // already logged this case when validating the status check
+    return;
+  }
+
+  await platform.setBranchStatus({
+    branchName,
+    context,
+    description,
+    state,
+  });
 }

--- a/lib/workers/repository/reconfigure/validate.ts
+++ b/lib/workers/repository/reconfigure/validate.ts
@@ -7,33 +7,13 @@ import { logger } from '../../../logger';
 import { platform } from '../../../modules/platform';
 import { ensureComment } from '../../../modules/platform/comment';
 import { scm } from '../../../modules/platform/scm';
-import type { BranchStatus } from '../../../types';
 import { getCache } from '../../../util/cache/repository';
 import { readLocalFile } from '../../../util/fs';
 import { getBranchCommit } from '../../../util/git';
 import { regEx } from '../../../util/regex';
 import { detectConfigFile } from '../init/merge';
 import { setReconfigureBranchCache } from './reconfigure-cache';
-import { getReconfigureBranchName } from './utils';
-
-async function setBranchStatus(
-  branchName: string,
-  description: string,
-  state: BranchStatus,
-  context?: string | null,
-): Promise<void> {
-  if (!is.nonEmptyString(context)) {
-    // already logged this case when validating the status check
-    return;
-  }
-
-  await platform.setBranchStatus({
-    branchName,
-    context,
-    description,
-    state,
-  });
-}
+import { getReconfigureBranchName, setBranchStatus } from './utils';
 
 export async function validateReconfigureBranch(
   config: RenovateConfig,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- Move `setBranchStatus` fn to `reconfigure/utils`
<!-- Describe what behavior is changed by this PR. -->

## Context
- Reduce changes in https://github.com/renovatebot/renovate/pull/34696 ([comment](https://github.com/renovatebot/renovate/pull/34696#discussion_r2024973178))
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
