### PR TITLE
refactor(manager): Prepare CNB support for Spring Boot Maven plugin

### DIFF
--- a/lib/modules/manager/maven/extract.spec.ts
+++ b/lib/modules/manager/maven/extract.spec.ts
@@ -20,14 +20,14 @@ const profileSettingsContent = Fixtures.get('profile.settings.xml');
 describe('modules/manager/maven/extract', () => {
   describe('extractPackage', () => {
     it('returns null for invalid XML', () => {
-      expect(extractPackage('', 'some-file')).toBeNull();
-      expect(extractPackage('invalid xml content', 'some-file')).toBeNull();
-      expect(extractPackage('<foobar></foobar>', 'some-file')).toBeNull();
-      expect(extractPackage('<project></project>', 'some-file')).toBeNull();
+      expect(extractPackage('', 'some-file', {})).toBeNull();
+      expect(extractPackage('invalid xml content', 'some-file', {})).toBeNull();
+      expect(extractPackage('<foobar></foobar>', 'some-file', {})).toBeNull();
+      expect(extractPackage('<project></project>', 'some-file', {})).toBeNull();
     });
 
     it('extract dependencies from any XML position', () => {
-      const res = extractPackage(simpleContent, 'some-file');
+      const res = extractPackage(simpleContent, 'some-file', {});
       expect(res).toMatchObject({
         datasource: 'maven',
         deps: [
@@ -238,6 +238,7 @@ describe('modules/manager/maven/extract', () => {
       extractPackage(
         '<?xml version="1.0" encoding="UTF-8"?> \r\n',
         'some-file',
+        {},
       );
       expect(logger.logger.warn).toHaveBeenCalledWith(
         'Your pom.xml contains windows line endings. This is not supported and may result in parsing issues.',
@@ -245,7 +246,11 @@ describe('modules/manager/maven/extract', () => {
     });
 
     it('tries minimum manifests', () => {
-      const res = extractPackage(Fixtures.get('minimum.pom.xml'), 'some-file');
+      const res = extractPackage(
+        Fixtures.get('minimum.pom.xml'),
+        'some-file',
+        {},
+      );
       expect(res).toEqual({
         datasource: 'maven',
         deps: [],
@@ -259,6 +264,7 @@ describe('modules/manager/maven/extract', () => {
       const res = extractPackage(
         Fixtures.get(`minimum_snapshot.pom.xml`),
         'some-file',
+        {},
       );
       expect(res).toEqual({
         datasource: 'maven',
@@ -275,6 +281,7 @@ describe('modules/manager/maven/extract', () => {
       const packages = extractPackage(
         Fixtures.get('recursive_props.pom.xml'),
         'some-file',
+        {},
       );
       const [{ deps }] = resolveParents([packages!]);
       expect(deps).toMatchObject([
@@ -289,6 +296,7 @@ describe('modules/manager/maven/extract', () => {
       const packages = extractPackage(
         Fixtures.get('multiple_usages_props.pom.xml'),
         'some-file',
+        {},
       );
       const [{ deps }] = resolveParents([packages!]);
       expect(deps).toMatchObject([
@@ -303,6 +311,7 @@ describe('modules/manager/maven/extract', () => {
       const packages = extractPackage(
         Fixtures.get('infinite_recursive_props.pom.xml'),
         'some-file',
+        {},
       );
       const [{ deps }] = resolveParents([packages!]);
       expect(deps).toMatchObject([

--- a/lib/modules/manager/maven/extract.ts
+++ b/lib/modules/manager/maven/extract.ts
@@ -219,7 +219,11 @@ function applyPropsInternal(
       return substr;
     });
 
-  const depName = replaceAll(dep.depName!);
+  let depName = dep.depName;
+  if (dep.depName) {
+    depName = replaceAll(dep.depName);
+  }
+
   const registryUrls = dep.registryUrls!.map((url) => replaceAll(url));
 
   let fileReplacePosition = dep.fileReplacePosition;
@@ -293,6 +297,7 @@ interface MavenInterimPackageFile extends PackageFile {
 export function extractPackage(
   rawContent: string,
   packageFile: string,
+  _config: ExtractConfig,
 ): PackageFile | null {
   if (!rawContent) {
     return null;
@@ -504,7 +509,9 @@ function cleanResult(packageFiles: MavenInterimPackageFile[]): PackageFile[] {
     packageFile.deps.forEach((dep) => {
       delete dep.propSource;
       //Add Registry From SuperPom
-      dep.registryUrls!.push(MAVEN_REPO);
+      if (dep.datasource === MavenDatasource.id) {
+        dep.registryUrls!.push(MAVEN_REPO);
+      }
     });
   });
   return packageFiles;
@@ -535,7 +542,7 @@ export function extractExtensions(
 }
 
 export async function extractAllPackageFiles(
-  _config: ExtractConfig,
+  config: ExtractConfig,
   packageFiles: string[],
 ): Promise<PackageFile[]> {
   const packages: PackageFile[] = [];
@@ -564,7 +571,7 @@ export async function extractAllPackageFiles(
         logger.trace({ packageFile }, 'can not read extensions');
       }
     } else {
-      const pkg = extractPackage(content, packageFile);
+      const pkg = extractPackage(content, packageFile, config);
       if (pkg) {
         packages.push(pkg);
       } else {

--- a/lib/modules/manager/maven/index.spec.ts
+++ b/lib/modules/manager/maven/index.spec.ts
@@ -25,7 +25,7 @@ describe('modules/manager/maven/index', () => {
     it('should update an existing dependency', () => {
       const newValue = '9.9.9.9-final';
 
-      const { deps } = extractPackage(simpleContent, 'some-file')!;
+      const { deps } = extractPackage(simpleContent, 'some-file', {})!;
       const dep = selectDep(deps);
       const updatedContent = updateDependency({
         fileContent: simpleContent,
@@ -33,7 +33,7 @@ describe('modules/manager/maven/index', () => {
       })!;
 
       const updatedDep = selectDep(
-        extractPackage(updatedContent, 'some-file')!.deps,
+        extractPackage(updatedContent, 'some-file', {})!.deps,
       );
       expect(updatedDep?.currentValue).toEqual(newValue);
     });
@@ -42,8 +42,8 @@ describe('modules/manager/maven/index', () => {
       const newValue = '9.9.9.9-final';
 
       const packages = resolveParents([
-        extractPackage(parentPomContent, 'parent.pom.xml')!,
-        extractPackage(childPomContent, 'child.pom.xml')!,
+        extractPackage(parentPomContent, 'parent.pom.xml', {})!,
+        extractPackage(childPomContent, 'child.pom.xml', {})!,
       ]);
       const [{ deps }] = packages;
       const dep = selectDep(deps, 'org.example:quux');
@@ -53,8 +53,8 @@ describe('modules/manager/maven/index', () => {
       })!;
 
       const [updatedPkg] = resolveParents([
-        extractPackage(updatedContent, 'parent.pom.xml')!,
-        extractPackage(childPomContent, 'child.pom.xml')!,
+        extractPackage(updatedContent, 'parent.pom.xml', {})!,
+        extractPackage(childPomContent, 'child.pom.xml', {})!,
       ]);
       const updatedDep = selectDep(updatedPkg.deps, 'org.example:quux');
       expect(updatedDep?.registryUrls).toContain('http://example.com/');
@@ -62,7 +62,7 @@ describe('modules/manager/maven/index', () => {
     });
 
     it('should not touch content if new and old versions are equal', () => {
-      const { deps } = extractPackage(simpleContent, 'some-file')!;
+      const { deps } = extractPackage(simpleContent, 'some-file', {})!;
       const dep = selectDep(deps);
       const updatedContent = updateDependency({
         fileContent: simpleContent,
@@ -130,7 +130,7 @@ describe('modules/manager/maven/index', () => {
     });
 
     it('should return null if current versions in content and upgrade are not same', () => {
-      const { deps } = extractPackage(simpleContent, 'some-file')!;
+      const { deps } = extractPackage(simpleContent, 'some-file', {})!;
       const dep = selectDep(deps);
 
       const updatedContent = updateDependency({
@@ -144,7 +144,7 @@ describe('modules/manager/maven/index', () => {
       const newValue = '[1.2.3]';
       const select = (depSet: PackageFileContent) =>
         selectDep(depSet.deps, 'org.example:hard-range');
-      const oldContent = extractPackage(simpleContent, 'some-file');
+      const oldContent = extractPackage(simpleContent, 'some-file', {});
       const dep = select(oldContent!);
       const newContent = extractPackage(
         updateDependency({
@@ -152,6 +152,7 @@ describe('modules/manager/maven/index', () => {
           upgrade: { ...dep, newValue },
         })!,
         'some-file',
+        {},
       );
       const newDep = select(newContent!);
       expect(newDep?.currentValue).toEqual(newValue);
@@ -160,7 +161,7 @@ describe('modules/manager/maven/index', () => {
     it('should preserve ranges', () => {
       const select = (depSet: PackageFileContent) =>
         depSet?.deps ? selectDep(depSet.deps, 'org.example:hard-range') : null;
-      const oldContent = extractPackage(simpleContent, 'some-file');
+      const oldContent = extractPackage(simpleContent, 'some-file', {});
       const dep = select(oldContent!);
       expect(dep).not.toBeNull();
 


### PR DESCRIPTION
## Changes

This is a preparation to add support for updating Cloud Native Buildpacks in the Maven plugin for Spring Boot.
See conversation on PR: #35183

## Context

Maven plugin for Spring Boot allows to create an OCI image from a jar or war file using [Cloud Native Buildpacks](https://buildpacks.io/). The plugin offers to provide remote docker resources for builder and run images including custom buildpacks in pom.xml.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository
