### PR TITLE
fix(manager/gomod): use regex to remove version suffix from name

### DIFF
--- a/lib/modules/manager/gomod/__fixtures__/1/go-mod
+++ b/lib/modules/manager/gomod/__fixtures__/1/go-mod
@@ -12,3 +12,5 @@ replace github.com/pkg/errors => ../errors
 replace golang.org/x/foo => github.com/pravesht/gocql v0.0.0
 
 require github.com/caarlos0/env v3.5.0+incompatible
+
+require sigs.k8s.io/structured-merge-diff/v4 v4.7.0

--- a/lib/modules/manager/gomod/__fixtures__/1/go-mod
+++ b/lib/modules/manager/gomod/__fixtures__/1/go-mod
@@ -14,3 +14,4 @@ replace golang.org/x/foo => github.com/pravesht/gocql v0.0.0
 require github.com/caarlos0/env v3.5.0+incompatible
 
 require sigs.k8s.io/structured-merge-diff/v4 v4.7.0
+require github.com/cucumber/common/messages/go/v18 v18.0.0

--- a/lib/modules/manager/gomod/__snapshots__/extract.spec.ts.snap
+++ b/lib/modules/manager/gomod/__snapshots__/extract.spec.ts.snap
@@ -783,5 +783,14 @@ exports[`modules/manager/gomod/extract > extractPackageFile() > extracts single-
       "lineNumber": 15,
     },
   },
+  {
+    "currentValue": "v18.0.0",
+    "datasource": "go",
+    "depName": "github.com/cucumber/common/messages/go/v18",
+    "depType": "require",
+    "managerData": {
+      "lineNumber": 16,
+    },
+  },
 ]
 `;

--- a/lib/modules/manager/gomod/__snapshots__/extract.spec.ts.snap
+++ b/lib/modules/manager/gomod/__snapshots__/extract.spec.ts.snap
@@ -774,5 +774,14 @@ exports[`modules/manager/gomod/extract > extractPackageFile() > extracts single-
       "lineNumber": 13,
     },
   },
+  {
+    "currentValue": "v4.7.0",
+    "datasource": "go",
+    "depName": "sigs.k8s.io/structured-merge-diff/v4",
+    "depType": "require",
+    "managerData": {
+      "lineNumber": 15,
+    },
+  },
 ]
 `;

--- a/lib/modules/manager/gomod/__snapshots__/update.spec.ts.snap
+++ b/lib/modules/manager/gomod/__snapshots__/update.spec.ts.snap
@@ -15,6 +15,8 @@ replace github.com/pkg/errors => ../errors
 replace golang.org/x/foo => github.com/pravesht/gocql v0.0.0
 
 require github.com/caarlos0/env v3.5.0+incompatible
+
+require sigs.k8s.io/structured-merge-diff/v4 v4.7.0
 "
 `;
 
@@ -100,5 +102,7 @@ replace github.com/pkg/errors => ../errors
 replace golang.org/x/foo => github.com/pravesht/gocql v0.0.0
 
 require github.com/caarlos0/env v3.5.0+incompatible
+
+require sigs.k8s.io/structured-merge-diff/v4 v4.7.0
 "
 `;

--- a/lib/modules/manager/gomod/__snapshots__/update.spec.ts.snap
+++ b/lib/modules/manager/gomod/__snapshots__/update.spec.ts.snap
@@ -17,6 +17,7 @@ replace golang.org/x/foo => github.com/pravesht/gocql v0.0.0
 require github.com/caarlos0/env v3.5.0+incompatible
 
 require sigs.k8s.io/structured-merge-diff/v4 v4.7.0
+require github.com/cucumber/common/messages/go/v18 v18.0.0
 "
 `;
 
@@ -104,5 +105,6 @@ replace golang.org/x/foo => github.com/pravesht/gocql v0.0.0
 require github.com/caarlos0/env v3.5.0+incompatible
 
 require sigs.k8s.io/structured-merge-diff/v4 v4.7.0
+require github.com/cucumber/common/messages/go/v18 v18.0.0
 "
 `;

--- a/lib/modules/manager/gomod/extract.spec.ts
+++ b/lib/modules/manager/gomod/extract.spec.ts
@@ -14,8 +14,8 @@ describe('modules/manager/gomod/extract', () => {
     it('extracts single-line requires', () => {
       const res = extractPackageFile(gomod1)?.deps;
       expect(res).toMatchSnapshot();
-      expect(res).toHaveLength(11);
-      expect(res?.filter((e) => e.depType === 'require')).toHaveLength(8);
+      expect(res).toHaveLength(12);
+      expect(res?.filter((e) => e.depType === 'require')).toHaveLength(9);
       expect(res?.filter((e) => e.depType === 'indirect')).toHaveLength(1);
       expect(res?.filter((e) => e.skipReason)).toHaveLength(2);
       expect(res?.filter((e) => e.depType === 'replace')).toHaveLength(2);

--- a/lib/modules/manager/gomod/extract.spec.ts
+++ b/lib/modules/manager/gomod/extract.spec.ts
@@ -14,8 +14,8 @@ describe('modules/manager/gomod/extract', () => {
     it('extracts single-line requires', () => {
       const res = extractPackageFile(gomod1)?.deps;
       expect(res).toMatchSnapshot();
-      expect(res).toHaveLength(10);
-      expect(res?.filter((e) => e.depType === 'require')).toHaveLength(7);
+      expect(res).toHaveLength(11);
+      expect(res?.filter((e) => e.depType === 'require')).toHaveLength(8);
       expect(res?.filter((e) => e.depType === 'indirect')).toHaveLength(1);
       expect(res?.filter((e) => e.skipReason)).toHaveLength(2);
       expect(res?.filter((e) => e.depType === 'replace')).toHaveLength(2);

--- a/lib/modules/manager/gomod/update.spec.ts
+++ b/lib/modules/manager/gomod/update.spec.ts
@@ -112,6 +112,21 @@ describe('modules/manager/gomod/update', () => {
       expect(res).toContain('github.com/pkg/errors/v2 v2.0.0');
     });
 
+    it('bumps major with short name', () => {
+      const upgrade = {
+        depName: 'sigs.k8s.io/structured-merge-diff/v4',
+        managerData: { lineNumber: 15 },
+        currentValue: 'v4.7.0',
+        newValue: 'v6.0.0',
+        newMajor: 6,
+        updateType: 'major' as UpdateType,
+        depType: 'require',
+      };
+      const res = updateDependency({ fileContent: gomod1, upgrade });
+      expect(res).not.toEqual(gomod1);
+      expect(res).toContain('sigs.k8s.io/structured-merge-diff/v6 v6.0.0');
+    });
+
     it('replaces major gopkg.in updates', () => {
       const upgrade = {
         depName: 'gopkg.in/russross/blackfriday.v1',

--- a/lib/modules/manager/gomod/update.spec.ts
+++ b/lib/modules/manager/gomod/update.spec.ts
@@ -112,7 +112,7 @@ describe('modules/manager/gomod/update', () => {
       expect(res).toContain('github.com/pkg/errors/v2 v2.0.0');
     });
 
-    it('bumps major with short name', () => {
+    it('bumps major with single package name component', () => {
       const upgrade = {
         depName: 'sigs.k8s.io/structured-merge-diff/v4',
         managerData: { lineNumber: 15 },
@@ -125,6 +125,23 @@ describe('modules/manager/gomod/update', () => {
       const res = updateDependency({ fileContent: gomod1, upgrade });
       expect(res).not.toEqual(gomod1);
       expect(res).toContain('sigs.k8s.io/structured-merge-diff/v6 v6.0.0');
+    });
+
+    it('bumps major with multiple package name components', () => {
+      const upgrade = {
+        depName: 'github.com/cucumber/common/messages/go/v18',
+        managerData: { lineNumber: 16 },
+        currentValue: 'v18.0.0',
+        newValue: 'v19.0.0',
+        newMajor: 19,
+        updateType: 'major' as UpdateType,
+        depType: 'require',
+      };
+      const res = updateDependency({ fileContent: gomod1, upgrade });
+      expect(res).not.toEqual(gomod1);
+      expect(res).toContain(
+        'github.com/cucumber/common/messages/go/v19 v19.0.0',
+      );
     });
 
     it('replaces major gopkg.in updates', () => {

--- a/lib/modules/manager/gomod/update.ts
+++ b/lib/modules/manager/gomod/update.ts
@@ -4,7 +4,9 @@ import { newlineRegex, regEx } from '../../../util/regex';
 import type { UpdateDependencyConfig } from '../types';
 
 function getNameWithNoVersion(name: string): string {
-  let nameNoVersion = name.split('/').slice(0, 3).join('/');
+  // remove version suffixes like /v1 or /v2
+  let nameNoVersion = name.replace(/\/v\d+$/, '');
+  // gopkg.in is a special case where the major version is added with a dot rather than a slash
   if (nameNoVersion.startsWith('gopkg.in')) {
     nameNoVersion = nameNoVersion.replace(regEx(/\.v\d+$/), '');
   }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This PR uses a regular expression to remove the `/v2` or `/v3` suffix from go packages. This is later used to determine if suffix can be updated or appended. 

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

The change is required for packages which don't contain a `org/repo` but only a package name like `sigs.k8s.io/structured-merge-diff`. Currently Renovate appends here the new major version to construct the wrong `sigs.k8s.io/structured-merge-diff/v4/v6` rather than the expected `sigs.k8s.io/structured-merge-diff/v6` 

fixes #35507

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository 

Tests are added both for the short example as well as an example with multiple (3+) name components.

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
