### PR TITLE
refactor(util): interpolator

### DIFF
--- a/lib/config/secrets.ts
+++ b/lib/config/secrets.ts
@@ -13,7 +13,7 @@ const secretNamePattern = '[A-Za-z][A-Za-z0-9_]*';
 const secretNameRegex = regEx(`^${secretNamePattern}$`);
 const secretTemplateRegex = regEx(`{{ secrets\\.(${secretNamePattern}) }}`);
 
-const options: InterpolatorOptions = {
+export const options: InterpolatorOptions = {
   name: 'secrets',
   nameRegex: secretNameRegex,
   templateRegex: secretTemplateRegex,

--- a/lib/config/secrets.ts
+++ b/lib/config/secrets.ts
@@ -1,9 +1,9 @@
 import is from '@sindresorhus/is';
+import type { InterpolatorOptions } from '../util/interpolator';
 import {
-  CONFIG_SECRETS_INVALID,
-  CONFIG_VALIDATION,
-} from '../constants/error-messages';
-import { logger } from '../logger';
+  replaceInterpolatedValuesInObject,
+  validateInterpolatedValues,
+} from '../util/interpolator';
 import { regEx } from '../util/regex';
 import { addSecretForSanitizing } from '../util/sanitize';
 import type { AllConfig, RenovateConfig } from './types';
@@ -13,107 +13,21 @@ const secretNamePattern = '[A-Za-z][A-Za-z0-9_]*';
 const secretNameRegex = regEx(`^${secretNamePattern}$`);
 const secretTemplateRegex = regEx(`{{ secrets\\.(${secretNamePattern}) }}`);
 
-function validateSecrets(secrets_: unknown): void {
-  if (!secrets_) {
-    return;
-  }
-  const validationErrors: string[] = [];
-  if (is.plainObject(secrets_)) {
-    for (const [secretName, secretValue] of Object.entries(secrets_)) {
-      if (!secretNameRegex.test(secretName)) {
-        validationErrors.push(`Invalid secret name "${secretName}"`);
-      }
-      if (!is.string(secretValue)) {
-        validationErrors.push(
-          `Secret values must be strings. Found type ${typeof secretValue} for secret ${secretName}`,
-        );
-      }
-    }
-  } else {
-    validationErrors.push(
-      `Config secrets must be a plain object. Found: ${typeof secrets_}`,
-    );
-  }
-  if (validationErrors.length) {
-    logger.error({ validationErrors }, 'Invalid secrets configured');
-    throw new Error(CONFIG_SECRETS_INVALID);
-  }
-}
+const options: InterpolatorOptions = {
+  name: 'secrets',
+  nameRegex: secretNameRegex,
+  templateRegex: secretTemplateRegex,
+};
 
 export function validateConfigSecrets(config: AllConfig): void {
-  validateSecrets(config.secrets);
+  validateInterpolatedValues(config.secrets, options);
   if (config.repositories) {
     for (const repository of config.repositories) {
       if (is.plainObject(repository)) {
-        validateSecrets(repository.secrets);
+        validateInterpolatedValues(repository.secrets, options);
       }
     }
   }
-}
-
-function replaceSecretsInString(
-  key: string,
-  value: string,
-  secrets: Record<string, string>,
-): string {
-  // do nothing if no secret template found
-  if (!secretTemplateRegex.test(value)) {
-    return value;
-  }
-
-  const disallowedPrefixes = ['branch', 'commit', 'group', 'pr', 'semantic'];
-  if (disallowedPrefixes.some((prefix) => key.startsWith(prefix))) {
-    const error = new Error(CONFIG_VALIDATION);
-    error.validationSource = 'config';
-    error.validationError = 'Disallowed secret substitution';
-    error.validationMessage = `The field \`${key}\` may not use secret substitution`;
-    throw error;
-  }
-  return value.replace(secretTemplateRegex, (_, secretName) => {
-    if (secrets?.[secretName]) {
-      return secrets[secretName];
-    }
-    const error = new Error(CONFIG_VALIDATION);
-    error.validationSource = 'config';
-    error.validationError = 'Unknown secret name';
-    error.validationMessage = `The following secret name was not found in config: ${String(
-      secretName,
-    )}`;
-    throw error;
-  });
-}
-
-function replaceSecretsInObject(
-  config_: RenovateConfig,
-  secrets: Record<string, string>,
-  deleteSecrets: boolean,
-): RenovateConfig {
-  const config = { ...config_ };
-  if (deleteSecrets) {
-    delete config.secrets;
-  }
-  for (const [key, value] of Object.entries(config)) {
-    if (is.plainObject(value)) {
-      config[key] = replaceSecretsInObject(value, secrets, deleteSecrets);
-    }
-    if (is.string(value)) {
-      config[key] = replaceSecretsInString(key, value, secrets);
-    }
-    if (is.array(value)) {
-      for (const [arrayIndex, arrayItem] of value.entries()) {
-        if (is.plainObject(arrayItem)) {
-          value[arrayIndex] = replaceSecretsInObject(
-            arrayItem,
-            secrets,
-            deleteSecrets,
-          );
-        } else if (is.string(arrayItem)) {
-          value[arrayIndex] = replaceSecretsInString(key, arrayItem, secrets);
-        }
-      }
-    }
-  }
-  return config;
 }
 
 export function applySecretsToConfig(
@@ -128,5 +42,10 @@ export function applySecretsToConfig(
     }
   }
   // TODO: fix types (#9610)
-  return replaceSecretsInObject(config, secrets as never, deleteSecrets);
+  return replaceInterpolatedValuesInObject(
+    config,
+    secrets!,
+    options,
+    deleteSecrets,
+  );
 }

--- a/lib/util/interpolator.spec.ts
+++ b/lib/util/interpolator.spec.ts
@@ -1,0 +1,162 @@
+import { options as SECRET_INTERPOLATOR_OPTIONS } from '../config/secrets';
+import {
+  CONFIG_SECRETS_INVALID,
+  CONFIG_VALIDATION,
+} from '../constants/error-messages';
+import {
+  replaceInterpolatedValuesInObject,
+  validateInterpolatedValues,
+} from './interpolator';
+
+describe('util/interpolator', () => {
+  describe('validateInterpolatedValues', () => {
+    it('does nothing if not input', () => {
+      expect(() =>
+        validateInterpolatedValues(undefined, SECRET_INTERPOLATOR_OPTIONS),
+      ).not.toThrow();
+    });
+
+    it('does not throw error when keys and values are valid', () => {
+      expect(() =>
+        validateInterpolatedValues(
+          { SOME_SECRET: 'secret' },
+          SECRET_INTERPOLATOR_OPTIONS,
+        ),
+      ).not.toThrow();
+    });
+
+    it('throws when input is not a valid object', () => {
+      expect(() =>
+        validateInterpolatedValues(
+          'not_an_object',
+          SECRET_INTERPOLATOR_OPTIONS,
+        ),
+      ).toThrow(CONFIG_SECRETS_INVALID);
+    });
+
+    it('throws when keys do not follow specified regex patterns', () => {
+      expect(() =>
+        validateInterpolatedValues(
+          { 'SOME-SECRET': 'secret' },
+          SECRET_INTERPOLATOR_OPTIONS,
+        ),
+      ).toThrow(CONFIG_SECRETS_INVALID);
+    });
+
+    it('throws when values are not of type string', () => {
+      expect(() =>
+        validateInterpolatedValues(
+          { SOME_SECRET: 1 },
+          SECRET_INTERPOLATOR_OPTIONS,
+        ),
+      ).toThrow(CONFIG_SECRETS_INVALID);
+    });
+  });
+
+  describe('replaceInterpolatedValuesInObject', () => {
+    it('replaces values and deletes secrets', () => {
+      const secrets = {
+        SECRET_HOST: 'host',
+        SECRET_MODE: 'silent',
+        SECRET_LABEL: 'secret',
+        SECRET_PACKAGE: 'package',
+      };
+      const res = replaceInterpolatedValuesInObject(
+        {
+          mode: '{{ secrets.SECRET_MODE }}',
+          labels: ['{{ secrets.SECRET_LABEL }}', 'renovate'],
+          prBodyDefinitions: {
+            Package: '{{ secrets.SECRET_PACKAGE }}',
+            Type: 'peer',
+          },
+          productLinks: {
+            documentation: 'https://docs.renovatebot.com/',
+          },
+          hostRules: [
+            {
+              matchHost: '{{ secrets.SECRET_HOST }}',
+            },
+          ],
+          secrets,
+        },
+        secrets,
+        SECRET_INTERPOLATOR_OPTIONS,
+        true,
+      );
+
+      expect(res).toEqual({
+        mode: 'silent',
+        labels: ['secret', 'renovate'],
+        prBodyDefinitions: {
+          Package: 'package',
+          Type: 'peer',
+        },
+        productLinks: {
+          documentation: 'https://docs.renovatebot.com/',
+        },
+        hostRules: [
+          {
+            matchHost: 'host',
+          },
+        ],
+      });
+    });
+
+    it('replaces values and keeps secrets', () => {
+      const res = replaceInterpolatedValuesInObject(
+        {
+          mode: '{{ secrets.SECRET_MODE }}',
+          secrets: { SECRET_MODE: 'silent' },
+        },
+        { SECRET_MODE: 'silent' },
+        SECRET_INTERPOLATOR_OPTIONS,
+        false,
+      );
+
+      expect(res).toEqual({
+        mode: 'silent',
+        secrets: { SECRET_MODE: 'silent' },
+      });
+    });
+
+    it('throws error if secrets are used in disallowed options', () => {
+      const error = new Error(CONFIG_VALIDATION);
+      error.validationSource = 'config';
+      error.validationError = `Disallowed secrets substitution`;
+      error.validationMessage =
+        'The field `prHeader` may not use secrets substitution';
+
+      expect(() =>
+        replaceInterpolatedValuesInObject(
+          {
+            prHeader: '{{ secrets.SECRET_HEADER }}',
+            secrets: { SECRET_HEADER: 'header' },
+          },
+          { SECRET_HEADER: 'header' },
+          SECRET_INTERPOLATOR_OPTIONS,
+          false,
+        ),
+      ).toThrow(error);
+    });
+
+    it('throws error if secret key is not present in config', () => {
+      const error = new Error(CONFIG_VALIDATION);
+      error.validationSource = 'config';
+      error.validationError = `Unknown secrets name`;
+      error.validationMessage =
+        'The following secrets name was not found in config: SECRET_MODE';
+
+      expect(() =>
+        replaceInterpolatedValuesInObject(
+          {
+            mode: '{{ secrets.SECRET_MODE }}',
+            secrets: { SECRET_NOT_MODE: 'silent' },
+          },
+          { SECRET_NOT_MODE: 'silent' },
+          SECRET_INTERPOLATOR_OPTIONS,
+          false,
+        ),
+      ).toThrow(error);
+    });
+  });
+});

--- a/lib/util/interpolator.ts
+++ b/lib/util/interpolator.ts
@@ -40,6 +40,7 @@ export function validateInterpolatedValues(
       `Config ${name}s must be a plain object. Found: ${typeof input}`,
     );
   }
+
   if (validationErrors.length) {
     logger.error({ validationErrors }, `Invalid ${name}s configured`);
     throw new Error(CONFIG_SECRETS_INVALID);

--- a/lib/util/interpolator.ts
+++ b/lib/util/interpolator.ts
@@ -1,0 +1,132 @@
+import is from '@sindresorhus/is';
+import type { RenovateConfig } from '../config/types';
+import {
+  CONFIG_SECRETS_INVALID,
+  CONFIG_VALIDATION,
+} from '../constants/error-messages';
+import { logger } from '../logger';
+import { capitalize } from './string';
+
+export interface InterpolatorOptions {
+  name: 'secrets' | 'variables';
+  templateRegex: RegExp;
+  nameRegex: RegExp;
+}
+
+export function validateInterpolatedValues(
+  input: unknown,
+  options: InterpolatorOptions,
+): void {
+  if (!input) {
+    return;
+  }
+
+  const { name, nameRegex } = options;
+
+  const validationErrors: string[] = [];
+  if (is.plainObject(input)) {
+    for (const [key, value] of Object.entries(input)) {
+      if (!nameRegex.test(key)) {
+        validationErrors.push(`Invalid ${name} name "${key}"`);
+      }
+      if (!is.string(value)) {
+        validationErrors.push(
+          `${capitalize(name)} values must be strings. Found type ${typeof value} for ${name} ${key}`,
+        );
+      }
+    }
+  } else {
+    validationErrors.push(
+      `Config ${name}s must be a plain object. Found: ${typeof input}`,
+    );
+  }
+  if (validationErrors.length) {
+    logger.error({ validationErrors }, `Invalid ${name}s configured`);
+    throw new Error(CONFIG_SECRETS_INVALID);
+  }
+}
+
+function replaceInterpolatedValuesInString(
+  key: string,
+  value: string,
+  input: Record<string, string>,
+  options: InterpolatorOptions,
+): string {
+  const { name, templateRegex } = options;
+  // do nothing if no interpolator template found
+  if (!templateRegex.test(value)) {
+    return value;
+  }
+
+  const disallowedPrefixes = ['branch', 'commit', 'group', 'pr', 'semantic'];
+  if (disallowedPrefixes.some((prefix) => key.startsWith(prefix))) {
+    const error = new Error(CONFIG_VALIDATION);
+    error.validationSource = 'config';
+    error.validationError = `Disallowed ${name} substitution`;
+    error.validationMessage = `The field \`${key}\` may not use ${name} substitution`;
+    throw error;
+  }
+  return value.replace(templateRegex, (_, key) => {
+    if (input?.[key]) {
+      return input[key];
+    }
+    const error = new Error(CONFIG_VALIDATION);
+    error.validationSource = 'config';
+    error.validationError = `Unknown ${name} name`;
+    error.validationMessage = `The following ${name} name was not found in config: ${String(
+      key,
+    )}`;
+    throw error;
+  });
+}
+
+export function replaceInterpolatedValuesInObject(
+  config_: RenovateConfig,
+  input: Record<string, string>,
+  options: InterpolatorOptions,
+  deleteValues: boolean,
+): RenovateConfig {
+  const config = { ...config_ };
+  const { name } = options;
+  if (deleteValues) {
+    delete config[name];
+  }
+  for (const [key, value] of Object.entries(config)) {
+    if (is.plainObject(value)) {
+      config[key] = replaceInterpolatedValuesInObject(
+        value,
+        input,
+        options,
+        deleteValues,
+      );
+    }
+    if (is.string(value)) {
+      config[key] = replaceInterpolatedValuesInString(
+        key,
+        value,
+        input,
+        options,
+      );
+    }
+    if (is.array(value)) {
+      for (const [arrayIndex, arrayItem] of value.entries()) {
+        if (is.plainObject(arrayItem)) {
+          value[arrayIndex] = replaceInterpolatedValuesInObject(
+            arrayItem,
+            input,
+            options,
+            deleteValues,
+          );
+        } else if (is.string(arrayItem)) {
+          value[arrayIndex] = replaceInterpolatedValuesInString(
+            key,
+            arrayItem,
+            input,
+            options,
+          );
+        }
+      }
+    }
+  }
+  return config;
+}


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- Add new `interpolator` module in the `/util` directory which houses the repeated logic between secrets and [variables](https://github.com/renovatebot/renovate/pull/35350)
<!-- Describe what behavior is changed by this PR. -->

## Context
- https://github.com/renovatebot/renovate/pull/35350#pullrequestreview-2767067065
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
