### PR TITLE
feat(datasource/maven)!: use latest and release values as tags

### DIFF
--- a/lib/modules/datasource/clojure/__snapshots__/index.spec.ts.snap
+++ b/lib/modules/datasource/clojure/__snapshots__/index.spec.ts.snap
@@ -34,6 +34,10 @@ exports[`modules/datasource/clojure/index > falls back to next registry url 1`] 
       "version": "2.0.0",
     },
   ],
+  "tags": {
+    "latest": "2.0.0",
+    "release": "2.0.0",
+  },
 }
 `;
 
@@ -101,6 +105,10 @@ exports[`modules/datasource/clojure/index > returns releases from custom reposit
       "version": "2.0.0",
     },
   ],
+  "tags": {
+    "latest": "2.0.0",
+    "release": "2.0.0",
+  },
 }
 `;
 
@@ -138,6 +146,10 @@ exports[`modules/datasource/clojure/index > skips registry with invalid XML 1`] 
       "version": "2.0.0",
     },
   ],
+  "tags": {
+    "latest": "2.0.0",
+    "release": "2.0.0",
+  },
 }
 `;
 
@@ -175,5 +187,9 @@ exports[`modules/datasource/clojure/index > skips registry with invalid metadata
       "version": "2.0.0",
     },
   ],
+  "tags": {
+    "latest": "2.0.0",
+    "release": "2.0.0",
+  },
 }
 `;

--- a/lib/modules/datasource/index.spec.ts
+++ b/lib/modules/datasource/index.spec.ts
@@ -499,8 +499,14 @@ describe('modules/datasource/index', () => {
         }
 
         const registries: RegistriesMock = {
-          'https://reg1.com': () => ({ releases: [{ version: '1.0.0' }] }),
-          'https://reg2.com': () => ({ releases: [{ version: '1.1.0' }] }),
+          'https://reg1.com': () => ({
+            releases: [{ version: '1.0.0' }],
+            tags: { release: '2.0.0' },
+          }),
+          'https://reg2.com': () => ({
+            releases: [{ version: '1.1.0' }],
+            tags: { latest: '1.1.0', release: '1.1.0' },
+          }),
           'https://reg3.com': () => {
             throw new ExternalHostError(new Error());
           },
@@ -513,7 +519,10 @@ describe('modules/datasource/index', () => {
           // for coverage
           'https://reg6.com': null,
           // has the same result as reg1 url, to test de-deplication of releases
-          'https://reg7.com': () => ({ releases: [{ version: '1.0.0' }] }),
+          'https://reg7.com': () => ({
+            releases: [{ version: '1.0.0' }],
+            tags: { latest: '1.2.0', release: '2.1.0' },
+          }),
         };
 
         beforeEach(() => {
@@ -531,6 +540,10 @@ describe('modules/datasource/index', () => {
               { registryUrl: 'https://reg1.com', version: '1.0.0' },
               { registryUrl: 'https://reg2.com', version: '1.1.0' },
             ],
+            tags: {
+              latest: '1.1.0',
+              release: '2.0.0',
+            },
           });
         });
 
@@ -575,6 +588,10 @@ describe('modules/datasource/index', () => {
               { registryUrl: 'https://reg1.com', version: '1.0.0' },
               // { registryUrl: 'https://reg2.com', version: '1.0.0' },
             ],
+            tags: {
+              latest: '1.2.0',
+              release: '2.1.0',
+            },
           });
         });
 

--- a/lib/modules/datasource/index.spec.ts
+++ b/lib/modules/datasource/index.spec.ts
@@ -521,7 +521,7 @@ describe('modules/datasource/index', () => {
           // has the same result as reg1 url, to test de-deplication of releases
           'https://reg7.com': () => ({
             releases: [{ version: '1.0.0' }],
-            tags: { latest: '1.2.0', release: '2.1.0' },
+            tags: { latest: '1.2.0.0', release: '2.1.0' },
           }),
         };
 
@@ -589,7 +589,7 @@ describe('modules/datasource/index', () => {
               // { registryUrl: 'https://reg2.com', version: '1.0.0' },
             ],
             tags: {
-              latest: '1.2.0',
+              latest: '1.2.0.0',
               release: '2.1.0',
             },
           });

--- a/lib/modules/datasource/index.ts
+++ b/lib/modules/datasource/index.ts
@@ -42,8 +42,6 @@ export const getDatasourceList = (): string[] => Array.from(datasources.keys());
 
 const cacheNamespace = 'datasource-releases';
 
-const mavenVersioning = versioning.get('maven');
-
 type GetReleasesInternalConfig = GetReleasesConfig & GetPkgReleasesConfig;
 
 // TODO: fix error Type
@@ -167,6 +165,7 @@ async function mergeRegistries(
   let combinedRes: ReleaseResult | undefined;
   let lastErr: Error | undefined;
   let singleRegistry = true;
+  const releaseVersioning = versioning.get(config.versioning);
   for (const registryUrl of registryUrls) {
     try {
       const res = await getRegistryReleases(datasource, config, registryUrl);
@@ -206,20 +205,20 @@ async function mergeRegistries(
           for (const tag of ['release', 'latest']) {
             const existingTag = combinedRes?.tags?.[tag];
             const newTag = res.tags?.[tag];
-            if (is.string(newTag) && mavenVersioning.isVersion(newTag)) {
+            if (is.string(newTag) && releaseVersioning.isVersion(newTag)) {
               if (
                 is.string(existingTag) &&
-                mavenVersioning.isVersion(existingTag)
+                releaseVersioning.isVersion(existingTag)
               ) {
                 // We need to compare them
-                if (mavenVersioning.isGreaterThan(newTag, existingTag)) {
+                if (releaseVersioning.isGreaterThan(newTag, existingTag)) {
                   // New tag is greater than the existing one
-                  tags![tag] = newTag;
+                  tags[tag] = newTag;
                 }
               } else {
                 // Existing tag was not present or not a version
                 // so we can just use the new one
-                tags![tag] = newTag;
+                tags[tag] = newTag;
               }
             }
           }

--- a/lib/modules/datasource/index.ts
+++ b/lib/modules/datasource/index.ts
@@ -201,9 +201,7 @@ async function mergeRegistries(
       // Merge the tags from the two results
       let tags = combinedRes.tags;
       if (tags) {
-        console.warn('combinedRes.tags exists');
         if (res.tags) {
-          console.warn('res.tags exists');
           // Both results had tags, so we need to compare them
           ['release', 'latest'].forEach((tag) => {
             const existingTag = combinedRes?.tags?.[tag];
@@ -227,7 +225,6 @@ async function mergeRegistries(
           });
         }
       } else {
-        console.warn('No combinedRes.tags');
         // Existing results had no tags, so we can just use the new ones
         tags = res.tags;
       }

--- a/lib/modules/datasource/index.ts
+++ b/lib/modules/datasource/index.ts
@@ -203,7 +203,7 @@ async function mergeRegistries(
       if (tags) {
         if (res.tags) {
           // Both results had tags, so we need to compare them
-          ['release', 'latest'].forEach((tag) => {
+          for (const tag of ['release', 'latest']) {
             const existingTag = combinedRes?.tags?.[tag];
             const newTag = res.tags?.[tag];
             if (is.string(newTag) && mavenVersioning.isVersion(newTag)) {
@@ -222,7 +222,7 @@ async function mergeRegistries(
                 tags![tag] = newTag;
               }
             }
-          });
+          }
         }
       } else {
         // Existing results had no tags, so we can just use the new ones

--- a/lib/modules/datasource/maven/__snapshots__/index.spec.ts.snap
+++ b/lib/modules/datasource/maven/__snapshots__/index.spec.ts.snap
@@ -34,6 +34,10 @@ exports[`modules/datasource/maven/index > falls back to next registry url 1`] = 
       "version": "2.0.0",
     },
   ],
+  "tags": {
+    "latest": "2.0.0",
+    "release": "2.0.0",
+  },
 }
 `;
 
@@ -101,6 +105,10 @@ exports[`modules/datasource/maven/index > removes authentication header after re
       "version": "2.0.0",
     },
   ],
+  "tags": {
+    "latest": "2.0.0",
+    "release": "2.0.0",
+  },
 }
 `;
 
@@ -138,6 +146,10 @@ exports[`modules/datasource/maven/index > returns releases 1`] = `
       "version": "2.0.0",
     },
   ],
+  "tags": {
+    "latest": "2.0.0",
+    "release": "2.0.0",
+  },
 }
 `;
 
@@ -176,6 +188,10 @@ exports[`modules/datasource/maven/index > returns releases from custom repositor
       "version": "2.0.0",
     },
   ],
+  "tags": {
+    "latest": "2.0.0",
+    "release": "2.0.0",
+  },
 }
 `;
 
@@ -213,6 +229,10 @@ exports[`modules/datasource/maven/index > skips registry with invalid XML 1`] = 
       "version": "2.0.0",
     },
   ],
+  "tags": {
+    "latest": "2.0.0",
+    "release": "2.0.0",
+  },
 }
 `;
 
@@ -250,5 +270,9 @@ exports[`modules/datasource/maven/index > skips registry with invalid metadata s
       "version": "2.0.0",
     },
   ],
+  "tags": {
+    "latest": "2.0.0",
+    "release": "2.0.0",
+  },
 }
 `;

--- a/lib/modules/datasource/maven/index.spec.ts
+++ b/lib/modules/datasource/maven/index.spec.ts
@@ -162,6 +162,10 @@ describe('modules/datasource/maven/index', () => {
       packageScope: 'org.example',
       registryUrl: 'https://repo.maven.apache.org/maven2',
       releases: [{ version: '1.0.3-SNAPSHOT' }],
+      tags: {
+        latest: '1.0.3-SNAPSHOT',
+        release: '1.0.3-SNAPSHOT',
+      },
     });
   });
 
@@ -193,6 +197,10 @@ describe('modules/datasource/maven/index', () => {
       packageScope: 'org.example',
       registryUrl: 'https://repo.maven.apache.org/maven2',
       releases: [{ version: '1.0.3-SNAPSHOT' }],
+      tags: {
+        latest: '1.0.3-SNAPSHOT',
+        release: '1.0.3-SNAPSHOT',
+      },
     });
   });
 
@@ -471,6 +479,10 @@ describe('modules/datasource/maven/index', () => {
         { version: '1.0.5-SNAPSHOT' },
         { version: '2.0.0' },
       ],
+      tags: {
+        latest: '2.0.0',
+        release: '2.0.0',
+      },
       isPrivate: true,
     });
     expect(googleAuth).toHaveBeenCalledTimes(2);
@@ -516,6 +528,10 @@ describe('modules/datasource/maven/index', () => {
         { version: '1.0.5-SNAPSHOT' },
         { version: '2.0.0' },
       ],
+      tags: {
+        latest: '2.0.0',
+        release: '2.0.0',
+      },
       isPrivate: true,
     });
     expect(googleAuth).toHaveBeenCalledTimes(2);

--- a/lib/modules/datasource/maven/readme.md
+++ b/lib/modules/datasource/maven/readme.md
@@ -27,3 +27,8 @@ For example:
 ```xml
 <url>https://project.example.com</url>
 ```
+
+#### latest and release tags
+
+When `latest` or `release` values are present in a package's `maven-metadata.xml`, Renovate will map these to its `tags` concept.
+This enables the use of Renovate's `followTag` feature.

--- a/lib/modules/datasource/maven/s3.spec.ts
+++ b/lib/modules/datasource/maven/s3.spec.ts
@@ -65,6 +65,10 @@ describe('modules/datasource/maven/s3', () => {
           { version: '1.0.2' },
           { version: '1.0.3' },
         ],
+        tags: {
+          latest: '1.0.2',
+          release: '1.0.2',
+        },
         isPrivate: true,
       });
     });

--- a/lib/modules/datasource/maven/types.ts
+++ b/lib/modules/datasource/maven/types.ts
@@ -1,6 +1,11 @@
 import type { Result } from '../../../util/result';
 import type { ReleaseResult } from '../types';
 
+export interface MetadataResults {
+  tags?: Record<string, string>;
+  versions?: string[];
+}
+
 export interface MavenDependency {
   display: string;
   group?: string;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Uses "latest" and "release" values in `maven-metadata.xml` as tags if present.

This could have an effect on some exist package lookups because prior to this PR, the Renovate concept of `respectLatest` was not applicable, whereas now it is.

## Context

- Closes #35503

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
