### PR TITLE
docs: added docs for Job Scheduling and Renovate Status

### DIFF
--- a/docs/usage/mend-hosted/.pages
+++ b/docs/usage/mend-hosted/.pages
@@ -2,5 +2,6 @@ title: Mend-hosted Apps
 nav:
   - 'Overview': 'overview.md'
   - 'Configuration': 'hosted-apps-config.md'
+  - 'Job Scheduling': 'job-scheduling.md'
   - 'Credentials': 'credentials.md'
   - 'Migrating Secrets': 'migrating-secrets.md'

--- a/docs/usage/mend-hosted/job-scheduling.md
+++ b/docs/usage/mend-hosted/job-scheduling.md
@@ -16,7 +16,7 @@ There are four types of job schedulers, each with a different frequency and sele
 
 (1) Renovate Enterprise jobs are scheduled every hour for repositories on GitHub and Azure DevOps.
 
-## Renovate Statuses
+## Renovate Status
 
 Each repository installed with Renovate Cloud has a Renovate Status. The Renovate Status is used by the job scheduler to determine which repositories will be selected.
 The status appears in the list of repositories shown on the Org page of the Developer Portal.

--- a/docs/usage/mend-hosted/job-scheduling.md
+++ b/docs/usage/mend-hosted/job-scheduling.md
@@ -7,12 +7,12 @@ When the scheduler runs, selected repositories are added to the Job Queue, and e
 
 There are four types of job schedulers, each with a different frequency and selection of repositories.
 
-|                            | Frequency    | Renovate statuses             |
-|----------------------------|--------------|-------------------------------|
-| Active jobs (Hot)          | 4-hourly (1) | new, activated                |
-| Inactive jobs (Cold)       | Daily        | onboarded, onboarding, failed |
-| Blocked                    | Weekly       | resource-limit, timeout       |
-| All repos                  | Monthly      | All enabled repos             |
+| Job Scheduler        | Frequency    | Renovate statuses             |
+|----------------------|--------------|-------------------------------|
+| Active jobs (Hot)    | 4-hourly (1) | new, activated                |
+| Inactive jobs (Cold) | Daily        | onboarded, onboarding, failed |
+| Blocked              | Weekly       | resource-limit, timeout       |
+| All repos            | Monthly      | All enabled repos             |
 
 (1) Renovate Enterprise jobs are scheduled every hour for repositories on GitHub and Azure DevOps.
 

--- a/docs/usage/mend-hosted/job-scheduling.md
+++ b/docs/usage/mend-hosted/job-scheduling.md
@@ -12,7 +12,7 @@ There are four types of job schedulers, each with a different frequency and sele
 | Active jobs   | 4-hourly (1) | new, activated                                         |
 | Inactive jobs | Daily        | onboarded, onboarding, silent, failed                  |
 | Blocked       | Weekly       | timeout, resource-limit, kernel-out-of-memory, unknown |
-| All repos     | Monthly      | All installed repos                                    |
+| All repos     | Monthly      | All installed repos (including disabled)               |
 
 (1) Renovate Enterprise jobs are scheduled every hour for repositories on GitHub and Azure DevOps.
 
@@ -30,9 +30,9 @@ The table below describes all the Renovate statuses.
 | onboarded            | Onboarding PR has been merged. No Renovate PRs merged | Daily    |
 | activated            | At least one Renovate PR has been merged              | Hourly   |
 | silent               | Renovate will run, but not deliver PRs or issues      | Daily    |
-| disabled             | Renovate will not run on this repository              | Monthly  |
 | failed               | An error occurred while running the last job          | Daily    |
 | timeout              | A timeout occurred while running the last job         | Weekly   |
 | kernel-out-of-memory | An OOM error occurred while running the last job      | Weekly   |
 | resource-limit       | A resource limit was hit while running the last job   | Weekly   |
 | unknown              | An unknown error occurred while running the last job  | Weekly   |
+| disabled             | Renovate will not run on this repository              | Monthly  |

--- a/docs/usage/mend-hosted/job-scheduling.md
+++ b/docs/usage/mend-hosted/job-scheduling.md
@@ -1,0 +1,37 @@
+# Job Scheduling & Renovate Status
+
+Mend Renovate Cloud will automatically schedule Renovate jobs to be run on installed repos.
+When the scheduler runs, selected repositories are added to the Job Queue, and eventually executed by the job runners.
+
+## Job Schedulers
+
+There are four types of job schedulers, each with a different frequency and selection of repositories.
+
+|                            | Frequency    | Renovate statuses             |
+|----------------------------|--------------|-------------------------------|
+| Active jobs (Hot)          | 4-hourly (1) | new, activated                |
+| Inactive jobs (Cold)       | Daily        | onboarded, onboarding, failed |
+| Blocked                    | Weekly       | resource-limit, timeout       |
+| All repos                  | Monthly      | All enabled repos             |
+(1) Renovate Enterprise jobs are scheduled every hour for repositories on GitHub and Azure DevOps.
+
+## Renovate Statuses
+
+Each repository installed with Renovate Cloud has a Renovate Status. The Renovate Status is used by the job scheduler to determine which repositories will be selected.
+The status appears in the list of repositories shown on the Org page of the Developer Portal.
+
+The table below describes all the Renovate statuses.
+
+| Renovate Status      | Description                                           | Schedule |
+|----------------------|-------------------------------------------------------|----------|
+| <-blank->            | New repo. Renovate has never run on this repo.        | Active   |
+| onboarding           | Onboarding PR has not been merged                     | Inactive |
+| onboarded            | Onboarding PR has been merged. No Renovate PRs merged | Inactive |
+| activated            | At least one Renovate PR has been merged              | Active   |
+| silent               | Renovate will run, but not deliver PRs or issues      | Inactive |
+| disabled             | Renovate will not run on this repository              | [ None ] |
+| failed               | An error occurred while running the last job          | Inactive |
+| timeout              | A timeout occurred while running the last job         | Blocked  |
+| kernel-out-of-memory | An OOM error occurred while running the last job      | Blocked  |
+| resource-limit       | A resource limit was hit while running the last job   | Blocked  |
+| unknown              | An unknown error occurred while running the last job  | Blocked  |

--- a/docs/usage/mend-hosted/job-scheduling.md
+++ b/docs/usage/mend-hosted/job-scheduling.md
@@ -13,6 +13,7 @@ There are four types of job schedulers, each with a different frequency and sele
 | Inactive jobs (Cold)       | Daily        | onboarded, onboarding, failed |
 | Blocked                    | Weekly       | resource-limit, timeout       |
 | All repos                  | Monthly      | All enabled repos             |
+
 (1) Renovate Enterprise jobs are scheduled every hour for repositories on GitHub and Azure DevOps.
 
 ## Renovate Statuses

--- a/docs/usage/mend-hosted/job-scheduling.md
+++ b/docs/usage/mend-hosted/job-scheduling.md
@@ -7,12 +7,12 @@ When the scheduler runs, selected repositories are added to the Job Queue, and e
 
 There are four types of job schedulers, each with a different frequency and selection of repositories.
 
-| Job Scheduler        | Frequency    | Renovate statuses             |
-|----------------------|--------------|-------------------------------|
-| Active jobs (Hot)    | 4-hourly (1) | new, activated                |
-| Inactive jobs (Cold) | Daily        | onboarded, onboarding, failed |
-| Blocked              | Weekly       | resource-limit, timeout       |
-| All repos            | Monthly      | All enabled repos             |
+| Job Scheduler | Frequency    | Renovate statuses                                      |
+|---------------|--------------|--------------------------------------------------------|
+| Active jobs   | 4-hourly (1) | new, activated                                         |
+| Inactive jobs | Daily        | onboarded, onboarding, silent, failed                  |
+| Blocked       | Weekly       | timeout, resource-limit, kernel-out-of-memory, unknown |
+| All repos     | Monthly      | All installed repos                                    |
 
 (1) Renovate Enterprise jobs are scheduled every hour for repositories on GitHub and Azure DevOps.
 
@@ -25,14 +25,14 @@ The table below describes all the Renovate statuses.
 
 | Renovate Status      | Description                                           | Schedule |
 |----------------------|-------------------------------------------------------|----------|
-| <-blank->            | New repo. Renovate has never run on this repo.        | Active   |
-| onboarding           | Onboarding PR has not been merged                     | Inactive |
-| onboarded            | Onboarding PR has been merged. No Renovate PRs merged | Inactive |
-| activated            | At least one Renovate PR has been merged              | Active   |
-| silent               | Renovate will run, but not deliver PRs or issues      | Inactive |
-| disabled             | Renovate will not run on this repository              | [ None ] |
-| failed               | An error occurred while running the last job          | Inactive |
-| timeout              | A timeout occurred while running the last job         | Blocked  |
-| kernel-out-of-memory | An OOM error occurred while running the last job      | Blocked  |
-| resource-limit       | A resource limit was hit while running the last job   | Blocked  |
-| unknown              | An unknown error occurred while running the last job  | Blocked  |
+| <-blank->            | New repo. Renovate has never run on this repo.        | Hourly   |
+| onboarding           | Onboarding PR has not been merged                     | Daily    |
+| onboarded            | Onboarding PR has been merged. No Renovate PRs merged | Daily    |
+| activated            | At least one Renovate PR has been merged              | Hourly   |
+| silent               | Renovate will run, but not deliver PRs or issues      | Daily    |
+| disabled             | Renovate will not run on this repository              | Monthly  |
+| failed               | An error occurred while running the last job          | Daily    |
+| timeout              | A timeout occurred while running the last job         | Weekly   |
+| kernel-out-of-memory | An OOM error occurred while running the last job      | Weekly   |
+| resource-limit       | A resource limit was hit while running the last job   | Weekly   |
+| unknown              | An unknown error occurred while running the last job  | Weekly   |

--- a/docs/usage/mend-hosted/job-scheduling.md
+++ b/docs/usage/mend-hosted/job-scheduling.md
@@ -8,7 +8,7 @@ When the scheduler runs, selected repositories are added to the Job Queue, and e
 There are four types of job schedulers, each with a different frequency and selection of repositories.
 
 | Job Scheduler | Frequency    | Renovate statuses                                      |
-|---------------|--------------|--------------------------------------------------------|
+| ------------- | ------------ | ------------------------------------------------------ |
 | Active jobs   | 4-hourly (1) | new, activated                                         |
 | Inactive jobs | Daily        | onboarded, onboarding, silent, failed                  |
 | Blocked       | Weekly       | timeout, resource-limit, kernel-out-of-memory, unknown |
@@ -24,7 +24,7 @@ The status appears in the list of repositories shown on the Org page of the Deve
 The table below describes all the Renovate statuses.
 
 | Renovate Status      | Description                                           | Schedule |
-|----------------------|-------------------------------------------------------|----------|
+| -------------------- | ----------------------------------------------------- | -------- |
 | <-blank->            | New repo. Renovate has never run on this repo.        | Hourly   |
 | onboarding           | Onboarding PR has not been merged                     | Daily    |
 | onboarded            | Onboarding PR has been merged. No Renovate PRs merged | Daily    |


### PR DESCRIPTION
## Changes

Added documentation in the Mend-hosted Apps section for Renovate Cloud repo status and job scheduling

## Context

Users have been asking for the meanings of the various Renovate Status values that appear on the Developer Portal in the list of Installed Repositories on Org page.
This documentation explains what each status means, and how it relates to the job scheduling.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository