### PR TITLE
feat(pep621): extract python as a dependency

### DIFF
--- a/lib/modules/manager/pep621/extract.spec.ts
+++ b/lib/modules/manager/pep621/extract.spec.ts
@@ -239,7 +239,7 @@ describe('modules/manager/pep621/extract', () => {
         {
           commitMessageTopic: 'Python',
           currentValue: '>=3.7',
-          datasource: 'docker',
+          datasource: 'python-version',
           depType: 'requires-python',
           packageName: 'python',
           versioning: 'pep440',
@@ -518,7 +518,7 @@ describe('modules/manager/pep621/extract', () => {
           {
             commitMessageTopic: 'Python',
             currentValue: '>=3.11',
-            datasource: 'docker',
+            datasource: 'python-version',
             depType: 'requires-python',
             packageName: 'python',
             versioning: 'pep440',
@@ -586,7 +586,7 @@ describe('modules/manager/pep621/extract', () => {
           {
             commitMessageTopic: 'Python',
             currentValue: '>=3.11',
-            datasource: 'docker',
+            datasource: 'python-version',
             depType: 'requires-python',
             packageName: 'python',
             versioning: 'pep440',
@@ -622,7 +622,7 @@ describe('modules/manager/pep621/extract', () => {
           {
             packageName: 'python',
             depType: 'requires-python',
-            datasource: 'docker',
+            datasource: 'python-version',
             versioning: 'pep440',
           },
           {

--- a/lib/modules/manager/pep621/extract.spec.ts
+++ b/lib/modules/manager/pep621/extract.spec.ts
@@ -237,6 +237,14 @@ describe('modules/manager/pep621/extract', () => {
 
       expect(result?.deps).toEqual([
         {
+          commitMessageTopic: 'Python',
+          currentValue: '>=3.7',
+          datasource: 'docker',
+          depType: 'requires-python',
+          packageName: 'python',
+          versioning: 'pep440',
+        },
+        {
           packageName: 'blinker',
           depName: 'blinker',
           datasource: 'pypi',
@@ -508,6 +516,14 @@ describe('modules/manager/pep621/extract', () => {
         extractedConstraints: { python: '>=3.11' },
         deps: [
           {
+            commitMessageTopic: 'Python',
+            currentValue: '>=3.11',
+            datasource: 'docker',
+            depType: 'requires-python',
+            packageName: 'python',
+            versioning: 'pep440',
+          },
+          {
             packageName: 'jwcrypto',
             depName: 'jwcrypto',
             datasource: 'pypi',
@@ -568,6 +584,14 @@ describe('modules/manager/pep621/extract', () => {
         extractedConstraints: { python: '>=3.11' },
         deps: [
           {
+            commitMessageTopic: 'Python',
+            currentValue: '>=3.11',
+            datasource: 'docker',
+            depType: 'requires-python',
+            packageName: 'python',
+            versioning: 'pep440',
+          },
+          {
             packageName: 'attrs',
             depName: 'attrs',
             datasource: 'pypi',
@@ -596,6 +620,12 @@ describe('modules/manager/pep621/extract', () => {
         extractedConstraints: { python: '>=3.11' },
         deps: [
           {
+            packageName: 'python',
+            depType: 'requires-python',
+            datasource: 'docker',
+            versioning: 'pep440',
+          },
+          {
             packageName: 'attrs',
             depName: 'attrs',
             datasource: 'pypi',
@@ -623,7 +653,7 @@ describe('modules/manager/pep621/extract', () => {
             readme = "README.md"
           `;
       const res = await extractPackageFile(content, 'pyproject.toml');
-      expect(res?.deps).toHaveLength(2);
+      expect(res?.deps).toHaveLength(3);
     });
   });
 });

--- a/lib/modules/manager/pep621/extract.ts
+++ b/lib/modules/manager/pep621/extract.ts
@@ -1,6 +1,6 @@
 import is from '@sindresorhus/is';
 import { logger } from '../../../logger';
-import { DockerDatasource } from '../../datasource/docker';
+import { PythonVersionDatasource } from '../../datasource/python-version';
 import * as pep440 from '../../versioning/pep440';
 import type {
   ExtractConfig,
@@ -41,7 +41,7 @@ export async function extractPackageFile(
       depType: 'requires-python',
       currentValue: pythonConstraint,
       commitMessageTopic: 'Python',
-      datasource: DockerDatasource.id,
+      datasource: PythonVersionDatasource.id,
       versioning: pep440.id,
     });
   } else {

--- a/lib/modules/manager/pep621/extract.ts
+++ b/lib/modules/manager/pep621/extract.ts
@@ -1,5 +1,7 @@
 import is from '@sindresorhus/is';
 import { logger } from '../../../logger';
+import { DockerDatasource } from '../../datasource/docker';
+import * as pep440 from '../../versioning/pep440';
 import type {
   ExtractConfig,
   PackageDependency,
@@ -29,9 +31,22 @@ export async function extractPackageFile(
 
   const packageFileVersion = def.project?.version;
   const pythonConstraint = def.project?.['requires-python'];
-  const extractedConstraints = is.nonEmptyString(pythonConstraint)
-    ? { extractedConstraints: { python: pythonConstraint } }
-    : {};
+  let extractedConstraints;
+  if (is.nonEmptyString(pythonConstraint)) {
+    extractedConstraints = {
+      extractedConstraints: { python: pythonConstraint },
+    };
+    deps.push({
+      packageName: 'python',
+      depType: 'requires-python',
+      currentValue: pythonConstraint,
+      commitMessageTopic: 'Python',
+      datasource: DockerDatasource.id,
+      versioning: pep440.id,
+    });
+  } else {
+    extractedConstraints = {};
+  }
 
   // pyProject standard definitions
   deps.push(

--- a/lib/modules/manager/pep621/processors/pdm.ts
+++ b/lib/modules/manager/pep621/processors/pdm.ts
@@ -53,7 +53,9 @@ export class PdmProcessor implements PyProjectProcessor {
       registryUrls.push(source.url);
     }
     for (const dep of deps) {
-      dep.registryUrls = [...registryUrls];
+      if (dep.datasource === PypiDatasource.id) {
+        dep.registryUrls = [...registryUrls];
+      }
     }
 
     return deps;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Extracts `requires-python` as a dependency, so that it can be updated automatically by Renovate.

## Context

Closes #35533

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
