### PR TITLE
feat(preset): Add Scala module to Jackson monorepo group

### DIFF
--- a/lib/data/monorepo.json
+++ b/lib/data/monorepo.json
@@ -359,7 +359,8 @@
       "https://github.com/FasterXML/jackson-dataformats-binary",
       "https://github.com/FasterXML/jackson-dataformats-text",
       "https://github.com/FasterXML/jackson-jaxrs-providers",
-      "https://github.com/FasterXML/jackson-module-kotlin"
+      "https://github.com/FasterXML/jackson-module-kotlin",
+      "https://github.com/FasterXML/jackson-module-scala"
     ],
     "jasmine": "https://github.com/jasmine/jasmine",
     "javahamcrest": "https://github.com/hamcrest/JavaHamcrest",


### PR DESCRIPTION
## Changes

Include [scala add-on module](https://github.com/FasterXML/jackson-module-scala) in existing Jackson grouping.

## Context

This extension must be updated in lockstep with `jackson-databind` as it enforces tight version correspondence at runtime (see: https://github.com/FasterXML/jackson-module-scala/blob/e85eec93831dab91055b49212eceddbb928f2e33/src/main/scala/com/fasterxml/jackson/module/scala/JacksonModule.scala#L53 ).

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
