### PR TITLE
fix: Do not update conflicting Onboarding MR comment in dry run

### DIFF
--- a/lib/modules/platform/gitlab/readme.md
+++ b/lib/modules/platform/gitlab/readme.md
@@ -46,16 +46,12 @@ We refer to personal access tokens, project access tokens and group access token
 For real runs, give the access token these scopes:
 
 - `api`
-- `write_repository`
-- `read_registry` (only if Renovate needs to access the [GitLab Container registry](https://docs.gitlab.com/ee/user/packages/container_registry/))
 
 #### Permissions for access tokens on dry runs
 
 For dry runs, give the access token these scopes:
 
 - `read_api`
-- `read_repository`
-- `read_registry` (only if Renovate needs to access the [GitLab Container registry](https://docs.gitlab.com/ee/user/packages/container_registry/))
 
 #### Letting Renovate use your access token
 

--- a/lib/modules/platform/gitlab/readme.md
+++ b/lib/modules/platform/gitlab/readme.md
@@ -46,12 +46,16 @@ We refer to personal access tokens, project access tokens and group access token
 For real runs, give the access token these scopes:
 
 - `api`
+- `write_repository`
+- `read_registry` (only if Renovate needs to access the [GitLab Container registry](https://docs.gitlab.com/ee/user/packages/container_registry/))
 
 #### Permissions for access tokens on dry runs
 
 For dry runs, give the access token these scopes:
 
 - `read_api`
+- `read_repository`
+- `read_registry` (only if Renovate needs to access the [GitLab Container registry](https://docs.gitlab.com/ee/user/packages/container_registry/))
 
 #### Letting Renovate use your access token
 

--- a/lib/workers/repository/onboarding/pr/index.spec.ts
+++ b/lib/workers/repository/onboarding/pr/index.spec.ts
@@ -227,6 +227,25 @@ describe('workers/repository/onboarding/pr/index', () => {
       expect(platform.updatePr).toHaveBeenCalledTimes(0);
     });
 
+    it('does nothing in dry run when PR is conflicted', async () => {
+      GlobalConfig.set({ dryRun: 'full' });
+      config.baseBranch = 'some-branch';
+      platform.getBranchPr.mockResolvedValueOnce(
+        partial<Pr>({
+          title: 'Configure Renovate',
+          bodyStruct,
+        }),
+      );
+      scm.isBranchConflicted.mockResolvedValueOnce(true);
+      await ensureOnboardingPr(config, {}, branches);
+      expect(logger.info).toHaveBeenLastCalledWith(
+        'DRY-RUN: Would comment that Onboarding PR is conflicted and needs manual resolving',
+      );
+      expect(platform.ensureComment).toHaveBeenCalledTimes(0);
+      expect(platform.createPr).toHaveBeenCalledTimes(0);
+      expect(platform.updatePr).toHaveBeenCalledTimes(0);
+    });
+
     it('updates PR when modified', async () => {
       config.baseBranch = 'some-branch';
       platform.getBranchPr.mockResolvedValueOnce(

--- a/lib/workers/repository/onboarding/pr/index.ts
+++ b/lib/workers/repository/onboarding/pr/index.ts
@@ -58,7 +58,9 @@ export async function ensureOnboardingPr(
       )
     ) {
       if (GlobalConfig.get('dryRun')) {
-        logger.info('DRY-RUN: Would comment that Onboarding PR is conflicted and needs manual resolving');
+        logger.info(
+          'DRY-RUN: Would comment that Onboarding PR is conflicted and needs manual resolving',
+        );
         return;
       }
       await ensureComment({

--- a/lib/workers/repository/onboarding/pr/index.ts
+++ b/lib/workers/repository/onboarding/pr/index.ts
@@ -57,6 +57,10 @@ export async function ensureOnboardingPr(
         config.onboardingBranch!,
       )
     ) {
+      if (GlobalConfig.get('dryRun')) {
+        logger.info('DRY-RUN: Would comment that Onboarding PR is conflicted and needs manual resolving');
+        return;
+      }
       await ensureComment({
         number: existingPr.number,
         topic: 'Branch Conflicted',


### PR DESCRIPTION
## Changes

Added an `if` condition which simply returns in dry-run mode if an conflicting onboarding PR is detected.

## Context

- See discussion #35549 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
