### PR TITLE
fix(gradle): Correctly download the new Gradle wrapper files after updating Gradle

### DIFF
--- a/lib/modules/manager/gradle-wrapper/artifacts.spec.ts
+++ b/lib/modules/manager/gradle-wrapper/artifacts.spec.ts
@@ -114,6 +114,28 @@ describe('modules/manager/gradle-wrapper/artifacts', () => {
             },
           },
         },
+        {
+          cmd: './gradlew :wrapper ---write-locks',
+          options: {
+            cwd: '/tmp/github/some/repo',
+            encoding: 'utf-8',
+            env: {
+              GRADLE_OPTS:
+                '-Dorg.gradle.parallel=true -Dorg.gradle.configureondemand=true -Dorg.gradle.daemon=false -Dorg.gradle.caching=false',
+            },
+          },
+        },
+        {
+          cmd: './gradlew :wrapper',
+          options: {
+            cwd: '/tmp/github/some/repo',
+            encoding: 'utf-8',
+            env: {
+              GRADLE_OPTS:
+                '-Dorg.gradle.parallel=true -Dorg.gradle.configureondemand=true -Dorg.gradle.daemon=false -Dorg.gradle.caching=false',
+            },
+          },
+        },
       ]);
     });
 


### PR DESCRIPTION
## Changes

When updating Gradle, there is a requirement that the wrapper task be run twice; first to update the version that the wrapper uses, and second to update the wrapper and associated files correctly.

## Context

https://github.com/renovatebot/renovate/discussions/34273

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
