### PR TITLE
feat(config)!: validate allowedCommands against post-compiled commands

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -3554,7 +3554,8 @@ The `postUpgradeTasks` configuration consists of three fields:
 
 A list of commands that are executed after Renovate has updated a dependency but before the commit is made.
 
-You can use variable templating in your commands as long as [`allowCommandTemplating`](./self-hosted-configuration.md#allowcommandtemplating) is enabled.
+You can use handlebars templating in these commands.
+They will be compiled _prior_ to the comparison against [`allowedCommands`](./self-hosted-configuration.md#allowedcommands).
 
 <!-- prettier-ignore -->
 !!! note

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -17,48 +17,6 @@ Please also see [Self-Hosted Experimental Options](./self-hosted-experimental.md
 !!! note
     Config options with `type=string` are always non-mergeable, so `mergeable=false`.
 
-## allowCommandTemplating
-
-Let's look at an example of configuring packages with existing Angular migrations.
-
-```javascript
-module.exports = {
-  allowedCommands: ['^npm ci --ignore-scripts$', '^npx ng update'],
-};
-```
-
-In the `renovate.json` file, define the commands and files to be included in the final commit.
-
-The command to install dependencies (`npm ci --ignore-scripts`) is needed because, by default, the installation of dependencies is skipped (see the `skipInstalls` global option).
-
-```json
-{
-  "packageRules": [
-    {
-      "matchPackageNames": ["@angular/core"],
-      "postUpgradeTasks": {
-        "commands": [
-          "npm ci --ignore-scripts",
-          "npx ng update {{{depName}}} --from={{{currentVersion}}} --to={{{newVersion}}} --migrate-only --allow-dirty --force"
-        ]
-      }
-    }
-  ]
-}
-```
-
-With this configuration, the executable command for `@angular/core` looks like this:
-
-```bash
-npm ci --ignore-scripts
-npx ng update @angular/core --from=10.0.0 --to=11.0.0 --migrate-only --allow-dirty --force
-```
-
-If you wish to disable templating because of any security or performance concern, you may set `allowCommandTemplating` to `false`.
-But before you disable templating completely, try the `allowedCommands` config option to limit what commands are allowed to run.
-
-This configuration option was previously named `allowPostUpgradeCommandTemplating`.
-
 ## allowCustomCrateRegistries
 
 ## allowPlugins
@@ -69,7 +27,7 @@ This configuration option was previously named `allowPostUpgradeCommandTemplatin
 
 A list of regular expressions that decide which commands in `postUpgradeTasks` are allowed to run.
 
-If you are using a template command, the regular expression should match the template itself, not the final resolved value.
+If you are using a template command, the regular expression should match the final resolved value.
 If this list is empty then no tasks will be executed.
 
 For example:

--- a/lib/config/global.ts
+++ b/lib/config/global.ts
@@ -5,7 +5,6 @@ export class GlobalConfig {
   private static readonly OPTIONS: (keyof RepoGlobalConfig)[] = [
     'allowedCommands',
     'allowedEnv',
-    'allowCommandTemplating',
     'allowCustomCrateRegistries',
     'allowedHeaders',
     'allowPlugins',

--- a/lib/config/migrations/migrations-service.ts
+++ b/lib/config/migrations/migrations-service.ts
@@ -82,7 +82,6 @@ export class MigrationsService {
 
   static readonly renamedProperties: ReadonlyMap<string, string> = new Map([
     ['adoptium-java', 'java-version'],
-    ['allowPostUpgradeCommandTemplating', 'allowCommandTemplating'],
     ['allowedPostUpgradeCommands', 'allowedCommands'],
     ['azureAutoApprove', 'autoApprove'],
     ['customChangelogUrl', 'changelogUrl'],

--- a/lib/config/migrations/migrations-service.ts
+++ b/lib/config/migrations/migrations-service.ts
@@ -79,7 +79,7 @@ export class MigrationsService {
     'yarnMaintenancePrTitle',
     'raiseDeprecationWarnings',
     'allowPostUpgradeCommandTemplating',
-    'allowCommandTemplating'
+    'allowCommandTemplating',
   ]);
 
   static readonly renamedProperties: ReadonlyMap<string, string> = new Map([

--- a/lib/config/migrations/migrations-service.ts
+++ b/lib/config/migrations/migrations-service.ts
@@ -61,6 +61,8 @@ import type { Migration, MigrationConstructor } from './types';
 
 export class MigrationsService {
   static readonly removedProperties: ReadonlySet<string> = new Set([
+    'allowCommandTemplating',
+    'allowPostUpgradeCommandTemplating',
     'deepExtract',
     'gitFs',
     'groupBranchName',
@@ -69,6 +71,7 @@ export class MigrationsService {
     'groupPrTitle',
     'lazyGrouping',
     'maintainYarnLock',
+    'raiseDeprecationWarnings',
     'statusCheckVerify',
     'supportPolicy',
     'transitiveRemediation',
@@ -77,9 +80,6 @@ export class MigrationsService {
     'yarnMaintenanceCommitMessage',
     'yarnMaintenancePrBody',
     'yarnMaintenancePrTitle',
-    'raiseDeprecationWarnings',
-    'allowPostUpgradeCommandTemplating',
-    'allowCommandTemplating',
   ]);
 
   static readonly renamedProperties: ReadonlyMap<string, string> = new Map([

--- a/lib/config/migrations/migrations-service.ts
+++ b/lib/config/migrations/migrations-service.ts
@@ -78,6 +78,8 @@ export class MigrationsService {
     'yarnMaintenancePrBody',
     'yarnMaintenancePrTitle',
     'raiseDeprecationWarnings',
+    'allowPostUpgradeCommandTemplating',
+    'allowCommandTemplating'
   ]);
 
   static readonly renamedProperties: ReadonlyMap<string, string> = new Map([

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -108,14 +108,6 @@ const options: RenovateOptions[] = [
     globalOnly: true,
   },
   {
-    name: 'allowCommandTemplating',
-    description:
-      'Set this to `false` to disable template compilation for post-upgrade commands.',
-    type: 'boolean',
-    default: true,
-    globalOnly: true,
-  },
-  {
     name: 'allowedCommands',
     description:
       'A list of regular expressions that decide which commands are allowed in post-upgrade tasks.',

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -133,7 +133,6 @@ export interface GlobalOnlyConfig {
 // The below should contain config options where globalOnly=true
 export interface RepoGlobalConfig {
   allowedCommands?: string[];
-  allowCommandTemplating?: boolean;
   allowCustomCrateRegistries?: boolean;
   allowPlugins?: boolean;
   allowScripts?: boolean;

--- a/lib/workers/global/config/parse/env.ts
+++ b/lib/workers/global/config/parse/env.ts
@@ -42,7 +42,6 @@ const renameKeys = {
   gitLabAutomerge: 'platformAutomerge', // migrate: gitLabAutomerge
   mergeConfidenceApiBaseUrl: 'mergeConfidenceEndpoint',
   mergeConfidenceSupportedDatasources: 'mergeConfidenceDatasources',
-  allowPostUpgradeCommandTemplating: 'allowCommandTemplating',
   allowedPostUpgradeCommands: 'allowedCommands',
 };
 

--- a/lib/workers/repository/update/branch/index.spec.ts
+++ b/lib/workers/repository/update/branch/index.spec.ts
@@ -1626,12 +1626,12 @@ describe('workers/repository/update/branch/index', () => {
       GlobalConfig.set({
         ...adminConfig,
         allowedCommands: ['^echo {{{versioning}}}$'],
-        allowCommandTemplating: true,
         exposeAllEnv: true,
         localDir: '/localDir',
       });
       const inconfig = {
         ...config,
+        versioning: 'semver',
         postUpgradeTasks: {
           executionMode: 'update',
           commands: ['echo {{{versioning}}}', 'disallowed task'],
@@ -1724,7 +1724,6 @@ describe('workers/repository/update/branch/index', () => {
       GlobalConfig.set({
         ...adminConfig,
         allowedCommands: ['^exit 1$'],
-        allowCommandTemplating: true,
         exposeAllEnv: true,
         localDir: '/localDir',
       });
@@ -1808,8 +1807,7 @@ describe('workers/repository/update/branch/index', () => {
       commit.commitFilesToBranch.mockResolvedValueOnce(null);
       GlobalConfig.set({
         ...adminConfig,
-        allowedCommands: ['^echo {{{versioning}}}$'],
-        allowCommandTemplating: false,
+        allowedCommands: ['^echo'],
         exposeAllEnv: true,
         localDir: '/localDir',
       });
@@ -1823,6 +1821,7 @@ describe('workers/repository/update/branch/index', () => {
         upgrades: [
           partial<BranchUpgradeConfig>({
             depName: 'some-dep-name',
+            versioning: 'semver',
             postUpgradeTasks: {
               executionMode: 'update',
               commands: ['echo {{{versioning}}}', 'disallowed task'],
@@ -1839,7 +1838,7 @@ describe('workers/repository/update/branch/index', () => {
         result: 'done',
         commitSha: null,
       });
-      expect(exec.exec).toHaveBeenCalledWith('echo {{{versioning}}}', {
+      expect(exec.exec).toHaveBeenCalledWith('echo semver', {
         cwd: '/localDir',
       });
     });
@@ -1910,8 +1909,7 @@ describe('workers/repository/update/branch/index', () => {
 
       GlobalConfig.set({
         ...adminConfig,
-        allowedCommands: ['^echo {{{depName}}}$'],
-        allowCommandTemplating: true,
+        allowedCommands: ['^echo some'],
         exposeAllEnv: true,
         localDir: '/localDir',
       });
@@ -2061,7 +2059,6 @@ describe('workers/repository/update/branch/index', () => {
       GlobalConfig.set({
         ...adminConfig,
         allowedCommands: ['^echo hardcoded-string$'],
-        allowCommandTemplating: true,
         trustLevel: 'high',
         localDir: '/localDir',
       });


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Removes `allowCommandTemplating` (it is now always allowed)
- Modifies `allowedCommands` logic so that it is evaluated against the _post_-compiled command not pre-compiled command

BREAKING CHANGE: allowedCommands need to be specified against the final post-compiled command and not the pre-compilation templated command.

## Context

It is safer for admins to be able to enforce allowed commands against the final post-compiled command not try to "lock down" templates

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
