### PR TITLE
fix: support separateMultipleMinor when using hashed branches

### DIFF
--- a/lib/workers/repository/updates/branch-name.spec.ts
+++ b/lib/workers/repository/updates/branch-name.spec.ts
@@ -322,10 +322,13 @@ describe('workers/repository/updates/branch-name', () => {
         branchPrefix: 'dep-',
         depNameSanitized: 'jest',
         newMajor: '42',
+        updateType: 'minor',
+        separateMultipleMinor: true,
+        newMinor: '3',
         group: {},
       };
       generateBranchName(upgrade);
-      expect(upgrade.branchName).toBe('dep-df9ca0f348');
+      expect(upgrade.branchName).toBe('dep-2e27927800');
     });
 
     it('enforces valid git branch name', () => {

--- a/lib/workers/repository/updates/branch-name.spec.ts
+++ b/lib/workers/repository/updates/branch-name.spec.ts
@@ -312,6 +312,22 @@ describe('workers/repository/updates/branch-name', () => {
       expect(upgrade.branchName).toBe('dep-cf83e1');
     });
 
+    it('hashedBranchLength separates minor when separateMultipleMinor=true', () => {
+      const upgrade: RenovateConfig = {
+        branchName:
+          '{{{branchPrefix}}}{{{additionalBranchPrefix}}}{{{branchTopic}}}',
+        branchTopic:
+          '{{{depNameSanitized}}}-{{{newMajor}}}{{#if isPatch}}.{{{newMinor}}}{{/if}}.x{{#if isLockfileUpdate}}-lockfile{{/if}}',
+        hashedBranchLength: 14,
+        branchPrefix: 'dep-',
+        depNameSanitized: 'jest',
+        newMajor: '42',
+        group: {},
+      };
+      generateBranchName(upgrade);
+      expect(upgrade.branchName).toBe('dep-df9ca0f348');
+    });
+
     it('enforces valid git branch name', () => {
       const fixtures = [
         {

--- a/lib/workers/repository/updates/branch-name.ts
+++ b/lib/workers/repository/updates/branch-name.ts
@@ -116,6 +116,10 @@ export function generateBranchName(update: RenovateConfig): void {
 
     let hashInput = additionalBranchPrefix + branchTopic;
 
+    if (update.updateType === 'minor' && update.separateMultipleMinor) {
+      hashInput = hashInput.replace('.x', `.${newMinor}.x`);
+    }
+
     // Compile extra times in case of nested templates
     hashInput = template.compile(hashInput, update);
     hashInput = template.compile(hashInput, update);


### PR DESCRIPTION
## Changes

Ensures that `separateMultipleMinor` is respected when `hashedBranchLength` is set by incorporating the minor version into the hash input.

(This is an alternative solution to #35606 - only one or the other should be merged)

## Context

- #35553

The current implementation (from #24538) uses hard-coded logic to add the minor version to the branch name:

https://github.com/renovatebot/renovate/blob/8c78a7e1ceb238845760d851affc5fabffc86e05/lib/workers/repository/updates/branch-name.ts#L123-L125

But this code never runs if `hashedBranchLength` is set, thus breaking this feature!

We could fix this either by:

- Duplicating the existing hardcoded logic into the other `if` branch (**this PR**); or,
- Moving the implementation of this feature into the `branchTopic` template (#35606)

This PR implements the former.

Closes #35553

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
