### PR TITLE
fix(gomod): Exclude multi-line `exclude` directives from extraction

### DIFF
--- a/lib/modules/manager/gomod/extract.spec.ts
+++ b/lib/modules/manager/gomod/extract.spec.ts
@@ -125,11 +125,20 @@ describe('modules/manager/gomod/extract', () => {
     });
 
     // https://go.dev/doc/modules/gomod-ref#exclude
-    it('ignores exclude directives from single line', () => {
+    it('ignores exclude directives from multi-line and single line', () => {
       const goMod = codeBlock`
         module github.com/renovate-tests/gomod
 
         exclude github.com/pravesht/gocql v0.0.0
+
+        exclude (
+              k8s.io/client-go v0.21.9
+              )
+        exclude (
+          k8s.io/cloud-provider v0.17.3
+          k8s.io/cluster-bootstrap v0.17.3 // indirect
+          k8s.io/code-generator v0.17.3
+        )
       `;
       const res = extractPackageFile(goMod);
       expect(res).toBeNull();

--- a/lib/modules/manager/gomod/extract.spec.ts
+++ b/lib/modules/manager/gomod/extract.spec.ts
@@ -124,6 +124,17 @@ describe('modules/manager/gomod/extract', () => {
       });
     });
 
+    // https://go.dev/doc/modules/gomod-ref#exclude
+    it('ignores exclude directives from single line', () => {
+      const goMod = codeBlock`
+        module github.com/renovate-tests/gomod
+
+        exclude github.com/pravesht/gocql v0.0.0
+      `;
+      const res = extractPackageFile(goMod);
+      expect(res).toBeNull();
+    });
+
     it('extracts the toolchain directive', () => {
       const goMod = codeBlock`
         module github.com/renovate-tests/gomod
@@ -295,6 +306,35 @@ describe('modules/manager/gomod/extract', () => {
   it('extracts tool directives with no matching dependencies', () => {
     const goMod = codeBlock`
         tool github.com/foo/bar/sub/cmd/hello
+      `;
+    const res = extractPackageFile(goMod);
+    expect(res).toBeNull();
+  });
+
+  /**
+   *
+   * https://go.dev/doc/modules/gomod-ref#retract
+   * https://go.dev/doc/modules/gomod-ref#godebug
+   */
+  it('ignores directives unrelated to dependencies', () => {
+    const goMod = codeBlock`
+        module github.com/renovate-tests/gomod
+
+        godebug asynctimerchan=0
+
+        godebug (
+          default=go1.21
+          panicnil=1
+        )
+
+        retract v3.0.0
+
+        retract [v2.0.0,v2.0.5] // Build broken on some platforms.
+
+        retract (
+            v1.0.0 // Published accidentally.
+            v1.0.1 // Contains retractions only.
+        )
       `;
     const res = extractPackageFile(goMod);
     expect(res).toBeNull();

--- a/lib/modules/manager/gomod/line-parser.ts
+++ b/lib/modules/manager/gomod/line-parser.ts
@@ -17,6 +17,10 @@ const replaceRegex = regEx(
   /^(?<keyword>replace)?\s+(?<module>[^\s]+\/[^\s]+)\s*=>\s*(?<replacement>[^\s]+)(?:\s+(?<version>[^\s]+))?(?:\s*\/\/\s*(?<comment>[^\s]+)\s*)?$/,
 );
 
+export const excludeBlockStartRegex = regEx(/^(?<keyword>exclude)\s+\(\s*$/);
+
+export const endBlockRegex = regEx(/^\s+\)\s*$/);
+
 const toolRegex = regEx(/^(?<keyword>tool)?\s+(?<module>[^\s]+\/?[^\s]+)\s*$/);
 
 const goVersionRegex = regEx(/^\s*go\s+(?<version>[^\s]+)\s*$/);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes & context

**chore(gomod): Specs for go.mod directives unrelated to dependencies**

This adds a few unit tests for go.mod directives that are not related to
dependencies: `godebug`, `retract` and single-line `exclude`. All of
those should be ignored.

> The `exclude` directive prevents a module version from being loaded by
> the `go` command.
> https://go.dev/ref/mod#go-mod-file-exclude

Apparently they can be used to e.g. block a specific version of a
dependency which has a known vulnerability. Simply updating the
`exclude` section doesn't make the most sense as someone wanted to
exclude a specific version of a dependency.

Note: This commit doesn't fix the behaviour for multi-line excludes, it
just increases test coverage to show that single-line excludes are
already ignored.

References:
- https://go.dev/doc/modules/gomod-ref

**fix(gomod): Exclude multi-line `exclude` directives from extraction**

With https://github.com/renovatebot/renovate/pull/28852, suddenly
multiline `exclude` directives have been renovated.

Given that single-line `exclude` directives are not renovated, this just
aligns the behaviour between the two. In a future iteration the
`exclude`s could be parsed in order to change the behaviour for renovate
with regards to the dependency updates, but it is unclear what that
would entail.

So simply skipping them could be good enough.

Side-note: The regex based parsing seems to be really tricky for a lock
file which might contain multi line blocks. One should consider
rewriting it in a proper loop.

References:
- https://github.com/renovatebot/renovate/discussions/31905

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
