### PR TITLE
feat(cache): Track repeating package cache read access

### DIFF
--- a/lib/util/cache/package/index.ts
+++ b/lib/util/cache/package/index.ts
@@ -1,5 +1,5 @@
 import type { AllConfig } from '../../../config/types';
-import { PackageCacheStats } from '../../stats';
+import { PackageCacheStats, RepeatingPackageCacheKeyLogger } from '../../stats';
 import * as memCache from '../memory';
 import * as fileCache from './file';
 import { getCombinedKey } from './key';
@@ -19,7 +19,9 @@ export async function get<T = any>(
 
   const combinedKey = getCombinedKey(namespace, key);
   let p = memCache.get(combinedKey);
-  if (!p) {
+  if (p) {
+    RepeatingPackageCacheKeyLogger.write(namespace, key);
+  } else {
     p = PackageCacheStats.wrapGet(() =>
       cacheProxy!.get<number[]>(namespace, key),
     );

--- a/lib/util/cache/package/index.ts
+++ b/lib/util/cache/package/index.ts
@@ -20,7 +20,7 @@ export async function get<T = any>(
   const combinedKey = getCombinedKey(namespace, key);
   let p = memCache.get(combinedKey);
   if (p) {
-    RepeatingPackageCacheKeyLogger.write(namespace, key);
+    RepeatingPackageCacheKeyLogger.track(namespace, key);
   } else {
     p = PackageCacheStats.wrapGet(() =>
       cacheProxy!.get<number[]>(namespace, key),

--- a/lib/util/stats.ts
+++ b/lib/util/stats.ts
@@ -548,20 +548,19 @@ export class ObsoleteCacheHitLogger {
       'Cache fallback URLs',
     );
   }
-}
-/* v8 ignore stop: temporary code */
+} /* v8 ignore stop: temporary code */
 
 /* v8 ignore start: temporary code */
 export class RepeatingPackageCacheKeyLogger {
-  static getData(): Record<PackageCacheNamespace, Record<string, number>> {
+  static getData(): Record<string, Record<string, number>> {
     return (
-      memCache.get<Record<PackageCacheNamespace, Record<string, number>>>(
+      memCache.get<Record<string, Record<string, number>>>(
         'repeating-package-cache-keys',
       ) ?? {}
     );
   }
 
-  static write(namespace: PackageCacheNamespace, key: string): void {
+  static track(namespace: PackageCacheNamespace, key: string): void {
     const data = this.getData();
     data[namespace] ??= {};
     data[namespace][key] = (data[namespace][key] ?? 0) + 1;
@@ -573,13 +572,10 @@ export class RepeatingPackageCacheKeyLogger {
     const report: Record<string, Record<string, number>> = {};
 
     for (const [namespace, keys] of Object.entries(data)) {
-      const repeatingKeys = Object.entries(keys)
-        .filter(([_, count]) => count > 1)
-        .sort((a, b) => b[1] - a[1]);
+      const repeatingKeys = Object.entries(keys).sort((a, b) => b[1] - a[1]);
 
       if (repeatingKeys.length > 0) {
-        report[namespace as PackageCacheNamespace] =
-          Object.fromEntries(repeatingKeys);
+        report[namespace] = Object.fromEntries(repeatingKeys);
       }
     }
 

--- a/lib/workers/repository/index.ts
+++ b/lib/workers/repository/index.ts
@@ -26,6 +26,7 @@ import {
   LookupStats,
   ObsoleteCacheHitLogger,
   PackageCacheStats,
+  RepeatingPackageCacheKeyLogger,
 } from '../../util/stats';
 import { setBranchCache } from './cache';
 import { extractRepoProblems } from './common';
@@ -149,6 +150,7 @@ export async function renovateRepository(
   HttpCacheStats.report();
   LookupStats.report();
   ObsoleteCacheHitLogger.report();
+  RepeatingPackageCacheKeyLogger.report();
   const cloned = isCloned();
   logger.info({ cloned, durationMs: splits.total }, 'Repository finished');
   resetRepositoryLogLevelRemaps();


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

We deliberately leak all the `Promise` objects returned by `packageCache.get(...)` or passed to `packageCache.set(...)` which makes it the biggest contributor to the memory footprint.

We need to discover the keys with repeating access and apply such caching to the limited set of namespaces/keys.

## Context

- #6202

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
