### PR TITLE
fix(memcache): http requests being garbage collected

### DIFF
--- a/lib/util/cache/memory/index.spec.ts
+++ b/lib/util/cache/memory/index.spec.ts
@@ -5,16 +5,45 @@ describe('util/cache/memory/index', () => {
     expect(memCache.get('key1')).toBeUndefined();
   });
 
-  it('sets and gets repo cache', () => {
+  it('sets and gets repo cache for strings', () => {
     memCache.init();
     memCache.set('key2', 'value');
     expect(memCache.get('key2')).toBe('value');
   });
 
+  it('sets and gets repo cache for objects', () => {
+    memCache.init();
+    const obj = { some: 'thing' };
+    memCache.set('key3', obj);
+    expect(memCache.get('key3')).toBe(obj);
+  });
+
+  it('sets and gets repo cache for promises', () => {
+    memCache.init();
+    const promise = new Promise(() => undefined);
+    memCache.set('key4', promise);
+    expect(memCache.get('key4')).toBe(promise);
+  });
+
+  it('sets and gets repo cache for functions', () => {
+    memCache.init();
+    const fn = () => undefined;
+    memCache.set('key5', fn);
+    expect(memCache.get('key5')).toBe(fn);
+  });
+
+  it('does not set and gets repo cache for null or undefined', () => {
+    memCache.init();
+    memCache.set('key6', null);
+    expect(memCache.get('key6')).toBeUndefined();
+    memCache.set('key7', undefined);
+    expect(memCache.get('key7')).toBeUndefined();
+  });
+
   it('resets', () => {
     memCache.init();
-    memCache.set('key3', 'value');
+    memCache.set('key8', 'value');
     memCache.reset();
-    expect(memCache.get('key3')).toBeUndefined();
+    expect(memCache.get('key8')).toBeUndefined();
   });
 });

--- a/lib/util/cache/memory/index.ts
+++ b/lib/util/cache/memory/index.ts
@@ -1,19 +1,59 @@
-let repoCache: Record<string, any> | undefined;
+import Database from 'better-sqlite3';
+import type { Database as DatabaseInstance } from 'better-sqlite3';
+
+// db for strings
+let stringsDb: DatabaseInstance | undefined;
+// map for anything else
+let cache: Map<string, any> | undefined;
 
 export function init(): void {
-  repoCache = {};
+  stringsDb = new Database(':memory:');
+  stringsDb.exec(`
+    CREATE TABLE IF NOT EXISTS repoCache (
+      key TEXT PRIMARY KEY,
+      value TEXT
+    )
+  `);
+  cache = new Map();
 }
 
 export function reset(): void {
-  repoCache = undefined;
+  stringsDb?.close();
+  stringsDb = undefined;
+  cache = undefined;
 }
 
 export function get<T = any>(key: string): T {
-  return repoCache?.[key];
+  if (!stringsDb || !cache) {
+    return undefined as T;
+  }
+  if (cache.has(key)) {
+    return cache.get(key);
+  }
+  const row = stringsDb
+    .prepare('SELECT value FROM repoCache WHERE key = ?')
+    .get(key) as { value: string } | undefined;
+  if (!row) {
+    return undefined as T;
+  }
+  return row.value as T;
 }
 
-export function set(key: string, value: unknown): void {
-  if (repoCache) {
-    repoCache[key] = value;
+export function set(key: string, value: any): void {
+  if (!stringsDb || !cache || value === null || value === undefined) {
+    return;
   }
+  if (typeof value !== 'string') {
+    cache.set(key, value);
+    return;
+  }
+  stringsDb
+    .prepare(
+      `
+    INSERT INTO repoCache (key, value)
+    VALUES (?, ?)
+    ON CONFLICT(key) DO UPDATE SET value = excluded.value
+  `,
+    )
+    .run(key, value);
 }

--- a/lib/util/http/cache/memory-http-cache-provider.ts
+++ b/lib/util/http/cache/memory-http-cache-provider.ts
@@ -9,12 +9,17 @@ export class MemoryHttpCacheProvider extends AbstractHttpCacheProvider {
   }
 
   protected override load(url: string): Promise<unknown> {
-    const data = memCache.get<HttpCache>(this.cacheKey(url));
+    const data = memCache.get<string | undefined>(this.cacheKey(url));
+    if (typeof data === 'string') {
+      const parsed = JSON.parse(data);
+      return Promise.resolve(parsed);
+    }
     return Promise.resolve(data);
   }
 
   protected override persist(url: string, data: HttpCache): Promise<void> {
-    memCache.set(this.cacheKey(url), data);
+    const stringData = JSON.stringify(data);
+    memCache.set(this.cacheKey(url), stringData);
     return Promise.resolve();
   }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

This changes the `memCache` to use an in-memory SQLite database for storing strings. Such database is not subject to garbage collection.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

It took me a long while to understand this issue.

To begin, this issue started with:

- https://github.com/renovatebot/renovate/pull/33901

I thought I had fixed everything about it for Gerrit platform in:

- https://github.com/renovatebot/renovate/pull/35056

However, a colleague noticed that all `prNo` were being set as `null` in our Renovate reports. We identified it started happening (consistently) after some Renovate upgrade. Then we pinned down to #33901.

Now that http responses are being cached in a JavaScript object in memory, such object is subject to garbage collection.

The garbage collector starts erasing some properties like `httpResponse.body` when memory usage gets high.

Because of that, the memory cache starts serving broken requests as if they were properly cached.

This also seems to be the root cause of:

- https://github.com/renovatebot/renovate/discussions/35367

Note I also considered saving a hash of the `httpResponse` together with the response itself so that the cache could be validated upon read, but in that case, it would mean more http requests because instead of ensuring the cache is not erased, it only ensures the cache is valid.

To be honest I have not profiled Renovate to ensure the culprit is actually the garbage collector, however I verified that this solution fixes the issue.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
