### PR TITLE
fix(bitbucket-server): do not persist bearer token in git config as it leads to issues behind aws elb

### DIFF
--- a/lib/modules/platform/azure/index.ts
+++ b/lib/modules/platform/azure/index.ts
@@ -239,7 +239,7 @@ export async function initRepo({
   await git.initRepo({
     ...config,
     url,
-    extraCloneOpts: getStorageExtraCloneOpts(opts),
+    extraGitOptions: getStorageExtraCloneOpts(opts),
     cloneSubmodules,
     cloneSubmodulesFilter,
   });

--- a/lib/modules/platform/bitbucket-server/index.ts
+++ b/lib/modules/platform/bitbucket-server/index.ts
@@ -59,7 +59,7 @@ import type {
   BbsRestUserRef,
 } from './types';
 import * as utils from './utils';
-import { getExtraCloneOpts } from './utils';
+import { getExtraGitOpts } from './utils';
 
 /*
  * Version: 5.3 (EOL Date: 15 Aug 2019)
@@ -287,7 +287,7 @@ export async function initRepo({
     await git.initRepo({
       ...config,
       url,
-      extraCloneOpts: getExtraCloneOpts(opts),
+      extraGitOptions: getExtraGitOpts(opts),
       cloneSubmodules,
       cloneSubmodulesFilter,
       fullClone: semver.lte(defaults.version, '8.0.0'),

--- a/lib/modules/platform/bitbucket-server/utils.spec.ts
+++ b/lib/modules/platform/bitbucket-server/utils.spec.ts
@@ -7,7 +7,7 @@ import type {
 } from './types';
 import {
   BITBUCKET_INVALID_REVIEWERS_EXCEPTION,
-  getExtraCloneOpts,
+  getExtraGitOpts,
   getInvalidReviewers,
   getRepoGitUrl,
 } from './utils';
@@ -289,14 +289,14 @@ describe('modules/platform/bitbucket-server/utils', () => {
     });
   });
 
-  describe('getExtraCloneOpts', () => {
+  describe('getExtraGitOpts', () => {
     it('should not configure bearer token', () => {
-      const res = getExtraCloneOpts({});
+      const res = getExtraGitOpts({});
       expect(res).toEqual({});
     });
 
     it('should configure bearer token', () => {
-      const res = getExtraCloneOpts({ token: 'abc' });
+      const res = getExtraGitOpts({ token: 'abc' });
       expect(res).toEqual({
         '-c': 'http.extraheader=Authorization: Bearer abc',
       });

--- a/lib/modules/platform/bitbucket-server/utils.ts
+++ b/lib/modules/platform/bitbucket-server/utils.ts
@@ -140,7 +140,7 @@ export function getRepoGitUrl(
   return cloneUrl.href;
 }
 
-export function getExtraCloneOpts(opts: HostRule): GitOptions {
+export function getExtraGitOpts(opts: HostRule): GitOptions {
   if (opts.token) {
     return {
       '-c': `http.extraheader=Authorization: Bearer ${opts.token}`,

--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -931,6 +931,36 @@ describe('util/git/index', { timeout: 10000 }, () => {
       const res = (await repo.raw(['config', 'extra.clone.config'])).trim();
       expect(res).toBe('test-extra-config-value');
     });
+
+    it('should use extra git configuration', async () => {
+      await fs.emptyDir(tmpDir.path);
+
+      const rawSpy = vi.spyOn(SimpleGit.prototype, 'raw');
+
+      await git.initRepo({
+        url: origin.path,
+        extraGitOptions: {
+          '-c': 'extra.git.config=test-extra-config-value',
+        },
+        fullClone: true,
+      });
+      git.getBranchCommit(defaultBranch);
+      await git.syncGit();
+      expect(rawSpy).nthCalledWith(1, [
+        '-c',
+        'extra.git.config=test-extra-config-value',
+        'ls-remote',
+        '--heads',
+        origin.path,
+      ]);
+      expect(rawSpy).nthCalledWith(2, [
+        '-c',
+        'extra.git.config=test-extra-config-value',
+        'clone',
+        origin.path,
+        '.',
+      ]);
+    });
   });
 
   describe('setGitAuthor()', () => {

--- a/lib/util/git/types.ts
+++ b/lib/util/git/types.ts
@@ -19,6 +19,7 @@ export interface StorageConfig {
   currentBranch?: string;
   defaultBranch?: string;
   url: string;
+  extraGitOptions?: GitOptions;
   upstreamUrl?: string | undefined;
   extraCloneOpts?: GitOptions;
   cloneSubmodules?: boolean;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
As described in #30180 when a repository is cloned with bearer token, it will be written to the `.git/config` file. Now then another call on this repo is done, the bearer token is taken twice in the http call, which is invalid and therefore rejected by the AWS ELB.
This PR changed the clone options and moves the extraheader to the git command options (<https://git-scm.com/docs/git#Documentation/git.txt--cltnamegtltvaluegt>) rather than the clone command options. These are not written to the repository config. 

## Context

This change is only done for the bitbucket-server and azure platform, as these are the only ones using the extra options.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
