### PR TITLE
fix(pnpm): Ensure --recursive flag is added for pnpm update operations in workspace

### DIFF
--- a/lib/modules/manager/npm/post-update/pnpm.spec.ts
+++ b/lib/modules/manager/npm/post-update/pnpm.spec.ts
@@ -115,7 +115,35 @@ describe('modules/manager/npm/post-update/pnpm', () => {
     expect(res.lockFile).toBe('package-lock-contents');
     expect(execSnapshots).toMatchObject([
       {
-        cmd: 'pnpm update --no-save some-dep@1.0.1 some-other-dep@1.1.0 --lockfile-only --recursive --ignore-scripts --ignore-pnpmfile',
+        cmd: 'pnpm update --no-save --recursive some-dep@1.0.1 some-other-dep@1.1.0 --lockfile-only --ignore-scripts --ignore-pnpmfile',
+      },
+    ]);
+  });
+
+  it('performs install for workspace with --recursive for pnpm v8', async () => {
+    const execSnapshots = mockExecAll();
+    fs.readLocalFile.mockResolvedValue('package-lock-contents');
+    fs.localPathExists.mockResolvedValueOnce(true); // pnpm-workspace.yaml
+    const res = await pnpmHelper.generateLockFile(
+      'some-folder',
+      {},
+      {
+        ...config,
+        constraints: { pnpm: '^8.0.0' },
+      },
+      [
+        {
+          packageName: 'some-dep',
+          newVersion: '1.0.1',
+          isLockfileUpdate: false,
+        },
+      ],
+    );
+    expect(fs.readLocalFile).toHaveBeenCalledTimes(1);
+    expect(res.lockFile).toBe('package-lock-contents');
+    expect(execSnapshots).toMatchObject([
+      {
+        cmd: 'pnpm install --recursive --lockfile-only --ignore-scripts --ignore-pnpmfile',
       },
     ]);
   });

--- a/lib/modules/manager/npm/post-update/pnpm.spec.ts
+++ b/lib/modules/manager/npm/post-update/pnpm.spec.ts
@@ -101,7 +101,9 @@ describe('modules/manager/npm/post-update/pnpm', () => {
 
   it('performs lock file updates for workspace with --recursive', async () => {
     const execSnapshots = mockExecAll();
-    fs.readLocalFile.mockResolvedValue('package-lock-contents');
+    fs.readLocalFile
+      .mockResolvedValueOnce(`packages:\n  - package-1\n  - package-2`)
+      .mockResolvedValueOnce('package-lock-contents'); // pnpm-workspace.yaml
     fs.localPathExists.mockResolvedValueOnce(true); // pnpm-workspace.yaml
     const res = await pnpmHelper.generateLockFile('some-folder', {}, config, [
       { packageName: 'some-dep', newVersion: '1.0.1', isLockfileUpdate: true },
@@ -111,7 +113,7 @@ describe('modules/manager/npm/post-update/pnpm', () => {
         isLockfileUpdate: true,
       },
     ]);
-    expect(fs.readLocalFile).toHaveBeenCalledTimes(1);
+    expect(fs.readLocalFile).toHaveBeenCalledTimes(2);
     expect(res.lockFile).toBe('package-lock-contents');
     expect(execSnapshots).toMatchObject([
       {
@@ -122,7 +124,9 @@ describe('modules/manager/npm/post-update/pnpm', () => {
 
   it('performs install for workspace with --recursive for pnpm v8', async () => {
     const execSnapshots = mockExecAll();
-    fs.readLocalFile.mockResolvedValue('package-lock-contents');
+    fs.readLocalFile
+      .mockResolvedValueOnce(`packages:\n  - package-1\n  - package-2`)
+      .mockResolvedValueOnce('package-lock-contents'); // pnpm-workspace.yaml
     fs.localPathExists.mockResolvedValueOnce(true); // pnpm-workspace.yaml
     const res = await pnpmHelper.generateLockFile(
       'some-folder',
@@ -139,7 +143,7 @@ describe('modules/manager/npm/post-update/pnpm', () => {
         },
       ],
     );
-    expect(fs.readLocalFile).toHaveBeenCalledTimes(1);
+    expect(fs.readLocalFile).toHaveBeenCalledTimes(2);
     expect(res.lockFile).toBe('package-lock-contents');
     expect(execSnapshots).toMatchObject([
       {


### PR DESCRIPTION
## Changes

- Ensure --recursive flag is added for `pnpm update` whenever in a PNPM workspace
- Add test for ensuring the recursive flag is added to `pnpm install` for pnpm v8 in a PNPM workspace

## Context

Fixing a bug where RenovateBot was not triggering updates in the lockfile within PNPM workspaces from this discussion: https://github.com/renovatebot/renovate/discussions/35406

@viceice mentioned I should create a PR to resolve this (https://github.com/renovatebot/renovate/discussions/35406#discussioncomment-12880633)

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [X] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository