### PR TITLE
fix(memCache): disallow http requests in cache to be mutable

### DIFF
--- a/lib/util/http/cache/memory-http-cache-provider.spec.ts
+++ b/lib/util/http/cache/memory-http-cache-provider.spec.ts
@@ -36,4 +36,38 @@ describe('util/http/cache/memory-http-cache-provider', () => {
       body: { msg: 'Hello, world!' },
     });
   });
+
+  it('does not allow cached responses to be mutated', async () => {
+    httpMock
+      .scope('https://example.com')
+      .get('/foo/bar')
+      .reply(200, [{ msg: 'Hello, world!' }]);
+
+    const res1 = await http.getJsonUnchecked<[]>(
+      'https://example.com/foo/bar',
+      {
+        cacheProvider: memCacheProvider,
+      },
+    );
+    expect(res1.statusCode).toBe(200);
+    expect(res1.body.pop()).toMatchObject({ msg: 'Hello, world!' });
+
+    const res2 = await http.getJsonUnchecked<[]>(
+      'https://example.com/foo/bar',
+      {
+        cacheProvider: memCacheProvider,
+      },
+    );
+    expect(res2.statusCode).toBe(200);
+    expect(res2.body.pop()).toMatchObject({ msg: 'Hello, world!' });
+
+    const res3 = await http.getJsonUnchecked<[]>(
+      'https://example.com/foo/bar',
+      {
+        cacheProvider: memCacheProvider,
+      },
+    );
+    expect(res3.statusCode).toBe(200);
+    expect(res3.body).toMatchObject([{ msg: 'Hello, world!' }]);
+  });
 });

--- a/lib/util/http/cache/memory-http-cache-provider.ts
+++ b/lib/util/http/cache/memory-http-cache-provider.ts
@@ -1,4 +1,5 @@
 import * as memCache from '../../cache/memory';
+import { clone } from '../../clone';
 import type { HttpResponse } from '../types';
 import { AbstractHttpCacheProvider } from './abstract-http-cache-provider';
 import type { HttpCache } from './schema';
@@ -10,7 +11,8 @@ export class MemoryHttpCacheProvider extends AbstractHttpCacheProvider {
 
   protected override load(url: string): Promise<unknown> {
     const data = memCache.get<HttpCache>(this.cacheKey(url));
-    return Promise.resolve(data);
+    const cloned = clone(data); // Ensures cached responses cannot be mutated
+    return Promise.resolve(cloned);
   }
 
   protected override persist(url: string, data: HttpCache): Promise<void> {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Fixes an issue with the memoery http cache provider where the cached http reponses could be mutated after being read from the cache.

This could cause several unexected issues, like returning a cache hit with a different body than the one that was cached.

So far, only the Gerrit platform was identified as being affected by this issue.

<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

- Closes https://github.com/renovatebot/renovate/discussions/35638
- Supersedes https://github.com/renovatebot/renovate/pull/35634

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
