### PR TITLE
fix(workers/auto-replace): Correctly replace with digest and without replaceString

### DIFF
--- a/lib/workers/repository/update/branch/auto-replace.ts
+++ b/lib/workers/repository/update/branch/auto-replace.ts
@@ -318,6 +318,7 @@ export async function doAutoReplace(
     let newContent = existingContent;
     let nameReplaced = !newName;
     let valueReplaced = !newValue;
+    let digestReplaced = !newDigest;
     let startIndex = searchIndex;
     // Iterate through the rest of the file
     for (; searchIndex < newContent.length; searchIndex += 1) {
@@ -339,8 +340,9 @@ export async function doAutoReplace(
             searchIndex = startIndex - 1;
             await writeLocalFile(upgrade.packageFile!, existingContent);
             newContent = existingContent;
-            nameReplaced = false;
-            valueReplaced = false;
+            nameReplaced = !newName;
+            valueReplaced = !newValue;
+            digestReplaced = !newDigest;
             continue;
           }
           // replace with newName
@@ -366,8 +368,9 @@ export async function doAutoReplace(
             searchIndex = startIndex - 1;
             await writeLocalFile(upgrade.packageFile!, existingContent);
             newContent = existingContent;
-            nameReplaced = false;
-            valueReplaced = false;
+            nameReplaced = !newName;
+            valueReplaced = !newValue;
+            digestReplaced = !newDigest;
             continue;
           }
           // Now test if the result matches
@@ -380,8 +383,41 @@ export async function doAutoReplace(
           await writeLocalFile(upgrade.packageFile!, newContent);
           valueReplaced = true;
           searchIndex += newValue.length - 1;
+        } else if (
+          newDigest &&
+          matchAt(newContent, searchIndex, currentDigest!)
+        ) {
+          logger.debug(
+            { packageFile, currentDigest },
+            `Found currentDigest at index ${searchIndex}`,
+          );
+          if (digestReplaced) {
+            startIndex = firstIndexOf(
+              existingContent,
+              depName!,
+              currentValue!,
+              startIndex + 1,
+            );
+            searchIndex = startIndex - 1;
+            await writeLocalFile(upgrade.packageFile!, existingContent);
+            newContent = existingContent;
+            nameReplaced = !newName;
+            valueReplaced = !newValue;
+            digestReplaced = !newDigest;
+            continue;
+          }
+          // Now test if the result matches
+          newContent = replaceAt(
+            newContent,
+            searchIndex,
+            currentDigest!,
+            newDigest,
+          );
+          await writeLocalFile(upgrade.packageFile!, newContent);
+          digestReplaced = true;
+          searchIndex += newDigest.length - 1;
         }
-        if (nameReplaced && valueReplaced) {
+        if (nameReplaced && valueReplaced && digestReplaced) {
           if (await confirmIfDepUpdated(upgrade, newContent)) {
             return newContent;
           }
@@ -394,8 +430,9 @@ export async function doAutoReplace(
           searchIndex = startIndex - 1;
           await writeLocalFile(upgrade.packageFile!, existingContent);
           newContent = existingContent;
-          nameReplaced = false;
-          valueReplaced = false;
+          nameReplaced = !newName;
+          valueReplaced = !newValue;
+          digestReplaced = !newDigest;
         }
       } else if (matchAt(newContent, searchIndex, replaceString!)) {
         logger.debug(


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Fix replacements if a digest it present (and no `replaceString` exists).

## Context
There are some managers which can't set a `replaceString`. If there is at the same time a digest present and the update is a replacement, it won't work without the fix.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
