### PR TITLE
feat(parser): support JSON5 parsing for URLs containing “.json5”

### DIFF
--- a/lib/config/presets/gitlab/index.spec.ts
+++ b/lib/config/presets/gitlab/index.spec.ts
@@ -291,11 +291,6 @@ describe('config/presets/gitlab/index', () => {
       expect(result).toBe('config.json5');
     });
 
-    it('should handle invalid URL and return as is', () => {
-      const result = gitlab.extractFilenameFromGitLabPath('not-a-url-at-all');
-      expect(result).toBe('not-a-url-at-all');
-    });
-
     it('should handle non-URL string and return as is', () => {
       const result = gitlab.extractFilenameFromGitLabPath(
         'just-a-filename.json',

--- a/lib/config/presets/gitlab/index.spec.ts
+++ b/lib/config/presets/gitlab/index.spec.ts
@@ -250,6 +250,60 @@ describe('config/presets/gitlab/index', () => {
     });
   });
 
+  describe('extractFilenameFromGitLabPath()', () => {
+    it('should extract filename from simple filename', () => {
+      const result = gitlab.extractFilenameFromGitLabPath('config.json5');
+      expect(result).toBe('config.json5');
+    });
+
+    it('should extract filename from path', () => {
+      const result = gitlab.extractFilenameFromGitLabPath(
+        'src/renovate/config.json5',
+      );
+      expect(result).toBe('src/renovate/config.json5');
+    });
+
+    it('should extract filename from URL-encoded path', () => {
+      const result = gitlab.extractFilenameFromGitLabPath(
+        'src%2Frenovate%2Fconfig.json5',
+      );
+      expect(result).toBe('src%2Frenovate%2Fconfig.json5');
+    });
+
+    it('should extract filename from GitLab API URL', () => {
+      const result = gitlab.extractFilenameFromGitLabPath(
+        'https://gitlab.example.com/api/v4/projects/13083/repository/files/config.json5?ref=main',
+      );
+      expect(result).toBe('config.json5');
+    });
+
+    it('should handle GitLab API URL with /raw suffix', () => {
+      const result = gitlab.extractFilenameFromGitLabPath(
+        'https://gitlab.example.com/api/v4/projects/13083/repository/files/config.json5/raw?ref=main',
+      );
+      expect(result).toBe('config.json5');
+    });
+
+    it('should handle GitLab API URL with nested path and /raw suffix', () => {
+      const result = gitlab.extractFilenameFromGitLabPath(
+        'https://gitlab.example.com/api/v4/projects/13083/repository/files/src/renovate/config.json5/raw?ref=main',
+      );
+      expect(result).toBe('config.json5');
+    });
+
+    it('should handle invalid URL and return as is', () => {
+      const result = gitlab.extractFilenameFromGitLabPath('not-a-url-at-all');
+      expect(result).toBe('not-a-url-at-all');
+    });
+
+    it('should handle non-URL string and return as is', () => {
+      const result = gitlab.extractFilenameFromGitLabPath(
+        'just-a-filename.json',
+      );
+      expect(result).toBe('just-a-filename.json');
+    });
+  });
+
   describe('getPreset()', () => {
     it('throws EXTERNAL_HOST_ERROR', async () => {
       httpMock.scope(gitlabApiHost).get(projectPath).reply(500);

--- a/lib/config/presets/gitlab/index.spec.ts
+++ b/lib/config/presets/gitlab/index.spec.ts
@@ -8,6 +8,248 @@ const projectPath = '/api/v4/projects/some%2Frepo';
 const basePath = `${projectPath}/repository`;
 
 describe('config/presets/gitlab/index', () => {
+  describe('fetchJSONFile()', () => {
+    it('should parse JSON5 file with simple filename', async () => {
+      const content = '{\n  // comment\n  "foo": "bar"\n}';
+      httpMock
+        .scope(gitlabApiHost)
+        .get(projectPath)
+        .reply(200, {
+          default_branch: 'main',
+        })
+        .get(`${basePath}/files/config.json5/raw?ref=main`)
+        .reply(200, content);
+
+      const result = await gitlab.fetchJSONFile(
+        'some/repo',
+        'config.json5',
+        'https://gitlab.com/api/v4/',
+      );
+      expect(result).toEqual({ foo: 'bar' });
+    });
+
+    it('should parse JSON5 file with path', async () => {
+      const content = '{\n  // comment\n  "foo": "bar"\n}';
+      httpMock
+        .scope(gitlabApiHost)
+        .get(projectPath)
+        .reply(200, {
+          default_branch: 'main',
+        })
+        .get(`${basePath}/files/src%2Frenovate%2Fconfig.json5/raw?ref=main`)
+        .reply(200, content);
+
+      const result = await gitlab.fetchJSONFile(
+        'some/repo',
+        'src/renovate/config.json5',
+        'https://gitlab.com/api/v4/',
+      );
+      expect(result).toEqual({ foo: 'bar' });
+    });
+
+    it('should parse JSON5 file with URL-encoded path', async () => {
+      const content = '{\n  // comment\n  "foo": "bar"\n}';
+      httpMock
+        .scope(gitlabApiHost)
+        .get(projectPath)
+        .reply(200, {
+          default_branch: 'main',
+        })
+        .get(`${basePath}/files/src%252Frenovate%252Fconfig.json5/raw?ref=main`)
+        .reply(200, content);
+
+      const result = await gitlab.fetchJSONFile(
+        'some/repo',
+        'src%2Frenovate%2Fconfig.json5',
+        'https://gitlab.com/api/v4/',
+      );
+      expect(result).toEqual({ foo: 'bar' });
+    });
+
+    it('should parse JSON5 file with complex URL-encoded path', async () => {
+      const content = '{\n  // comment\n  "foo": "bar"\n}';
+      httpMock
+        .scope('https://gitlab.example.com')
+        .get('/api/v4/projects/some%2Frepo')
+        .reply(200, {
+          default_branch: 'main',
+        })
+        .get(
+          `/api/v4/projects/some%2Frepo/repository/files/configs%252Fsrc%252Frenovate%252Fconfig%252Ejson5/raw?ref=main`,
+        )
+        .reply(200, content);
+
+      const result = await gitlab.fetchJSONFile(
+        'some/repo',
+        'configs%2Fsrc%2Frenovate%2Fconfig%2Ejson5',
+        'https://gitlab.example.com/api/v4/',
+      );
+      expect(result).toEqual({ foo: 'bar' });
+    });
+
+    it('should parse regular JSON file correctly', async () => {
+      const content = '{"foo": "bar"}';
+      httpMock
+        .scope(gitlabApiHost)
+        .get(projectPath)
+        .reply(200, {
+          default_branch: 'main',
+        })
+        .get(`${basePath}/files/config.json/raw?ref=main`)
+        .reply(200, content);
+
+      const result = await gitlab.fetchJSONFile(
+        'some/repo',
+        'config.json',
+        'https://gitlab.com/api/v4/',
+      );
+      expect(result).toEqual({ foo: 'bar' });
+    });
+
+    it('should handle JSONC files with path extraction', async () => {
+      const content = '{\n  // comment\n  "foo": "bar"\n}';
+      httpMock
+        .scope(gitlabApiHost)
+        .get(projectPath)
+        .reply(200, {
+          default_branch: 'main',
+        })
+        .get(`${basePath}/files/src%2Fconfig.jsonc/raw?ref=main`)
+        .reply(200, content);
+
+      const result = await gitlab.fetchJSONFile(
+        'some/repo',
+        'src/config.jsonc',
+        'https://gitlab.com/api/v4/',
+      );
+      expect(result).toEqual({ foo: 'bar' });
+    });
+
+    it('should throw error when file not found', async () => {
+      httpMock
+        .scope(gitlabApiHost)
+        .get(projectPath)
+        .reply(200, {
+          default_branch: 'main',
+        })
+        .get(`${basePath}/files/nonexistent.json5/raw?ref=main`)
+        .reply(404);
+
+      await expect(
+        gitlab.fetchJSONFile(
+          'some/repo',
+          'nonexistent.json5',
+          'https://gitlab.com/api/v4/',
+        ),
+      ).rejects.toThrow(PRESET_DEP_NOT_FOUND);
+    });
+
+    it('should correctly extract .json5 extension from nested path for parsing', async () => {
+      // Test that JSON5 content is parsed correctly when filename has .json5 extension
+      // even when buried in a nested path
+      const json5Content =
+        '{\n  // This is a JSON5 comment\n  "extends": ["config:base"],\n  "timezone": "America/New_York"\n}';
+      httpMock
+        .scope(gitlabApiHost)
+        .get(projectPath)
+        .reply(200, {
+          default_branch: 'main',
+        })
+        .get(
+          `${basePath}/files/deep%2Fnested%2Fpath%2Fto%2Frenovate.json5/raw?ref=main`,
+        )
+        .reply(200, json5Content);
+
+      const result = await gitlab.fetchJSONFile(
+        'some/repo',
+        'deep/nested/path/to/renovate.json5',
+        'https://gitlab.com/api/v4/',
+      );
+      expect(result).toEqual({
+        extends: ['config:base'],
+        timezone: 'America/New_York',
+      });
+    });
+
+    it('should correctly extract .json extension from nested path for parsing', async () => {
+      // Test that regular JSON content is parsed correctly when filename has .json extension
+      const jsonContent =
+        '{"extends": ["config:base"], "timezone": "America/New_York"}';
+      httpMock
+        .scope(gitlabApiHost)
+        .get(projectPath)
+        .reply(200, {
+          default_branch: 'main',
+        })
+        .get(
+          `${basePath}/files/deep%2Fnested%2Fpath%2Fto%2Frenovate.json/raw?ref=main`,
+        )
+        .reply(200, jsonContent);
+
+      const result = await gitlab.fetchJSONFile(
+        'some/repo',
+        'deep/nested/path/to/renovate.json',
+        'https://gitlab.com/api/v4/',
+      );
+      expect(result).toEqual({
+        extends: ['config:base'],
+        timezone: 'America/New_York',
+      });
+    });
+
+    it('should handle deeply URL-encoded paths with .json5 extension', async () => {
+      // Test that complex URL-encoded paths with .json5 extension are handled correctly
+      const json5Content =
+        '{\n  // Complex configuration\n  "extends": ["config:base"]\n}';
+      httpMock
+        .scope(gitlabApiHost)
+        .get(projectPath)
+        .reply(200, {
+          default_branch: 'main',
+        })
+        .get(
+          `${basePath}/files/src%252Fconfigs%252Frenovate%252Fdefault.json5/raw?ref=main`,
+        )
+        .reply(200, json5Content);
+
+      const result = await gitlab.fetchJSONFile(
+        'some/repo',
+        'src%2Fconfigs%2Frenovate%2Fdefault.json5',
+        'https://gitlab.com/api/v4/',
+      );
+      expect(result).toEqual({
+        extends: ['config:base'],
+      });
+    });
+
+    it('should handle self-hosted GitLab Repository files API scenario', async () => {
+      // Test the specific scenario mentioned: self-hosted GitLab instances using Repository files API
+      // with URLs like: https://gitlab.example.com/api/v4/projects/13083/repository/files/src%2Frenovate%2Fconfig%2Ejson5?ref=main
+      const json5Content =
+        '{\n  // Self-hosted GitLab config\n  "extends": ["config:base"],\n  "enabled": true\n}';
+      httpMock
+        .scope('https://gitlab.example.com')
+        .get('/api/v4/projects/myorg%2Fmyrepo')
+        .reply(200, {
+          default_branch: 'main',
+        })
+        .get(
+          '/api/v4/projects/myorg%2Fmyrepo/repository/files/src%252Frenovate%252Fconfig%252Ejson5/raw?ref=main',
+        )
+        .reply(200, json5Content);
+
+      const result = await gitlab.fetchJSONFile(
+        'myorg/myrepo',
+        'src%2Frenovate%2Fconfig%2Ejson5',
+        'https://gitlab.example.com/api/v4/',
+      );
+      expect(result).toEqual({
+        extends: ['config:base'],
+        enabled: true,
+      });
+    });
+  });
+
   describe('getPreset()', () => {
     it('throws EXTERNAL_HOST_ERROR', async () => {
       httpMock.scope(gitlabApiHost).get(projectPath).reply(500);

--- a/lib/config/presets/gitlab/index.spec.ts
+++ b/lib/config/presets/gitlab/index.spec.ts
@@ -325,6 +325,31 @@ describe('config/presets/gitlab/index', () => {
       );
       expect(result).toBe('config.json5');
     });
+
+    it('should handle URL with only slashes in pathname', () => {
+      const result = gitlab.extractFilenameFromGitLabPath(
+        'https://gitlab.example.com///',
+      );
+      expect(result).toBe('');
+    });
+
+    it('should handle URL with pathname that becomes empty after processing', () => {
+      // Test the specific line 83 fallback: pathWithoutQuery.split('/').pop() ?? ''
+      const result = gitlab.extractFilenameFromGitLabPath(
+        'https://gitlab.example.com/',
+      );
+      expect(result).toBe('');
+    });
+
+    it('should handle URL with complex path that results in empty filename', () => {
+      // Additional test for line 83: pathWithoutQuery.split('/').pop() ?? ''
+      // This tests the defensive programming fallback even though split('/').pop()
+      // should never return undefined in practice
+      const result = gitlab.extractFilenameFromGitLabPath(
+        'https://gitlab.example.com/projects/123/repository/files//raw',
+      );
+      expect(result).toBe('');
+    });
   });
 
   describe('getPreset()', () => {

--- a/lib/config/presets/gitlab/index.spec.ts
+++ b/lib/config/presets/gitlab/index.spec.ts
@@ -297,6 +297,34 @@ describe('config/presets/gitlab/index', () => {
       );
       expect(result).toBe('just-a-filename.json');
     });
+
+    it('should handle URL with empty pathname', () => {
+      const result = gitlab.extractFilenameFromGitLabPath(
+        'https://gitlab.example.com',
+      );
+      expect(result).toBe('');
+    });
+
+    it('should handle URL with pathname that is just "/raw"', () => {
+      const result = gitlab.extractFilenameFromGitLabPath(
+        'https://gitlab.example.com/raw',
+      );
+      expect(result).toBe('');
+    });
+
+    it('should handle URL with pathname that becomes empty after removing /raw', () => {
+      const result = gitlab.extractFilenameFromGitLabPath(
+        'https://gitlab.example.com/raw?ref=main',
+      );
+      expect(result).toBe('');
+    });
+
+    it('should handle URL with root-level path', () => {
+      const result = gitlab.extractFilenameFromGitLabPath(
+        'https://gitlab.example.com/config.json5',
+      );
+      expect(result).toBe('config.json5');
+    });
   });
 
   describe('getPreset()', () => {

--- a/lib/config/presets/gitlab/index.ts
+++ b/lib/config/presets/gitlab/index.ts
@@ -72,7 +72,7 @@ export async function fetchJSONFile(
  * @param fileName - The filename or path to extract from
  * @returns The extracted filename without path or query parameters
  */
-function extractFilenameFromGitLabPath(fileName: string): string {
+export function extractFilenameFromGitLabPath(fileName: string): string {
   try {
     const url = parseUrl(fileName);
     if (url) {
@@ -90,7 +90,7 @@ function extractFilenameFromGitLabPath(fileName: string): string {
       // Extract filename from the path
       return pathWithoutQuery.split('/').slice(-1)[0];
     }
-  } catch (error) {
+  } catch {
     // If parseUrl fails, it's not a URL, so return as is
   }
 

--- a/lib/config/presets/gitlab/index.ts
+++ b/lib/config/presets/gitlab/index.ts
@@ -73,25 +73,21 @@ export async function fetchJSONFile(
  * @returns The extracted filename without path or query parameters
  */
 export function extractFilenameFromGitLabPath(fileName: string): string {
-  try {
-    const url = parseUrl(fileName);
-    if (url) {
-      // If it's a valid URL, extract the pathname and process it
-      let pathWithoutQuery = url.pathname;
+  const url = parseUrl(fileName);
+  if (url) {
+    // If it's a valid URL, extract the pathname and process it
+    let pathWithoutQuery = url.pathname;
 
-      // Handle GitLab "/raw" suffix that's appended to the filename
-      if (pathWithoutQuery.endsWith('/raw')) {
-        pathWithoutQuery = pathWithoutQuery.substring(
-          0,
-          pathWithoutQuery.length - 4,
-        );
-      }
-
-      // Extract filename from the path
-      return pathWithoutQuery.split('/').slice(-1)[0];
+    // Handle GitLab "/raw" suffix that's appended to the filename
+    if (pathWithoutQuery.endsWith('/raw')) {
+      pathWithoutQuery = pathWithoutQuery.substring(
+        0,
+        pathWithoutQuery.length - 4,
+      );
     }
-  } catch {
-    // If parseUrl fails, it's not a URL, so return as is
+
+    // Extract filename from the path
+    return pathWithoutQuery.split('/').slice(-1)[0];
   }
 
   // Return as is - should be a normal filename with extension

--- a/lib/config/presets/gitlab/index.ts
+++ b/lib/config/presets/gitlab/index.ts
@@ -79,12 +79,7 @@ export function extractFilenameFromGitLabPath(fileName: string): string {
     let pathWithoutQuery = url.pathname;
 
     // Handle GitLab "/raw" suffix that's appended to the filename
-    if (pathWithoutQuery.endsWith('/raw')) {
-      pathWithoutQuery = pathWithoutQuery.substring(
-        0,
-        pathWithoutQuery.length - 4,
-      );
-    }
+ pathWithoutQuery= pathWithoutQuery.replace(regEx(/\/raw$/), '');
 
     // Extract filename from the path
     return pathWithoutQuery.split('/').pop();

--- a/lib/config/presets/gitlab/index.ts
+++ b/lib/config/presets/gitlab/index.ts
@@ -6,6 +6,7 @@ import type { GitlabProject } from '../../../types/platform/gitlab';
 import { GitlabHttp } from '../../../util/http/gitlab';
 import type { HttpResponse } from '../../../util/http/types';
 import { parseUrl } from '../../../util/url';
+import { regEx } from '../../../util/regex';
 import type { Preset, PresetConfig } from '../types';
 import { PRESET_DEP_NOT_FOUND, fetchPreset, parsePreset } from '../util';
 
@@ -79,7 +80,7 @@ export function extractFilenameFromGitLabPath(fileName: string): string {
     let pathWithoutQuery = url.pathname;
 
     // Handle GitLab "/raw" suffix that's appended to the filename
-    pathWithoutQuery = pathWithoutQuery.replace(/\/raw$/, '');
+    pathWithoutQuery = pathWithoutQuery.replace(regEx(/\/raw$/), '');
 
     // Extract filename from the path
     return pathWithoutQuery.split('/').pop() || '';

--- a/lib/config/presets/gitlab/index.ts
+++ b/lib/config/presets/gitlab/index.ts
@@ -83,7 +83,7 @@ export function extractFilenameFromGitLabPath(fileName: string): string {
     pathWithoutQuery = pathWithoutQuery.replace(regEx(/\/raw$/), '');
 
     // Extract filename from the path
-    return pathWithoutQuery.split('/').pop() || '';
+    return pathWithoutQuery.split('/').pop() ?? '';
   }
 
   // Return as is - should be a normal filename with extension

--- a/lib/config/presets/gitlab/index.ts
+++ b/lib/config/presets/gitlab/index.ts
@@ -79,7 +79,7 @@ export function extractFilenameFromGitLabPath(fileName: string): string {
     let pathWithoutQuery = url.pathname;
 
     // Handle GitLab "/raw" suffix that's appended to the filename
- pathWithoutQuery= pathWithoutQuery.replace(regEx(/\/raw$/), '');
+    pathWithoutQuery = pathWithoutQuery.replace(regEx(/\/raw$/), '');
 
     // Extract filename from the path
     return pathWithoutQuery.split('/').pop();

--- a/lib/config/presets/gitlab/index.ts
+++ b/lib/config/presets/gitlab/index.ts
@@ -79,10 +79,10 @@ export function extractFilenameFromGitLabPath(fileName: string): string {
     let pathWithoutQuery = url.pathname;
 
     // Handle GitLab "/raw" suffix that's appended to the filename
-    pathWithoutQuery = pathWithoutQuery.replace(regEx(/\/raw$/), '');
+    pathWithoutQuery = pathWithoutQuery.replace(/\/raw$/, '');
 
     // Extract filename from the path
-    return pathWithoutQuery.split('/').pop();
+    return pathWithoutQuery.split('/').pop() || '';
   }
 
   // Return as is - should be a normal filename with extension

--- a/lib/config/presets/gitlab/index.ts
+++ b/lib/config/presets/gitlab/index.ts
@@ -5,6 +5,7 @@ import { ExternalHostError } from '../../../types/errors/external-host-error';
 import type { GitlabProject } from '../../../types/platform/gitlab';
 import { GitlabHttp } from '../../../util/http/gitlab';
 import type { HttpResponse } from '../../../util/http/types';
+import { parseUrl } from '../../../util/url';
 import type { Preset, PresetConfig } from '../types';
 import { PRESET_DEP_NOT_FOUND, fetchPreset, parsePreset } from '../util';
 
@@ -55,7 +56,46 @@ export async function fetchJSONFile(
     throw new Error(PRESET_DEP_NOT_FOUND);
   }
 
-  return parsePreset(res.body, fileName);
+  // Extract the actual filename without path or query parameters
+  const cleanFileName = extractFilenameFromGitLabPath(fileName);
+
+  return parsePreset(res.body, cleanFileName);
+}
+
+/**
+ * Extracts the actual filename from a GitLab path, which could be:
+ * - A simple filename: "renovate.json5"
+ * - A path: "path/to/renovate.json5"
+ * - A URL-encoded path: "src%2Frenovate%2Fconfig.json5"
+ * - A GitLab API URL: "https://gitlab.example.com/api/v4/projects/13083/repository/files/renovate.json5?ref=main"
+ *
+ * @param fileName - The filename or path to extract from
+ * @returns The extracted filename without path or query parameters
+ */
+function extractFilenameFromGitLabPath(fileName: string): string {
+  try {
+    const url = parseUrl(fileName);
+    if (url) {
+      // If it's a valid URL, extract the pathname and process it
+      let pathWithoutQuery = url.pathname;
+
+      // Handle GitLab "/raw" suffix that's appended to the filename
+      if (pathWithoutQuery.endsWith('/raw')) {
+        pathWithoutQuery = pathWithoutQuery.substring(
+          0,
+          pathWithoutQuery.length - 4,
+        );
+      }
+
+      // Extract filename from the path
+      return pathWithoutQuery.split('/').slice(-1)[0];
+    }
+  } catch (error) {
+    // If parseUrl fails, it's not a URL, so return as is
+  }
+
+  // Return as is - should be a normal filename with extension
+  return fileName;
 }
 
 export function getPresetFromEndpoint(

--- a/lib/config/presets/gitlab/index.ts
+++ b/lib/config/presets/gitlab/index.ts
@@ -87,7 +87,7 @@ export function extractFilenameFromGitLabPath(fileName: string): string {
     }
 
     // Extract filename from the path
-    return pathWithoutQuery.split('/').slice(-1)[0];
+    return pathWithoutQuery.split('/').pop();
   }
 
   // Return as is - should be a normal filename with extension

--- a/lib/config/presets/gitlab/index.ts
+++ b/lib/config/presets/gitlab/index.ts
@@ -5,8 +5,8 @@ import { ExternalHostError } from '../../../types/errors/external-host-error';
 import type { GitlabProject } from '../../../types/platform/gitlab';
 import { GitlabHttp } from '../../../util/http/gitlab';
 import type { HttpResponse } from '../../../util/http/types';
-import { parseUrl } from '../../../util/url';
 import { regEx } from '../../../util/regex';
+import { parseUrl } from '../../../util/url';
 import type { Preset, PresetConfig } from '../types';
 import { PRESET_DEP_NOT_FOUND, fetchPreset, parsePreset } from '../util';
 


### PR DESCRIPTION
Use `path.includes('.json5')` (instead of `endsWith`) so URLs like “…/renovate.json5/raw?ref=…” are correctly detected

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Switch from `endsWith('.json5')` to `path.includes('.json5')`, so we catch URLs like `…/foo.json5/raw?ref=…`
- Retain the `.jsonc` check first via `path.includes('.jsonc')` for backwards compatibility

## Context

Some GitLab “raw” file URLs append a `/raw` segment and include query parameters (e.g. `?ref=0.6.0`), which prevented our old `endsWith('.json5')` check from matching. This change makes our JSON5 detection more robust and avoids warnings about invalid JSON in renovate’s parser when handling `.json5` files served via raw URLs.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->