### PR TITLE
docs: Mend hosted apps no longer using encrypted secrets

### DIFF
--- a/docs/usage/mend-hosted/credentials.md
+++ b/docs/usage/mend-hosted/credentials.md
@@ -10,7 +10,7 @@ If you self-host, you can skip reading this page.
 
 ## :warning: Migrate secrets in your Renovate config file :warning:
 
-The Mend Renovate cloud apps no longer reads encrypted secrets from Renovate config files in your repositories.
+The Mend Renovate cloud apps no longer read encrypted secrets from Renovate config files in your repositories.
 You must migrate any secrets you currently keep in a Renovate config file, and put them in the app settings page on [developer.mend.io](https://developer.mend.io).
 To add secrets you must have admin-level rights.
 

--- a/docs/usage/mend-hosted/credentials.md
+++ b/docs/usage/mend-hosted/credentials.md
@@ -10,8 +10,8 @@ If you self-host, you can skip reading this page.
 
 ## :warning: Migrate secrets in your Renovate config file :warning:
 
-Use of encrypted secrets in the Mend Renovate cloud apps has been deprecated and soon the apps will stop reading secrets from the Renovate config file in your repository.
-You must migrate any secrets you currently keep in the Renovate config file, and put them in the app settings page on [developer.mend.io](https://developer.mend.io).
+The Mend Renovate cloud apps no longer reads encrypted secrets from Renovate config files in your repositories.
+You must migrate any secrets you currently keep in a Renovate config file, and put them in the app settings page on [developer.mend.io](https://developer.mend.io).
 To add secrets you must have admin-level rights.
 
 Read [Migrating encrypted secrets from Repo Config to App Settings](migrating-secrets.md) to learn more.

--- a/docs/usage/mend-hosted/credentials.md
+++ b/docs/usage/mend-hosted/credentials.md
@@ -10,8 +10,8 @@ If you self-host, you can skip reading this page.
 
 ## :warning: Migrate secrets in your Renovate config file :warning:
 
-The Mend Renovate cloud apps no longer read encrypted secrets from Renovate config files in your repositories.
-You must migrate any secrets you currently keep in a Renovate config file, and put them in the app settings page on [developer.mend.io](https://developer.mend.io).
+The Mend Renovate cloud apps no longer read `encrypted` secrets from Renovate config files in your repositories.
+You must migrate any secrets you currently keep in a Renovate config file, and upload them as secrets to org or repo settings pages on [developer.mend.io](https://developer.mend.io).
 To add secrets you must have admin-level rights.
 
 Read [Migrating encrypted secrets from Repo Config to App Settings](migrating-secrets.md) to learn more.

--- a/docs/usage/mend-hosted/migrating-secrets.md
+++ b/docs/usage/mend-hosted/migrating-secrets.md
@@ -1,6 +1,6 @@
 # Migrating Secrets from Repo Config to App Settings
 
-The Mend Renovate Cloud apps no longer reads encrypted secrets from Renovate config files in your repositories.
+The Mend Renovate Cloud apps no longer read encrypted secrets from Renovate config files in your repositories.
 Previously, you could encrypt a secret with the [Renovate encryption tool](https://app.renovatebot.com/encrypt) and then put it in your Renovate config file.
 
 When using the Mend Renovate Cloud apps, all secrets must be stored in the App settings on the cloud.
@@ -60,6 +60,7 @@ You must Migrate encrypted secrets using the PLAIN TEXT value. You can not use t
 ### Add the secret to the correct Org or Repo
 
 When you migrate a secret from a repository, make sure you are adding the secret to the _same_ organization or repository for which you generated the secret!
+
 - A secret generated for a specific repository can only be added to that _same_ repository.
 - A secret generated for a specific repository can only be added to the repository settings for the matching repository. This secret can _not_ be added to the organization's settings.
 - A secret generated without a specific repository _can_ be added into the organization _or_ into the repository settings under that organization.
@@ -83,8 +84,8 @@ When you migrate a secret from a repository, make sure you are adding the secret
 
 The secret might be wrong. Try uploading the secret again.
 
-* Ensure that the PLAIN TEXT value of the secret is used - not the encrypted value.
-* Ensure that the secret was uploaded to the correct Org or Repo.
+- Ensure that the PLAIN TEXT value of the secret is used - not the encrypted value.
+- Ensure that the secret was uploaded to the correct Org or Repo.
 
 ## Related links
 

--- a/docs/usage/mend-hosted/migrating-secrets.md
+++ b/docs/usage/mend-hosted/migrating-secrets.md
@@ -1,10 +1,10 @@
 # Migrating Secrets from Repo Config to App Settings
 
-Use of encrypted secrets in the Mend Renovate cloud apps has been deprecated and soon the apps will stop reading any encrypted secrets from the Renovate configuration file on your repository.
+The Mend Renovate Cloud apps no longer reads encrypted secrets from Renovate config files in your repositories.
 Previously, you could encrypt a secret with the [Renovate encryption tool](https://app.renovatebot.com/encrypt) and then put it in your Renovate config file.
 
-Going forward, all secrets must be stored in the App settings on the cloud.
-They can be referenced from the Renovate config files inside the repo using `{{ secrets.SECRET_NAME }}` notation.
+When using the Mend Renovate Cloud apps, all secrets must be stored in the App settings on the cloud.
+The secrets can be referenced from the Renovate config files inside the repo using `{{ secrets.SECRET_NAME }}` notation.
 
 ## Old method
 
@@ -40,65 +40,51 @@ This is the new method that you should start using:
 
 ## Tips
 
-### Migrate your secrets in encrypted form
-
-Mend recommends that you copy your secrets in their _encrypted_ form when you migrate.
-The web UI will decrypt and store the value securely.
-
 ### Do not change the secret during migration
 
-Mend also recommends that you do _not_ change the secret during the migration, as this introduces an extra point of failure.
+Mend recommends that you do _not_ change the secret during the migration, as this introduces an extra point of failure.
 After the migration you can of course change/rotate the secret.
 
-## Two ways to migrate
+### Migrate your secrets in the raw form (plain text)
 
-There are two ways to migrate your secrets:
+When migrating secrets, DO NOT migrate the encrypted form of the secret.
+You must input the secret in the web UI from plain text. (The web UI will store the value securely.)
+If you do not have the original plain text form of the secret being migrated, you will need to create a new secret.
 
-1. Migrate encrypted secrets using the encrypted value
-2. Migrate encrypted secrets using the plain text value
+## How to migrate secrets
 
-Mend recommends the first way.
+### Use Plain text values - not encrypted values
 
-### Migrate encrypted secrets using the encrypted value
+You must Migrate encrypted secrets using the PLAIN TEXT value. You can not use the encrypted version of the secret.
 
-1. Copy the encrypted secret from your Renovate config file.
-2. Go to the correct settings page for your organization or repository in the web UI at [developer.mend.io](https://developer.mend.io).
-3. On the **Credentials** page, select `ADD SECRET` to add the encrypted secret.
-4. Give a value for `Secret name`, paste the encrypted secret into the `Secret Value` field, and select `SAVE`.
-5. When you migrate a secret from a repository, make sure you are adding the secret to the _same_ organization or repository for which you generated the secret!
-   - A secret generated for a specific repository can only be added to that _same_ repository.
-   - A secret generated for a specific repository can only be added to the repository settings for the matching repository. This secret can _not_ be added to the organization's settings.
-   - A secret generated without a specific repository _can_ be added into the organization _or_ into the repository settings under that organization.
-6. If you see the confirmation box with the text: **“Successfully migrated secret”**, your secret is now stored in the correct organization or repository.
-   ![Successfully migrated secret](../assets/images/app-settings/stored-secret-encrypted.png)
+### Add the secret to the correct Org or Repo
 
-### Migrate encrypted secrets using the plain text value
+When you migrate a secret from a repository, make sure you are adding the secret to the _same_ organization or repository for which you generated the secret!
+- A secret generated for a specific repository can only be added to that _same_ repository.
+- A secret generated for a specific repository can only be added to the repository settings for the matching repository. This secret can _not_ be added to the organization's settings.
+- A secret generated without a specific repository _can_ be added into the organization _or_ into the repository settings under that organization.
 
-1. Go to the settings for the correct organization or repository in the web UI at [developer.mend.io](https://developer.mend.io).
+### Steps to migrate a secret to the Renovate Cloud App
+
+1. Go to the correct settings page for your organization or repository in the web UI at [developer.mend.io](https://developer.mend.io).
+
 2. On the **Credentials** page, select `ADD SECRET` to add the plaintext secret.
    ![Add repo secret](../assets/images/app-settings/add-repo-secret.png)
+
 3. Give a value for `Secret name`, paste the plaintext secret into the `Secret Value` field, and select `SAVE`.
    ![Add a Secret dialog box](../assets/images/app-settings/add-a-secret.png)
+
 4. Wait for the confirmation dialog: **“Successfully stored secret”**.
    ![Successfully stored secret](../assets/images/app-settings/stored-secret-plaintext.png)
 
 ## Troubleshooting
 
-### Are you trying to add the secret to the wrong place?
+### Secret is stored successfully, but it doesn't work when used in the app
 
-If you accidentally end up in the wrong place, the settings UI will help you:
+The secret might be wrong. Try uploading the secret again.
 
-![Migrating secrets error](../assets/images/app-settings/encrypted-secrets-error.png)
-
-## The confirmation box says "Successfully store secret", what does this mean?
-
-If the confirmation box says: **“Successfully stored secret”** then the secret was not detected as a Renovate encrypted secret.
-This means the value was treated as plaintext.
-
-If you were expecting to import a secret originally encrypted by Renovate:
-
-1. Make sure you are pasting the secret into the correct organization or repository
-2. Check that you copied the encrypted secret correctly, and try again.
+* Ensure that the PLAIN TEXT value of the secret is used - not the encrypted value.
+* Ensure that the secret was uploaded to the correct Org or Repo.
 
 ## Related links
 


### PR DESCRIPTION
## Changes

Docs for Mend-hosted Apps have been updated to declare that encrypted secrets are no longer in use. Also, encrypted secrets can not be used when adding secrets to the Cloud app through Developer Portal.

## Context

This change has come about as the secret key has been removed from the cloud app job runners and is no longer available to decrypt secrets in Renovate config files that were encrypted by the Mend Renovate encryption tool.
This was planned and communicated many months ago and has now taken place.

Users have been instructed to migrate encrypted secrets to the relevant Org or Repo in the Developer Portal web UI.
Migration instructions are on the RenovateBot Docs site.
https://docs.renovatebot.com/mend-hosted/migrating-secrets/

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
