### PR TITLE
docs: add note about enabledManagers within customManagers

### DIFF
--- a/lib/modules/manager/custom/jsonata/readme.md
+++ b/lib/modules/manager/custom/jsonata/readme.md
@@ -10,6 +10,8 @@ The JSONata manager is unique in Renovate, because:
 - It can be configured via [JSONata](https://jsonata.org/) queries
 - You can create multiple "JSONata managers" in the same repository
 
+If you have limited managers to run within [`enabledManagers` config option](../../../configuration-options.md#enabledmanagers), you need to add `"custom.jsonata"` to the list.
+
 ### Required Fields
 
 The first two required fields are `managerFilePatterns` and `matchStrings`:

--- a/lib/modules/manager/custom/regex/readme.md
+++ b/lib/modules/manager/custom/regex/readme.md
@@ -13,6 +13,8 @@ The `regex` manager is unique in Renovate because:
 We have [additional Handlebars helpers](../../../templates.md#additional-handlebars-helpers) to help you perform common transformations on the regex manager's template fields.
 Also read the documentation for the [`customManagers` config option](../../../configuration-options.md#custommanagers).
 
+If you have limited managers to run within [`enabledManagers` config option](../../../configuration-options.md#enabledmanagers), you need to add `"custom.regex"` to the list.
+
 ### Required Fields
 
 The first two required fields are `managerFilePatterns` and `matchStrings`:


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

There is missing note about allowing custom manager within `enabledManagers` config option. 

## Context

It was hard for me to realize, that adding custom manager will not turn it on, but it must be added to enabled managers too.
See Discussion https://github.com/renovatebot/renovate/discussions/35763#discussioncomment-13050757

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
