### PR TITLE
refactor(libyears): restructure exported type

### DIFF
--- a/lib/instrumentation/reporting.spec.ts
+++ b/lib/instrumentation/reporting.spec.ts
@@ -79,7 +79,10 @@ describe('instrumentation/reporting', () => {
       branches: [],
       packageFiles: {},
     });
-    addLibYears(config, {}, 0, 0, 0);
+    addLibYears(config, {
+      libYears: { managers: {}, total: 0 },
+      dependencyStatus: { outdated: 0, total: 0 },
+    });
 
     expect(getReport()).toEqual({
       problems: [],
@@ -240,7 +243,10 @@ describe('instrumentation/reporting', () => {
 
     addBranchStats(config, branchInformation);
     addExtractionStats(config, { branchList: [], branches: [], packageFiles });
-    addLibYears(config, { npm: 1 }, 1, 1, 1);
+    addLibYears(config, {
+      libYears: { managers: { npm: 1 }, total: 1 },
+      dependencyStatus: { outdated: 1, total: 1 },
+    });
 
     expect(getReport()).toEqual({
       problems: [],
@@ -249,11 +255,17 @@ describe('instrumentation/reporting', () => {
           problems: [],
           branches: branchInformation,
           packageFiles,
-          libYears: {
-            managerLibYears: { npm: 1 },
-            totalLibYears: 1,
-            totalDepsCount: 1,
-            outdatedDepsCount: 1,
+          libYearsWithStatus: {
+            libYears: {
+              managers: {
+                npm: 1,
+              },
+              total: 1,
+            },
+            dependencyStatus: {
+              outdated: 1,
+              total: 1,
+            },
           },
         },
       },

--- a/lib/instrumentation/reporting.ts
+++ b/lib/instrumentation/reporting.ts
@@ -7,7 +7,7 @@ import type { BranchCache } from '../util/cache/repository/types';
 import { writeSystemFile } from '../util/fs';
 import { getS3Client, parseS3Url } from '../util/s3';
 import type { ExtractResult } from '../workers/repository/process/extract-update';
-import type { Report } from './types';
+import type { LibYearsWithStatus, Report } from './types';
 
 const report: Report = {
   problems: [],
@@ -50,22 +50,15 @@ export function addExtractionStats(
 
 export function addLibYears(
   config: RenovateConfig,
-  managerLibYears: Record<string, number>,
-  totalLibYears: number,
-  totalDepsCount: number,
-  outdatedDepsCount: number,
+  libYearsWithDepCount: LibYearsWithStatus,
 ): void {
   if (is.nullOrUndefined(config.reportType)) {
     return;
   }
 
   coerceRepo(config.repository!);
-  report.repositories[config.repository!].libYears = {
-    managerLibYears,
-    totalLibYears,
-    totalDepsCount,
-    outdatedDepsCount,
-  };
+  report.repositories[config.repository!].libYearsWithStatus =
+    libYearsWithDepCount;
 }
 
 export function finalizeReport(): void {

--- a/lib/instrumentation/types.ts
+++ b/lib/instrumentation/types.ts
@@ -37,12 +37,20 @@ interface RepoReport {
   problems: BunyanRecord[];
   branches: Partial<BranchCache>[];
   packageFiles: Record<string, PackageFile[]>;
-  libYears?: LibYears;
+  libYearsWithStatus?: LibYearsWithStatus;
+}
+
+export interface LibYearsWithStatus {
+  libYears: LibYears;
+  dependencyStatus: DependencyStatus;
 }
 
 export interface LibYears {
-  outdatedDepsCount: number;
-  totalDepsCount: number;
-  totalLibYears: number;
-  managerLibYears: Record<string, number>;
+  total: number;
+  managers: Record<string, number>;
+}
+
+export interface DependencyStatus {
+  outdated: number;
+  total: number;
 }

--- a/lib/workers/repository/process/libyear.spec.ts
+++ b/lib/workers/repository/process/libyear.spec.ts
@@ -105,30 +105,35 @@ describe('workers/repository/process/libyear', () => {
       );
       expect(logger.logger.debug).toHaveBeenCalledWith(
         {
-          managerLibYears: {
+          libYears: {
+            managers: {
+              bundler: 0.5027322404371585,
+              dockerfile: 0,
+              npm: 1,
+            },
+            total: 1.5027322404371586,
+          },
+          dependencyStatus: {
+            outdated: 4,
+            total: 5,
+          },
+        },
+        'Repository libYears',
+      );
+      expect(addLibYears).toHaveBeenCalledWith(config, {
+        libYears: {
+          managers: {
             bundler: 0.5027322404371585,
             dockerfile: 0,
             npm: 1,
           },
-          // eslint-disable-next-line no-loss-of-precision
-          totalLibYears: 1.5027322404371585,
-          totalDepsCount: 5,
-          outdatedDepsCount: 4,
+          total: 1.5027322404371586,
         },
-        'Repository libYears',
-      );
-      expect(addLibYears).toHaveBeenCalledWith(
-        config,
-        {
-          bundler: 0.5027322404371585,
-          dockerfile: 0,
-          npm: 1,
+        dependencyStatus: {
+          outdated: 4,
+          total: 5,
         },
-        // eslint-disable-next-line no-loss-of-precision
-        1.5027322404371585,
-        5,
-        4,
-      );
+      });
     });
 
     it('de-duplicates if same dep found in different files', () => {
@@ -193,14 +198,17 @@ describe('workers/repository/process/libyear', () => {
       calculateLibYears(config, packageFiles);
       expect(logger.logger.debug).toHaveBeenCalledWith(
         {
-          managerLibYears: {
-            npm: 1,
-            regex: 1,
+          libYears: {
+            managers: {
+              npm: 1,
+              regex: 1,
+            },
+            total: 2,
           },
-
-          totalLibYears: 2,
-          totalDepsCount: 2,
-          outdatedDepsCount: 2,
+          dependencyStatus: {
+            outdated: 2,
+            total: 2,
+          },
         },
         'Repository libYears',
       );


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Changes the exported `libYears` type by deduplicating field names and restructuring by context.


```
DEBUG: Repository libYears (repository=ladzaretti-testing/static-cfg-testing)
       "libYears": {"managers": {"npm": 13.836221378484872}, "total": 13.836221378484872},
       "dependencyStatus": {"outdated": 3, "total": 3}

```

<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
