### PR TITLE
fix: don't exclude deprecated currentVersion exact match

### DIFF
--- a/lib/workers/repository/process/lookup/current.ts
+++ b/lib/workers/repository/process/lookup/current.ts
@@ -1,5 +1,4 @@
 import is from '@sindresorhus/is';
-import { logger } from '../../../../logger';
 import type { VersioningApi } from '../../../../modules/versioning/types';
 import { regEx } from '../../../../util/regex';
 
@@ -14,10 +13,6 @@ export function getCurrentVersion(
   // istanbul ignore if
   if (!is.string(currentValue)) {
     return null;
-  }
-  logger.trace(`currentValue ${currentValue} is range`);
-  if (allVersions.includes(currentValue)) {
-    return currentValue;
   }
   let useVersions = allVersions.filter((v) =>
     versioningApi.matches(v, currentValue),

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -295,6 +295,9 @@ export async function lookupUpdates(
       if (rangeStrategy === 'update-lockfile') {
         currentVersion = config.lockedVersion!;
       }
+      if (allVersions.find((v) => v.version === compareValue)) {
+        currentVersion = compareValue!;
+      }
       // TODO #22198
       currentVersion ??=
         getCurrentVersion(


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Refactors a check for exact match currentVersion/currentValue so that a deprecated currentVersion is still matched.

## Context

- #35588

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
