### PR TITLE
fix(manager): Migrate to `managerFilePatterns` of config-presets

### DIFF
--- a/lib/modules/manager/renovate-config-presets/index.ts
+++ b/lib/modules/manager/renovate-config-presets/index.ts
@@ -8,9 +8,9 @@ export { extractPackageFile } from './extract';
 export const url = '../../../config-presets.md';
 
 export const defaultConfig = {
-  managerFilePatterns: configFileNames
-    .filter((name) => name !== 'package.json')
-    .map((name) => `/^${name.replaceAll('.', '\\.')}$/`),
+  managerFilePatterns: configFileNames.filter(
+    (name) => name !== 'package.json',
+  ),
 };
 
 export const supportedDatasources = [

--- a/lib/modules/manager/renovate-config-presets/index.ts
+++ b/lib/modules/manager/renovate-config-presets/index.ts
@@ -8,9 +8,9 @@ export { extractPackageFile } from './extract';
 export const url = '../../../config-presets.md';
 
 export const defaultConfig = {
-  fileMatch: configFileNames
+  managerFilePatterns: configFileNames
     .filter((name) => name !== 'package.json')
-    .map((name) => `^${name.replaceAll('.', '\\.')}$`),
+    .map((name) => `/^${name.replaceAll('.', '\\.')}$/`),
 };
 
 export const supportedDatasources = [


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Change the `fileMatch` to `managerFilePatterns` in the `defaultConfig` object
- Prepend and append a slash to specify it's a RegExp syntax

<!-- Describe what behavior is changed by this PR. -->

## Context

- https://github.com/renovatebot/renovate/discussions/35797

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
