### PR TITLE
feat(gitlab): add gitLabNotesMerge option to support merge trains

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -1866,6 +1866,11 @@ Under the hood, it creates a MR-level approval rule where `approvals_required` i
 This option works only when `automerge=true` and either `automergeType=pr` or `automergeType=branch`.
 Also, approval rules overriding should not be [prevented in GitLab settings](https://docs.gitlab.com/ee/user/project/merge_requests/approvals/settings.html#prevent-editing-approval-rules-in-merge-requests).
 
+## gitLabNotesMerge
+
+Uses the [Gitlab Notes API](https://docs.gitlab.com/api/notes/#create-new-merge-request-note) to send the [`/merge` quick action](https://docs.gitlab.com/user/project/quick_actions/).
+By default, Renovate uses [the Merge requests API](https://docs.gitlab.com/api/merge_requests/#merge-a-merge-request) to do this, but [this doesn't support Merge Trains yet](https://gitlab.com/gitlab-org/gitlab/-/issues/32665).
+
 ## goGetDirs
 
 By default, Renovate will run `go get -d -t ./...` to update the `go.sum`.

--- a/docs/usage/faq.md
+++ b/docs/usage/faq.md
@@ -44,7 +44,6 @@ Some major platform features are not supported at all by Renovate.
 | --------------------------------------- | ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Jira issues                             | Bitbucket                                 | [#20568](https://github.com/renovatebot/renovate/issues/20568)                                                                                                                               |
 | Jira issues                             | Bitbucket Server                          | [#3796](https://github.com/renovatebot/renovate/issues/3796)                                                                                                                                 |
-| Merge trains                            | GitLab                                    | [#5573](https://github.com/renovatebot/renovate/issues/5573)                                                                                                                                 |
 | Configurable merge strategy and message | Only Bitbucket, Forgejo and Gitea for now | [#10867](https://github.com/renovatebot/renovate/issues/10867) [#10869](https://github.com/renovatebot/renovate/issues/10869) [#10870](https://github.com/renovatebot/renovate/issues/10870) |
 
 ## What is this `main` branch I see in the documentation?

--- a/docs/usage/upgrade-best-practices.md
+++ b/docs/usage/upgrade-best-practices.md
@@ -134,7 +134,6 @@ If you want a third-party dependency update _now_, instead of waiting two weeks,
 #### Use GitHub Pull Request Merge Queues
 
 You may also start using [GitHub's pull request merge queues](./key-concepts/automerge.md#github-merge-queue) to speed up the merge process.
-Renovate does not support GitLab's Merge Trains, see [issue #5573](https://github.com/renovatebot/renovate/issues/5573).
 
 ## Starting from a new project
 

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -2903,6 +2903,12 @@ const options: RenovateOptions[] = [
     default: false,
   },
   {
+    name: 'gitLabNotesMerge',
+    description: `Uses Gitlab's Note API instead of the /merge API. Supports adding to merge trains.`,
+    type: 'boolean',
+    default: false,
+  },
+  {
     name: 'customManagers',
     description: 'Custom managers using regex matching.',
     type: 'array',

--- a/lib/modules/platform/gitlab/index.spec.ts
+++ b/lib/modules/platform/gitlab/index.spec.ts
@@ -2242,6 +2242,50 @@ describe('modules/platform/gitlab/index', () => {
       expect(timers.setTimeout.mock.calls).toMatchObject([[100], [400]]);
     });
 
+    it('auto-accepts the MR over Notes API when requested', async () => {
+      await initPlatform('13.3.6-ee');
+      httpMock
+        .scope(gitlabApiHost)
+        .get(
+          '/api/v4/projects/undefined/merge_requests?per_page=100&scope=created_by_me',
+        )
+        .reply(200, [])
+        .post('/api/v4/projects/undefined/merge_requests')
+        .reply(200, {
+          id: 1,
+          iid: 12345,
+          title: 'some title',
+          source_branch: 'some-branch',
+          target_branch: 'master',
+          description: 'the-body',
+        })
+        .get('/api/v4/projects/undefined/merge_requests/12345')
+        .reply(200)
+        .get('/api/v4/projects/undefined/merge_requests/12345')
+        .reply(200)
+        .post('/api/v4/projects/undefined/merge_requests/12345/notes')
+        .reply(200);
+      expect(
+        await gitlab.createPr({
+          sourceBranch: 'some-branch',
+          targetBranch: 'master',
+          prTitle: 'some-title',
+          prBody: 'the-body',
+          labels: [],
+          platformPrOptions: {
+            usePlatformAutomerge: true,
+            gitLabNotesMerge: true,
+          },
+        }),
+      ).toMatchObject({
+        number: 12345,
+        sourceBranch: 'some-branch',
+        title: 'some title',
+      });
+
+      expect(timers.setTimeout.mock.calls).toMatchObject([[100], [400]]);
+    });
+
     it('should parse merge_status attribute if detailed_merge_status is not set (on < 15.6)', async () => {
       await initPlatform('13.3.6-ee');
       const reply_body = {

--- a/lib/modules/platform/types.ts
+++ b/lib/modules/platform/types.ts
@@ -104,6 +104,7 @@ export interface PlatformPrOptions {
   bbUseDefaultReviewers?: boolean;
   bbAutoResolvePrTasks?: boolean;
   gitLabIgnoreApprovals?: boolean;
+  gitLabNotesMerge?: boolean;
   usePlatformAutomerge?: boolean;
   forkModeDisallowMaintainerEdits?: boolean;
 }

--- a/lib/workers/repository/update/pr/index.ts
+++ b/lib/workers/repository/update/pr/index.ts
@@ -61,6 +61,7 @@ export function getPlatformPrOptions(
     bbAutoResolvePrTasks: !!config.bbAutoResolvePrTasks,
     bbUseDefaultReviewers: !!config.bbUseDefaultReviewers,
     gitLabIgnoreApprovals: !!config.gitLabIgnoreApprovals,
+    gitLabNotesMerge: !!config.gitLabNotesMerge,
     forkModeDisallowMaintainerEdits: !!config.forkModeDisallowMaintainerEdits,
     usePlatformAutomerge,
   };


### PR DESCRIPTION
- closes https://github.com/renovatebot/renovate/issues/5573

- prior PR: https://github.com/renovatebot/renovate/pull/34102

Gitlab's /merge API does not support merge trains, but sending "/merge" over the MR comment (notes) API does work:
https://gitlab.com/gitlab-org/gitlab/-/issues/32665

This introduces a configuration option to use this API as a workaround until Gitlab introduces support to the merge API for Merge Trains.

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

When using automerge with Gitlab and `gitLabNotesMerge` is enabled, renovate will use the `/merge` quick reactions api, which supports adding MRs to merge trains. 
Gitlab Docs:

- https://docs.gitlab.com/api/notes/#create-new-merge-request-note
- https://docs.gitlab.com/user/project/quick_actions/

This can be understood of as [a workaround](https://gitlab.com/gitlab-org/gitlab/-/issues/32665#note_974671680) until Gitlab implements support for Merge Trains in the [merge API](https://gitlab.com/gitlab-org/gitlab/-/issues/32665). This option can then be removed/deprecated.

## Context

- https://github.com/renovatebot/renovate/issues/5573

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
