### PR TITLE
refactor: Make package caching params explicit

### DIFF
--- a/lib/modules/datasource/maven/util.ts
+++ b/lib/modules/datasource/maven/util.ts
@@ -67,6 +67,7 @@ function isUnsupportedHostError(err: HttpError): boolean {
 const cacheProvider = new PackageHttpCacheProvider({
   namespace: 'datasource-maven:cache-provider',
   ttlMinutes: 7 * 24 * 60,
+  checkAuthorizationHeader: true,
   checkCacheControlHeader: false, // Maven doesn't respond with `cache-control` headers
 });
 

--- a/lib/modules/datasource/npm/get.ts
+++ b/lib/modules/datasource/npm/get.ts
@@ -78,7 +78,8 @@ export async function getDependency(
   try {
     const cacheProvider = new PackageHttpCacheProvider({
       namespace: 'datasource-npm:cache-provider',
-      checkAuthorizationHeader: false,
+      checkAuthorizationHeader: false, // We don't rely on whether user token is provided or not
+      checkCacheControlHeader: true,
     });
     const options: HttpOptions = { cacheProvider };
 

--- a/lib/util/http/cache/package-http-cache-provider.spec.ts
+++ b/lib/util/http/cache/package-http-cache-provider.spec.ts
@@ -51,6 +51,8 @@ describe('util/http/cache/package-http-cache-provider', () => {
     const cacheProvider = new PackageHttpCacheProvider({
       namespace: '_test-namespace',
       ttlMinutes: 0,
+      checkAuthorizationHeader: false,
+      checkCacheControlHeader: false,
     });
     httpMock.scope(url).get('').reply(200, 'new response');
 
@@ -69,6 +71,8 @@ describe('util/http/cache/package-http-cache-provider', () => {
     };
     const cacheProvider = new PackageHttpCacheProvider({
       namespace: '_test-namespace',
+      checkAuthorizationHeader: false,
+      checkCacheControlHeader: false,
     });
 
     const res = await http.getText(url, { cacheProvider });
@@ -90,6 +94,8 @@ describe('util/http/cache/package-http-cache-provider', () => {
   it('handles cache miss', async () => {
     const cacheProvider = new PackageHttpCacheProvider({
       namespace: '_test-namespace',
+      checkAuthorizationHeader: false,
+      checkCacheControlHeader: false,
     });
     httpMock.scope(url).get('').reply(200, 'fetched response', {
       etag: 'foobar',
@@ -118,6 +124,8 @@ describe('util/http/cache/package-http-cache-provider', () => {
 
     const cacheProvider = new PackageHttpCacheProvider({
       namespace: '_test-namespace',
+      checkAuthorizationHeader: false,
+      checkCacheControlHeader: true,
     });
 
     httpMock.scope(url).get('').reply(200, 'private response', {
@@ -135,6 +143,8 @@ describe('util/http/cache/package-http-cache-provider', () => {
 
     const cacheProvider = new PackageHttpCacheProvider({
       namespace: '_test-namespace',
+      checkAuthorizationHeader: true,
+      checkCacheControlHeader: false,
     });
 
     httpMock.scope(url).get('').reply(200, 'private response');
@@ -155,6 +165,7 @@ describe('util/http/cache/package-http-cache-provider', () => {
 
     const cacheProvider = new PackageHttpCacheProvider({
       namespace: '_test-namespace',
+      checkAuthorizationHeader: false,
       checkCacheControlHeader: false,
     });
 
@@ -174,6 +185,7 @@ describe('util/http/cache/package-http-cache-provider', () => {
 
     const cacheProvider = new PackageHttpCacheProvider({
       namespace: '_test-namespace',
+      checkAuthorizationHeader: false,
       checkCacheControlHeader: false,
     });
 
@@ -198,6 +210,8 @@ describe('util/http/cache/package-http-cache-provider', () => {
     };
     const cacheProvider = new PackageHttpCacheProvider({
       namespace: '_test-namespace',
+      checkAuthorizationHeader: false,
+      checkCacheControlHeader: false,
     });
     httpMock.scope(url).get('').reply(500);
 
@@ -299,6 +313,8 @@ describe('util/http/cache/package-http-cache-provider', () => {
 
       const cacheProvider = new PackageHttpCacheProvider({
         namespace: '_test-namespace',
+        checkAuthorizationHeader: false,
+        checkCacheControlHeader: true,
       });
 
       const response = {

--- a/lib/util/http/cache/package-http-cache-provider.ts
+++ b/lib/util/http/cache/package-http-cache-provider.ts
@@ -13,8 +13,8 @@ import type { HttpCache } from './schema';
 export interface PackageHttpCacheProviderOptions {
   namespace: PackageCacheNamespace;
   ttlMinutes?: number;
-  checkCacheControlHeader?: boolean;
-  checkAuthorizationHeader?: boolean;
+  checkCacheControlHeader: boolean;
+  checkAuthorizationHeader: boolean;
 }
 
 export class PackageHttpCacheProvider extends AbstractHttpCacheProvider {
@@ -29,8 +29,8 @@ export class PackageHttpCacheProvider extends AbstractHttpCacheProvider {
   constructor({
     namespace,
     ttlMinutes = 15,
-    checkCacheControlHeader = true,
-    checkAuthorizationHeader = true,
+    checkCacheControlHeader = false,
+    checkAuthorizationHeader = false,
   }: PackageHttpCacheProviderOptions) {
     super();
     this.namespace = namespace;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Make options explicit in order to avoid confusion when using package cache provider class.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
