### PR TITLE
fix(manager/pep621): use `depName` in lock update commands

### DIFF
--- a/lib/modules/manager/pep621/processors/uv.spec.ts
+++ b/lib/modules/manager/pep621/processors/uv.spec.ts
@@ -472,8 +472,8 @@ describe('modules/manager/pep621/processors/uv', () => {
       const updatedDeps = [
         { packageName: 'dep1', depType: depTypes.dependencies },
         { packageName: 'dep2', depType: depTypes.dependencies },
-        { depName: 'group1/dep3', depType: depTypes.optionalDependencies },
-        { depName: 'group1/dep4', depType: depTypes.optionalDependencies },
+        { depName: 'dep3', depType: depTypes.optionalDependencies },
+        { depName: 'dep4', depType: depTypes.optionalDependencies },
         { depName: 'dep5', depType: depTypes.uvDevDependencies },
         { depName: 'dep6', depType: depTypes.uvDevDependencies },
         { depName: 'dep7', depType: depTypes.buildSystemRequires },

--- a/lib/modules/manager/pep621/processors/uv.ts
+++ b/lib/modules/manager/pep621/processors/uv.ts
@@ -231,7 +231,7 @@ function generateCMD(updatedDeps: Upgrade[]): string {
   for (const dep of updatedDeps) {
     switch (dep.depType) {
       case depTypes.optionalDependencies: {
-        deps.push(dep.depName!.split('/')[1]);
+        deps.push(dep.depName!);
         break;
       }
       case depTypes.uvDevDependencies:


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Use the full `depName` in the commands we generate to update the package in lockfile, for the `uv` processor
<!-- Describe what behavior is changed by this PR. -->

## Context
- Closes: #35639 
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository 
https://github.com/Rahul-renovate-testing/35396/pull/1/files (to differentiate between the open PRs, look at the PR which updates the pytest dep and check the `uv.lock` file)

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
