### PR TITLE
fix(kubernetes): add underscore tag support

### DIFF
--- a/lib/modules/manager/kubernetes/__fixtures__/underscore-tag.yaml
+++ b/lib/modules/manager/kubernetes/__fixtures__/underscore-tag.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: litellm
+  namespace: kube-system
+  labels:
+    app: litellm
+spec:
+  selector:
+    matchLabels:
+      app: litellm
+  template:
+    spec:
+      containers:
+      - name: litellm
+        image: "ghcr.io/berriai/litellm:litellm_stable_release_branch-v1.67.0-stable"

--- a/lib/modules/manager/kubernetes/extract.spec.ts
+++ b/lib/modules/manager/kubernetes/extract.spec.ts
@@ -4,6 +4,7 @@ import { Fixtures } from '~test/fixtures';
 const kubernetesImagesFile = Fixtures.get('kubernetes.yaml');
 const kubernetesConfigMapFile = Fixtures.get('configmap.yaml');
 const kubernetesArraySyntaxFile = Fixtures.get('array-syntax.yaml');
+const underscoreTagFile = Fixtures.get('underscore-tag.yaml');
 const kubernetesRegistryAlias = Fixtures.get('kubernetes.registry-alias.yaml');
 const otherYamlFile = Fixtures.get('gitlab-ci.yaml');
 
@@ -88,6 +89,29 @@ describe('modules/manager/kubernetes/extract', () => {
           currentValue: 'apps/v1',
           datasource: 'kubernetes-api',
           depName: 'DaemonSet',
+          versioning: 'kubernetes-api',
+        },
+      ]);
+    });
+
+    it('extracts image tag when it contains underscores', () => {
+      const res = extractPackageFile(underscoreTagFile, 'file.yaml', {});
+      expect(res?.deps).toStrictEqual([
+        {
+          autoReplaceStringTemplate:
+            '{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}',
+          currentDigest: undefined,
+          currentValue: 'litellm_stable_release_branch-v1.67.0-stable',
+          datasource: 'docker',
+          depName: 'ghcr.io/berriai/litellm',
+          packageName: 'ghcr.io/berriai/litellm',
+          replaceString:
+            'ghcr.io/berriai/litellm:litellm_stable_release_branch-v1.67.0-stable',
+        },
+        {
+          currentValue: 'apps/v1',
+          datasource: 'kubernetes-api',
+          depName: 'Deployment',
           versioning: 'kubernetes-api',
         },
       ]);

--- a/lib/modules/manager/kubernetes/extract.ts
+++ b/lib/modules/manager/kubernetes/extract.ts
@@ -38,8 +38,8 @@ export function extractPackageFile(
 }
 
 // Comes from https://github.com/distribution/reference/blob/v0.6.0/regexp.go
-// Extracted & converted with https://go.dev/play/p/ZwF3vvRD9Rs
-const dockerImageRegexPattern = `((?:(?:(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))*|\\[(?:[a-fA-F0-9:]+)\\])(?::[0-9]+)?/)?[a-z0-9]+(?:(?:[._]|__|[-]+)[a-z0-9]+)*(?:/[a-z0-9]+(?:(?:[._]|__|[-]+)[a-z0-9]+)*)*)(?::([A-Za-z0-9][A-Za-z0-9.-]{0,127}))?(?:@([A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][0-9a-fA-F]{32,}))?`;
+// Extracted & converted with https://go.dev/play/p/KQQAONGp__2
+const dockerImageRegexPattern = `((?:(?:(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))*|\\[(?:[a-fA-F0-9:]+)\\])(?::[0-9]+)?/)?[a-z0-9]+(?:(?:[._]|__|[-]+)[a-z0-9]+)*(?:/[a-z0-9]+(?:(?:[._]|__|[-]+)[a-z0-9]+)*)*)(?::([A-Za-z0-9_][A-Za-z0-9_.-]{0,127}))?(?:@([A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][0-9a-fA-F]{32,}))?`;
 
 const k8sImageRegex = regEx(
   `^\\s*-?\\s*image:\\s*['"]?(${dockerImageRegexPattern})['"]?\\s*`,


### PR DESCRIPTION
## Changes

Adjust the Kubernetes manager to add support for underscores in Docker image tags.

## Context

We have observed that Renovate would not us update automatically the Docker image for LiteLLM when used in a Kubernetes deployment file, even after specifying a custom regex versioning pattern. LiteLLM uses a unique versioning scheme, where the Docker tag is, for example: litellm_stable_release_branch-v1.69.0-stable ([link to registry](https://github.com/berriai/litellm/pkgs/container/litellm/412669894?tag=litellm_stable_release_branch-v1.69.0-stable)). With such a tag, Renovate debug output shows "currentValue = litellm", where we would expect "currentValue = litellm_stable_release_branch-v1.69.0-stable".

The root cause is a slight miss in the Regex characters used to parse Docker image references. The '\w' metacharacter includes the underscore, as described in https://github.com/google/re2/wiki/Syntax.

So here we regenerate the regex for the Docker images to allow the underscore, and we add a unit test for that scenario.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [X] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
