### PR TITLE
docs: replace Markdown-style link with HTML-style link

### DIFF
--- a/tools/mkdocs/overrides/main.html
+++ b/tools/mkdocs/overrides/main.html
@@ -9,6 +9,6 @@
   If you use a Mend-hosted Renovate App <em>and</em> you have encrypted secrets in your Renovate config, then you must migrate the secrets to the Developer Portal UI. If you do not migrate the secrets, eventually Renovate will stop running on repositories that use the Mend-hosted Renovate App. Please read the <a href="https://github.com/renovatebot/renovate/discussions/33407">announcement about the disabling of Encrypted Secrets in Mend-hosted Renovate apps</a> to learn more.
 </p>
 <p>
-  We released a new major version of Renovate. Read the [Renovate 40 changelog on GitHub](https://github.com/renovatebot/renovate/releases/tag/40.0.0).
+  We released a new major version of Renovate. Read the <a href="https://github.com/renovatebot/renovate/releases/tag/40.0.0">Renovate 40 changelog on GitHub</a>.
 </p>
 {% endblock %}


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Replace Markdown-style link with HTML-style link

## Context

I accidentally used the wrong style link in our announcement bar. Fixing up a change made in this PR:

- #35886

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
