### PR TITLE
fix(gerrit): use change instead of change-request terminology

### DIFF
--- a/lib/modules/platform/gerrit/index.spec.ts
+++ b/lib/modules/platform/gerrit/index.spec.ts
@@ -1,3 +1,4 @@
+import { codeBlock } from 'common-tags';
 import { DateTime } from 'luxon';
 import { REPOSITORY_ARCHIVED } from '../../../constants/error-messages';
 import type { BranchStatus } from '../../../types';
@@ -885,9 +886,30 @@ describe('modules/platform/gerrit/index', () => {
 
   describe('massageMarkdown()', () => {
     it('massageMarkdown()', () => {
-      expect(gerrit.massageMarkdown('Pull Requests')).toBe('Change-Requests');
+      expect(
+        gerrit.massageMarkdown(codeBlock`
+          Pull Request
+          PR
+          Branch creation
+          Disabled because a matching PR was automerged previously
+          Whenever PR becomes conflicted
+          close this Pull Request unmerged
+          Close this PR
+          you tick the rebase/retry checkbox
+          checking the rebase/retry box above
+          `),
+      ).toBe(codeBlock`
+        change
+        change
+        Change creation
+        Disabled because a matching change was automerged previously
+        Whenever change becomes conflicted
+        abandon or vote this change with Code-Review -2
+        Abandon or vote this change with Code-Review -2
+        add \`rebase!\` at the beginning of the commit message
+        adding \`rebase!\` at the beginning of the commit message
+        `);
     });
-    //TODO: add some tests for Gerrit-specific replacements..
   });
 
   describe('currently unused/not-implemented functions', () => {

--- a/lib/modules/platform/gerrit/index.ts
+++ b/lib/modules/platform/gerrit/index.ts
@@ -447,28 +447,34 @@ export async function ensureComment(
 }
 
 export function massageMarkdown(prBody: string): string {
-  //TODO: do more Gerrit specific replacements?
-  return smartTruncate(readOnlyIssueBody(prBody), maxBodyLength())
-    .replace(regEx(/Pull Request(s)?/g), 'Change-Request$1')
-    .replace(regEx(/\bPR(s)?\b/g), 'Change-Request$1')
-    .replace(regEx(/<\/?summary>/g), '**')
-    .replace(regEx(/<\/?details>/g), '')
-    .replace(regEx(/&#8203;/g), '') //remove zero-width-space not supported in gerrit-markdown
-    .replace(
-      'close this Change-Request unmerged.',
-      'abandon or down vote this Change-Request with -2.',
-    )
-    .replace('Branch creation', 'Change creation')
-    .replace(
-      'Close this Change-Request',
-      'Down-vote this Change-Request with -2',
-    )
-    .replace(
-      'you tick the rebase/retry checkbox',
-      'add "rebase!" at the beginning of the commit message.',
-    )
-    .replace(regEx(`\n---\n\n.*?<!-- rebase-check -->.*?\n`), '')
-    .replace(regEx(/<!--renovate-(?:debug|config-hash):.*?-->/g), '');
+  return (
+    smartTruncate(readOnlyIssueBody(prBody), maxBodyLength())
+      .replace('Branch creation', 'Change creation')
+      .replace(
+        'close this Pull Request unmerged',
+        'abandon or vote this change with Code-Review -2',
+      )
+      .replace(
+        'Close this PR',
+        'Abandon or vote this change with Code-Review -2',
+      )
+      .replace(
+        'you tick the rebase/retry checkbox',
+        'add `rebase!` at the beginning of the commit message',
+      )
+      .replace(
+        'checking the rebase/retry box above',
+        'adding `rebase!` at the beginning of the commit message',
+      )
+      .replace(regEx(/\b(?:Pull Request|PR)/g), 'change')
+      // Remove HTML tags not supported in Gerrit markdown
+      .replace(regEx(/<\/?summary>/g), '**')
+      .replace(regEx(/<\/?(details|blockquote)>/g), '')
+      .replace(regEx(`\n---\n\n.*?<!-- rebase-check -->.*?\n`), '')
+      .replace(regEx(/<!--renovate-(?:debug|config-hash):.*?-->/g), '')
+      // Remove zero-width-space not supported in Gerrit markdown
+      .replace(regEx(/&#8203;/g), '')
+  );
 }
 
 export function maxBodyLength(): number {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

This PR improves the "PR Body" for the Gerrit platform:

- Replace _Change-Request_ terminoly with _change_. _Change Request_ is a non-official term used by many Gerrit users, but it is not the official term used by Gerrit. The official term is simply _change_. If you scan Gerrit's documentation, there will be no mention of _Change Request_.
- Adds missing tests for `massageMarkdown` function and remove `TODO`s from the code.
- Better organize the code in `massageMarkdown` function following the example of the BitBucket platform.
- Improve text assertiveness by clarifying that _Down-vote_ actually means to _vote with Code-Review -2_.
- And some minor phrasing improvements.

**Before:**
![image](https://github.com/user-attachments/assets/81295ce0-eb37-49dc-99b0-f01e440511f4)

**After:**

**Disclaimer: this screenshot is outdated because refactoring of the rebase instructions to use hashtags is no longer part of this PR.**

![image](https://github.com/user-attachments/assets/45548185-e459-429c-99ff-7dffa34887d3)

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

I got to see this part of the code while working on https://github.com/renovatebot/renovate/pull/35900, which was when I realized improvements were due.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
