### PR TITLE
refactor(workers): enhance some fns

### DIFF
--- a/lib/workers/repository/init/merge.ts
+++ b/lib/workers/repository/init/merge.ts
@@ -61,13 +61,19 @@ export async function detectConfigFile(): Promise<string | null> {
   return null;
 }
 
-export async function detectRepoFileConfig(): Promise<RepoFileConfig> {
+export async function detectRepoFileConfig(
+  branchName?: string,
+): Promise<RepoFileConfig> {
   const cache = getCache();
   let { configFileName } = cache;
   if (is.nonEmptyString(configFileName)) {
     let configFileRaw: string | null;
     try {
-      configFileRaw = await platform.getRawFile(configFileName);
+      configFileRaw = await platform.getRawFile(
+        configFileName,
+        undefined,
+        branchName,
+      );
     } catch (err) {
       // istanbul ignore if
       if (err instanceof ExternalHostError) {
@@ -172,11 +178,12 @@ export function checkForRepoConfigError(repoConfig: RepoFileConfig): void {
 // Check for repository config
 export async function mergeRenovateConfig(
   config: RenovateConfig,
+  branchName?: string,
 ): Promise<RenovateConfig> {
   let returnConfig = { ...config };
   let repoConfig: RepoFileConfig = {};
   if (config.requireConfig !== 'ignored') {
-    repoConfig = await detectRepoFileConfig();
+    repoConfig = await detectRepoFileConfig(branchName);
   }
   if (!repoConfig.configFileParsed && config.mode === 'silent') {
     logger.debug(

--- a/lib/workers/repository/process/index.ts
+++ b/lib/workers/repository/process/index.ts
@@ -114,6 +114,7 @@ function unfoldBaseBranches(
 
 export async function extractDependencies(
   config: RenovateConfig,
+  overwriteCache = true,
 ): Promise<ExtractResult> {
   await readDashboardBody(config);
   let res: ExtractResult = {
@@ -132,7 +133,7 @@ export async function extractDependencies(
       addMeta({ baseBranch });
       if (await scm.branchExists(baseBranch)) {
         const baseBranchConfig = await getBaseBranchConfig(baseBranch, config);
-        extracted[baseBranch] = await extract(baseBranchConfig);
+        extracted[baseBranch] = await extract(baseBranchConfig, overwriteCache);
       } else {
         logger.warn({ baseBranch }, 'Base branch does not exist - skipping');
       }
@@ -155,7 +156,7 @@ export async function extractDependencies(
     removeMeta(['baseBranch']);
   } else {
     logger.debug('No baseBranches');
-    const packageFiles = await extract(config);
+    const packageFiles = await extract(config, overwriteCache);
     addSplit('extract');
     if (GlobalConfig.get('dryRun') === 'extract') {
       res.packageFiles = packageFiles;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
1. Added `overwriteCache` param to the `extractDependecnies` & `extract` fn so that we prevent using the cached extract from the same run while processing the reconfigure PR
2. Pass the `branchName` to the `mergeRenovateConfig` and `detectRenovateConfig` fn inorder to fetch the config file  from correct branch ie. reconfigure branch instead of default branch
<!-- Describe what behavior is changed by this PR. -->

## Context
- Ref: https://github.com/renovatebot/renovate/pull/34696/files#r2075329471
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
