### PR TITLE
fix(datasource/docker): ignore unknown sub-manifests in OciImageIndexManifest

### DIFF
--- a/lib/modules/datasource/docker/schema.spec.ts
+++ b/lib/modules/datasource/docker/schema.spec.ts
@@ -152,6 +152,61 @@ describe('modules/datasource/docker/schema', () => {
     });
   });
 
+  it('parses OCI image index and ignores unknown sub manifests', () => {
+    const manifest = {
+      schemaVersion: 2,
+      mediaType: 'application/vnd.oci.image.index.v1+json',
+      manifests: [
+        {
+          mediaType: 'application/vnd.oci.image.manifest.v1+json',
+          size: 7143,
+          digest:
+            'sha256:e692418e4cbaf90ca69d05a66403747baa33ee08806650b51fab815ad7fc331f',
+          platform: {
+            architecture: 'ppc64le',
+            os: 'linux',
+          },
+        },
+        {
+          mediaType: 'application/vnd.oci.image.manifest.v1+json',
+          size: 7682,
+          digest:
+            'sha256:5b0bcabd1ed22e9fb1310cf6c2dec7cdef19f0ad69efa1f392e94a4333501270',
+          platform: {
+            architecture: 'amd64',
+            os: 'linux',
+          },
+        },
+        {
+          annotations: {
+            'com.docker.official-images.bashbrew.arch': 'windows-amd64',
+          },
+          digest:
+            'sha256:68b622deabed02180f6c985925143b02076942a3d5390e7bae36c037d646eee2',
+          mediaType: 'application/vnd.docker.distribution.manifest.v2+json',
+          platform: {
+            architecture: 'amd64',
+            os: 'windows',
+            'os.version': '10.0.17763.7314',
+          },
+          size: 3042,
+        },
+      ],
+      annotations: {
+        'com.example.key1': 'value1',
+        'com.example.key2': 'value2',
+      },
+    };
+    const parsedManifest = OciImageIndexManifest.parse(manifest);
+
+    expect(parsedManifest).toMatchObject({
+      schemaVersion: 2,
+      mediaType: 'application/vnd.oci.image.index.v1+json',
+    });
+
+    expect(parsedManifest.manifests).toHaveLength(2);
+  });
+
   it('parses OCI flux artifact', () => {
     const manifest = {
       schemaVersion: 2,

--- a/lib/modules/datasource/docker/schema.ts
+++ b/lib/modules/datasource/docker/schema.ts
@@ -83,7 +83,7 @@ export type OciImageManifest = z.infer<typeof OciImageManifest>;
  */
 export const OciImageIndexManifest = ManifestObject.extend({
   mediaType: z.literal('application/vnd.oci.image.index.v1+json'),
-  manifests: z.array(
+  manifests: LooseArray(
     Descriptor.extend({
       mediaType: z.enum([
         'application/vnd.oci.image.manifest.v1+json',


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This PR makes the sub manifests of `application/vnd.oci.image.index.v1+json` optional and gracefully ignores them if they are not one of the known mediatypes.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->
Renovate’s schema validation enforces acceptance of only a strict subset of manifest media types and raises an error when it encounters an unknown type. This conflicts with the [OCI Image Index specification](https://github.com/opencontainers/image-spec/blob/main/image-index.md), which states:
> An encountered mediaType that is unknown to the implementation MUST NOT generate an error.

This cause Renovate to not be able to parse metadata of images and render e.g. the sourceUrl for these images.

Fixes #35949

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

Before: 
![grafik](https://github.com/user-attachments/assets/69c6df41-9e99-434c-b4f9-4dcbe1707eb0)


After:
<img width="945" alt="grafik" src="https://github.com/user-attachments/assets/7b41f17d-d179-474b-a96f-3773c73de8a2" />


<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
