### PR TITLE
fix(manager/nuget): deduplicate registryUrls

### DIFF
--- a/lib/modules/manager/nuget/util.spec.ts
+++ b/lib/modules/manager/nuget/util.spec.ts
@@ -75,6 +75,27 @@ describe('modules/manager/nuget/util', () => {
       ]);
     });
 
+    it('deduplicates registries', async () => {
+      fs.findUpLocal.mockResolvedValue('NuGet.config');
+      fs.readLocalFile.mockResolvedValueOnce(
+        codeBlock`
+          <?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+  </packageSources>
+</configuration>`,
+      );
+
+      const registries = await getConfiguredRegistries('NuGet.config');
+      expect(registries).toEqual([
+        {
+          name: 'nuget.org',
+          url: 'https://api.nuget.org/v3/index.json#protocolVersion=3',
+        },
+      ]);
+    });
+
     it('reads nuget config file with default registry', async () => {
       fs.findUpLocal.mockResolvedValue('NuGet.config');
       fs.readLocalFile.mockResolvedValueOnce(

--- a/lib/modules/manager/nuget/util.ts
+++ b/lib/modules/manager/nuget/util.ts
@@ -142,12 +142,18 @@ export async function getConfiguredRegistries(
   }
 
   // Deduplicate registries
-  const registryUrls = registries.map((r) => r.url);
-  registries = registries.filter(
-    (r) =>
-      !registryUrls.includes(r.url + '#protocolVersion=2') &&
-      !registryUrls.includes(r.url + '#protocolVersion=3'),
+  const registryUrlsWithSourceMappings = registries.map(
+    (r) => r.sourceMappedPackagePatterns + r.url,
   );
+  registries = registries.filter((r) => {
+    const lookupKey = r.sourceMappedPackagePatterns + r.url;
+    return (
+      !registryUrlsWithSourceMappings.includes(
+        lookupKey + '#protocolVersion=2',
+      ) &&
+      !registryUrlsWithSourceMappings.includes(lookupKey + '#protocolVersion=3')
+    );
+  });
 
   return registries;
 }

--- a/lib/modules/manager/nuget/util.ts
+++ b/lib/modules/manager/nuget/util.ts
@@ -146,12 +146,8 @@ export async function getConfiguredRegistries(
     (r) => r.sourceMappedPackagePatterns + r.url,
   );
   registries = registries.filter((r) => {
-    const lookupKey = r.sourceMappedPackagePatterns + r.url;
-    return (
-      !registryUrlsWithSourceMappings.includes(
-        lookupKey + '#protocolVersion=2',
-      ) &&
-      !registryUrlsWithSourceMappings.includes(lookupKey + '#protocolVersion=3')
+    return !registryUrlsWithSourceMappings.includes(
+      r.sourceMappedPackagePatterns + r.url + '#protocolVersion=3',
     );
   });
 

--- a/lib/modules/manager/nuget/util.ts
+++ b/lib/modules/manager/nuget/util.ts
@@ -145,7 +145,7 @@ export async function getConfiguredRegistries(
   // Keep any which include sourceMappedPackagePatterns
   const plainRegistryUrls = registries
     .filter((r) => !r.sourceMappedPackagePatterns)
-    .map((r) => `${r.url}`);
+    .map((r) => r.url);
   registries = registries.filter((r) => {
     return (
       r.sourceMappedPackagePatterns ??

--- a/lib/modules/manager/nuget/util.ts
+++ b/lib/modules/manager/nuget/util.ts
@@ -148,7 +148,7 @@ export async function getConfiguredRegistries(
     .map((r) => `${r.url}`);
   registries = registries.filter((r) => {
     return (
-      r.sourceMappedPackagePatterns ||
+      r.sourceMappedPackagePatterns ??
       !plainRegistryUrls.includes(`${r.url}#protocolVersion=3`)
     );
   });

--- a/lib/modules/manager/nuget/util.ts
+++ b/lib/modules/manager/nuget/util.ts
@@ -141,6 +141,14 @@ export async function getConfiguredRegistries(
     }
   }
 
+  // Deduplicate registries
+  const registryUrls = registries.map((r) => r.url);
+  registries = registries.filter(
+    (r) =>
+      !registryUrls.includes(r.url + '#protocolVersion=2') &&
+      !registryUrls.includes(r.url + '#protocolVersion=3'),
+  );
+
   return registries;
 }
 

--- a/lib/modules/manager/nuget/util.ts
+++ b/lib/modules/manager/nuget/util.ts
@@ -141,13 +141,15 @@ export async function getConfiguredRegistries(
     }
   }
 
-  // Deduplicate registries
-  const registryUrlsWithSourceMappings = registries.map(
-    (r) => r.sourceMappedPackagePatterns + r.url,
-  );
+  // Deduplicate registries with #procolVersion=3
+  // Keep any which include sourceMappedPackagePatterns
+  const plainRegistryUrls = registries
+    .filter((r) => !r.sourceMappedPackagePatterns)
+    .map((r) => `${r.url}`);
   registries = registries.filter((r) => {
-    return !registryUrlsWithSourceMappings.includes(
-      r.sourceMappedPackagePatterns + r.url + '#protocolVersion=3',
+    return (
+      r.sourceMappedPackagePatterns ||
+      !plainRegistryUrls.includes(`${r.url}#protocolVersion=3`)
     );
   });
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds a deduplication step in nuget's registry detection to avoid having essentially identical registryUrls together due to protocolVersion.

## Context

This otherwise results in duplicate lookups.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
