### PR TITLE
fix(manager/composer): update default registry url.

### DIFF
--- a/lib/modules/manager/composer/extract.spec.ts
+++ b/lib/modules/manager/composer/extract.spec.ts
@@ -195,7 +195,7 @@ describe('modules/manager/composer/extract', () => {
             registryUrls: [
               'https://wpackagist.org',
               'https://gitlab.vendor.com/api/v4/group/2/-/packages/composer',
-              'https://packagist.org',
+              'https://repo.packagist.org',
             ],
           },
           {
@@ -255,7 +255,10 @@ describe('modules/manager/composer/extract', () => {
             datasource: 'packagist',
             depName: 'aws/aws-sdk-php',
             depType: 'require',
-            registryUrls: ['https://wpackagist.org', 'https://packagist.org'],
+            registryUrls: [
+              'https://wpackagist.org',
+              'https://repo.packagist.org',
+            ],
           },
           {
             currentValue: 'dev-trunk',

--- a/lib/modules/manager/composer/schema.spec.ts
+++ b/lib/modules/manager/composer/schema.spec.ts
@@ -78,7 +78,7 @@ describe('modules/manager/composer/schema', () => {
         pathRepos: {
           somePath: { name: 'somePath', type: 'path', url: '/some/path' },
         },
-        registryUrls: ['https://wpackagist.org', 'https://packagist.org'],
+        registryUrls: ['https://wpackagist.org', 'https://repo.packagist.org'],
         gitRepos: {
           someGit: {
             name: 'someGit',

--- a/lib/modules/manager/composer/schema.ts
+++ b/lib/modules/manager/composer/schema.ts
@@ -151,7 +151,7 @@ export const Repos = z
     }
 
     if (packagist && repoUrls.length) {
-      repoUrls.push('https://packagist.org');
+      repoUrls.push('https://repo.packagist.org');
     }
     const registryUrls = repoUrls.length ? repoUrls : null;
 

--- a/lib/workers/repository/process/lookup/index.spec.ts
+++ b/lib/workers/repository/process/lookup/index.spec.ts
@@ -3580,10 +3580,12 @@ describe('workers/repository/process/lookup/index', () => {
       config.datasource = PackagistDatasource.id;
       config.packageFile = 'composer.json';
       config.currentValue = '1.0.0';
-      config.registryUrls = ['https://packagist.org'];
+      config.registryUrls = ['https://repo.packagist.org'];
       httpMock
-        .scope('https://packagist.org')
-        .get('/packages/foo/bar.json')
+        .scope('https://repo.packagist.org')
+        .get('/packages.json')
+        .reply(200, { 'metadata-url': '/p2/%package%.json' })
+        .get('/p2/foo/bar.json')
         .reply(404);
 
       const { updates } = await Result.wrap(


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
ref https://github.com/renovatebot/renovate/pull/34595
I have updated the other locations with this PR. In particular, it fixes the fallback registry URL if you have specified a private repository.

Note:
The test in [`lib/workers/repository/process/lookup/index.spec.ts`](https://github.com/renovatebot/renovate/pull/36002/files#diff-1c526155c924f563903b975fc441921419421277013c7d2b504a50b4f6eeed8cL3578-L3594) has “worked” both with and without my changes, so I'm not sure if this is testing anything at all?

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->
This should fix the Problem described https://github.com/renovatebot/renovate/discussions/35746 and https://github.com/renovatebot/renovate/discussions/35975.

If a user-defined repository was specified, `https://packagist.org` was previously used as a fallback, but `https://repo.packagist.org` would be correct.

Example:
`composer.json`:
```json
{
  "require": {
    "php": "^8.2"
  },
  "require-dev": {
    "phpstan/phpstan": "^2.1.12"
  },
  "repositories": {
    "example.com/4": {
      "type": "composer",
      "url": "https://example.com/-/packages/composer/packages.json"
    }
  }
}
```
`renovate.json`:
```json
{
  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
    "extends": [
      "config:recommended"
    ],
    "packageRules": [
      {
        "matchPackageNames": [
          "phpstan/phpstan"
        ],
        "rangeStrategy": "bump"
      }
    ]
}
```
without this fix:
```json
DEBUG: packageFiles with updates (repository=local)
       "config": {
         "composer": [
           {
             "deps": [
               {
                 "depType": "require",
                 "depName": "php",
                 "currentValue": "^8.2",
                 "datasource": "github-tags",
                 "packageName": "containerbase/php-prebuild",
                 "skipReason": "github-token-required",
                 "updates": []
               },
               {
                 "depType": "require-dev",
                 "depName": "phpstan/phpstan",
                 "currentValue": "^2.1.12",
                 "datasource": "packagist",
                 "registryUrls": [
                   "https://example.com/-/packages/composer",
                   "https://packagist.org"
                 ],
                 "updates": [],
                 "packageName": "phpstan/phpstan",
                 "versioning": "composer",
                 "warnings": [],
                 "sourceUrl": "https://github.com/phpstan/phpstan",
                 "registryUrl": "https://packagist.org",
                 "currentVersion": "2.1.12",
                 "currentVersionTimestamp": "2025-04-16T13:19:18.000Z",
                 "currentVersionAgeInDays": 31
               }
             ],
             "extractedConstraints": {"php": "^8.2"},
             "packageFile": "composer.json"
           }
         ]
       }
```

with this fix (notice the `updates` for `phpstan/phpstan`):
```json
DEBUG: packageFiles with updates (repository=local)
       "config": {
         "composer": [
           {
             "deps": [
               {
                 "depType": "require",
                 "depName": "php",
                 "currentValue": "^8.2",
                 "datasource": "github-tags",
                 "packageName": "containerbase/php-prebuild",
                 "skipReason": "github-token-required",
                 "updates": []
               },
               {
                 "depType": "require-dev",
                 "depName": "phpstan/phpstan",
                 "currentValue": "^2.1.12",
                 "datasource": "packagist",
                 "registryUrls": [
                   "https://example.com/-/packages/composer",
                   "https://repo.packagist.org"
                 ],
                 "updates": [
                   {
                     "bucket": "non-major",
                     "newVersion": "2.1.16",
                     "newValue": "^2.1.16",
                     "releaseTimestamp": "2025-05-16T09:40:10.000Z",
                     "newVersionAgeInDays": 1,
                     "newMajor": 2,
                     "newMinor": 1,
                     "newPatch": 16,
                     "updateType": "patch",
                     "isBreaking": false,
                     "isRange": true,
                     "isBump": true,
                     "libYears": 0.08177486047691528,
                     "branchName": "renovate/phpstan-packages"
                   }
                 ],
                 "packageName": "phpstan/phpstan",
                 "versioning": "composer",
                 "warnings": [],
                 "sourceUrl": "https://github.com/phpstan/phpstan",
                 "registryUrl": "https://repo.packagist.org",
                 "currentVersion": "2.1.12",
                 "currentVersionTimestamp": "2025-04-16T13:19:18.000Z",
                 "currentVersionAgeInDays": 31,
                 "isSingleVersion": false
               }
             ],
             "extractedConstraints": {"php": "^8.2"},
             "packageFile": "composer.json"
           }
         ]
       }
```

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
