### PR TITLE
feat: Introduce data files for post-upgrade commands

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -3708,7 +3708,7 @@ e.g.
 }
 ```
 
-The `postUpgradeTasks` configuration consists of three fields:
+The `postUpgradeTasks` configuration consists of four fields:
 
 ### commands
 
@@ -3720,6 +3720,44 @@ They will be compiled _prior_ to the comparison against [`allowedCommands`](./se
 <!-- prettier-ignore -->
 !!! note
     Do not use `git add` in your commands to add new files to be tracked, add them by including them in your [`fileFilters`](#filefilters) instead.
+
+### dataFiles
+
+A list of additional data files for the commands.
+The primary purpose of the data files is to store some update information in a file which would be consumed from a post-upgrade command.
+This is particulary useful if a post-upgrade command need to have a long line of arguments.
+Example:
+
+```json
+{
+  "postUpgradeTasks": {
+    "commands": ["my-script.py --data update-data.json"],
+    "dataFiles": [
+      {
+        "path": "update-data.json",
+        "template": "[{{#each upgrades}}{\"depName\": \"{{{depName}}}\", \"currentValue\": \"{{{currentValue}}}\", \"newValue\": \"{{{newValue}}}\"}{{#unless @last}},{{\/unless}}{{\/each}}]"
+      }
+    ],
+    "executionMode": "branch"
+  }
+}
+```
+
+<!-- prettier-ignore -->
+!!! note
+   `dataFiles` are ignored if there is no `commands` configured.
+
+Each data file configuration consists of two fields:
+
+#### path
+
+Path to the data file including the file name.
+If the path is relative, e.g. `data.json`, then it will be evaluated against git repository root directory.
+
+#### template
+
+A template from which data file content is created.
+The template format is identical to the one in `commands`.
 
 ### executionMode
 

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -173,6 +173,34 @@ const options: RenovateOptions[] = [
     cli: false,
   },
   {
+    name: 'dataFiles',
+    description:
+      'A list of data files to be created from specified template for post-upgrade commands that are executed before a commit is made by Renovate.',
+    type: 'array',
+    subType: 'object',
+    parents: ['postUpgradeTasks'],
+    default: [],
+    cli: false,
+  },
+  {
+    name: 'path',
+    description:
+      'Path where this data file for post-upgrade commands should be created.',
+    type: 'string',
+    parents: ['dataFiles'],
+    default: '',
+    cli: false,
+  },
+  {
+    name: 'template',
+    description:
+      'A template from which data file for post-upgrade commands should be created. Format is the same as in commands.',
+    type: 'string',
+    parents: ['dataFiles'],
+    default: '',
+    cli: false,
+  },
+  {
     name: 'fileFilters',
     description:
       'Files that match the glob pattern will be committed after running a post-upgrade task.',

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -192,8 +192,14 @@ export interface LegacyAdminConfig {
 
 export type ExecutionMode = 'branch' | 'update';
 
+export interface DataFile {
+  path: string;
+  template: string;
+}
+
 export interface PostUpgradeTasks {
   commands?: string[];
+  dataFiles?: DataFile[];
   fileFilters?: string[];
   executionMode: ExecutionMode;
 }
@@ -405,6 +411,7 @@ export type AllowedParents =
   | 'bumpVersions'
   | 'customDatasources'
   | 'customManagers'
+  | 'dataFiles'
   | 'hostRules'
   | 'logLevelRemap'
   | 'packageRules'


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Introduce data files for post-upgrade commands.
Data files are created using the same template as the commands.
Example configuration:
```json
{
  "postUpgradeTasks": {
    "commands": ["my-script.py --data update-data.json"],
    "dataFiles": [
      {
        "path": "update-data.json",
        "template": "[{{#each upgrades}}{\"depName\": \"{{{depName}}}\", \"currentValue\": \"{{{currentValue}}}\", \"newValue\": \"{{{newValue}}}\"}{{#unless @last}},{{\/unless}}{{\/each}}]"
      }
    ],
    "executionMode": "branch"
  }
}
```

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

Sometimes, post-upgrade commands need to have information about changed by renovate dependencies in order to perform required custom actions. Currently, the only way of achieving that is to configure the post-upgrade command like:
```
my-script.py --data '[{{#each upgrades}}{\"depName\": \"{{{depName}}}\", \"currentValue\": \"{{{currentValue}}}\", \"newValue\": \"{{{newValue}}}\"}{{#unless @last}},{{\/unless}}{{\/each}}]'
```
However, when there are a lot of updates are made by renovate, the template is expanded into a very long line which could exceed the maximum allowed command length and renovate will fail to run post-upgrade command (`spawn E2BIG` in case of Linux host).

To overcome the above problem, this PR introduces data files for post-upgrade commands.
Also, transferring such a big data chunk as an argument(s) doesn't look right and the commands list looks more neat when using a file.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
