### PR TITLE
fix(helm): helm login should not use host path

### DIFF
--- a/lib/modules/manager/helmfile/utils.ts
+++ b/lib/modules/manager/helmfile/utils.ts
@@ -47,5 +47,5 @@ export async function generateRegistryLoginCmd(
     }),
   };
 
-  return await generateLoginCmd(repositoryRule, 'helm registry login');
+  return await generateLoginCmd(repositoryRule);
 }

--- a/lib/modules/manager/helmv3/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/modules/manager/helmv3/__snapshots__/artifacts.spec.ts.snap
@@ -123,7 +123,7 @@ exports[`modules/manager/helmv3/artifacts > do not add registryAliases to reposi
 exports[`modules/manager/helmv3/artifacts > log into private registries and repositories NOT defined in registryAliases 1`] = `
 [
   {
-    "cmd": "helm registry login --username registryUser --password password registry.gitlab.com/user/oci-helm-test",
+    "cmd": "helm registry login --username registryUser --password password registry.gitlab.com",
     "options": {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",
@@ -194,7 +194,7 @@ exports[`modules/manager/helmv3/artifacts > log into private registries and repo
 exports[`modules/manager/helmv3/artifacts > log into private registries and repositories already defined in registryAliases 1`] = `
 [
   {
-    "cmd": "helm registry login --username test --password aPassword registry.example.com/organization",
+    "cmd": "helm registry login --username test --password aPassword registry.example.com",
     "options": {
       "cwd": "/tmp/github/some/repo",
       "encoding": "utf-8",

--- a/lib/modules/manager/helmv3/artifacts.ts
+++ b/lib/modules/manager/helmv3/artifacts.ts
@@ -48,7 +48,7 @@ async function helmCommands(
 
   // if credentials for the registry have been found, log into it
   await pMap(registries, async (value) => {
-    const loginCmd = await generateLoginCmd(value, 'helm registry login');
+    const loginCmd = await generateLoginCmd(value);
     if (loginCmd) {
       cmd.push(loginCmd);
     }

--- a/lib/modules/manager/helmv3/common.spec.ts
+++ b/lib/modules/manager/helmv3/common.spec.ts
@@ -1,7 +1,7 @@
 import { generateLoginCmd } from './common';
-import { RepositoryRule } from './types';
+import type { RepositoryRule } from './types';
 
-describe('generateLoginCmd', () => {
+describe('modules/manager/helmv3/common', () => {
   it('should generate a login command with username and password', async () => {
     const repositoryRule: RepositoryRule = {
       name: 'test-repo',

--- a/lib/modules/manager/helmv3/common.spec.ts
+++ b/lib/modules/manager/helmv3/common.spec.ts
@@ -12,8 +12,7 @@ describe('generateLoginCmd', () => {
         password: 'testpass',
       },
     };
-    const command = 'helm registry login';
-    expect(await generateLoginCmd(repositoryRule, command)).toEqual(
+    expect(await generateLoginCmd(repositoryRule)).toEqual(
       'helm registry login --username testuser --password testpass example.com',
     );
   });

--- a/lib/modules/manager/helmv3/common.spec.ts
+++ b/lib/modules/manager/helmv3/common.spec.ts
@@ -1,0 +1,20 @@
+import { generateLoginCmd } from './common';
+import { RepositoryRule } from './types';
+
+describe('generateLoginCmd', () => {
+  it('should generate a login command with username and password', async () => {
+    const repositoryRule: RepositoryRule = {
+      name: 'test-repo',
+      repository: 'example.com/repo',
+      hostRule: {
+        hostType: 'docker',
+        username: 'testuser',
+        password: 'testpass',
+      },
+    };
+    const command = 'helm registry login';
+    expect(await generateLoginCmd(repositoryRule, command)).toEqual(
+      'helm registry login --username testuser --password testpass example.com',
+    );
+  });
+});

--- a/lib/modules/manager/helmv3/common.ts
+++ b/lib/modules/manager/helmv3/common.ts
@@ -12,14 +12,11 @@ import type { RepositoryRule } from './types';
 
 export async function generateLoginCmd(
   repositoryRule: RepositoryRule,
-  loginCMD: string,
 ): Promise<string | null> {
-  logger.trace(
-    { repositoryRule, loginCMD },
-    'Generating Helm registry login command',
-  );
+  logger.trace({ repositoryRule }, 'Generating Helm registry login command');
   const { hostRule, repository } = repositoryRule;
   const { username, password } = hostRule;
+  const loginCMD = 'helm registry login';
   if (username !== 'AWS' && ecrRegex.test(repository)) {
     logger.trace({ repository }, `Using ecr auth for Helm registry`);
     const [, region] = coerceArray(ecrRegex.exec(repository));
@@ -39,7 +36,7 @@ export async function generateLoginCmd(
   }
   if (username && password) {
     logger.trace({ repository }, `Using basic auth for Helm registry`);
-    // Split off any path as it's not needed for the login command
+    // Split off any path as it's not valid for the helm registry login command
     const hostPart = repository.split('/')[0];
     const cmd = `${loginCMD} --username ${quote(username)} --password ${quote(
       password,

--- a/lib/modules/manager/helmv3/common.ts
+++ b/lib/modules/manager/helmv3/common.ts
@@ -14,6 +14,10 @@ export async function generateLoginCmd(
   repositoryRule: RepositoryRule,
   loginCMD: string,
 ): Promise<string | null> {
+  logger.trace(
+    { repositoryRule, loginCMD },
+    'Generating Helm registry login command',
+  );
   const { hostRule, repository } = repositoryRule;
   const { username, password } = hostRule;
   if (username !== 'AWS' && ecrRegex.test(repository)) {
@@ -35,9 +39,13 @@ export async function generateLoginCmd(
   }
   if (username && password) {
     logger.trace({ repository }, `Using basic auth for Helm registry`);
-    return `${loginCMD} --username ${quote(username)} --password ${quote(
+    // Split off any path as it's not needed for the login command
+    const hostPart = repository.split('/')[0];
+    const cmd = `${loginCMD} --username ${quote(username)} --password ${quote(
       password,
-    )} ${repository}`;
+    )} ${hostPart}`;
+    logger.trace({ cmd }, 'Generated Helm registry login command');
+    return cmd;
   }
   return null;
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Strips path part from host for "helm login"

## Context

- #36052

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
