### PR TITLE
fix(gradle): include registryType and content during registry deduplication

### DIFF
--- a/lib/modules/manager/gradle/extract.spec.ts
+++ b/lib/modules/manager/gradle/extract.spec.ts
@@ -753,6 +753,70 @@ describe('modules/manager/gradle/extract', () => {
         },
       ]);
     });
+
+    it('exclusiveContent with repeated repository definition', async () => {
+      const fsMock = {
+        'build.gradle': codeBlock`
+          repositories {
+            google()
+            exclusiveContent {
+              forRepository {
+                maven {
+                  url "https://artifactory.foo.bar/artifactory/test"
+                }
+              }
+              filter {
+                includeGroup "some.dll"
+              }
+            }
+            exclusiveContent {
+              forRepository {
+                maven {
+                  url "https://artifactory.foo.bar/artifactory/test"
+                }
+              }
+              filter {
+                includeGroup "foo.bar"
+              }
+            }
+          }
+
+          dependencies {
+            implementation "com.google.protobuf:protobuf-java:2.17.1"
+            implementation "foo.bar:protobuf-java:2.17.0"
+            implementation "some.dll:dll-1:1.0.0"
+          }
+        `,
+      };
+      mockFs(fsMock);
+
+      const res = await extractAllPackageFiles(
+        partial<ExtractConfig>(),
+        Object.keys(fsMock),
+      );
+
+      expect(res).toMatchObject([
+        {
+          deps: [
+            {
+              depName: 'com.google.protobuf:protobuf-java',
+              currentValue: '2.17.1',
+              registryUrls: ['https://dl.google.com/android/maven2/'],
+            },
+            {
+              depName: 'foo.bar:protobuf-java',
+              currentValue: '2.17.0',
+              registryUrls: ['https://artifactory.foo.bar/artifactory/test'],
+            },
+            {
+              depName: 'some.dll:dll-1',
+              currentValue: '1.0.0',
+              registryUrls: ['https://artifactory.foo.bar/artifactory/test'],
+            },
+          ],
+        },
+      ]);
+    });
   });
 
   describe('version catalogs', () => {

--- a/lib/modules/manager/gradle/extract.ts
+++ b/lib/modules/manager/gradle/extract.ts
@@ -40,7 +40,10 @@ function updatePackageRegistries(
   for (const url of urls) {
     const registryAlreadyKnown = packageRegistries.some(
       (item) =>
-        item.registryUrl === url.registryUrl && item.scope === url.scope,
+        item.registryUrl === url.registryUrl &&
+        item.scope === url.scope &&
+        item.registryType === url.registryType &&
+        item.content === url.content,
     );
     if (!registryAlreadyKnown) {
       packageRegistries.push(url);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds `registryType` and `content` to the comparison criteria while collecting gradle repository definitions. 

This impacts how registry deduplication works for `exclusiveContent { .... }` definitions with registries being defined multiple times but each with different `content` blocks. Until now, only the first seen definition was recorded and further `content` blocks were mistakenly ignored.

Thx to @patrick-dedication for the test-case.

<!-- Describe what behavior is changed by this PR. -->

## Context

- https://github.com/renovatebot/renovate/pull/35421#issuecomment-2841980462

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
