### PR TITLE
chore: fix lint

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -217,8 +217,9 @@ jobs:
         uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: .cache/eslint
-          key: eslint-cache
-          restore-keys: eslint-cache-
+          # we need to add the hash because eslint cache doesn't detect plugin changes
+          key: eslint-cache-${{ hashFiles('pnpm-lock.yaml', 'package.json') }}
+          restore-keys: eslint-cache-${{ hashFiles('pnpm-lock.yaml', 'package.json') }}-
 
       - name: Lint
         run: pnpm eslint-ci
@@ -228,7 +229,7 @@ jobs:
         uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: .cache/eslint
-          key: eslint-cache-${{ github.run_id }}-${{ github.run_attempt }}
+          key: eslint-cache-${{ hashFiles('pnpm-lock.yaml', 'package.json') }}-${{ github.run_id }}-${{ github.run_attempt }}
 
   lint-prettier:
     needs:
@@ -252,8 +253,9 @@ jobs:
         uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: .cache/prettier
-          key: prettier-cache
-          restore-keys: prettier-cache-
+          # we need to add the hash because prettier cache doesn't detect plugin changes
+          key: prettier-cache-${{ hashFiles('pnpm-lock.yaml', 'package.json') }}
+          restore-keys: prettier-cache-${{ hashFiles('pnpm-lock.yaml', 'package.json') }}-
 
       - name: Lint
         run: |
@@ -269,7 +271,7 @@ jobs:
         uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: .cache/prettier
-          key: prettier-cache-${{ github.run_id }}-${{ github.run_attempt }}
+          key: prettier-cache-${{ hashFiles('pnpm-lock.yaml', 'package.json') }}-${{ github.run_id }}-${{ github.run_attempt }}
 
   lint-docs:
     needs:

--- a/lib/logger/once.ts
+++ b/lib/logger/once.ts
@@ -12,6 +12,8 @@ type OmitFn = (...args: any[]) => any;
  */
 function getCallSite(omitFn: OmitFn): string | null {
   const stackTraceLimitOrig = Error.stackTraceLimit;
+  // We don't use `Error.captureStackTrace` directly, we simply restore it later.
+  // eslint-disable-next-line @typescript-eslint/unbound-method
   const prepareStackTraceOrig = Error.prepareStackTrace;
 
   let result: string | null = null;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Intentionally ignore this error, because we only use it to restore the original function.
Sadly this error doesn't occure on CI because of caching.
The prettier and eslint cache keys now depend on `package.json` and `pnpm-lock.yaml` to avoid undetected eslint errors.
<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
