### PR TITLE
feat: add `replace` method for `useBaseBranch` option

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -1384,6 +1384,10 @@ The description field can be used inside any configuration object to add a human
 A description field embedded within a preset is also collated as part of the onboarding description unless the preset only consists of presets itself.
 Presets which consist only of other presets have their own description omitted from the onboarding description because they will be fully described by the preset descriptions within.
 
+## detectBaseBranchConfigFileName
+
+Set this option to true if the config file name in the base branches is different to the config file name in the default branch.
+
 ## digest
 
 Add to this object if you wish to define rules that apply only to PRs that update digests.
@@ -4361,8 +4365,9 @@ You can set this option to `false` if you wish to disable updating for pinned (s
 
 By default, Renovate will read config file from the default branch only and will ignore any config files in base branches.
 You can configure `useBaseBranchConfig=merge` to instruct Renovate to merge the config from each base branch over the top of the config in the default branch.
+You can also configure `useBaseBranchConfig=replace` to instruct Renovate to use the config from each base branch as is and not use the config in the default branch.
 
-The config file name in the base branch must be the same as in the default branch and cannot be `package.json`.
+By default, the config file name in the base branch must be the same as in the default branch and cannot be `package.json`. To allow a different config file name in the base branches, use the `detectBaseBranchConfigFileName` option.
 This scenario may be useful for testing the config changes in base branches instantly.
 
 ## userStrings

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -1074,8 +1074,15 @@ const options: RenovateOptions[] = [
     description:
       'Whether to read configuration from `baseBranches` instead of only the default branch.',
     type: 'string',
-    allowedValues: ['merge', 'none'],
+    allowedValues: ['merge', 'replace', 'none'],
     default: 'none',
+  },
+  {
+    name: 'detectBaseBranchConfigFileName',
+    description:
+      'Whether to detect the configuration file name on a base branch using the same logic that is used to detect the configuration file on the default branch.',
+    type: 'boolean',
+    default: false,
   },
   {
     name: 'gitAuthor',

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -209,7 +209,7 @@ export type RenovateRepository =
       secrets?: Record<string, string>;
     };
 
-export type UseBaseBranchConfigType = 'merge' | 'none';
+export type UseBaseBranchConfigType = 'merge' | 'replace' | 'none';
 export type ConstraintsFilter = 'strict' | 'none';
 
 export const allowedStatusCheckStrings = [
@@ -236,6 +236,7 @@ export interface RenovateConfig
   baseBranches?: string[];
   commitBody?: string;
   useBaseBranchConfig?: UseBaseBranchConfigType;
+  detectBaseBranchConfigFileName?: boolean;
   baseBranch?: string;
   defaultBranch?: string;
   branchList?: string[];

--- a/lib/workers/global/config/parse/__fixtures__/with-pr-title.js
+++ b/lib/workers/global/config/parse/__fixtures__/with-pr-title.js
@@ -1,0 +1,4 @@
+// @ts-ignore
+module.exports = {
+  prTitle: 'pr title',
+};

--- a/lib/workers/global/config/parse/index.ts
+++ b/lib/workers/global/config/parse/index.ts
@@ -38,11 +38,19 @@ export async function parseConfigs(
   env: NodeJS.ProcessEnv,
   argv: string[],
 ): Promise<AllConfig> {
+  const fileConfig = await fileParser.getConfig(env);
+  return await parseConfigsUsingFile(env, argv, fileConfig);
+}
+
+export async function parseConfigsUsingFile(
+  env: NodeJS.ProcessEnv,
+  argv: string[],
+  fileConfig: AllConfig,
+): Promise<AllConfig> {
   logger.debug('Parsing configs');
 
   // Get configs
   const defaultConfig = defaultsParser.getConfig();
-  const fileConfig = await fileParser.getConfig(env);
   const cliConfig = cliParser.getConfig(argv);
   const envConfig = await envParser.getConfig(env);
 

--- a/lib/workers/repository/init/index.ts
+++ b/lib/workers/repository/init/index.ts
@@ -16,7 +16,7 @@ import { initializeCaches, resetCaches } from './cache';
 import { getRepoConfig } from './config';
 import { detectVulnerabilityAlerts } from './vulnerability';
 
-function initializeConfig(config: RenovateConfig): RenovateConfig {
+export function initializeConfig(config: RenovateConfig): RenovateConfig {
   return {
     ...clone(config),
     errors: [],

--- a/lib/workers/repository/process/index.spec.ts
+++ b/lib/workers/repository/process/index.spec.ts
@@ -1,8 +1,10 @@
+import { configFileNames } from '../../../config/app-strings';
 import { getConfig } from '../../../config/defaults';
 import { GlobalConfig } from '../../../config/global';
 import { CONFIG_VALIDATION } from '../../../constants/error-messages';
 import { addMeta } from '../../../logger';
 import { getCache } from '../../../util/cache/repository';
+import * as _vulnerability from '../init/vulnerability';
 import * as _extractUpdate from './extract-update';
 import { lookup } from './extract-update';
 import { extractDependencies, updateRepo } from '.';
@@ -10,13 +12,17 @@ import { git, logger, platform, scm } from '~test/util';
 import type { RenovateConfig } from '~test/util';
 
 vi.mock('./extract-update');
+vi.mock('../init/vulnerability');
 
 const extract = vi.mocked(_extractUpdate).extract;
+const detectVulnerabilityAlerts =
+  vi.mocked(_vulnerability).detectVulnerabilityAlerts;
 
 let config: RenovateConfig;
 
 beforeEach(() => {
   config = getConfig();
+  detectVulnerabilityAlerts.mockImplementation((x) => Promise.resolve(x));
 });
 
 describe('workers/repository/process/index', () => {
@@ -61,13 +67,18 @@ describe('workers/repository/process/index', () => {
       );
     });
 
-    it('reads config from branches in baseBranches if useBaseBranchConfig specified', async () => {
+    it('reads config from branches in baseBranches if useBaseBranchConfig="merge"', async () => {
       scm.branchExists.mockResolvedValue(true);
       platform.getJsonFile = vi
         .fn()
-        .mockResolvedValue({ extends: [':approveMajorUpdates'] });
+        .mockResolvedValueOnce({ addLabels: ['a'] })
+        .mockResolvedValueOnce({ addLabels: ['b'] })
+        .mockResolvedValueOnce({ addLabels: ['a'] })
+        .mockResolvedValueOnce({ addLabels: ['b'] });
       config.baseBranches = ['master', 'dev'];
       config.useBaseBranchConfig = 'merge';
+      config.repository = 'renovate-test';
+      config.addLabels = ['x'];
       getCache().configFileName = 'renovate.json';
       const res = await extractDependencies(config);
       expect(res).toEqual({
@@ -77,14 +88,24 @@ describe('workers/repository/process/index', () => {
       });
       expect(platform.getJsonFile).toHaveBeenCalledWith(
         'renovate.json',
-        undefined,
+        'renovate-test',
         'dev',
       );
       expect(addMeta).toHaveBeenNthCalledWith(1, { baseBranch: 'master' });
       expect(addMeta).toHaveBeenNthCalledWith(2, { baseBranch: 'dev' });
+      expect(extract).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ addLabels: ['x', 'a'] }),
+        true,
+      );
+      expect(extract).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ addLabels: ['x', 'b'] }),
+        true,
+      );
     });
 
-    it('handles config name mismatch between baseBranches if useBaseBranchConfig specified', async () => {
+    it('handles config name mismatch between baseBranches if useBaseBranchConfig="merge"', async () => {
       scm.branchExists.mockResolvedValue(true);
       platform.getJsonFile = vi
         .fn()
@@ -102,6 +123,220 @@ describe('workers/repository/process/index', () => {
       );
       expect(addMeta).toHaveBeenNthCalledWith(1, { baseBranch: 'master' });
       expect(addMeta).toHaveBeenNthCalledWith(2, { baseBranch: 'dev' });
+    });
+
+    it('reads config from branches in baseBranches if useBaseBranchConfig="replace"', async () => {
+      scm.branchExists.mockResolvedValue(true);
+      platform.getJsonFile = vi
+        .fn()
+        .mockResolvedValueOnce({ addLabels: ['a'] })
+        .mockResolvedValueOnce({ addLabels: ['b'] })
+        .mockResolvedValueOnce({ addLabels: ['a'] })
+        .mockResolvedValueOnce({ addLabels: ['b'] });
+      config.baseBranches = ['one', 'two'];
+      config.useBaseBranchConfig = 'replace';
+      config.repository = 'renovate-test';
+      getCache().configFileName = 'renovate.json';
+      const res = await extractDependencies(config);
+      expect(res).toEqual({
+        branchList: [undefined, undefined],
+        branches: [undefined, undefined],
+        packageFiles: undefined,
+      });
+      expect(platform.getJsonFile).toHaveBeenNthCalledWith(
+        1,
+        'renovate.json',
+        'renovate-test',
+        'one',
+      );
+      expect(platform.getJsonFile).toHaveBeenNthCalledWith(
+        2,
+        'renovate.json',
+        'renovate-test',
+        'two',
+      );
+      expect(addMeta).toHaveBeenNthCalledWith(1, { baseBranch: 'one' });
+      expect(addMeta).toHaveBeenNthCalledWith(2, { baseBranch: 'two' });
+      expect(extract).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ addLabels: ['a'] }),
+        true,
+      );
+      expect(extract).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ addLabels: ['b'] }),
+        true,
+      );
+    });
+
+    it('can detect config file name on base branch when detectBaseBranchConfigFileName=true', async () => {
+      scm.branchExists.mockResolvedValue(true);
+      platform.getJsonFile = vi.fn().mockImplementation((fileName) => {
+        if (fileName === '.renovaterc') {
+          return { addLabels: ['a'] };
+        }
+        throw new Error();
+      });
+      config.baseBranches = ['one'];
+      config.useBaseBranchConfig = 'replace';
+      config.detectBaseBranchConfigFileName = true;
+      config.repository = 'renovate-test';
+      getCache().configFileName = '.gitlab/renovate.json';
+      const res = await extractDependencies(config);
+      expect(res).toEqual({
+        branchList: [undefined],
+        branches: [undefined],
+        packageFiles: undefined,
+      });
+
+      expect(platform.getJsonFile).toHaveBeenCalledWith(
+        'renovate.json',
+        'renovate-test',
+        'one',
+      );
+      expect(platform.getJsonFile).toHaveBeenCalledWith(
+        'renovate.json5',
+        'renovate-test',
+        'one',
+      );
+      expect(platform.getJsonFile).toHaveBeenCalledWith(
+        '.github/renovate.json',
+        'renovate-test',
+        'one',
+      );
+      expect(platform.getJsonFile).toHaveBeenCalledWith(
+        '.github/renovate.json5',
+        'renovate-test',
+        'one',
+      );
+      expect(platform.getJsonFile).toHaveBeenCalledWith(
+        '.gitlab/renovate.json',
+        'renovate-test',
+        'one',
+      );
+      expect(platform.getJsonFile).toHaveBeenCalledWith(
+        '.gitlab/renovate.json5',
+        'renovate-test',
+        'one',
+      );
+      expect(platform.getJsonFile).toHaveBeenCalledWith(
+        '.renovaterc',
+        'renovate-test',
+        'one',
+      );
+      // Found the config file. The remaining possible
+      // config file names should not have been used.
+      expect(platform.getJsonFile).not.toHaveBeenCalledWith(
+        '.renovaterc.json',
+        'renovate-test',
+        'one',
+      );
+      expect(platform.getJsonFile).not.toHaveBeenCalledWith(
+        '.renovaterc.json5',
+        'renovate-test',
+        'one',
+      );
+      expect(platform.getJsonFile).not.toHaveBeenCalledWith(
+        'package.json',
+        'renovate-test',
+        'one',
+      );
+
+      expect(extract).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ addLabels: ['a'] }),
+        true,
+      );
+    });
+
+    it('uses config file name from default branch when base branch config file name is not found and detectBaseBranchConfigFileName=true', async () => {
+      scm.branchExists.mockResolvedValue(true);
+      platform.getJsonFile = vi.fn().mockImplementation((fileName) => {
+        if (fileName === 'use-this-file.json') {
+          return { addLabels: ['a'] };
+        }
+        throw new Error();
+      });
+      config.baseBranches = ['one'];
+      config.useBaseBranchConfig = 'replace';
+      config.detectBaseBranchConfigFileName = true;
+      config.repository = 'renovate-test';
+      getCache().configFileName = 'use-this-file.json';
+      const res = await extractDependencies(config);
+      expect(res).toEqual({
+        branchList: [undefined],
+        branches: [undefined],
+        packageFiles: undefined,
+      });
+
+      for (const configFileName of configFileNames) {
+        // package.json should never be used for base branches.
+        if (configFileName === 'package.json') {
+          expect(platform.getJsonFile).not.toHaveBeenCalledWith(
+            configFileName,
+            'renovate-test',
+            'one',
+          );
+        } else {
+          expect(platform.getJsonFile).toHaveBeenCalledWith(
+            configFileName,
+            'renovate-test',
+            'one',
+          );
+        }
+      }
+      expect(platform.getJsonFile).toHaveBeenCalledWith(
+        'use-this-file.json',
+        'renovate-test',
+        'one',
+      );
+
+      expect(extract).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ addLabels: ['a'] }),
+        true,
+      );
+    });
+
+    it('initializes config and detects vulnerability alerts when useBaseBranchConfig="replace"', async () => {
+      scm.branchExists.mockResolvedValue(true);
+
+      detectVulnerabilityAlerts.mockImplementation((x) =>
+        Promise.resolve({ ...x, remediations: {} }),
+      );
+
+      platform.getJsonFile = vi.fn().mockResolvedValue({ addLabels: ['a'] });
+      config.baseBranches = ['one'];
+      config.useBaseBranchConfig = 'replace';
+      config.repository = 'renovate-test';
+      getCache().configFileName = 'renovate.json';
+      const res = await extractDependencies(config);
+      expect(res).toEqual({
+        branchList: [undefined],
+        branches: [undefined],
+        packageFiles: undefined,
+      });
+      expect(detectVulnerabilityAlerts).toHaveBeenCalledWith(
+        expect.objectContaining({
+          addLabels: ['a'],
+          // These properties should have been added via initialization.
+          errors: [],
+          warnings: [],
+          branchList: [],
+        }),
+      );
+      expect(extract).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({
+          addLabels: ['a'],
+          errors: [],
+          warnings: [],
+          branchList: [],
+          // This property should have been added via the
+          // mocked detectVulnerabilityAlerts function.
+          remediations: {},
+        }),
+        true,
+      );
     });
 
     it('processes baseBranches dryRun extract', async () => {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

#### New `useBaseBranch` method

This adds a `replace` method for the `useBaseBranch` option. When set to `replace`, instead of merging the config from the base branch into the config from the default branch, the config from the base branch is used to create a new config that is used for the "extract" and "lookup" phases.

This proved to be a bit more complicated than I anticipated. We cannot simply _replace_ the config with the one we load from the base branch, because Renovate applies defaults, environment variables and command line arguments to the config that it loads from the default branch. We need to do the same thing to the config that we load from the base branch.

#### Base Branch Config File Name Detection

The discovery of the config from the base branch has also been changed. Previously, the config on the base branch had to have the exact same name as the config from the default branch, which meant you could not test a different type of config file - for example, you might have `renovate.json` on the default branch, but you are changing it to `renovate.json5` and want to test that config before it is merged into the default branch.

To allow this, while also keeping the existing behavior, I've added a new option called `detectBaseBranchConfigFileName`. When this is false or unspecified, the config file name from the default branch is used when looking for the config on the default branch. If a file with that name does not exist on the base branch, then an error occurs.
When the value is true, Renovate will look for each allowed config file name on the base branch. If one of those files is found, that file is used. If none of those files are found, Renovate will fall back to looking for the file name from the default branch.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

- #22264

Also related to:
- #16108
- #19916

The primary goal of these changes is to allow testing config changes without having to first merge them into the default branch. The workflow would be something like this:
1. You already have a config on the default branch, and you want to make changes to it.
2. You create a branch - let's call it `renovate-changes`.
3. You edit the Renovate config on that branch, adding new package rules, editing existing package rules, and so on.
4. You commit the changes on that branch.
5. You run Renovate with these options:
    - `dryRun: true`
    - `baseBranches: ['renovate-changes']`
    - `useBaseBranchConfig: 'replace'`
6. You check the logs to confirm that the changes you made to the config produce the expected results. Iterate through steps 3 to 5 until you are happy with the config changes.
7. Merge the `renovate-changes` branch into the default branch.

No more broken Renovate configs merged to the default branch. 🎉 


## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
