### PR TITLE
feat(presets): Add replacement for `netlify`

### DIFF
--- a/lib/data/replacements.json
+++ b/lib/data/replacements.json
@@ -764,6 +764,18 @@
       }
     ]
   },
+  "netlify-to-scoped": {
+    "description": "The Netlify API client has been renamed to `@netlify/api` (`netlify` is now used by the Netlify CLI).",
+    "packageRules": [
+      {
+        "matchCurrentVersion": ">=13.3.5",
+        "matchDatasources": ["npm"],
+        "matchPackageNames": ["netlify"],
+        "replacementName": "@netlify/api",
+        "replacementVersion": "14.0.1"
+      }
+    ]
+  },
   "now-to-vercel": {
     "description": "`now` was renamed to `vercel`.",
     "packageRules": [


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds a replacement for the `netlify` package, which historically has been used to publish the JavaScript client for the Netlify API. That client is now published as [`@netlify/api`](https://www.npmjs.com/package/@netlify/api) and [`netlify`](https://www.npmjs.com/package/netlify) is used by the Netlify CLI.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
