### PR TITLE
docs: Reviewers are only added during PR/MR creation, but not modified afterwards

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -151,6 +151,9 @@ This option _adds_ to the existing reviewer list, rather than _replacing_ it lik
 Use `additionalReviewers` when you want to add to a preset or base list, without replacing the original.
 For example, when adding focused reviewers for a specific package group.
 
+Please note that Reviewers are only added during creation of a PR, but are not
+modified afterwards.
+
 ## assignAutomerge
 
 By default, Renovate will not assign reviewers and assignees to an automerge-enabled PR unless it fails status checks.
@@ -2372,6 +2375,9 @@ In the case that a user is automatically added as reviewer (such as Renovate App
 }
 ```
 
+Please note that Reviewers are only added during creation of a PR, but are not
+modified afterwards.
+
 ## ignoreScripts
 
 By default, Renovate will disable package manager scripts.
@@ -4158,6 +4164,9 @@ For example: if the username or team name is `bar` then you would set the config
 }
 ```
 
+Please note that Reviewers are only added during creation of a PR, but are not
+modified afterwards.
+
 ## reviewersFromCodeOwners
 
 If enabled Renovate tries to determine PR reviewers by matching rules defined in a CODEOWNERS file against the changes in the PR.
@@ -4167,6 +4176,9 @@ Read the docs for your platform for details on syntax and allowed file locations
 - [GitHub Docs, About code owners](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)
 - [GitLab, Code Owners](https://docs.gitlab.com/ee/user/project/codeowners/)
 - [Bitbucket, Set up and use code owners](https://support.atlassian.com/bitbucket-cloud/docs/set-up-and-use-code-owners/)
+
+Please note that Reviewers are only added during creation of a PR, but are not
+modified afterwards.
 
 <!-- prettier-ignore -->
 !!! note

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -151,8 +151,7 @@ This option _adds_ to the existing reviewer list, rather than _replacing_ it lik
 Use `additionalReviewers` when you want to add to a preset or base list, without replacing the original.
 For example, when adding focused reviewers for a specific package group.
 
-Please note that Reviewers are only added during creation of a PR, but are not
-modified afterwards.
+Please note that Reviewers are only added during creation of a PR, but are not modified afterwards.
 
 ## assignAutomerge
 
@@ -2375,8 +2374,7 @@ In the case that a user is automatically added as reviewer (such as Renovate App
 }
 ```
 
-Please note that Reviewers are only added during creation of a PR, but are not
-modified afterwards.
+Please note that Reviewers are only added during creation of a PR, but are not modified afterwards.
 
 ## ignoreScripts
 
@@ -4164,8 +4162,7 @@ For example: if the username or team name is `bar` then you would set the config
 }
 ```
 
-Please note that Reviewers are only added during creation of a PR, but are not
-modified afterwards.
+Please note that Reviewers are only added during creation of a PR, but are not modified afterwards.
 
 ## reviewersFromCodeOwners
 
@@ -4177,8 +4174,7 @@ Read the docs for your platform for details on syntax and allowed file locations
 - [GitLab, Code Owners](https://docs.gitlab.com/ee/user/project/codeowners/)
 - [Bitbucket, Set up and use code owners](https://support.atlassian.com/bitbucket-cloud/docs/set-up-and-use-code-owners/)
 
-Please note that Reviewers are only added during creation of a PR, but are not
-modified afterwards.
+Please note that Reviewers are only added during creation of a PR, but are not modified afterwards.
 
 <!-- prettier-ignore -->
 !!! note


### PR DESCRIPTION
## Changes

Add a note in the documentation that reviewers are only added during PR/MR creation, but not modified afterwards.

## Context

fixes #34880

## Documentation (please check one with an [x])

- [X] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
- [X] Documentation-only change, no code changes