### PR TITLE
docs(aws-eks-addon): add configuration snippet for sane commit/pr mes…

### DIFF
--- a/lib/modules/datasource/aws-eks-addon/readme.md
+++ b/lib/modules/datasource/aws-eks-addon/readme.md
@@ -69,7 +69,8 @@ Here's an example of using the custom manager to configure this datasource:
 {
   "packageRules": [
     {
-      "matchDatasources": ["aws-eks-addon"]
+      "matchDatasources": ["aws-eks-addon"],
+      "overrideDepName": "{{replace '.*\"addonName\":\"([^\"]+)\".*' '$1' depName}}"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This PR adds a small snippet to the example configuration at https://docs.renovatebot.com/modules/datasource/aws-eks-addon/ that makes the commits, PRs and branch names for `aws-eks-addon`s more readable (read: usable).

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

Because this datasource uses a minified JSON object as `depName` and `depName` is used pretty much everywhere in renovate's PRs, the default names without this snippet are terrible.

To save everyone's time, it should be in the example configuration. I suppose virtually every user of this feature will want to have that snippet (or will spend time building something similar).

Before this change:
![image](https://github.com/user-attachments/assets/7b7f7f85-747b-4064-92b4-2d80ae802563)

After this change:
![image](https://github.com/user-attachments/assets/2f02aea2-891a-44d2-84fc-d5a0a3040e0b)

Functionally, the change uses `overrideDepName` to extract the `addonName` from the minified-JSON `depName`. 

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
