### PR TITLE
fix(git): use custom name for upstream

### DIFF
--- a/lib/modules/platform/default-scm.spec.ts
+++ b/lib/modules/platform/default-scm.spec.ts
@@ -1,3 +1,4 @@
+import { RENOVATE_FORK_UPSTREAM } from '../../util/git';
 import type { CommitFilesConfig, LongCommitSha } from '../../util/git/types';
 import { DefaultGitScm } from './default-scm';
 import { git, partial } from '~test/util';
@@ -78,7 +79,10 @@ describe('modules/platform/default-scm', () => {
   });
 
   it('syncs fork with upstream', async () => {
-    git.getRemotes.mockResolvedValueOnce(['somebranch', 'upstream']);
+    git.getRemotes.mockResolvedValueOnce([
+      'somebranch',
+      RENOVATE_FORK_UPSTREAM,
+    ]);
     await defaultGitScm.syncForkWithUpstream('branchName');
     expect(git.syncForkWithUpstream).toHaveBeenCalledWith('branchName');
   });

--- a/lib/modules/platform/default-scm.ts
+++ b/lib/modules/platform/default-scm.ts
@@ -51,7 +51,7 @@ export class DefaultGitScm implements PlatformScm {
 
   async syncForkWithUpstream(branchName: string): Promise<void> {
     const remotes = await git.getRemotes();
-    if (remotes?.includes('upstream')) {
+    if (remotes?.includes(git.RENOVATE_FORK_UPSTREAM)) {
       await git.syncForkWithUpstream(branchName);
     }
   }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Change hardcoded "upstream" remote name when in fork mode to be a name unlikely to be used elsewhere

## Context

The most likely explanation of #36142 is that there's somehow an `upstream` git remote already in use. This PR changes that to use `renovate-fork-upstream` to eliminate this risk, and also better logging.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
