### PR TITLE
fix(git): remotes sync

### DIFF
--- a/lib/modules/platform/default-scm.spec.ts
+++ b/lib/modules/platform/default-scm.spec.ts
@@ -72,12 +72,6 @@ describe('modules/platform/default-scm', () => {
     expect(git.mergeToLocal).toHaveBeenCalledWith('branchName');
   });
 
-  it('does not sync fork with upstream', async () => {
-    git.getRemotes.mockResolvedValueOnce(['somebranch']);
-    await defaultGitScm.syncForkWithUpstream('branchName');
-    expect(git.syncForkWithUpstream).not.toHaveBeenCalled();
-  });
-
   it('syncs fork with upstream', async () => {
     git.getRemotes.mockResolvedValueOnce([
       'somebranch',

--- a/lib/modules/platform/default-scm.ts
+++ b/lib/modules/platform/default-scm.ts
@@ -49,10 +49,7 @@ export class DefaultGitScm implements PlatformScm {
     return git.mergeToLocal(branchName);
   }
 
-  async syncForkWithUpstream(branchName: string): Promise<void> {
-    const remotes = await git.getRemotes();
-    if (remotes?.includes(git.RENOVATE_FORK_UPSTREAM)) {
-      await git.syncForkWithUpstream(branchName);
-    }
+  syncForkWithUpstream(branchName: string): Promise<void> {
+    return git.syncForkWithUpstream(branchName);
   }
 }

--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -1383,17 +1383,13 @@ describe('util/git/index', { timeout: 10000 }, () => {
       ).rejects.toThrow(TEMPORARY_ERROR);
     });
 
-    it('syncForkWithRemote() - throws error if no upstream exists', async () => {
+    it('syncForkWithRemote() - returns if no upstream exists', async () => {
       await git.initRepo({
         url: origin.path,
         defaultBranch,
       });
 
-      await git.syncGit();
-
-      await expect(git.syncForkWithUpstream(defaultBranch)).rejects.toThrow(
-        'No upstream remote exists, cannot sync fork',
-      );
+      await expect(git.syncForkWithUpstream(defaultBranch)).toResolve();
     });
   });
 });

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -1542,8 +1542,8 @@ export async function getRemotes(): Promise<string[]> {
     const remotes = await git.getRemotes();
     logger.debug(`Found remotes: ${remotes.map((r) => r.name).join(', ')}`);
     return remotes.map((remote) => remote.name);
-  } catch (err) {
+  } catch (err) /* v8 ignore start */ {
     logger.error({ err }, 'Error getting remotes');
     throw err;
-  }
+  } /* v8 ignore stop */
 }

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -1506,7 +1506,7 @@ async function localBranchExists(branchName: string): Promise<boolean> {
  * 5. Force push the (updated) local branch to the origin repository.
  *
  * @param {string} branchName - The name of the branch to synchronize.
- * @returns {Promise<LongCommitSha>} - A promise that resolves to True if the synchronization is successful, or `false` if an error occurs.
+  * @returns A promise that resolves to True if the synchronization is successful, or `false` if an error occurs.
  */
 export async function syncForkWithUpstream(branchName: string): Promise<void> {
   if (!config.upstreamUrl) {

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -1516,6 +1516,7 @@ export async function syncForkWithUpstream(branchName: string): Promise<void> {
     `Synchronizing fork with "${RENOVATE_FORK_UPSTREAM}" remote for branch ${branchName}`,
   );
   const remotes = await getRemotes();
+  /* v8 ignore next 3 -- this should not be possible if upstreamUrl exists */
   if (!remotes.some((r) => r === RENOVATE_FORK_UPSTREAM)) {
     throw new Error('No upstream remote exists, cannot sync fork');
   }
@@ -1528,7 +1529,7 @@ export async function syncForkWithUpstream(branchName: string): Promise<void> {
     }
     await resetHardFromRemote(`${RENOVATE_FORK_UPSTREAM}/${branchName}`);
     await forcePushToRemote(branchName, 'origin');
-  } catch (err) {
+  } catch (err) /* v8 ignore next 3 -- shouldn't happen */ {
     logger.error({ err }, 'Error synchronizing fork');
     throw new Error(UNKNOWN_ERROR);
   }

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -1506,7 +1506,7 @@ async function localBranchExists(branchName: string): Promise<boolean> {
  * 5. Force push the (updated) local branch to the origin repository.
  *
  * @param {string} branchName - The name of the branch to synchronize.
-  * @returns A promise that resolves to True if the synchronization is successful, or `false` if an error occurs.
+ * @returns A promise that resolves to True if the synchronization is successful, or `false` if an error occurs.
  */
 export async function syncForkWithUpstream(branchName: string): Promise<void> {
   if (!config.upstreamUrl) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Refactors fork syncing logic to avoid errors when:
- git isn't sync'd yet (due to repository cache)
- simplegit attempts to fetch the list of remotes

## Context

#36142

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
