### PR TITLE
feat(gerrit): add message when abandoning change due to Code-Review -2

### DIFF
--- a/lib/modules/platform/gerrit/client.spec.ts
+++ b/lib/modules/platform/gerrit/client.spec.ts
@@ -190,9 +190,23 @@ describe('modules/platform/gerrit/client', () => {
     it('abandon', async () => {
       httpMock
         .scope(gerritEndpointUrl)
-        .post('/a/changes/123456/abandon')
+        .post('/a/changes/123456/abandon', {
+          notify: 'OWNER_REVIEWERS',
+        })
         .reply(200, gerritRestResponse({}), jsonResultHeader);
       await expect(client.abandonChange(123456)).toResolve();
+    });
+    it('abandon with message', async () => {
+      httpMock
+        .scope(gerritEndpointUrl)
+        .post('/a/changes/123456/abandon', {
+          message: 'The abandon reason is important.',
+          notify: 'OWNER_REVIEWERS',
+        })
+        .reply(200, gerritRestResponse({}), jsonResultHeader);
+      await expect(
+        client.abandonChange(123456, 'The abandon reason is important.'),
+      ).toResolve();
     });
   });
 

--- a/lib/modules/platform/gerrit/client.ts
+++ b/lib/modules/platform/gerrit/client.ts
@@ -103,8 +103,13 @@ class GerritClient {
     return mergeable.body;
   }
 
-  async abandonChange(changeNumber: number): Promise<void> {
-    await this.gerritHttp.postJson(`a/changes/${changeNumber}/abandon`);
+  async abandonChange(changeNumber: number, message?: string): Promise<void> {
+    await this.gerritHttp.postJson(`a/changes/${changeNumber}/abandon`, {
+      body: {
+        message,
+        notify: 'OWNER_REVIEWERS', // Avoids notifying cc's
+      },
+    });
   }
 
   async submitChange(changeNumber: number): Promise<GerritChange> {

--- a/lib/modules/platform/gerrit/index.spec.ts
+++ b/lib/modules/platform/gerrit/index.spec.ts
@@ -131,6 +131,14 @@ describe('modules/platform/gerrit/index', () => {
         { branchName: '', label: '-2', state: 'open' },
       ]);
       expect(clientMock.abandonChange.mock.calls).toEqual([[1], [2]]);
+      expect(clientMock.addMessage.mock.calls[0]).toEqual([
+        1,
+        'This change has been abandoned as it was voted with Code-Review -2.',
+      ]);
+      expect(clientMock.addMessage.mock.calls[1]).toEqual([
+        2,
+        'This change has been abandoned as it was voted with Code-Review -2.',
+      ]);
     });
   });
 

--- a/lib/modules/platform/gerrit/index.spec.ts
+++ b/lib/modules/platform/gerrit/index.spec.ts
@@ -130,14 +130,15 @@ describe('modules/platform/gerrit/index', () => {
         'test/repo',
         { branchName: '', label: '-2', state: 'open' },
       ]);
-      expect(clientMock.abandonChange.mock.calls).toEqual([[1], [2]]);
-      expect(clientMock.addMessage.mock.calls[0]).toEqual([
-        1,
-        'This change has been abandoned as it was voted with Code-Review -2.',
-      ]);
-      expect(clientMock.addMessage.mock.calls[1]).toEqual([
-        2,
-        'This change has been abandoned as it was voted with Code-Review -2.',
+      expect(clientMock.abandonChange.mock.calls).toEqual([
+        [
+          1,
+          'This change has been abandoned as it was voted with Code-Review -2.',
+        ],
+        [
+          2,
+          'This change has been abandoned as it was voted with Code-Review -2.',
+        ],
       ]);
     });
   });

--- a/lib/modules/platform/gerrit/index.ts
+++ b/lib/modules/platform/gerrit/index.ts
@@ -120,6 +120,13 @@ export async function initRepo({
   });
   for (const change of rejectedChanges) {
     await client.abandonChange(change._number);
+    logger.info(
+      `Abandoned change ${change._number} with Code-Review -2 in repository ${repository}`,
+    );
+    await client.addMessage(
+      change._number,
+      'This change has been abandoned as it was voted with Code-Review -2.',
+    );
   }
   const repoConfig: RepoResult = {
     defaultBranch: config.head!,

--- a/lib/modules/platform/gerrit/index.ts
+++ b/lib/modules/platform/gerrit/index.ts
@@ -119,13 +119,12 @@ export async function initRepo({
     label: '-2',
   });
   for (const change of rejectedChanges) {
-    await client.abandonChange(change._number);
-    logger.info(
-      `Abandoned change ${change._number} with Code-Review -2 in repository ${repository}`,
-    );
-    await client.addMessage(
+    await client.abandonChange(
       change._number,
       'This change has been abandoned as it was voted with Code-Review -2.',
+    );
+    logger.info(
+      `Abandoned change ${change._number} with Code-Review -2 in repository ${repository}`,
     );
   }
   const repoConfig: RepoResult = {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

When Renovate automatically abandons a Gerrit change because of Code-Review -2, it now also adds a message that explains why it was abandoned. Also, it will print **info** logs for it, and avoid sending email notifications for the change's ccs. 

![image](https://github.com/user-attachments/assets/b79c98fd-749e-4a17-ba5c-9fc14f5b6bb1)

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

When you vote a Gerrit change with Code-Review -2, it means a strong opposition and that the change **should not be merged**. Here is a reference, from [Gerrit documentation](https://gerrit-review.googlesource.com/Documentation/intro-gerrit-walkthrough.html):

![image](https://github.com/user-attachments/assets/a8255e12-011b-42cc-84fe-a0cd9cf05f62)

Renovate currently understands this concept and automatically abandons changes that received Code-Review -2. That's nice, but for users who are not familiar with Renovate's Gerrit integration, it may not be clear why the change was abandoned. This is worse when Renovate is not ran frequently, as users may see the change being abandoned only several hours later, yet without an explanation.

There was also no indication in the logs whatsoever on whether some change was being abandoned or not.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
