### PR TITLE
feat(git): support x.509 commit signing

### DIFF
--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -695,9 +695,16 @@ To learn more about Git hooks, read the [Pro Git 2 book, section on Git Hooks](h
 
 ## gitPrivateKey
 
-This is a private PGP or SSH key for signing Git commits.
+This is a private PGP, SSH, or x.509 key for signing Git commits.
+
+Renovate automatically detects the key format and uses the appropriate signing method:
+
+- **PGP keys**: Uses `gpg` for import and sets `gpg.format` to `openpgp`
+- **SSH keys**: Uses `ssh-keygen` for key handling and sets `gpg.format` to `ssh`
+- **x.509 certificates**: Uses `gpgsm` for import and sets `gpg.format` to `x509`
 
 For PGP, it should be an armored private key, so the type you get from running `gpg --export-secret-keys --armor 92066A17F0D1707B4E96863955FEF5171C45FAE5 > private.key`.
+For x.509, provide the certificate in PEM format with `-----BEGIN CERTIFICATE-----` and `-----END CERTIFICATE-----` boundaries.
 Replace the newlines with `\n` before adding the resulting single-line value to your bot's config.
 
 <!-- prettier-ignore -->
@@ -707,7 +714,7 @@ Replace the newlines with `\n` before adding the resulting single-line value to 
 It will be loaded _lazily_.
 Before the first commit in a repository, Renovate will:
 
-1. Run `gpg import` (if you haven't before) when using PGP
+1. Run `gpg import` (for PGP), `gpgsm --import` (for x.509), or prepare SSH keys (for SSH)
 1. Run `git config user.signingkey`, `git config commit.gpgsign true` and `git config gpg.format`
 
 The `git` commands are run locally in the cloned repo instead of globally.

--- a/lib/util/git/private-key.ts
+++ b/lib/util/git/private-key.ts
@@ -127,7 +127,7 @@ class X509Key extends PrivateKey {
   protected async importKey(): Promise<string | undefined> {
     const keyFileName = upath.join(os.tmpdir() + '/git-private-x509.key');
     await fs.outputFile(keyFileName, this.key);
-    const { stdout, stderr } = await exec(`gpgsm --import ${keyFileName}`);
+    const { stdout, stderr } = await exec(['gpgsm', '--import', keyFileName]);
     logger.debug({ stdout, stderr }, 'X.509 private key import result');
     await fs.remove(keyFileName);
     // gpgsm does not output a key id in the same way; log and return filename


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds support for x.509 commit signing

## Context

- Closes #36219

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
