### PR TITLE
fix: Support encrypted values in inherited config

### DIFF
--- a/lib/workers/repository/init/inherited.spec.ts
+++ b/lib/workers/repository/init/inherited.spec.ts
@@ -1,3 +1,4 @@
+import * as decrypt from '../../../config/decrypt';
 import * as presets_ from '../../../config/presets';
 import type { RenovateConfig } from '../../../config/types';
 import * as validation from '../../../config/validation';
@@ -9,7 +10,6 @@ import {
 import { logger } from '../../../logger';
 import { mergeInheritedConfig } from './inherited';
 import { hostRules, platform } from '~test/util';
-import * as decrypt from '../../../config/decrypt';
 
 vi.mock('../../../config/presets');
 

--- a/lib/workers/repository/init/inherited.spec.ts
+++ b/lib/workers/repository/init/inherited.spec.ts
@@ -128,28 +128,14 @@ describe('workers/repository/init/inherited', () => {
       }`,
     );
 
-    function mockDecrypt(config: any): any {
-      if (Array.isArray(config)) {
-        return config.map(mockDecrypt);
-      } else if (config !== null && typeof config === 'object') {
-        let newObj: any = {};
-
-        for (const [key, value] of Object.entries(config)) {
-          if (key === 'encrypted' && value && typeof value === 'object') {
-            const unwrapped = mockDecrypt(value);
-            // Merge unwrapped encrypted properties into the parent
-            newObj = { ...newObj, ...unwrapped };
-          } else {
-            newObj[key] = mockDecrypt(value);
-          }
-        }
-        return newObj;
-      } else {
-        return config; // primitive values
-      }
-    }
-
-    vi.spyOn(decrypt, 'decryptConfig').mockImplementation(mockDecrypt);
+    vi.spyOn(decrypt, 'decryptConfig').mockResolvedValueOnce({
+      hostRules: [
+        {
+          matchHost: 'some-host-url',
+          token: 'some-secret-token',
+        },
+      ],
+    });
 
     const res = await mergeInheritedConfig({
       ...config,

--- a/lib/workers/repository/init/inherited.ts
+++ b/lib/workers/repository/init/inherited.ts
@@ -104,7 +104,7 @@ export async function mergeInheritedConfig(
   let filteredConfig = removeGlobalConfig(decryptedConfig, true);
   if (!dequal(decryptedConfig, filteredConfig)) {
     logger.debug(
-      { inheritedConfig, filteredConfig },
+      { inheritedConfig: decryptedConfig, filteredConfig },
       'Removed global config from inherited config.',
     );
   }
@@ -145,7 +145,7 @@ export async function mergeInheritedConfig(
   filteredConfig = removeGlobalConfig(decryptedConfig, true);
   if (!dequal(decryptedConfig, filteredConfig)) {
     logger.debug(
-      { inheritedConfig: resolvedConfig, filteredConfig },
+      { inheritedConfig: decryptedConfig, filteredConfig },
       'Removed global config from inherited config presets.',
     );
   }

--- a/lib/workers/repository/init/inherited.ts
+++ b/lib/workers/repository/init/inherited.ts
@@ -1,6 +1,7 @@
 import is from '@sindresorhus/is';
 import { dequal } from 'dequal';
 import { mergeChildConfig, removeGlobalConfig } from '../../../config';
+import { decryptConfig } from '../../../config/decrypt';
 import { parseFileConfig } from '../../../config/parse';
 import { resolveConfigPresets } from '../../../config/presets';
 import { applySecretsToConfig } from '../../../config/secrets';
@@ -97,8 +98,11 @@ export async function mergeInheritedConfig(
       'Found warnings in inherited configuration.',
     );
   }
-  let filteredConfig = removeGlobalConfig(inheritedConfig, true);
-  if (!dequal(inheritedConfig, filteredConfig)) {
+
+  let decryptedConfig = await decryptConfig(inheritedConfig, config.repository);
+
+  let filteredConfig = removeGlobalConfig(decryptedConfig, true);
+  if (!dequal(decryptedConfig, filteredConfig)) {
     logger.debug(
       { inheritedConfig, filteredConfig },
       'Removed global config from inherited config.',
@@ -134,9 +138,12 @@ export async function mergeInheritedConfig(
     );
   }
 
+  // decrypt again, as resolved presets could contain encrypted values
+  decryptedConfig = await decryptConfig(resolvedConfig, config.repository);
+
   // remove global config options once again, as resolved presets could have added some
-  filteredConfig = removeGlobalConfig(resolvedConfig, true);
-  if (!dequal(resolvedConfig, filteredConfig)) {
+  filteredConfig = removeGlobalConfig(decryptedConfig, true);
+  if (!dequal(decryptedConfig, filteredConfig)) {
     logger.debug(
       { inheritedConfig: resolvedConfig, filteredConfig },
       'Removed global config from inherited config presets.',


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This PR adds support for encrypted values inside inherited config.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->
- #36214.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [X] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
