### PR TITLE
feat(manager/mise): committed, hk, lefthook and ruff shortnames

### DIFF
--- a/lib/modules/manager/mise/extract.spec.ts
+++ b/lib/modules/manager/mise/extract.spec.ts
@@ -58,13 +58,17 @@ describe('modules/manager/mise/extract', () => {
       buf = "1.27.0"
       ccache = "4.11.3"
       consul = "1.14.3"
+      committed = "1.1.7"
       hivemind = "1.1.0"
+      hk = "1.1.2"
       jq = "1.7.1"
       kafka = "apache-3.9.0"
+      lefthook = "1.11.13"
       localstack = "4.3.0"
       opentofu = "1.6.1"
       protoc = "30.2"
       redis = "8.0.1"
+      ruff = "0.11.12"
       shellcheck = "0.10.0"
       skeema = "1.12.3"
       sops = "3.10.2"
@@ -125,11 +129,25 @@ describe('modules/manager/mise/extract', () => {
             packageName: 'hashicorp/consul',
           },
           {
+            currentValue: '1.1.7',
+            datasource: 'github-releases',
+            depName: 'committed',
+            extractVersion: '^v(?<version>\\S+)',
+            packageName: 'crate-ci/committed',
+          },
+          {
             currentValue: '1.1.0',
             datasource: 'github-releases',
             depName: 'hivemind',
             extractVersion: '^v(?<version>\\S+)',
             packageName: 'DarthSim/hivemind',
+          },
+          {
+            currentValue: '1.1.2',
+            datasource: 'github-releases',
+            depName: 'hk',
+            extractVersion: '^v(?<version>\\S+)',
+            packageName: 'jdx/hk',
           },
           {
             currentValue: '1.7.1',
@@ -143,6 +161,13 @@ describe('modules/manager/mise/extract', () => {
             datasource: 'github-tags',
             depName: 'kafka',
             packageName: 'apache/kafka',
+          },
+          {
+            currentValue: '1.11.13',
+            datasource: 'github-releases',
+            depName: 'lefthook',
+            extractVersion: '^v(?<version>\\S+)',
+            packageName: 'evilmartians/lefthook',
           },
           {
             currentValue: '4.3.0',
@@ -170,6 +195,12 @@ describe('modules/manager/mise/extract', () => {
             datasource: 'github-releases',
             depName: 'redis',
             packageName: 'redis/redis',
+          },
+          {
+            currentValue: '0.11.12',
+            datasource: 'github-releases',
+            depName: 'ruff',
+            packageName: 'astral-sh/ruff',
           },
           {
             currentValue: '0.10.0',

--- a/lib/modules/manager/mise/upgradeable-tooling.ts
+++ b/lib/modules/manager/mise/upgradeable-tooling.ts
@@ -223,6 +223,14 @@ const miseRegistryTooling: Record<string, ToolingDefinition> = {
       extractVersion: '^v(?<version>\\S+)',
     },
   },
+  committed: {
+    misePluginUrl: 'https://mise.jdx.dev/registry.html#tools',
+    config: {
+      packageName: 'crate-ci/committed',
+      datasource: GithubReleasesDatasource.id,
+      extractVersion: '^v(?<version>\\S+)',
+    },
+  },
   consul: {
     misePluginUrl: 'https://mise.jdx.dev/registry.html#tools',
     config: {
@@ -247,6 +255,14 @@ const miseRegistryTooling: Record<string, ToolingDefinition> = {
       extractVersion: '^jq-v(?<version>\\S+)',
     },
   },
+  hk: {
+    misePluginUrl: 'https://mise.jdx.dev/registry.html#tools',
+    config: {
+      packageName: 'jdx/hk',
+      datasource: GithubReleasesDatasource.id,
+      extractVersion: '^v(?<version>\\S+)',
+    },
+  },
   kafka: {
     misePluginUrl: 'https://mise.jdx.dev/registry.html#tools',
     config: (version) => {
@@ -260,6 +276,14 @@ const miseRegistryTooling: Record<string, ToolingDefinition> = {
       }
 
       return undefined;
+    },
+  },
+  lefthook: {
+    misePluginUrl: 'https://mise.jdx.dev/registry.html#tools',
+    config: {
+      packageName: 'evilmartians/lefthook',
+      datasource: GithubReleasesDatasource.id,
+      extractVersion: '^v(?<version>\\S+)',
     },
   },
   localstack: {
@@ -290,6 +314,13 @@ const miseRegistryTooling: Record<string, ToolingDefinition> = {
     misePluginUrl: 'https://mise.jdx.dev/registry.html#tools',
     config: {
       packageName: 'redis/redis',
+      datasource: GithubReleasesDatasource.id,
+    },
+  },
+  ruff: {
+    misePluginUrl: 'https://mise.jdx.dev/registry.html#tools',
+    config: {
+      packageName: 'astral-sh/ruff',
       datasource: GithubReleasesDatasource.id,
     },
   },


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Add mise manager shortname support for committed, hk, lefthook, and ruff.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

Make it easier to update these tools.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

I am not sure about this, but I suppose the tools list at https://docs.renovatebot.com/modules/manager/mise/#supported-default-registry-tool-short-names is automatically generated.

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
