### PR TITLE
docs: Mention that allowedVersions and matchUpdateTypes can't be used together

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2884,6 +2884,10 @@ For example, if you want to upgrade to Angular v1.5 but _not_ to `angular` v1.6 
 
 Renovate calculates the valid syntax for this at runtime, because it depends on the dynamic versioning scheme.
 
+<!-- prettier-ignore -->
+!!! warning
+    `allowedVersions` and `matchUpdateTypes` cannot be used in the same package rule.
+
 #### Using regular expressions
 
 You can use Regular Expressions in the `allowedVersion` config.
@@ -3406,6 +3410,10 @@ For more details on supported syntax see Renovate's [string pattern matching doc
     Check if you're using any `0.x` package, and see if you need custom `packageRules` for it.
     When setting up automerge for dependencies, make sure to stop accidental automerges of `0.x` versions.
     Read the [automerge non-major updates](./key-concepts/automerge.md#automerge-non-major-updates) docs for a config example that blocks `0.x` updates.
+
+<!-- prettier-ignore -->
+!!! warning
+    `matchUpdateTypes` and `allowedVersions` cannot be used in the same package rule.
 
 Tokens can be configured via `hostRules` using the `"merge-confidence"` `hostType`:
 

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2890,7 +2890,7 @@ Renovate calculates the valid syntax for this at runtime, because it depends on 
 
 #### Using regular expressions
 
-You can use Regular Expressions in the `allowedVersion` config.
+You can use Regular Expressions in the `allowedVersions` config.
 You must _begin_ and _end_ your Regular Expression with the `/` character!
 
 For example, this config only allows 3 or 4-part versions, without any prefixes in the version:


### PR DESCRIPTION
## Changes

`allowedVersions` and `matchUpdateTypes` [can't](https://github.com/renovatebot/renovate/issues/9172) be used within the same package rule. I think it would be useful if this was mentioned in the docs. I've added warning notices, but I could also see info notices (or just regular text) making sense too.

This also fixes a minor typo in the docs -- `allowedVersion` -> `allowedVersions` (plural). I'm happy to open a separate PR for this if necessary.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

I spent a long time trying to figure out why an `allowedVersions` directive wasn't working in a package rule that also contained `matchUpdateTypes`. I get a build error when I run Renovate locally with a package rule that mixes the two, but my production repository has a massive debug log output, and dozens of package rules configured, so it's easy to miss this. I think it'd be useful if the docs mentioned this.

## Documentation (please check one with an [x])

- [X] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [X] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository


<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
