### PR TITLE
docs: updated matchSourceUrls config option

### DIFF
--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -1445,7 +1445,7 @@ const options: RenovateOptions[] = [
   },
   {
     name: 'matchSourceUrls',
-    description: 'A list of source URLs to match against. Each element can be a string, glob pattern or regex',
+    description: 'A list of exact match URLs or URL patterns to match sourceUrl against.',
     type: 'array',
     subType: 'string',
     allowString: true,

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -1445,7 +1445,7 @@ const options: RenovateOptions[] = [
   },
   {
     name: 'matchSourceUrls',
-    description: 
+    description:
       'A list of exact match URLs or URL patterns to match sourceUrl against.',
     type: 'array',
     subType: 'string',

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -1446,7 +1446,7 @@ const options: RenovateOptions[] = [
   {
     name: 'matchSourceUrls',
     description:
-      'A list of exact match URLs or URL patterns to match sourceUrl against.',
+      'A list of exact match URLs (or URL patterns) to match sourceUrl against.',
     type: 'array',
     subType: 'string',
     allowString: true,

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -1445,7 +1445,7 @@ const options: RenovateOptions[] = [
   },
   {
     name: 'matchSourceUrls',
-    description: 'A list of source URLs to exact match against.',
+    description: 'A list of source URLs to match against. Each element can be a string, glob pattern or regex',
     type: 'array',
     subType: 'string',
     allowString: true,

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -1445,7 +1445,8 @@ const options: RenovateOptions[] = [
   },
   {
     name: 'matchSourceUrls',
-    description: 'A list of exact match URLs or URL patterns to match sourceUrl against.',
+    description: 
+      'A list of exact match URLs or URL patterns to match sourceUrl against.',
     type: 'array',
     subType: 'string',
     allowString: true,


### PR DESCRIPTION
make matchSourceUrls more explicit

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Include more info of possible values for `matchSourceUrls`

## Context

The current docs were confusing to me (and also made AI agents confuse) cause as it is now it can be think that only exact matches are allowed.

See discussion: https://github.com/renovatebot/renovate/discussions/36218

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
