### PR TITLE
feat(gitea): Support repos with fast forward only merge

### DIFF
--- a/lib/modules/platform/gitea/gitea-helper.spec.ts
+++ b/lib/modules/platform/gitea/gitea-helper.spec.ts
@@ -71,6 +71,7 @@ describe('modules/platform/gitea/gitea-helper', () => {
 
   const mockRepo: Repo = partial<Repo>({
     id: 123,
+    allow_fast_forward_only_merge: true,
     allow_rebase: true,
     allow_rebase_explicit: true,
     allow_merge_commits: true,

--- a/lib/modules/platform/gitea/index.spec.ts
+++ b/lib/modules/platform/gitea/index.spec.ts
@@ -555,6 +555,26 @@ describe('modules/platform/gitea/index', () => {
       );
     });
 
+    it('should fall back to merge method "fast-forward"', async () => {
+      const scope = httpMock
+        .scope('https://gitea.com/api/v1')
+        .get(`/repos/${initRepoCfg.repository}`)
+        .reply(200, {
+          ...mockRepo,
+          allow_rebase: false,
+          allow_fast_forward_only_merge: true,
+        });
+      await initFakePlatform(scope);
+
+      await gitea.initRepo(initRepoCfg);
+
+      expect(git.initRepo).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({
+          mergeMethod: 'fast-forward',
+        }),
+      );
+    });
+
     it('should fall back to merge method "rebase-merge"', async () => {
       const scope = httpMock
         .scope('https://gitea.com/api/v1')

--- a/lib/modules/platform/gitea/index.ts
+++ b/lib/modules/platform/gitea/index.ts
@@ -328,6 +328,8 @@ const platform: Platform = {
       config.mergeMethod = 'squash';
     } else if (repo.allow_merge_commits) {
       config.mergeMethod = 'merge';
+    } else if (repo.allow_fast_forward_only_merge) {
+      config.mergeMethod = 'fast-forward';
     } else {
       logger.debug(
         'Repository has no allowed merge methods - aborting renovation',

--- a/lib/modules/platform/gitea/types.ts
+++ b/lib/modules/platform/gitea/types.ts
@@ -15,7 +15,12 @@ export type CommitStatusType =
   | 'failure'
   | 'warning'
   | 'unknown';
-export type PRMergeMethod = 'merge' | 'rebase' | 'rebase-merge' | 'squash';
+export type PRMergeMethod =
+  | 'fast-forward'
+  | 'merge'
+  | 'rebase'
+  | 'rebase-merge'
+  | 'squash';
 
 export interface GiteaLabel {
   id: number;
@@ -69,6 +74,7 @@ export interface User {
 
 export interface Repo {
   id: number;
+  allow_fast_forward_only_merge: boolean;
   allow_merge_commits: boolean;
   allow_rebase: boolean;
   allow_rebase_explicit: boolean;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Add support for repos with only fast forward merge strategy enabled

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

If a gitea repo is configured to only allow fast forward merge strategy, renovate will not open PRs. This was added to gitea in PR https://github.com/go-gitea/gitea/pull/28954

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
