### PR TITLE
docs: Update aws-rds docs to use packageName instead of lookupName

### DIFF
--- a/lib/modules/datasource/aws-rds/readme.md
+++ b/lib/modules/datasource/aws-rds/readme.md
@@ -65,7 +65,7 @@ For example:
       "customType": "regex",
       "managerFilePatterns": ["**.yaml"],
       "matchStrings": [
-        ".*rdsFilter=(?<lookupName>.+?)[ ]*\n[ ]*(?<depName>[a-zA-Z0-9-_:]*)[ ]*?:[ ]*?[\"|']?(?<currentValue>[.\\d]+)[\"|']?.*"
+        ".*rdsFilter=(?<packageName>.+?)[ ]*\n[ ]*(?<depName>[a-zA-Z0-9-_:]*)[ ]*?:[ ]*?[\"|']?(?<currentValue>[.\\d]+)[\"|']?.*"
       ],
       "datasourceTemplate": "aws-rds"
     }
@@ -93,7 +93,7 @@ Here is the Renovate configuration to use Terraform, `aws-rds` and Aurora MySQL:
       "customType": "regex",
       "managerFilePatterns": ["/.+\\.tf$/"],
       "matchStrings": [
-        "\\s*#\\s*renovate:\\s*rdsFilter=(?<lookupName>.+?) depName=(?<depName>.*) versioning=(?<versioning>.*)\\s*.*_version\\s*=\\s*\"(?<currentValue>.*)\""
+        "\\s*#\\s*renovate:\\s*rdsFilter=(?<packageName>.+?) depName=(?<depName>.*) versioning=(?<versioning>.*)\\s*.*_version\\s*=\\s*\"(?<currentValue>.*)\""
       ],
       "datasourceTemplate": "aws-rds"
     }


### PR DESCRIPTION
## Changes

Update the aws-rds datasource docs to use `packageName` instead of `lookupName` - the latter of which triggers a renovate config migration

## Context

I used the aws-rds datasource today and it triggered a config migration because I used what the docs had.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
