### PR TITLE
fix(bumpVersions): correctly default to patch

### DIFF
--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -132,7 +132,6 @@ const options: RenovateOptions[] = [
     description:
       'The semver level to use when bumping versions. This is used by the `bumpVersions` feature.',
     type: 'string',
-    default: 'patch',
     parents: ['bumpVersions'],
   },
   {
@@ -148,7 +147,6 @@ const options: RenovateOptions[] = [
     description:
       'A name for the bumpVersion config. This is used for logging and debugging.',
     type: 'string',
-    default: null,
     parents: ['bumpVersions'],
   },
   {

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -591,8 +591,8 @@ export interface ValidationResult {
 }
 
 export interface BumpVersionConfig {
-  bumpType: string;
+  bumpType?: string;
   filePatterns: string[];
   matchStrings: string[];
-  name: string | null;
+  name?: string;
 }

--- a/lib/workers/repository/update/branch/bump-versions.spec.ts
+++ b/lib/workers/repository/update/branch/bump-versions.spec.ts
@@ -30,7 +30,6 @@ describe('workers/repository/update/branch/bump-versions', () => {
       const config = partial<BranchConfig>({
         bumpVersions: [
           {
-            name: null,
             filePatterns: ['\\.release-version'],
             bumpType: 'minor',
             matchStrings: ['^(?<version>.+)$'],
@@ -54,7 +53,6 @@ describe('workers/repository/update/branch/bump-versions', () => {
       const config = partial<BranchConfig>({
         bumpVersions: [
           {
-            name: null,
             filePatterns: ['\\^'],
             bumpType: 'minor',
             matchStrings: ['^(?<version>.+)$'],
@@ -131,7 +129,6 @@ describe('workers/repository/update/branch/bump-versions', () => {
       const config = partial<BranchConfig>({
         bumpVersions: [
           {
-            name: null,
             filePatterns: ['foo'],
             bumpType: 'minor',
             matchStrings: ['^(?<version>.+)$'],
@@ -164,7 +161,6 @@ describe('workers/repository/update/branch/bump-versions', () => {
       const config = partial<BranchConfig>({
         bumpVersions: [
           {
-            name: null,
             filePatterns: ['\\.release-version'],
             bumpType: 'minor',
             matchStrings: ['^(?<version>.+)$'],
@@ -193,11 +189,41 @@ describe('workers/repository/update/branch/bump-versions', () => {
       });
     });
 
+    it('should bump version with patch by default', async () => {
+      const config = partial<BranchConfig>({
+        bumpVersions: [
+          {
+            filePatterns: ['\\.release-version'],
+            matchStrings: ['^(?<version>.+)$'],
+          },
+        ],
+        updatedPackageFiles: [
+          {
+            type: 'addition',
+            path: 'foo',
+            contents: 'bar',
+          },
+        ],
+      });
+      scm.getFileList.mockResolvedValueOnce(['foo', '.release-version']);
+      fs.readLocalFile.mockResolvedValueOnce('1.0.0');
+      await bumpVersions(config);
+
+      expect(config).toMatchObject({
+        updatedArtifacts: [
+          {
+            type: 'addition',
+            path: '.release-version',
+            contents: '1.0.1',
+          },
+        ],
+      });
+    });
+
     it('should bump version in an already changed packageFiles', async () => {
       const config = partial<BranchConfig>({
         bumpVersions: [
           {
-            name: null,
             filePatterns: ['foo'],
             bumpType: 'minor',
             matchStrings: ['\\s*version:\\s+(?<version>[^\\s]+)'],
@@ -243,7 +269,6 @@ describe('workers/repository/update/branch/bump-versions', () => {
       const config = partial<BranchConfig>({
         bumpVersions: [
           {
-            name: null,
             filePatterns: ['foo'],
             bumpType: 'minor',
             matchStrings: ['\\s*version:\\s+(?<version>[^\\s]+)'],
@@ -289,7 +314,6 @@ describe('workers/repository/update/branch/bump-versions', () => {
       const config = partial<BranchConfig>({
         bumpVersions: [
           {
-            name: null,
             filePatterns: ['foo'],
             bumpType: 'minor',
             matchStrings: ['\\s*version:\\s+(?<version>[^\\s]+)'],
@@ -343,7 +367,6 @@ describe('workers/repository/update/branch/bump-versions', () => {
       const config = partial<BranchConfig>({
         bumpVersions: [
           {
-            name: null,
             filePatterns: ['foo'],
             bumpType: 'minor',
             matchStrings: ['\\s*version:\\s+(?<version>[^\\s]+)'],
@@ -417,7 +440,6 @@ describe('workers/repository/update/branch/bump-versions', () => {
       const config = partial<BranchConfig>({
         bumpVersions: [
           {
-            name: null,
             filePatterns: ['foo'],
             bumpType: 'minor',
             matchStrings: [

--- a/lib/workers/repository/update/branch/bump-versions.ts
+++ b/lib/workers/repository/update/branch/bump-versions.ts
@@ -55,6 +55,8 @@ async function bumpVersion(
   packageFiles: Record<string, FileChange[]>,
   artifactFiles: Record<string, FileChange[]>,
 ): Promise<void> {
+  const rawBumpType = config.bumpType ?? 'patch';
+
   const bumpVersionsDescr = config.name
     ? `bumpVersions(${config.name})`
     : 'bumpVersions';
@@ -113,7 +115,7 @@ async function bumpVersion(
       // getting new version
       let newVersion: string | null = null;
       try {
-        const bumpType = compile(config.bumpType, branchConfig);
+        const bumpType = compile(rawBumpType, branchConfig);
         newVersion = inc(version, bumpType as ReleaseType);
       } catch (e) {
         addArtifactError(


### PR DESCRIPTION

## Changes

Handles `bumpType` defaulting of `bumpVersion` inside of the  `bumpVersion` function. 

## Context

Renovate does not support defaulting via config options if there is a parent defined

https://github.com/renovatebot/renovate/blob/d908ca3c2e825774a7fc2e05ed858cd951ae6386/lib/config/defaults.ts#L26

https://github.com/renovatebot/renovate/discussions/35770#discussioncomment-13331125

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
