### PR TITLE
docs: add info about semantic commits feature not working together with `commitMessagePrefix`

### DIFF
--- a/docs/usage/semantic-commits.md
+++ b/docs/usage/semantic-commits.md
@@ -22,6 +22,8 @@ There are some exceptions:
 - if the `depType` is a known "production dependency" type (e.g. `dependencies` or `require`), then Renovate uses the `fix` prefix
 - if an update uses the `maven` datasource _and_ `matchDepTypes` is a known production type (e.g. `compile`, `provided`, `runtime`, `system`, `import` or `parent`) then Renovate uses the `fix` prefix
 
+Be aware that the semantic commits feature does not work if you have a `commitMessagePrefix` configured.
+
 ## Manually enabling or disabling semantic commits
 
 You can override the default settings, and disable or enable Semantic Commits.

--- a/docs/usage/semantic-commits.md
+++ b/docs/usage/semantic-commits.md
@@ -22,7 +22,7 @@ There are some exceptions:
 - if the `depType` is a known "production dependency" type (e.g. `dependencies` or `require`), then Renovate uses the `fix` prefix
 - if an update uses the `maven` datasource _and_ `matchDepTypes` is a known production type (e.g. `compile`, `provided`, `runtime`, `system`, `import` or `parent`) then Renovate uses the `fix` prefix
 
-Be aware that the semantic commits feature does not work if you have a `commitMessagePrefix` configured.
+Be aware that the semantic commits feature does not work if you have a `commitMessagePrefix` configured - `commitMessagePrefix` will take priority.
 
 ## Manually enabling or disabling semantic commits
 


### PR DESCRIPTION
## Changes

Amended the "semantic commits" docs.

## Context

https://github.com/renovatebot/renovate/blob/cdbaa1ff421231223cf35b0f2bb8db2915efeaac/lib/workers/repository/updates/generate.ts#L69

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required
