### PR TITLE
fix(util/host-rules): compare normalized URLs when matching hostRules

### DIFF
--- a/lib/util/host-rules.spec.ts
+++ b/lib/util/host-rules.spec.ts
@@ -55,6 +55,30 @@ describe('util/host-rules', () => {
         password: 'pass1',
         username: 'user1',
       });
+      expect(find({ url: 'https://some.endpoint/' })).toEqual({
+        password: 'pass1',
+        username: 'user1',
+      });
+      expect(find({ url: 'https://some.endpoint' })).toEqual({
+        password: 'pass1',
+        username: 'user1',
+      });
+      expect(find({ url: 'https://some.endpoint:443' })).toEqual({
+        password: 'pass1',
+        username: 'user1',
+      });
+    });
+
+    it('does not match subpart of hostname', () => {
+      add({
+        matchHost: 'https://some.endpoint',
+        username: 'user1',
+        password: 'pass1',
+      });
+      expect(find({ url: 'https://some.endpoint.example.com' })).toEqual({});
+      expect(find({ url: 'https://some.endpoint:blub@example.com' })).toEqual(
+        {},
+      );
     });
 
     it('massages host url', () => {

--- a/lib/util/host-rules.ts
+++ b/lib/util/host-rules.ts
@@ -84,8 +84,8 @@ export function matchesHost(url: string, matchHost: string): boolean {
   }
 
   const parsedMatchHost = parseUrl(matchHost);
-  if (isHttpUrl(url) && parsedMatchHost && isHttpUrl(matchHost)) {
-    return parsedUrl.href.startsWith(parsedMatchHost.href);
+  if (isHttpUrl(parsedUrl) && isHttpUrl(parsedMatchHost)) {
+    return parsedUrl.href.startsWith(parsedMatchHost!.href);
   }
 
   const { hostname } = parsedUrl;

--- a/lib/util/host-rules.ts
+++ b/lib/util/host-rules.ts
@@ -78,13 +78,14 @@ export interface HostRuleSearch {
 }
 
 export function matchesHost(url: string, matchHost: string): boolean {
-  if (isHttpUrl(url) && isHttpUrl(matchHost)) {
-    return url.startsWith(matchHost);
-  }
-
   const parsedUrl = parseUrl(url);
   if (!parsedUrl) {
     return false;
+  }
+
+  const parsedMatchHost = parseUrl(matchHost);
+  if (isHttpUrl(url) && parsedMatchHost && isHttpUrl(matchHost)) {
+    return parsedUrl.href.startsWith(parsedMatchHost.href);
   }
 
   const { hostname } = parsedUrl;

--- a/lib/util/http/queue.spec.ts
+++ b/lib/util/http/queue.spec.ts
@@ -6,7 +6,7 @@ describe('util/http/queue', () => {
     clear();
     hostRules.clear();
     hostRules.add({
-      matchHost: 'https://example.com',
+      matchHost: 'example.com',
       concurrentRequestLimit: 143,
     });
   });

--- a/lib/util/http/throttle.spec.ts
+++ b/lib/util/http/throttle.spec.ts
@@ -6,7 +6,7 @@ describe('util/http/throttle', () => {
     clear();
     hostRules.clear();
     hostRules.add({
-      matchHost: 'https://example.com',
+      matchHost: 'example.com',
       maxRequestsPerSecond: 143,
     });
   });


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This PR modifies the matching behavior of `http(s)://` hostRules. Instead of using a basic string comparison, it now creates a URL object from the hostRule and compares the normalized `.href` value.

## Context

This change prevents hostRule confusion and prevents unintended application to incorrect hosts.

For example, `https://test` will no longer match `https://test.example.com` because the `.href` adds a trailing `/`, making the comparison `https://test/` vs. `https://test.example.com/`. 
Similarly, `https://example.com` will not match `https://example.com:8080`, although it will match the standard port (`https://example.com:443`). Consequently, changes were made to the `queue` and `throttle` tests to set domain-level hosts appropriately.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
