### PR TITLE
fix(repository/config-migration): skip prettier formatting if no parser is detected

### DIFF
--- a/lib/workers/repository/config-migration/branch/migrated-data.spec.ts
+++ b/lib/workers/repository/config-migration/branch/migrated-data.spec.ts
@@ -174,6 +174,19 @@ describe('workers/repository/config-migration/branch/migrated-data', () => {
       ).resolves.toEqual(formatted);
     });
 
+    it('formats without prettier if in .renovaterc', async () => {
+      const migratedDataRenovaterc = vi
+        .mocked(scm.getFileList)
+        .mockResolvedValue(['.prettierrc']);
+      await MigratedDataFactory.getAsync();
+      await expect(
+        MigratedDataFactory.applyPrettierFormatting({
+          ...migratedData,
+          filename: '.renovaterc',
+        }),
+      ).resolves.toEqual(migratedData.content);
+    });
+
     it('formats when finds prettier config inside the package.json file', async () => {
       const formatted = formattedMigratedData.content;
       vi.mocked(detectRepoFileConfig).mockResolvedValueOnce({

--- a/lib/workers/repository/config-migration/branch/migrated-data.spec.ts
+++ b/lib/workers/repository/config-migration/branch/migrated-data.spec.ts
@@ -175,9 +175,7 @@ describe('workers/repository/config-migration/branch/migrated-data', () => {
     });
 
     it('formats without prettier if in .renovaterc', async () => {
-      const migratedDataRenovaterc = vi
-        .mocked(scm.getFileList)
-        .mockResolvedValue(['.prettierrc']);
+      vi.mocked(scm.getFileList).mockResolvedValue(['.prettierrc']);
       await MigratedDataFactory.getAsync();
       await expect(
         MigratedDataFactory.applyPrettierFormatting({

--- a/lib/workers/repository/config-migration/branch/migrated-data.ts
+++ b/lib/workers/repository/config-migration/branch/migrated-data.ts
@@ -70,7 +70,7 @@ export async function applyPrettierFormatting(
       }
     }
 
-    if (!prettierExists) {
+    if (!prettierExists || !parser) {
       return content;
     }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Check if a parser is defined (e.g. `json/json5`) for prettier formatting and if not return the "unformatted", migrated string similar to when no `prettier` config file exists rather than trying to use prettier and then run into a "unknown error".

## Context

In case we can't reliable identify the format (e.g. for the `.renovaterc` without file extension) we currently invoke prettier without a parser. This causes prettier to throw an Error and abort a full Renovate run: 
```
 INFO: Renovate is exiting with a non-zero code due to the following logged errors
       "loggerErrors": [
         {
           "name": "renovate",
           "level": 50,
           "logContext": "zUZLjrU3p4vqlVZO6kJA4",
           "repository": "org/repo",
           "err": {
             "name": "UndefinedParserError",
             "message": "No parser and no file path given, couldn't infer a parser.",
             "stack": "UndefinedParserError: No parser and no file path given, couldn't infer a parser.\n    at normalizeFormatOptions (file:///usr/local/renovate/node_modules/.pnpm/prettier@3.5.3/node_modules/prettier/index.mjs:19919:13)\n    at formatWithCursor (file:///usr/local/renovate/node_modules/.pnpm/prettier@3.5.3/node_modules/prettier/index.mjs:20727:11)\n    at file:///usr/local/renovate/node_modules/.pnpm/prettier@3.5.3/node_modules/prettier/index.mjs:22177:12\n    at Module.format2 (file:///usr/local/renovate/node_modules/.pnpm/prettier@3.5.3/node_modules/prettier/index.mjs:22182:25)\n    at createConfigMigrationBranch (/usr/local/renovate/lib/workers/repository/config-migration/branch/create.ts:39:5)\n    at checkConfigMigrationBranch (/usr/local/renovate/lib/workers/repository/config-migration/branch/index.ts:112:5)\n    at configMigration (/usr/local/renovate/lib/workers/repository/config-migration/index.ts:30:15)\n    at Object.renovateRepository (/usr/local/renovate/lib/workers/repository/index.ts:107:36)\n    at attributes.repository (/usr/local/renovate/lib/workers/global/index.ts:184:11)\n    at start (/usr/local/renovate/lib/workers/global/index.ts:169:7)\n    at /usr/local/renovate/lib/renovate.ts:19:22"
           },
           "msg": "Repository has unknown error"
         }
       ]
```

This changed behavior ensures that Renovate will not fail and rather just returns the unformatted string as config migration. 
While not ideal, the [low number (175) of public repos using `.renovaterc`](https://github.com/search?q=path%3A**%2F.renovaterc&type=code) I think this is a reasonable quick fix.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
