### PR TITLE
fix(presets): fix `helpers:pinGitHubActionDigestsToSemver`

### DIFF
--- a/lib/config/presets/internal/helpers.ts
+++ b/lib/config/presets/internal/helpers.ts
@@ -35,8 +35,8 @@ export const presets: Record<string, Preset> = {
     packageRules: [
       {
         extends: ['helpers:pinGitHubActionDigests'],
-        versioning: 'npm',
         rangeStrategy: 'pin',
+        versioning: 'npm',
       },
     ],
   },

--- a/lib/config/presets/internal/helpers.ts
+++ b/lib/config/presets/internal/helpers.ts
@@ -31,13 +31,12 @@ export const presets: Record<string, Preset> = {
     ],
   },
   pinGitHubActionDigestsToSemver: {
-    description: 'Convert pinned GitHub Action digests to SemVer.',
+    description: 'Pin `github-action` digests and versions.',
     packageRules: [
       {
         extends: ['helpers:pinGitHubActionDigests'],
-        extractVersion: '^(?<version>v?\\d+\\.\\d+\\.\\d+)$',
-        versioning:
-          'regex:^v?(?<major>\\d+)(\\.(?<minor>\\d+)\\.(?<patch>\\d+))?$',
+        versioning: 'npm',
+        rangeStrategy: 'pin',
       },
     ],
   },


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Fix `helpers:pinGitHubActionDigestsToSemver` to really do pinning.

## Context

- The preset with regex versioning failed in some cases - for example, with codeql-action: https://github.com/renovatebot/renovate/discussions/36322 (because there's no `v3.0.0` tag in the repository).

- When it didn't fail, it created "update" pull requests, not "pin" - https://github.com/amezin/renovate-pin-actions-digest-semver-codeql/pull/5

- Also, the description was misleading. It didn't convert from digest pinning to version. It just changed the version in the comment.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
