### PR TITLE
fix(ci): Skip coverage jobs when tests are failed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -389,7 +389,7 @@ jobs:
           done
 
       - name: Move coverage files
-        if: (success() || failure()) && github.event.pull_request.draft != true && matrix.coverage
+        if: github.event.pull_request.draft != true && matrix.coverage
         run: |
           mkdir -p ./coverage/lcov
           mkdir -p ./coverage/json
@@ -400,7 +400,7 @@ jobs:
           done
 
       - name: Save coverage artifacts
-        if: (success() || failure()) && github.event.pull_request.draft != true && matrix.coverage
+        if: github.event.pull_request.draft != true && matrix.coverage
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ matrix.upload-artifact-name }}
@@ -412,7 +412,7 @@ jobs:
     needs: [test]
     runs-on: ubuntu-latest
     timeout-minutes: 3
-    if: (success() || failure()) && github.event_name != 'merge_group' && github.event.pull_request.draft != true
+    if: github.event_name != 'merge_group' && github.event.pull_request.draft != true
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -441,7 +441,7 @@ jobs:
       - setup-build
     runs-on: ubuntu-latest
     timeout-minutes: 3
-    if: (success() || failure()) && github.event.pull_request.draft != true
+    if: github.event.pull_request.draft != true
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -389,7 +389,7 @@ jobs:
           done
 
       - name: Move coverage files
-        if: github.event.pull_request.draft != true && matrix.coverage
+        if: success() && github.event.pull_request.draft != true && matrix.coverage
         run: |
           mkdir -p ./coverage/lcov
           mkdir -p ./coverage/json
@@ -400,7 +400,7 @@ jobs:
           done
 
       - name: Save coverage artifacts
-        if: github.event.pull_request.draft != true && matrix.coverage
+        if: success() && github.event.pull_request.draft != true && matrix.coverage
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ matrix.upload-artifact-name }}
@@ -412,7 +412,7 @@ jobs:
     needs: [test]
     runs-on: ubuntu-latest
     timeout-minutes: 3
-    if: github.event_name != 'merge_group' && github.event.pull_request.draft != true
+    if: success() && github.event_name != 'merge_group' && github.event.pull_request.draft != true
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -441,7 +441,7 @@ jobs:
       - setup-build
     runs-on: ubuntu-latest
     timeout-minutes: 3
-    if: github.event.pull_request.draft != true
+    if: success() && github.event.pull_request.draft != true
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

When unit tests fail, we also see the coverage failure, which makes it harder to track down the problem.

This PR replaces the `success() || failure()` conditions to just `success()` ones.

The _"catch all"_ job named `test-success` still makes sure none of the required steps is missing.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
