### PR TITLE
fix(gerrit): add codeowners support for gerrit

### DIFF
--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -12,7 +12,7 @@ import { newlineRegex, regEx } from '../regex';
 import * as _behindBaseCache from './behind-base-branch-cache';
 import * as _conflictsCache from './conflicts-cache';
 import * as _modifiedCache from './modified-cache';
-import type { FileChange, LongCommitSha } from './types';
+import type { FileChange } from './types';
 import * as git from '.';
 import { setNoVerify } from '.';
 import { logger } from '~test/util';
@@ -452,9 +452,7 @@ describe('util/git/index', { timeout: 10000 }, () => {
         ],
         message: 'Create something',
       });
-      const branchFiles = await git.getBranchFilesFromCommit(
-        sha as LongCommitSha,
-      );
+      const branchFiles = await git.getBranchFilesFromCommit(sha!);
       expect(branchFiles).toEqual(['some-new-file']);
     });
   });

--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -12,7 +12,7 @@ import { newlineRegex, regEx } from '../regex';
 import * as _behindBaseCache from './behind-base-branch-cache';
 import * as _conflictsCache from './conflicts-cache';
 import * as _modifiedCache from './modified-cache';
-import type { FileChange } from './types';
+import type { FileChange, LongCommitSha } from './types';
 import * as git from '.';
 import { setNoVerify } from '.';
 import { logger } from '~test/util';
@@ -432,6 +432,28 @@ describe('util/git/index', { timeout: 10000 }, () => {
       });
       const branchFiles = await git.getBranchFiles(
         'renovate/branch_with_changes',
+      );
+      expect(branchFiles).toEqual(['some-new-file']);
+    });
+  });
+
+  describe('getBranchFilesFromCommit(sha)', () => {
+    it('detects changed files compared to the parent commit', async () => {
+      const file: FileChange = {
+        type: 'addition',
+        path: 'some-new-file',
+        contents: 'some new-contents',
+      };
+      const sha = await git.commitFiles({
+        branchName: 'renovate/branch_with_changes',
+        files: [
+          file,
+          { type: 'addition', path: 'dummy', contents: null as never },
+        ],
+        message: 'Create something',
+      });
+      const branchFiles = await git.getBranchFilesFromCommit(
+        sha as LongCommitSha,
       );
       expect(branchFiles).toEqual(['some-new-file']);
     });

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -1030,35 +1030,27 @@ export async function getBranchLastCommitTime(
 export async function getBranchFiles(
   branchName: string,
 ): Promise<string[] | null> {
-  await syncGit();
-  try {
-    const diff = await gitRetry(() =>
-      git.diffSummary([`origin/${branchName}`, `origin/${branchName}^`]),
-    );
-    return diff.files.map((file) => file.file);
-    /* v8 ignore next 8 -- TODO: add test */
-  } catch (err) {
-    logger.warn({ err }, 'getBranchFiles error');
-    const errChecked = checkForPlatformFailure(err);
-    if (errChecked) {
-      throw errChecked;
-    }
-    return null;
-  }
+  return getBranchFilesFromRef(`origin/${branchName}`);
 }
 
 export async function getBranchFilesFromCommit(
   referenceCommit: LongCommitSha,
 ): Promise<string[] | null> {
+  return getBranchFilesFromRef(referenceCommit);
+}
+
+export async function getBranchFilesFromRef(
+  refName: string,
+): Promise<string[] | null> {
   await syncGit();
   try {
     const diff = await gitRetry(() =>
-      git.diffSummary([referenceCommit, referenceCommit + `^`]),
+      git.diffSummary([refName, `${refName}^`]),
     );
     return diff.files.map((file) => file.file);
     /* v8 ignore next 8 -- TODO: add test */
   } catch (err) {
-    logger.warn({ err }, 'getBranchFiles error');
+    logger.warn({ err }, 'getBranchFilesFromRef error');
     const errChecked = checkForPlatformFailure(err);
     if (errChecked) {
       throw errChecked;

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -1027,13 +1027,11 @@ export async function getBranchLastCommitTime(
   }
 }
 
-export async function getBranchFiles(
-  branchName: string,
-): Promise<string[] | null> {
+export function getBranchFiles(branchName: string): Promise<string[] | null> {
   return getBranchFilesFromRef(`origin/${branchName}`);
 }
 
-export async function getBranchFilesFromCommit(
+export function getBranchFilesFromCommit(
   referenceCommit: LongCommitSha,
 ): Promise<string[] | null> {
   return getBranchFilesFromRef(referenceCommit);

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -1037,7 +1037,7 @@ export function getBranchFilesFromCommit(
   return getBranchFilesFromRef(referenceCommit);
 }
 
-export async function getBranchFilesFromRef(
+async function getBranchFilesFromRef(
   refName: string,
 ): Promise<string[] | null> {
   await syncGit();

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -1047,6 +1047,26 @@ export async function getBranchFiles(
   }
 }
 
+export async function getBranchFilesFromCommit(
+  referenceCommit: LongCommitSha,
+): Promise<string[] | null> {
+  await syncGit();
+  try {
+    const diff = await gitRetry(() =>
+      git.diffSummary([referenceCommit, referenceCommit + `^`]),
+    );
+    return diff.files.map((file) => file.file);
+    /* v8 ignore next 8 -- TODO: add test */
+  } catch (err) {
+    logger.warn({ err }, 'getBranchFiles error');
+    const errChecked = checkForPlatformFailure(err);
+    if (errChecked) {
+      throw errChecked;
+    }
+    return null;
+  }
+}
+
 export async function getFile(
   filePath: string,
   branchName?: string,

--- a/lib/workers/repository/update/pr/code-owners.spec.ts
+++ b/lib/workers/repository/update/pr/code-owners.spec.ts
@@ -1,6 +1,5 @@
 import { codeBlock } from 'common-tags';
 import { mock } from 'vitest-mock-extended';
-import { GlobalConfig } from '../../../../config/global';
 import type { Pr } from '../../../../modules/platform';
 import * as gitlab from '../../../../modules/platform/gitlab';
 import type { LongCommitSha } from '../../../../util/git/types';
@@ -16,15 +15,13 @@ describe('workers/repository/update/pr/code-owners', () => {
       writable: true,
     });
   });
-  beforeEach(() => {
-    GlobalConfig.reset();
-  });
 
   describe('codeOwnersForPr', () => {
     let pr: Pr;
 
     beforeEach(() => {
       pr = mock<Pr>();
+      pr.sha = undefined;
     });
 
     it('returns global code owner', async () => {
@@ -34,10 +31,7 @@ describe('workers/repository/update/pr/code-owners', () => {
       expect(codeOwners).toEqual(['@jimmy']);
     });
 
-    it('returns global code owner for gerrit', async () => {
-      GlobalConfig.set({
-        platform: 'gerrit',
-      });
+    it('returns global code owner for commit with sha set', async () => {
       pr.sha = 'f7374c2de8a4c95a7fd7182ab24044e3896aac02' as LongCommitSha;
       fs.readLocalFile.mockResolvedValueOnce(['* @jimmy'].join('\n'));
       git.getBranchFilesFromCommit.mockResolvedValueOnce(['README.md']);

--- a/lib/workers/repository/update/pr/code-owners.spec.ts
+++ b/lib/workers/repository/update/pr/code-owners.spec.ts
@@ -33,7 +33,7 @@ describe('workers/repository/update/pr/code-owners', () => {
 
     it('returns global code owner for commit with sha set', async () => {
       pr.sha = 'f7374c2de8a4c95a7fd7182ab24044e3896aac02' as LongCommitSha;
-      fs.readLocalFile.mockResolvedValueOnce(['* @jimmy'].join('\n'));
+      fs.readLocalFile.mockResolvedValueOnce('* @jimmy');
       git.getBranchFilesFromCommit.mockResolvedValueOnce(['README.md']);
       const codeOwners = await codeOwnersForPr(pr);
       expect(codeOwners).toEqual(['@jimmy']);

--- a/lib/workers/repository/update/pr/code-owners.spec.ts
+++ b/lib/workers/repository/update/pr/code-owners.spec.ts
@@ -1,11 +1,11 @@
 import { codeBlock } from 'common-tags';
 import { mock } from 'vitest-mock-extended';
+import { GlobalConfig } from '../../../../config/global';
 import type { Pr } from '../../../../modules/platform';
 import * as gitlab from '../../../../modules/platform/gitlab';
+import type { LongCommitSha } from '../../../../util/git/types';
 import { codeOwnersForPr } from './code-owners';
 import { fs, git, platform } from '~test/util';
-import { GlobalConfig } from '../../../../config/global';
-import { LongCommitSha } from '../../../../util/git/types';
 
 vi.mock('../../../../util/fs');
 

--- a/lib/workers/repository/update/pr/code-owners.ts
+++ b/lib/workers/repository/update/pr/code-owners.ts
@@ -1,6 +1,5 @@
 import is from '@sindresorhus/is';
 import ignore from 'ignore';
-import { GlobalConfig } from '../../../../config/global';
 import { logger } from '../../../../logger';
 import type { FileOwnerRule, Pr } from '../../../../modules/platform';
 import { platform } from '../../../../modules/platform';
@@ -99,12 +98,11 @@ export async function codeOwnersForPr(pr: Pr): Promise<string[]> {
     }
 
     logger.debug(`Found CODEOWNERS file: ${codeOwnersFile}`);
-    const pl = GlobalConfig.get('platform');
 
     // Get list of modified files in PR
-    //on the gerrit platform, the source branch does not exists. Instead of the branch, we can take the commit sha and diff against the parent
+    // if the commit sha is known, we can directly compare against the parent, otherwise use the branch
     const prFiles =
-      'gerrit' === pl && pr.sha
+      pr.sha
         ? await getBranchFilesFromCommit(pr.sha)
         : await getBranchFiles(pr.sourceBranch);
 

--- a/lib/workers/repository/update/pr/code-owners.ts
+++ b/lib/workers/repository/update/pr/code-owners.ts
@@ -101,10 +101,9 @@ export async function codeOwnersForPr(pr: Pr): Promise<string[]> {
 
     // Get list of modified files in PR
     // if the commit sha is known, we can directly compare against the parent, otherwise use the branch
-    const prFiles =
-      pr.sha
-        ? await getBranchFilesFromCommit(pr.sha)
-        : await getBranchFiles(pr.sourceBranch);
+    const prFiles = pr.sha
+      ? await getBranchFilesFromCommit(pr.sha)
+      : await getBranchFiles(pr.sourceBranch);
 
     if (!prFiles?.length) {
       logger.debug('PR includes no files');

--- a/lib/workers/repository/update/pr/code-owners.ts
+++ b/lib/workers/repository/update/pr/code-owners.ts
@@ -1,12 +1,12 @@
 import is from '@sindresorhus/is';
 import ignore from 'ignore';
+import { GlobalConfig } from '../../../../config/global';
 import { logger } from '../../../../logger';
 import type { FileOwnerRule, Pr } from '../../../../modules/platform';
 import { platform } from '../../../../modules/platform';
 import { readLocalFile } from '../../../../util/fs';
 import { getBranchFiles, getBranchFilesFromCommit } from '../../../../util/git';
 import { newlineRegex, regEx } from '../../../../util/regex';
-import { GlobalConfig } from '../../../../config/global';
 
 interface FileOwnersScore {
   file: string;


### PR DESCRIPTION
## Changes

Fixes CODEOWNERS support for the gerrit platform

## Context

I tried using CODEOWNERS in gerrit to automatically add reviewers, but found out it's not working. I came to the conclusion, that the problem is in code-owner#getBranchFiles, because it uses the sourceBranch of the Pr to diff.
With Gerrit, the value in sourceBranch isn't a real branch, so the diff fails. To fix that, I use the commit sha as a diff base for the gerrit platform.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [X] Both unit tests + ran on a real repository
