### PR TITLE
fix(codecommit): reset cached pull request list when initializing repository

### DIFF
--- a/lib/modules/platform/codecommit/index.ts
+++ b/lib/modules/platform/codecommit/index.ts
@@ -53,7 +53,7 @@ interface Config {
 
 export const id = 'codecommit';
 
-export const config: Config = {};
+let config: Config = {} as any;
 
 export async function initPlatform({
   endpoint,
@@ -106,7 +106,7 @@ export async function initRepo({
 }: RepoParams): Promise<RepoResult> {
   logger.debug(`initRepo("${repository}")`);
 
-  config.repository = repository;
+  config = { repository } as Config;
 
   let repo;
   try {


### PR DESCRIPTION

## Changes

Updates the CodeCommit platform to re-initialize its configuration fully when calling `initRepo`. This fixes an issue where duplicate PRs would be created for any repository after the first being processed.

## Context

The background information, including supporting logs, is covered in discussion  #26357 .

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

I have been running a monkey patched version of the node module for a few months now with this change and have not seen the duplicate issue re-occur since. 

The existing unit tests continue to pass with some modifications were required to avoid direct access to a field which is no longer defined as a constant, but should have the same intended effect (although I'm a little sceptical that the tests I modified test what they say they test - could be reading it wrong though, my TS/JS is a little rusty). 

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
