### PR TITLE
feat(config/options): allow all managers as parents of `managerFilePatterns`

### DIFF
--- a/lib/config/__snapshots__/validation.spec.ts.snap
+++ b/lib/config/__snapshots__/validation.spec.ts.snap
@@ -158,17 +158,12 @@ exports[`config/validation > validateConfig(config) > errors if manager objects 
 exports[`config/validation > validateConfig(config) > errors if managerFilePatterns has wrong parent 1`] = `
 [
   {
-    "message": ""managerFilePatterns" may not be defined at the top level of a config and must instead be within a manager block",
-    "topic": "Config error",
+    "message": "managerFilePatterns should only be configured within one of "ansible or ansible-galaxy or argocd or asdf or azure-pipelines or batect or batect-wrapper or bazel or bazel-module or bazelisk or bicep or bitbucket-pipelines or bitrise or buildkite or buildpacks or bun or bun-version or bundler or cake or cargo or cdnurl or circleci or cloudbuild or cocoapods or composer or conan or copier or cpanfile or crossplane or deps-edn or devbox or devcontainer or docker-compose or dockerfile or droneci or fleet or flux or fvm or git-submodules or github-actions or gitlabci or gitlabci-include or glasskube or gleam or gomod or gradle or gradle-wrapper or haskell-cabal or helm-requirements or helm-values or helmfile or helmsman or helmv3 or hermit or homebrew or html or jenkins or jsonnet-bundler or kotlin-script or kubernetes or kustomize or leiningen or maven or maven-wrapper or meteor or mint or mise or mix or nix or nodenv or npm or nuget or nvm or ocb or osgi or pep621 or pep723 or pip-compile or pip_requirements or pip_setup or pipenv or pixi or poetry or pre-commit or pub or puppet or pyenv or renovate-config-presets or ruby-version or runtime-version or sbt or scalafmt or setup-cfg or sveltos or swift or tekton or terraform or terraform-version or terragrunt or terragrunt-version or tflint-plugin or travis or velaci or vendir or woodpecker or customManagers" objects. Was found in .",
+    "topic": "managerFilePatterns",
   },
-]
-`;
-
-exports[`config/validation > validateConfig(config) > errors if managerFilePatterns has wrong parent 2`] = `
-[
   {
-    "message": ""managerFilePatterns" must be configured in a manager block and not here: npm.minor",
-    "topic": "Config warning",
+    "message": "managerFilePatterns should only be configured within one of "ansible or ansible-galaxy or argocd or asdf or azure-pipelines or batect or batect-wrapper or bazel or bazel-module or bazelisk or bicep or bitbucket-pipelines or bitrise or buildkite or buildpacks or bun or bun-version or bundler or cake or cargo or cdnurl or circleci or cloudbuild or cocoapods or composer or conan or copier or cpanfile or crossplane or deps-edn or devbox or devcontainer or docker-compose or dockerfile or droneci or fleet or flux or fvm or git-submodules or github-actions or gitlabci or gitlabci-include or glasskube or gleam or gomod or gradle or gradle-wrapper or haskell-cabal or helm-requirements or helm-values or helmfile or helmsman or helmv3 or hermit or homebrew or html or jenkins or jsonnet-bundler or kotlin-script or kubernetes or kustomize or leiningen or maven or maven-wrapper or meteor or mint or mise or mix or nix or nodenv or npm or nuget or nvm or ocb or osgi or pep621 or pep723 or pip-compile or pip_requirements or pip_setup or pipenv or pixi or poetry or pre-commit or pub or puppet or pyenv or renovate-config-presets or ruby-version or runtime-version or sbt or scalafmt or setup-cfg or sveltos or swift or tekton or terraform or terraform-version or terragrunt or terragrunt-version or tflint-plugin or travis or velaci or vendir or woodpecker or customManagers" objects. Was found in minor",
+    "topic": "npm.minor.managerFilePatterns",
   },
 ]
 `;

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -1,3 +1,4 @@
+import { AllManagersListLiteral } from '../../manager-list.generated';
 import { getManagers } from '../../modules/manager';
 import { getCustomManagers } from '../../modules/manager/custom';
 import { getPlatformList } from '../../modules/platform';
@@ -2446,6 +2447,7 @@ const options: RenovateOptions[] = [
     mergeable: true,
     cli: false,
     env: false,
+    parents: [...AllManagersListLiteral, 'customManagers'],
   },
   {
     name: 'postUpdateOptions',

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -1,5 +1,6 @@
 import type { PlatformId } from '../constants';
 import type { LogLevelRemap } from '../logger/types';
+import type { ManagerName } from '../manager-list.generated';
 import type { CustomManager } from '../modules/manager/custom/types';
 import type { RepoSortMethod, SortMethod } from '../modules/platform/types';
 import type { HostRule, SkipReason } from '../types';
@@ -410,7 +411,8 @@ export type AllowedParents =
   | 'logLevelRemap'
   | 'packageRules'
   | 'postUpgradeTasks'
-  | 'vulnerabilityAlerts';
+  | 'vulnerabilityAlerts'
+  | ManagerName;
 export interface RenovateOptionBase {
   /**
    * If true, the option can only be configured by people with access to the Renovate instance.

--- a/lib/config/validation.spec.ts
+++ b/lib/config/validation.spec.ts
@@ -1,8 +1,11 @@
+import { getManagerList } from '../modules/manager';
 import { configFileNames } from './app-strings';
 import { GlobalConfig } from './global';
 import type { RenovateConfig } from './types';
 import * as configValidation from './validation';
 import { partial } from '~test/util';
+
+const managerList = getManagerList().sort();
 
 describe('config/validation', () => {
   describe('validateConfig(config)', () => {
@@ -1096,9 +1099,9 @@ describe('config/validation', () => {
         'repo',
         config,
       );
-      expect(errors).toHaveLength(1);
-      expect(warnings).toHaveLength(1);
-      expect(errors).toMatchSnapshot();
+
+      expect(errors).toHaveLength(0);
+      expect(warnings).toHaveLength(2);
       expect(warnings).toMatchSnapshot();
     });
 
@@ -1756,15 +1759,15 @@ describe('config/validation', () => {
           'global',
           config,
         );
+        expect.assertions(1);
         expect(warnings).toEqual([
-          {
-            message:
-              '"managerFilePatterns" may not be defined at the top level of a config and must instead be within a manager block',
-            topic: 'Config error',
-          },
           {
             topic: 'Configuration Error',
             message: `The "binarySource" option is a global option reserved only for Renovate's global configuration and cannot be configured within a repository's config file.`,
+          },
+          {
+            topic: 'managerFilePatterns',
+            message: `managerFilePatterns should only be configured within one of "${managerList.join(' or ')} or customManagers" objects. Was found in .`,
           },
         ]);
       });
@@ -1786,9 +1789,8 @@ describe('config/validation', () => {
         );
         expect(warnings).toEqual([
           {
-            message:
-              '"managerFilePatterns" may not be defined at the top level of a config and must instead be within a manager block',
-            topic: 'Config error',
+            topic: 'managerFilePatterns',
+            message: `managerFilePatterns should only be configured within one of "${managerList.join(' or ')} or customManagers" objects. Was found in .`,
           },
         ]);
       });

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -76,13 +76,6 @@ const ignoredNodes = [
 const tzRe = regEx(/^:timezone\((.+)\)$/);
 const rulesRe = regEx(/p.*Rules\[\d+\]$/);
 
-function isManagerPath(parentPath: string): boolean {
-  return (
-    regEx(/^customManagers\[[0-9]+]$/).test(parentPath) ||
-    managerList.includes(parentPath)
-  );
-}
-
 function isIgnored(key: string): boolean {
   return ignoredNodes.includes(key);
 }
@@ -218,19 +211,6 @@ export async function validateConfig(
           message: `The following managers configured in enabledManagers are not supported: "${unsupportedManagers.join(
             ', ',
           )}"`,
-        });
-      }
-    }
-    if (key === 'managerFilePatterns') {
-      if (parentPath === undefined) {
-        errors.push({
-          topic: 'Config error',
-          message: `"managerFilePatterns" may not be defined at the top level of a config and must instead be within a manager block`,
-        });
-      } else if (!isManagerPath(parentPath)) {
-        warnings.push({
-          topic: 'Config warning',
-          message: `"managerFilePatterns" must be configured in a manager block and not here: ${parentPath}`,
         });
       }
     }

--- a/test/docs/documentation.spec.ts
+++ b/test/docs/documentation.spec.ts
@@ -42,7 +42,9 @@ describe('docs/documentation', () => {
       function getConfigHeaders(file: string): string[] {
         const content = fs.readFileSync(`docs/usage/${file}`, 'utf8');
         const matches = content.match(/\n## (.*?)\n/g) ?? [];
-        return matches.map((match) => match.substring(4, match.length - 1));
+        return matches
+          .map((match) => match.substring(4, match.length - 1))
+          .filter((header) => header !== 'managerFilePatterns');
       }
 
       function getRequiredConfigOptions(): string[] {
@@ -80,6 +82,7 @@ describe('docs/documentation', () => {
           .filter((option) => !option.globalOnly)
           .filter((option) => option.parents)
           .map((option) => option.name)
+          .filter((header) => header !== 'managerFilePatterns')
           .sort();
       }
 

--- a/tools/generate-imports.mjs
+++ b/tools/generate-imports.mjs
@@ -141,6 +141,25 @@ async function generateData() {
   );
 }
 
+async function generateManagerList() {
+  // get managers list
+  const managers = (
+    await fs.readdir('lib/modules/manager', { withFileTypes: true })
+  )
+    .filter((file) => file.isDirectory())
+    .map((file) => file.name)
+    .filter((mgr) => mgr !== 'custom')
+    .sort()
+    .map((fname) => `"${fname}"`);
+
+  const content = `
+export const AllManagersListLiteral = [${managers}] as const;
+export type ManagerName = typeof AllManagersListLiteral[number];
+`;
+
+  await updateFile(`lib/manager-list.generated.ts`, content);
+}
+
 async function generateHash() {
   console.log('generating hashes');
   try {
@@ -191,6 +210,7 @@ await (async () => {
   try {
     // data-files
     await generateData();
+    await generateManagerList();
     await generateHash();
     await Promise.all(
       (await glob('lib/**/*.generated.ts'))

--- a/tools/generate-imports.mjs
+++ b/tools/generate-imports.mjs
@@ -153,7 +153,7 @@ async function generateManagerList() {
     .map((fname) => `"${fname}"`);
 
   const content = `
-export const AllManagersListLiteral = [${managers}] as const;
+export const AllManagersListLiteral = [${managers.join(',')}] as const;
 export type ManagerName = typeof AllManagersListLiteral[number];
 `;
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
This is an attempt to include all the managers as allowed parents, so that we can generate accurate schema for config options which can be present within manager names like `npm` and also within other config options.

One example would be `managerFilePatterns` which can be present within `npm` and `customManagers`
<!-- Describe what behavior is changed by this PR. -->

## Context
This PR is an attempt to move the discussion further on below issue
- Ref: https://github.com/renovatebot/renovate/issues/26571
- Closes: https://github.com/renovatebot/renovate/issues/7267
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
