### PR TITLE
docs(nuget): Fix NuGet casing

### DIFF
--- a/docs/usage/.pages
+++ b/docs/usage/.pages
@@ -20,7 +20,7 @@ nav:
       - 'Java': 'java.md'
       - 'JavaScript': 'javascript.md'
       - 'Node.js Versions': 'node.md'
-      - 'Nuget': 'nuget.md'
+      - 'NuGet': 'nuget.md'
       - 'PHP': 'php.md'
       - 'Python': 'python.md'
       - 'Ruby': 'ruby.md'

--- a/docs/usage/key-concepts/changelogs.md
+++ b/docs/usage/key-concepts/changelogs.md
@@ -104,6 +104,6 @@ Read [`maven` datasource, making your changelogs fetchable](../modules/datasourc
 
 Read the [Docker datasource](../modules/datasource/docker/index.md) docs.
 
-### Nuget package maintainers
+### NuGet package maintainers
 
 See [Renovate issue #14128 about using NuGet's changelogs](https://github.com/renovatebot/renovate/issues/14128).

--- a/lib/modules/manager/nuget/readme.md
+++ b/lib/modules/manager/nuget/readme.md
@@ -22,7 +22,7 @@ For Renovate to work with .NET Framework projects, you need to update these file
 
 ### Disabling updates for pinned versions
 
-In Nuget, when you use versions like `Version="1.2.3"` then it means "1.2.3 or greater, up to v2"
+In NuGet, when you use versions like `Version="1.2.3"` then it means "1.2.3 or greater, up to v2"
 When you use versions like `Version="[1.2.3]"` then it means "exactly 1.2.3".
 
 If you would like Renovate to disable updating of exact versions (warning: you might end up years out of date and not realize it) then here is an example configuration to achieve that:


### PR DESCRIPTION
## Changes

Fix the casing of "NuGet" in documentation.

## Context

Just updating for consistency. Spotted while reading the documentation.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
