### PR TITLE
fix(terragrunt): handle local includes and return empty deps array

### DIFF
--- a/lib/modules/manager/terragrunt/extract.spec.ts
+++ b/lib/modules/manager/terragrunt/extract.spec.ts
@@ -696,5 +696,14 @@ describe('modules/manager/terragrunt/extract', () => {
       `),
       ).toBeNull();
     });
+
+    it('returns empty deps if only local terragrunt includes', () => {
+      expect(
+        extractPackageFile(`include "root" {
+        path = find_in_parent_folders("root.hcl")
+      }
+      `),
+      ).toStrictEqual({ deps: [] });
+    });
   });
 });

--- a/lib/modules/manager/terragrunt/extract.ts
+++ b/lib/modules/manager/terragrunt/extract.ts
@@ -10,6 +10,7 @@ import {
 
 const dependencyBlockExtractionRegex = regEx(/^\s*(?<type>[a-z_]+)\s+{\s*$/);
 const contentCheckList = ['terraform {'];
+const includeBlockCheck = 'include "';
 
 export function extractPackageFile(
   content: string,
@@ -17,6 +18,9 @@ export function extractPackageFile(
 ): PackageFileContent | null {
   logger.trace({ content }, `terragrunt.extractPackageFile(${packageFile!})`);
   if (!checkFileContainsDependency(content, contentCheckList)) {
+    if (content.includes(includeBlockCheck)) {
+      return { deps: [] };
+    }
     return null;
   }
   let deps: PackageDependency<TerraformManagerData>[] = [];

--- a/lib/modules/manager/terragrunt/extract.ts
+++ b/lib/modules/manager/terragrunt/extract.ts
@@ -10,7 +10,7 @@ import {
 
 const dependencyBlockExtractionRegex = regEx(/^\s*(?<type>[a-z_]+)\s+{\s*$/);
 const contentCheckList = ['terraform {'];
-const includeBlockCheck = 'include "';
+const includeBlockCheck = regEx(/include\s*(?:".*")?\s*\{/);
 
 export function extractPackageFile(
   content: string,
@@ -18,7 +18,7 @@ export function extractPackageFile(
 ): PackageFileContent | null {
   logger.trace({ content }, `terragrunt.extractPackageFile(${packageFile!})`);
   if (!checkFileContainsDependency(content, contentCheckList)) {
-    if (content.includes(includeBlockCheck)) {
+    if (content.match(includeBlockCheck)) {
       return { deps: [] };
     }
     return null;


### PR DESCRIPTION
## Changes

  This fix enables lock file maintenance for Terragrunt modules that don't directly contain a `terraform {}` block but instead include one from another location on the local filesystem using `include` blocks.

  Previously, Terragrunt files containing only local includes (like `include "root" { path = find_in_parent_folders("root.hcl") }`) would return `null` from the package file extraction, preventing lock file maintenance. Now these
  files return an empty dependencies array (`{ deps: [] }`), allowing Renovate to properly track and maintain lock files for such configurations.

  ## Context

  In Terragrunt configurations, it's common to have modules that don't directly define a `terraform {}` block but inherit it from parent configurations using `include` blocks. These configurations should still be eligible for lock
  file maintenance even though they don't contain direct Terraform dependencies.

  The fix specifically handles the case where:
  - A Terragrunt file contains `include "` blocks (indicating local includes)
  - But does not contain `terraform {` blocks (the current dependency detection criteria)

  ## Documentation (please check one with an [x])

  - [x] No documentation update is required

  ## How I've tested my work (please select one)

  I have verified these changes via:

  - [x] Newly added/modified unit tests

  The fix includes a new unit test that verifies files with only local Terragrunt includes return `{ deps: [] }` instead of `null`, ensuring proper lock file maintenance support.