### PR TITLE
fix(gitlab): approve PR after automerge is added

### DIFF
--- a/lib/modules/platform/gitlab/index.ts
+++ b/lib/modules/platform/gitlab/index.ts
@@ -766,11 +766,11 @@ export async function createPr({
     !!config.ignorePrAuthor,
   );
 
+  await tryPrAutomerge(pr.number, platformPrOptions);
+
   if (platformPrOptions?.autoApprove) {
     await approveMr(pr.number);
   }
-
-  await tryPrAutomerge(pr.number, platformPrOptions);
 
   return pr;
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

I would like to send "approve" for gitlab MRs to happen after we add "auto merge".

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

More often then not, I get into a scenario like this: 
![Screenshot 2025-06-14 at 17 32 52](https://github.com/user-attachments/assets/8b20dc8b-adba-4fd3-8d96-9827de8b3746)

17:16:45 We approve the PR
17.16:53 The first commit is pushed (which according to my gitlab settings, will reset approvals)
17.16.54 We enable auto merge

This leaves my PRs open because they are never approved. 

Looking at the `tryPrAutomerge()`, I am fairly sure (please correct if I am wrong), that we will still call the API to merge because the PR will be in state `ci_still_running` or `not_approved`. 


## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
