### PR TITLE
feat(presets): Add OpenAPI.NET as monorepo

### DIFF
--- a/lib/data/monorepo.json
+++ b/lib/data/monorepo.json
@@ -453,6 +453,7 @@
       "https://github.com/nuxt/nuxt"
     ],
     "okhttp": "https://github.com/square/okhttp",
+    "openapi-dotnet": "https://github.com/microsoft/OpenAPI.NET",
     "opencost": [
       "https://github.com/opencost/opencost",
       "https://github.com/opencost/opencost-ui"


### PR DESCRIPTION
## Changes

Add monorepo for OpenAPI.NET's NuGet packages.

## Context

Add monorepo for [OpenAPI.NET](https://github.com/microsoft/OpenAPI.NET) so all the NuGet packages get updated together.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
