### PR TITLE
chore(bumpVersion): add more logging based on feedback for easier debugging

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -568,6 +568,22 @@ In this configuration:
 - The version string is extracted from lines matching `version: <value>`.
 - The `bumpType` is dynamically set to `patch` for if the dependency update is a patch update and `minor` otherwise.
 
+**debugging `bumpVersions`**
+
+Use [`logLevelRemap`](#loglevelremap) to remap, `trace` log level messages to a higher level e.g. `debug`.
+All messages are prefixed with `bumpVersions` or `bumpVersions(<name>)` to help you filter them in the logs.
+
+```json
+{
+  "logLevelRemap": [
+    {
+      "matchMessage": "/bumpVersions/",
+      "newLogLevel": "info"
+    }
+  ]
+}
+```
+
 ### bumpType
 
 The `bumpType` field specifies the type of version bump to apply.

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -578,7 +578,7 @@ All messages are prefixed with `bumpVersions` or `bumpVersions(<name>)` to help 
   "logLevelRemap": [
     {
       "matchMessage": "/bumpVersions/",
-      "newLogLevel": "info"
+      "newLogLevel": "debug"
     }
   ]
 }

--- a/lib/workers/repository/update/branch/bump-versions.spec.ts
+++ b/lib/workers/repository/update/branch/bump-versions.spec.ts
@@ -119,6 +119,45 @@ describe('workers/repository/update/branch/bump-versions', () => {
       });
     });
 
+    it('should noop if no files are matching', async () => {
+      const compile = vi.spyOn(templates, 'compile');
+      compile.mockReturnValueOnce('foo');
+      compile.mockReturnValueOnce('^(?<version>.+)$');
+      const config = partial<BranchConfig>({
+        bumpVersions: [
+          {
+            filePatterns: ['foo'],
+            bumpType: 'minor',
+            matchStrings: ['^(?<version>.+)$'],
+          },
+        ],
+        artifactErrors: [],
+        updatedPackageFiles: [
+          {
+            type: 'addition',
+            path: 'foo',
+            contents: '1.0.0',
+          },
+        ],
+        updatedArtifacts: [],
+      });
+      scm.getFileList.mockResolvedValueOnce(['bar']);
+
+      await bumpVersions(config);
+
+      expect(config).toMatchObject({
+        artifactErrors: [],
+        updatedPackageFiles: [
+          {
+            type: 'addition',
+            path: 'foo',
+            contents: '1.0.0',
+          },
+        ],
+        updatedArtifacts: [],
+      });
+    });
+
     it('should catch template error in bumpType', async () => {
       const compile = vi.spyOn(templates, 'compile');
       compile.mockReturnValueOnce('foo');

--- a/lib/workers/repository/update/branch/bump-versions.spec.ts
+++ b/lib/workers/repository/update/branch/bump-versions.spec.ts
@@ -1,5 +1,4 @@
 import { codeBlock } from 'common-tags';
-import { expect } from 'vitest';
 import * as templates from '../../../../util/template';
 import type { BranchConfig } from '../../../types';
 import { bumpVersions } from './bump-versions';

--- a/lib/workers/repository/update/branch/bump-versions.ts
+++ b/lib/workers/repository/update/branch/bump-versions.ts
@@ -57,7 +57,7 @@ async function bumpVersion(
 ): Promise<void> {
   const rawBumpType = config.bumpType ?? 'patch';
 
-  // all log messages should be prefixed with this string to allow logLevelRemapping
+  // all log messages should be prefixed with this string to facilitate easier logLevelRemapping
   const bumpVersionsDescr = config.name
     ? `bumpVersions(${config.name})`
     : 'bumpVersions';

--- a/lib/workers/repository/update/branch/bump-versions.ts
+++ b/lib/workers/repository/update/branch/bump-versions.ts
@@ -57,13 +57,21 @@ async function bumpVersion(
 ): Promise<void> {
   const rawBumpType = config.bumpType ?? 'patch';
 
+  // all log messages should be prefixed with this string to allow logLevelRemapping
   const bumpVersionsDescr = config.name
     ? `bumpVersions(${config.name})`
     : 'bumpVersions';
 
   const files: string[] = [];
   try {
-    files.push(...getMatchedFiles(config.filePatterns, branchConfig, fileList));
+    files.push(
+      ...getMatchedFiles(
+        bumpVersionsDescr,
+        config.filePatterns,
+        branchConfig,
+        fileList,
+      ),
+    );
   } catch (e) {
     addArtifactError(
       branchConfig,
@@ -71,11 +79,26 @@ async function bumpVersion(
     );
     return;
   }
+
+  if (!files.length) {
+    logger.debug(`${bumpVersionsDescr}: filePatterns did not match any files`);
+    return;
+  }
+
+  logger.trace(
+    { files },
+    `${bumpVersionsDescr}: Found ${files.length} files to bump versions`,
+  );
+
+  // keeping this only for logging purposes
+  const matchStrings: string[] = [];
+
   // prepare the matchStrings
   const matchStringsRegexes: RegExp[] = [];
   for (const matchString of config.matchStrings) {
     try {
       const templated = compile(matchString, branchConfig);
+      matchStrings.push(templated);
       matchStringsRegexes.push(regEx(templated));
     } catch (e) {
       addArtifactError(
@@ -86,7 +109,11 @@ async function bumpVersion(
     }
   }
 
+  logger.trace({ matchStrings }, `${bumpVersionsDescr}: Compiled matchStrings`);
+
   for (const filePath of files) {
+    let fileBumped = false;
+
     const fileContents = await getFileContent(
       bumpVersionsDescr,
       filePath,
@@ -155,17 +182,28 @@ async function bumpVersion(
           contents: newFileContents,
         });
       }
+
+      fileBumped = true;
+    }
+
+    if (!fileBumped) {
+      logger.debug(
+        { file: filePath },
+        `${bumpVersionsDescr}: No match found for bumping version`,
+      );
     }
   }
 }
 
 /**
  * Get files that match ANY of the fileMatches pattern. fileMatches are compiled with the branchConfig.
+ * @param bumpVersionsDescr log description for the bump version config
  * @param filePatternTemplates list of regex patterns
  * @param branchConfig compile metadata
  * @param fileList list of files to match against
  */
 function getMatchedFiles(
+  bumpVersionsDescr: string,
   filePatternTemplates: string[],
   branchConfig: BranchConfig,
   fileList: string[],
@@ -176,6 +214,9 @@ function getMatchedFiles(
     const filePattern = compile(filePatternTemplateElement, branchConfig);
     filePatterns.push(filePattern);
   }
+
+  logger.trace({ filePatterns }, `${bumpVersionsDescr}: Compiled filePatterns`);
+
   // get files that match the fileMatch
   const files: string[] = [];
   for (const file of fileList) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds more logging for ´bumpVersions` to ease debugging especially when dealing with templates in the config options.

## Context

https://github.com/renovatebot/renovate/discussions/35770#discussioncomment-13475645

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
