### PR TITLE
docs(pre-commit): fix spelling and example package name

### DIFF
--- a/lib/modules/manager/pre-commit/readme.md
+++ b/lib/modules/manager/pre-commit/readme.md
@@ -29,12 +29,12 @@ Alternatively, add `:enablePreCommit` to your `extends` array.
 
 ### Additional Dependencies
 
-renovate has partial support for `additional_dependencies`, currently python only.
+Renovate has partial support for `additional_dependencies`, currently Python only.
 
-for python hooks, you will need to **explicitly add language** to your hooks with `additional_dependencies`
-to let renovatebot know what kind of dependencies they are.
+For Python hooks, you will need to **explicitly add language** to your hooks with `additional_dependencies`
+to let Renovate know what kind of dependencies they are.
 
-For example, this work for `request`:
+For example, this works for `requests`:
 
 ```yaml
 - repo: https://github.com/psf/black
@@ -43,10 +43,10 @@ For example, this work for `request`:
     - id: black
       language: python
       additional_dependencies:
-        - 'request==1.1.1'
+        - 'requests==1.1.1'
 ```
 
-this won't work:
+This won't work:
 
 ```yaml
 - repo: https://github.com/psf/black
@@ -54,5 +54,5 @@ this won't work:
   hooks:
     - id: black
       additional_dependencies:
-        - 'request==1.1.1'
+        - 'requests==1.1.1'
 ```


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Just some minor spelling and content fixes.

## Context

I was reading up on pre-commit support and stumbled over some opportunities for enhancing the docs.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
