### PR TITLE
fix(gitea): automerge of repos with only fast forward only merge

### DIFF
--- a/lib/modules/platform/gitea/index.spec.ts
+++ b/lib/modules/platform/gitea/index.spec.ts
@@ -555,7 +555,7 @@ describe('modules/platform/gitea/index', () => {
       );
     });
 
-    it('should fall back to merge method "fast-forward"', async () => {
+    it('should fall back to merge method "fast-forward-only"', async () => {
       const scope = httpMock
         .scope('https://gitea.com/api/v1')
         .get(`/repos/${initRepoCfg.repository}`)
@@ -570,7 +570,7 @@ describe('modules/platform/gitea/index', () => {
 
       expect(git.initRepo).toHaveBeenCalledExactlyOnceWith(
         expect.objectContaining({
-          mergeMethod: 'fast-forward',
+          mergeMethod: 'fast-forward-only',
         }),
       );
     });

--- a/lib/modules/platform/gitea/index.ts
+++ b/lib/modules/platform/gitea/index.ts
@@ -329,7 +329,7 @@ const platform: Platform = {
     } else if (repo.allow_merge_commits) {
       config.mergeMethod = 'merge';
     } else if (repo.allow_fast_forward_only_merge) {
-      config.mergeMethod = 'fast-forward';
+      config.mergeMethod = 'fast-forward-only';
     } else {
       logger.debug(
         'Repository has no allowed merge methods - aborting renovation',

--- a/lib/modules/platform/gitea/types.ts
+++ b/lib/modules/platform/gitea/types.ts
@@ -16,7 +16,7 @@ export type CommitStatusType =
   | 'warning'
   | 'unknown';
 export type PRMergeMethod =
-  | 'fast-forward'
+  | 'fast-forward-only'
   | 'merge'
   | 'rebase'
   | 'rebase-merge'


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Add support for automerge on repos with only fast forward merge strategy enabled. PR creation support was added in #36272 but the strategy string was incorrectly set to `fast-forward` rather than `fast-forward-only` which prevents automerge working - see [gitea API](https://docs.gitea.com/api#tag/repository/operation/repoMergePullRequest)
<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

If a gitea repo is configured to only allow fast forward merge strategy, renovate is unable to automerge PRs.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
