### PR TITLE
fix(npm): set `hasPackageManager:true` if `devEngines` detected

### DIFF
--- a/lib/modules/manager/npm/extract/common/package-file.ts
+++ b/lib/modules/manager/npm/extract/common/package-file.ts
@@ -140,9 +140,9 @@ export function extractPackageJson(
     packageFileVersion,
     managerData: {
       packageJsonName,
-      hasPackageManager: is.nonEmptyStringAndNotWhitespace(
-        packageJson.packageManager,
-      ),
+      hasPackageManager:
+        is.nonEmptyStringAndNotWhitespace(packageJson.packageManager) ||
+        is.nonEmptyObject(packageJson.devEngines?.packageManager),
       workspaces: packageJson.workspaces,
     },
   };

--- a/lib/modules/manager/npm/extract/index.spec.ts
+++ b/lib/modules/manager/npm/extract/index.spec.ts
@@ -906,6 +906,43 @@ describe('modules/manager/npm/extract/index', () => {
             prettyDepType: 'packageManager',
           },
         ],
+        managerData: {
+          hasPackageManager: true,
+        },
+      });
+    });
+
+    it('sets hasPackageManager to true when devEngines detected in package file', async () => {
+      const pJson = {
+        devEngines: {
+          packageManager: {
+            name: 'yarn',
+            version: '3.0.0',
+          },
+        },
+        dependencies: {
+          express: '2.0.0',
+        },
+      };
+      const pJsonStr = JSON.stringify(pJson);
+      const res = await npmExtract.extractPackageFile(
+        pJsonStr,
+        'package.json',
+        defaultExtractConfig,
+      );
+      expect(res).toMatchObject({
+        deps: [
+          {
+            currentValue: '2.0.0',
+            datasource: 'npm',
+            depName: 'express',
+            depType: 'dependencies',
+            prettyDepType: 'dependency',
+          },
+        ],
+        managerData: {
+          hasPackageManager: true,
+        },
       });
     });
 

--- a/lib/modules/manager/npm/extract/index.ts
+++ b/lib/modules/manager/npm/extract/index.ts
@@ -213,9 +213,9 @@ export async function extractPackageFile(
       ...res.managerData,
       ...lockFiles,
       yarnZeroInstall,
-      hasPackageManager: is.nonEmptyStringAndNotWhitespace(
-        packageJson.packageManager,
-      ),
+      hasPackageManager:
+        is.nonEmptyStringAndNotWhitespace(packageJson.packageManager) ||
+        is.nonEmptyObject(packageJson.devEngines?.packageManager),
       workspacesPackages,
       npmrcFileName, // store npmrc file name so we can later tell if it came from the workspace or not
     },

--- a/lib/modules/manager/npm/extract/types.ts
+++ b/lib/modules/manager/npm/extract/types.ts
@@ -6,6 +6,13 @@ export type DependenciesMeta = Record<
   { optional: boolean; built: boolean; unplugged: boolean }
 >;
 
+// https://docs.npmjs.com/cli/v11/configuring-npm/package-json#devengines
+interface DevEngineItem {
+  name: string;
+  version?: string;
+  onFail?: 'warn' | 'error' | 'ignore';
+}
+
 export type NpmPackage = PackageJson & {
   renovate?: unknown;
   _from?: any;
@@ -16,6 +23,9 @@ export type NpmPackage = PackageJson & {
   volta?: PackageJson.Dependency;
   pnpm?: {
     overrides?: PackageJson.Dependency;
+  };
+  devEngines?: {
+    packageManager?: DevEngineItem | DevEngineItem[];
   };
 };
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- Set `hasPackageManager` to true when `devEngines` with `packageManager` configured is found in `package.json`
<!-- Describe what behavior is changed by this PR. -->

## Context
- Ref: https://github.com/renovatebot/renovate/discussions/36407
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository https://github.com/Rahul-renovate-testing/repro-36407

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
