### PR TITLE
fix: pnpm recursive update for workspace project

### DIFF
--- a/lib/modules/manager/npm/post-update/pnpm.spec.ts
+++ b/lib/modules/manager/npm/post-update/pnpm.spec.ts
@@ -14,6 +14,23 @@ vi.mock('./node-version');
 delete process.env.NPM_CONFIG_CACHE;
 process.env.CONTAINERBASE = 'true';
 
+function mockPnpmFiles(workspaceFileContent?: string) {
+  fs.getSiblingFileName.mockReturnValue('some-folder/pnpm-workspace.yaml');
+  fs.readLocalFile.mockImplementation((fileName: string): Promise<string> => {
+    if (fileName === 'some-folder/pnpm-lock.yaml') {
+      return Promise.resolve('package-lock-contents');
+    }
+    if (
+      fileName === 'some-folder/pnpm-workspace.yaml' &&
+      workspaceFileContent
+    ) {
+      return Promise.resolve(workspaceFileContent);
+    }
+    return Promise.resolve('unexpected file name');
+  });
+  fs.localPathExists.mockResolvedValueOnce(workspaceFileContent !== undefined); // pnpm-workspace.yaml
+}
+
 describe('modules/manager/npm/post-update/pnpm', () => {
   let config: PostUpdateConfig;
   const upgrades: Upgrade[] = [{}];
@@ -100,24 +117,15 @@ describe('modules/manager/npm/post-update/pnpm', () => {
     ]);
   });
 
-  it('performs lock file updates for workspace with --recursive', async () => {
+  it('performs lock file updates for workspace with packages', async () => {
     const execSnapshots = mockExecAll();
-    fs.getSiblingFileName.mockReturnValue('some-folder/pnpm-workspace.yaml');
-    fs.readLocalFile.mockImplementation((fileName: string): Promise<string> => {
-      if (fileName === 'some-folder/pnpm-lock.yaml') {
-        return Promise.resolve('package-lock-contents');
-      }
-      if (fileName === 'some-folder/pnpm-workspace.yaml') {
-        return Promise.resolve(
-          codeBlock`
-            packages:
-              - pkg-a
-          `,
-        );
-      }
-      return Promise.resolve('unexpected file name');
-    });
-    fs.localPathExists.mockResolvedValueOnce(true); // pnpm-workspace.yaml
+    mockPnpmFiles(
+      codeBlock`
+        packages:
+          - pkg-a
+      `,
+    );
+
     const res = await pnpmHelper.generateLockFile('some-folder', {}, config, [
       { packageName: 'some-dep', newVersion: '1.0.1', isLockfileUpdate: true },
       {
@@ -135,24 +143,15 @@ describe('modules/manager/npm/post-update/pnpm', () => {
     ]);
   });
 
-  it('performs lock file updates for workspace with --recursive using pnpm 10.x', async () => {
+  it('performs lock file updates for workspace with packages using pnpm 10.x', async () => {
     const execSnapshots = mockExecAll();
-    fs.getSiblingFileName.mockReturnValue('some-folder/pnpm-workspace.yaml');
-    fs.readLocalFile.mockImplementation((fileName: string): Promise<string> => {
-      if (fileName === 'some-folder/pnpm-lock.yaml') {
-        return Promise.resolve('package-lock-contents');
-      }
-      if (fileName === 'some-folder/pnpm-workspace.yaml') {
-        return Promise.resolve(
-          codeBlock`
-            packages:
-              - pkg-a
-          `,
-        );
-      }
-      return Promise.resolve('unexpected file name');
-    });
-    fs.localPathExists.mockResolvedValueOnce(true); // pnpm-workspace.yaml
+    mockPnpmFiles(
+      codeBlock`
+        packages:
+          - pkg-a
+          - pkg-b
+      `,
+    );
     const res = await pnpmHelper.generateLockFile(
       'some-folder',
       {},
@@ -179,10 +178,9 @@ describe('modules/manager/npm/post-update/pnpm', () => {
     ]);
   });
 
-  it('performs lock file updates for non workspace without --recursive using pnpm 10.x', async () => {
+  it('performs lock file updates for non workspace using pnpm 10.x', async () => {
     const execSnapshots = mockExecAll();
-    fs.readLocalFile.mockResolvedValue('package-lock-contents');
-    fs.localPathExists.mockResolvedValueOnce(false); // pnpm-workspace.yaml
+    mockPnpmFiles(); // no workspace file
     const res = await pnpmHelper.generateLockFile(
       'some-folder',
       {},
@@ -201,6 +199,57 @@ describe('modules/manager/npm/post-update/pnpm', () => {
       ],
     );
     expect(fs.readLocalFile).toHaveBeenCalledTimes(1);
+    expect(res.lockFile).toBe('package-lock-contents');
+    expect(execSnapshots).toMatchObject([
+      {
+        cmd: 'pnpm update --no-save some-dep@1.0.1 some-other-dep@1.1.0 --lockfile-only --ignore-scripts --ignore-pnpmfile',
+      },
+    ]);
+  });
+
+  it('performs lock file updates for workspace with empty package list', async () => {
+    const execSnapshots = mockExecAll();
+    mockPnpmFiles(codeBlock`packages: []`);
+    const res = await pnpmHelper.generateLockFile('some-folder', {}, config, [
+      {
+        packageName: 'some-dep',
+        newVersion: '1.0.1',
+        isLockfileUpdate: true,
+      },
+      {
+        packageName: 'some-other-dep',
+        newVersion: '1.1.0',
+        isLockfileUpdate: true,
+      },
+    ]);
+    expect(fs.readLocalFile).toHaveBeenCalledTimes(2);
+    expect(res.lockFile).toBe('package-lock-contents');
+    expect(execSnapshots).toMatchObject([
+      {
+        cmd: 'pnpm update --no-save some-dep@1.0.1 some-other-dep@1.1.0 --lockfile-only --ignore-scripts --ignore-pnpmfile',
+      },
+    ]);
+  });
+
+  it('performs lock file updates for workspace with config but no package list', async () => {
+    const execSnapshots = mockExecAll();
+    mockPnpmFiles(codeBlock`
+      overrides:
+        "foo@1.0.0>bar": "-"
+`);
+    const res = await pnpmHelper.generateLockFile('some-folder', {}, config, [
+      {
+        packageName: 'some-dep',
+        newVersion: '1.0.1',
+        isLockfileUpdate: true,
+      },
+      {
+        packageName: 'some-other-dep',
+        newVersion: '1.1.0',
+        isLockfileUpdate: true,
+      },
+    ]);
+    expect(fs.readLocalFile).toHaveBeenCalledTimes(2);
     expect(res.lockFile).toBe('package-lock-contents');
     expect(execSnapshots).toMatchObject([
       {

--- a/lib/modules/manager/npm/post-update/pnpm.spec.ts
+++ b/lib/modules/manager/npm/post-update/pnpm.spec.ts
@@ -102,7 +102,21 @@ describe('modules/manager/npm/post-update/pnpm', () => {
 
   it('performs lock file updates for workspace with --recursive', async () => {
     const execSnapshots = mockExecAll();
-    fs.readLocalFile.mockResolvedValue('package-lock-contents');
+    fs.getSiblingFileName.mockReturnValue('some-folder/pnpm-workspace.yaml');
+    fs.readLocalFile.mockImplementation((fileName: string): Promise<string> => {
+      if (fileName === 'some-folder/pnpm-lock.yaml') {
+        return Promise.resolve('package-lock-contents');
+      }
+      if (fileName === 'some-folder/pnpm-workspace.yaml') {
+        return Promise.resolve(
+          codeBlock`
+            packages:
+              - pkg-a
+          `,
+        );
+      }
+      return Promise.resolve('unexpected file name');
+    });
     fs.localPathExists.mockResolvedValueOnce(true); // pnpm-workspace.yaml
     const res = await pnpmHelper.generateLockFile('some-folder', {}, config, [
       { packageName: 'some-dep', newVersion: '1.0.1', isLockfileUpdate: true },
@@ -112,7 +126,7 @@ describe('modules/manager/npm/post-update/pnpm', () => {
         isLockfileUpdate: true,
       },
     ]);
-    expect(fs.readLocalFile).toHaveBeenCalledTimes(1);
+    expect(fs.readLocalFile).toHaveBeenCalledTimes(2);
     expect(res.lockFile).toBe('package-lock-contents');
     expect(execSnapshots).toMatchObject([
       {
@@ -123,7 +137,21 @@ describe('modules/manager/npm/post-update/pnpm', () => {
 
   it('performs lock file updates for workspace with --recursive using pnpm 10.x', async () => {
     const execSnapshots = mockExecAll();
-    fs.readLocalFile.mockResolvedValue('package-lock-contents');
+    fs.getSiblingFileName.mockReturnValue('some-folder/pnpm-workspace.yaml');
+    fs.readLocalFile.mockImplementation((fileName: string): Promise<string> => {
+      if (fileName === 'some-folder/pnpm-lock.yaml') {
+        return Promise.resolve('package-lock-contents');
+      }
+      if (fileName === 'some-folder/pnpm-workspace.yaml') {
+        return Promise.resolve(
+          codeBlock`
+            packages:
+              - pkg-a
+          `,
+        );
+      }
+      return Promise.resolve('unexpected file name');
+    });
     fs.localPathExists.mockResolvedValueOnce(true); // pnpm-workspace.yaml
     const res = await pnpmHelper.generateLockFile(
       'some-folder',
@@ -142,7 +170,7 @@ describe('modules/manager/npm/post-update/pnpm', () => {
         },
       ],
     );
-    expect(fs.readLocalFile).toHaveBeenCalledTimes(1);
+    expect(fs.readLocalFile).toHaveBeenCalledTimes(2);
     expect(res.lockFile).toBe('package-lock-contents');
     expect(execSnapshots).toMatchObject([
       {

--- a/lib/modules/manager/npm/post-update/pnpm.ts
+++ b/lib/modules/manager/npm/post-update/pnpm.ts
@@ -1,5 +1,4 @@
 import is from '@sindresorhus/is';
-import semver from 'semver';
 import { quote } from 'shlex';
 import upath from 'upath';
 import { GlobalConfig } from '../../../../config/global';
@@ -87,16 +86,10 @@ export async function generateLockFile(
 
     let args = '--lockfile-only';
 
-    // pnpm v9+ is doing recursive automatically when it detects workspaces.
-    //
     // If it's not a workspaces project/monorepo, but single project with unrelated other npm project in source tree (for example, a git submodule),
     // `--recursive` will install un-wanted project.
     // we should avoid this.
-    if (
-      pnpmToolConstraint.constraint &&
-      !semver.intersects(pnpmToolConstraint.constraint, '>=9') &&
-      (await localPathExists(pnpmWorkspaceFilePath))
-    ) {
+    if (await localPathExists(pnpmWorkspaceFilePath)) {
       args += ' --recursive';
     }
     if (!GlobalConfig.get('allowScripts') || config.ignoreScripts) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

add `--recursive` if the project is a pnpm workspace

## Context

- #36413

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
