### PR TITLE
fix(nuget): only deprecate entire package if all releases are deprecated

### DIFF
--- a/lib/modules/datasource/nuget/__fixtures__/nunit/v3_registration.json
+++ b/lib/modules/datasource/nuget/__fixtures__/nunit/v3_registration.json
@@ -118,6 +118,13 @@
             "@id": "https://api.nuget.org/v3/catalog0/data/2018.10.16.13.04.06/nunit.2.6.0.12051.json",
             "@type": "PackageDetails",
             "authors": "Charlie Poole",
+            "deprecation": {
+              "@id": "https://api.nuget.org/v3/catalog0/data/2018.10.16.13.04.06/nunit.2.6.0.12051.json#deprecation",
+              "@type": "deprecation",
+              "reasons": [
+                "Legacy"
+              ]
+            },
             "description": "NUnit features a fluent assert syntax, parameterized, generic and theory tests and is user-extensible. A number of runners, both from the NUnit project and by third parties, are able to execute NUnit tests.\n\nVersion 2.6 is the seventh major release of this well-known and well-tested programming tool.\n\nThis package includes only the framework assembly. You will need to install the NUnit.Runners package unless you are using a third-party runner.",
             "iconUrl": "https://api.nuget.org/v3-flatcontainer/nunit/2.6.0.12051/icon",
             "id": "NUnit",


### PR DESCRIPTION
## Changes

This fixes the issue in discussion #36584 where the previous implementation (#36373) marked packages as deprecated that only had _some_ deprecated versions.

## Context

This was a misunderstanding from my side, how `isDeprecated` and `deprecationMessage` works.
- `isDeprecated`: marks one release/version of a package as deprecated
- `deprecationMessage`: marks the entire package as deprecated

The later is only the case if _all_ versions of a package are deprecated.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository