### PR TITLE
feat(changelog-urls): add urls for scalar packages

### DIFF
--- a/lib/data/changelog-urls.json
+++ b/lib/data/changelog-urls.json
@@ -49,5 +49,10 @@
     "org.slf4j:slf4j-nop": "https://www.slf4j.org/news.html",
     "org.slf4j:slf4j-reload4j": "https://www.slf4j.org/news.html",
     "org.slf4j:slf4j-simple": "https://www.slf4j.org/news.html"
+  },
+  "nuget": {
+    "Scalar.AspNetCore": "https://github.com/scalar/scalar/blob/main/integrations/aspnetcore/CHANGELOG.md",
+    "Scalar.AspNetCore.Microsoft": "https://github.com/scalar/scalar/blob/main/integrations/aspnetcore/CHANGELOG.md",
+    "Scalar.AspNetCore.Swashbuckle": "https://github.com/scalar/scalar/blob/main/integrations/aspnetcore/CHANGELOG.md"
   }
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This PR introduces a changelog URL for the following packages: `Scalar.AspNetCore`, `Scalar.AspNetCore.Microsoft` and `Scalar.AspNetCore.Swashbuckle`.

## Context
AFAIK, NuGet doesn't support specifying a source URL that points to a subdirectory. That's why changelog checks are performed in the repository’s root directory rather than within the specific integration’s folder.


## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
