### PR TITLE
fix(changelogs): support bitbucket-server URLs in subfolder installations

### DIFF
--- a/lib/workers/repository/update/pr/changelog/bitbucket-server/index.spec.ts
+++ b/lib/workers/repository/update/pr/changelog/bitbucket-server/index.spec.ts
@@ -245,6 +245,25 @@ describe('workers/repository/update/pr/changelog/bitbucket-server/index', () => 
   });
 
   describe('source', () => {
+    describe('getBaseUrl', () => {
+      it.each`
+        sourceUrl                                                                     | expected
+        ${'https://bitbucket.some-host.org/projects/some-org/repos/some-repo'}        | ${'https://bitbucket.some-host.org/'}
+        ${'https://some-host.org/bitbucket/projects/some-org/repos/some-repo/browse'} | ${'https://some-host.org/bitbucket/'}
+        ${'https://some-host.org:7990/extra/path/projects/some-org/repos/some-repo/'} | ${'https://some-host.org:7990/extra/path/'}
+        ${'git+https://some-host.org:7990/scm/some-org/some-repo.git'}                | ${'https://some-host.org:7990/'}
+        ${'https://tools.domain.com/bitbucket/projects/mygroup/repos/my-library'}     | ${'https://tools.domain.com/bitbucket/'}
+        ${'some-random-value'}                                                        | ${''}
+      `('$sourceUrl', ({ sourceUrl, expected }) => {
+        expect(
+          changelogSource.getBaseUrl({
+            ...upgrade,
+            sourceUrl,
+          }),
+        ).toBe(expected);
+      });
+    });
+
     it('getAPIBaseUrl', () => {
       expect(changelogSource.getAPIBaseUrl(upgrade)).toBe(apiBaseUrl);
     });
@@ -267,6 +286,7 @@ describe('workers/repository/update/pr/changelog/bitbucket-server/index', () => 
         ${'ssh://git@some-host.org:7999/some-org/some-repo.git'}                                   | ${'some-org/some-repo'}
         ${'https://some-host.org:7990/scm/some-org/some-repo.git'}                                 | ${'some-org/some-repo'}
         ${'https://some-host:7990/projects/some-org/repos/some-repo/raw/src/CHANGELOG.md?at=HEAD'} | ${'some-org/some-repo'}
+        ${'https://tools.domain.com/bitbucket/projects/mygroup/repos/my-library'}                  | ${'mygroup/my-library'}
         ${'some-random-value'}                                                                     | ${''}
       `('$input', ({ input, expected }) => {
         expect(


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

* `getBaseUrl` override to find bitbucket-server instances in subfolders, e.g. `https://some-host.org/bitbucket/projects/...`
* More targeted (and better maintainable) regEx to extract project and repo slugs from URLs

<!-- Describe what behavior is changed by this PR. -->

## Context

- Closes https://github.com/renovatebot/renovate/issues/36399

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
