### PR TITLE
chore(presets): add @jest/** to jsUnitTest list

### DIFF
--- a/lib/config/presets/internal/packages.ts
+++ b/lib/config/presets/internal/packages.ts
@@ -80,6 +80,7 @@ export const presets: Record<string, Preset> = {
       'ts-auto-mock',
       'ts-jest',
       'vitest',
+      '@jest/**',
       '@testing-library/**',
       '@types/testing-library__**',
       '@vitest/**',


### PR DESCRIPTION
## Changes

Add @jest/** to jsUnitTest list so that packages such as @jest/globals can be grouped with other jest** packages.

## Context

@jest/globals was not being grouped with other jest packages in PRs on my repos.

## Documentation (please check one with an [x])

- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository