### PR TITLE
feat: add support for Bitbucket API tokens

### DIFF
--- a/lib/modules/platform/bitbucket/index.spec.ts
+++ b/lib/modules/platform/bitbucket/index.spec.ts
@@ -61,7 +61,7 @@ describe('modules/platform/bitbucket/index', () => {
   }
 
   describe('initPlatform()', () => {
-    it('should throw if no token, username/password or email/password', async () => {
+    it('should throw if no token or username/password', async () => {
       expect.assertions(1);
       await expect(bitbucket.initPlatform({})).rejects.toThrow();
     });
@@ -86,20 +86,6 @@ describe('modules/platform/bitbucket/index', () => {
         await bitbucket.initPlatform({
           endpoint: baseUrl,
           username: 'abc',
-          password: '123',
-        }),
-      ).toEqual(expectedResult);
-    });
-
-    it('should init with email/password', async () => {
-      const expectedResult: PlatformResult = {
-        endpoint: baseUrl,
-      };
-      httpMock.scope(baseUrl).get('/2.0/user').reply(200);
-      expect(
-        await bitbucket.initPlatform({
-          endpoint: baseUrl,
-          email: 'abc@gmail.com',
           password: '123',
         }),
       ).toEqual(expectedResult);

--- a/lib/modules/platform/bitbucket/index.spec.ts
+++ b/lib/modules/platform/bitbucket/index.spec.ts
@@ -212,7 +212,7 @@ describe('modules/platform/bitbucket/index', () => {
     it('works with only API token', async () => {
       hostRules.clear();
       hostRules.find.mockReturnValue({
-        password: 'ATCTIAMACONTAINERTOKEN3407361359',
+        password: 'ATATIAMACONTAINERTOKEN3407361359',
       });
       httpMock
         .scope(baseUrl)

--- a/lib/modules/platform/bitbucket/index.ts
+++ b/lib/modules/platform/bitbucket/index.ts
@@ -78,7 +78,7 @@ export async function initPlatform({
 }: PlatformParams): Promise<PlatformResult> {
   if (!(username && password) && !token) {
     throw new Error(
-      'Init: You must configure either a Bitbucket access token or email and password',
+      'Init: You must configure either a Bitbucket token or username and password',
     );
   }
   if (endpoint && endpoint !== BITBUCKET_PROD_ENDPOINT) {

--- a/lib/modules/platform/bitbucket/index.ts
+++ b/lib/modules/platform/bitbucket/index.ts
@@ -73,11 +73,10 @@ let renovateUserUuid: string | null = null;
 export async function initPlatform({
   endpoint,
   username,
-  email,
   password,
   token,
 }: PlatformParams): Promise<PlatformResult> {
-  if (!(username && password) && !(email && password) && !token) {
+  if (!(username && password) && !token) {
     throw new Error(
       'Init: You must configure either a Bitbucket access token or email and password',
     );
@@ -93,9 +92,6 @@ export async function initPlatform({
   const options: HttpOptions = { memCache: false };
   if (token) {
     options.token = token;
-  } else if (email) {
-    options.username = email;
-    options.password = password;
   } else {
     options.username = username;
     options.password = password;

--- a/lib/modules/platform/types.ts
+++ b/lib/modules/platform/types.ts
@@ -14,6 +14,7 @@ export interface PlatformParams {
   endpoint?: string;
   token?: string;
   username?: string;
+  email?: string;
   password?: string;
   gitAuthor?: string;
 }

--- a/lib/modules/platform/types.ts
+++ b/lib/modules/platform/types.ts
@@ -14,7 +14,6 @@ export interface PlatformParams {
   endpoint?: string;
   token?: string;
   username?: string;
-  email?: string;
   password?: string;
   gitAuthor?: string;
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

When users set up Renovate on Bitbucket with API tokens, they would:

- set the `username` field with Atlassian email
- set the `password` field with the API token (prefix of ATAT)

The docs should be updated to direct users to authenticate with the method above.

Please note for git operations if we detect the password to be an API token, we can authenticate with a static username `x-bitbucket-api-token-auth`.

This code change is designed to be backwards compatible so it does not break existing integrations with app passwords.

## Context

Renovate to support Bitbucket API tokens since app passwords are being deprecated.

https://github.com/renovatebot/renovate/issues/36503

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
