### PR TITLE
fix(pip-compile): add missing uv resolver flags.

### DIFF
--- a/lib/modules/manager/pip-compile/common.ts
+++ b/lib/modules/manager/pip-compile/common.ts
@@ -127,6 +127,10 @@ const pipOptionsWithArguments = [
 const uvOptionsWithArguments = [
   '--constraints',
   '--python-version',
+  '--resolution',
+  '--prerelease',
+  '--fork-strategy',
+  '--exclude-newer',
   ...commonOptionsWithArguments,
 ];
 export const optionsWithArguments = [


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Add resolver flags to fully support uv
<!-- Describe what behavior is changed by this PR. -->

## Context
UV has special resolver flags when running `uv pip compile`. Upon upgrade they're aded to requirements.txt and renovate crashes with them. This PR add those uv specific flags to list of allowed flags.
Reference: https://docs.astral.sh/uv/reference/cli/#uv-pip-compile

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
