### PR TITLE
feat(config): add support for JSONC

### DIFF
--- a/lib/config/app-strings.ts
+++ b/lib/config/app-strings.ts
@@ -1,12 +1,16 @@
 export const configFileNames = [
   'renovate.json',
   'renovate.json5',
+  'renovate.jsonc',
   '.github/renovate.json',
   '.github/renovate.json5',
+  '.github/renovate.jsonc',
   '.gitlab/renovate.json',
   '.gitlab/renovate.json5',
+  '.gitlab/renovate.jsonc',
   '.renovaterc',
   '.renovaterc.json',
   '.renovaterc.json5',
+  '.renovaterc.jsonc',
   'package.json',
 ];

--- a/lib/config/parse.spec.ts
+++ b/lib/config/parse.spec.ts
@@ -56,4 +56,37 @@ describe('config/parse', () => {
       });
     });
   });
+
+  describe('jsonc', () => {
+    it('parses', () => {
+      expect(parseFileConfig('config.jsonc', '{}')).toEqual({
+        success: true,
+        parsedContents: {},
+      });
+    });
+
+    it('parses with comments', () => {
+      const jsoncContent = `{
+        // This is a comment
+        "extends": ["config:base"],
+        "enabled": true // Another comment
+      }`;
+      expect(parseFileConfig('config.jsonc', jsoncContent)).toEqual({
+        success: true,
+        parsedContents: {
+          extends: ['config:base'],
+          enabled: true,
+        },
+      });
+    });
+
+    it('returns error', () => {
+      expect(parseFileConfig('config.jsonc', '{')).toEqual({
+        success: false,
+        validationError: 'Invalid JSONC (parsing failed)',
+        validationMessage:
+          'JSONC.parse error: `Invalid JSONC`',
+      });
+    });
+  });
 });

--- a/lib/config/parse.spec.ts
+++ b/lib/config/parse.spec.ts
@@ -84,8 +84,7 @@ describe('config/parse', () => {
       expect(parseFileConfig('config.jsonc', '{')).toEqual({
         success: false,
         validationError: 'Invalid JSONC (parsing failed)',
-        validationMessage:
-          'JSONC.parse error: `Invalid JSONC`',
+        validationMessage: 'JSONC.parse error: `Invalid JSONC`',
       });
     });
   });

--- a/lib/config/parse.ts
+++ b/lib/config/parse.ts
@@ -30,7 +30,10 @@ export function parseFileConfig(
     }
   } else if (fileType === '.jsonc') {
     try {
-      return { success: true, parsedContents: parseJson(fileContents, fileName) };
+      return {
+        success: true,
+        parsedContents: parseJson(fileContents, fileName),
+      };
     } catch (err) {
       logger.debug({ fileName, fileContents }, 'Error parsing JSONC file');
       const validationError = 'Invalid JSONC (parsing failed)';

--- a/lib/config/parse.ts
+++ b/lib/config/parse.ts
@@ -28,6 +28,22 @@ export function parseFileConfig(
         validationMessage,
       };
     }
+  } else if (fileType === '.jsonc') {
+    try {
+      return { success: true, parsedContents: parseJson(fileContents, fileName) };
+    } catch (err) {
+      logger.debug({ fileName, fileContents }, 'Error parsing JSONC file');
+      const validationError = 'Invalid JSONC (parsing failed)';
+      const validationMessage = `JSONC.parse error: \`${err.message.replaceAll(
+        '`',
+        "'",
+      )}\``;
+      return {
+        success: false,
+        validationError,
+        validationMessage,
+      };
+    }
   } else {
     let allowDuplicateKeys = true;
     let jsonValidationError = jsonValidator.validate(

--- a/lib/workers/global/config/parse/file.ts
+++ b/lib/workers/global/config/parse/file.ts
@@ -21,6 +21,7 @@ export async function getParsedContent(file: string): Promise<RenovateConfig> {
     case '.yml':
       return parseSingleYaml(await readSystemFile(file, 'utf8'));
     case '.json5':
+    case '.jsonc':
     case '.json':
       return parseJson(
         await readSystemFile(file, 'utf8'),

--- a/lib/workers/repository/init/merge.spec.ts
+++ b/lib/workers/repository/init/merge.spec.ts
@@ -199,6 +199,19 @@ describe('workers/repository/init/merge', () => {
       });
     });
 
+    it('finds and parse renovate.jsonc', async () => {
+      const configFileRaw = `{
+        // this is jsonc format with comments
+        "extends": ["config:base"]
+      }`;
+      scm.getFileList.mockResolvedValue(['package.json', 'renovate.jsonc']);
+      fs.readLocalFile.mockResolvedValue(configFileRaw);
+      expect(await detectRepoFileConfig()).toEqual({
+        configFileName: 'renovate.jsonc',
+        configFileParsed: { extends: ['config:base'] },
+      });
+    });
+
     it('finds .github/renovate.json', async () => {
       scm.getFileList.mockResolvedValue([
         'package.json',
@@ -220,6 +233,36 @@ describe('workers/repository/init/merge', () => {
       expect(await detectRepoFileConfig()).toEqual({
         configFileName: '.gitlab/renovate.json',
         configFileParsed: {},
+      });
+    });
+
+    it('finds .github/renovate.jsonc', async () => {
+      scm.getFileList.mockResolvedValue([
+        'package.json',
+        '.github/renovate.jsonc',
+      ]);
+      fs.readLocalFile.mockResolvedValue(`{
+        // JSONC config with comments
+        "extends": ["config:base"]
+      }`);
+      expect(await detectRepoFileConfig()).toEqual({
+        configFileName: '.github/renovate.jsonc',
+        configFileParsed: { extends: ['config:base'] },
+      });
+    });
+
+    it('finds .gitlab/renovate.jsonc', async () => {
+      scm.getFileList.mockResolvedValue([
+        'package.json',
+        '.gitlab/renovate.jsonc',
+      ]);
+      fs.readLocalFile.mockResolvedValue(`{
+        // JSONC config with comments  
+        "enabled": true
+      }`);
+      expect(await detectRepoFileConfig()).toEqual({
+        configFileName: '.gitlab/renovate.jsonc',
+        configFileParsed: { enabled: true },
       });
     });
 

--- a/lib/workers/repository/init/merge.spec.ts
+++ b/lib/workers/repository/init/merge.spec.ts
@@ -257,7 +257,7 @@ describe('workers/repository/init/merge', () => {
         '.gitlab/renovate.jsonc',
       ]);
       fs.readLocalFile.mockResolvedValue(`{
-        // JSONC config with comments  
+        // JSONC config with comments
         "enabled": true
       }`);
       expect(await detectRepoFileConfig()).toEqual({


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Add support of JSONC files discussed here https://github.com/renovatebot/renovate/pull/36141

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->
As discussed [here](https://github.com/renovatebot/renovate/pull/36141) the support on the syntax JSONC is now deployed but the files JSONC itself not yet, and when we want to using JSONC files to permit the IDE  ( like VSCODE) to validate the syntax if we put some comments
## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
