### PR TITLE
docs(composer): private repositories must include the package name

### DIFF
--- a/docs/usage/getting-started/private-packages.md
+++ b/docs/usage/getting-started/private-packages.md
@@ -187,13 +187,15 @@ Avoid adding a `hostRule` with `hostType=github` because:
 - it overrides the default Renovate application token for everything else
 - it causes unwanted side effects
 
-The repository in `composer.json` should have the `vcs` type with a `https` URL.
+The repository in `composer.json` should have the `vcs` type with a `https` URL
+and must include the package's name.
 For example:
 
 ```json
 {
   "repositories": [
     {
+      "name": "organization/private",
       "type": "vcs",
       "url": "https://github.com/organization/private-repository"
     }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Update the private package documentation for Composer to indicate that the `name` key is required.

<!-- Describe what behavior is changed by this PR. -->

## Context

This requirement was noticed in https://github.com/renovatebot/renovate/discussions/35609#discussioncomment-13036012 but is otherwise undocumented. It is true.

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
