### PR TITLE
feat: add decodeBase64 handlebars helper

### DIFF
--- a/docs/usage/templates.md
+++ b/docs/usage/templates.md
@@ -45,6 +45,14 @@ Returns `true` if a given string is a substring.
 
 `{{#if (containsString depName 'python')}}Python{{else}}Other{{/if}}`
 
+### decodeBase64
+
+If you want to convert a Base64 value to a string, use the built-in function `decodeBase64` like this:
+
+`{{{decodeBase64 body}}}`
+
+In the example above `body` is the base64 encoded value you want to decode.
+
 ### decodeURIComponent
 
 If you want to decode a percent-encoded string, use the built-in function `decodeURIComponent` like this:
@@ -68,14 +76,6 @@ If you want to convert a string to Base64, use the built-in function `encodeBase
 `{{{encodeBase64 body}}}`
 
 In the example above `body` is the string you want to transform into a Base64-encoded value.
-
-### decodeBase64
-
-If you want to convert a Base64 value to a string, use the built-in function `decodeBase64` like this:
-
-`{{{decodeBase64 body}}}`
-
-In the example above `body` is the base64 encoded value you want to decode.
 
 ### encodeURIComponent
 

--- a/docs/usage/templates.md
+++ b/docs/usage/templates.md
@@ -69,6 +69,14 @@ If you want to convert a string to Base64, use the built-in function `encodeBase
 
 In the example above `body` is the string you want to transform into a Base64-encoded value.
 
+### decodeBase64
+
+If you want to convert a Base64 value to a string, use the built-in function `decodeBase64` like this:
+
+`{{{decodeBase64 body}}}`
+
+In the example above `body` is the base64 encoded value you want to decode.
+
 ### encodeURIComponent
 
 If you want to convert a string to a valid URI, use the built-in function `encodeURIComponent` like this:

--- a/lib/util/template/index.spec.ts
+++ b/lib/util/template/index.spec.ts
@@ -294,6 +294,30 @@ describe('util/template/index', () => {
     });
   });
 
+  describe('base64 decoding', () => {
+    it('decode values', () => {
+      const output = template.compile(
+        '{{{decodeBase64 "QGZzb3V6YS9wcmV0dGllcmQ="}}}',
+        undefined as never,
+      );
+      expect(output).toBe('@fsouza/prettierd');
+    });
+
+    it('handles null values gracefully', () => {
+      const output = template.compile('{{{decodeBase64 packageName}}}', {
+        packageName: null,
+      });
+      expect(output).toBe('');
+    });
+
+    it('handles undefined values gracefully', () => {
+      const output = template.compile('{{{decodeBase64 packageName}}}', {
+        packageName: undefined,
+      });
+      expect(output).toBe('');
+    });
+  });
+
   describe('equals', () => {
     it('equals', () => {
       const output = template.compile(

--- a/lib/util/template/index.ts
+++ b/lib/util/template/index.ts
@@ -19,7 +19,7 @@ handlebars.registerHelper('encodeBase64', (str: string) =>
 );
 
 handlebars.registerHelper('decodeBase64', (str: string) =>
-  Buffer.from(str ?? '', 'base64').toString('ascii'),
+  Buffer.from(str ?? '', 'base64').toString(),
 );
 
 handlebars.registerHelper('stringToPrettyJSON', (input: string): string =>

--- a/lib/util/template/index.ts
+++ b/lib/util/template/index.ts
@@ -18,6 +18,10 @@ handlebars.registerHelper('encodeBase64', (str: string) =>
   Buffer.from(str ?? '').toString('base64'),
 );
 
+handlebars.registerHelper('decodeBase64', (str: string) =>
+  Buffer.from(str ?? '', 'base64').toString('ascii'),
+);
+
 handlebars.registerHelper('stringToPrettyJSON', (input: string): string =>
   JSON.stringify(JSON.parse(input), null, 2),
 );


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Add a `decodeBase64` handlebar helper, similar to `encodeBase64`.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

I have a custom datasource providing a base64 encoded value, and would like to perform `{{ decodeBase64 content }}` in `autoReplaceStringTemplate` rather than `$base64decode(content)` in `transformTemplates`.


<details>
<summary><h2>Detailed usecase</h2></summary>

The reason is that I _hackishly_ use `sourceDirectory` to pass a value into `autoReplaceStringTemplate` via `transformTemplates`, and want to base64 decode the value at a later point, to avoid the value being parsed as handlebars (ref https://github.com/renovatebot/renovate/pull/32701).

The usecase is having Renovate update GitLab files based on the content of others. Eg. here inserting the content of `source.txt` after the `renovate-git-file` marker:

`source.txt`

```txt
hello renovate
```

`target.txt`

```txt
# Updated by Renovate.
# renovate-git-file: https://gitlab.bigcorp.com/foo/bar/-/blob/42c8a064e16a20c5cedf80deb0d7d90fd1568f03/source.txt
hello renovate
```

To achieve it, I'm using the following config:

```json

{
  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
  "customManagers": [
    {
      "customType": "regex",
      "datasourceTemplate": "custom.gitlab-file",
      "fileMatch": [".*"],
      "matchStrings": [
        "# renovate-git-file:( ref=(?<ref>[^\\s]+))? https:\\/\\/gitlab.bigcorp.com\\/(?<repo>.*?)\\/-\\/blob\\/(?<currentDigest>[a-f0-9]{40})\\/(?<file>[^\\n]+)\\n(?<currentContent>[\\s\\S]*)"
      ],
      "currentValueTemplate": "{{#if ref}}{{{ ref }}}{{else}}main{{/if}}",
      "versioningTemplate": "rpm",
      "depNameTemplate": "{{ repo }}//{{ file }}",
      "packageNameTemplate": "gitlab.bigcorp.com/{{ repo }}//{{ file }}?ref={{#if ref}}{{{ ref }}}{{else}}main{{/if}}",
      "registryUrlTemplate": "https://gitlab.bigcorp.com/api/v4/projects/{{{ encodeURIComponent repo }}}/repository/files/{{{ encodeURIComponent file }}}?ref={{#if ref}}{{{ ref }}}{{else}}main{{/if}}",
      "autoReplaceStringTemplate": "# renovate-git-file:{{#if (equals currentValue 'main')}}{{else}} ref={{ currentValue }}{{/if}} https://gitlab.bigcorp.com/{{ lookup (split depName '//') 0 }}/-/blob/{{ newDigest }}/{{ lookup (split depName '//') 1 }}\n{{{ sourceDirectory }}}"
    }
  ],
  "customDatasources": {
    "gitlab-file": {
      "format": "json",
      "transformTemplates": [
        "{ \"releases\": [{ \"version\": \"{{ currentValue }}\", \"digest\": last_commit_id }], \"sourceDirectory\": $base64decode(content) }"
      ]
    }
  }
}
```

However, it cannot sync files including `{{` as it will be parsed as part of `sourceDirectory` (ref https://github.com/renovatebot/renovate/pull/32701).

An alternative would be to allow for more fields in `transformTemplates` to be usable in `autoReplaceStringTemplate`.
</details>

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
