### PR TITLE
fix(galaxy-collection): suppress incorrect warning if collection is not found in registry

### DIFF
--- a/lib/modules/datasource/galaxy-collection/index.ts
+++ b/lib/modules/datasource/galaxy-collection/index.ts
@@ -1,6 +1,7 @@
 import is from '@sindresorhus/is';
 import { logger } from '../../../logger';
 import { cache } from '../../../util/cache/package/decorator';
+import { HttpError } from '../../../util/http';
 import * as p from '../../../util/promises';
 import { regEx } from '../../../util/regex';
 import { ensureTrailingSlash, joinUrlParts } from '../../../util/url';
@@ -51,7 +52,7 @@ export class GalaxyCollectionDatasource extends Datasource {
     const { val: baseProject, err: baseErr } = await this.http
       .getJsonSafe(baseUrl, GalaxyV3)
       .onError((err) => {
-        if (err.response?.statusCode !== 404) {
+        if (!(err instanceof HttpError && err.response?.statusCode === 404)) {
           logger.warn(
             { url: baseUrl, datasource: this.id, packageName, err },
             'Error fetching from url',

--- a/lib/modules/datasource/galaxy-collection/index.ts
+++ b/lib/modules/datasource/galaxy-collection/index.ts
@@ -51,10 +51,12 @@ export class GalaxyCollectionDatasource extends Datasource {
     const { val: baseProject, err: baseErr } = await this.http
       .getJsonSafe(baseUrl, GalaxyV3)
       .onError((err) => {
-        logger.warn(
-          { url: baseUrl, datasource: this.id, packageName, err },
-          'Error fetching from url',
-        );
+        if (err.response?.statusCode !== 404) {
+          logger.warn(
+            { url: baseUrl, datasource: this.id, packageName, err },
+            'Error fetching from url',
+          );
+        }
       })
       .unwrap();
     if (baseErr) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Prevent logging of warnings if a collection is not found in a registry

## Context

If a collection is not found in one or more of the defined galaxy-collection registries, a warning is logged. This shows up in the logs and in the Dependency Dashboard. This is misleading and should be considered normal behavior.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
