### PR TITLE
fix(presets): place migrations correctly

### DIFF
--- a/lib/config/migrations/migrations-service.ts
+++ b/lib/config/migrations/migrations-service.ts
@@ -91,7 +91,6 @@ export class MigrationsService {
     ['endpoints', 'hostRules'],
     ['excludedPackageNames', 'excludePackageNames'],
     ['exposeEnv', 'exposeAllEnv'],
-    ['group:junit5Monorepo', 'group:junit-frameworkMonorepo'],
     ['keepalive', 'keepAlive'],
     ['managerBranchPrefix', 'additionalBranchPrefix'],
     ['multipleMajorPrs', 'separateMultipleMajor'],
@@ -106,7 +105,6 @@ export class MigrationsService {
     ['masterIssueFooter', 'dependencyDashboardFooter'],
     ['masterIssueTitle', 'dependencyDashboardTitle'],
     ['masterIssueLabels', 'dependencyDashboardLabels'],
-    ['monorepo:junit5', 'monorepo:junit-framework'],
     ['regexManagers', 'customManagers'],
   ]);
 

--- a/lib/config/presets/common.ts
+++ b/lib/config/presets/common.ts
@@ -27,6 +27,7 @@ export const removedPresets: Record<string, string | null> = {
   'default:unpublishSafe': 'npm:unpublishSafe',
   'helpers:oddIsUnstable': null,
   'helpers:oddIsUnstablePackages': null,
+  'group:junit5Monorepo': 'group:junit-frameworkMonorepo',
   'group:jsTestMonMajor': 'group:jsTestNonMajor',
   'github>whitesource/merge-confidence:beta': 'mergeConfidence:all-badges',
   'replacements:messageFormat-{{package}}-to-@messageformat/{{package}}':
@@ -63,6 +64,7 @@ const renamedMonorepos: Record<string, string> = {
   hamcrest: 'javahamcrest',
   HotChocolate: 'hotchocolate',
   infrastructure: 'infrastructure-ui',
+  junit5: 'junit-framework',
   lingui: 'linguijs',
   MassTransit: 'masstransit',
   material: 'material-components-web',

--- a/lib/config/presets/common.ts
+++ b/lib/config/presets/common.ts
@@ -27,7 +27,6 @@ export const removedPresets: Record<string, string | null> = {
   'default:unpublishSafe': 'npm:unpublishSafe',
   'helpers:oddIsUnstable': null,
   'helpers:oddIsUnstablePackages': null,
-  'group:junit5Monorepo': 'group:junit-frameworkMonorepo',
   'group:jsTestMonMajor': 'group:jsTestNonMajor',
   'github>whitesource/merge-confidence:beta': 'mergeConfidence:all-badges',
   'replacements:messageFormat-{{package}}-to-@messageformat/{{package}}':


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- Moves migrations from `migration-service` -> `presets/common`
<!-- Describe what behavior is changed by this PR. -->

## Context
- Fixes incorrect placement of preset migrations in: https://github.com/renovatebot/renovate/pull/36691
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
