### PR TITLE
fix(npm): update pnpm dedupe ignore-scripts flag

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -3760,7 +3760,7 @@ Table with options:
 | `helmUpdateSubChartArchives` | Update subchart archives in the `/charts` folder.                                                                                                          |
 | `kustomizeInflateHelmCharts` | Inflate updated helm charts referenced in the kustomization.                                                                                               |
 | `npmDedupe`                  | Run `npm install` with `--prefer-dedupe` for npm >= 7 or `npm dedupe` after `package-lock.json` update for npm <= 6.                                       |
-| `pnpmDedupe`                 | Run `pnpm dedupe --config.ignore-scripts=true` after `pnpm-lock.yaml` updates.                                                                             |
+| `pnpmDedupe`                 | Run `pnpm dedupe --ignore-scripts` after `pnpm-lock.yaml` updates.                                                                                         |
 | `yarnDedupeFewer`            | Run `yarn-deduplicate --strategy fewer` after `yarn.lock` updates.                                                                                         |
 | `yarnDedupeHighest`          | Run `yarn-deduplicate --strategy highest` (`yarn dedupe --strategy highest` for Yarn >=2.2.0) after `yarn.lock` updates.                                   |
 

--- a/lib/modules/manager/npm/post-update/pnpm.spec.ts
+++ b/lib/modules/manager/npm/post-update/pnpm.spec.ts
@@ -316,7 +316,7 @@ describe('modules/manager/npm/post-update/pnpm', () => {
         cmd: 'pnpm install --lockfile-only --ignore-scripts --ignore-pnpmfile',
       },
       {
-        cmd: 'pnpm dedupe --config.ignore-scripts=true',
+        cmd: 'pnpm dedupe --ignore-scripts',
       },
     ]);
   });

--- a/lib/modules/manager/npm/post-update/pnpm.ts
+++ b/lib/modules/manager/npm/post-update/pnpm.ts
@@ -130,7 +130,7 @@ export async function generateLockFile(
 
     // postUpdateOptions
     if (config.postUpdateOptions?.includes('pnpmDedupe')) {
-      commands.push('pnpm dedupe --config.ignore-scripts=true');
+      commands.push('pnpm dedupe --ignore-scripts');
     }
 
     if (upgrades.find((upgrade) => upgrade.isLockFileMaintenance)) {


### PR DESCRIPTION
## Changes

Update pnpm dedupe ignore-scripts flag

## Context

Follow up on #36727 and separate the changes to an individual PR.

This should be safe because:
- `pnpm install` before this command is already using the flag this way. https://github.com/renovatebot/renovate/blob/e749c7b9c833f06f758c04c1209ae518ffedc3a5/lib/modules/manager/npm/post-update/pnpm.ts#L106
- `--ignore-scripts` on pnpm dedupe was introduced in [v8.8.0](https://github.com/pnpm/pnpm/releases/tag/v8.8.0), it was always in the form of `--ignore-scripts`
- Probably `--config.ignore-scripts=true` works only because [v5.5.0](https://github.com/pnpm/pnpm/releases/tag/v5.5.0) introduced the `--config.` prefix to accept unknown (so as known?) options.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
