### PR TITLE
fix(presets): Add percentage to regex, to allow for URL encoded repo names

### DIFF
--- a/lib/config/presets/parse.spec.ts
+++ b/lib/config/presets/parse.spec.ts
@@ -249,6 +249,26 @@ describe('config/presets/parse', () => {
       });
     });
 
+    it('parses local repo with presetPath with URL-encoded characters', () => {
+      expect(parsePreset('local>some%20group/some%20repo//some-dir/some-file')).toEqual({
+        repo: 'some%20group/some%20repo',
+        params: undefined,
+        presetName: 'some-file',
+        presetPath: 'some-dir',
+        presetSource: 'local',
+      });
+    });
+
+    it('parses local repo with URL-encoded characters', () => {
+      expect(parsePreset('local>some%20group/some%20repo//some-file')).toEqual({
+        repo: 'some%20group/some%20repo',
+        params: undefined,
+        presetName: 'some-file',
+        presetPath: undefined,
+        presetSource: 'local',
+      });
+    });
+
     it('parses no prefix as local', () => {
       expect(parsePreset('some/repo')).toEqual({
         repo: 'some/repo',

--- a/lib/config/presets/parse.spec.ts
+++ b/lib/config/presets/parse.spec.ts
@@ -250,7 +250,9 @@ describe('config/presets/parse', () => {
     });
 
     it('parses local repo with presetPath with URL-encoded characters', () => {
-      expect(parsePreset('local>some%20group/some%20repo//some-dir/some-file')).toEqual({
+      expect(
+        parsePreset('local>some%20group/some%20repo//some-dir/some-file'),
+      ).toEqual({
         repo: 'some%20group/some%20repo',
         params: undefined,
         presetName: 'some-file',

--- a/lib/config/presets/parse.ts
+++ b/lib/config/presets/parse.ts
@@ -5,10 +5,10 @@ import type { ParsedPreset } from './types';
 import { PRESET_INVALID, PRESET_PROHIBITED_SUBPRESET } from './util';
 
 const nonScopedPresetWithSubdirRegex = regEx(
-  /^(?<repo>~?[\w\-. /]+?)\/\/(?:(?<presetPath>[\w\-./]+)\/)?(?<presetName>[\w\-.]+)(?:#(?<tag>[\w\-./]+?))?$/,
+  /^(?<repo>~?[\w\-. /%]+?)\/\/(?:(?<presetPath>[\w\-./]+)\/)?(?<presetName>[\w\-.]+)(?:#(?<tag>[\w\-./]+?))?$/,
 );
 const gitPresetRegex = regEx(
-  /^(?<repo>~?[\w\-. /]+)(?::(?<presetName>[\w\-.+/]+))?(?:#(?<tag>[\w\-./]+?))?$/,
+  /^(?<repo>~?[\w\-. /%]+)(?::(?<presetName>[\w\-.+/]+))?(?:#(?<tag>[\w\-./]+?))?$/,
 );
 
 export function parsePreset(input: string): ParsedPreset {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
Added support in Preset parsing for allowing URL encoded repo references.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->
Related discussion: https://github.com/renovatebot/renovate/discussions/36749

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
