### PR TITLE
docs(versioning): docker versioning precision

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -4562,6 +4562,27 @@ We do not recommend overriding the default versioning, but there are some cases 
 Renovate supports 4-part versions (1.2.3.4) in full for the NuGet package manager.
 Other managers can use the `"loose"` versioning fallback: the first 3 parts are used as the version, all trailing parts are used for alphanumeric sorting.
 
+A key characteristic of the `"docker"` versioning is that it attempts to preserve the precision of the current version string. For example, if your current version has two parts (e.g., 5.6), Renovate will propose updates that also have two parts (e.g., 5.7), rather than a three-part SemVer equivalent (e.g., 5.7.0).
+
+### Example Use Case: "Floating Patch Versions" using 2 digits versioning
+
+You may want to use a 2-part version like 5.6 to indicate the minor version while automatically receiving the latest patch updates (a "floating patch"). At the same time, you still want Renovate to create merge requests for minor or major updates like 5.7 or 6.2. The default semver versioning would update 5.6 to a 3-part version like 5.6.1, which would break the floating patch behavior.
+
+In the below `renovate.json` extract example, Renovate will use the `docker` versioning for the `.gitlab-ci.yml` file, so you can pin the minor version while still receiving the latest patch updates.
+
+```json
+{
+  "packageRules": [
+    {
+      "matchPackageFileNames": [".gitlab-ci.yml"],
+      "versioning": "docker"
+    }
+  ]
+}
+```
+
+When using this strategy, make sure that the package you're referencing does support 2-part versions, e.g. that it has a version like `5.6` available in the registry in addition to `5.6.1` or `5.6.2`.
+
 ## vulnerabilityAlerts
 
 Renovate can read GitHub's Vulnerability Alerts to customize its Pull Requests.

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -4564,7 +4564,7 @@ Other managers can use the `"loose"` versioning fallback: the first 3 parts are 
 
 A key characteristic of the `"docker"` versioning is that it attempts to preserve the precision of the current version string. For example, if your current version has two parts (e.g., 5.6), Renovate will propose updates that also have two parts (e.g., 5.7), rather than a three-part SemVer equivalent (e.g., 5.7.0).
 
-### Example Use Case: "Floating Patch Versions" using 2 digits versioning
+Example Use Case: "Floating Patch Versions" using 2 digits versioning
 
 You may want to use a 2-part version like 5.6 to indicate the minor version while automatically receiving the latest patch updates (a "floating patch"). At the same time, you still want Renovate to create merge requests for minor or major updates like 5.7 or 6.2. The default semver versioning would update 5.6 to a 3-part version like 5.6.1, which would break the floating patch behavior.
 


### PR DESCRIPTION
## Documentation

docs: add precision on `docker` and 2-part versioning

- [x ] I have updated the documentation, or
- [ ] No documentation update is required

It follows [this discussion](https://github.com/renovatebot/renovate/discussions/36650).

## How I've tested my work 

I have verified these changes via: locally deploying the renovate markdown-based website

