### PR TITLE
feat(npm): support pnpm v11 environment variables

### DIFF
--- a/lib/modules/manager/npm/artifacts.ts
+++ b/lib/modules/manager/npm/artifacts.ts
@@ -72,7 +72,8 @@ export async function updateArtifacts({
     cwdFile: packageFileName,
     extraEnv: {
       // To make sure pnpm store location is consistent between "corepack use"
-      // here and the pnpm commands in ./post-update/pnpm.ts
+      // here and the pnpm commands in ./post-update/pnpm.ts. Check
+      // ./post-update/pnpm.ts for more details.
       npm_config_cache_dir: pnpmConfigCacheDir,
       npm_config_store_dir: pnpmConfigStoreDir,
       pnpm_config_cache_dir: pnpmConfigCacheDir,

--- a/lib/modules/manager/npm/artifacts.ts
+++ b/lib/modules/manager/npm/artifacts.ts
@@ -66,13 +66,17 @@ export async function updateArtifacts({
     lazyPkgJson,
   );
 
+  const pnpmConfigCacheDir = await ensureCacheDir(PNPM_CACHE_DIR);
+  const pnpmConfigStoreDir = await ensureCacheDir(PNPM_STORE_DIR);
   const execOptions: ExecOptions = {
     cwdFile: packageFileName,
     extraEnv: {
       // To make sure pnpm store location is consistent between "corepack use"
       // here and the pnpm commands in ./post-update/pnpm.ts
-      npm_config_cache_dir: await ensureCacheDir(PNPM_CACHE_DIR),
-      npm_config_store_dir: await ensureCacheDir(PNPM_STORE_DIR),
+      npm_config_cache_dir: pnpmConfigCacheDir,
+      npm_config_store_dir: pnpmConfigStoreDir,
+      pnpm_config_cache_dir: pnpmConfigCacheDir,
+      pnpm_config_store_dir: pnpmConfigStoreDir,
     },
     toolConstraints: [
       nodeConstraints,

--- a/lib/modules/manager/npm/post-update/pnpm.ts
+++ b/lib/modules/manager/npm/post-update/pnpm.ts
@@ -64,7 +64,7 @@ export async function generateLockFile(
       // those arwe no longer working and it's unclear if they ever worked
       NPM_CONFIG_CACHE: env.NPM_CONFIG_CACHE,
       npm_config_store: env.npm_config_store,
-      // these are used by pnpm v5 and above. Maybe earlier versions too
+      // these are used by pnpm v5 to v10. Maybe earlier versions too
       npm_config_cache_dir: pnpmConfigCacheDir,
       npm_config_store_dir: pnpmConfigStoreDir,
       // pnpm stops reading npm_config_* env vars since v11

--- a/lib/modules/manager/npm/post-update/pnpm.ts
+++ b/lib/modules/manager/npm/post-update/pnpm.ts
@@ -58,13 +58,18 @@ export async function generateLockFile(
         (await getConstraintFromLockFile(lockFileName)), // use lockfileVersion to find pnpm version range
     };
 
+    const pnpmConfigCacheDir = await ensureCacheDir(PNPM_CACHE_DIR);
+    const pnpmConfigStoreDir = await ensureCacheDir(PNPM_STORE_DIR);
     const extraEnv: ExtraEnv = {
       // those arwe no longer working and it's unclear if they ever worked
       NPM_CONFIG_CACHE: env.NPM_CONFIG_CACHE,
       npm_config_store: env.npm_config_store,
       // these are used by pnpm v5 and above. Maybe earlier versions too
-      npm_config_cache_dir: await ensureCacheDir(PNPM_CACHE_DIR),
-      npm_config_store_dir: await ensureCacheDir(PNPM_STORE_DIR),
+      npm_config_cache_dir: pnpmConfigCacheDir,
+      npm_config_store_dir: pnpmConfigStoreDir,
+      // pnpm stops reading npm_config_* env vars since v11
+      pnpm_config_cache_dir: pnpmConfigCacheDir,
+      pnpm_config_store_dir: pnpmConfigStoreDir,
     };
     const execOptions: ExecOptions = {
       cwdFile: lockFileName,


### PR DESCRIPTION
## Changes

Add environment variables to support pnpm v11

## Context

Follow up on https://github.com/renovatebot/renovate/pull/36727#issuecomment-3016921942, pnpm v11 will stop reading `npm_config_*` env vars (https://github.com/orgs/pnpm/discussions/9238), so adding the new env vars to support pnpm v11 migration smoothly when it is released.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
