### PR TITLE
feat(presets): substitute entire parameter string for `{{args}}`

### DIFF
--- a/docs/usage/config-presets.md
+++ b/docs/usage/config-presets.md
@@ -169,6 +169,10 @@ Parameters must be strings, non-quoted, and separated by commas if there are mor
 If you find that you are repeating config a lot, you might consider publishing one of these types of parameterized presets yourself.
 Or if you think your preset would be valuable for others, please contribute a PR to the Renovate repository, see [Contributing to presets](#contributing-to-presets).
 
+Also, the entire parameter string is available as `{{args}}`.
+It includes everything between parentheses, verbatim, without the parentheses themselves.
+If you want to include a comma in the parameter value, you need to use `{{args}}` instead of `{{arg0}}`.
+
 ## GitHub-hosted Presets
 
 To host your preset config on GitHub:

--- a/lib/config/presets/index.spec.ts
+++ b/lib/config/presets/index.spec.ts
@@ -666,6 +666,33 @@ describe('config/presets/index', () => {
       });
     });
 
+    it('substitutes {{args}}', async () => {
+      local.getPreset.mockResolvedValueOnce({
+        customManagers: [
+          {
+            customType: 'regex',
+            managerFilePatterns: ['{{args}}'],
+            matchStrings: ['# renovate: ...'],
+          },
+        ],
+      });
+      const res = await presets.getPreset(
+        'local>customManager(**/{*.py, *.yaml})',
+        {},
+      );
+      expect(res).toEqual({
+        customManagers: [
+          {
+            customType: 'regex',
+            // The space after comma is obviously incorrect here.
+            // But the test must ensure that spaces aren't removed.
+            managerFilePatterns: ['**/{*.py, *.yaml}'],
+            matchStrings: ['# renovate: ...'],
+          },
+        ],
+      });
+    });
+
     it('handles 404 packages', async () => {
       let e: Error | undefined;
       try {

--- a/lib/config/presets/index.ts
+++ b/lib/config/presets/index.ts
@@ -112,8 +112,15 @@ export async function getPreset(
   if (newPreset === null) {
     return {};
   }
-  const { presetSource, repo, presetPath, presetName, tag, params } =
-    parsePreset(preset);
+  const {
+    presetSource,
+    repo,
+    presetPath,
+    presetName,
+    tag,
+    params,
+    paramString,
+  } = parsePreset(preset);
   const cacheKey = `preset:${preset}`;
   const presetCachePersistence = GlobalConfig.get(
     'presetCachePersistence',
@@ -154,6 +161,9 @@ export async function getPreset(
     const argMapping: Record<string, string> = {};
     for (const [index, value] of params.entries()) {
       argMapping[`arg${index}`] = value;
+    }
+    if (paramString) {
+      argMapping.args = paramString;
     }
     presetConfig = replaceArgs(presetConfig, argMapping);
   }

--- a/lib/config/presets/index.ts
+++ b/lib/config/presets/index.ts
@@ -112,15 +112,8 @@ export async function getPreset(
   if (newPreset === null) {
     return {};
   }
-  const {
-    presetSource,
-    repo,
-    presetPath,
-    presetName,
-    tag,
-    params,
-    paramString,
-  } = parsePreset(preset);
+  const { presetSource, repo, presetPath, presetName, tag, params, rawParams } =
+    parsePreset(preset);
   const cacheKey = `preset:${preset}`;
   const presetCachePersistence = GlobalConfig.get(
     'presetCachePersistence',
@@ -162,8 +155,8 @@ export async function getPreset(
     for (const [index, value] of params.entries()) {
       argMapping[`arg${index}`] = value;
     }
-    if (paramString) {
-      argMapping.args = paramString;
+    if (rawParams) {
+      argMapping.args = rawParams;
     }
     presetConfig = replaceArgs(presetConfig, argMapping);
   }

--- a/lib/config/presets/parse.spec.ts
+++ b/lib/config/presets/parse.spec.ts
@@ -7,6 +7,7 @@ describe('config/presets/parse', () => {
       expect(parsePreset(':base')).toEqual({
         repo: 'default',
         params: undefined,
+        paramString: undefined,
         presetName: 'base',
         presetPath: undefined,
         presetSource: 'internal',
@@ -17,6 +18,7 @@ describe('config/presets/parse', () => {
       expect(parsePreset('github>some/repo')).toEqual({
         repo: 'some/repo',
         params: undefined,
+        paramString: undefined,
         presetName: 'default',
         presetPath: undefined,
         presetSource: 'github',
@@ -27,6 +29,7 @@ describe('config/presets/parse', () => {
       expect(parsePreset('github>some/repo:foo+bar')).toEqual({
         repo: 'some/repo',
         params: undefined,
+        paramString: undefined,
         presetName: 'foo+bar',
         presetPath: undefined,
         presetSource: 'github',
@@ -37,6 +40,7 @@ describe('config/presets/parse', () => {
       expect(parsePreset('github>some/repo:somefile')).toEqual({
         repo: 'some/repo',
         params: undefined,
+        paramString: undefined,
         presetName: 'somefile',
         presetPath: undefined,
         presetSource: 'github',
@@ -47,6 +51,7 @@ describe('config/presets/parse', () => {
       expect(parsePreset('github>some/repo:somefile/somepreset')).toEqual({
         repo: 'some/repo',
         params: undefined,
+        paramString: undefined,
         presetName: 'somefile/somepreset',
         presetPath: undefined,
         presetSource: 'github',
@@ -57,6 +62,7 @@ describe('config/presets/parse', () => {
       expect(parsePreset('github>some/repo:somefile.json')).toEqual({
         repo: 'some/repo',
         params: undefined,
+        paramString: undefined,
         presetName: 'somefile.json',
         presetPath: undefined,
         presetSource: 'github',
@@ -68,6 +74,7 @@ describe('config/presets/parse', () => {
       expect(parsePreset('github>some/repo:somefile.json5')).toEqual({
         repo: 'some/repo',
         params: undefined,
+        paramString: undefined,
         presetName: 'somefile.json5',
         presetPath: undefined,
         presetSource: 'github',
@@ -79,6 +86,7 @@ describe('config/presets/parse', () => {
       expect(parsePreset('github>some/repo:somefile.json/somepreset')).toEqual({
         repo: 'some/repo',
         params: undefined,
+        paramString: undefined,
         presetName: 'somefile.json/somepreset',
         presetPath: undefined,
         presetSource: 'github',
@@ -91,6 +99,7 @@ describe('config/presets/parse', () => {
         {
           repo: 'some/repo',
           params: undefined,
+          paramString: undefined,
           presetName: 'somefile.json5/somepreset',
           presetPath: undefined,
           presetSource: 'github',
@@ -105,6 +114,7 @@ describe('config/presets/parse', () => {
       ).toEqual({
         repo: 'some/repo',
         params: undefined,
+        paramString: undefined,
         presetName: 'somefile/somepreset/somesubpreset',
         presetPath: undefined,
         presetSource: 'github',
@@ -117,6 +127,7 @@ describe('config/presets/parse', () => {
       ).toEqual({
         repo: 'some/repo',
         params: undefined,
+        paramString: undefined,
         presetName: 'somefile',
         presetPath: 'somepath/somesubpath',
         presetSource: 'github',
@@ -127,6 +138,7 @@ describe('config/presets/parse', () => {
       expect(parsePreset('github>some/repo//somefile')).toEqual({
         repo: 'some/repo',
         params: undefined,
+        paramString: undefined,
         presetName: 'somefile',
         presetPath: undefined,
         presetSource: 'github',
@@ -137,6 +149,7 @@ describe('config/presets/parse', () => {
       expect(parsePreset('gitlab>some/repo')).toEqual({
         repo: 'some/repo',
         params: undefined,
+        paramString: undefined,
         presetName: 'default',
         presetPath: undefined,
         presetSource: 'gitlab',
@@ -147,6 +160,7 @@ describe('config/presets/parse', () => {
       expect(parsePreset('gitea>some/repo')).toEqual({
         repo: 'some/repo',
         params: undefined,
+        paramString: undefined,
         presetName: 'default',
         presetPath: undefined,
         presetSource: 'gitea',
@@ -157,6 +171,7 @@ describe('config/presets/parse', () => {
       expect(parsePreset('local>some/repo')).toEqual({
         repo: 'some/repo',
         params: undefined,
+        paramString: undefined,
         presetName: 'default',
         presetPath: undefined,
         presetSource: 'local',
@@ -167,6 +182,7 @@ describe('config/presets/parse', () => {
       expect(parsePreset('local>A2B CD/A2B_Renovate')).toEqual({
         repo: 'A2B CD/A2B_Renovate',
         params: undefined,
+        paramString: undefined,
         presetName: 'default',
         presetPath: undefined,
         presetSource: 'local',
@@ -179,6 +195,7 @@ describe('config/presets/parse', () => {
       ).toEqual({
         repo: 'some-group/some-repo',
         params: undefined,
+        paramString: undefined,
         presetName: 'some-file',
         presetPath: 'some-dir',
         presetSource: 'local',
@@ -191,6 +208,7 @@ describe('config/presets/parse', () => {
       ).toEqual({
         repo: 'A2B CD/A2B_Renovate',
         params: undefined,
+        paramString: undefined,
         presetName: 'some-file',
         presetPath: 'some-dir',
         presetSource: 'local',
@@ -203,6 +221,7 @@ describe('config/presets/parse', () => {
       ).toEqual({
         repo: 'some-group/some-repo',
         params: undefined,
+        paramString: undefined,
         presetName: 'some-file/subpreset',
         presetPath: undefined,
         presetSource: 'local',
@@ -216,6 +235,7 @@ describe('config/presets/parse', () => {
       ).toEqual({
         repo: 'some-group/some-repo',
         params: undefined,
+        paramString: undefined,
         presetName: 'some-file',
         presetPath: 'some-dir',
         presetSource: 'local',
@@ -229,6 +249,7 @@ describe('config/presets/parse', () => {
       ).toEqual({
         repo: 'PROJECT/repository',
         params: undefined,
+        paramString: undefined,
         presetName: 'preset',
         presetPath: 'path/to',
         presetSource: 'local',
@@ -242,6 +263,7 @@ describe('config/presets/parse', () => {
       ).toEqual({
         repo: 'PROJECT/repository',
         params: undefined,
+        paramString: undefined,
         presetName: 'preset/subpreset',
         presetPath: undefined,
         presetSource: 'local',
@@ -255,6 +277,7 @@ describe('config/presets/parse', () => {
       ).toEqual({
         repo: 'some%20group/some%20repo',
         params: undefined,
+        paramString: undefined,
         presetName: 'some-file',
         presetPath: 'some-dir',
         presetSource: 'local',
@@ -265,6 +288,7 @@ describe('config/presets/parse', () => {
       expect(parsePreset('local>some%20group/some%20repo//some-file')).toEqual({
         repo: 'some%20group/some%20repo',
         params: undefined,
+        paramString: undefined,
         presetName: 'some-file',
         presetPath: undefined,
         presetSource: 'local',
@@ -275,6 +299,7 @@ describe('config/presets/parse', () => {
       expect(parsePreset('some/repo')).toEqual({
         repo: 'some/repo',
         params: undefined,
+        paramString: undefined,
         presetName: 'default',
         presetPath: undefined,
         presetSource: 'local',
@@ -285,6 +310,7 @@ describe('config/presets/parse', () => {
       expect(parsePreset('local>~john_doe/repo//somefile')).toEqual({
         repo: '~john_doe/repo',
         params: undefined,
+        paramString: undefined,
         presetName: 'somefile',
         presetPath: undefined,
         presetSource: 'local',
@@ -295,6 +321,7 @@ describe('config/presets/parse', () => {
       expect(parsePreset('local>~john_doe/renovate-config')).toEqual({
         repo: '~john_doe/renovate-config',
         params: undefined,
+        paramString: undefined,
         presetName: 'default',
         presetPath: undefined,
         presetSource: 'local',
@@ -305,6 +332,7 @@ describe('config/presets/parse', () => {
       expect(parsePreset(':group(packages/eslint, eslint)')).toEqual({
         repo: 'default',
         params: ['packages/eslint', 'eslint'],
+        paramString: 'packages/eslint, eslint',
         presetName: 'group',
         presetPath: undefined,
         presetSource: 'internal',
@@ -316,6 +344,7 @@ describe('config/presets/parse', () => {
       expect(parsePreset('@somescope')).toEqual({
         repo: '@somescope/renovate-config',
         params: undefined,
+        paramString: undefined,
         presetName: 'default',
         presetPath: undefined,
         presetSource: 'npm',
@@ -326,6 +355,7 @@ describe('config/presets/parse', () => {
       expect(parsePreset('@somescope(param1)')).toEqual({
         repo: '@somescope/renovate-config',
         params: ['param1'],
+        paramString: 'param1',
         presetName: 'default',
         presetPath: undefined,
         presetSource: 'npm',
@@ -336,6 +366,7 @@ describe('config/presets/parse', () => {
       expect(parsePreset('@somescope/somepackagename')).toEqual({
         repo: '@somescope/somepackagename',
         params: undefined,
+        paramString: undefined,
         presetName: 'default',
         presetPath: undefined,
         presetSource: 'npm',
@@ -348,6 +379,7 @@ describe('config/presets/parse', () => {
       ).toEqual({
         repo: '@somescope/somepackagename',
         params: ['param1', 'param2', 'param3'],
+        paramString: 'param1, param2, param3',
         presetName: 'default',
         presetPath: undefined,
         presetSource: 'npm',
@@ -358,6 +390,7 @@ describe('config/presets/parse', () => {
       expect(parsePreset('@somescope:somePresetName')).toEqual({
         repo: '@somescope/renovate-config',
         params: undefined,
+        paramString: undefined,
         presetName: 'somePresetName',
         presetPath: undefined,
         presetSource: 'npm',
@@ -368,6 +401,7 @@ describe('config/presets/parse', () => {
       expect(parsePreset('@somescope:somePresetName(param1)')).toEqual({
         repo: '@somescope/renovate-config',
         params: ['param1'],
+        paramString: 'param1',
         presetName: 'somePresetName',
         presetPath: undefined,
         presetSource: 'npm',
@@ -378,6 +412,7 @@ describe('config/presets/parse', () => {
       expect(parsePreset('@somescope/somepackagename:somePresetName')).toEqual({
         repo: '@somescope/somepackagename',
         params: undefined,
+        paramString: undefined,
         presetName: 'somePresetName',
         presetPath: undefined,
         presetSource: 'npm',
@@ -392,6 +427,7 @@ describe('config/presets/parse', () => {
       ).toEqual({
         repo: '@somescope/somepackagename',
         params: ['param1', 'param2'],
+        paramString: 'param1, param2',
         presetName: 'somePresetName',
         presetPath: undefined,
         presetSource: 'npm',
@@ -403,6 +439,7 @@ describe('config/presets/parse', () => {
       expect(parsePreset('somepackage')).toEqual({
         repo: 'renovate-config-somepackage',
         params: undefined,
+        paramString: undefined,
         presetName: 'default',
         presetPath: undefined,
         presetSource: 'npm',
@@ -413,6 +450,7 @@ describe('config/presets/parse', () => {
       expect(parsePreset('somepackage:webapp')).toEqual({
         repo: 'renovate-config-somepackage',
         params: undefined,
+        paramString: undefined,
         presetName: 'webapp',
         presetPath: undefined,
         presetSource: 'npm',
@@ -423,6 +461,7 @@ describe('config/presets/parse', () => {
       expect(parsePreset('renovate-config-somepackage:webapp')).toEqual({
         repo: 'renovate-config-somepackage',
         params: undefined,
+        paramString: undefined,
         presetName: 'webapp',
         presetPath: undefined,
         presetSource: 'npm',
@@ -433,6 +472,7 @@ describe('config/presets/parse', () => {
       expect(parsePreset('somepackage:webapp(param1)')).toEqual({
         repo: 'renovate-config-somepackage',
         params: ['param1'],
+        paramString: 'param1',
         presetName: 'webapp',
         presetPath: undefined,
         presetSource: 'npm',
@@ -447,6 +487,7 @@ describe('config/presets/parse', () => {
       ).toEqual({
         repo: 'https://my.server/gitea/renovate-config/raw/branch/main/default.json',
         params: undefined,
+        paramString: undefined,
         presetName: '',
         presetPath: undefined,
         presetSource: 'http',
@@ -461,6 +502,7 @@ describe('config/presets/parse', () => {
       ).toEqual({
         repo: 'http://my.server/users/me/repos/renovate-presets/raw/default.json?at=refs%2Fheads%2Fmain',
         params: undefined,
+        paramString: undefined,
         presetName: '',
         presetPath: undefined,
         presetSource: 'http',
@@ -475,6 +517,7 @@ describe('config/presets/parse', () => {
       ).toEqual({
         repo: 'https://my.server/gitea/renovate-config/raw/branch/main/default.json',
         params: ['param1'],
+        paramString: 'param1',
         presetName: '',
         presetPath: undefined,
         presetSource: 'http',

--- a/lib/config/presets/parse.spec.ts
+++ b/lib/config/presets/parse.spec.ts
@@ -7,7 +7,7 @@ describe('config/presets/parse', () => {
       expect(parsePreset(':base')).toEqual({
         repo: 'default',
         params: undefined,
-        paramString: undefined,
+        rawParams: undefined,
         presetName: 'base',
         presetPath: undefined,
         presetSource: 'internal',
@@ -18,7 +18,7 @@ describe('config/presets/parse', () => {
       expect(parsePreset('github>some/repo')).toEqual({
         repo: 'some/repo',
         params: undefined,
-        paramString: undefined,
+        rawParams: undefined,
         presetName: 'default',
         presetPath: undefined,
         presetSource: 'github',
@@ -29,7 +29,7 @@ describe('config/presets/parse', () => {
       expect(parsePreset('github>some/repo:foo+bar')).toEqual({
         repo: 'some/repo',
         params: undefined,
-        paramString: undefined,
+        rawParams: undefined,
         presetName: 'foo+bar',
         presetPath: undefined,
         presetSource: 'github',
@@ -40,7 +40,7 @@ describe('config/presets/parse', () => {
       expect(parsePreset('github>some/repo:somefile')).toEqual({
         repo: 'some/repo',
         params: undefined,
-        paramString: undefined,
+        rawParams: undefined,
         presetName: 'somefile',
         presetPath: undefined,
         presetSource: 'github',
@@ -51,7 +51,7 @@ describe('config/presets/parse', () => {
       expect(parsePreset('github>some/repo:somefile/somepreset')).toEqual({
         repo: 'some/repo',
         params: undefined,
-        paramString: undefined,
+        rawParams: undefined,
         presetName: 'somefile/somepreset',
         presetPath: undefined,
         presetSource: 'github',
@@ -62,7 +62,7 @@ describe('config/presets/parse', () => {
       expect(parsePreset('github>some/repo:somefile.json')).toEqual({
         repo: 'some/repo',
         params: undefined,
-        paramString: undefined,
+        rawParams: undefined,
         presetName: 'somefile.json',
         presetPath: undefined,
         presetSource: 'github',
@@ -74,7 +74,7 @@ describe('config/presets/parse', () => {
       expect(parsePreset('github>some/repo:somefile.json5')).toEqual({
         repo: 'some/repo',
         params: undefined,
-        paramString: undefined,
+        rawParams: undefined,
         presetName: 'somefile.json5',
         presetPath: undefined,
         presetSource: 'github',
@@ -86,7 +86,7 @@ describe('config/presets/parse', () => {
       expect(parsePreset('github>some/repo:somefile.json/somepreset')).toEqual({
         repo: 'some/repo',
         params: undefined,
-        paramString: undefined,
+        rawParams: undefined,
         presetName: 'somefile.json/somepreset',
         presetPath: undefined,
         presetSource: 'github',
@@ -99,7 +99,7 @@ describe('config/presets/parse', () => {
         {
           repo: 'some/repo',
           params: undefined,
-          paramString: undefined,
+          rawParams: undefined,
           presetName: 'somefile.json5/somepreset',
           presetPath: undefined,
           presetSource: 'github',
@@ -114,7 +114,7 @@ describe('config/presets/parse', () => {
       ).toEqual({
         repo: 'some/repo',
         params: undefined,
-        paramString: undefined,
+        rawParams: undefined,
         presetName: 'somefile/somepreset/somesubpreset',
         presetPath: undefined,
         presetSource: 'github',
@@ -127,7 +127,7 @@ describe('config/presets/parse', () => {
       ).toEqual({
         repo: 'some/repo',
         params: undefined,
-        paramString: undefined,
+        rawParams: undefined,
         presetName: 'somefile',
         presetPath: 'somepath/somesubpath',
         presetSource: 'github',
@@ -138,7 +138,7 @@ describe('config/presets/parse', () => {
       expect(parsePreset('github>some/repo//somefile')).toEqual({
         repo: 'some/repo',
         params: undefined,
-        paramString: undefined,
+        rawParams: undefined,
         presetName: 'somefile',
         presetPath: undefined,
         presetSource: 'github',
@@ -149,7 +149,7 @@ describe('config/presets/parse', () => {
       expect(parsePreset('gitlab>some/repo')).toEqual({
         repo: 'some/repo',
         params: undefined,
-        paramString: undefined,
+        rawParams: undefined,
         presetName: 'default',
         presetPath: undefined,
         presetSource: 'gitlab',
@@ -160,7 +160,7 @@ describe('config/presets/parse', () => {
       expect(parsePreset('gitea>some/repo')).toEqual({
         repo: 'some/repo',
         params: undefined,
-        paramString: undefined,
+        rawParams: undefined,
         presetName: 'default',
         presetPath: undefined,
         presetSource: 'gitea',
@@ -171,7 +171,7 @@ describe('config/presets/parse', () => {
       expect(parsePreset('local>some/repo')).toEqual({
         repo: 'some/repo',
         params: undefined,
-        paramString: undefined,
+        rawParams: undefined,
         presetName: 'default',
         presetPath: undefined,
         presetSource: 'local',
@@ -182,7 +182,7 @@ describe('config/presets/parse', () => {
       expect(parsePreset('local>A2B CD/A2B_Renovate')).toEqual({
         repo: 'A2B CD/A2B_Renovate',
         params: undefined,
-        paramString: undefined,
+        rawParams: undefined,
         presetName: 'default',
         presetPath: undefined,
         presetSource: 'local',
@@ -195,7 +195,7 @@ describe('config/presets/parse', () => {
       ).toEqual({
         repo: 'some-group/some-repo',
         params: undefined,
-        paramString: undefined,
+        rawParams: undefined,
         presetName: 'some-file',
         presetPath: 'some-dir',
         presetSource: 'local',
@@ -208,7 +208,7 @@ describe('config/presets/parse', () => {
       ).toEqual({
         repo: 'A2B CD/A2B_Renovate',
         params: undefined,
-        paramString: undefined,
+        rawParams: undefined,
         presetName: 'some-file',
         presetPath: 'some-dir',
         presetSource: 'local',
@@ -221,7 +221,7 @@ describe('config/presets/parse', () => {
       ).toEqual({
         repo: 'some-group/some-repo',
         params: undefined,
-        paramString: undefined,
+        rawParams: undefined,
         presetName: 'some-file/subpreset',
         presetPath: undefined,
         presetSource: 'local',
@@ -235,7 +235,7 @@ describe('config/presets/parse', () => {
       ).toEqual({
         repo: 'some-group/some-repo',
         params: undefined,
-        paramString: undefined,
+        rawParams: undefined,
         presetName: 'some-file',
         presetPath: 'some-dir',
         presetSource: 'local',
@@ -249,7 +249,7 @@ describe('config/presets/parse', () => {
       ).toEqual({
         repo: 'PROJECT/repository',
         params: undefined,
-        paramString: undefined,
+        rawParams: undefined,
         presetName: 'preset',
         presetPath: 'path/to',
         presetSource: 'local',
@@ -263,7 +263,7 @@ describe('config/presets/parse', () => {
       ).toEqual({
         repo: 'PROJECT/repository',
         params: undefined,
-        paramString: undefined,
+        rawParams: undefined,
         presetName: 'preset/subpreset',
         presetPath: undefined,
         presetSource: 'local',
@@ -277,7 +277,7 @@ describe('config/presets/parse', () => {
       ).toEqual({
         repo: 'some%20group/some%20repo',
         params: undefined,
-        paramString: undefined,
+        rawParams: undefined,
         presetName: 'some-file',
         presetPath: 'some-dir',
         presetSource: 'local',
@@ -288,7 +288,7 @@ describe('config/presets/parse', () => {
       expect(parsePreset('local>some%20group/some%20repo//some-file')).toEqual({
         repo: 'some%20group/some%20repo',
         params: undefined,
-        paramString: undefined,
+        rawParams: undefined,
         presetName: 'some-file',
         presetPath: undefined,
         presetSource: 'local',
@@ -299,7 +299,7 @@ describe('config/presets/parse', () => {
       expect(parsePreset('some/repo')).toEqual({
         repo: 'some/repo',
         params: undefined,
-        paramString: undefined,
+        rawParams: undefined,
         presetName: 'default',
         presetPath: undefined,
         presetSource: 'local',
@@ -310,7 +310,7 @@ describe('config/presets/parse', () => {
       expect(parsePreset('local>~john_doe/repo//somefile')).toEqual({
         repo: '~john_doe/repo',
         params: undefined,
-        paramString: undefined,
+        rawParams: undefined,
         presetName: 'somefile',
         presetPath: undefined,
         presetSource: 'local',
@@ -321,7 +321,7 @@ describe('config/presets/parse', () => {
       expect(parsePreset('local>~john_doe/renovate-config')).toEqual({
         repo: '~john_doe/renovate-config',
         params: undefined,
-        paramString: undefined,
+        rawParams: undefined,
         presetName: 'default',
         presetPath: undefined,
         presetSource: 'local',
@@ -332,7 +332,7 @@ describe('config/presets/parse', () => {
       expect(parsePreset(':group(packages/eslint, eslint)')).toEqual({
         repo: 'default',
         params: ['packages/eslint', 'eslint'],
-        paramString: 'packages/eslint, eslint',
+        rawParams: 'packages/eslint, eslint',
         presetName: 'group',
         presetPath: undefined,
         presetSource: 'internal',
@@ -344,7 +344,7 @@ describe('config/presets/parse', () => {
       expect(parsePreset('@somescope')).toEqual({
         repo: '@somescope/renovate-config',
         params: undefined,
-        paramString: undefined,
+        rawParams: undefined,
         presetName: 'default',
         presetPath: undefined,
         presetSource: 'npm',
@@ -355,7 +355,7 @@ describe('config/presets/parse', () => {
       expect(parsePreset('@somescope(param1)')).toEqual({
         repo: '@somescope/renovate-config',
         params: ['param1'],
-        paramString: 'param1',
+        rawParams: 'param1',
         presetName: 'default',
         presetPath: undefined,
         presetSource: 'npm',
@@ -366,7 +366,7 @@ describe('config/presets/parse', () => {
       expect(parsePreset('@somescope/somepackagename')).toEqual({
         repo: '@somescope/somepackagename',
         params: undefined,
-        paramString: undefined,
+        rawParams: undefined,
         presetName: 'default',
         presetPath: undefined,
         presetSource: 'npm',
@@ -379,7 +379,7 @@ describe('config/presets/parse', () => {
       ).toEqual({
         repo: '@somescope/somepackagename',
         params: ['param1', 'param2', 'param3'],
-        paramString: 'param1, param2, param3',
+        rawParams: 'param1, param2, param3',
         presetName: 'default',
         presetPath: undefined,
         presetSource: 'npm',
@@ -390,7 +390,7 @@ describe('config/presets/parse', () => {
       expect(parsePreset('@somescope:somePresetName')).toEqual({
         repo: '@somescope/renovate-config',
         params: undefined,
-        paramString: undefined,
+        rawParams: undefined,
         presetName: 'somePresetName',
         presetPath: undefined,
         presetSource: 'npm',
@@ -401,7 +401,7 @@ describe('config/presets/parse', () => {
       expect(parsePreset('@somescope:somePresetName(param1)')).toEqual({
         repo: '@somescope/renovate-config',
         params: ['param1'],
-        paramString: 'param1',
+        rawParams: 'param1',
         presetName: 'somePresetName',
         presetPath: undefined,
         presetSource: 'npm',
@@ -412,7 +412,7 @@ describe('config/presets/parse', () => {
       expect(parsePreset('@somescope/somepackagename:somePresetName')).toEqual({
         repo: '@somescope/somepackagename',
         params: undefined,
-        paramString: undefined,
+        rawParams: undefined,
         presetName: 'somePresetName',
         presetPath: undefined,
         presetSource: 'npm',
@@ -427,7 +427,7 @@ describe('config/presets/parse', () => {
       ).toEqual({
         repo: '@somescope/somepackagename',
         params: ['param1', 'param2'],
-        paramString: 'param1, param2',
+        rawParams: 'param1, param2',
         presetName: 'somePresetName',
         presetPath: undefined,
         presetSource: 'npm',
@@ -439,7 +439,7 @@ describe('config/presets/parse', () => {
       expect(parsePreset('somepackage')).toEqual({
         repo: 'renovate-config-somepackage',
         params: undefined,
-        paramString: undefined,
+        rawParams: undefined,
         presetName: 'default',
         presetPath: undefined,
         presetSource: 'npm',
@@ -450,7 +450,7 @@ describe('config/presets/parse', () => {
       expect(parsePreset('somepackage:webapp')).toEqual({
         repo: 'renovate-config-somepackage',
         params: undefined,
-        paramString: undefined,
+        rawParams: undefined,
         presetName: 'webapp',
         presetPath: undefined,
         presetSource: 'npm',
@@ -461,7 +461,7 @@ describe('config/presets/parse', () => {
       expect(parsePreset('renovate-config-somepackage:webapp')).toEqual({
         repo: 'renovate-config-somepackage',
         params: undefined,
-        paramString: undefined,
+        rawParams: undefined,
         presetName: 'webapp',
         presetPath: undefined,
         presetSource: 'npm',
@@ -472,7 +472,7 @@ describe('config/presets/parse', () => {
       expect(parsePreset('somepackage:webapp(param1)')).toEqual({
         repo: 'renovate-config-somepackage',
         params: ['param1'],
-        paramString: 'param1',
+        rawParams: 'param1',
         presetName: 'webapp',
         presetPath: undefined,
         presetSource: 'npm',
@@ -487,7 +487,7 @@ describe('config/presets/parse', () => {
       ).toEqual({
         repo: 'https://my.server/gitea/renovate-config/raw/branch/main/default.json',
         params: undefined,
-        paramString: undefined,
+        rawParams: undefined,
         presetName: '',
         presetPath: undefined,
         presetSource: 'http',
@@ -502,7 +502,7 @@ describe('config/presets/parse', () => {
       ).toEqual({
         repo: 'http://my.server/users/me/repos/renovate-presets/raw/default.json?at=refs%2Fheads%2Fmain',
         params: undefined,
-        paramString: undefined,
+        rawParams: undefined,
         presetName: '',
         presetPath: undefined,
         presetSource: 'http',
@@ -517,7 +517,7 @@ describe('config/presets/parse', () => {
       ).toEqual({
         repo: 'https://my.server/gitea/renovate-config/raw/branch/main/default.json',
         params: ['param1'],
-        paramString: 'param1',
+        rawParams: 'param1',
         presetName: '',
         presetPath: undefined,
         presetSource: 'http',

--- a/lib/config/presets/parse.ts
+++ b/lib/config/presets/parse.ts
@@ -18,6 +18,7 @@ export function parsePreset(input: string): ParsedPreset {
   let repo: string;
   let presetName: string;
   let tag: string | undefined;
+  let paramString: string | undefined;
   let params: string[] | undefined;
   if (str.startsWith('github>')) {
     presetSource = 'github';
@@ -43,14 +44,12 @@ export function parsePreset(input: string): ParsedPreset {
   str = str.replace(regEx(/^npm>/), '');
   presetSource = presetSource ?? 'npm';
   if (str.includes('(')) {
-    params = str
-      .slice(str.indexOf('(') + 1, -1)
-      .split(',')
-      .map((elem) => elem.trim());
+    paramString = str.slice(str.indexOf('(') + 1, -1);
+    params = paramString.split(',').map((elem) => elem.trim());
     str = str.slice(0, str.indexOf('('));
   }
   if (presetSource === 'http') {
-    return { presetSource, repo: str, presetName: '', params };
+    return { presetSource, repo: str, presetName: '', params, paramString };
   }
   const presetsPackages = [
     'abandonments',
@@ -124,5 +123,6 @@ export function parsePreset(input: string): ParsedPreset {
     presetName,
     tag,
     params,
+    paramString,
   };
 }

--- a/lib/config/presets/parse.ts
+++ b/lib/config/presets/parse.ts
@@ -18,7 +18,7 @@ export function parsePreset(input: string): ParsedPreset {
   let repo: string;
   let presetName: string;
   let tag: string | undefined;
-  let paramString: string | undefined;
+  let rawParams: string | undefined;
   let params: string[] | undefined;
   if (str.startsWith('github>')) {
     presetSource = 'github';
@@ -44,12 +44,12 @@ export function parsePreset(input: string): ParsedPreset {
   str = str.replace(regEx(/^npm>/), '');
   presetSource = presetSource ?? 'npm';
   if (str.includes('(')) {
-    paramString = str.slice(str.indexOf('(') + 1, -1);
-    params = paramString.split(',').map((elem) => elem.trim());
+    rawParams = str.slice(str.indexOf('(') + 1, -1);
+    params = rawParams.split(',').map((elem) => elem.trim());
     str = str.slice(0, str.indexOf('('));
   }
   if (presetSource === 'http') {
-    return { presetSource, repo: str, presetName: '', params, paramString };
+    return { presetSource, repo: str, presetName: '', params, rawParams };
   }
   const presetsPackages = [
     'abandonments',
@@ -123,6 +123,6 @@ export function parsePreset(input: string): ParsedPreset {
     presetName,
     tag,
     params,
-    paramString,
+    rawParams,
   };
 }

--- a/lib/config/presets/types.ts
+++ b/lib/config/presets/types.ts
@@ -23,6 +23,7 @@ export interface ParsedPreset {
   presetName: string;
   tag?: string | undefined;
   params?: string[] | undefined;
+  paramString?: string | undefined;
 }
 
 export type PresetFetcher = (

--- a/lib/config/presets/types.ts
+++ b/lib/config/presets/types.ts
@@ -23,7 +23,7 @@ export interface ParsedPreset {
   presetName: string;
   tag?: string | undefined;
   params?: string[] | undefined;
-  paramString?: string | undefined;
+  rawParams?: string | undefined;
 }
 
 export type PresetFetcher = (


### PR DESCRIPTION
## Changes

Allow passing values containing commas to presets. Substitute `{{args}}` in the preset with the entire string between parentheses.

## Context

I use presets for custom regex managers. I pass `managerFilePatterns` as a parameter. Glob syntax is much more convenient than regex, but glob syntax often needs commas.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository