### PR TITLE
fix(gitea): prefer default merge method

### DIFF
--- a/lib/modules/platform/gitea/index.spec.ts
+++ b/lib/modules/platform/gitea/index.spec.ts
@@ -54,6 +54,7 @@ describe('modules/platform/gitea/index', () => {
 
   const mockRepo = mockedRepo({
     allow_rebase: true,
+    default_merge_style: 'rebase',
     clone_url: 'https://gitea.renovatebot.com/some/repo.git',
     ssh_url: 'git@gitea.renovatebot.com/some/repo.git',
     default_branch: 'master',
@@ -563,6 +564,7 @@ describe('modules/platform/gitea/index', () => {
           ...mockRepo,
           allow_rebase: false,
           allow_fast_forward_only_merge: true,
+          default_merge_style: 'fast-forward-only',
         });
       await initFakePlatform(scope);
 
@@ -583,6 +585,7 @@ describe('modules/platform/gitea/index', () => {
           ...mockRepo,
           allow_rebase: false,
           allow_rebase_explicit: true,
+          default_merge_style: 'rebase-merge',
         });
       await initFakePlatform(scope);
 
@@ -603,6 +606,7 @@ describe('modules/platform/gitea/index', () => {
           ...mockRepo,
           allow_rebase: false,
           allow_squash_merge: true,
+          default_merge_style: 'squash',
         });
       await initFakePlatform(scope);
 
@@ -623,6 +627,7 @@ describe('modules/platform/gitea/index', () => {
           ...mockRepo,
           allow_rebase: false,
           allow_merge_commits: true,
+          default_merge_style: 'merge',
         });
       await initFakePlatform(scope);
 

--- a/lib/modules/platform/gitea/index.ts
+++ b/lib/modules/platform/gitea/index.ts
@@ -320,15 +320,27 @@ const platform: Platform = {
       throw new Error(REPOSITORY_BLOCKED);
     }
 
-    if (repo.allow_rebase) {
+    if (repo.allow_rebase && repo.default_merge_style === 'rebase') {
       config.mergeMethod = 'rebase';
-    } else if (repo.allow_rebase_explicit) {
+    } else if (
+      repo.allow_rebase_explicit &&
+      repo.default_merge_style === 'rebase-merge'
+    ) {
       config.mergeMethod = 'rebase-merge';
-    } else if (repo.allow_squash_merge) {
+    } else if (
+      repo.allow_squash_merge &&
+      repo.default_merge_style === 'squash'
+    ) {
       config.mergeMethod = 'squash';
-    } else if (repo.allow_merge_commits) {
+    } else if (
+      repo.allow_merge_commits &&
+      repo.default_merge_style === 'merge'
+    ) {
       config.mergeMethod = 'merge';
-    } else if (repo.allow_fast_forward_only_merge) {
+    } else if (
+      repo.allow_fast_forward_only_merge &&
+      repo.default_merge_style === 'fast-forward-only'
+    ) {
       config.mergeMethod = 'fast-forward-only';
     } else {
       logger.debug(

--- a/lib/modules/platform/gitea/types.ts
+++ b/lib/modules/platform/gitea/types.ts
@@ -81,7 +81,7 @@ export interface Repo {
   allow_squash_merge: boolean;
   archived: boolean;
   clone_url?: string;
-  default_merge_style: string;
+  default_merge_style: PRMergeMethod;
   external_tracker?: unknown;
   has_issues: boolean;
   has_pull_requests: boolean;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Currently renovate just tries to guess the enabled merge methods and ignores the configured default merge method on repo.
This is probably partially breaking, as it's now following the default merge method instead of trying the first working method.
<!-- Describe what behavior is changed by this PR. -->

## Context

The `default_merge_style` is always filled but it seems you can set a merge method wich is disabled.
I consider that a platform bug and we don't need a fallback.
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
