### PR TITLE
feat(manager/ocb): add support for providers

### DIFF
--- a/lib/modules/manager/ocb/extract.spec.ts
+++ b/lib/modules/manager/ocb/extract.spec.ts
@@ -24,6 +24,9 @@ describe('modules/manager/ocb/extract', () => {
 
         processors:
           - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.86.0
+
+        providers:
+          - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.0.0-rcv0015
       `;
       const result = extractPackageFile(content, 'builder-config.yaml');
       expect(result?.deps).toEqual([
@@ -59,6 +62,12 @@ describe('modules/manager/ocb/extract', () => {
           datasource: 'go',
           depName: 'go.opentelemetry.io/collector/processor/batchprocessor',
           depType: 'processors',
+        },
+        {
+          currentValue: 'v1.0.0-rcv0015',
+          datasource: 'go',
+          depName: 'go.opentelemetry.io/collector/confmap/provider/envprovider',
+          depType: 'providers',
         },
         {
           currentValue: 'v0.86.0',

--- a/lib/modules/manager/ocb/extract.ts
+++ b/lib/modules/manager/ocb/extract.ts
@@ -51,6 +51,7 @@ export function extractPackageFile(
   deps.push(...processModule(definition.exporters, 'exports'));
   deps.push(...processModule(definition.extensions, 'extensions'));
   deps.push(...processModule(definition.processors, 'processors'));
+  deps.push(...processModule(definition.providers, 'providers'));
   deps.push(...processModule(definition.receivers, 'receivers'));
 
   return {

--- a/lib/modules/manager/ocb/schema.ts
+++ b/lib/modules/manager/ocb/schema.ts
@@ -17,6 +17,7 @@ export const OCBConfigSchema = z.object({
   exporters: ModuleSchema,
   receivers: ModuleSchema,
   processors: ModuleSchema,
+  providers: ModuleSchema,
   connectors: ModuleSchema,
 });
 export type OCBConfig = z.infer<typeof OCBConfigSchema>;


### PR DESCRIPTION
## Changes
Add support for `providers` to `ocb` manager (OpenTelemetry Collector Builder).

Example:
https://github.com/open-telemetry/opentelemetry-collector/blob/3bcdf802e64ab5de6b00ec390b77b6d9a43854c2/cmd/builder/internal/config/default.yaml#L32-L37

## Context
Closes #31747.

See also:
 * #31754

## Documentation (please check one with an [x])
- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)
I have verified these changes via:
- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
