### PR TITLE
feat(replacements): improve `Package` field for prs 

### DIFF
--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -2732,7 +2732,7 @@ const options: RenovateOptions[] = [
     mergeable: true,
     default: {
       Package:
-        '{{{depNameLinked}}}{{#ifChanged depName newName}} → {{{newNameLinked}}}{{/ifChanged}}',
+        '{{{depNameLinked}}}{{#ifNotEquals depName newName}} → {{{newNameLinked}}}{{/ifNotEquals}}',
       Type: '{{{depType}}}',
       Update: '{{{updateType}}}',
       'Current value': '{{{currentValue}}}',

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -2732,7 +2732,7 @@ const options: RenovateOptions[] = [
     mergeable: true,
     default: {
       Package:
-        '{{{depNameLinked}}}{{#ifNotEquals depName newName}} → {{{newNameLinked}}}{{/ifNotEquals}}',
+        '{{{depNameLinked}}}{{#if newName}}{{#unless (equals depName newName)}} → {{{newNameLinked}}}{{/unless}}{{/if}}',
       Type: '{{{depType}}}',
       Update: '{{{updateType}}}',
       'Current value': '{{{currentValue}}}',

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -2731,7 +2731,8 @@ const options: RenovateOptions[] = [
     freeChoice: true,
     mergeable: true,
     default: {
-      Package: '{{{depNameLinked}}}',
+      Package:
+        '{{{depNameLinked}}}{{#ifChanged depName newName}} → {{{newNameLinked}}}{{/ifChanged}}',
       Type: '{{{depType}}}',
       Update: '{{{updateType}}}',
       'Current value': '{{{currentValue}}}',

--- a/lib/util/template/index.spec.ts
+++ b/lib/util/template/index.spec.ts
@@ -48,17 +48,17 @@ describe('util/template/index', () => {
     expect(output).toContain('True');
   });
 
-  it('ifChanged - yes', () => {
+  it('ifNotEquals - yes', () => {
     const userTemplate =
-      '{{#ifChanged depName newName}}{{{newName}}}{{/ifChanged}}';
+      '{{#ifNotEquals depName newName}}{{{newName}}}{{/ifNotEquals}}';
     const input = { depName: 'nodemon', newName: 'nodemon-new' };
     const output = template.compile(userTemplate, input, false);
     expect(output).toBe('nodemon-new');
   });
 
-  it('ifChanged - no', () => {
+  it('ifNotEquals - no', () => {
     const userTemplate =
-      '{{#ifChanged depName newName}}{{{newName}}}{{/ifChanged}}';
+      '{{#ifNotEquals depName newName}}{{{newName}}}{{/ifNotEquals}}';
     const input = { depName: 'nodemon', newName: 'nodemon' };
     const output = template.compile(userTemplate, input, false);
     expect(output).toBeEmptyString();

--- a/lib/util/template/index.spec.ts
+++ b/lib/util/template/index.spec.ts
@@ -48,20 +48,28 @@ describe('util/template/index', () => {
     expect(output).toContain('True');
   });
 
-  it('ifNotEquals - yes', () => {
+  it('unless with equals - 1', () => {
     const userTemplate =
-      '{{#ifNotEquals depName newName}}{{{newName}}}{{/ifNotEquals}}';
-    const input = { depName: 'nodemon', newName: 'nodemon-new' };
+      '{{{depNameLinked}}}{{#if newName}}{{#unless (equals depName newName)}} -> {{{newNameLinked}}}{{/unless}}{{/if}}';
+    const input = {
+      depName: 'nodemon',
+      depNameLinked: 'nodemonLinked',
+      newName: 'nodemon-new',
+      newNameLinked: 'nodemonNewLinked',
+    };
     const output = template.compile(userTemplate, input, false);
-    expect(output).toBe('nodemon-new');
+    expect(output).toBe('nodemonLinked -> nodemonNewLinked');
   });
 
-  it('ifNotEquals - no', () => {
+  it('unless with equals - 2', () => {
     const userTemplate =
-      '{{#ifNotEquals depName newName}}{{{newName}}}{{/ifNotEquals}}';
-    const input = { depName: 'nodemon', newName: 'nodemon' };
+      '{{{depNameLinked}}}{{#if newName}}{{#unless (equals depName newName)}} -> {{{newNameLinked}}}{{/unless}}{{/if}}';
+    const input = {
+      depName: 'nodemon',
+      depNameLinked: 'nodemonLinked',
+    };
     const output = template.compile(userTemplate, input, false);
-    expect(output).toBeEmptyString();
+    expect(output).toBe('nodemonLinked');
   });
 
   it('not containsString', () => {

--- a/lib/util/template/index.spec.ts
+++ b/lib/util/template/index.spec.ts
@@ -48,6 +48,22 @@ describe('util/template/index', () => {
     expect(output).toContain('True');
   });
 
+  it('ifChanged - yes', () => {
+    const userTemplate =
+      '{{#ifChanged depName newName}}{{{newName}}}{{/ifChanged}}';
+    const input = { depName: 'nodemon', newName: 'nodemon-new' };
+    const output = template.compile(userTemplate, input, false);
+    expect(output).toBe('nodemon-new');
+  });
+
+  it('ifChanged - no', () => {
+    const userTemplate =
+      '{{#ifChanged depName newName}}{{{newName}}}{{/ifChanged}}';
+    const input = { depName: 'nodemon', newName: 'nodemon' };
+    const output = template.compile(userTemplate, input, false);
+    expect(output).toBeEmptyString();
+  });
+
   it('not containsString', () => {
     const userTemplate =
       "{{#if (containsString platform 'hub')}}True{{else}}False{{/if}}";

--- a/lib/util/template/index.ts
+++ b/lib/util/template/index.ts
@@ -14,6 +14,22 @@ type Options = HelperOptions & {
 handlebars.registerHelper('encodeURIComponent', encodeURIComponent);
 handlebars.registerHelper('decodeURIComponent', decodeURIComponent);
 
+handlebars.registerHelper(
+  'ifChanged',
+  function (
+    this: any,
+    depName: string,
+    newName: string,
+    options: HelperOptions,
+  ) {
+    if (newName && newName !== depName) {
+      return options.fn(this);
+    } else {
+      return options.inverse(this);
+    }
+  },
+);
+
 handlebars.registerHelper('encodeBase64', (str: string) =>
   Buffer.from(str ?? '').toString('base64'),
 );
@@ -207,6 +223,8 @@ export const allowedFields = {
     'The patch version of the new version. e.g. "0" if the new version is "3.1.0"',
   newName:
     'The name of the new dependency that replaces the current deprecated dependency',
+  newNameLinked:
+    'The new dependency name already linked to its home page using markdown',
   newValue:
     'The new value in the upgrade. Can be a range or version e.g. "^3.0.0" or "3.1.0"',
   newVersion: 'The new version in the upgrade, e.g. "3.1.0"',

--- a/lib/util/template/index.ts
+++ b/lib/util/template/index.ts
@@ -15,14 +15,9 @@ handlebars.registerHelper('encodeURIComponent', encodeURIComponent);
 handlebars.registerHelper('decodeURIComponent', decodeURIComponent);
 
 handlebars.registerHelper(
-  'ifChanged',
-  function (
-    this: any,
-    depName: string,
-    newName: string,
-    options: HelperOptions,
-  ) {
-    if (newName && newName !== depName) {
+  'ifNotEquals',
+  function (this: any, a: string, b: string, options: HelperOptions) {
+    if (a && b && a !== b) {
       return options.fn(this);
     } else {
       return options.inverse(this);

--- a/lib/util/template/index.ts
+++ b/lib/util/template/index.ts
@@ -14,17 +14,6 @@ type Options = HelperOptions & {
 handlebars.registerHelper('encodeURIComponent', encodeURIComponent);
 handlebars.registerHelper('decodeURIComponent', decodeURIComponent);
 
-handlebars.registerHelper(
-  'ifNotEquals',
-  function (this: any, a: string, b: string, options: HelperOptions) {
-    if (a && b && a !== b) {
-      return options.fn(this);
-    } else {
-      return options.inverse(this);
-    }
-  },
-);
-
 handlebars.registerHelper('encodeBase64', (str: string) =>
   Buffer.from(str ?? '').toString('base64'),
 );

--- a/lib/workers/repository/update/pr/body/index.ts
+++ b/lib/workers/repository/update/pr/body/index.ts
@@ -27,9 +27,11 @@ function massageUpdateMetadata(config: BranchConfig): void {
     } = upgrade;
     // TODO: types (#22198)
     let depNameLinked = upgrade.depName!;
+    let newNameLinked = upgrade.newName!;
     const primaryLink = homepage ?? sourceUrl ?? dependencyUrl;
     if (primaryLink) {
       depNameLinked = `[${depNameLinked}](${primaryLink})`;
+      newNameLinked = `[${newNameLinked}](${primaryLink})`;
     }
 
     let sourceRootPath = 'tree/HEAD';
@@ -58,6 +60,7 @@ function massageUpdateMetadata(config: BranchConfig): void {
       depNameLinked += ` (${otherLinks.join(', ')})`;
     }
     upgrade.depNameLinked = depNameLinked;
+    upgrade.newNameLinked = newNameLinked;
     const references: string[] = [];
     if (homepage) {
       references.push(`[homepage](${homepage})`);

--- a/lib/workers/repository/update/pr/body/updates-table.spec.ts
+++ b/lib/workers/repository/update/pr/body/updates-table.spec.ts
@@ -260,7 +260,7 @@ describe('workers/repository/update/pr/body/updates-table', () => {
       branchName: 'some-branch',
       prBodyDefinitions: {
         Package:
-          '{{{depNameLinked}}}{{#ifNotEquals depName newName}} → {{{newNameLinked}}}{{/ifNotEquals}}',
+          '{{{depNameLinked}}}{{#if newName}}{{#unless (equals depName newName)}} → {{{newNameLinked}}}{{/unless}}{{/if}}',
         Type: '{{{depType}}}',
         Update: '{{{updateType}}}',
         'Current value': '{{{currentValue}}}',
@@ -290,7 +290,7 @@ describe('workers/repository/update/pr/body/updates-table', () => {
       prBodyColumns: ['Package', 'Type', 'Update', 'Change', 'Pending'],
       prBodyDefinitions: {
         Package:
-          '{{{depNameLinked}}}{{#ifNotEquals depName newName}} → {{{newNameLinked}}}{{/ifNotEquals}}',
+          '{{{depNameLinked}}}{{#if newName}}{{#unless (equals depName newName)}} → {{{newNameLinked}}}{{/unless}}{{/if}}',
         Type: '{{{depType}}}',
         Update: '{{{updateType}}}',
         'Current value': '{{{currentValue}}}',

--- a/lib/workers/repository/update/pr/body/updates-table.spec.ts
+++ b/lib/workers/repository/update/pr/body/updates-table.spec.ts
@@ -253,4 +253,65 @@ describe('workers/repository/update/pr/body/updates-table', () => {
         '\n',
     );
   });
+
+  it('handles replacements with new names', () => {
+    const upgrade = partial<BranchUpgradeConfig>({
+      manager: 'some-manager',
+      branchName: 'some-branch',
+      prBodyDefinitions: {
+        Package:
+          '{{{depNameLinked}}}{{#ifChanged depName newName}} → {{{newNameLinked}}}{{/ifChanged}}',
+        Type: '{{{depType}}}',
+        Update: '{{{updateType}}}',
+        'Current value': '{{{currentValue}}}',
+        'New value': '{{{newValue}}}',
+        Change:
+          "[{{#if displayFrom}}`{{{displayFrom}}}` -> {{else}}{{#if currentValue}}`{{{currentValue}}}` -> {{/if}}{{/if}}{{#if displayTo}}`{{{displayTo}}}`{{else}}`{{{newValue}}}`{{/if}}]({{#if depName}}https://renovatebot.com/diffs/npm/{{replace '/' '%2f' depName}}/{{{currentVersion}}}/{{{newVersion}}}{{/if}})",
+      },
+      updateType: 'replacement',
+      depNameLinked: '[mocha](https://mochajs.org/)',
+      depType: 'devDependencies',
+      depName: 'mocha',
+      currentValue: '6.2.3',
+      newValue: '6.2.4',
+      currentVersion: '6.2.3',
+      newVersion: '6.2.4',
+      displayFrom: '6.2.3',
+      displayTo: '6.2.4',
+      newName: 'mochaNew',
+      newNameLinked: '[mochaNew](https://mochajs.org/)',
+    });
+
+    const configObj: BranchConfig = {
+      manager: 'some-manager',
+      branchName: 'some-branch',
+      baseBranch: 'base',
+      upgrades: [upgrade],
+      prBodyColumns: ['Package', 'Type', 'Update', 'Change', 'Pending'],
+      prBodyDefinitions: {
+        Package:
+          '{{{depNameLinked}}}{{#ifChanged depName newName}} → {{{newNameLinked}}}{{/ifChanged}}',
+        Type: '{{{depType}}}',
+        Update: '{{{updateType}}}',
+        'Current value': '{{{currentValue}}}',
+        'New value': '{{{newValue}}}',
+        Change: 'All locks refreshed',
+        Pending: '{{{displayPending}}}',
+        References: '{{{references}}}',
+        'Package file': '{{{packageFile}}}',
+      },
+    };
+    const result = getPrUpdatesTable(configObj);
+    expect(result).toMatch(
+      '\n' +
+        '\n' +
+        'This PR contains the following updates:\n' +
+        '\n' +
+        '| Package | Type | Update | Change |\n' +
+        '|---|---|---|---|\n' +
+        '| [mocha](https://mochajs.org/) → [mochaNew](https://mochajs.org/) | devDependencies | replacement | [`6.2.3` -> `6.2.4`](https://renovatebot.com/diffs/npm/mocha/6.2.3/6.2.4) |\n' +
+        '\n' +
+        '\n',
+    );
+  });
 });

--- a/lib/workers/repository/update/pr/body/updates-table.spec.ts
+++ b/lib/workers/repository/update/pr/body/updates-table.spec.ts
@@ -260,7 +260,7 @@ describe('workers/repository/update/pr/body/updates-table', () => {
       branchName: 'some-branch',
       prBodyDefinitions: {
         Package:
-          '{{{depNameLinked}}}{{#ifChanged depName newName}} → {{{newNameLinked}}}{{/ifChanged}}',
+          '{{{depNameLinked}}}{{#ifNotEquals depName newName}} → {{{newNameLinked}}}{{/ifNotEquals}}',
         Type: '{{{depType}}}',
         Update: '{{{updateType}}}',
         'Current value': '{{{currentValue}}}',
@@ -290,7 +290,7 @@ describe('workers/repository/update/pr/body/updates-table', () => {
       prBodyColumns: ['Package', 'Type', 'Update', 'Change', 'Pending'],
       prBodyDefinitions: {
         Package:
-          '{{{depNameLinked}}}{{#ifChanged depName newName}} → {{{newNameLinked}}}{{/ifChanged}}',
+          '{{{depNameLinked}}}{{#ifNotEquals depName newName}} → {{{newNameLinked}}}{{/ifNotEquals}}',
         Type: '{{{depType}}}',
         Update: '{{{updateType}}}',
         'Current value': '{{{currentValue}}}',


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- Add a new custom helper `ifNotEquals`: check if a value exists and is equal to another value or not
- Update the `Package` template to show both oldName and newName during replacements
<!-- Describe what behavior is changed by this PR. -->

## Context
- Ref: https://github.com/renovatebot/renovate/pull/29575#issuecomment-2241104100
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository
No replacement pr: https://github.com/Rahul-renovate-testing/replacements-table-2/pull/3
Replacement pr: https://github.com/Rahul-renovate-testing/replacements-table-2/pull/1

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
