### PR TITLE
fix(gradle): update dependency verification metadata also without `verify-metadata` enabled

### DIFF
--- a/lib/modules/manager/gradle/artifacts.spec.ts
+++ b/lib/modules/manager/gradle/artifacts.spec.ts
@@ -587,6 +587,59 @@ describe('modules/manager/gradle/artifacts', () => {
       ]);
     });
 
+    it('updates existing checksums also if verify-checksums is disabled', async () => {
+      const execSnapshots = mockExecAll();
+      scm.getFileList.mockResolvedValue([
+        'gradlew',
+        'build.gradle',
+        'gradle/wrapper/gradle-wrapper.properties',
+        'gradle/verification-metadata.xml',
+      ]);
+      git.getRepoStatus.mockResolvedValue(
+        partial<StatusResult>({
+          modified: ['build.gradle', 'gradle/verification-metadata.xml'],
+        }),
+      );
+      fs.readLocalFile.mockImplementation((fileName: string): Promise<any> => {
+        let content = '';
+        if (fileName === 'gradle/verification-metadata.xml') {
+          content =
+            '<verify-metadata>false</verify-metadata><sha256 value="hash" origin="test data"/>';
+        }
+        return Promise.resolve(content);
+      });
+
+      const res = await updateArtifacts({
+        packageFileName: 'build.gradle',
+        updatedDeps: [
+          { depName: 'org.junit.jupiter:junit-jupiter-api' },
+          { depName: 'org.junit.jupiter:junit-jupiter-engine' },
+        ],
+        newPackageFileContent: '',
+        config: {},
+      });
+
+      expect(res).toEqual([
+        {
+          file: {
+            type: 'addition',
+            path: 'gradle/verification-metadata.xml',
+            contents:
+              '<verify-metadata>false</verify-metadata><sha256 value="hash" origin="test data"/>',
+          },
+        },
+      ]);
+      expect(execSnapshots).toMatchObject([
+        {
+          cmd: './gradlew --console=plain --dependency-verification lenient -q --write-verification-metadata sha256 dependencies',
+          options: {
+            cwd: '/tmp/github/some/repo',
+            stdio: ['pipe', 'ignore', 'pipe'],
+          },
+        },
+      ]);
+    });
+
     it('updates verification metadata and lock file', async () => {
       const execSnapshots = mockExecAll();
       scm.getFileList.mockResolvedValue([
@@ -742,7 +795,7 @@ describe('modules/manager/gradle/artifacts', () => {
       ]);
     });
 
-    it('does not exec any commands when verification metadata exists, but neither checksum nor signature verification is enabled', async () => {
+    it('does not write verification metadata, when no checksums exist and neither checksum nor signature verification is enabled', async () => {
       const execSnapshots = mockExecAll();
       scm.getFileList.mockResolvedValue([
         'gradlew',
@@ -774,7 +827,7 @@ describe('modules/manager/gradle/artifacts', () => {
         config: {},
       });
 
-      expect(execSnapshots).toMatchObject([]);
+      expect(execSnapshots).toBeEmptyArray();
     });
   });
 });


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Enables refreshing dependency checksums during gradle artifact updates when `<verify-metadata>false</verify-metadata>`. Until now, this was only done if metadata verification was also enabled. This covers cases, such as seen with [groovy](https://github.com/apache/groovy/blob/master/gradle/verification-metadata.xml#L42) or [elasticsearch](https://github.com/elastic/elasticsearch/blob/5e16bc3fa615d76a5f188e0b722691da2981e633/gradle/verification-metadata.xml#L4-L5), where checkums are present for JARs (that gradle is verifying), but where no additional metadata verification is enabled.

<!-- Describe what behavior is changed by this PR. -->

## Context

- https://github.com/renovatebot/renovate/discussions/32747
- gradle documentation on [disabling metadata verification](https://docs.gradle.org/current/userguide/dependency_verification.html#sec:disabling-metadata-verification)
- [gradle source code](https://github.com/gradle/gradle/blob/b06b7de4572c102a02ed831ae1f37e2da8255c35/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/verification/verifier/DependencyVerifier.java#L87) that shows that dependency verification is still run on deps that are not of type `ArtifactVerificationOperation.ArtifactKind.METADATA` if metadata verification is disabled

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
