### PR TITLE
refactor: Improve HTTP cache stat reporting

### DIFF
--- a/lib/util/http/cache/abstract-http-cache-provider.ts
+++ b/lib/util/http/cache/abstract-http-cache-provider.ts
@@ -54,7 +54,7 @@ export abstract class AbstractHttpCacheProvider implements HttpCacheProvider {
       const etag = resp.headers?.etag;
       const lastModified = resp.headers?.['last-modified'];
 
-      HttpCacheStats.incRemoteMisses(url);
+      HttpCacheStats.httpMiss(url);
 
       const httpResponse = copyResponse(resp, true);
       const timestamp = new Date().toISOString();
@@ -89,7 +89,7 @@ export abstract class AbstractHttpCacheProvider implements HttpCacheProvider {
       logger.debug(
         `http cache: Using cached response: ${url} from ${timestamp}`,
       );
-      HttpCacheStats.incRemoteHits(url);
+      HttpCacheStats.httpHit(url);
       const cachedResp = copyResponse(
         httpCache.httpResponse as HttpResponse<T>,
         true,

--- a/lib/util/http/cache/abstract-http-cache-provider.ts
+++ b/lib/util/http/cache/abstract-http-cache-provider.ts
@@ -54,7 +54,7 @@ export abstract class AbstractHttpCacheProvider implements HttpCacheProvider {
       const etag = resp.headers?.etag;
       const lastModified = resp.headers?.['last-modified'];
 
-      HttpCacheStats.httpMiss(url);
+      HttpCacheStats.etagMiss(url);
 
       const httpResponse = copyResponse(resp, true);
       const timestamp = new Date().toISOString();
@@ -89,7 +89,7 @@ export abstract class AbstractHttpCacheProvider implements HttpCacheProvider {
       logger.debug(
         `http cache: Using cached response: ${url} from ${timestamp}`,
       );
-      HttpCacheStats.httpHit(url);
+      HttpCacheStats.etagHit(url);
       const cachedResp = copyResponse(
         httpCache.httpResponse as HttpResponse<T>,
         true,

--- a/lib/util/http/cache/package-http-cache-provider.ts
+++ b/lib/util/http/cache/package-http-cache-provider.ts
@@ -55,6 +55,7 @@ export class PackageHttpCacheProvider extends AbstractHttpCacheProvider {
   ): Promise<HttpResponse<T> | null> {
     const cached = await this.get(url);
     if (!cached) {
+      HttpCacheStats.localMiss(url);
       return null;
     }
 
@@ -66,11 +67,11 @@ export class PackageHttpCacheProvider extends AbstractHttpCacheProvider {
     const deadline = cachedAt.plus({ minutes: this.softTtlMinutes });
     const now = DateTime.now();
     if (now >= deadline) {
-      HttpCacheStats.incLocalMisses(url);
+      HttpCacheStats.localMiss(url);
       return null;
     }
 
-    HttpCacheStats.incLocalHits(url);
+    HttpCacheStats.localHit(url);
     return cached.httpResponse as HttpResponse<T>;
   }
 

--- a/lib/util/http/cache/package-http-cache-provider.ts
+++ b/lib/util/http/cache/package-http-cache-provider.ts
@@ -55,7 +55,6 @@ export class PackageHttpCacheProvider extends AbstractHttpCacheProvider {
   ): Promise<HttpResponse<T> | null> {
     const cached = await this.get(url);
     if (!cached) {
-      HttpCacheStats.localMiss(url);
       return null;
     }
 

--- a/lib/util/stats.spec.ts
+++ b/lib/util/stats.spec.ts
@@ -525,29 +525,29 @@ describe('util/stats', () => {
     });
 
     it('ignores wrong url', () => {
-      HttpCacheStats.incLocalHits('<invalid>');
+      HttpCacheStats.localHit('<invalid>');
       expect(HttpCacheStats.getData()).toEqual({});
     });
 
     it('writes data points', () => {
-      HttpCacheStats.incLocalHits('https://example.com/foo');
-      HttpCacheStats.incLocalHits('https://example.com/foo');
-      HttpCacheStats.incLocalMisses('https://example.com/foo');
-      HttpCacheStats.incLocalMisses('https://example.com/bar');
-      HttpCacheStats.incRemoteHits('https://example.com/bar');
-      HttpCacheStats.incRemoteMisses('https://example.com/bar');
+      HttpCacheStats.localHit('https://example.com/foo');
+      HttpCacheStats.localHit('https://example.com/foo');
+      HttpCacheStats.localMiss('https://example.com/foo');
+      HttpCacheStats.localMiss('https://example.com/bar');
+      HttpCacheStats.httpHit('https://example.com/bar');
+      HttpCacheStats.httpMiss('https://example.com/bar');
 
       const res = HttpCacheStats.getData();
 
       expect(res).toEqual({
         'https://example.com/bar': {
-          hit: 1,
-          miss: 1,
+          httpHit: 1,
+          httpMiss: 1,
           localMiss: 1,
         },
         'https://example.com/foo': {
-          hit: 0,
-          miss: 0,
+          httpHit: 0,
+          httpMiss: 0,
           localHit: 2,
           localMiss: 1,
         },
@@ -555,12 +555,12 @@ describe('util/stats', () => {
     });
 
     it('prints report', () => {
-      HttpCacheStats.incLocalHits('https://example.com/foo');
-      HttpCacheStats.incLocalHits('https://example.com/foo');
-      HttpCacheStats.incLocalMisses('https://example.com/foo');
-      HttpCacheStats.incLocalMisses('https://example.com/bar');
-      HttpCacheStats.incRemoteHits('https://example.com/bar');
-      HttpCacheStats.incRemoteMisses('https://example.com/bar');
+      HttpCacheStats.localHit('https://example.com/foo');
+      HttpCacheStats.localHit('https://example.com/foo');
+      HttpCacheStats.localMiss('https://example.com/foo');
+      HttpCacheStats.localMiss('https://example.com/bar');
+      HttpCacheStats.httpHit('https://example.com/bar');
+      HttpCacheStats.httpMiss('https://example.com/bar');
 
       HttpCacheStats.report();
 
@@ -569,8 +569,8 @@ describe('util/stats', () => {
       expect(msg).toBe('HTTP cache statistics');
       expect(data).toEqual({
         'https://example.com': {
-          '/foo': { hit: 0, localHit: 2, localMiss: 1, miss: 0 },
-          '/bar': { hit: 1, localMiss: 1, miss: 1 },
+          '/foo': { httpHit: 0, localHit: 2, localMiss: 1, httpMiss: 0 },
+          '/bar': { httpHit: 1, localMiss: 1, httpMiss: 1 },
         },
       });
     });

--- a/lib/util/stats.spec.ts
+++ b/lib/util/stats.spec.ts
@@ -534,20 +534,18 @@ describe('util/stats', () => {
       HttpCacheStats.localHit('https://example.com/foo');
       HttpCacheStats.localMiss('https://example.com/foo');
       HttpCacheStats.localMiss('https://example.com/bar');
-      HttpCacheStats.httpHit('https://example.com/bar');
-      HttpCacheStats.httpMiss('https://example.com/bar');
+      HttpCacheStats.etagHit('https://example.com/bar');
+      HttpCacheStats.etagMiss('https://example.com/bar');
 
       const res = HttpCacheStats.getData();
 
       expect(res).toEqual({
         'https://example.com/bar': {
-          httpHit: 1,
-          httpMiss: 1,
+          etagHit: 1,
+          etagMiss: 1,
           localMiss: 1,
         },
         'https://example.com/foo': {
-          httpHit: 0,
-          httpMiss: 0,
           localHit: 2,
           localMiss: 1,
         },
@@ -559,8 +557,8 @@ describe('util/stats', () => {
       HttpCacheStats.localHit('https://example.com/foo');
       HttpCacheStats.localMiss('https://example.com/foo');
       HttpCacheStats.localMiss('https://example.com/bar');
-      HttpCacheStats.httpHit('https://example.com/bar');
-      HttpCacheStats.httpMiss('https://example.com/bar');
+      HttpCacheStats.etagHit('https://example.com/bar');
+      HttpCacheStats.etagMiss('https://example.com/bar');
 
       HttpCacheStats.report();
 
@@ -569,8 +567,8 @@ describe('util/stats', () => {
       expect(msg).toBe('HTTP cache statistics');
       expect(data).toEqual({
         'https://example.com': {
-          '/foo': { httpHit: 0, localHit: 2, localMiss: 1, httpMiss: 0 },
-          '/bar': { httpHit: 1, localMiss: 1, httpMiss: 1 },
+          '/foo': { localHit: 2, localMiss: 1 },
+          '/bar': { etagHit: 1, localMiss: 1, etagMiss: 1 },
         },
       });
     });

--- a/lib/util/stats.ts
+++ b/lib/util/stats.ts
@@ -379,8 +379,8 @@ export class HttpStats {
 }
 
 interface HttpCacheHostStatsData {
-  hit: number;
-  miss: number;
+  httpHit: number;
+  httpMiss: number;
   localHit?: number;
   localMiss?: number;
 }
@@ -401,12 +401,7 @@ export class HttpCacheStats {
   }
 
   static read(key: string): HttpCacheHostStatsData {
-    return (
-      this.getData()?.[key] ?? {
-        hit: 0,
-        miss: 0,
-      }
-    );
+    return this.getData()?.[key] ?? {};
   }
 
   static write(key: string, data: HttpCacheHostStatsData): void {
@@ -426,7 +421,7 @@ export class HttpCacheStats {
     return baseUrl;
   }
 
-  static incLocalHits(url: string): void {
+  static localHit(url: string): void {
     const baseUrl = HttpCacheStats.getBaseUrl(url);
     if (baseUrl) {
       const host = baseUrl;
@@ -437,7 +432,7 @@ export class HttpCacheStats {
     }
   }
 
-  static incLocalMisses(url: string): void {
+  static localMiss(url: string): void {
     const baseUrl = HttpCacheStats.getBaseUrl(url);
     if (baseUrl) {
       const host = baseUrl;
@@ -448,22 +443,24 @@ export class HttpCacheStats {
     }
   }
 
-  static incRemoteHits(url: string): void {
+  static httpHit(url: string): void {
     const baseUrl = HttpCacheStats.getBaseUrl(url);
     if (baseUrl) {
       const host = baseUrl;
       const stats = HttpCacheStats.read(host);
-      stats.hit += 1;
+      stats.httpHit ??= 0;
+      stats.httpHit += 1;
       HttpCacheStats.write(host, stats);
     }
   }
 
-  static incRemoteMisses(url: string): void {
+  static httpMiss(url: string): void {
     const baseUrl = HttpCacheStats.getBaseUrl(url);
     if (baseUrl) {
       const host = baseUrl;
       const stats = HttpCacheStats.read(host);
-      stats.miss += 1;
+      stats.httpMiss ??= 0;
+      stats.httpMiss += 1;
       HttpCacheStats.write(host, stats);
     }
   }

--- a/lib/util/stats.ts
+++ b/lib/util/stats.ts
@@ -379,10 +379,10 @@ export class HttpStats {
 }
 
 interface HttpCacheHostStatsData {
-  httpHit: number;
-  httpMiss: number;
   localHit?: number;
   localMiss?: number;
+  etagHit?: number;
+  etagMiss?: number;
 }
 
 type HttpCacheStatsData = Record<string, HttpCacheHostStatsData>;
@@ -443,24 +443,24 @@ export class HttpCacheStats {
     }
   }
 
-  static httpHit(url: string): void {
+  static etagHit(url: string): void {
     const baseUrl = HttpCacheStats.getBaseUrl(url);
     if (baseUrl) {
       const host = baseUrl;
       const stats = HttpCacheStats.read(host);
-      stats.httpHit ??= 0;
-      stats.httpHit += 1;
+      stats.etagHit ??= 0;
+      stats.etagHit += 1;
       HttpCacheStats.write(host, stats);
     }
   }
 
-  static httpMiss(url: string): void {
+  static etagMiss(url: string): void {
     const baseUrl = HttpCacheStats.getBaseUrl(url);
     if (baseUrl) {
       const host = baseUrl;
       const stats = HttpCacheStats.read(host);
-      stats.httpMiss ??= 0;
-      stats.httpMiss += 1;
+      stats.etagMiss ??= 0;
+      stats.etagMiss += 1;
       HttpCacheStats.write(host, stats);
     }
   }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Keep `localHit`/`localMiss` counter names
- Rename `hit`/`miss` to `etagHit`/`etagMiss` to avoid confusion
  - `httpHit`/`httpMiss` is also possible and more precise since the caching also works with `Last-Modified` value, but `etagHit`/`etagMiss` looks better the same way we prefer to say "Linux" instead of "GNU/Linux"
- Rename the increment methods to exactly match counter name: `localHit()`, `etagMiss()`, etc
- Don't report zero values

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
