### PR TITLE
fix(platform/azure): support getRawFile from tags if branch lookup fails

### DIFF
--- a/lib/modules/platform/azure/index.spec.ts
+++ b/lib/modules/platform/azure/index.spec.ts
@@ -2048,9 +2048,7 @@ describe('modules/platform/azure/index', () => {
           versionDescriptor &&
           versionDescriptor.versionType === GitVersionType.Branch
         ) {
-          return Promise.reject(
-            Object.assign(new Error('Branch not found'), { statusCode: 404 }),
-          );
+          return Promise.resolve(null);
         }
         if (
           versionDescriptor &&

--- a/lib/modules/platform/azure/index.spec.ts
+++ b/lib/modules/platform/azure/index.spec.ts
@@ -2043,7 +2043,7 @@ describe('modules/platform/azure/index', () => {
         resolveLfs?: boolean,
         sanitize?: boolean,
       ) => {
-        callArgs.push(versionDescriptor);
+        callArgs.push(versionDescriptor?.versionType);
         if (
           versionDescriptor &&
           versionDescriptor.versionType === GitVersionType.Branch
@@ -2074,7 +2074,7 @@ describe('modules/platform/azure/index', () => {
     );
     const result = await azure.getJsonFile('file.json', 'some/repo', '1.1.1');
     expect(result).toEqual({ test: 'tag content' });
-    expect(callArgs[0].versionType).toBe(GitVersionType.Branch);
-    expect(callArgs[1].versionType).toBe(GitVersionType.Tag);
+    expect(callArgs[0]).toBe(GitVersionType.Branch);
+    expect(callArgs[1]).toBe(GitVersionType.Tag);
   });
 });

--- a/lib/modules/platform/azure/index.spec.ts
+++ b/lib/modules/platform/azure/index.spec.ts
@@ -23,7 +23,6 @@ import type * as _git from '../../../util/git';
 import type * as _hostRules from '../../../util/host-rules';
 import type { Platform, RepoParams } from '../types';
 import { AzurePrVote } from './types';
-import { getJsonFile } from '.';
 import { partial } from '~test/util';
 
 vi.mock('./azure-got-wrapper', () => mockDeep());

--- a/lib/modules/platform/azure/index.ts
+++ b/lib/modules/platform/azure/index.ts
@@ -146,8 +146,8 @@ export async function getRawFile(
       return null;
     }
 
-        let item: GitItem | undefined;
-        const versionDescriptor: GitVersionDescriptor = {
+    let item: GitItem | undefined;
+    const versionDescriptor: GitVersionDescriptor = {
       version: branchOrTag,
     } satisfies GitVersionDescriptor;
     // Try to get file from repo with branch, if not found, then try with tag #36835

--- a/lib/modules/platform/azure/index.ts
+++ b/lib/modules/platform/azure/index.ts
@@ -170,7 +170,7 @@ export async function getRawFile(
         break; // exit loop if item is found
       } else {
         logger.debug(
-          `File: ${fileName} not found in ${repoName} with ${versionType}: ${branchOrTag}`
+          `File: ${fileName} not found in ${repoName} with ${versionType}: ${branchOrTag}`,
         );
       }
     }

--- a/lib/modules/platform/azure/index.ts
+++ b/lib/modules/platform/azure/index.ts
@@ -128,77 +128,79 @@ export async function getRawFile(
   repoName?: string,
   branchOrTag?: string,
 ): Promise<string | null> {
-  const azureApiGit = await azureApi.gitApi();
+  try {
+    const azureApiGit = await azureApi.gitApi();
 
-  let repoId: string | undefined;
-  if (repoName) {
-    const repos = await azureApiGit.getRepositories();
-    const repo = getRepoByName(repoName, repos);
-    repoId = repo?.id;
-  } else {
-    repoId = config.repoId;
-  }
+    let repoId: string | undefined;
+    if (repoName) {
+      const repos = await azureApiGit.getRepositories();
+      const repo = getRepoByName(repoName, repos);
+      repoId = repo?.id;
+    } else {
+      repoId = config.repoId;
+    }
 
-  if (!repoId) {
-    logger.debug('No repoId so cannot getRawFile');
-    return null;
-  }
+    if (!repoId) {
+      logger.debug('No repoId so cannot getRawFile');
+      return null;
+    }
 
-  let item: any = null;
+    let item: any = null;
 
-  // Try to get file from repo with branch, if not found, then try with tag #36835
-  for (const versionType of [GitVersionType.Branch, GitVersionType.Tag]) {
-    const versionDescriptor: GitVersionDescriptor = {
-      version: branchOrTag,
-      versionType,
-    };
+    // Try to get file from repo with branch, if not found, then try with tag #36835
+    for (const versionType of [GitVersionType.Branch, GitVersionType.Tag]) {
+      const versionDescriptor: GitVersionDescriptor = {
+        version: branchOrTag,
+        versionType,
+      };
 
-    try {
+      try {
+        logger.debug(
+          `Looking for file: ${fileName} ${repoName} with ${versionType} ${branchOrTag}`,
+        );
+        item = await azureApiGit.getItem(
+          repoId,
+          fileName,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          versionDescriptor,
+          true,
+        );
+        if (item) {
+          break;
+        }
+      } catch (err) /* v8 ignore start */ {
+        if (err.statusCode && err.statusCode === 404) {
+          logger.debug(
+            `File: ${fileName} not found in ${repoName} as a ${versionType} ${branchOrTag} - trying next versionType`,
+          );
+          continue; // try next versionType
+        }
+        throw err;
+      } /* v8 ignore stop */
+    }
+    return item?.content ?? null;
+  } catch (err) /* v8 ignore start */ {
+    if (
+      err.message?.includes('<title>Azure DevOps Services Unavailable</title>')
+    ) {
       logger.debug(
-        `Looking for file: ${fileName} ${repoName} with ${versionType} ${branchOrTag}`,
+        'Azure DevOps is currently unavailable when attempting to fetch file - throwing ExternalHostError',
       );
-      item = await azureApiGit.getItem(
-        repoId,
-        fileName,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        versionDescriptor,
-        true,
-      );
-      if (item) {
-        break;
-      }
-    } catch (err) /* v8 ignore start */ {
-      if (err.statusCode && err.statusCode === 404) {
-        logger.debug(
-          `File: ${fileName} not found in ${repoName} as a ${versionType} ${branchOrTag} - trying next versionType`,
-        );
-        continue; // try next versionType
-      }
-      if (
-        err.message?.includes(
-          '<title>Azure DevOps Services Unavailable</title>',
-        )
-      ) {
-        logger.debug(
-          'Azure DevOps is currently unavailable when attempting to fetch file - throwing ExternalHostError',
-        );
-        throw new ExternalHostError(err, id);
-      }
-      if (err.code === 'ECONNRESET' || err.code === 'ETIMEDOUT') {
-        throw new ExternalHostError(err, id);
-      }
-      if (err.statusCode && err.statusCode >= 500 && err.statusCode < 600) {
-        throw new ExternalHostError(err, id);
-      }
-      throw err;
-    } /* v8 ignore stop */
-  }
-  return item?.content ?? null;
+      throw new ExternalHostError(err, id);
+    }
+    if (err.code === 'ECONNRESET' || err.code === 'ETIMEDOUT') {
+      throw new ExternalHostError(err, id);
+    }
+    if (err.statusCode && err.statusCode >= 500 && err.statusCode < 600) {
+      throw new ExternalHostError(err, id);
+    }
+    throw err;
+  } /* v8 ignore stop */
 }
 
 export async function getJsonFile(

--- a/lib/modules/platform/azure/index.ts
+++ b/lib/modules/platform/azure/index.ts
@@ -160,16 +160,16 @@ export async function getRawFile(
           `Looking for file: ${fileName} ${repoName} with ${versionType} ${branchOrTag}`,
         );
         item = await azureApiGit.getItem(
-          repoId,
-          fileName,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          versionDescriptor,
-          true,
+          repoId, // repositoryId
+          fileName, // path
+          undefined, // project
+          undefined, // scopePath
+          undefined, // recursionLevel
+          undefined, // includeContentMetadata
+          undefined, // latestProcessedChange
+          undefined, // download
+          branchOrTag ? versionDescriptor : undefined, // versionDescriptor
+          true, // includeContent
         );
         if (item) {
           break; // exit loop if item is found

--- a/lib/modules/platform/azure/index.ts
+++ b/lib/modules/platform/azure/index.ts
@@ -155,34 +155,25 @@ export async function getRawFile(
         versionType,
       };
 
-      try {
+      item = await azureApiGit.getItem(
+        repoId, // repositoryId
+        fileName, // path
+        undefined, // project
+        undefined, // scopePath
+        undefined, // recursionLevel
+        undefined, // includeContentMetadata
+        undefined, // latestProcessedChange
+        undefined, // download
+        branchOrTag ? versionDescriptor : undefined, // versionDescriptor
+        true, // includeContent
+      );
+      if (item) {
+        break; // exit loop if item is found
+      } else {
         logger.debug(
-          `Looking for file: ${fileName} ${repoName} with ${versionType} ${branchOrTag}`,
+          `File: ${fileName} not found in ${repoName} as ${versionType} ${branchOrTag} - trying next versionType`,
         );
-        item = await azureApiGit.getItem(
-          repoId, // repositoryId
-          fileName, // path
-          undefined, // project
-          undefined, // scopePath
-          undefined, // recursionLevel
-          undefined, // includeContentMetadata
-          undefined, // latestProcessedChange
-          undefined, // download
-          branchOrTag ? versionDescriptor : undefined, // versionDescriptor
-          true, // includeContent
-        );
-        if (item) {
-          break; // exit loop if item is found
-        }
-      } catch (err) /* v8 ignore start */ {
-        if (err.statusCode && err.statusCode === 404) {
-          logger.debug(
-            `File: ${fileName} not found in ${repoName} as a ${versionType} ${branchOrTag} - trying next versionType`,
-          );
-          continue; // try next versionType
-        }
-        throw err;
-      } /* v8 ignore stop */
+      }
     }
   } catch (err) /* v8 ignore start */ {
     if (

--- a/lib/modules/platform/azure/index.ts
+++ b/lib/modules/platform/azure/index.ts
@@ -150,8 +150,8 @@ export async function getRawFile(
     const versionDescriptor: GitVersionDescriptor = {
       version: branchOrTag,
     } satisfies GitVersionDescriptor;
-    // Try to get file from repo with branch, if not found, then try with tag #36835
-    for (const versionType of [GitVersionType.Branch, GitVersionType.Tag]) {
+    // Try to get file from repo with tag first, if not found, then try with branch #36835
+    for (const versionType of [GitVersionType.Tag, GitVersionType.Branch]) {
       versionDescriptor.versionType = versionType;
 
       item = await azureApiGit.getItem(

--- a/lib/modules/platform/azure/index.ts
+++ b/lib/modules/platform/azure/index.ts
@@ -171,10 +171,12 @@ export async function getRawFile(
         break; // exit loop if item is found
       } else {
         logger.debug(
-          `File: ${fileName} not found in ${repoName} as ${versionType} ${branchOrTag} - trying next versionType`,
+          `File: ${fileName} not found in ${repoName} with ${versionType}: ${branchOrTag} - trying next versionType`,
         );
+        continue;
       }
     }
+    return item?.content ?? null;
   } catch (err) /* v8 ignore start */ {
     if (
       err.message?.includes('<title>Azure DevOps Services Unavailable</title>')
@@ -192,8 +194,6 @@ export async function getRawFile(
     }
     throw err;
   } /* v8 ignore stop */
-
-  return item?.content ?? null;
 }
 
 export async function getJsonFile(

--- a/lib/modules/platform/azure/index.ts
+++ b/lib/modules/platform/azure/index.ts
@@ -172,7 +172,7 @@ export async function getRawFile(
           true,
         );
         if (item) {
-          break;
+          break; // exit loop if item is found
         }
       } catch (err) /* v8 ignore start */ {
         if (err.statusCode && err.statusCode === 404) {

--- a/lib/modules/platform/azure/index.ts
+++ b/lib/modules/platform/azure/index.ts
@@ -129,8 +129,6 @@ export async function getRawFile(
   repoName?: string,
   branchOrTag?: string,
 ): Promise<string | null> {
-  let item: GitItem | undefined;
-
   try {
     const azureApiGit = await azureApi.gitApi();
 
@@ -148,12 +146,13 @@ export async function getRawFile(
       return null;
     }
 
+        let item: GitItem | undefined;
+        const versionDescriptor: GitVersionDescriptor = {
+      version: branchOrTag,
+    } satisfies GitVersionDescriptor;
     // Try to get file from repo with branch, if not found, then try with tag #36835
     for (const versionType of [GitVersionType.Branch, GitVersionType.Tag]) {
-      const versionDescriptor: GitVersionDescriptor = {
-        version: branchOrTag,
-        versionType,
-      };
+      versionDescriptor.versionType = versionType;
 
       item = await azureApiGit.getItem(
         repoId, // repositoryId
@@ -171,9 +170,8 @@ export async function getRawFile(
         break; // exit loop if item is found
       } else {
         logger.debug(
-          `File: ${fileName} not found in ${repoName} with ${versionType}: ${branchOrTag} - trying next versionType`,
+          `File: ${fileName} not found in ${repoName} with ${versionType}: ${branchOrTag}`
         );
-        continue;
       }
     }
     return item?.content ?? null;

--- a/lib/modules/platform/azure/index.ts
+++ b/lib/modules/platform/azure/index.ts
@@ -1,6 +1,7 @@
 import { setTimeout } from 'timers/promises';
 import is from '@sindresorhus/is';
 import type {
+  GitItem,
   GitPullRequest,
   GitPullRequestCommentThread,
   GitStatus,
@@ -128,6 +129,8 @@ export async function getRawFile(
   repoName?: string,
   branchOrTag?: string,
 ): Promise<string | null> {
+  let item: GitItem | undefined;
+
   try {
     const azureApiGit = await azureApi.gitApi();
 
@@ -144,8 +147,6 @@ export async function getRawFile(
       logger.debug('No repoId so cannot getRawFile');
       return null;
     }
-
-    let item: any = null;
 
     // Try to get file from repo with branch, if not found, then try with tag #36835
     for (const versionType of [GitVersionType.Branch, GitVersionType.Tag]) {
@@ -183,7 +184,6 @@ export async function getRawFile(
         throw err;
       } /* v8 ignore stop */
     }
-    return item?.content ?? null;
   } catch (err) /* v8 ignore start */ {
     if (
       err.message?.includes('<title>Azure DevOps Services Unavailable</title>')
@@ -201,6 +201,8 @@ export async function getRawFile(
     }
     throw err;
   } /* v8 ignore stop */
+
+  return item?.content ?? null;
 }
 
 export async function getJsonFile(


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
<!-- Describe what behavior is changed by this PR. -->
Added functionality to platform/azure git getRawFile azure-devops-node-api usage to try to find file with both git branch and git tag and not fail until both options are tried.
Added test that returns null first on git branch lookup as it fails to find file, to simulate git tag lookup second call.

## Context
- #36835
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
