### PR TITLE
feat(datasource/kubernetes-api): add external secrets types

### DIFF
--- a/data/kubernetes-api.json5
+++ b/data/kubernetes-api.json5
@@ -170,4 +170,26 @@
     'kustomize.toolkit.fluxcd.io/v1',
     'kustomize.config.k8s.io/v1beta1',
   ],
+
+  // https://external-secrets.io/latest/api/spec/
+  ExternalSecret: [
+    'external-secrets.io/v1alpha1',
+    'external-secrets.io/v1beta1',
+    'external-secrets.io/v1',
+  ],
+  ClusterExternalSecret: [
+    'external-secrets.io/v1alpha1',
+    'external-secrets.io/v1beta1',
+    'external-secrets.io/v1',
+  ],
+  SecretStore: [
+    'external-secrets.io/v1alpha1',
+    'external-secrets.io/v1beta1',
+    'external-secrets.io/v1',
+  ],
+  ClusterSecretStore: [
+    'external-secrets.io/v1alpha1',
+    'external-secrets.io/v1beta1',
+    'external-secrets.io/v1',
+  ],
 }

--- a/lib/modules/datasource/kubernetes-api/readme.md
+++ b/lib/modules/datasource/kubernetes-api/readme.md
@@ -1,6 +1,7 @@
 Kubernetes API upgrade versions are manually transcribed from the [Kubernetes API deprecation guide][1].
 The Kubernetes API deprecation guide is updated regularly, so this list may be out of date.
-This also contains some flux custom resources which where also manually added from [flux releases][2].
+This also contains some flux custom resources which where also manually added from [flux releases][2] as well as [external secrets][3] custom resources.
 
 [1]: https://kubernetes.io/docs/reference/using-api/deprecation-guide/
 [2]: https://github.com/fluxcd/flux2/releases
+[3]: https://external-secrets.io/latest/api/spec/


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds [External Secrets](https://external-secrets.io) types to the kubernetes-api datasource.

## Context

[v0.16.0](https://github.com/external-secrets/external-secrets/releases/tag/v0.16.0) of external-secrets has moved some custom resources from v1beta1 to v1.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
