### PR TITLE
docs(docker): more specific dockerhub registry auth

### DIFF
--- a/docs/usage/docker.md
+++ b/docs/usage/docker.md
@@ -199,7 +199,7 @@ We will explain how to authenticate for the most common registries.
 
 #### DockerHub
 
-Here is an example of configuring a default Docker username/password in `config.js`.
+Here is an example of configuring a Docker username/password for DockerHub in `config.js`.
 The Docker Hub password is stored in a process environment variable.
 
 ```js title="config.js"
@@ -207,6 +207,7 @@ module.exports = {
   hostRules: [
     {
       hostType: 'docker',
+      matchHost: 'docker.io',
       username: '<your-username>',
       password: process.env.DOCKER_HUB_PASSWORD,
     },

--- a/docs/usage/docker.md
+++ b/docs/usage/docker.md
@@ -197,7 +197,7 @@ If you want Renovate to commit directly to your base branch without opening a PR
 There are many different registries, and many ways to authenticate to those registries.
 We will explain how to authenticate for the most common registries.
 
-#### DockerHub
+#### Docker Hub
 
 Here is an example of configuring a Docker username/password for DockerHub in `config.js`.
 The Docker Hub password is stored in a process environment variable.

--- a/docs/usage/docker.md
+++ b/docs/usage/docker.md
@@ -199,7 +199,7 @@ We will explain how to authenticate for the most common registries.
 
 #### Docker Hub
 
-Here is an example of configuring a Docker username/password for DockerHub in `config.js`.
+Here is an example of configuring a Docker username/password for Docker Hub in `config.js`.
 The Docker Hub password is stored in a process environment variable.
 
 ```js title="config.js"


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds hostRule to the dockerhub authentication example. Without hostrule, the config is applied to all registries, which probably fails if you have any dependency from a different registry e.g. AWS ECR.

## Context

Closes #36479

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required
