### PR TITLE
fix(manager/pep621): depType requires-python should ignore implicit default registry url

### DIFF
--- a/lib/modules/manager/pep621/processors/uv.spec.ts
+++ b/lib/modules/manager/pep621/processors/uv.spec.ts
@@ -286,6 +286,11 @@ describe('modules/manager/pep621/processors/uv', () => {
 
     const dependencies = [
       {
+        depName: 'python',
+        packageName: 'python',
+        depType: 'requires-python',
+      },
+      {
         depName: 'dep1',
         packageName: 'dep1',
       },
@@ -298,6 +303,11 @@ describe('modules/manager/pep621/processors/uv', () => {
     const result = processor.process(pyproject, dependencies);
 
     expect(result).toEqual([
+      {
+        depName: 'python',
+        depType: 'requires-python',
+        packageName: 'python',
+      },
       {
         depName: 'dep1',
         registryUrls: ['https://foo.com/simple'],

--- a/lib/modules/manager/pep621/processors/uv.ts
+++ b/lib/modules/manager/pep621/processors/uv.ts
@@ -58,6 +58,10 @@ export class UvProcessor implements PyProjectProcessor {
           continue;
         }
 
+        if (dep.depType === 'requires-python') {
+          continue;
+        }
+
         // Using `packageName` as it applies PEP 508 normalization, which is
         // also applied by uv when matching a source to a dependency.
         const depSource = uv.sources?.[dep.packageName];


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
ignore implicit registryUrls for `depType: 'requires-python'`.

`python-version` is not a normal python requirements from pypi.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->
fix: #36347

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
