### PR TITLE
fix(http): improve URL validation logging for non-HTTP URLs

### DIFF
--- a/lib/util/http/http.ts
+++ b/lib/util/http/http.ts
@@ -282,7 +282,12 @@ export abstract class HttpBase<
     }
 
     const parsedUrl = parseUrl(url);
-    if (!parsedUrl || !isHttpUrl(parsedUrl)) {
+    if (parsedUrl && !isHttpUrl(parsedUrl)) {
+      logger.warn(
+        { url: requestUrl, baseUrl, resolvedUrl: url },
+        'Request Warning: is not an HTTP URL',
+      );
+    } else if (!parsedUrl) {
       logger.error(
         { url: requestUrl, baseUrl, resolvedUrl: url },
         'Request Error: cannot parse url',

--- a/lib/util/http/index.ts
+++ b/lib/util/http/index.ts
@@ -7,3 +7,5 @@ export { RequestError as HttpError, EmptyResultError };
 export type * from './types';
 
 export class Http extends HttpBase {}
+
+// alles doof


### PR DESCRIPTION
## Changes

Changed the log level from `logger.error` to `logger.warn` when encountering an invalid URL in the `resolveUrl` method in `lib/util/http/http.ts`. Also updated the log message to reflect that it's a warning instead of an error.

## Context

Related to discussion: https://github.com/renovatebot/renovate/discussions/36734

My first try is to change the log level from `error` to `warn` in the `resolveUrl` method in `lib/util/http/http.ts`, if the URL parseable but not a HTTP(S) URL.
Problem now is that Got cannot Handle URLs that are not HTTP(S) URLs, so it throws an error.

So I need a little bit help here to find a way to handle this case properly.

## Documentation (please check one with an [x])

- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only
