### PR TITLE
fix(gitlab): codeowners section name handling

### DIFF
--- a/lib/modules/platform/gitlab/code-owners.spec.ts
+++ b/lib/modules/platform/gitlab/code-owners.spec.ts
@@ -57,5 +57,75 @@ describe('modules/platform/gitlab/code-owners', () => {
         },
       ]);
     });
+
+    it('should extract an owner rule from a line after a section header with spaces', () => {
+      const lines = ['[Backend Team] @backend-team', 'filename'];
+      const rules = extractRulesFromCodeOwnersLines(lines);
+
+      expect(rules).toEqual([
+        {
+          pattern: 'filename',
+          usernames: ['@backend-team'],
+          score: 8,
+          match: expect.any(Function),
+        },
+      ]);
+    });
+
+    it('should extract an owner rule from a line after a section header with spaces and no usernames', () => {
+      const lines = ['[Backend Team]', 'filename'];
+      const rules = extractRulesFromCodeOwnersLines(lines);
+
+      expect(rules).toEqual([
+        {
+          pattern: 'filename',
+          usernames: [],
+          score: 8,
+          match: expect.any(Function),
+        },
+      ]);
+    });
+
+    it('should extract an owner rule from a line after a section header with spaces and multiple usernames', () => {
+      const lines = ['[Backend Team] @backend-team @backend-lead', 'filename'];
+      const rules = extractRulesFromCodeOwnersLines(lines);
+
+      expect(rules).toEqual([
+        {
+          pattern: 'filename',
+          usernames: ['@backend-team', '@backend-lead'],
+          score: 8,
+          match: expect.any(Function),
+        },
+      ]);
+    });
+
+    it('should extract an owner rule from a line after an optional section header with spaces', () => {
+      const lines = ['^[Backend Team] @backend-team', 'filename'];
+      const rules = extractRulesFromCodeOwnersLines(lines);
+
+      expect(rules).toEqual([
+        {
+          pattern: 'filename',
+          usernames: ['@backend-team'],
+          score: 8,
+          match: expect.any(Function),
+        },
+      ]);
+    });
+
+    it('should extract an owner rule from a line after a section header with approval count and spaces', () => {
+      const lines = ['[Backend Team][2] @backend-team', 'filename'];
+      const rules = extractRulesFromCodeOwnersLines(lines);
+
+      expect(rules).toEqual([
+        {
+          pattern: 'filename',
+          usernames: ['@backend-team'],
+          score: 8,
+          match: expect.any(Function),
+        },
+      ]);
+    });
   });
 });

--- a/lib/modules/platform/gitlab/code-owners.ts
+++ b/lib/modules/platform/gitlab/code-owners.ts
@@ -26,8 +26,17 @@ export function extractRulesFromCodeOwnersLines(
 }
 
 function changeCurrentSection(line: string): CodeOwnersSection {
-  const [name, ...usernames] = line.split(regEx(/\s+/));
-  return { name, defaultUsers: usernames };
+  // Find the last closing bracket to handle section names with approval counts
+  const lastClosingBracketIndex = line.lastIndexOf(']');
+
+  // Extract section name (including any approval counts)
+  const sectionName = line.substring(0, lastClosingBracketIndex + 1);
+  const remainingLine = line.substring(lastClosingBracketIndex + 1).trim();
+
+  // Parse any default users after the section name
+  const usernames = remainingLine ? remainingLine.split(regEx(/\s+/)) : [];
+
+  return { name: sectionName, defaultUsers: usernames };
 }
 
 function extractOwnersFromLine(


### PR DESCRIPTION
## Changes

Changed the `changeCurrentSection` function so it looks for the closing bracket of the section name rather than assuming that section names do not include spaces.

## Context

This fixes discussion #36393 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
