### PR TITLE
fix(post-upgrade-tasks): handle renamed files as add/delete pairs

### DIFF
--- a/lib/workers/repository/update/branch/execute-post-upgrade-commands.ts
+++ b/lib/workers/repository/update/branch/execute-post-upgrade-commands.ts
@@ -158,6 +158,7 @@ export async function postUpgradeCommandsExecutor(
           addedCount: status.not_added?.length,
           modifiedCount: status.modified?.length,
           deletedCount: status.deleted?.length,
+          renamedCount: status.renamed?.length,
         },
         'git status counts after post-upgrade tasks',
       );
@@ -165,10 +166,12 @@ export async function postUpgradeCommandsExecutor(
       const addedOrModifiedFiles = [
         ...coerceArray(status.not_added),
         ...coerceArray(status.modified),
+        ...coerceArray(status.renamed?.map((x) => x.to)),
       ];
       const changedFiles = [
         ...addedOrModifiedFiles,
         ...coerceArray(status.deleted),
+        ...coerceArray(status.renamed?.map((x) => x.from)),
       ];
 
       // Check for files which were previously deleted but have been re-added without modification


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

In some cases the upgrade process causes file changes that git detects as renames. These get returned by simple-git's status() function in the renamed array. This was previously ignored by renovate, which resulted in deleted (i.e. renamed) files get added back when they shouldn't have been.

This PR treats any renames as add/delete pairs and ensures the files are handled correctly.

## Context

- See https://github.com/renovatebot/renovate/discussions/36162
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
