### PR TITLE
fix(changelog-urls): Fix `npm:sharp` changelog url

### DIFF
--- a/lib/data/changelog-urls.json
+++ b/lib/data/changelog-urls.json
@@ -6,7 +6,7 @@
     "flow-bin": "https://github.com/facebook/flow/blob/master/Changelog.md",
     "gatsby": "https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/CHANGELOG.md",
     "react-native": "https://github.com/react-native-community/react-native-releases/blob/master/CHANGELOG.md",
-    "sharp": "https://github.com/lovell/sharp/blob/main/docs/changelog.md",
+    "sharp": "https://github.com/lovell/sharp/blob/main/docs/src/content/docs/changelog.md",
     "tailwindcss-classnames": "https://github.com/muhammadsammy/tailwindcss-classnames/blob/master/CHANGELOG.md",
     "zone.js": "https://github.com/angular/angular/blob/master/packages/zone.js/CHANGELOG.md"
   },


### PR DESCRIPTION
## Changes

Fixed the changelog-url of https://www.npmjs.com/package/sharp (https://github.com/lovell/sharp):
- Old URL: https://github.com/lovell/sharp/blob/main/docs/changelog.md
- New URL: https://github.com/lovell/sharp/blob/main/docs/src/content/docs/changelog.md

The URL could also be changed to https://sharp.pixelplumbing.com/changelog/, but most of the other changelog URLs link to a file on github.

## Context

The changelog location of the sharp npm package was moved in January (https://github.com/lovell/sharp/commit/eeac8d46566406de17ebc06a7311906f9a1d9385#diff-977a9cc3cf5e995ae5a5d1cd1a5a83c624ac26c5e680d215e26434ba8ec54d68).

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
