### PR TITLE
fix(datasource/gitlab-packages): prefer `conan_package_name` if it exists

### DIFF
--- a/lib/modules/datasource/gitlab-packages/index.spec.ts
+++ b/lib/modules/datasource/gitlab-packages/index.spec.ts
@@ -45,6 +45,43 @@ describe('modules/datasource/gitlab-packages/index', () => {
       expect(res?.releases).toHaveLength(3);
     });
 
+    it('returns conan package from custom registry', async () => {
+      const body = [
+        {
+          version: '1.0.0',
+          created_at: '2020-03-04T12:01:37.000-06:00',
+          name: 'myconanpkg/1.0.0@mycompany/stable',
+          conan_package_name: 'myconanpkg',
+        },
+        {
+          version: 'v2.0.0',
+          created_at: '2020-05-04T12:01:37.000-06:00',
+          name: 'otherpkg/2.0.0@mycompany/stable',
+          conan_package_name: 'otherpkg',
+        },
+      ];
+      httpMock
+        .scope('https://gitlab.com')
+        .get('/api/v4/projects/user%2Fproject1/packages')
+        .query({
+          package_name: 'myconanpkg',
+          per_page: '100',
+        })
+        .reply(200, body);
+      const res = await getPkgReleases({
+        datasource,
+        registryUrls: ['https://gitlab.com'],
+        packageName: 'user/project1:myconanpkg',
+      });
+
+      expect(res?.releases).toMatchObject([
+        {
+          releaseTimestamp: '2020-03-04T18:01:37.000Z',
+          version: '1.0.0',
+        },
+      ]);
+    });
+
     it('returns null for 404', async () => {
       httpMock
         .scope('https://gitlab.com')

--- a/lib/modules/datasource/gitlab-packages/index.ts
+++ b/lib/modules/datasource/gitlab-packages/index.ts
@@ -83,7 +83,7 @@ export class GitlabPackagesDatasource extends Datasource {
       result.releases = response
         // Setting the package_name option when calling the GitLab API isn't enough to filter information about other packages
         // because this option is only implemented on GitLab > 12.9 and it only does a fuzzy search.
-        .filter((r) => r.name === packagePart)
+        .filter((r) => (r.conan_package_name ?? r.name) === packagePart)
         .map(({ version, created_at }) => ({
           version,
           releaseTimestamp: asTimestamp(created_at),

--- a/lib/modules/datasource/gitlab-packages/types.ts
+++ b/lib/modules/datasource/gitlab-packages/types.ts
@@ -2,4 +2,5 @@ export interface GitlabPackage {
   version: string;
   created_at: string;
   name: string;
+  conan_package_name?: string;
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

- Recreating PR with work from: https://github.com/renovatebot/renovate/pull/33099 by @FFace32

## Changes
Checks if conan_package_name exists and matches the filtered package name for the gitlab-packages datasource.


<!-- Describe what behavior is changed by this PR. -->

## Context
When querying for uploaded Conan packages on GitLab, the name value contains the version and the channel as well, and this doesn't pass the filter in lib/modules/datasource/gitlab-packages/index.ts.

conan_package_name, if it exists, contains only the package name.

This can also be seen in the GitLab documentation as an example here: https://gitlab.com/gitlab-org/gitlab/-/blob/master/doc/api/packages.md?plain=1#L69-70
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
