### PR TITLE
feat(gerrit): suggest use of rebase hashtag

### DIFF
--- a/lib/modules/platform/gerrit/index.spec.ts
+++ b/lib/modules/platform/gerrit/index.spec.ts
@@ -887,7 +887,8 @@ describe('modules/platform/gerrit/index', () => {
   describe('massageMarkdown()', () => {
     it('massageMarkdown()', () => {
       expect(
-        gerrit.massageMarkdown(codeBlock`
+        gerrit.massageMarkdown(
+          codeBlock`
           Pull Request
           PR
           Branch creation
@@ -897,7 +898,9 @@ describe('modules/platform/gerrit/index', () => {
           Close this PR
           you tick the rebase/retry checkbox
           checking the rebase/retry box above
-          `),
+          `,
+          'rebase',
+        ),
       ).toBe(codeBlock`
         change
         change
@@ -906,8 +909,8 @@ describe('modules/platform/gerrit/index', () => {
         Whenever change becomes conflicted
         abandon or vote this change with Code-Review -2
         Abandon or vote this change with Code-Review -2
-        add \`rebase!\` at the beginning of the commit message
-        adding \`rebase!\` at the beginning of the commit message
+        you add the _rebase_ hashtag to this change
+        adding the _rebase_ hashtag to this change
         `);
     });
   });

--- a/lib/modules/platform/gerrit/index.ts
+++ b/lib/modules/platform/gerrit/index.ts
@@ -446,7 +446,7 @@ export async function ensureComment(
   return true;
 }
 
-export function massageMarkdown(prBody: string): string {
+export function massageMarkdown(prBody: string, rebaseLabel: string): string {
   return (
     smartTruncate(readOnlyIssueBody(prBody), maxBodyLength())
       .replace('Branch creation', 'Change creation')
@@ -460,11 +460,11 @@ export function massageMarkdown(prBody: string): string {
       )
       .replace(
         'you tick the rebase/retry checkbox',
-        'add `rebase!` at the beginning of the commit message',
+        `you add the _${rebaseLabel}_ hashtag to this change`,
       )
       .replace(
         'checking the rebase/retry box above',
-        'adding `rebase!` at the beginning of the commit message',
+        `adding the _${rebaseLabel}_ hashtag to this change`,
       )
       .replace(regEx(/\b(?:Pull Request|PR)/g), 'change')
       // Remove HTML tags not supported in Gerrit markdown


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

After this change, Renovate will suggest Gerrit users to use the _rebase_ hashtag instead of suggesting them to add `rebase!` at the beginning of the commit message for rebasing changes.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

- Refs https://github.com/renovatebot/renovate/pull/35900
- Refs https://github.com/renovatebot/renovate/discussions/36130

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
