### PR TITLE
fix(datasource/maven): remove tags

### DIFF
--- a/lib/modules/datasource/clojure/__snapshots__/index.spec.ts.snap
+++ b/lib/modules/datasource/clojure/__snapshots__/index.spec.ts.snap
@@ -34,10 +34,6 @@ exports[`modules/datasource/clojure/index > falls back to next registry url 1`] 
       "version": "2.0.0",
     },
   ],
-  "tags": {
-    "latest": "2.0.0",
-    "release": "2.0.0",
-  },
 }
 `;
 
@@ -105,10 +101,6 @@ exports[`modules/datasource/clojure/index > returns releases from custom reposit
       "version": "2.0.0",
     },
   ],
-  "tags": {
-    "latest": "2.0.0",
-    "release": "2.0.0",
-  },
 }
 `;
 
@@ -146,10 +138,6 @@ exports[`modules/datasource/clojure/index > skips registry with invalid XML 1`] 
       "version": "2.0.0",
     },
   ],
-  "tags": {
-    "latest": "2.0.0",
-    "release": "2.0.0",
-  },
 }
 `;
 
@@ -187,9 +175,5 @@ exports[`modules/datasource/clojure/index > skips registry with invalid metadata
       "version": "2.0.0",
     },
   ],
-  "tags": {
-    "latest": "2.0.0",
-    "release": "2.0.0",
-  },
 }
 `;

--- a/lib/modules/datasource/maven/__snapshots__/index.spec.ts.snap
+++ b/lib/modules/datasource/maven/__snapshots__/index.spec.ts.snap
@@ -34,10 +34,6 @@ exports[`modules/datasource/maven/index > falls back to next registry url 1`] = 
       "version": "2.0.0",
     },
   ],
-  "tags": {
-    "latest": "2.0.0",
-    "release": "2.0.0",
-  },
 }
 `;
 
@@ -105,10 +101,6 @@ exports[`modules/datasource/maven/index > removes authentication header after re
       "version": "2.0.0",
     },
   ],
-  "tags": {
-    "latest": "2.0.0",
-    "release": "2.0.0",
-  },
 }
 `;
 
@@ -146,10 +138,6 @@ exports[`modules/datasource/maven/index > returns releases 1`] = `
       "version": "2.0.0",
     },
   ],
-  "tags": {
-    "latest": "2.0.0",
-    "release": "2.0.0",
-  },
 }
 `;
 
@@ -188,10 +176,6 @@ exports[`modules/datasource/maven/index > returns releases from custom repositor
       "version": "2.0.0",
     },
   ],
-  "tags": {
-    "latest": "2.0.0",
-    "release": "2.0.0",
-  },
 }
 `;
 
@@ -229,10 +213,6 @@ exports[`modules/datasource/maven/index > skips registry with invalid XML 1`] = 
       "version": "2.0.0",
     },
   ],
-  "tags": {
-    "latest": "2.0.0",
-    "release": "2.0.0",
-  },
 }
 `;
 
@@ -270,9 +250,5 @@ exports[`modules/datasource/maven/index > skips registry with invalid metadata s
       "version": "2.0.0",
     },
   ],
-  "tags": {
-    "latest": "2.0.0",
-    "release": "2.0.0",
-  },
 }
 `;

--- a/lib/modules/datasource/maven/index.spec.ts
+++ b/lib/modules/datasource/maven/index.spec.ts
@@ -162,10 +162,6 @@ describe('modules/datasource/maven/index', () => {
       packageScope: 'org.example',
       registryUrl: 'https://repo.maven.apache.org/maven2',
       releases: [{ version: '1.0.3-SNAPSHOT' }],
-      tags: {
-        latest: '1.0.3-SNAPSHOT',
-        release: '1.0.3-SNAPSHOT',
-      },
     });
   });
 
@@ -197,10 +193,6 @@ describe('modules/datasource/maven/index', () => {
       packageScope: 'org.example',
       registryUrl: 'https://repo.maven.apache.org/maven2',
       releases: [{ version: '1.0.3-SNAPSHOT' }],
-      tags: {
-        latest: '1.0.3-SNAPSHOT',
-        release: '1.0.3-SNAPSHOT',
-      },
     });
   });
 
@@ -479,10 +471,6 @@ describe('modules/datasource/maven/index', () => {
         { version: '1.0.5-SNAPSHOT' },
         { version: '2.0.0' },
       ],
-      tags: {
-        latest: '2.0.0',
-        release: '2.0.0',
-      },
       isPrivate: true,
     });
     expect(googleAuth).toHaveBeenCalledTimes(2);
@@ -528,10 +516,6 @@ describe('modules/datasource/maven/index', () => {
         { version: '1.0.5-SNAPSHOT' },
         { version: '2.0.0' },
       ],
-      tags: {
-        latest: '2.0.0',
-        release: '2.0.0',
-      },
       isPrivate: true,
     });
     expect(googleAuth).toHaveBeenCalledTimes(2);

--- a/lib/modules/datasource/maven/index.ts
+++ b/lib/modules/datasource/maven/index.ts
@@ -49,16 +49,6 @@ function extractVersions(metadata: XmlDocument): MetadataResults {
     return res;
   }
   res.versions = elements.map((el) => el.val);
-  const latest = metadata.descendantWithPath('versioning.latest');
-  if (latest?.val) {
-    res.tags ??= {};
-    res.tags.latest = latest.val;
-  }
-  const release = metadata.descendantWithPath('versioning.release');
-  if (release?.val) {
-    res.tags ??= {};
-    res.tags.release = release.val;
-  }
 
   return res;
 }

--- a/lib/modules/datasource/maven/readme.md
+++ b/lib/modules/datasource/maven/readme.md
@@ -30,5 +30,9 @@ For example:
 
 #### latest and release tags
 
-When `latest` or `release` values are present in a package's `maven-metadata.xml`, Renovate will map these to its `tags` concept.
-This enables the use of Renovate's `followTag` feature.
+Although a package's `maven-metadata.xml` may contain `latest` and `release` tags, we do not map them to `tags.latest` or `tags.release` in Renovate internal data.
+The reason for not doing this is that Maven registries don't use these tags as an indicator of stability - `latest` essentially means "the most recent version which was published".
+
+For more information on this, see the analysis done in [Discussion #36927](https://github.com/renovatebot/renovate/discussions/36927).
+
+As a result, neither `followTag` nor `respectLatest` concepts apply to Maven dependencies.

--- a/lib/modules/datasource/maven/s3.spec.ts
+++ b/lib/modules/datasource/maven/s3.spec.ts
@@ -65,10 +65,6 @@ describe('modules/datasource/maven/s3', () => {
           { version: '1.0.2' },
           { version: '1.0.3' },
         ],
-        tags: {
-          latest: '1.0.2',
-          release: '1.0.2',
-        },
         isPrivate: true,
       });
     });


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Removes tags handling from Maven datasource

## Context

Maven registries seem to simply use latest as "the last version which was published" and not as any form of stability indication as we expected.

https://github.com/renovatebot/renovate/discussions/36927

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
