### PR TITLE
fix(gitlab): Prevent early pagination termination in PR cache sync

### DIFF
--- a/lib/modules/platform/gitlab/pr-cache.ts
+++ b/lib/modules/platform/gitlab/pr-cache.ts
@@ -105,7 +105,9 @@ export class GitlabPrCache {
     const { items: oldItems } = this.cache;
     let { updated_at } = this.cache;
 
-    let needNextPage = true;
+    if (rawItems.length === 0) {
+      return false;
+    }
 
     for (const rawItem of rawItems) {
       const id = rawItem.iid;
@@ -116,7 +118,6 @@ export class GitlabPrCache {
       const itemNewTime = DateTime.fromISO(rawItem.updated_at);
 
       if (dequal(oldItem, newItem)) {
-        needNextPage = false;
         continue;
       }
 
@@ -129,7 +130,8 @@ export class GitlabPrCache {
     }
 
     this.cache.updated_at = updated_at;
-    return needNextPage;
+    
+    return true;
   }
 
   private async sync(http: GitlabHttp): Promise<GitlabPrCache> {


### PR DESCRIPTION
Fixes a pagination bug in GitLab PR cache that caused Renovate to attempt reusing merged PRs when searching for open ones. The cache sync would stop fetching pages prematurely when any PR matched cached data, leaving older PRs with stale state information.

- https://github.com/renovatebot/renovate/discussions/37010

## Changes

* Remove early pagination termination logic in `GitlabPrCache.reconcile()` method
* Continue fetching all pages until GitLab returns empty results instead of stopping when unchanged PRs are found
* Add check to properly terminate pagination only when no more results are available (`rawItems.length === 0`)

## Context

The `reconcile()` method incorrectly assumed that if any PR in the current page matched cached data (`dequal(oldItem, newItem) === true`), then all older PRs must also be unchanged, so it would stop pagination with `needNextPage = false`. This flawed logic caused issues when:

1. Recent PRs hadn't changed (triggering early termination)
2. Older PRs had state changes (e.g., merged) but weren't reached due to stopped pagination
3. Renovate would find these stale "open" PRs in cache when searching for reusable branches

The bug became apparent when PR volume increased enough to push older PRs to later pages that weren't being fetched due to the premature termination.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
