### PR TITLE
fix: Include architecture when resolving latest JVM release version

### DIFF
--- a/lib/modules/datasource/java-version/index.ts
+++ b/lib/modules/datasource/java-version/index.ts
@@ -1,3 +1,4 @@
+import { arch } from 'node:os';
 import { logger } from '../../../logger';
 import { ExternalHostError } from '../../../types/errors/external-host-error';
 import { cache } from '../../../util/cache/package/decorator';
@@ -67,8 +68,11 @@ export class JavaVersionDatasource extends Datasource {
       { registryUrl, packageName, imageType },
       'fetching java release',
     );
+
+    const architecture = this.getJvmArch();
+
     // TODO: types (#22198)
-    const url = `${registryUrl!}v3/info/release_versions?page_size=${pageSize}&image_type=${imageType}&project=jdk&release_type=ga&sort_method=DATE&sort_order=DESC`;
+    const url = `${registryUrl!}v3/info/release_versions?page_size=${pageSize}&image_type=${imageType}&project=jdk&release_type=ga&architecture=${architecture}&sort_method=DATE&sort_order=DESC`;
 
     const result: ReleaseResult = {
       homepage: 'https://adoptium.net',
@@ -95,5 +99,17 @@ export class JavaVersionDatasource extends Datasource {
     }
 
     return result.releases.length ? result : null;
+  }
+
+  private getJvmArch() {
+    switch (arch()) {
+      case 'arm64':
+        return 'aarch64';
+      case 'x64':
+        return 'x64';
+      default:
+        // should never happen
+        throw new Error('Unsupported architecture: ' + arch());
+    }
   }
 }


### PR DESCRIPTION
## Changes

When resolving JVM release version pass the current system architecture.


## Context

On July 17, 2025, my Renovate jobs started to fail because the Adoptium JDK was releasing a new version, and, when querying release_versions, the new version shows up even though specific architectures have lower availabile versions. By passing the current system architecture, we ensure that the version lookup is bounded by what's actually available.

See also https://github.com/renovatebot/renovate/discussions/37046


## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

