### PR TITLE
feat(pep621): Add support for uv workspaces

### DIFF
--- a/lib/modules/manager/pep621/processors/uv.spec.ts
+++ b/lib/modules/manager/pep621/processors/uv.spec.ts
@@ -370,7 +370,7 @@ describe('modules/manager/pep621/processors/uv', () => {
 
   describe('updateArtifacts()', () => {
     it('returns null if there is no lock file', async () => {
-      fs.getSiblingFileName.mockReturnValueOnce('uv.lock');
+      fs.findLocalSiblingOrParent.mockResolvedValueOnce('uv.lock');
       const updatedDeps = [{ packageName: 'dep1' }];
       const result = await processor.updateArtifacts(
         {
@@ -391,7 +391,7 @@ describe('modules/manager/pep621/processors/uv', () => {
         binarySource: 'docker',
         dockerSidecarImage: 'ghcr.io/containerbase/sidecar',
       });
-      fs.getSiblingFileName.mockReturnValueOnce('uv.lock');
+      fs.findLocalSiblingOrParent.mockResolvedValueOnce('uv.lock');
       fs.readLocalFile.mockResolvedValueOnce('test content');
       fs.readLocalFile.mockResolvedValueOnce('test content');
       // python
@@ -452,7 +452,7 @@ describe('modules/manager/pep621/processors/uv', () => {
     it('returns artifact error', async () => {
       const execSnapshots = mockExecAll();
       GlobalConfig.set({ ...adminConfig, binarySource: 'docker' });
-      fs.getSiblingFileName.mockReturnValueOnce('uv.lock');
+      fs.findLocalSiblingOrParent.mockResolvedValueOnce('uv.lock');
       fs.readLocalFile.mockImplementationOnce(() => {
         throw new Error('test error');
       });
@@ -476,7 +476,7 @@ describe('modules/manager/pep621/processors/uv', () => {
     it('return update dep update', async () => {
       const execSnapshots = mockExecAll();
       GlobalConfig.set(adminConfig);
-      fs.getSiblingFileName.mockReturnValueOnce('uv.lock');
+      fs.findLocalSiblingOrParent.mockResolvedValueOnce('uv.lock');
       fs.readLocalFile.mockResolvedValueOnce('test content');
       fs.readLocalFile.mockResolvedValueOnce('changed test content');
       // python
@@ -542,7 +542,7 @@ describe('modules/manager/pep621/processors/uv', () => {
           getAccessToken: vi.fn().mockResolvedValue('some-token'),
         })),
       );
-      fs.getSiblingFileName.mockReturnValueOnce('uv.lock');
+      fs.findLocalSiblingOrParent.mockResolvedValueOnce('uv.lock');
       fs.readLocalFile.mockResolvedValueOnce('test content');
       fs.readLocalFile.mockResolvedValueOnce('changed test content');
       // python
@@ -684,7 +684,7 @@ describe('modules/manager/pep621/processors/uv', () => {
           getAccessToken: vi.fn().mockResolvedValue(undefined),
         })),
       );
-      fs.getSiblingFileName.mockReturnValueOnce('uv.lock');
+      fs.findLocalSiblingOrParent.mockResolvedValueOnce('uv.lock');
       fs.readLocalFile.mockResolvedValueOnce('test content');
       fs.readLocalFile.mockResolvedValueOnce('changed test content');
       // python
@@ -783,7 +783,7 @@ describe('modules/manager/pep621/processors/uv', () => {
           getAccessToken: vi.fn().mockResolvedValue(undefined),
         })),
       );
-      fs.getSiblingFileName.mockReturnValueOnce('uv.lock');
+      fs.findLocalSiblingOrParent.mockResolvedValueOnce('uv.lock');
       fs.readLocalFile.mockResolvedValueOnce('test content');
       fs.readLocalFile.mockResolvedValueOnce('changed test content');
       // python
@@ -839,7 +839,7 @@ describe('modules/manager/pep621/processors/uv', () => {
     it('return update on lockfileMaintenance', async () => {
       const execSnapshots = mockExecAll();
       GlobalConfig.set(adminConfig);
-      fs.getSiblingFileName.mockReturnValueOnce('uv.lock');
+      fs.findLocalSiblingOrParent.mockResolvedValueOnce('uv.lock');
       fs.readLocalFile.mockResolvedValueOnce('test content');
       fs.readLocalFile.mockResolvedValueOnce('changed test content');
       // python

--- a/lib/modules/manager/pep621/processors/uv.ts
+++ b/lib/modules/manager/pep621/processors/uv.ts
@@ -5,7 +5,7 @@ import { logger } from '../../../../logger';
 import type { HostRule } from '../../../../types';
 import { exec } from '../../../../util/exec';
 import type { ExecOptions, ToolConstraint } from '../../../../util/exec/types';
-import { getSiblingFileName, readLocalFile } from '../../../../util/fs';
+import { findLocalSiblingOrParent, readLocalFile } from '../../../../util/fs';
 import { getGitEnvironmentVariables } from '../../../../util/git/auth';
 import { find } from '../../../../util/host-rules';
 import { Result } from '../../../../util/result';
@@ -122,21 +122,25 @@ export class UvProcessor implements PyProjectProcessor {
     deps: PackageDependency[],
     packageFile: string,
   ): Promise<PackageDependency[]> {
-    const lockFileName = getSiblingFileName(packageFile, 'uv.lock');
-    const lockFileContent = await readLocalFile(lockFileName, 'utf8');
-    if (lockFileContent) {
-      const { val: lockFileMapping, err } = Result.parse(
-        lockFileContent,
-        UvLockfileSchema,
-      ).unwrap();
+    const lockFileName = await findLocalSiblingOrParent(packageFile, 'uv.lock');
+    if (lockFileName === null) {
+      logger.debug({ packageFile }, `No uv lock file found`);
+    } else {
+      const lockFileContent = await readLocalFile(lockFileName, 'utf8');
+      if (lockFileContent) {
+        const { val: lockFileMapping, err } = Result.parse(
+          lockFileContent,
+          UvLockfileSchema,
+        ).unwrap();
 
-      if (err) {
-        logger.debug({ packageFile, err }, `Error parsing uv lock file`);
-      } else {
-        for (const dep of deps) {
-          const packageName = dep.packageName;
-          if (packageName && packageName in lockFileMapping) {
-            dep.lockedVersion = lockFileMapping[packageName];
+        if (err) {
+          logger.debug({ packageFile, err }, `Error parsing uv lock file`);
+        } else {
+          for (const dep of deps) {
+            const packageName = dep.packageName;
+            if (packageName && packageName in lockFileMapping) {
+              dep.lockedVersion = lockFileMapping[packageName];
+            }
           }
         }
       }
@@ -154,7 +158,14 @@ export class UvProcessor implements PyProjectProcessor {
     const { isLockFileMaintenance } = config;
 
     // abort if no lockfile is defined
-    const lockFileName = getSiblingFileName(packageFileName, 'uv.lock');
+    const lockFileName = await findLocalSiblingOrParent(
+      packageFileName,
+      'uv.lock',
+    );
+    if (lockFileName === null) {
+      logger.debug({ packageFileName }, `No uv lock file found`);
+      return null;
+    }
     try {
       const existingLockFileContent = await readLocalFile(lockFileName, 'utf8');
       if (is.nullOrUndefined(existingLockFileContent)) {

--- a/lib/modules/manager/pep621/readme.md
+++ b/lib/modules/manager/pep621/readme.md
@@ -3,7 +3,7 @@ This manager supports updating dependencies inside `pyproject.toml` files.
 In addition to standard dependencies, these toolsets are also supported:
 
 - `pdm` (including `pdm.lock` files)
-- `uv` (including `uv.lock` files)
+- `uv` (including `uv.lock` files and `uv` workspaces)
 - `hatch`
 
 Available `depType`s:


### PR DESCRIPTION
## Changes

Use `findLocalSiblingOrParent` for lockfile resolution instead of `getSiblingFileName`.

## Context

Supports #33874, for uv. I'm not familiar enough with Poetry to provide the same kind of PR.

In uv, [workspace repos](https://docs.astral.sh/uv/concepts/projects/workspaces/) consist of a "root package" along with a set of other packages that are all managed with a single environment, and therefore a single lockfile. Currently, renovate locates the `uv.lock` file for a given project by concatenating the directory of the `pyproject.toml` file with the filename `uv.lock`. This is accurate for non-workspaces.

This PR takes a relatively simple approach, using an existing utility function to search for a `uv.lock` file up the file tree, stopping at the first one found. Missing lockfiles are treated identically to missing lockfiles in the "sibling-only" / single-project case.

For re-locking, no change is needed; uv itself will handle the lockfile resolution via `uv lock`, even if it is run in a subdirectory.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository (see https://github.com/akern40/renovate-uv-workspace-test/pull/4)

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
