### PR TITLE
docs(gitlab): remove `TERM` workaround for coloured output

### DIFF
--- a/lib/modules/platform/gitlab/readme.md
+++ b/lib/modules/platform/gitlab/readme.md
@@ -80,7 +80,7 @@ You may also use a dedicated [Deploy Token](https://docs.gitlab.com/ee/user/proj
 
 #### Get colored output
 
-You may want to set `FORCE_COLOR: 3` or `TERM: ansi` to the job, in order to get colored output.
+You may want to set `FORCE_COLOR: 3` to the job, in order to get colored output.
 [GitLab Runner runs the container’s shell in non-interactive mode, so the shell’s `TERM` environment variable is set to `dumb`.](https://docs.gitlab.com/ee/ci/yaml/script.html#job-log-output-is-not-formatted-as-expected-or-contains-unexpected-characters)
 
 ## Features awaiting implementation


### PR DESCRIPTION
## Changes

Remove outdated documentation, as it doesn't seem to work any more.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

When tested[0] with only `TERM: ansi` set, we see no coloured output[1].

When setting `FORCE_COLOR: 3`[2], this now works[3].

Tested on GitLab.com, running v18.3.0-pre.

[0]: https://gitlab.com/tanna.dev/dependency-management-data-example/-/commit/22474e7993b4338a0caf6561360e3b45a27cbeb6
[1]: https://gitlab.com/tanna.dev/dependency-management-data-example/-/jobs/10713438705#L897
[2]: https://gitlab.com/tanna.dev/dependency-management-data-example/-/commit/7af8f1d2cd1f01c07cb2a79aa6519f53116d385b
[3]: https://gitlab.com/tanna.dev/dependency-management-data-example/-/jobs/10725367896#L405


<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->

