### PR TITLE
chore: add Repository Result metadata to "Repository Finished" log

### DIFF
--- a/lib/workers/repository/index.ts
+++ b/lib/workers/repository/index.ts
@@ -156,7 +156,18 @@ export async function renovateRepository(
   ObsoleteCacheHitLogger.report();
   AbandonedPackageStats.report();
   const cloned = isCloned();
-  logger.info({ cloned, durationMs: splits.total }, 'Repository finished');
+  /* v8 ignore next 11 -- coverage not required of these `undefined` checks, as we're happy receiving an `undefined` in the logs */
+  logger.info(
+    {
+      cloned,
+      durationMs: splits.total,
+      result: repoResult?.res,
+      status: repoResult?.status,
+      enabled: repoResult?.enabled,
+      onboarded: repoResult?.onboarded,
+    },
+    'Repository finished',
+  );
   resetRepositoryLogLevelRemaps();
   return repoResult;
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Add log metadata to the log line (so it becomes part of i.e. the JSON object that is then logged)

## Context

The `Repository result` log message is useful for understanding
at-a-glance why a Renovate run may have not worked.

Adding the metadata that currently exists in the log line as Meta keys
would allow for logging tools to be able to more meaningfully
interpolate the data, without requiring parsing of the underlying
string.

Co-authored-by: Jamie Tanna <jamie.tanna@elastic.co>



<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
