### PR TITLE
fix(gitea,forgejo): dedupe base64 decode

### DIFF
--- a/lib/config/presets/forgejo/index.ts
+++ b/lib/config/presets/forgejo/index.ts
@@ -2,7 +2,6 @@ import { logger } from '../../../logger';
 import { getRepoContents } from '../../../modules/platform/forgejo/forgejo-helper';
 import type { RepoContents } from '../../../modules/platform/forgejo/types';
 import { ExternalHostError } from '../../../types/errors/external-host-error';
-import { fromBase64 } from '../../../util/string';
 import type { Preset, PresetConfig } from '../types';
 import { PRESET_DEP_NOT_FOUND, fetchPreset, parsePreset } from '../util';
 
@@ -30,7 +29,7 @@ export async function fetchJSONFile(
   }
 
   // TODO: null check #22198
-  return parsePreset(fromBase64(res.content!), fileName);
+  return parsePreset(res.contentString!, fileName);
 }
 
 export function getPresetFromEndpoint(

--- a/lib/config/presets/gitea/index.ts
+++ b/lib/config/presets/gitea/index.ts
@@ -2,7 +2,6 @@ import { logger } from '../../../logger';
 import { getRepoContents } from '../../../modules/platform/gitea/gitea-helper';
 import type { RepoContents } from '../../../modules/platform/gitea/types';
 import { ExternalHostError } from '../../../types/errors/external-host-error';
-import { fromBase64 } from '../../../util/string';
 import type { Preset, PresetConfig } from '../types';
 import { PRESET_DEP_NOT_FOUND, fetchPreset, parsePreset } from '../util';
 
@@ -30,7 +29,7 @@ export async function fetchJSONFile(
   }
 
   // TODO: null check #22198
-  return parsePreset(fromBase64(res.content!), fileName);
+  return parsePreset(res.contentString!, fileName);
 }
 
 export function getPresetFromEndpoint(

--- a/lib/modules/platform/forgejo/forgejo-helper.ts
+++ b/lib/modules/platform/forgejo/forgejo-helper.ts
@@ -2,6 +2,7 @@ import { logger } from '../../../logger';
 import type { BranchStatus } from '../../../types';
 import type { ForgejoHttpOptions } from '../../../util/http/forgejo';
 import { ForgejoHttp } from '../../../util/http/forgejo';
+import { fromBase64 } from '../../../util/string';
 import { getQueryString } from '../../../util/url';
 import type {
   Branch,
@@ -117,7 +118,7 @@ export async function getRepoContents(
   const res = await forgejoHttp.getJsonUnchecked<RepoContents>(url, options);
 
   if (res.body.content) {
-    res.body.contentString = Buffer.from(res.body.content, 'base64').toString();
+    res.body.contentString = fromBase64(res.body.content);
   }
 
   return res.body;

--- a/lib/modules/platform/gitea/gitea-helper.ts
+++ b/lib/modules/platform/gitea/gitea-helper.ts
@@ -2,6 +2,7 @@ import { logger } from '../../../logger';
 import type { BranchStatus } from '../../../types';
 import type { GiteaHttpOptions } from '../../../util/http/gitea';
 import { GiteaHttp } from '../../../util/http/gitea';
+import { fromBase64 } from '../../../util/string';
 import { getQueryString } from '../../../util/url';
 import type {
   Branch,
@@ -115,7 +116,7 @@ export async function getRepoContents(
   const res = await giteaHttp.getJsonUnchecked<RepoContents>(url, options);
 
   if (res.body.content) {
-    res.body.contentString = Buffer.from(res.body.content, 'base64').toString();
+    res.body.contentString = fromBase64(res.body.content);
   }
 
   return res.body;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Currently base64 decode is done twice on Gitea and Forgejo
<!-- Describe what behavior is changed by this PR. -->

## Context
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
