### PR TITLE
fix(jsonata): Eval later queries despite non-match

### DIFF
--- a/lib/modules/manager/custom/jsonata/index.spec.ts
+++ b/lib/modules/manager/custom/jsonata/index.spec.ts
@@ -332,6 +332,36 @@ describe('modules/manager/custom/jsonata/index', () => {
     });
   });
 
+  it('extracts other matchStrings if one finds no match', async () => {
+    const config = {
+      fileFormat: 'json',
+      matchStrings: [
+        `packages.{ "depName": package }`,
+        `{"depName": "bar"}`],
+      currentValueTemplate: '1.0.0',
+      datasourceTemplate: 'npm',
+    };
+    const res = await extractPackageFile('{}', 'unused', config);
+    expect(logger.logger.debug).toHaveBeenCalledWith(
+      {
+        packageFile: 'unused',
+        jsonataQuery:
+          'packages.{ "depName": package }',
+      },
+      'The jsonata query returned no matches. Possible error, please check your query. Skipping',
+    );
+    expect(res).toMatchObject({
+      ...config,
+      deps: [
+        {
+          depName: 'bar',
+          currentValue: '1.0.0',
+          datasource: 'npm',
+        },
+      ],
+    });
+  });
+
   it('populates manager config and jsonata manager template fields in extract result', async () => {
     const config = {
       fileFormat: 'json',

--- a/lib/modules/manager/custom/jsonata/index.spec.ts
+++ b/lib/modules/manager/custom/jsonata/index.spec.ts
@@ -335,9 +335,7 @@ describe('modules/manager/custom/jsonata/index', () => {
   it('extracts other matchStrings if one finds no match', async () => {
     const config = {
       fileFormat: 'json',
-      matchStrings: [
-        `packages.{ "depName": package }`,
-        `{"depName": "bar"}`],
+      matchStrings: [`packages.{ "depName": package }`, `{"depName": "bar"}`],
       currentValueTemplate: '1.0.0',
       datasourceTemplate: 'npm',
     };
@@ -345,8 +343,7 @@ describe('modules/manager/custom/jsonata/index', () => {
     expect(logger.logger.debug).toHaveBeenCalledWith(
       {
         packageFile: 'unused',
-        jsonataQuery:
-          'packages.{ "depName": package }',
+        jsonataQuery: 'packages.{ "depName": package }',
       },
       'The jsonata query returned no matches. Possible error, please check your query. Skipping',
     );

--- a/lib/modules/manager/custom/jsonata/utils.ts
+++ b/lib/modules/manager/custom/jsonata/utils.ts
@@ -33,7 +33,7 @@ export async function handleMatching(
         },
         'The jsonata query returned no matches. Possible error, please check your query. Skipping',
       );
-      return [];
+      continue;
     }
 
     const parsed = QueryResultZodSchema.safeParse(queryResult);
@@ -44,7 +44,7 @@ export async function handleMatching(
         { err: parsed.error, jsonataQuery: query, packageFile, queryResult },
         'Query results failed schema validation',
       );
-      return [];
+      continue;
     }
   }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This commit lets the jsonata custom manager continue with the other queries in the same file if one doesn't match or produces errors.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->
The jsonata custom manager can be provided with multiple queries via the matchStrings configuration option.

Before this commit, if any of those doesn't match for a file, all later querites are skipped. This doesn't make sense, since the queries can be completely independent. As an example, one might want to look for image names in several places of every CI pipeline. Not matching in one place of one pipeline shouldn't cause the other places to be ignored in that
file.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->