### PR TITLE
docs: update bitbucket server example version

### DIFF
--- a/lib/modules/platform/bitbucket-server/readme.md
+++ b/lib/modules/platform/bitbucket-server/readme.md
@@ -49,7 +49,7 @@ Once it's running and initialized, the quickest way to testing with Renovate is:
 At this point you should have a project ready for Renovate, and the `@renovate-bot` account ready to run on it. You can then run like this:
 
 ```
-pnpm start --platform=bitbucket-server --endpoint=http://localhost:7990 --git-fs=http --username=renovate-bot --password=abc123456789! --log-level=debug --autodiscover=true
+npx renovate --platform=bitbucket-server --endpoint=http://localhost:7990 --git-fs=http --username=renovate-bot --password=abc123456789! --log-level=debug --autodiscover=true
 ```
 
 Alternatively using env:
@@ -61,7 +61,7 @@ export RENOVATE_GIT_FS=http
 export RENOVATE_USERNAME=renovate-bot
 export RENOVATE_PASSWORD=abc123456789!
 export LOG_LEVEL=debug
-pnpm start --autodiscover=true
+npx renovate --autodiscover=true
 ```
 
 You should then get a "Configure Renovate" onboarding PR in any projects that `@renovate-bot` has been invited to.

--- a/lib/modules/platform/bitbucket-server/readme.md
+++ b/lib/modules/platform/bitbucket-server/readme.md
@@ -35,7 +35,7 @@ In line with their instructions, the following commands bring up a new server:
 
 ```
 docker volume create --name bitbucketVolume
-docker run -v bitbucketVolume:/var/atlassian/application-data/bitbucket --name="bitbucket" -d -p 7990:7990 -p 7999:7999 atlassian/bitbucket-server:5.12.3
+docker run -v bitbucketVolume:/var/atlassian/application-data/bitbucket --name="bitbucket" -d -p 7990:7990 -p 7999:7999 atlassian/bitbucket-server:8.9.6
 ```
 
 Once it's running and initialized, the quickest way to testing with Renovate is:
@@ -49,7 +49,7 @@ Once it's running and initialized, the quickest way to testing with Renovate is:
 At this point you should have a project ready for Renovate, and the `@renovate-bot` account ready to run on it. You can then run like this:
 
 ```
-npx renovate --platform=bitbucket-server --endpoint=http://localhost:7990 --git-fs=http --username=renovate-bot --password=abc123456789! --log-level=debug --autodiscover=true
+pnpm start --platform=bitbucket-server --endpoint=http://localhost:7990 --git-fs=http --username=renovate-bot --password=abc123456789! --log-level=debug --autodiscover=true
 ```
 
 Alternatively using env:
@@ -61,7 +61,7 @@ export RENOVATE_GIT_FS=http
 export RENOVATE_USERNAME=renovate-bot
 export RENOVATE_PASSWORD=abc123456789!
 export LOG_LEVEL=debug
-npx renovate --autodiscover=true
+pnpm start --autodiscover=true
 ```
 
 You should then get a "Configure Renovate" onboarding PR in any projects that `@renovate-bot` has been invited to.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

* Updates BitBucket Server readme.md to use pnpm commands
* Updates BitBucket Server readme.md to use up-to-date image

## Context

When working on implementing CODEOWNERS rules for BitBucket Server see: https://github.com/renovatebot/renovate/discussions/36996, this crossed my eyes and needed updating.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
