### PR TITLE
fix: only strip .git from end of url

### DIFF
--- a/lib/modules/datasource/metadata.spec.ts
+++ b/lib/modules/datasource/metadata.spec.ts
@@ -5,6 +5,7 @@ import { MavenDatasource } from './maven';
 import {
   addMetaData,
   massageGithubUrl,
+  massageGitlabUrl,
   massageUrl,
   shouldDeleteHomepage,
 } from './metadata';
@@ -451,6 +452,12 @@ describe('modules/datasource/metadata', () => {
     expect(massageGithubUrl('git://example.com/foo/bar')).toMatch(
       'https://example.com/foo/bar',
     );
+  });
+
+  it('Should massage gitlab git url to valid https url', () => {
+    expect(
+      massageGitlabUrl('git://example.gitlab-dedicated.com/foo/bar'),
+    ).toMatch('https://example.gitlab-dedicated.com/foo/bar');
   });
 
   it('Should remove homepage when homepage and sourceUrl are same', () => {

--- a/lib/modules/datasource/metadata.ts
+++ b/lib/modules/datasource/metadata.ts
@@ -44,7 +44,7 @@ export function massageGithubUrl(url: string): string {
     .join('/');
 }
 
-function massageGitlabUrl(url: string): string {
+export function massageGitlabUrl(url: string): string {
   const massagedUrl = massageGitAtUrl(url);
 
   return massagedUrl
@@ -52,7 +52,7 @@ function massageGitlabUrl(url: string): string {
     .replace(gitPrefix, 'https://')
     .replace(regEx(/\/tree\/.*$/i), '')
     .replace(regEx(/\/$/i), '')
-    .replace('.git', '');
+    .replace(regEx(/\.git$/i), '');
 }
 
 function massageGitAtUrl(url: string): string {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Fixes gitlab url massaging for dedicated instances. Currently `example.gitlab-dedicated.com` is getting massaged to `examplelab.dedicated.com`. 

## Context

See https://github.com/renovatebot/renovate/discussions/37221

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
