### PR TITLE
fix(azure,bitbucket-server): bearer auth for cloning repos sets extra header correctly

### DIFF
--- a/lib/modules/platform/azure/__snapshots__/util.spec.ts.snap
+++ b/lib/modules/platform/azure/__snapshots__/util.spec.ts.snap
@@ -61,19 +61,19 @@ exports[`modules/platform/azure/util > getRenovatePRFormat > should be formated 
 
 exports[`modules/platform/azure/util > getStorageExtraCloneOpts > should configure basic auth 1`] = `
 {
-  "-c": "http.extraheader=AUTHORIZATION: basic dXNlcjpwYXNz",
+  "-c": "http.extraHeader=AUTHORIZATION: basic dXNlcjpwYXNz",
 }
 `;
 
 exports[`modules/platform/azure/util > getStorageExtraCloneOpts > should configure bearer token 1`] = `
 {
-  "-c": "http.extraheader=AUTHORIZATION: bearer token",
+  "-c": "http.extraHeader=AUTHORIZATION: bearer token",
 }
 `;
 
 exports[`modules/platform/azure/util > getStorageExtraCloneOpts > should configure personal access token 1`] = `
 {
-  "-c": "http.extraheader=AUTHORIZATION: basic OjEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3OHRlc3Q=",
+  "-c": "http.extraHeader=AUTHORIZATION: basic OjEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3OHRlc3Q=",
 }
 `;
 

--- a/lib/modules/platform/azure/util.ts
+++ b/lib/modules/platform/azure/util.ts
@@ -131,7 +131,7 @@ export function getStorageExtraCloneOpts(config: HostRule): GitOptions {
   }
   addSecretForSanitizing(authValue, 'global');
   return {
-    '-c': `http.extraheader=AUTHORIZATION: ${authType} ${authValue}`,
+    '-c': `http.extraHeader=AUTHORIZATION: ${authType} ${authValue}`,
   };
 }
 

--- a/lib/modules/platform/bitbucket-server/utils.spec.ts
+++ b/lib/modules/platform/bitbucket-server/utils.spec.ts
@@ -298,7 +298,7 @@ describe('modules/platform/bitbucket-server/utils', () => {
     it('should configure bearer token', () => {
       const res = getExtraCloneOpts({ token: 'abc' });
       expect(res).toEqual({
-        '-c': 'http.extraheader=Authorization: Bearer abc',
+        '-c': 'http.extraHeader=Authorization: Bearer abc',
       });
     });
   });

--- a/lib/modules/platform/bitbucket-server/utils.ts
+++ b/lib/modules/platform/bitbucket-server/utils.ts
@@ -143,7 +143,7 @@ export function getRepoGitUrl(
 export function getExtraCloneOpts(opts: HostRule): GitOptions {
   if (opts.token) {
     return {
-      '-c': `http.extraheader=Authorization: Bearer ${opts.token}`,
+      '-c': `http.extraHeader=Authorization: Bearer ${opts.token}`,
     };
   }
   return {};


### PR DESCRIPTION
## Changes

Fixed the git config option from `http.extraheader` to the correct `http.extraHeader` when cloning repos.

## Context

BTW this method is not super secure... it would be better if `${authValue}` was instead an environment variable reference. Inlining secrets into a CLI command is considered a bad practice cause it can be read by getting the list of running processes. The same applies to the basic auth credentials injected into the host URL when cloning repos. I don't have time to provide a fix for this but wanted to mention it anyway.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository
