### PR TITLE
fix: Revert "feat(presets): added fumadocs to mono repo groups"

### DIFF
--- a/lib/data/monorepo.json
+++ b/lib/data/monorepo.json
@@ -326,7 +326,6 @@
     ],
     "formatjs": "https://github.com/formatjs/formatjs",
     "framework7": "https://github.com/framework7io/framework7",
-    "fumadocs": "https://github.com/fuma-nama/fumadocs",
     "funogram": "https://github.com/Dolfik1/Funogram",
     "fusioncache": "https://github.com/ZiggyCreatures/FusionCache",
     "gatsby": "https://github.com/gatsbyjs/gatsby",


### PR DESCRIPTION
It releases each package separately with different versions and they don't need to be grouped by default.

No answer from author so revert.

https://github.com/renovatebot/renovate/pull/36781#issuecomment-3041071135
 
Reverts renovatebot/renovate#36781