### PR TITLE
feat(asdf): Add support for renovating vektra/mockery by shortname

### DIFF
--- a/lib/modules/manager/asdf/extract.spec.ts
+++ b/lib/modules/manager/asdf/extract.spec.ts
@@ -105,6 +105,7 @@ markdownlint-cli2 0.13.0
 maven 3.9.6
 mimirtool 2.11.0
 minikube 1.33.1
+mockery 3.5.1
 nim 1.6.8
 nodejs 18.12.0
 ocaml 4.14.0
@@ -562,6 +563,13 @@ dummy 1.2.3
             datasource: 'github-releases',
             packageName: 'kubernetes/minikube',
             depName: 'minikube',
+            extractVersion: '^v(?<version>\\S+)',
+          },
+          {
+            currentValue: '3.5.1',
+            datasource: 'github-releases',
+            packageName: 'vektra/mockery',
+            depName: 'mockery',
             extractVersion: '^v(?<version>\\S+)',
           },
           {

--- a/lib/modules/manager/asdf/upgradeable-tooling.ts
+++ b/lib/modules/manager/asdf/upgradeable-tooling.ts
@@ -556,6 +556,14 @@ export const upgradeableTooling: Record<string, ToolingDefinition> = {
       extractVersion: '^v(?<version>\\S+)',
     },
   },
+  mockery: {
+    asdfPluginUrl: 'https://github.com/cabify/asdf-mockery.git',
+    config: {
+      datasource: GithubReleasesDatasource.id,
+      packageName: 'vektra/mockery',
+      extractVersion: '^v(?<version>\\S+)',
+    },
+  },
   nim: {
     asdfPluginUrl: 'https://github.com/asdf-community/asdf-nim',
     config: {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

I'm adding support for renovating https://github.com/vektra/mockery via asdf (and therefore, mise) 

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->
I was surprised to see mise renovate `golangci-lint` but not mockery, until I read the docs.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
