### PR TITLE
feat(gitlab): implement merge_after for automergeSchedule

### DIFF
--- a/lib/modules/platform/gitlab/index.spec.ts
+++ b/lib/modules/platform/gitlab/index.spec.ts
@@ -3919,6 +3919,39 @@ describe('modules/platform/gitlab/index', () => {
         'Skipping automerge retry - merge_when_pipeline_succeeds already enabled',
       );
     });
+
+    it('should include merge_after in the request body when provided', async () => {
+      const mergeAfterDate = '2026-04-01T10:00:00.000Z';
+      await initPlatform('13.3.6-ee');
+      httpMock
+        .scope(gitlabApiHost)
+        .get('/api/v4/projects/undefined/merge_requests/12345')
+        .reply(200)
+        .get('/api/v4/projects/undefined/merge_requests/12345')
+        .reply(200, {
+          merge_status: 'can_be_merged',
+          pipeline: {
+            status: 'running',
+          },
+        })
+        .put('/api/v4/projects/undefined/merge_requests/12345/merge')
+        .reply(200);
+
+      await expect(
+        gitlab.reattemptPlatformAutomerge?.({
+          number: 12345,
+          platformPrOptions: {
+            usePlatformAutomerge: true,
+            mergeAfter: mergeAfterDate,
+          },
+        }),
+      ).toResolve();
+
+      expect(logger.logger.debug).toHaveBeenCalledWith(
+        { merge_after: mergeAfterDate },
+        'Setting merge_after from platform options',
+      );
+    });
   });
 
   describe('mergePr(pr)', () => {

--- a/lib/modules/platform/gitlab/index.ts
+++ b/lib/modules/platform/gitlab/index.ts
@@ -670,13 +670,24 @@ async function tryPrAutomerge(
               },
             );
           } else {
+            const requestBody: Record<string, unknown> = {
+              should_remove_source_branch: true,
+              merge_when_pipeline_succeeds: true,
+            };
+
+            // Set merge_after on the GitLab API request when scheduled in the future
+            if (platformPrOptions?.mergeAfter) {
+              requestBody.merge_after = platformPrOptions.mergeAfter;
+              logger.debug(
+                { merge_after: platformPrOptions.mergeAfter },
+                'Setting merge_after from platform options',
+              );
+            }
+
             await gitlabApi.putJson(
               `projects/${config.repository}/merge_requests/${pr}/merge`,
               {
-                body: {
-                  should_remove_source_branch: true,
-                  merge_when_pipeline_succeeds: true,
-                },
+                body: requestBody,
               },
             );
           }

--- a/lib/modules/platform/types.ts
+++ b/lib/modules/platform/types.ts
@@ -99,6 +99,7 @@ export interface PlatformPrOptions {
   gitLabIgnoreApprovals?: boolean;
   usePlatformAutomerge?: boolean;
   forkModeDisallowMaintainerEdits?: boolean;
+  mergeAfter?: string;
 }
 
 export interface CreatePRConfig {

--- a/lib/workers/repository/update/branch/schedule.spec.ts
+++ b/lib/workers/repository/update/branch/schedule.spec.ts
@@ -479,6 +479,112 @@ describe('workers/repository/update/branch/schedule', () => {
     });
   });
 
+  describe('getNextScheduleTime(config)', () => {
+    let config: RenovateConfig;
+
+    beforeAll(() => {
+      vi.useFakeTimers();
+    });
+
+    beforeEach(() => {
+      vi.setSystemTime(new Date('2017-06-30T10:50:00.000'));
+      config = {};
+    });
+
+    it('returns null if no schedule defined', () => {
+      expect(schedule.getNextScheduleTime(config)).toBeNull();
+    });
+
+    it('returns null for empty schedule array', () => {
+      config.automergeSchedule = [];
+      expect(schedule.getNextScheduleTime(config)).toBeNull();
+    });
+
+    it('returns null for "at any time"', () => {
+      config.automergeSchedule = ['at any time'];
+      expect(schedule.getNextScheduleTime(config)).toBeNull();
+    });
+
+    it('returns null for invalid schedule', () => {
+      config.automergeSchedule = ['this is not a valid schedule'];
+      expect(schedule.getNextScheduleTime(config)).toBeNull();
+    });
+
+    it('returns null for invalid timezone', () => {
+      config.automergeSchedule = ['after 4:00pm'];
+      config.timezone = 'Not/ATimezone';
+      expect(schedule.getNextScheduleTime(config)).toBeNull();
+    });
+
+    it('returns a future date for a later.js schedule', () => {
+      config.automergeSchedule = ['after 4:00pm'];
+      const res = schedule.getNextScheduleTime(config);
+      expect(res).not.toBeNull();
+      expect(res!.getTime()).toBeGreaterThan(Date.now());
+    });
+
+    it('returns a future date for a cron schedule', () => {
+      config.automergeSchedule = ['* 22 * * *'];
+      const res = schedule.getNextScheduleTime(config);
+      expect(res).not.toBeNull();
+      expect(res!.getTime()).toBeGreaterThan(Date.now());
+    });
+
+    it('returns the earliest of multiple schedules', () => {
+      const resLater = schedule.getNextScheduleTime({
+        automergeSchedule: ['after 11:00pm'],
+      });
+      const resEarliest = schedule.getNextScheduleTime({
+        automergeSchedule: ['after 11:00pm', 'after 4:00pm'],
+      });
+      expect(resEarliest!.getTime()).toBeLessThan(resLater!.getTime());
+    });
+
+    it('respects timezone', () => {
+      config.automergeSchedule = ['after 4:00pm'];
+      config.timezone = 'Asia/Singapore';
+      const res = schedule.getNextScheduleTime(config);
+      expect(res).not.toBeNull();
+      expect(res!.getTime()).toBeGreaterThan(Date.now());
+    });
+
+    it('supports the schedule key parameter', () => {
+      config.schedule = ['after 4:00pm'];
+      const res = schedule.getNextScheduleTime(config, 'schedule');
+      expect(res).not.toBeNull();
+      expect(res!.getTime()).toBeGreaterThan(Date.now());
+    });
+
+    it('massages string automergeSchedule to array', () => {
+      config.automergeSchedule = 'after 4:00pm' as never;
+      const res = schedule.getNextScheduleTime(config);
+      expect(res).not.toBeNull();
+      expect(res!.getTime()).toBeGreaterThan(Date.now());
+    });
+
+    it('returns the earliest of multiple cron schedules', () => {
+      // fake time 10:50am — '* 22 * * *' fires at 22:00, '* 23 * * *' at 23:00
+      const resEarliest = schedule.getNextScheduleTime({
+        automergeSchedule: ['* 22 * * *', '* 23 * * *'],
+      });
+      const resLater = schedule.getNextScheduleTime({
+        automergeSchedule: ['* 23 * * *'],
+      });
+      expect(resEarliest!.getTime()).toBeLessThan(resLater!.getTime());
+    });
+
+    it('keeps earliest when a later.js schedule fires after the current earliest', () => {
+      // fake time 10:50am — 'after 4pm' is earlier than 'after 11pm'
+      const resWithBoth = schedule.getNextScheduleTime({
+        automergeSchedule: ['after 4:00pm', 'after 11:00pm'],
+      });
+      const resOnlyFirst = schedule.getNextScheduleTime({
+        automergeSchedule: ['after 4:00pm'],
+      });
+      expect(resWithBoth!.getTime()).toBe(resOnlyFirst!.getTime());
+    });
+  });
+
   describe('log cron schedules', () => {
     it('should correctly convert "* 22 4 * *" to human-readable format', () => {
       const result = cronstrue.toString('* 22 4 * *');

--- a/lib/workers/repository/update/branch/schedule.ts
+++ b/lib/workers/repository/update/branch/schedule.ts
@@ -127,6 +127,106 @@ export function cronMatches(
   );
 }
 
+export function getNextScheduleTime(
+  config: RenovateConfig,
+  scheduleKey: 'schedule' | 'automergeSchedule' = 'automergeSchedule',
+): Date | null {
+  let configSchedule = config[scheduleKey];
+  logger.debug(
+    `Getting next schedule time for (schedule=${String(configSchedule)}, tz=${config.timezone!})`,
+  );
+
+  if (
+    !configSchedule ||
+    configSchedule.length === 0 ||
+    configSchedule[0] === '' ||
+    configSchedule[0] === 'at any time'
+  ) {
+    logger.debug('No schedule defined - returning null');
+    return null;
+  }
+
+  if (!isArray(configSchedule)) {
+    logger.warn(
+      { schedule: configSchedule },
+      'config schedule is not an array',
+    );
+    configSchedule = [configSchedule];
+  }
+
+  const validSchedule = hasValidSchedule(configSchedule);
+  if (!validSchedule[0]) {
+    logger.warn(validSchedule[1]);
+    return null;
+  }
+
+  let now: DateTime = DateTime.local();
+  logger.trace(`now=${now.toISO()!}`);
+
+  // Adjust the time if repo is in a different timezone to renovate
+  if (config.timezone) {
+    logger.debug(`Found timezone: ${config.timezone}`);
+    const validTimezone = hasValidTimezone(config.timezone);
+    if (!validTimezone[0]) {
+      logger.warn(validTimezone[1]);
+      return null;
+    }
+    logger.debug('Adjusting now for timezone');
+    now = now.setZone(config.timezone);
+    logger.trace(`now=${now.toISO()!}`);
+  }
+
+  // later is timezone agnostic (as in, it purely relies on the underlying UTC date/time that is stored in the Date),
+  // which means we have to pass it a Date that has an underlying UTC date/time in the same timezone as the schedule
+  const jsNow = now.setZone('utc', { keepLocalTime: true }).toJSDate();
+
+  // Find the earliest next run time from all schedules
+  let earliestNextRun: Date | null = null;
+
+  for (const scheduleText of configSchedule) {
+    const cronSchedule = parseCron(scheduleText);
+    if (cronSchedule) {
+      // We have Cron syntax - create a temporary Cron instance to get next run
+      const tempCron = new Cron(scheduleText);
+      const nextRun = tempCron.nextRun();
+      tempCron.stop(); // Clean up
+      // istanbul ignore if: should not happen for a valid cron schedule
+      if (!nextRun) {
+        continue;
+      }
+      if (!earliestNextRun || nextRun < earliestNextRun) {
+        earliestNextRun = nextRun;
+      }
+    } else {
+      // We have Later syntax
+      const massagedText = scheduleMappings[scheduleText] || scheduleText;
+      const parsedSchedule = later.parse.text(fixShortHours(massagedText));
+      logger.debug({ parsedSchedule }, `Checking schedule "${scheduleText}"`);
+
+      const nextOccurrence = later.schedule(parsedSchedule).next(1, jsNow) as
+        | Date
+        | 0;
+      // istanbul ignore else: should not happen for a valid later.js schedule
+      if (nextOccurrence instanceof Date) {
+        if (!earliestNextRun || nextOccurrence < earliestNextRun) {
+          earliestNextRun = nextOccurrence;
+        }
+      }
+    }
+  }
+
+  // v8 ignore else: unreachable for valid schedules
+  if (earliestNextRun) {
+    logger.debug(`Next schedule time: ${earliestNextRun.toISOString()}`);
+    return earliestNextRun;
+  }
+
+  // istanbul ignore next
+  logger.debug('No next schedule time found');
+  // istanbul ignore next
+  return null;
+}
+
 export function isScheduledNow(
   config: RenovateConfig,
   scheduleKey: 'schedule' | 'automergeSchedule' = 'schedule',

--- a/lib/workers/repository/update/pr/index.spec.ts
+++ b/lib/workers/repository/update/pr/index.spec.ts
@@ -16,10 +16,11 @@ import { toBase64 } from '../../../../util/string.ts';
 import * as _limits from '../../../global/limits.ts';
 import type { BranchConfig, BranchUpgradeConfig } from '../../../types.ts';
 import { embedChangelogs } from '../../changelog/index.ts';
+import * as _schedule from '../branch/schedule.ts';
 import * as _statusChecks from '../branch/status-checks.ts';
 import * as _prBody from './body/index.ts';
 import type { ChangeLogChange, ChangeLogRelease } from './changelog/types.ts';
-import { ensurePr } from './index.ts';
+import { ensurePr, getPlatformPrOptions } from './index.ts';
 import * as _participants from './participants.ts';
 import * as _prCache from './pr-cache.ts';
 import { generatePrBodyFingerprintConfig } from './pr-fingerprint.ts';
@@ -43,6 +44,9 @@ const comment = vi.mocked(_comment);
 
 vi.mock('./pr-cache.ts');
 const prCache = vi.mocked(_prCache);
+
+vi.mock('../branch/schedule.ts');
+const scheduleMock = vi.mocked(_schedule);
 
 describe('workers/repository/update/pr/index', () => {
   describe('ensurePr', () => {
@@ -1309,6 +1313,73 @@ describe('workers/repository/update/pr/index', () => {
         expect(platform.updatePr).toHaveBeenCalled();
         expect(platform.createPr).not.toHaveBeenCalled();
       });
+    });
+  });
+
+  describe('getPlatformPrOptions', () => {
+    const baseConfig: BranchConfig = {
+      manager: 'some-manager',
+      branchName: 'renovate/branch',
+      baseBranch: 'main',
+      upgrades: [],
+      prTitle: 'Some title',
+      automerge: true,
+      automergeType: 'pr',
+      platformAutomerge: true,
+    };
+
+    beforeEach(() => {
+      scheduleMock.isScheduledNow.mockReturnValue(false);
+      scheduleMock.getNextScheduleTime.mockReturnValue(
+        new Date('2026-04-01T10:00:00.000Z'),
+      );
+    });
+
+    it('returns base options without mergeAfter when usePlatformAutomerge is false', () => {
+      const result = getPlatformPrOptions({ ...baseConfig, automerge: false });
+      expect(result.usePlatformAutomerge).toBeFalse();
+      expect(result.mergeAfter).toBeUndefined();
+    });
+
+    it('does not set mergeAfter when automergeSchedule is undefined', () => {
+      const result = getPlatformPrOptions(baseConfig);
+      expect(result.mergeAfter).toBeUndefined();
+    });
+
+    it('does not set mergeAfter when automergeSchedule is empty', () => {
+      const result = getPlatformPrOptions({
+        ...baseConfig,
+        automergeSchedule: [],
+      });
+      expect(result.mergeAfter).toBeUndefined();
+    });
+
+    it('does not set mergeAfter when isScheduledNow returns true', () => {
+      scheduleMock.isScheduledNow.mockReturnValue(true);
+      const result = getPlatformPrOptions({
+        ...baseConfig,
+        automergeSchedule: ['after 10pm'],
+      });
+      expect(result.mergeAfter).toBeUndefined();
+    });
+
+    it('does not set mergeAfter when getNextScheduleTime returns null', () => {
+      scheduleMock.getNextScheduleTime.mockReturnValue(null);
+      const result = getPlatformPrOptions({
+        ...baseConfig,
+        automergeSchedule: ['after 10pm'],
+      });
+      expect(result.mergeAfter).toBeUndefined();
+    });
+
+    it('sets mergeAfter when outside schedule and next time is available', () => {
+      const nextTime = new Date('2026-04-01T10:00:00.000Z');
+      scheduleMock.getNextScheduleTime.mockReturnValue(nextTime);
+      const result = getPlatformPrOptions({
+        ...baseConfig,
+        automergeSchedule: ['after 10pm'],
+      });
+      expect(result.mergeAfter).toBe(nextTime.toISOString());
     });
   });
 });

--- a/lib/workers/repository/update/pr/index.ts
+++ b/lib/workers/repository/update/pr/index.ts
@@ -34,6 +34,7 @@ import type {
   PrBlockedBy,
 } from '../../../types.ts';
 import { embedChangelogs } from '../../changelog/index.ts';
+import { getNextScheduleTime, isScheduledNow } from '../branch/schedule.ts';
 import { resolveBranchStatus } from '../branch/status-checks.ts';
 import { getPrBody } from './body/index.ts';
 import {
@@ -58,7 +59,7 @@ export function getPlatformPrOptions(
     config.platformAutomerge,
   );
 
-  return {
+  const options: PlatformPrOptions = {
     autoApprove: !!config.autoApprove,
     automergeCommitMessage: config.commitMessage,
     automergeStrategy: config.automergeStrategy,
@@ -69,6 +70,22 @@ export function getPlatformPrOptions(
     forkModeDisallowMaintainerEdits: !!config.forkModeDisallowMaintainerEdits,
     usePlatformAutomerge,
   };
+
+  // Handle automergeSchedule for GitLab merge_after parameter
+  if (
+    usePlatformAutomerge &&
+    config.automergeSchedule &&
+    config.automergeSchedule.length > 0
+  ) {
+    if (!isScheduledNow(config)) {
+      const nextScheduleTime = getNextScheduleTime(config);
+      if (nextScheduleTime) {
+        options.mergeAfter = nextScheduleTime.toISOString();
+      }
+    }
+  }
+
+  return options;
 }
 
 export interface ResultWithPr {


### PR DESCRIPTION



<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- Add automergeSchedule and timezone to PlatformPrOptions interface
- Extend getPlatformPrOptions to pass schedule configuration to platforms
- Modify GitLab tryPrAutomerge to set merge_after when outside schedule
- Use existing getNextScheduleTime and isScheduledNow functions
- Support both Cron and Later.js schedule syntax with timezone awareness
- Add comprehensive documentation for the new functionality
<!-- Describe what behavior is changed by this PR. -->

## Context

- Closes #37028
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
