### PR TITLE
fix: Always use default import from `upath` and `semver-stable`

### DIFF
--- a/lib/config/migrations/migrations-service.spec.ts
+++ b/lib/config/migrations/migrations-service.spec.ts
@@ -1,5 +1,5 @@
 import fs from 'node:fs';
-import { join } from 'upath';
+import upath from 'upath';
 import type { RenovateConfig } from '../types';
 import { AbstractMigration } from './base/abstract-migration';
 import { MigrationsService } from './migrations-service';
@@ -102,7 +102,7 @@ describe('config/migrations/migrations-service', () => {
 
   it('includes all defined migration classes in MigrationsService.customMigrations', () => {
     const allDefinedMigrationClasses: string[] = fs
-      .readdirSync(join(__dirname, 'custom'), { withFileTypes: true })
+      .readdirSync(upath.join(__dirname, 'custom'), { withFileTypes: true })
       .map((file) => file.name)
       .filter((name) => !name.includes('spec.ts'));
 

--- a/lib/modules/datasource/crate/index.spec.ts
+++ b/lib/modules/datasource/crate/index.spec.ts
@@ -4,7 +4,7 @@ import type { SimpleGit } from 'simple-git';
 import _simpleGit from 'simple-git';
 import type { DirectoryResult } from 'tmp-promise';
 import { dir } from 'tmp-promise';
-import { dirname, join } from 'upath';
+import upath from 'upath';
 import type { MockedFunction } from 'vitest';
 import { getPkgReleases } from '..';
 import { GlobalConfig } from '../../../config/global';
@@ -40,7 +40,7 @@ function setupGitMocks(delayMs?: number): {
         }
 
         const path = `${clonePath}/my/pk/mypkg`;
-        fs.mkdirSync(dirname(path), { recursive: true });
+        fs.mkdirSync(upath.dirname(path), { recursive: true });
         fs.writeFileSync(path, Fixtures.get('mypkg'), { encoding: 'utf8' });
       },
     );
@@ -114,8 +114,8 @@ describe('modules/datasource/crate/index', () => {
       tmpDir = await dir({ unsafeCleanup: true });
 
       adminConfig = {
-        localDir: join(tmpDir.path, 'local'),
-        cacheDir: join(tmpDir.path, 'cache'),
+        localDir: upath.join(tmpDir.path, 'local'),
+        cacheDir: upath.join(tmpDir.path, 'cache'),
       };
       GlobalConfig.set(adminConfig);
 

--- a/lib/modules/datasource/nuget/index.spec.ts
+++ b/lib/modules/datasource/nuget/index.spec.ts
@@ -1,5 +1,5 @@
 import { Readable } from 'stream';
-import { join } from 'upath';
+import upath from 'upath';
 import { mockDeep } from 'vitest-mock-extended';
 import { getPkgReleases } from '..';
 import { GlobalConfig } from '../../../config/global';
@@ -323,7 +323,7 @@ describe('modules/datasource/nuget/index', () => {
     describe('determine source URL from nupkg', () => {
       beforeEach(() => {
         GlobalConfig.set({
-          cacheDir: join('/tmp/cache'),
+          cacheDir: upath.join('/tmp/cache'),
         });
         process.env.RENOVATE_X_NUGET_DOWNLOAD_NUPKGS = 'true';
       });

--- a/lib/modules/datasource/sbt-package/index.ts
+++ b/lib/modules/datasource/sbt-package/index.ts
@@ -1,4 +1,4 @@
-import * as upath from 'upath';
+import upath from 'upath';
 import { XmlDocument } from 'xmldoc';
 import { logger } from '../../../logger';
 import * as packageCache from '../../../util/cache/package';

--- a/lib/modules/manager/bazel-module/extract.ts
+++ b/lib/modules/manager/bazel-module/extract.ts
@@ -1,4 +1,4 @@
-import { dirname } from 'upath';
+import upath from 'upath';
 import { logger } from '../../../logger';
 import { isNotNullOrUndefined } from '../../../util/array';
 import { LooseArray } from '../../../util/schema-utils';
@@ -53,7 +53,7 @@ async function extractBazelPfc(
     .transform((deps) => ({ deps }))
     .parse(records);
 
-  const registryUrls = (await bazelrc.read(dirname(packageFile)))
+  const registryUrls = (await bazelrc.read(upath.dirname(packageFile)))
     // Ignore any entries for custom configurations
     .filter((ce) => ce.config === undefined)
     .map((ce) => ce.getOption('registry')?.value)

--- a/lib/modules/manager/bundler/artifacts.spec.ts
+++ b/lib/modules/manager/bundler/artifacts.spec.ts
@@ -1,4 +1,4 @@
-import { join } from 'upath';
+import upath from 'upath';
 import { mockDeep } from 'vitest-mock-extended';
 import { GlobalConfig } from '../../../config/global';
 import type { RepoGlobalConfig } from '../../../config/types';
@@ -29,9 +29,9 @@ process.env.CONTAINERBASE = 'true';
 
 const adminConfig: RepoGlobalConfig = {
   // `join` fixes Windows CI
-  localDir: join('/tmp/github/some/repo'),
-  cacheDir: join('/tmp/cache'),
-  containerbaseDir: join('/tmp/cache/containerbase'),
+  localDir: upath.join('/tmp/github/some/repo'),
+  cacheDir: upath.join('/tmp/cache'),
+  containerbaseDir: upath.join('/tmp/cache/containerbase'),
   dockerSidecarImage: 'ghcr.io/containerbase/sidecar',
 };
 

--- a/lib/modules/manager/bundler/common.spec.ts
+++ b/lib/modules/manager/bundler/common.spec.ts
@@ -1,4 +1,4 @@
-import { join } from 'upath';
+import upath from 'upath';
 import { GlobalConfig } from '../../../config/global';
 import type { RepoGlobalConfig } from '../../../config/types';
 import type { UpdateArtifact } from '../types';
@@ -17,9 +17,9 @@ const lockedContent = Fixtures.get('Gemfile.gitlab-foss.lock');
 
 const adminConfig: RepoGlobalConfig = {
   // `join` fixes Windows CI
-  localDir: join('/tmp/github/some/repo'),
-  cacheDir: join('/tmp/cache'),
-  containerbaseDir: join('/tmp/cache/containerbase'),
+  localDir: upath.join('/tmp/github/some/repo'),
+  cacheDir: upath.join('/tmp/cache'),
+  containerbaseDir: upath.join('/tmp/cache/containerbase'),
 };
 
 describe('modules/manager/bundler/common', () => {

--- a/lib/modules/manager/cargo/artifacts.spec.ts
+++ b/lib/modules/manager/cargo/artifacts.spec.ts
@@ -1,4 +1,4 @@
-import { join } from 'upath';
+import upath from 'upath';
 import { mockDeep } from 'vitest-mock-extended';
 import { GlobalConfig } from '../../../config/global';
 import type { RepoGlobalConfig } from '../../../config/types';
@@ -21,9 +21,9 @@ const config: UpdateArtifactsConfig = {};
 
 const adminConfig: RepoGlobalConfig = {
   // `join` fixes Windows CI
-  localDir: join('/tmp/github/some/repo'),
-  cacheDir: join('/tmp/cache'),
-  containerbaseDir: join('/tmp/cache/containerbase'),
+  localDir: upath.join('/tmp/github/some/repo'),
+  cacheDir: upath.join('/tmp/cache'),
+  containerbaseDir: upath.join('/tmp/cache/containerbase'),
   dockerSidecarImage: 'ghcr.io/containerbase/sidecar',
 };
 

--- a/lib/modules/manager/cocoapods/artifacts.spec.ts
+++ b/lib/modules/manager/cocoapods/artifacts.spec.ts
@@ -1,4 +1,4 @@
-import { join } from 'upath';
+import upath from 'upath';
 import { mockDeep } from 'vitest-mock-extended';
 import { GlobalConfig } from '../../../config/global';
 import type { RepoGlobalConfig } from '../../../config/types';
@@ -22,9 +22,9 @@ process.env.CONTAINERBASE = 'true';
 const config: UpdateArtifactsConfig = {};
 
 const adminConfig: RepoGlobalConfig = {
-  localDir: join('/tmp/github/some/repo'),
-  cacheDir: join('/tmp/cache'),
-  containerbaseDir: join('/tmp/cache/containerbase'),
+  localDir: upath.join('/tmp/github/some/repo'),
+  cacheDir: upath.join('/tmp/cache'),
+  containerbaseDir: upath.join('/tmp/cache/containerbase'),
   dockerSidecarImage: 'ghcr.io/containerbase/sidecar',
 };
 

--- a/lib/modules/manager/composer/artifacts.spec.ts
+++ b/lib/modules/manager/composer/artifacts.spec.ts
@@ -1,4 +1,4 @@
-import { join } from 'upath';
+import upath from 'upath';
 import { mockDeep } from 'vitest-mock-extended';
 import { GlobalConfig } from '../../../config/global';
 import type { RepoGlobalConfig } from '../../../config/types';
@@ -30,9 +30,9 @@ const adminConfig: RepoGlobalConfig = {
   allowPlugins: false,
   allowScripts: false,
   // `join` fixes Windows CI
-  localDir: join('/tmp/github/some/repo'),
-  cacheDir: join('/tmp/renovate/cache'),
-  containerbaseDir: join('/tmp/renovate/cache/containerbase'),
+  localDir: upath.join('/tmp/github/some/repo'),
+  cacheDir: upath.join('/tmp/renovate/cache'),
+  containerbaseDir: upath.join('/tmp/renovate/cache/containerbase'),
   dockerSidecarImage: 'ghcr.io/containerbase/sidecar',
 };
 
@@ -650,9 +650,9 @@ describe('modules/manager/composer/artifacts', () => {
   });
 
   it('supports vendor directory update', async () => {
-    const foo = join('vendor/foo/Foo.php');
-    const bar = join('vendor/bar/Bar.php');
-    const baz = join('vendor/baz/Baz.php');
+    const foo = upath.join('vendor/foo/Foo.php');
+    const bar = upath.join('vendor/bar/Bar.php');
+    const baz = upath.join('vendor/baz/Baz.php');
     fs.localPathExists.mockResolvedValueOnce(true);
     fs.readLocalFile.mockResolvedValueOnce('{}');
     const execSnapshots = mockExecAll();

--- a/lib/modules/manager/conan/artifacts.spec.ts
+++ b/lib/modules/manager/conan/artifacts.spec.ts
@@ -1,4 +1,4 @@
-import { join } from 'upath';
+import upath from 'upath';
 import { GlobalConfig } from '../../../config/global';
 import type { RepoGlobalConfig } from '../../../config/types';
 import { TEMPORARY_ERROR } from '../../../constants/error-messages';
@@ -15,9 +15,9 @@ process.env.CONTAINERBASE = 'true';
 const config: UpdateArtifactsConfig = {};
 
 const adminConfig: RepoGlobalConfig = {
-  localDir: join('/tmp/github/some/repo'),
-  cacheDir: join('/tmp/cache'),
-  containerbaseDir: join('/tmp/cache/containerbase'),
+  localDir: upath.join('/tmp/github/some/repo'),
+  cacheDir: upath.join('/tmp/cache'),
+  containerbaseDir: upath.join('/tmp/cache/containerbase'),
   dockerSidecarImage: 'ghcr.io/containerbase/sidecar',
 };
 

--- a/lib/modules/manager/copier/artifacts.spec.ts
+++ b/lib/modules/manager/copier/artifacts.spec.ts
@@ -1,4 +1,4 @@
-import { join } from 'upath';
+import upath from 'upath';
 import { mockDeep } from 'vitest-mock-extended';
 import { GlobalConfig } from '../../../config/global';
 import type { RepoGlobalConfig } from '../../../config/types';
@@ -30,9 +30,9 @@ const upgrades: Upgrade[] = [
 ];
 
 const adminConfig: RepoGlobalConfig = {
-  localDir: join('/tmp/github/some/repo'),
-  cacheDir: join('/tmp/cache'),
-  containerbaseDir: join('/tmp/renovate/cache/containerbase'),
+  localDir: upath.join('/tmp/github/some/repo'),
+  cacheDir: upath.join('/tmp/cache'),
+  containerbaseDir: upath.join('/tmp/renovate/cache/containerbase'),
   allowScripts: false,
 };
 

--- a/lib/modules/manager/git-submodules/update.spec.ts
+++ b/lib/modules/manager/git-submodules/update.spec.ts
@@ -2,7 +2,7 @@ import type { SimpleGit } from 'simple-git';
 import { simpleGit } from 'simple-git';
 import type { DirectoryResult } from 'tmp-promise';
 import { dir } from 'tmp-promise';
-import { join } from 'upath';
+import upath from 'upath';
 import { mock } from 'vitest-mock-extended';
 import { GlobalConfig } from '../../../config/global';
 import type { RepoGlobalConfig } from '../../../config/types';
@@ -37,7 +37,7 @@ describe('modules/manager/git-submodules/update', () => {
       upgrade = { depName: 'renovate' };
 
       tmpDir = await dir({ unsafeCleanup: true });
-      adminConfig = { localDir: join(tmpDir.path) };
+      adminConfig = { localDir: upath.join(tmpDir.path) };
       GlobalConfig.set(adminConfig);
     });
 

--- a/lib/modules/manager/gomod/artifacts.spec.ts
+++ b/lib/modules/manager/gomod/artifacts.spec.ts
@@ -1,5 +1,5 @@
 import { codeBlock } from 'common-tags';
-import { join } from 'upath';
+import upath from 'upath';
 import { mockDeep } from 'vitest-mock-extended';
 import { GlobalConfig } from '../../../config/global';
 import type { RepoGlobalConfig } from '../../../config/types';
@@ -57,9 +57,9 @@ const gomod1 = codeBlock`
 
 const adminConfig: RepoGlobalConfig = {
   // `join` fixes Windows CI
-  localDir: join('/tmp/github/some/repo'),
-  cacheDir: join('/tmp/renovate/cache'),
-  containerbaseDir: join('/tmp/renovate/cache/containerbase'),
+  localDir: upath.join('/tmp/github/some/repo'),
+  cacheDir: upath.join('/tmp/renovate/cache'),
+  containerbaseDir: upath.join('/tmp/renovate/cache/containerbase'),
   dockerSidecarImage: 'ghcr.io/containerbase/sidecar',
 };
 
@@ -293,9 +293,9 @@ describe('modules/manager/gomod/artifacts', () => {
   });
 
   it('supports vendor directory update', async () => {
-    const foo = join('vendor/github.com/foo/foo/go.mod');
-    const bar = join('vendor/github.com/bar/bar/go.mod');
-    const baz = join('vendor/github.com/baz/baz/go.mod');
+    const foo = upath.join('vendor/github.com/foo/foo/go.mod');
+    const bar = upath.join('vendor/github.com/bar/bar/go.mod');
+    const baz = upath.join('vendor/github.com/baz/baz/go.mod');
 
     fs.readLocalFile.mockResolvedValueOnce('Current go.sum');
     fs.readLocalFile.mockResolvedValueOnce('modules.txt content'); // vendor modules filename
@@ -382,9 +382,9 @@ describe('modules/manager/gomod/artifacts', () => {
   });
 
   it('skips vendor directory update with gomodSkipVendor', async () => {
-    const foo = join('vendor/github.com/foo/foo/go.mod');
-    const bar = join('vendor/github.com/bar/bar/go.mod');
-    const baz = join('vendor/github.com/baz/baz/go.mod');
+    const foo = upath.join('vendor/github.com/foo/foo/go.mod');
+    const bar = upath.join('vendor/github.com/bar/bar/go.mod');
+    const baz = upath.join('vendor/github.com/baz/baz/go.mod');
 
     fs.readLocalFile.mockResolvedValueOnce('Current go.sum');
     const execSnapshots = mockExecAll();
@@ -432,9 +432,9 @@ describe('modules/manager/gomod/artifacts', () => {
   });
 
   it('supports vendor directory update with go.work', async () => {
-    const foo = join('vendor/github.com/foo/foo/go.mod');
-    const bar = join('vendor/github.com/bar/bar/go.mod');
-    const baz = join('vendor/github.com/baz/baz/go.mod');
+    const foo = upath.join('vendor/github.com/foo/foo/go.mod');
+    const bar = upath.join('vendor/github.com/bar/bar/go.mod');
+    const baz = upath.join('vendor/github.com/baz/baz/go.mod');
 
     fs.readLocalFile.mockResolvedValueOnce('Current go.sum');
     fs.readLocalFile.mockResolvedValueOnce('modules.txt content'); // vendor modules filename

--- a/lib/modules/manager/gradle-wrapper/artifacts.spec.ts
+++ b/lib/modules/manager/gradle-wrapper/artifacts.spec.ts
@@ -1,6 +1,6 @@
 import type { Stats } from 'node:fs';
 import os from 'node:os';
-import { join } from 'upath';
+import upath from 'upath';
 import { mockDeep } from 'vitest-mock-extended';
 import { GlobalConfig } from '../../../config/global';
 import type { RepoGlobalConfig } from '../../../config/types';
@@ -25,9 +25,9 @@ process.env.CONTAINERBASE = 'true';
 
 const adminConfig: RepoGlobalConfig = {
   // `join` fixes Windows CI
-  localDir: join('/tmp/github/some/repo'),
-  cacheDir: join('/tmp/cache'),
-  containerbaseDir: join('/tmp/cache/containerbase'),
+  localDir: upath.join('/tmp/github/some/repo'),
+  cacheDir: upath.join('/tmp/cache'),
+  containerbaseDir: upath.join('/tmp/cache/containerbase'),
 };
 
 const config: UpdateArtifactsConfig = {

--- a/lib/modules/manager/gradle-wrapper/artifacts.ts
+++ b/lib/modules/manager/gradle-wrapper/artifacts.ts
@@ -1,7 +1,7 @@
 import is from '@sindresorhus/is';
 import { lang, query as q } from 'good-enough-parser';
 import { quote } from 'shlex';
-import { dirname, join } from 'upath';
+import upath from 'upath';
 import { TEMPORARY_ERROR } from '../../../constants/error-messages';
 import { logger } from '../../../logger';
 import { exec } from '../../../util/exec';
@@ -71,9 +71,9 @@ export async function updateBuildFile(
   localGradleDir: string,
   wrapperProperties: Record<string, string | undefined | null>,
 ): Promise<string> {
-  let buildFileName = join(localGradleDir, 'build.gradle');
+  let buildFileName = upath.join(localGradleDir, 'build.gradle');
   if (!(await localPathExists(buildFileName))) {
-    buildFileName = join(localGradleDir, 'build.gradle.kts');
+    buildFileName = upath.join(localGradleDir, 'build.gradle.kts');
   }
 
   const buildFileContent = await readLocalFile(buildFileName, 'utf8');
@@ -138,8 +138,8 @@ export async function updateArtifacts({
 }: UpdateArtifact): Promise<UpdateArtifactsResult[] | null> {
   try {
     logger.debug({ updatedDeps }, 'gradle-wrapper.updateArtifacts()');
-    const localGradleDir = join(dirname(packageFileName), '../../');
-    const gradlewFile = join(localGradleDir, gradleWrapperFileName());
+    const localGradleDir = upath.join(upath.dirname(packageFileName), '../../');
+    const gradlewFile = upath.join(localGradleDir, gradleWrapperFileName());
 
     let cmd = await prepareGradleCommand(gradlewFile);
     if (!cmd) {
@@ -206,7 +206,7 @@ export async function updateArtifacts({
       packageFileName,
       buildFileName,
       ...['gradle/wrapper/gradle-wrapper.jar', 'gradlew', 'gradlew.bat'].map(
-        (filename) => join(localGradleDir, filename),
+        (filename) => upath.join(localGradleDir, filename),
       ),
     ];
     const updateArtifactsResult = (

--- a/lib/modules/manager/gradle-wrapper/utils.ts
+++ b/lib/modules/manager/gradle-wrapper/utils.ts
@@ -1,5 +1,5 @@
 import os from 'node:os';
-import { dirname, join } from 'upath';
+import upath from 'upath';
 import { GlobalConfig } from '../../../config/global';
 import { logger } from '../../../logger';
 import {
@@ -97,8 +97,8 @@ export async function getJavaConstraint(
 export async function getJvmConfiguration(
   gradlewFile: string,
 ): Promise<string | null> {
-  const daemonJvmFile = join(
-    dirname(gradlewFile),
+  const daemonJvmFile = upath.join(
+    upath.dirname(gradlewFile),
     'gradle/gradle-daemon-jvm.properties',
   );
   const daemonJvm = await readLocalFile(daemonJvmFile, 'utf8');
@@ -122,10 +122,10 @@ export async function getJvmConfiguration(
 export async function getJavaLanguageVersion(
   gradlewFile: string,
 ): Promise<string | null> {
-  const localGradleDir = dirname(gradlewFile);
-  let buildFileName = join(localGradleDir, 'build.gradle');
+  const localGradleDir = upath.dirname(gradlewFile);
+  let buildFileName = upath.join(localGradleDir, 'build.gradle');
   if (!(await localPathExists(buildFileName))) {
-    buildFileName = join(localGradleDir, 'build.gradle.kts');
+    buildFileName = upath.join(localGradleDir, 'build.gradle.kts');
   }
 
   const buildFileContent = await readLocalFile(buildFileName, 'utf8');

--- a/lib/modules/manager/gradle/artifacts.spec.ts
+++ b/lib/modules/manager/gradle/artifacts.spec.ts
@@ -1,5 +1,5 @@
 import os from 'node:os';
-import { join } from 'upath';
+import upath from 'upath';
 import { mockDeep } from 'vitest-mock-extended';
 import { GlobalConfig } from '../../../config/global';
 import type { RepoGlobalConfig } from '../../../config/types';
@@ -20,9 +20,9 @@ process.env.CONTAINERBASE = 'true';
 
 const adminConfig: RepoGlobalConfig = {
   // `join` fixes Windows CI
-  localDir: join('/tmp/github/some/repo'),
-  cacheDir: join('/tmp/cache'),
-  containerbaseDir: join('/tmp/cache/containerbase'),
+  localDir: upath.join('/tmp/github/some/repo'),
+  cacheDir: upath.join('/tmp/cache'),
+  containerbaseDir: upath.join('/tmp/cache/containerbase'),
   dockerSidecarImage: 'ghcr.io/containerbase/sidecar',
 };
 

--- a/lib/modules/manager/gradle/artifacts.ts
+++ b/lib/modules/manager/gradle/artifacts.ts
@@ -131,7 +131,7 @@ async function buildUpdateVerificationMetadataCmd(
     return null;
   }
 
-  return `${baseCmd} --write-verification-metadata ${hashTypes.upath.join(',')} dependencies`;
+  return `${baseCmd} --write-verification-metadata ${hashTypes.join(',')} dependencies`;
 }
 
 export async function updateArtifacts({
@@ -207,7 +207,7 @@ export async function updateArtifacts({
       let lockfileCmd = `${baseCmd} ${subprojects
         .map((project) => `${project}:dependencies`)
         .map(quote)
-        .upath.join(' ')}`;
+        .join(' ')}`;
 
       if (
         config.isLockFileMaintenance === true ||
@@ -222,7 +222,7 @@ export async function updateArtifacts({
 
         lockfileCmd += ` --update-locks ${updatedDepNames
           .map(quote)
-          .upath.join(',')}`;
+          .join(',')}`;
       }
       cmds.push(lockfileCmd);
     }

--- a/lib/modules/manager/gradle/artifacts.ts
+++ b/lib/modules/manager/gradle/artifacts.ts
@@ -1,6 +1,6 @@
 import is from '@sindresorhus/is';
 import { quote } from 'shlex';
-import { dirname, join } from 'upath';
+import upath from 'upath';
 import { TEMPORARY_ERROR } from '../../../constants/error-messages';
 import { logger } from '../../../logger';
 import { exec } from '../../../util/exec';
@@ -79,8 +79,8 @@ async function getSubProjectList(
 }
 
 async function getGradleVersion(gradlewFile: string): Promise<string | null> {
-  const propertiesFile = join(
-    dirname(gradlewFile),
+  const propertiesFile = upath.join(
+    upath.dirname(gradlewFile),
     'gradle/wrapper/gradle-wrapper.properties',
   );
   const properties = await readLocalFile(propertiesFile, 'utf8');
@@ -131,7 +131,7 @@ async function buildUpdateVerificationMetadataCmd(
     return null;
   }
 
-  return `${baseCmd} --write-verification-metadata ${hashTypes.join(',')} dependencies`;
+  return `${baseCmd} --write-verification-metadata ${hashTypes.upath.join(',')} dependencies`;
 }
 
 export async function updateArtifacts({
@@ -155,7 +155,10 @@ export async function updateArtifacts({
   }
 
   const gradlewName = gradleWrapperFileName();
-  const gradlewFile = await findUpLocal(gradlewName, dirname(packageFileName));
+  const gradlewFile = await findUpLocal(
+    gradlewName,
+    upath.dirname(packageFileName),
+  );
   if (!gradlewFile) {
     logger.debug(
       'Found Gradle dependency lockfiles but no gradlew - aborting update',
@@ -166,7 +169,7 @@ export async function updateArtifacts({
   if (
     config.isLockFileMaintenance &&
     (!isGradleBuildFile(packageFileName) ||
-      dirname(packageFileName) !== dirname(gradlewFile))
+      upath.dirname(packageFileName) !== upath.dirname(gradlewFile))
   ) {
     logger.trace(
       'No build.gradle(.kts) file or not in root project - skipping lock file maintenance',
@@ -204,7 +207,7 @@ export async function updateArtifacts({
       let lockfileCmd = `${baseCmd} ${subprojects
         .map((project) => `${project}:dependencies`)
         .map(quote)
-        .join(' ')}`;
+        .upath.join(' ')}`;
 
       if (
         config.isLockFileMaintenance === true ||
@@ -219,7 +222,7 @@ export async function updateArtifacts({
 
         lockfileCmd += ` --update-locks ${updatedDepNames
           .map(quote)
-          .join(',')}`;
+          .upath.join(',')}`;
       }
       cmds.push(lockfileCmd);
     }

--- a/lib/modules/manager/helmfile/artifacts.spec.ts
+++ b/lib/modules/manager/helmfile/artifacts.spec.ts
@@ -1,5 +1,5 @@
 import { codeBlock } from 'common-tags';
-import { join } from 'upath';
+import upath from 'upath';
 import { mockDeep } from 'vitest-mock-extended';
 import { GlobalConfig } from '../../../config/global';
 import type { RepoGlobalConfig } from '../../../config/types';
@@ -21,9 +21,9 @@ const datasource = vi.mocked(_datasource);
 process.env.CONTAINERBASE = 'true';
 
 const adminConfig: RepoGlobalConfig = {
-  localDir: join('/tmp/github/some/repo'), // `join` fixes Windows CI
-  cacheDir: join('/tmp/renovate/cache'),
-  containerbaseDir: join('/tmp/renovate/cache/containerbase'),
+  localDir: upath.join('/tmp/github/some/repo'), // `join` fixes Windows CI
+  cacheDir: upath.join('/tmp/renovate/cache'),
+  containerbaseDir: upath.join('/tmp/renovate/cache/containerbase'),
   dockerSidecarImage: 'ghcr.io/containerbase/sidecar',
 };
 

--- a/lib/modules/manager/helmv3/artifacts.spec.ts
+++ b/lib/modules/manager/helmv3/artifacts.spec.ts
@@ -2,7 +2,7 @@ import type { GetAuthorizationTokenCommandOutput } from '@aws-sdk/client-ecr';
 import { ECRClient, GetAuthorizationTokenCommand } from '@aws-sdk/client-ecr';
 import { mockClient } from 'aws-sdk-client-mock';
 import { codeBlock } from 'common-tags';
-import { join } from 'upath';
+import upath from 'upath';
 import { mockDeep } from 'vitest-mock-extended';
 import { GlobalConfig } from '../../../config/global';
 import type { RepoGlobalConfig } from '../../../config/types';
@@ -25,9 +25,9 @@ vi.mock('../../../util/fs');
 const datasource = vi.mocked(_datasource);
 
 const adminConfig: RepoGlobalConfig = {
-  localDir: join('/tmp/github/some/repo'), // `join` fixes Windows CI
-  cacheDir: join('/tmp/renovate/cache'),
-  containerbaseDir: join('/tmp/renovate/cache/containerbase'),
+  localDir: upath.join('/tmp/github/some/repo'), // `join` fixes Windows CI
+  cacheDir: upath.join('/tmp/renovate/cache'),
+  containerbaseDir: upath.join('/tmp/renovate/cache/containerbase'),
 };
 
 const config: UpdateArtifactsConfig = {};

--- a/lib/modules/manager/index.spec.ts
+++ b/lib/modules/manager/index.spec.ts
@@ -1,4 +1,4 @@
-import { join } from 'upath';
+import upath from 'upath';
 import { loadModules } from '../../util/modules';
 import { getDatasourceList } from '../datasource';
 import * as customManager from './custom';
@@ -77,7 +77,7 @@ describe('modules/manager/index', () => {
 
     const loadedMgr = {
       ...(await loadModules(__dirname, validate)), // validate built-in managers
-      ...(await loadModules(join(__dirname, 'custom'), validate)), // validate custom managers
+      ...(await loadModules(upath.join(__dirname, 'custom'), validate)), // validate custom managers
     };
     delete loadedMgr.custom;
 

--- a/lib/modules/manager/jsonnet-bundler/artifacts.spec.ts
+++ b/lib/modules/manager/jsonnet-bundler/artifacts.spec.ts
@@ -1,4 +1,4 @@
-import { join } from 'upath';
+import upath from 'upath';
 import { GlobalConfig } from '../../../config/global';
 import type { RepoGlobalConfig } from '../../../config/types';
 import type { StatusResult } from '../../../util/git/types';
@@ -12,9 +12,9 @@ vi.mock('../../../util/fs');
 
 const adminConfig: RepoGlobalConfig = {
   // `join` fixes Windows CI
-  localDir: join('/tmp/github/some/repo'),
-  cacheDir: join('/tmp/renovate/cache'),
-  containerbaseDir: join('/tmp/renovate/cache/containerbase'),
+  localDir: upath.join('/tmp/github/some/repo'),
+  cacheDir: upath.join('/tmp/renovate/cache'),
+  containerbaseDir: upath.join('/tmp/renovate/cache/containerbase'),
 };
 const config: UpdateArtifactsConfig = {};
 

--- a/lib/modules/manager/jsonnet-bundler/extract.ts
+++ b/lib/modules/manager/jsonnet-bundler/extract.ts
@@ -1,4 +1,4 @@
-import { join } from 'upath';
+import upath from 'upath';
 import { logger } from '../../../logger';
 import { coerceArray } from '../../../util/array';
 import { coerceString } from '../../../util/string';
@@ -50,7 +50,7 @@ function extractDependency(dependency: Dependency): PackageDependency | null {
     return null;
   }
 
-  const depName = join(
+  const depName = upath.join(
     gitRemote.host,
     gitRemote.pathname.replace(/\.git$/, ''),
     coerceString(dependency.source.git.subdir),

--- a/lib/modules/manager/kustomize/artifacts.spec.ts
+++ b/lib/modules/manager/kustomize/artifacts.spec.ts
@@ -1,4 +1,4 @@
-import { join } from 'upath';
+import upath from 'upath';
 import { mockDeep } from 'vitest-mock-extended';
 import { envMock, mockExecAll } from '../../../../test/exec-util';
 import { env, fs, git, partial } from '../../../../test/util';
@@ -19,9 +19,9 @@ vi.mock('../../datasource', () => mockDeep());
 const getPkgReleases = vi.mocked(_getPkgReleases);
 
 const adminConfig: RepoGlobalConfig = {
-  localDir: join('/tmp/github/some/repo'), // `join` fixes Windows CI
-  cacheDir: join('/tmp/renovate/cache'),
-  containerbaseDir: join('/tmp/renovate/cache/containerbase'),
+  localDir: upath.join('/tmp/github/some/repo'), // `join` fixes Windows CI
+  cacheDir: upath.join('/tmp/renovate/cache'),
+  containerbaseDir: upath.join('/tmp/renovate/cache/containerbase'),
 };
 
 process.env.CONTAINERBASE = 'true';

--- a/lib/modules/manager/kustomize/common.spec.ts
+++ b/lib/modules/manager/kustomize/common.spec.ts
@@ -1,13 +1,13 @@
-import { join } from 'upath';
+import upath from 'upath';
 import { GlobalConfig } from '../../../config/global';
 import type { RepoGlobalConfig } from '../../../config/types';
 import { generateHelmEnvs } from './common';
 
 const adminConfig: RepoGlobalConfig = {
   // `join` fixes Windows CI
-  localDir: join('/tmp/github/some/repo'),
-  cacheDir: join('/tmp/cache'),
-  containerbaseDir: join('/tmp/cache/containerbase'),
+  localDir: upath.join('/tmp/github/some/repo'),
+  cacheDir: upath.join('/tmp/cache'),
+  containerbaseDir: upath.join('/tmp/cache/containerbase'),
 };
 
 describe('modules/manager/kustomize/common', () => {

--- a/lib/modules/manager/maven-wrapper/artifacts.spec.ts
+++ b/lib/modules/manager/maven-wrapper/artifacts.spec.ts
@@ -1,7 +1,7 @@
 import type { Stats } from 'node:fs';
 import os from 'node:os';
 import type { StatusResult } from 'simple-git';
-import { join } from 'upath';
+import upath from 'upath';
 import { mockDeep } from 'vitest-mock-extended';
 import { GlobalConfig } from '../../../config/global';
 import { resetPrefetchedImages } from '../../../util/exec/docker';
@@ -29,7 +29,7 @@ function mockMavenFileChangedInGit(fileName = 'maven-wrapper.properties') {
 describe('modules/manager/maven-wrapper/artifacts', () => {
   beforeEach(() => {
     osPlatformSpy.mockImplementation(() => 'linux');
-    GlobalConfig.set({ localDir: join('/tmp/github/some/repo') });
+    GlobalConfig.set({ localDir: upath.join('/tmp/github/some/repo') });
     fs.statLocalFile.mockResolvedValue(
       partial<Stats>({
         isFile: () => true,
@@ -271,7 +271,7 @@ describe('modules/manager/maven-wrapper/artifacts', () => {
     const execSnapshots = mockExecAll({ stdout: '', stderr: '' });
     mockMavenFileChangedInGit();
     GlobalConfig.set({
-      localDir: join('/tmp/github/some/repo'),
+      localDir: upath.join('/tmp/github/some/repo'),
       binarySource: 'install',
     });
     const updatedDeps = await updateArtifacts({

--- a/lib/modules/manager/maven-wrapper/artifacts.ts
+++ b/lib/modules/manager/maven-wrapper/artifacts.ts
@@ -242,7 +242,7 @@ async function prepareCommand(
   pathFileStats: Stats | null,
   args: string | null,
 ): Promise<string | null> {
-  // istanbul ignore if
+  /* v8 ignore start -- hard to test */
   if (pathFileStats?.isFile() === true) {
     // if the file is not executable by others
     if (os.platform() !== 'win32' && (pathFileStats.mode & 0o1) === 0) {
@@ -257,6 +257,6 @@ async function prepareCommand(
       return fileName;
     }
     return `${fileName} ${args}`;
-  }
+  } /* v8 ignore stop */
   return null;
 }

--- a/lib/modules/manager/maven-wrapper/artifacts.ts
+++ b/lib/modules/manager/maven-wrapper/artifacts.ts
@@ -1,7 +1,7 @@
 import type { Stats } from 'node:fs';
 import os from 'node:os';
 import is from '@sindresorhus/is';
-import { dirname, join } from 'upath';
+import upath from 'upath';
 import { GlobalConfig } from '../../../config/global';
 import { logger } from '../../../logger';
 import { exec } from '../../../util/exec';
@@ -224,8 +224,8 @@ function mavenWrapperFileName(): string {
 
 function getMavenPaths(packageFileName: string): MavenWrapperPaths {
   const wrapperExecutableFileName = mavenWrapperFileName();
-  const localProjectDir = join(dirname(packageFileName), '../../');
-  const wrapperFullyQualifiedPath = join(
+  const localProjectDir = upath.join(upath.dirname(packageFileName), '../../');
+  const wrapperFullyQualifiedPath = upath.join(
     localProjectDir,
     wrapperExecutableFileName,
   );
@@ -248,7 +248,10 @@ async function prepareCommand(
     if (os.platform() !== 'win32' && (pathFileStats.mode & 0o1) === 0) {
       // add the execution permission to the owner, group and others
       logger.warn('Maven wrapper is missing the executable bit');
-      await chmodLocalFile(join(cwd, fileName), pathFileStats.mode | 0o111);
+      await chmodLocalFile(
+        upath.join(cwd, fileName),
+        pathFileStats.mode | 0o111,
+      );
     }
     if (args === null) {
       return fileName;

--- a/lib/modules/manager/metadata.spec.ts
+++ b/lib/modules/manager/metadata.spec.ts
@@ -1,5 +1,5 @@
 import fs from 'fs-extra';
-import { join } from 'upath';
+import upath from 'upath';
 import { customManagerList as customManagers } from './custom';
 
 describe('modules/manager/metadata', () => {
@@ -11,7 +11,7 @@ describe('modules/manager/metadata', () => {
     .sort();
 
   const customManagerList = fs
-    .readdirSync(join(__dirname, 'custom'), { withFileTypes: true })
+    .readdirSync(upath.join(__dirname, 'custom'), { withFileTypes: true })
     .filter((dirent) => dirent.isDirectory())
     .map((dirent) => dirent.name)
     .filter((name) => !name.startsWith('__'))

--- a/lib/modules/manager/mix/artifacts.spec.ts
+++ b/lib/modules/manager/mix/artifacts.spec.ts
@@ -1,4 +1,4 @@
-import { join } from 'upath';
+import upath from 'upath';
 import { mockDeep } from 'vitest-mock-extended';
 import { GlobalConfig } from '../../../config/global';
 import type { RepoGlobalConfig } from '../../../config/types';
@@ -17,9 +17,9 @@ const getPkgReleases = vi.mocked(_getPkgReleases);
 
 const adminConfig: RepoGlobalConfig = {
   // `join` fixes Windows CI
-  localDir: join('/tmp/github/some/repo'),
-  cacheDir: join('/tmp/cache'),
-  containerbaseDir: join('/tmp/cache/containerbase'),
+  localDir: upath.join('/tmp/github/some/repo'),
+  cacheDir: upath.join('/tmp/cache'),
+  containerbaseDir: upath.join('/tmp/cache/containerbase'),
 };
 
 // support install mode

--- a/lib/modules/manager/nix/artifacts.spec.ts
+++ b/lib/modules/manager/nix/artifacts.spec.ts
@@ -1,5 +1,5 @@
 import type { StatusResult } from 'simple-git';
-import { join } from 'upath';
+import upath from 'upath';
 import { mockDeep } from 'vitest-mock-extended';
 import { GlobalConfig } from '../../../config/global';
 import type { RepoGlobalConfig } from '../../../config/types';
@@ -15,9 +15,9 @@ vi.mock('../../../util/host-rules', () => mockDeep());
 
 const adminConfig: RepoGlobalConfig = {
   // `join` fixes Windows CI
-  localDir: join('/tmp/github/some/repo'),
-  cacheDir: join('/tmp/renovate/cache'),
-  containerbaseDir: join('/tmp/renovate/cache/containerbase'),
+  localDir: upath.join('/tmp/github/some/repo'),
+  cacheDir: upath.join('/tmp/renovate/cache'),
+  containerbaseDir: upath.join('/tmp/renovate/cache/containerbase'),
 };
 const dockerAdminConfig = {
   ...adminConfig,

--- a/lib/modules/manager/npm/artifacts.spec.ts
+++ b/lib/modules/manager/npm/artifacts.spec.ts
@@ -1,4 +1,4 @@
-import { join } from 'upath';
+import upath from 'upath';
 import { GlobalConfig } from '../../../config/global';
 import type { RepoGlobalConfig } from '../../../config/types';
 import * as docker from '../../../util/exec/docker';
@@ -13,9 +13,9 @@ vi.mock('../../../util/fs');
 
 const adminConfig: RepoGlobalConfig = {
   // `join` fixes Windows CI
-  localDir: join('/tmp/github/some/repo'),
-  cacheDir: join('/tmp/renovate/cache'),
-  containerbaseDir: join('/tmp/renovate/cache/containerbase'),
+  localDir: upath.join('/tmp/github/some/repo'),
+  cacheDir: upath.join('/tmp/renovate/cache'),
+  containerbaseDir: upath.join('/tmp/renovate/cache/containerbase'),
 };
 const dockerAdminConfig = {
   ...adminConfig,

--- a/lib/modules/manager/npm/extract/post/locked-versions.ts
+++ b/lib/modules/manager/npm/extract/post/locked-versions.ts
@@ -1,6 +1,6 @@
 import is from '@sindresorhus/is';
 import semver from 'semver';
-import { dirname, relative } from 'upath';
+import upath from 'upath';
 import { logger } from '../../../../../logger';
 import type { PackageFile } from '../../../types';
 import type { NpmManagerData } from '../../types';
@@ -118,9 +118,9 @@ export async function getLockedVersions(
         lockFileCache[pnpmShrinkwrap] = await getPnpmLock(pnpmShrinkwrap);
       }
 
-      const packageDir = dirname(packageFile.packageFile);
-      const pnpmRootDir = dirname(pnpmShrinkwrap);
-      const relativeDir = relative(pnpmRootDir, packageDir) || '.';
+      const packageDir = upath.dirname(packageFile.packageFile);
+      const pnpmRootDir = upath.dirname(pnpmShrinkwrap);
+      const relativeDir = upath.relative(pnpmRootDir, packageDir) || '.';
 
       for (const dep of packageFile.deps) {
         const { depName, depType } = dep;

--- a/lib/modules/manager/nuget/artifacts.spec.ts
+++ b/lib/modules/manager/nuget/artifacts.spec.ts
@@ -1,4 +1,4 @@
-import { join } from 'upath';
+import upath from 'upath';
 import { mockDeep } from 'vitest-mock-extended';
 import { GlobalConfig } from '../../../config/global';
 import type { RepoGlobalConfig } from '../../../config/types';
@@ -20,9 +20,9 @@ process.env.CONTAINERBASE = 'true';
 
 const adminConfig: RepoGlobalConfig = {
   // `join` fixes Windows CI
-  localDir: join('/tmp/github/some/repo'),
-  cacheDir: join('/tmp/renovate/cache'),
-  containerbaseDir: join('/tmp/renovate/cache/containerbase'),
+  localDir: upath.join('/tmp/github/some/repo'),
+  cacheDir: upath.join('/tmp/renovate/cache'),
+  containerbaseDir: upath.join('/tmp/renovate/cache/containerbase'),
 };
 
 const config: UpdateArtifactsConfig = {};

--- a/lib/modules/manager/nuget/artifacts.ts
+++ b/lib/modules/manager/nuget/artifacts.ts
@@ -184,7 +184,7 @@ export async function updateArtifacts({
     return [
       {
         artifactError: {
-          lockFile: lockFileNames.upath.join(', '),
+          lockFile: lockFileNames.join(', '),
           // error is written to stdout
           stderr: err.stdout ?? err.message,
         },

--- a/lib/modules/manager/nuget/artifacts.ts
+++ b/lib/modules/manager/nuget/artifacts.ts
@@ -1,5 +1,5 @@
 import { quote } from 'shlex';
-import { join } from 'upath';
+import upath from 'upath';
 import { TEMPORARY_ERROR } from '../../../constants/error-messages';
 import { logger } from '../../../logger';
 import { exec } from '../../../util/exec';
@@ -40,7 +40,7 @@ async function createCachedNuGetConfigFile(
 
   const contents = createNuGetConfigXml(registries);
 
-  const cachedNugetConfigFile = join(nugetCacheDir, `nuget.config`);
+  const cachedNugetConfigFile = upath.join(nugetCacheDir, `nuget.config`);
   await ensureDir(nugetCacheDir);
   await outputCacheFile(cachedNugetConfigFile, contents);
 
@@ -52,7 +52,7 @@ async function runDotnetRestore(
   dependentPackageFileNames: string[],
   config: UpdateArtifactsConfig,
 ): Promise<void> {
-  const nugetCacheDir = join(privateCacheDir(), 'nuget');
+  const nugetCacheDir = upath.join(privateCacheDir(), 'nuget');
 
   const nugetConfigFile = await createCachedNuGetConfigFile(
     nugetCacheDir,
@@ -65,7 +65,7 @@ async function runDotnetRestore(
   const execOptions: ExecOptions = {
     docker: {},
     extraEnv: {
-      NUGET_PACKAGES: join(nugetCacheDir, 'packages'),
+      NUGET_PACKAGES: upath.join(nugetCacheDir, 'packages'),
       MSBUILDDISABLENODEREUSE: '1',
     },
     toolConstraints: [{ toolName: 'dotnet', constraint: dotnetVersion }],
@@ -184,7 +184,7 @@ export async function updateArtifacts({
     return [
       {
         artifactError: {
-          lockFile: lockFileNames.join(', '),
+          lockFile: lockFileNames.upath.join(', '),
           // error is written to stdout
           stderr: err.stdout ?? err.message,
         },

--- a/lib/modules/manager/pep621/artifacts.spec.ts
+++ b/lib/modules/manager/pep621/artifacts.spec.ts
@@ -1,5 +1,5 @@
 import { codeBlock } from 'common-tags';
-import { join } from 'upath';
+import upath from 'upath';
 import { mockDeep } from 'vitest-mock-extended';
 import { GlobalConfig } from '../../../config/global';
 import type { RepoGlobalConfig } from '../../../config/types';
@@ -16,9 +16,9 @@ const getPkgReleases = vi.mocked(_getPkgReleases);
 
 const config: UpdateArtifactsConfig = {};
 const adminConfig: RepoGlobalConfig = {
-  localDir: join('/tmp/github/some/repo'),
-  cacheDir: join('/tmp/cache'),
-  containerbaseDir: join('/tmp/cache/containerbase'),
+  localDir: upath.join('/tmp/github/some/repo'),
+  cacheDir: upath.join('/tmp/cache'),
+  containerbaseDir: upath.join('/tmp/cache/containerbase'),
 };
 
 describe('modules/manager/pep621/artifacts', () => {

--- a/lib/modules/manager/pep621/processors/pdm.spec.ts
+++ b/lib/modules/manager/pep621/processors/pdm.spec.ts
@@ -1,4 +1,4 @@
-import { join } from 'upath';
+import upath from 'upath';
 import { GlobalConfig } from '../../../../config/global';
 import type { RepoGlobalConfig } from '../../../../config/types';
 import { logger } from '../../../../logger';
@@ -17,9 +17,9 @@ const getPkgReleases = vi.mocked(_getPkgReleases);
 
 const config: UpdateArtifactsConfig = {};
 const adminConfig: RepoGlobalConfig = {
-  localDir: join('/tmp/github/some/repo'),
-  cacheDir: join('/tmp/cache'),
-  containerbaseDir: join('/tmp/cache/containerbase'),
+  localDir: upath.join('/tmp/github/some/repo'),
+  cacheDir: upath.join('/tmp/cache'),
+  containerbaseDir: upath.join('/tmp/cache/containerbase'),
 };
 
 const processor = new PdmProcessor();

--- a/lib/modules/manager/pep621/processors/uv.spec.ts
+++ b/lib/modules/manager/pep621/processors/uv.spec.ts
@@ -1,5 +1,5 @@
 import { GoogleAuth as _googleAuth } from 'google-auth-library';
-import { join } from 'upath';
+import upath from 'upath';
 import { GlobalConfig } from '../../../../config/global';
 import type { RepoGlobalConfig } from '../../../../config/types';
 import { getPkgReleases as _getPkgReleases } from '../../../datasource';
@@ -23,9 +23,9 @@ const getPkgReleases = vi.mocked(_getPkgReleases);
 
 const config: UpdateArtifactsConfig = {};
 const adminConfig: RepoGlobalConfig = {
-  localDir: join('/tmp/github/some/repo'),
-  cacheDir: join('/tmp/cache'),
-  containerbaseDir: join('/tmp/cache/containerbase'),
+  localDir: upath.join('/tmp/github/some/repo'),
+  cacheDir: upath.join('/tmp/cache'),
+  containerbaseDir: upath.join('/tmp/cache/containerbase'),
 };
 
 const processor = new UvProcessor();

--- a/lib/modules/manager/pip-compile/artifacts.spec.ts
+++ b/lib/modules/manager/pip-compile/artifacts.spec.ts
@@ -1,5 +1,5 @@
 import { codeBlock } from 'common-tags';
-import { join } from 'upath';
+import upath from 'upath';
 import { mockDeep } from 'vitest-mock-extended';
 import { GlobalConfig } from '../../../config/global';
 import type { RepoGlobalConfig } from '../../../config/types';
@@ -55,9 +55,9 @@ const simpleHeader = getCommandInHeader('pip-compile requirements.in');
 
 const adminConfig: RepoGlobalConfig = {
   // `join` fixes Windows CI
-  localDir: join('/tmp/github/some/repo'),
-  cacheDir: join('/tmp/renovate/cache'),
-  containerbaseDir: join('/tmp/renovate/cache/containerbase'),
+  localDir: upath.join('/tmp/github/some/repo'),
+  cacheDir: upath.join('/tmp/renovate/cache'),
+  containerbaseDir: upath.join('/tmp/renovate/cache/containerbase'),
 };
 const dockerAdminConfig = {
   ...adminConfig,

--- a/lib/modules/manager/pip-compile/extract.spec.ts
+++ b/lib/modules/manager/pip-compile/extract.spec.ts
@@ -1,4 +1,4 @@
-import { join } from 'upath';
+import upath from 'upath';
 import { GlobalConfig } from '../../../config/global';
 import type { RepoGlobalConfig } from '../../../config/types';
 import { logger } from '../../../logger';
@@ -10,9 +10,9 @@ vi.mock('../../../util/fs');
 
 const adminConfig: RepoGlobalConfig = {
   // `join` fixes Windows CI
-  localDir: join('/tmp/github/some/repo'),
-  cacheDir: join('/tmp/renovate/cache'),
-  containerbaseDir: join('/tmp/renovate/cache/containerbase'),
+  localDir: upath.join('/tmp/github/some/repo'),
+  cacheDir: upath.join('/tmp/renovate/cache'),
+  containerbaseDir: upath.join('/tmp/renovate/cache/containerbase'),
 };
 
 function getSimpleRequirementsFile(command: string, deps: string[] = []) {
@@ -23,7 +23,7 @@ function getSimpleRequirementsFile(command: string, deps: string[] = []) {
 #    ${command}
 #
 
-${deps.join('\n')}`;
+${deps.upath.join('\n')}`;
 }
 
 describe('modules/manager/pip-compile/extract', () => {

--- a/lib/modules/manager/pip-compile/extract.spec.ts
+++ b/lib/modules/manager/pip-compile/extract.spec.ts
@@ -23,7 +23,7 @@ function getSimpleRequirementsFile(command: string, deps: string[] = []) {
 #    ${command}
 #
 
-${deps.upath.join('\n')}`;
+${deps.join('\n')}`;
 }
 
 describe('modules/manager/pip-compile/extract', () => {

--- a/lib/modules/manager/pip_requirements/artifacts.spec.ts
+++ b/lib/modules/manager/pip_requirements/artifacts.spec.ts
@@ -1,4 +1,4 @@
-import { join } from 'upath';
+import upath from 'upath';
 import { mockDeep } from 'vitest-mock-extended';
 import { GlobalConfig } from '../../../config/global';
 import type { RepoGlobalConfig } from '../../../config/types';
@@ -18,9 +18,9 @@ process.env.CONTAINERBASE = 'true';
 
 const adminConfig: RepoGlobalConfig = {
   // `join` fixes Windows CI
-  localDir: join('/tmp/github/some/repo'),
-  cacheDir: join('/tmp/renovate/cache'),
-  containerbaseDir: join('/tmp/renovate/cache/containerbase'),
+  localDir: upath.join('/tmp/github/some/repo'),
+  cacheDir: upath.join('/tmp/renovate/cache'),
+  containerbaseDir: upath.join('/tmp/renovate/cache/containerbase'),
 };
 
 const config: UpdateArtifactsConfig = {

--- a/lib/modules/manager/pipenv/artifacts.spec.ts
+++ b/lib/modules/manager/pipenv/artifacts.spec.ts
@@ -1,5 +1,5 @@
 import * as _fsExtra from 'fs-extra';
-import { join } from 'upath';
+import upath from 'upath';
 import { mockDeep } from 'vitest-mock-extended';
 import { GlobalConfig } from '../../../config/global';
 import type { RepoGlobalConfig } from '../../../config/types';
@@ -43,9 +43,9 @@ process.env.CONTAINERBASE = 'true';
 
 const adminConfig: RepoGlobalConfig = {
   // `join` fixes Windows CI
-  localDir: join(join('/tmp/github/some/repo')),
-  cacheDir: join(join('/tmp/renovate/cache')),
-  containerbaseDir: join(join('/tmp/renovate/cache/containerbase')),
+  localDir: upath.join(upath.join('/tmp/github/some/repo')),
+  cacheDir: upath.join(upath.join('/tmp/renovate/cache')),
+  containerbaseDir: upath.join(upath.join('/tmp/renovate/cache/containerbase')),
 };
 const dockerAdminConfig = {
   ...adminConfig,
@@ -55,9 +55,11 @@ const dockerAdminConfig = {
 
 const config: UpdateArtifactsConfig = {};
 const lockMaintenanceConfig = { ...config, isLockFileMaintenance: true };
-const pipenvCacheDir = join('/tmp/renovate/cache/others/pipenv');
-const pipCacheDir = join('/tmp/renovate/cache/others/pip');
-const virtualenvsCacheDir = join('/tmp/renovate/cache/others/virtualenvs');
+const pipenvCacheDir = upath.join('/tmp/renovate/cache/others/pipenv');
+const pipCacheDir = upath.join('/tmp/renovate/cache/others/pip');
+const virtualenvsCacheDir = upath.join(
+  '/tmp/renovate/cache/others/virtualenvs',
+);
 
 type MockFiles = Record<string, string | string[]>;
 
@@ -151,7 +153,7 @@ describe('modules/manager/pipenv/artifacts', () => {
       {
         cmd: 'pipenv lock',
         options: {
-          cwd: join('/tmp/github/some/repo'),
+          cwd: upath.join('/tmp/github/some/repo'),
           env: {
             PIPENV_CACHE_DIR: pipenvCacheDir,
           },
@@ -160,15 +162,21 @@ describe('modules/manager/pipenv/artifacts', () => {
     ]);
 
     expect(fsExtra.ensureDir.mock.calls).toEqual([
-      [expect.toEndWith(join('/tmp/renovate/cache/others/pipenv'))],
-      [expect.toEndWith(join('/tmp/renovate/cache/others/pip'))],
-      [expect.toEndWith(join('/tmp/renovate/cache/others/virtualenvs'))],
+      [expect.toEndWith(upath.join('/tmp/renovate/cache/others/pipenv'))],
+      [expect.toEndWith(upath.join('/tmp/renovate/cache/others/pip'))],
+      [expect.toEndWith(upath.join('/tmp/renovate/cache/others/virtualenvs'))],
     ]);
     expect(fsExtra.readFile.mock.calls).toEqual([
-      [expect.toEndWith(join('/tmp/github/some/repo/Pipfile')), 'utf8'],
-      [expect.toEndWith(join('/tmp/github/some/repo/Pipfile.lock')), 'utf8'],
-      [expect.toEndWith(join('/tmp/github/some/repo/Pipfile')), 'utf8'],
-      [expect.toEndWith(join('/tmp/github/some/repo/Pipfile.lock')), 'utf8'],
+      [expect.toEndWith(upath.join('/tmp/github/some/repo/Pipfile')), 'utf8'],
+      [
+        expect.toEndWith(upath.join('/tmp/github/some/repo/Pipfile.lock')),
+        'utf8',
+      ],
+      [expect.toEndWith(upath.join('/tmp/github/some/repo/Pipfile')), 'utf8'],
+      [
+        expect.toEndWith(upath.join('/tmp/github/some/repo/Pipfile.lock')),
+        'utf8',
+      ],
     ]);
   });
 
@@ -204,7 +212,7 @@ describe('modules/manager/pipenv/artifacts', () => {
       {
         cmd: 'pipenv lock',
         options: {
-          cwd: join('/tmp/github/some/repo'),
+          cwd: upath.join('/tmp/github/some/repo'),
           env: {
             PIPENV_CACHE_DIR: pipenvCacheDir,
           },
@@ -213,15 +221,15 @@ describe('modules/manager/pipenv/artifacts', () => {
     ]);
 
     expect(fsExtra.ensureDir.mock.calls).toEqual([
-      [expect.toEndWith(join('/tmp/renovate/cache/others/pipenv'))],
-      [expect.toEndWith(join('/tmp/renovate/cache/others/pip'))],
-      [expect.toEndWith(join('/tmp/renovate/cache/others/virtualenvs'))],
+      [expect.toEndWith(upath.join('/tmp/renovate/cache/others/pipenv'))],
+      [expect.toEndWith(upath.join('/tmp/renovate/cache/others/pip'))],
+      [expect.toEndWith(upath.join('/tmp/renovate/cache/others/virtualenvs'))],
     ]);
     expect(fsExtra.readFile.mock.calls).toEqual([
-      [expect.toEndWith(join('/tmp/github/some/repo/Pipfile')), 'utf8'],
-      [expect.toEndWith(join('/tmp/github/some/repo/Pipfile')), 'utf8'],
-      [expect.toEndWith(join('/tmp/github/some/repo/Pipfile')), 'utf8'],
-      [expect.toEndWith(join('/tmp/github/some/repo/Pipfile')), 'utf8'],
+      [expect.toEndWith(upath.join('/tmp/github/some/repo/Pipfile')), 'utf8'],
+      [expect.toEndWith(upath.join('/tmp/github/some/repo/Pipfile')), 'utf8'],
+      [expect.toEndWith(upath.join('/tmp/github/some/repo/Pipfile')), 'utf8'],
+      [expect.toEndWith(upath.join('/tmp/github/some/repo/Pipfile')), 'utf8'],
     ]);
   });
 
@@ -257,7 +265,7 @@ describe('modules/manager/pipenv/artifacts', () => {
       {
         cmd: 'pipenv lock',
         options: {
-          cwd: join('/tmp/github/some/repo'),
+          cwd: upath.join('/tmp/github/some/repo'),
           env: {
             PIPENV_CACHE_DIR: pipenvCacheDir,
           },
@@ -266,15 +274,15 @@ describe('modules/manager/pipenv/artifacts', () => {
     ]);
 
     expect(fsExtra.ensureDir.mock.calls).toEqual([
-      [expect.toEndWith(join('/tmp/renovate/cache/others/pipenv'))],
-      [expect.toEndWith(join('/tmp/renovate/cache/others/pip'))],
-      [expect.toEndWith(join('/tmp/renovate/cache/others/virtualenvs'))],
+      [expect.toEndWith(upath.join('/tmp/renovate/cache/others/pipenv'))],
+      [expect.toEndWith(upath.join('/tmp/renovate/cache/others/pip'))],
+      [expect.toEndWith(upath.join('/tmp/renovate/cache/others/virtualenvs'))],
     ]);
     expect(fsExtra.readFile.mock.calls).toEqual([
-      [expect.toEndWith(join('/tmp/github/some/repo/Pipfile')), 'utf8'],
-      [expect.toEndWith(join('/tmp/github/some/repo/Pipfile')), 'utf8'],
-      [expect.toEndWith(join('/tmp/github/some/repo/Pipfile')), 'utf8'],
-      [expect.toEndWith(join('/tmp/github/some/repo/Pipfile')), 'utf8'],
+      [expect.toEndWith(upath.join('/tmp/github/some/repo/Pipfile')), 'utf8'],
+      [expect.toEndWith(upath.join('/tmp/github/some/repo/Pipfile')), 'utf8'],
+      [expect.toEndWith(upath.join('/tmp/github/some/repo/Pipfile')), 'utf8'],
+      [expect.toEndWith(upath.join('/tmp/github/some/repo/Pipfile')), 'utf8'],
     ]);
   });
 
@@ -306,7 +314,7 @@ describe('modules/manager/pipenv/artifacts', () => {
       {
         cmd: 'pipenv lock',
         options: {
-          cwd: join('/tmp/github/some/repo'),
+          cwd: upath.join('/tmp/github/some/repo'),
           env: {
             PIPENV_CACHE_DIR: pipenvCacheDir,
           },
@@ -315,16 +323,25 @@ describe('modules/manager/pipenv/artifacts', () => {
     ]);
 
     expect(fsExtra.ensureDir.mock.calls).toEqual([
-      [expect.toEndWith(join('/tmp/renovate/cache/others/pipenv'))],
-      [expect.toEndWith(join('/tmp/renovate/cache/others/pip'))],
-      [expect.toEndWith(join('/tmp/renovate/cache/others/virtualenvs'))],
+      [expect.toEndWith(upath.join('/tmp/renovate/cache/others/pipenv'))],
+      [expect.toEndWith(upath.join('/tmp/renovate/cache/others/pip'))],
+      [expect.toEndWith(upath.join('/tmp/renovate/cache/others/virtualenvs'))],
     ]);
     expect(fsExtra.readFile.mock.calls).toEqual([
-      [expect.toEndWith(join('/tmp/github/some/repo/Pipfile')), 'utf8'],
-      [expect.toEndWith(join('/tmp/github/some/repo/Pipfile.lock')), 'utf8'],
-      [expect.toEndWith(join('/tmp/github/some/repo/.python-version')), 'utf8'],
-      [expect.toEndWith(join('/tmp/github/some/repo/Pipfile')), 'utf8'],
-      [expect.toEndWith(join('/tmp/github/some/repo/Pipfile.lock')), 'utf8'],
+      [expect.toEndWith(upath.join('/tmp/github/some/repo/Pipfile')), 'utf8'],
+      [
+        expect.toEndWith(upath.join('/tmp/github/some/repo/Pipfile.lock')),
+        'utf8',
+      ],
+      [
+        expect.toEndWith(upath.join('/tmp/github/some/repo/.python-version')),
+        'utf8',
+      ],
+      [expect.toEndWith(upath.join('/tmp/github/some/repo/Pipfile')), 'utf8'],
+      [
+        expect.toEndWith(upath.join('/tmp/github/some/repo/Pipfile.lock')),
+        'utf8',
+      ],
     ]);
   });
 
@@ -355,7 +372,7 @@ describe('modules/manager/pipenv/artifacts', () => {
       {
         cmd: 'pipenv lock',
         options: {
-          cwd: join('/tmp/github/some/repo'),
+          cwd: upath.join('/tmp/github/some/repo'),
           env: {
             PIPENV_CACHE_DIR: pipenvCacheDir,
           },
@@ -364,16 +381,25 @@ describe('modules/manager/pipenv/artifacts', () => {
     ]);
 
     expect(fsExtra.ensureDir.mock.calls).toEqual([
-      [expect.toEndWith(join('/tmp/renovate/cache/others/pipenv'))],
-      [expect.toEndWith(join('/tmp/renovate/cache/others/pip'))],
-      [expect.toEndWith(join('/tmp/renovate/cache/others/virtualenvs'))],
+      [expect.toEndWith(upath.join('/tmp/renovate/cache/others/pipenv'))],
+      [expect.toEndWith(upath.join('/tmp/renovate/cache/others/pip'))],
+      [expect.toEndWith(upath.join('/tmp/renovate/cache/others/virtualenvs'))],
     ]);
     expect(fsExtra.readFile.mock.calls).toEqual([
-      [expect.toEndWith(join('/tmp/github/some/repo/Pipfile')), 'utf8'],
-      [expect.toEndWith(join('/tmp/github/some/repo/Pipfile.lock')), 'utf8'],
-      [expect.toEndWith(join('/tmp/github/some/repo/.python-version')), 'utf8'],
-      [expect.toEndWith(join('/tmp/github/some/repo/Pipfile')), 'utf8'],
-      [expect.toEndWith(join('/tmp/github/some/repo/Pipfile.lock')), 'utf8'],
+      [expect.toEndWith(upath.join('/tmp/github/some/repo/Pipfile')), 'utf8'],
+      [
+        expect.toEndWith(upath.join('/tmp/github/some/repo/Pipfile.lock')),
+        'utf8',
+      ],
+      [
+        expect.toEndWith(upath.join('/tmp/github/some/repo/.python-version')),
+        'utf8',
+      ],
+      [expect.toEndWith(upath.join('/tmp/github/some/repo/Pipfile')), 'utf8'],
+      [
+        expect.toEndWith(upath.join('/tmp/github/some/repo/Pipfile.lock')),
+        'utf8',
+      ],
     ]);
   });
 
@@ -400,7 +426,7 @@ describe('modules/manager/pipenv/artifacts', () => {
       {
         cmd: 'pipenv lock',
         options: {
-          cwd: join('/tmp/github/some/repo'),
+          cwd: upath.join('/tmp/github/some/repo'),
           env: {
             PIPENV_CACHE_DIR: pipenvCacheDir,
             PIP_CACHE_DIR: pipCacheDir,
@@ -411,16 +437,25 @@ describe('modules/manager/pipenv/artifacts', () => {
     ]);
 
     expect(fsExtra.ensureDir.mock.calls).toEqual([
-      [expect.toEndWith(join('/tmp/renovate/cache/others/pipenv'))],
-      [expect.toEndWith(join('/tmp/renovate/cache/others/pip'))],
-      [expect.toEndWith(join('/tmp/renovate/cache/others/virtualenvs'))],
+      [expect.toEndWith(upath.join('/tmp/renovate/cache/others/pipenv'))],
+      [expect.toEndWith(upath.join('/tmp/renovate/cache/others/pip'))],
+      [expect.toEndWith(upath.join('/tmp/renovate/cache/others/virtualenvs'))],
     ]);
     expect(fsExtra.readFile.mock.calls).toEqual([
-      [expect.toEndWith(join('/tmp/github/some/repo/Pipfile')), 'utf8'],
-      [expect.toEndWith(join('/tmp/github/some/repo/Pipfile.lock')), 'utf8'],
-      [expect.toEndWith(join('/tmp/github/some/repo/.python-version')), 'utf8'],
-      [expect.toEndWith(join('/tmp/github/some/repo/Pipfile')), 'utf8'],
-      [expect.toEndWith(join('/tmp/github/some/repo/Pipfile.lock')), 'utf8'],
+      [expect.toEndWith(upath.join('/tmp/github/some/repo/Pipfile')), 'utf8'],
+      [
+        expect.toEndWith(upath.join('/tmp/github/some/repo/Pipfile.lock')),
+        'utf8',
+      ],
+      [
+        expect.toEndWith(upath.join('/tmp/github/some/repo/.python-version')),
+        'utf8',
+      ],
+      [expect.toEndWith(upath.join('/tmp/github/some/repo/Pipfile')), 'utf8'],
+      [
+        expect.toEndWith(upath.join('/tmp/github/some/repo/Pipfile.lock')),
+        'utf8',
+      ],
     ]);
   });
 
@@ -459,7 +494,7 @@ describe('modules/manager/pipenv/artifacts', () => {
       {
         cmd: 'pipenv lock',
         options: {
-          cwd: join('/tmp/github/some/repo'),
+          cwd: upath.join('/tmp/github/some/repo'),
           env: {
             PIPENV_CACHE_DIR: pipenvCacheDir,
             PIP_CACHE_DIR: pipCacheDir,
@@ -470,14 +505,20 @@ describe('modules/manager/pipenv/artifacts', () => {
     ]);
 
     expect(fsExtra.ensureDir.mock.calls).toEqual([
-      [expect.toEndWith(join('/tmp/renovate/cache/others/pipenv'))],
-      [expect.toEndWith(join('/tmp/renovate/cache/others/pip'))],
-      [expect.toEndWith(join('/tmp/renovate/cache/others/virtualenvs'))],
+      [expect.toEndWith(upath.join('/tmp/renovate/cache/others/pipenv'))],
+      [expect.toEndWith(upath.join('/tmp/renovate/cache/others/pip'))],
+      [expect.toEndWith(upath.join('/tmp/renovate/cache/others/virtualenvs'))],
     ]);
     expect(fsExtra.readFile.mock.calls).toEqual([
-      [expect.toEndWith(join('/tmp/github/some/repo/Pipfile')), 'utf8'],
-      [expect.toEndWith(join('/tmp/github/some/repo/Pipfile.lock')), 'utf8'],
-      [expect.toEndWith(join('/tmp/github/some/repo/Pipfile.lock')), 'utf8'],
+      [expect.toEndWith(upath.join('/tmp/github/some/repo/Pipfile')), 'utf8'],
+      [
+        expect.toEndWith(upath.join('/tmp/github/some/repo/Pipfile.lock')),
+        'utf8',
+      ],
+      [
+        expect.toEndWith(upath.join('/tmp/github/some/repo/Pipfile.lock')),
+        'utf8',
+      ],
     ]);
   });
 
@@ -536,7 +577,7 @@ describe('modules/manager/pipenv/artifacts', () => {
           'pipenv lock' +
           '"',
         options: {
-          cwd: join('/tmp/github/some/repo'),
+          cwd: upath.join('/tmp/github/some/repo'),
           env: {
             PIPENV_CACHE_DIR: pipenvCacheDir,
             PIP_CACHE_DIR: pipCacheDir,
@@ -547,16 +588,25 @@ describe('modules/manager/pipenv/artifacts', () => {
     ]);
 
     expect(fsExtra.ensureDir.mock.calls).toEqual([
-      [expect.toEndWith(join('/tmp/renovate/cache/others/pipenv'))],
-      [expect.toEndWith(join('/tmp/renovate/cache/others/pip'))],
-      [expect.toEndWith(join('/tmp/renovate/cache/others/virtualenvs'))],
+      [expect.toEndWith(upath.join('/tmp/renovate/cache/others/pipenv'))],
+      [expect.toEndWith(upath.join('/tmp/renovate/cache/others/pip'))],
+      [expect.toEndWith(upath.join('/tmp/renovate/cache/others/virtualenvs'))],
     ]);
     expect(fsExtra.readFile.mock.calls).toEqual([
-      [expect.toEndWith(join('/tmp/github/some/repo/Pipfile')), 'utf8'],
-      [expect.toEndWith(join('/tmp/github/some/repo/Pipfile.lock')), 'utf8'],
-      [expect.toEndWith(join('/tmp/github/some/repo/Pipfile')), 'utf8'],
-      [expect.toEndWith(join('/tmp/github/some/repo/Pipfile.lock')), 'utf8'],
-      [expect.toEndWith(join('/tmp/github/some/repo/Pipfile.lock')), 'utf8'],
+      [expect.toEndWith(upath.join('/tmp/github/some/repo/Pipfile')), 'utf8'],
+      [
+        expect.toEndWith(upath.join('/tmp/github/some/repo/Pipfile.lock')),
+        'utf8',
+      ],
+      [expect.toEndWith(upath.join('/tmp/github/some/repo/Pipfile')), 'utf8'],
+      [
+        expect.toEndWith(upath.join('/tmp/github/some/repo/Pipfile.lock')),
+        'utf8',
+      ],
+      [
+        expect.toEndWith(upath.join('/tmp/github/some/repo/Pipfile.lock')),
+        'utf8',
+      ],
     ]);
   });
 
@@ -599,7 +649,7 @@ describe('modules/manager/pipenv/artifacts', () => {
       {
         cmd: 'pipenv lock',
         options: {
-          cwd: join('/tmp/github/some/repo'),
+          cwd: upath.join('/tmp/github/some/repo'),
           env: {
             PIPENV_CACHE_DIR: pipenvCacheDir,
             PIP_CACHE_DIR: pipCacheDir,
@@ -610,16 +660,25 @@ describe('modules/manager/pipenv/artifacts', () => {
     ]);
 
     expect(fsExtra.ensureDir.mock.calls).toEqual([
-      [expect.toEndWith(join('/tmp/renovate/cache/others/pipenv'))],
-      [expect.toEndWith(join('/tmp/renovate/cache/others/pip'))],
-      [expect.toEndWith(join('/tmp/renovate/cache/others/virtualenvs'))],
+      [expect.toEndWith(upath.join('/tmp/renovate/cache/others/pipenv'))],
+      [expect.toEndWith(upath.join('/tmp/renovate/cache/others/pip'))],
+      [expect.toEndWith(upath.join('/tmp/renovate/cache/others/virtualenvs'))],
     ]);
     expect(fsExtra.readFile.mock.calls).toEqual([
-      [expect.toEndWith(join('/tmp/github/some/repo/Pipfile')), 'utf8'],
-      [expect.toEndWith(join('/tmp/github/some/repo/Pipfile.lock')), 'utf8'],
-      [expect.toEndWith(join('/tmp/github/some/repo/Pipfile')), 'utf8'],
-      [expect.toEndWith(join('/tmp/github/some/repo/Pipfile.lock')), 'utf8'],
-      [expect.toEndWith(join('/tmp/github/some/repo/Pipfile.lock')), 'utf8'],
+      [expect.toEndWith(upath.join('/tmp/github/some/repo/Pipfile')), 'utf8'],
+      [
+        expect.toEndWith(upath.join('/tmp/github/some/repo/Pipfile.lock')),
+        'utf8',
+      ],
+      [expect.toEndWith(upath.join('/tmp/github/some/repo/Pipfile')), 'utf8'],
+      [
+        expect.toEndWith(upath.join('/tmp/github/some/repo/Pipfile.lock')),
+        'utf8',
+      ],
+      [
+        expect.toEndWith(upath.join('/tmp/github/some/repo/Pipfile.lock')),
+        'utf8',
+      ],
     ]);
   });
 
@@ -658,7 +717,7 @@ describe('modules/manager/pipenv/artifacts', () => {
       {
         cmd: 'pipenv lock',
         options: {
-          cwd: join('/tmp/github/some/repo'),
+          cwd: upath.join('/tmp/github/some/repo'),
           env: {
             PIPENV_CACHE_DIR: pipenvCacheDir,
             PIP_CACHE_DIR: pipCacheDir,
@@ -669,17 +728,29 @@ describe('modules/manager/pipenv/artifacts', () => {
     ]);
 
     expect(fsExtra.ensureDir.mock.calls).toEqual([
-      [expect.toEndWith(join('/tmp/renovate/cache/others/pipenv'))],
-      [expect.toEndWith(join('/tmp/renovate/cache/others/pip'))],
-      [expect.toEndWith(join('/tmp/renovate/cache/others/virtualenvs'))],
+      [expect.toEndWith(upath.join('/tmp/renovate/cache/others/pipenv'))],
+      [expect.toEndWith(upath.join('/tmp/renovate/cache/others/pip'))],
+      [expect.toEndWith(upath.join('/tmp/renovate/cache/others/virtualenvs'))],
     ]);
     expect(fsExtra.readFile.mock.calls).toEqual([
-      [expect.toEndWith(join('/tmp/github/some/repo/Pipfile')), 'utf8'],
-      [expect.toEndWith(join('/tmp/github/some/repo/Pipfile.lock')), 'utf8'],
-      [expect.toEndWith(join('/tmp/github/some/repo/.python-version')), 'utf8'],
-      [expect.toEndWith(join('/tmp/github/some/repo/Pipfile')), 'utf8'],
-      [expect.toEndWith(join('/tmp/github/some/repo/Pipfile.lock')), 'utf8'],
-      [expect.toEndWith(join('/tmp/github/some/repo/Pipfile.lock')), 'utf8'],
+      [expect.toEndWith(upath.join('/tmp/github/some/repo/Pipfile')), 'utf8'],
+      [
+        expect.toEndWith(upath.join('/tmp/github/some/repo/Pipfile.lock')),
+        'utf8',
+      ],
+      [
+        expect.toEndWith(upath.join('/tmp/github/some/repo/.python-version')),
+        'utf8',
+      ],
+      [expect.toEndWith(upath.join('/tmp/github/some/repo/Pipfile')), 'utf8'],
+      [
+        expect.toEndWith(upath.join('/tmp/github/some/repo/Pipfile.lock')),
+        'utf8',
+      ],
+      [
+        expect.toEndWith(upath.join('/tmp/github/some/repo/Pipfile.lock')),
+        'utf8',
+      ],
     ]);
   });
 
@@ -747,7 +818,7 @@ describe('modules/manager/pipenv/artifacts', () => {
       {
         cmd: 'pipenv lock',
         options: {
-          cwd: join('/tmp/github/some/repo'),
+          cwd: upath.join('/tmp/github/some/repo'),
           env: {
             PIPENV_CACHE_DIR: pipenvCacheDir,
             PIP_CACHE_DIR: pipCacheDir,
@@ -809,7 +880,7 @@ describe('modules/manager/pipenv/artifacts', () => {
           'pipenv lock' +
           '"',
         options: {
-          cwd: join('/tmp/github/some/repo'),
+          cwd: upath.join('/tmp/github/some/repo'),
           env: {
             PIPENV_CACHE_DIR: pipenvCacheDir,
             WORKON_HOME: virtualenvsCacheDir,
@@ -819,17 +890,29 @@ describe('modules/manager/pipenv/artifacts', () => {
     ]);
 
     expect(fsExtra.ensureDir.mock.calls).toEqual([
-      [expect.toEndWith(join('/tmp/renovate/cache/others/pipenv'))],
-      [expect.toEndWith(join('/tmp/renovate/cache/others/pip'))],
-      [expect.toEndWith(join('/tmp/renovate/cache/others/virtualenvs'))],
+      [expect.toEndWith(upath.join('/tmp/renovate/cache/others/pipenv'))],
+      [expect.toEndWith(upath.join('/tmp/renovate/cache/others/pip'))],
+      [expect.toEndWith(upath.join('/tmp/renovate/cache/others/virtualenvs'))],
     ]);
     expect(fsExtra.readFile.mock.calls).toEqual([
-      [expect.toEndWith(join('/tmp/github/some/repo/Pipfile')), 'utf8'],
-      [expect.toEndWith(join('/tmp/github/some/repo/Pipfile.lock')), 'utf8'],
-      [expect.toEndWith(join('/tmp/github/some/repo/.python-version')), 'utf8'],
-      [expect.toEndWith(join('/tmp/github/some/repo/Pipfile')), 'utf8'],
-      [expect.toEndWith(join('/tmp/github/some/repo/Pipfile.lock')), 'utf8'],
-      [expect.toEndWith(join('/tmp/github/some/repo/Pipfile.lock')), 'utf8'],
+      [expect.toEndWith(upath.join('/tmp/github/some/repo/Pipfile')), 'utf8'],
+      [
+        expect.toEndWith(upath.join('/tmp/github/some/repo/Pipfile.lock')),
+        'utf8',
+      ],
+      [
+        expect.toEndWith(upath.join('/tmp/github/some/repo/.python-version')),
+        'utf8',
+      ],
+      [expect.toEndWith(upath.join('/tmp/github/some/repo/Pipfile')), 'utf8'],
+      [
+        expect.toEndWith(upath.join('/tmp/github/some/repo/Pipfile.lock')),
+        'utf8',
+      ],
+      [
+        expect.toEndWith(upath.join('/tmp/github/some/repo/Pipfile.lock')),
+        'utf8',
+      ],
     ]);
   });
 
@@ -884,7 +967,7 @@ describe('modules/manager/pipenv/artifacts', () => {
           'pipenv lock' +
           '"',
         options: {
-          cwd: join('/tmp/github/some/repo'),
+          cwd: upath.join('/tmp/github/some/repo'),
           env: {
             PIPENV_CACHE_DIR: pipenvCacheDir,
             WORKON_HOME: virtualenvsCacheDir,
@@ -894,17 +977,29 @@ describe('modules/manager/pipenv/artifacts', () => {
     ]);
 
     expect(fsExtra.ensureDir.mock.calls).toEqual([
-      [expect.toEndWith(join('/tmp/renovate/cache/others/pipenv'))],
-      [expect.toEndWith(join('/tmp/renovate/cache/others/pip'))],
-      [expect.toEndWith(join('/tmp/renovate/cache/others/virtualenvs'))],
+      [expect.toEndWith(upath.join('/tmp/renovate/cache/others/pipenv'))],
+      [expect.toEndWith(upath.join('/tmp/renovate/cache/others/pip'))],
+      [expect.toEndWith(upath.join('/tmp/renovate/cache/others/virtualenvs'))],
     ]);
     expect(fsExtra.readFile.mock.calls).toEqual([
-      [expect.toEndWith(join('/tmp/github/some/repo/Pipfile')), 'utf8'],
-      [expect.toEndWith(join('/tmp/github/some/repo/Pipfile.lock')), 'utf8'],
-      [expect.toEndWith(join('/tmp/github/some/repo/.python-version')), 'utf8'],
-      [expect.toEndWith(join('/tmp/github/some/repo/Pipfile')), 'utf8'],
-      [expect.toEndWith(join('/tmp/github/some/repo/Pipfile.lock')), 'utf8'],
-      [expect.toEndWith(join('/tmp/github/some/repo/Pipfile.lock')), 'utf8'],
+      [expect.toEndWith(upath.join('/tmp/github/some/repo/Pipfile')), 'utf8'],
+      [
+        expect.toEndWith(upath.join('/tmp/github/some/repo/Pipfile.lock')),
+        'utf8',
+      ],
+      [
+        expect.toEndWith(upath.join('/tmp/github/some/repo/.python-version')),
+        'utf8',
+      ],
+      [expect.toEndWith(upath.join('/tmp/github/some/repo/Pipfile')), 'utf8'],
+      [
+        expect.toEndWith(upath.join('/tmp/github/some/repo/Pipfile.lock')),
+        'utf8',
+      ],
+      [
+        expect.toEndWith(upath.join('/tmp/github/some/repo/Pipfile.lock')),
+        'utf8',
+      ],
     ]);
   });
 
@@ -958,7 +1053,7 @@ describe('modules/manager/pipenv/artifacts', () => {
           'pipenv lock' +
           '"',
         options: {
-          cwd: join('/tmp/github/some/repo'),
+          cwd: upath.join('/tmp/github/some/repo'),
           env: {
             PIPENV_CACHE_DIR: pipenvCacheDir,
             WORKON_HOME: virtualenvsCacheDir,
@@ -968,15 +1063,24 @@ describe('modules/manager/pipenv/artifacts', () => {
     ]);
 
     expect(fsExtra.ensureDir.mock.calls).toEqual([
-      [expect.toEndWith(join('/tmp/renovate/cache/others/pipenv'))],
-      [expect.toEndWith(join('/tmp/renovate/cache/others/pip'))],
-      [expect.toEndWith(join('/tmp/renovate/cache/others/virtualenvs'))],
+      [expect.toEndWith(upath.join('/tmp/renovate/cache/others/pipenv'))],
+      [expect.toEndWith(upath.join('/tmp/renovate/cache/others/pip'))],
+      [expect.toEndWith(upath.join('/tmp/renovate/cache/others/virtualenvs'))],
     ]);
     expect(fsExtra.readFile.mock.calls).toEqual([
-      [expect.toEndWith(join('/tmp/github/some/repo/Pipfile')), 'utf8'],
-      [expect.toEndWith(join('/tmp/github/some/repo/Pipfile.lock')), 'utf8'],
-      [expect.toEndWith(join('/tmp/github/some/repo/.python-version')), 'utf8'],
-      [expect.toEndWith(join('/tmp/github/some/repo/Pipfile.lock')), 'utf8'],
+      [expect.toEndWith(upath.join('/tmp/github/some/repo/Pipfile')), 'utf8'],
+      [
+        expect.toEndWith(upath.join('/tmp/github/some/repo/Pipfile.lock')),
+        'utf8',
+      ],
+      [
+        expect.toEndWith(upath.join('/tmp/github/some/repo/.python-version')),
+        'utf8',
+      ],
+      [
+        expect.toEndWith(upath.join('/tmp/github/some/repo/Pipfile.lock')),
+        'utf8',
+      ],
     ]);
   });
 
@@ -1021,7 +1125,7 @@ describe('modules/manager/pipenv/artifacts', () => {
       {
         cmd: 'pipenv lock',
         options: {
-          cwd: join('/tmp/github/some/repo'),
+          cwd: upath.join('/tmp/github/some/repo'),
           env: {
             PIPENV_CACHE_DIR: pipenvCacheDir,
             WORKON_HOME: virtualenvsCacheDir,
@@ -1098,7 +1202,7 @@ describe('modules/manager/pipenv/artifacts', () => {
       {
         cmd: 'pipenv lock',
         options: {
-          cwd: join('/tmp/github/some/repo'),
+          cwd: upath.join('/tmp/github/some/repo'),
           env: {
             PIPENV_CACHE_DIR: pipenvCacheDir,
             WORKON_HOME: virtualenvsCacheDir,

--- a/lib/modules/manager/pipenv/extract.spec.ts
+++ b/lib/modules/manager/pipenv/extract.spec.ts
@@ -1,6 +1,6 @@
 import { codeBlock } from 'common-tags';
 import * as _fsExtra from 'fs-extra';
-import { join } from 'upath';
+import upath from 'upath';
 import { GlobalConfig } from '../../../config/global';
 import { extractPackageFile } from '.';
 import { Fixtures } from '~test/fixtures';
@@ -29,7 +29,7 @@ describe('modules/manager/pipenv/extract', () => {
   beforeEach(() => {
     Fixtures.reset();
     GlobalConfig.set({
-      localDir: join(localDir),
+      localDir: upath.join(localDir),
     });
   });
 

--- a/lib/modules/manager/pixi/artifacts.spec.ts
+++ b/lib/modules/manager/pixi/artifacts.spec.ts
@@ -1,5 +1,5 @@
 import { codeBlock } from 'common-tags';
-import { join } from 'upath';
+import upath from 'upath';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { mockDeep } from 'vitest-mock-extended';
 import { GlobalConfig } from '../../../config/global';
@@ -50,9 +50,9 @@ process.env.CONTAINERBASE = 'true';
 const datasource = vi.mocked(_datasource);
 
 const adminConfig: RepoGlobalConfig = {
-  localDir: join('/tmp/github/some/repo'),
-  cacheDir: join('/tmp/cache'),
-  containerbaseDir: join('/tmp/cache/containerbase'),
+  localDir: upath.join('/tmp/github/some/repo'),
+  cacheDir: upath.join('/tmp/cache'),
+  containerbaseDir: upath.join('/tmp/cache/containerbase'),
   dockerSidecarImage: 'ghcr.io/containerbase/sidecar',
 };
 

--- a/lib/modules/manager/poetry/artifacts.spec.ts
+++ b/lib/modules/manager/poetry/artifacts.spec.ts
@@ -1,6 +1,6 @@
 import { codeBlock } from 'common-tags';
 import { GoogleAuth as _googleAuth } from 'google-auth-library';
-import { join } from 'upath';
+import upath from 'upath';
 import { mockDeep } from 'vitest-mock-extended';
 import { GlobalConfig } from '../../../config/global';
 import type { RepoGlobalConfig } from '../../../config/types';
@@ -38,9 +38,9 @@ const hostRules = vi.mocked(_hostRules);
 const googleAuth = vi.mocked(_googleAuth);
 
 const adminConfig: RepoGlobalConfig = {
-  localDir: join('/tmp/github/some/repo'),
-  cacheDir: join('/tmp/cache'),
-  containerbaseDir: join('/tmp/cache/containerbase'),
+  localDir: upath.join('/tmp/github/some/repo'),
+  cacheDir: upath.join('/tmp/cache'),
+  containerbaseDir: upath.join('/tmp/cache/containerbase'),
 };
 
 const config: UpdateArtifactsConfig = {};

--- a/lib/modules/manager/pub/artifacts.spec.ts
+++ b/lib/modules/manager/pub/artifacts.spec.ts
@@ -22,7 +22,7 @@ const oldLockFileContent = 'Old pubspec.lock';
 const newLockFileContent = 'New pubspec.lock';
 const depNames = ['dep1', 'dep2', 'dep3'];
 const depNamesWithSdks = [...depNames, ...['dart', 'flutter']];
-const depNamesWithSpace = depNames.upath.join(' ');
+const depNamesWithSpace = depNames.join(' ');
 
 const datasource = vi.mocked(_datasource);
 

--- a/lib/modules/manager/pub/artifacts.spec.ts
+++ b/lib/modules/manager/pub/artifacts.spec.ts
@@ -1,5 +1,5 @@
 import { codeBlock } from 'common-tags';
-import { join } from 'upath';
+import upath from 'upath';
 import { mockDeep } from 'vitest-mock-extended';
 import { GlobalConfig } from '../../../config/global';
 import type { RepoGlobalConfig } from '../../../config/types';
@@ -22,14 +22,14 @@ const oldLockFileContent = 'Old pubspec.lock';
 const newLockFileContent = 'New pubspec.lock';
 const depNames = ['dep1', 'dep2', 'dep3'];
 const depNamesWithSdks = [...depNames, ...['dart', 'flutter']];
-const depNamesWithSpace = depNames.join(' ');
+const depNamesWithSpace = depNames.upath.join(' ');
 
 const datasource = vi.mocked(_datasource);
 
 const adminConfig: RepoGlobalConfig = {
-  localDir: join('/tmp/github/some/repo'),
-  cacheDir: join('/tmp/cache'),
-  containerbaseDir: join('/tmp/cache/containerbase'),
+  localDir: upath.join('/tmp/github/some/repo'),
+  cacheDir: upath.join('/tmp/cache'),
+  containerbaseDir: upath.join('/tmp/cache/containerbase'),
 };
 
 const config: UpdateArtifactsConfig = {};

--- a/lib/modules/manager/terraform/extract.spec.ts
+++ b/lib/modules/manager/terraform/extract.spec.ts
@@ -1,5 +1,5 @@
 import { codeBlock } from 'common-tags';
-import { join } from 'upath';
+import upath from 'upath';
 import { GlobalConfig } from '../../../config/global';
 import type { RepoGlobalConfig } from '../../../config/types';
 import * as hashicorp from '../../versioning/hashicorp';
@@ -22,9 +22,9 @@ const tfeWorkspaceBlock = Fixtures.get('tfeWorkspace.tf');
 
 const adminConfig: RepoGlobalConfig = {
   // `join` fixes Windows CI
-  localDir: join('/tmp/github/some/repo'),
-  cacheDir: join('/tmp/cache'),
-  containerbaseDir: join('/tmp/cache/containerbase'),
+  localDir: upath.join('/tmp/github/some/repo'),
+  cacheDir: upath.join('/tmp/cache'),
+  containerbaseDir: upath.join('/tmp/cache/containerbase'),
 };
 
 // auto-mock fs

--- a/lib/modules/manager/terraform/lockfile/index.spec.ts
+++ b/lib/modules/manager/terraform/lockfile/index.spec.ts
@@ -1,5 +1,5 @@
 import { codeBlock } from 'common-tags';
-import { join } from 'upath';
+import upath from 'upath';
 import { mockDeep } from 'vitest-mock-extended';
 import { GlobalConfig } from '../../../../config/global';
 import { getPkgReleases } from '../../../datasource';
@@ -20,9 +20,9 @@ const config = {
 
 const adminConfig = {
   // `join` fixes Windows CI
-  localDir: join('/tmp/github/some/repo'),
-  cacheDir: join('/tmp/renovate/cache'),
-  containerbaseDir: join('/tmp/renovate/cache/containerbase'),
+  localDir: upath.join('/tmp/github/some/repo'),
+  cacheDir: upath.join('/tmp/renovate/cache'),
+  containerbaseDir: upath.join('/tmp/renovate/cache/containerbase'),
 };
 
 const mockHash = vi.mocked(TerraformProviderHash).createHashes;

--- a/lib/modules/manager/terragrunt/artifacts.spec.ts
+++ b/lib/modules/manager/terragrunt/artifacts.spec.ts
@@ -1,4 +1,4 @@
-import { join } from 'upath';
+import upath from 'upath';
 import { GlobalConfig } from '../../../config/global';
 import type { UpdateType } from '../../../config/types';
 import * as terraformLockfile from '../terraform/lockfile';
@@ -13,9 +13,9 @@ const config = {
 
 const adminConfig = {
   // `join` fixes Windows CI
-  localDir: join('/tmp/github/some/repo'),
-  cacheDir: join('/tmp/renovate/cache'),
-  containerbaseDir: join('/tmp/renovate/cache/containerbase'),
+  localDir: upath.join('/tmp/github/some/repo'),
+  cacheDir: upath.join('/tmp/renovate/cache'),
+  containerbaseDir: upath.join('/tmp/renovate/cache/containerbase'),
 };
 
 describe('modules/manager/terragrunt/artifacts', () => {

--- a/lib/modules/manager/tflint-plugin/extract.spec.ts
+++ b/lib/modules/manager/tflint-plugin/extract.spec.ts
@@ -1,13 +1,13 @@
 import { codeBlock } from 'common-tags';
-import { join } from 'upath';
+import upath from 'upath';
 import { GlobalConfig } from '../../../config/global';
 import type { RepoGlobalConfig } from '../../../config/types';
 import { extractPackageFile } from '.';
 
 const adminConfig: RepoGlobalConfig = {
-  localDir: join('/tmp/github/some/repo'),
-  cacheDir: join('/tmp/cache'),
-  containerbaseDir: join('/tmp/cache/containerbase'),
+  localDir: upath.join('/tmp/github/some/repo'),
+  cacheDir: upath.join('/tmp/cache'),
+  containerbaseDir: upath.join('/tmp/cache/containerbase'),
 };
 
 // auto-mock fs

--- a/lib/modules/manager/vendir/artifacts.spec.ts
+++ b/lib/modules/manager/vendir/artifacts.spec.ts
@@ -1,4 +1,4 @@
-import { join } from 'upath';
+import upath from 'upath';
 import { mockDeep } from 'vitest-mock-extended';
 import { GlobalConfig } from '../../../config/global';
 import type { RepoGlobalConfig } from '../../../config/types';
@@ -20,9 +20,9 @@ vi.mock('../../../util/fs', () => mockDeep());
 vi.mock('../../../util/git', () => mockDeep());
 
 const adminConfig: RepoGlobalConfig = {
-  localDir: join('/tmp/github/some/repo'), // `join` fixes Windows CI
-  cacheDir: join('/tmp/renovate/cache'),
-  containerbaseDir: join('/tmp/cache/containerbase'),
+  localDir: upath.join('/tmp/github/some/repo'), // `join` fixes Windows CI
+  cacheDir: upath.join('/tmp/renovate/cache'),
+  containerbaseDir: upath.join('/tmp/cache/containerbase'),
   dockerSidecarImage: 'ghcr.io/containerbase/sidecar',
 };
 

--- a/lib/modules/versioning/cargo/index.ts
+++ b/lib/modules/versioning/cargo/index.ts
@@ -1,5 +1,5 @@
 import { major as getMajor, minor as getMinor } from 'semver';
-import { is as isStable } from 'semver-stable';
+import semver from 'semver-stable';
 import { logger } from '../../../logger';
 import type { RangeStrategy } from '../../../types/versioning';
 import { regEx } from '../../../util/regex';
@@ -153,7 +153,7 @@ function getNewValue({
 
 function isBreaking(current: string, version: string): boolean {
   // The change may be breaking if either version is unstable
-  if (!isStable(version) || !isStable(current)) {
+  if (!semver.is(version) || !semver.is(current)) {
     return true;
   }
   const currentMajor = getMajor(current);

--- a/lib/util/cache/package/sqlite.ts
+++ b/lib/util/cache/package/sqlite.ts
@@ -2,7 +2,7 @@ import { promisify } from 'node:util';
 import zlib, { constants } from 'node:zlib';
 import type { Database, Statement } from 'better-sqlite3';
 import { exists } from 'fs-extra';
-import * as upath from 'upath';
+import upath from 'upath';
 import { sqlite } from '../../../expose.cjs';
 import { logger } from '../../../logger';
 import { ensureDir } from '../../fs';

--- a/lib/util/fs/index.spec.ts
+++ b/lib/util/fs/index.spec.ts
@@ -2,7 +2,7 @@ import { findUp as _findUp } from 'find-up';
 import fs from 'fs-extra';
 import type { DirectoryResult } from 'tmp-promise';
 import tmp from 'tmp-promise';
-import { join, resolve } from 'upath';
+import upath from 'upath';
 import { GlobalConfig } from '../../config/global';
 import {
   cachePathExists,
@@ -188,7 +188,7 @@ describe('util/fs/index', () => {
   describe('ensureCacheDir', () => {
     it('prefers environment variables over global config', async () => {
       const res = await ensureCacheDir('bundler');
-      const path = join(cacheDir, 'others/bundler');
+      const path = upath.join(cacheDir, 'others/bundler');
       expect(res).toEqual(path);
       expect(await fs.pathExists(path)).toBeTrue();
     });
@@ -231,8 +231,8 @@ describe('util/fs/index', () => {
     it('reads symlink', async () => {
       await writeLocalFile('test/test.txt', '');
       await fs.symlink(
-        join(localDir, 'test/test.txt'),
-        join(localDir, 'test/test'),
+        upath.join(localDir, 'test/test.txt'),
+        upath.join(localDir, 'test/test'),
       );
 
       const result = await readLocalSymlink('test/test');
@@ -243,8 +243,8 @@ describe('util/fs/index', () => {
     it('return null when link not exists', async () => {
       await writeLocalFile('test/test.txt', '');
       await fs.symlink(
-        join(localDir, 'test/test.txt'),
-        join(localDir, 'test/test'),
+        upath.join(localDir, 'test/test.txt'),
+        upath.join(localDir, 'test/test'),
       );
 
       const notExistsResult = await readLocalSymlink('test/not-exists');
@@ -363,13 +363,15 @@ describe('util/fs/index', () => {
     });
 
     it('returns false for directory', async () => {
-      const path = resolve(`${localDir}/foobar`);
+      const path = upath.resolve(`${localDir}/foobar`);
       await fs.mkdir(path);
       expect(await localPathIsFile(path)).toBeFalse();
     });
 
     it('returns false for non-existing path', async () => {
-      expect(await localPathIsFile(resolve(`${localDir}/foobar`))).toBeFalse();
+      expect(
+        await localPathIsFile(upath.resolve(`${localDir}/foobar`)),
+      ).toBeFalse();
     });
   });
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Supersedes #37323

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
