### PR TITLE
fix(redis)!: add default auth to redis clusters

### DIFF
--- a/lib/util/cache/package/redis.spec.ts
+++ b/lib/util/cache/package/redis.spec.ts
@@ -1,4 +1,7 @@
-import { normalizeRedisUrl } from './redis';
+import { createClient, createCluster } from 'redis';
+import { init, normalizeRedisUrl } from './redis';
+
+vi.mock('redis');
 
 describe('util/cache/package/redis', () => {
   describe('normalizeRedisUrl', () => {
@@ -24,6 +27,110 @@ describe('util/cache/package/redis', () => {
       expect(normalizeRedisUrl(url)).toBe(
         'rediss://user:password@localhost:6379',
       );
+    });
+  });
+
+  describe('init', () => {
+    beforeEach(() => {
+      const mockClient = { connect: vi.fn() } as unknown as ReturnType<
+        typeof createClient
+      >;
+      vi.mocked(createClient).mockReturnValueOnce(mockClient);
+
+      const mockCluster = { connect: vi.fn() } as unknown as ReturnType<
+        typeof createCluster
+      >;
+      vi.mocked(createCluster).mockReturnValueOnce(mockCluster);
+    });
+
+    it('calls createClient with url', async () => {
+      const url = 'redis://user:password@localhost:6379';
+      await init(url, '');
+      expect(createClient).toHaveBeenCalledWith(
+        expect.objectContaining({ url }),
+      );
+    });
+
+    it('calls createClient with secure url', async () => {
+      const url = 'rediss://user:password@localhost:6379';
+      await init(url, '');
+      expect(createClient).toHaveBeenCalledWith(
+        expect.objectContaining({ url }),
+      );
+    });
+
+    it('calls createCluster with rewritten url', async () => {
+      const url = 'redis+cluster://user:password@localhost:6379';
+      await init(url, '');
+      expect(createCluster).toHaveBeenCalledWith({
+        rootNodes: [
+          expect.objectContaining({
+            url: 'redis://user:password@localhost:6379',
+          }),
+        ],
+        defaults: {
+          username: 'user',
+          password: 'password',
+        },
+      });
+    });
+
+    it('calls createCluster with rewritten secure url', async () => {
+      const url = 'rediss+cluster://user:password@localhost:6379';
+      await init(url, '');
+      expect(createCluster).toHaveBeenCalledWith({
+        rootNodes: [
+          expect.objectContaining({
+            url: 'rediss://user:password@localhost:6379',
+          }),
+        ],
+        defaults: {
+          username: 'user',
+          password: 'password',
+        },
+      });
+    });
+
+    it('calls createCluster with no username or password if not supplied', async () => {
+      const url = 'redis+cluster://localhost:6379';
+      await init(url, '');
+      expect(createCluster).toHaveBeenCalledWith({
+        rootNodes: [
+          expect.objectContaining({
+            url: 'redis://localhost:6379',
+          }),
+        ],
+      });
+    });
+
+    it('calls createCluster with username if supplied', async () => {
+      const url = 'redis+cluster://user@localhost:6379';
+      await init(url, '');
+      expect(createCluster).toHaveBeenCalledWith({
+        rootNodes: [
+          expect.objectContaining({
+            url: 'redis://user@localhost:6379',
+          }),
+        ],
+        defaults: {
+          username: 'user',
+        },
+      });
+    });
+
+    it('calls createCluster with password if supplied', async () => {
+      const url = 'redis+cluster://:password@localhost:6379';
+      await init(url, '');
+      expect(createCluster).toHaveBeenCalledWith({
+        rootNodes: [
+          expect.objectContaining({
+            url: 'redis://:password@localhost:6379',
+          }),
+        ],
+        defaults: {
+          password: 'password',
+        },
+      });
     });
   });
 });

--- a/lib/util/cache/package/redis.ts
+++ b/lib/util/cache/package/redis.ts
@@ -1,4 +1,5 @@
 import { DateTime } from 'luxon';
+import type { RedisClusterOptions } from 'redis';
 import { createClient, createCluster } from 'redis';
 import { logger } from '../../../logger';
 import { compressToBase64, decompressFromBase64 } from '../../compress';
@@ -120,9 +121,22 @@ export async function init(
     pingInterval: 30000, // 30s
   };
   if (clusteredMode) {
-    client = createCluster({
-      rootNodes: [config],
-    });
+    const clusterConfig: RedisClusterOptions = { rootNodes: [config] };
+
+    // only add defaults if username or password are present in the URL
+    const parsedUrl = new URL(rewrittenUrl);
+    if (parsedUrl.username) {
+      clusterConfig.defaults = {
+        username: parsedUrl.username,
+      };
+    }
+
+    if (parsedUrl.password) {
+      clusterConfig.defaults ??= {};
+      clusterConfig.defaults.password = parsedUrl.password;
+    }
+
+    client = createCluster(clusterConfig);
   } else {
     client = createClient(config);
   }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Using redis in a cluster with authentication causes the following error:
>  WARN: Error while setting Redis cache value (repository=<org>/<repo>)
>       "err": {"message": "NOAUTH Authentication required."}

This change adds the username and password from the redis URL as defaults for connections to non-root node servers as described in the [node redis](https://github.com/redis/node-redis/blob/master/docs/clustering.md#auth-with-password-and-username) docs

## Context

Logs and motivation in https://github.com/renovatebot/renovate/discussions/37319

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
