### PR TITLE
feat(presets): add UI5 Web Components monorepo

### DIFF
--- a/lib/data/monorepo.json
+++ b/lib/data/monorepo.json
@@ -626,7 +626,7 @@
     "typefaces": "https://github.com/KyleAMathews/typefaces",
     "typescript-eslint": "https://github.com/typescript-eslint/typescript-eslint",
     "typography-js": "https://github.com/KyleAMathews/typography.js",
-    "ui5-web-components": [
+    "ui5-webcomponents": [
       "https://github.com/SAP/ui5-webcomponents",
       "https://github.com/SAP/ui5-webcomponents-react",
       "https://github.com/SAP/ui5-webcomponents-ngx"

--- a/lib/data/monorepo.json
+++ b/lib/data/monorepo.json
@@ -626,6 +626,11 @@
     "typefaces": "https://github.com/KyleAMathews/typefaces",
     "typescript-eslint": "https://github.com/typescript-eslint/typescript-eslint",
     "typography-js": "https://github.com/KyleAMathews/typography.js",
+    "ui5-web-components": [
+      "https://github.com/SAP/ui5-webcomponents",
+      "https://github.com/SAP/ui5-webcomponents-react",
+      "https://github.com/SAP/ui5-webcomponents-ngx"
+    ],
     "unhead": "https://github.com/unjs/unhead",
     "unocss": "https://github.com/unocss/unocss",
     "uppy": "https://github.com/transloadit/uppy",


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds a monorepo preset for the UI5 Web Components repositories

## Context

UI5 Web Components (and their framework wrappers like `-react` or `-ngx`) consist of multiple packages which need to be updated in the same PR to avoid peer dependency conflicts.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
