### PR TITLE
feat(monorepo): Add langchain4j repository

### DIFF
--- a/lib/data/monorepo.json
+++ b/lib/data/monorepo.json
@@ -400,6 +400,7 @@
     "ksp": "https://github.com/google/ksp",
     "ktor": "https://github.com/ktorio/ktor",
     "lamar": "https://github.com/JasperFx/lamar",
+    "langchain4j": "https://github.com/langchain4j/langchain4j",
     "lerna": "https://github.com/lerna/lerna",
     "lerna-lite": "https://github.com/lerna-lite/lerna-lite",
     "lexical": "https://github.com/facebook/lexical",


### PR DESCRIPTION
## Changes

Adding the langchain4j monorepo URL https://github.com/langchain4j/langchain4j to the monorepo-preset.
LangChain4j has 8630 stars for time being. 

## Context

> The goal of LangChain4j is to simplify integrating LLMs into Java applications.
https://github.com/langchain4j/langchain4j

LangChain4j organizes itself in a stream-alined monorepo for developing the supported LLMs at the same time.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository