### PR TITLE
docs(bitbucket): add write scope to bot permissions

### DIFF
--- a/lib/modules/platform/bitbucket/readme.md
+++ b/lib/modules/platform/bitbucket/readme.md
@@ -27,6 +27,7 @@ Give the bot API token the following permission scopes:
 | Permission                                                                                                               | Scope                |
 | ------------------------------------------------------------------------------------------------------------------------ | -------------------- |
 | [`read:repository:bitbucket`](https://developer.atlassian.com/cloud/bitbucket/rest/intro/#read-repository-bitbucket)     | Repository: Read     |
+| [`write:repository:bitbucket`](https://developer.atlassian.com/cloud/bitbucket/rest/intro/#write-repository-bitbucket)   | Repository: Write    |
 | [`read:pullrequest:bitbucket`](https://developer.atlassian.com/cloud/bitbucket/rest/intro/#read-pullrequest-bitbucket)   | Pull requests: Read  |
 | [`write:pullrequest:bitbucket`](https://developer.atlassian.com/cloud/bitbucket/rest/intro/#write-pullrequest-bitbucket) | Pull requests: Write |
 | [`read:user:bitbucket`](https://developer.atlassian.com/cloud/bitbucket/rest/intro/#read-user-bitbucket)                 | User: Read           |


### PR DESCRIPTION
## Changes

Add missing write:repository:bitbucket scope as per https://github.com/renovatebot/renovate/discussions/37413

## Context

<https://github.com/renovatebot/renovate/discussions/37413>

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
