### PR TITLE
feat(bazel-module): Add support for rules_img

### DIFF
--- a/lib/modules/manager/bazel-module/extract.spec.ts
+++ b/lib/modules/manager/bazel-module/extract.spec.ts
@@ -618,5 +618,121 @@ describe('modules/manager/bazel-module/extract', () => {
         ],
       });
     });
+
+    it('returns rules_img pull dependencies', async () => {
+      const input = codeBlock`
+        pull = use_repo_rule("@rules_img//img:pull.bzl", "pull")
+
+        pull(
+          name = "ubuntu",
+          digest = "sha256:1e622c5f073b4f6bfad6632f2616c7f59ef256e96fe78bf6a595d1dc4376ac02",
+          registry = "index.docker.io",
+          repository = "library/ubuntu",
+          tag = "24.04",
+        )
+      `;
+      const res = await extractPackageFile(input, 'MODULE.bazel');
+
+      expect(res).toEqual({
+        deps: [
+          {
+            datasource: 'docker',
+            depType: 'rules_img_pull',
+            depName: 'ubuntu',
+            packageName: 'index.docker.io/library/ubuntu',
+            currentValue: '24.04',
+            currentDigest:
+              'sha256:1e622c5f073b4f6bfad6632f2616c7f59ef256e96fe78bf6a595d1dc4376ac02',
+            replaceString: expect.stringContaining('pull('),
+          },
+        ],
+      });
+    });
+
+    it('returns rules_img pull dependencies without tag', async () => {
+      const input = codeBlock`
+        pull = use_repo_rule("@rules_img//img:pull.bzl", "pull")
+
+        pull(
+          name = "distroless_cc",
+          digest = "sha256:d1b8e4c52be1111aa108e959ef2a822299bb70fd1819dd250871a2601ca1e4b6",
+          registry = "gcr.io",
+          repository = "distroless/cc-debian12",
+        )
+      `;
+      const res = await extractPackageFile(input, 'MODULE.bazel');
+
+      expect(res).toEqual({
+        deps: [
+          {
+            datasource: 'docker',
+            depType: 'rules_img_pull',
+            depName: 'distroless_cc',
+            packageName: 'gcr.io/distroless/cc-debian12',
+            currentDigest:
+              'sha256:d1b8e4c52be1111aa108e959ef2a822299bb70fd1819dd250871a2601ca1e4b6',
+            replaceString: expect.stringContaining('pull('),
+          },
+        ],
+      });
+    });
+
+    it('ignores non-rules_img use_repo_rule calls', async () => {
+      const input = codeBlock`
+        other_rule = use_repo_rule("@some_other//path:rule.bzl", "other_rule")
+
+        pull(
+          name = "ubuntu",
+          digest = "sha256:1e622c5f073b4f6bfad6632f2616c7f59ef256e96fe78bf6a595d1dc4376ac02",
+          registry = "index.docker.io",
+          repository = "library/ubuntu",
+          tag = "24.04",
+        )
+      `;
+      const res = await extractPackageFile(input, 'MODULE.bazel');
+
+      expect(res).toBeNull();
+    });
+
+    it('ignores non-rules_img use_repo_rule calls that use the name pull', async () => {
+      const input = codeBlock`
+        pull = use_repo_rule("@some_other//path:rule.bzl", "pull")
+
+        pull(
+          name = "test",
+          value = "ignored",
+        )
+      `;
+      const res = await extractPackageFile(input, 'MODULE.bazel');
+
+      expect(res).toBeNull();
+    });
+
+    it('handles multiple rules_img pulls', async () => {
+      const input = codeBlock`
+        pull = use_repo_rule("@rules_img//img:pull.bzl", "pull")
+
+        pull(
+          name = "ubuntu",
+          digest = "sha256:1e622c5f073b4f6bfad6632f2616c7f59ef256e96fe78bf6a595d1dc4376ac02",
+          registry = "index.docker.io",
+          repository = "library/ubuntu",
+          tag = "24.04",
+        )
+
+        pull(
+          name = "cuda",
+          digest = "sha256:f353ffca86e0cd93ab2470fe274ecf766519c24c37ed58cc2f91d915f7ebe53c",
+          registry = "index.docker.io",
+          repository = "nvidia/cuda",
+          tag = "12.8.1-cudnn-devel-ubuntu20.04",
+        )
+      `;
+      const res = await extractPackageFile(input, 'MODULE.bazel');
+
+      expect(res?.deps).toHaveLength(2);
+      expect(res?.deps[0].depName).toBe('ubuntu');
+      expect(res?.deps[1].depName).toBe('cuda');
+    });
   });
 });

--- a/lib/modules/manager/bazel-module/extract.ts
+++ b/lib/modules/manager/bazel-module/extract.ts
@@ -8,6 +8,7 @@ import { parse } from './parser';
 import type { ResultFragment } from './parser/fragments';
 import { RuleToMavenPackageDep, fillRegistryUrls } from './parser/maven';
 import { RuleToDockerPackageDep } from './parser/oci';
+import { RulesImgPullToDockerPackageDep } from './parser/rules-img';
 import {
   GitRepositoryToPackageDep,
   RuleToBazelModulePackageDep,
@@ -24,6 +25,7 @@ export async function extractPackageFile(
     const gitRepositoryDeps = extractGitRepositoryDeps(records);
     const mavenDeps = extractMavenDeps(records);
     const dockerDeps = LooseArray(RuleToDockerPackageDep).parse(records);
+    const rulesImgDeps = extractRulesImgDeps(records);
 
     if (gitRepositoryDeps.length) {
       pfc.deps.push(...gitRepositoryDeps);
@@ -35,6 +37,10 @@ export async function extractPackageFile(
 
     if (dockerDeps.length) {
       pfc.deps.push(...dockerDeps);
+    }
+
+    if (rulesImgDeps.length) {
+      pfc.deps.push(...rulesImgDeps);
     }
 
     return pfc.deps.length ? pfc : null;
@@ -75,4 +81,8 @@ function extractMavenDeps(records: ResultFragment[]): PackageDependency[] {
   return LooseArray(RuleToMavenPackageDep)
     .transform(fillRegistryUrls)
     .parse(records);
+}
+
+function extractRulesImgDeps(records: ResultFragment[]): PackageDependency[] {
+  return LooseArray(RulesImgPullToDockerPackageDep).parse(records);
 }

--- a/lib/modules/manager/bazel-module/parser/fragments.ts
+++ b/lib/modules/manager/bazel-module/parser/fragments.ts
@@ -57,6 +57,19 @@ export const ExtensionTagFragmentSchema = z.object({
   offset: z.number(), // start offset in the source string
   rawString: z.string().optional(), // raw source string
 });
+export const RepoRuleFunctionCallSchema = z.object({
+  type: z.literal('repoRuleFunctionCall'),
+  // The variable name used for the function call (e.g. "pull")
+  functionName: z.string(),
+  // The load path that was imported (e.g. "@rules_img//img:pull.bzl")
+  loadPath: z.string(),
+  // The original function name from use_repo_rule (e.g. "pull")
+  originalFunctionName: z.string(),
+  children: LooseRecord(ValueFragmentsSchema),
+  isComplete: z.boolean(),
+  offset: z.number(), // start offset in the source string
+  rawString: z.string().optional(), // raw source string
+});
 export const AttributeFragmentSchema = z.object({
   type: z.literal('attribute'),
   name: z.string(),
@@ -70,6 +83,7 @@ export const AllFragmentsSchema = z.discriminatedUnion('type', [
   RuleFragmentSchema,
   PreparedExtensionTagFragmentSchema,
   ExtensionTagFragmentSchema,
+  RepoRuleFunctionCallSchema,
   StringFragmentSchema,
 ]);
 
@@ -84,9 +98,15 @@ export type PreparedExtensionTagFragment = z.infer<
   typeof PreparedExtensionTagFragmentSchema
 >;
 export type ExtensionTagFragment = z.infer<typeof ExtensionTagFragmentSchema>;
+export type RepoRuleFunctionCallFragment = z.infer<
+  typeof RepoRuleFunctionCallSchema
+>;
 export type StringFragment = z.infer<typeof StringFragmentSchema>;
 export type ValueFragments = z.infer<typeof ValueFragmentsSchema>;
-export type ResultFragment = RuleFragment | ExtensionTagFragment;
+export type ResultFragment =
+  | RuleFragment
+  | ExtensionTagFragment
+  | RepoRuleFunctionCallFragment;
 
 export function string(value: string): StringFragment {
   return {
@@ -145,6 +165,27 @@ export function extensionTag(
     extension,
     rawExtension,
     tag,
+    offset,
+    rawString,
+    isComplete,
+    children,
+  };
+}
+
+export function repoRuleFunctionCall(
+  functionName: string,
+  loadPath: string,
+  originalFunctionName: string,
+  offset: number,
+  children: ChildFragments = {},
+  rawString?: string,
+  isComplete = false,
+): RepoRuleFunctionCallFragment {
+  return {
+    type: 'repoRuleFunctionCall',
+    functionName,
+    loadPath,
+    originalFunctionName,
     offset,
     rawString,
     isComplete,

--- a/lib/modules/manager/bazel-module/parser/index.ts
+++ b/lib/modules/manager/bazel-module/parser/index.ts
@@ -2,9 +2,15 @@ import { lang, query as q } from 'good-enough-parser';
 import { Ctx } from './context';
 import { extensionTags } from './extension-tags';
 import type { ResultFragment } from './fragments';
+import { dynamicFunctionCall, repoRuleAssignment } from './repo-rules';
 import { rules } from './rules';
 
-const rule = q.alt<Ctx>(rules, extensionTags);
+const rule = q.alt<Ctx>(
+  rules,
+  extensionTags,
+  repoRuleAssignment,
+  dynamicFunctionCall,
+);
 
 const query = q.tree<Ctx>({
   type: 'root-tree',

--- a/lib/modules/manager/bazel-module/parser/repo-rules.ts
+++ b/lib/modules/manager/bazel-module/parser/repo-rules.ts
@@ -1,0 +1,59 @@
+import { query as q } from 'good-enough-parser';
+import { kvParams } from './common';
+import type { Ctx } from './context';
+
+// Support for use_repo_rule assignments and dynamic function calls
+// Pattern: variable = use_repo_rule("load_path", "function_name")
+// Followed by: variable(parameters)
+
+// Parse use_repo_rule assignments like: pull = use_repo_rule("@rules_img//img:pull.bzl", "pull")
+export const repoRuleAssignment = q
+  .sym<Ctx>((ctx, token) => {
+    // Track the variable name being assigned (e.g., "pull")
+    return ctx.startRepoRuleAssignment(token.value);
+  })
+  .op('=')
+  .sym('use_repo_rule')
+  .join(
+    q.tree({
+      type: 'wrapped-tree',
+      maxDepth: 1,
+      search: q.many(
+        q.str<Ctx>((ctx, token) => {
+          // First string is load path, second is function name
+          if (token.value.startsWith('@')) {
+            return ctx.addRepoRuleLoadPath(token.value);
+          }
+          return ctx.addRepoRuleFunctionName(token.value);
+        }),
+      ),
+      postHandler: (ctx) => ctx.endRepoRuleAssignment(),
+    }),
+  );
+
+// Parse dynamic function calls like: pull(name = "ubuntu", digest = "sha256:...")
+// This needs to be dynamically matched based on tracked variables
+export const dynamicFunctionCall = q
+  .sym<Ctx>((ctx, token) => {
+    // Check if this token matches a tracked rules_img function variable
+    if (ctx.isRulesImgFunction(token.value)) {
+      return ctx.startDynamicFunctionCall(token.value, token.offset);
+    }
+    // If not a tracked function, continue without processing
+    return ctx;
+  })
+  .join(
+    q.tree({
+      type: 'wrapped-tree',
+      maxDepth: 1,
+      search: kvParams,
+      postHandler: (ctx, tree) => {
+        if (tree.type === 'wrapped-tree') {
+          const { endsWith } = tree;
+          const endOffset = endsWith.offset + endsWith.value.length;
+          return ctx.endDynamicFunctionCall(endOffset);
+        }
+        throw new Error(`Unexpected tree in postHandler: ${tree.type}`);
+      },
+    }),
+  );

--- a/lib/modules/manager/bazel-module/parser/rules-img.ts
+++ b/lib/modules/manager/bazel-module/parser/rules-img.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod';
+import { DockerDatasource } from '../../../datasource/docker';
+import type { PackageDependency } from '../../types';
+import { RepoRuleFunctionCallSchema, StringFragmentSchema } from './fragments';
+
+export const rulesImgLoadPaths = ['@rules_img//img:pull.bzl'] as const;
+
+export const RulesImgPullToDockerPackageDep = RepoRuleFunctionCallSchema.extend(
+  {
+    loadPath: z.enum(rulesImgLoadPaths),
+    originalFunctionName: z.literal('pull'),
+    children: z.object({
+      name: StringFragmentSchema,
+      digest: StringFragmentSchema,
+      registry: StringFragmentSchema,
+      repository: StringFragmentSchema,
+      tag: StringFragmentSchema.optional(),
+    }),
+  },
+).transform(
+  ({
+    rawString,
+    functionName,
+    children: { name, registry, repository, digest, tag },
+  }): PackageDependency => ({
+    datasource: DockerDatasource.id,
+    depType: 'rules_img_pull',
+    depName: name.value,
+    packageName: `${registry.value}/${repository.value}`,
+    currentValue: tag?.value,
+    currentDigest: digest.value,
+    // Provide a replace string so the auto replacer can replace both the tag
+    // and digest if applicable.
+    replaceString: rawString,
+  }),
+);

--- a/lib/modules/manager/bazel-module/parser/rules.ts
+++ b/lib/modules/manager/bazel-module/parser/rules.ts
@@ -21,6 +21,7 @@ const supportedRules = [
   'single_version_override',
   'git_repository',
   'new_git_repository',
+  'use_repo_rule',
 ];
 const supportedRulesRegex = regEx(`^${supportedRules.join('|')}$`);
 

--- a/lib/modules/manager/bazel-module/readme.md
+++ b/lib/modules/manager/bazel-module/readme.md
@@ -31,9 +31,9 @@ maven.artifact(
 
 ### Docker
 
-Similarly, it updates Docker / OCI images pulled with [oci_pull](https://github.com/bazel-contrib/rules_oci/blob/main/docs/pull.md).
+Similarly, it updates Docker / OCI images pulled with [oci_pull](https://github.com/bazel-contrib/rules_oci/blob/main/docs/pull.md) from rules_oci, or with [pull](https://github.com/tweag/rules_img/blob/main/docs/pull.md) from rules_img.
 
-Note that the extension must be called `oci`:
+Note that for rules_oci, the extension must be called `oci`:
 
 ```
 oci = use_extension("@rules_oci//oci:extensions.bzl", "oci")
@@ -43,6 +43,20 @@ oci.pull(
     digest = "sha256:287ff321f9e3cde74b600cc26197424404157a72043226cbbf07ee8304a2c720",
     image = "index.docker.io/library/nginx",
     platforms = ["linux/amd64"],
+    tag = "1.27.1",
+)
+```
+
+For rules_img, use the `pull` repo rule:
+
+```
+pull = use_repo_rule("@rules_img//img:pull.bzl", "pull")
+
+pull(
+    name = "nginx_image",
+    digest = "sha256:287ff321f9e3cde74b600cc26197424404157a72043226cbbf07ee8304a2c720",
+    registry = "index.docker.io",
+    repository = "library/nginx",
     tag = "1.27.1",
 )
 ```


### PR DESCRIPTION
## Changes

Added Mend Renovate support for `rules_img` container image dependencies in Bazel MODULE.bazel files. This enables automatic updates of base image hashes for projects using the `rules_img` Bazel ruleset, similar to the existing `rules_oci` support.

### Key Features:
- **Load path filtering**: Only processes `use_repo_rule` calls from `@rules_img//img:pull.bzl` 
- **Dynamic function matching**: Correctly identifies and parses `pull()` calls based on their repository rule assignments
- **Docker dependency conversion**: Transforms parsed image references to Docker datasource dependencies for automatic updates
- **Comprehensive edge case handling**: Ignores non-rules_img repositories, handles optional parameters, supports multiple image pulls

### Technical Implementation:
- Extended `bazel-module` manager with new parser components for repository rule assignments and dynamic function calls
- Added `RepoRuleFunctionCallFragment` schema for type-safe parsing and transformation
- Integrated with existing Docker datasource for seamless dependency management
- Follows established Renovate patterns and maintains backward compatibility

## Context

Closes https://github.com/tweag/rules_img/issues/8

This addresses the need for automatic dependency updates in projects using `rules_img` for container image management. Similar to how Renovate already supports `rules_oci` with `oci.pull()` calls, this PR adds equivalent support for `rules_img` with `pull()` calls from repository rules.

The implementation enables Renovate to:
- Detect container image dependencies defined via `rules_img` pull functions
- Automatically update image tags and digests when new versions are available
- Filter out non-rules_img repository rule calls to avoid false positives
- Handle various edge cases like missing tags, multiple images, and different load paths

## Documentation (please check one with an [x])

- [x] I have updated the documentation

## How I've tested my work (please select one)

I have verified these changes via:


- [x] Newly added/modified unit tests

