### PR TITLE
feat(preset): add Gradle group

### DIFF
--- a/lib/config/presets/internal/group.ts
+++ b/lib/config/presets/internal/group.ts
@@ -208,7 +208,7 @@ const staticGroups = {
         commitMessageTopic: 'Gradle',
         matchDatasources: ['docker', 'gradle-version'],
         matchPackageNames: [
-          '/(?:^|/)gradle/', // gradle or ends with "/gradle"
+          '/(?:^|/)gradle$/', // gradle or ends with "/gradle"
         ],
       },
     ],

--- a/lib/config/presets/internal/group.ts
+++ b/lib/config/presets/internal/group.ts
@@ -200,6 +200,19 @@ const staticGroups = {
       },
     ],
   },
+  gradle: {
+    description:
+      "Group anything that looks like Gradle together so that it's updated together.",
+    packageRules: [
+      {
+        commitMessageTopic: 'Gradle',
+        matchDatasources: ['docker', 'gradle-version'],
+        matchPackageNames: [
+          '/(?:^|/)gradle/', // gradle or ends with "/gradle"
+        ],
+      },
+    ],
+  },
   hibernateCommons: {
     description: 'Group Java Hibernate Commons packages.',
     packageRules: [
@@ -513,6 +526,7 @@ const staticGroups = {
       'group:githubArtifactActions',
       'group:glimmer',
       'group:goOpenapi',
+      'group:gradle',
       'group:hibernateCore',
       'group:hibernateValidator',
       'group:hibernateOgm',


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds a preset for Gradle Version updates.

It is based on the nodeJs group.
Explicitly not using groupName, see discussion in this PR: https://github.com/renovatebot/renovate/pull/34379

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
