### PR TITLE
feat(nuget): allow restoring workloads before restoring packages

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -3776,6 +3776,7 @@ Table with options:
 | Name                         | Description                                                                                                                                                |
 | ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `bundlerConservative`        | Enable conservative mode for `bundler` (Ruby dependencies). This will only update the immediate dependency in the lockfile instead of all subdependencies. |
+| `dotnetWorkloadRestore`      | Run `dotnet workload restore` before `dotnet restore` commands.                                                                                            |
 | `gomodMassage`               | Enable massaging `replace` directives before calling `go` commands.                                                                                        |
 | `gomodTidy`                  | Run `go mod tidy` after Go module updates. This is implicitly enabled for major module updates when `gomodUpdateImportPaths` is enabled.                   |
 | `gomodTidy1.17`              | Run `go mod tidy -compat=1.17` after Go module updates.                                                                                                    |

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -2514,6 +2514,7 @@ const options: RenovateOptions[] = [
     subType: 'string',
     allowedValues: [
       'bundlerConservative',
+      'dotnetWorkloadRestore',
       'gomodMassage',
       'gomodTidy',
       'gomodTidy1.17',

--- a/lib/modules/manager/nuget/artifacts.spec.ts
+++ b/lib/modules/manager/nuget/artifacts.spec.ts
@@ -94,7 +94,7 @@ describe('modules/manager/nuget/artifacts', () => {
     ]);
   });
 
-  it('updates lock file', async () => {
+  it('runs workload restore and updates lock file', async () => {
     const execSnapshots = mockExecAll();
     fs.getSiblingFileName.mockReturnValueOnce('packages.lock.json');
     git.getFiles.mockResolvedValueOnce({
@@ -108,7 +108,7 @@ describe('modules/manager/nuget/artifacts', () => {
         packageFileName: 'project.csproj',
         updatedDeps: [{ depName: 'dep' }],
         newPackageFileContent: '{}',
-        config,
+        config: { ...config, postUpdateOptions: ['dotnetWorkloadRestore'] },
       }),
     ).toEqual([
       {
@@ -120,6 +120,17 @@ describe('modules/manager/nuget/artifacts', () => {
       },
     ]);
     expect(execSnapshots).toMatchObject([
+      {
+        cmd: 'dotnet workload restore --configfile /tmp/renovate/cache/__renovate-private-cache/nuget/nuget.config',
+        options: {
+          cwd: '/tmp/github/some/repo',
+          env: {
+            NUGET_PACKAGES:
+              '/tmp/renovate/cache/__renovate-private-cache/nuget/packages',
+            MSBUILDDISABLENODEREUSE: '1',
+          },
+        },
+      },
       {
         cmd: 'dotnet restore project.csproj --force-evaluate --configfile /tmp/renovate/cache/__renovate-private-cache/nuget/nuget.config',
         options: {

--- a/lib/modules/manager/nuget/artifacts.ts
+++ b/lib/modules/manager/nuget/artifacts.ts
@@ -79,6 +79,13 @@ async function runDotnetRestore(
         )} --force-evaluate --configfile ${quote(nugetConfigFile)}`,
     ),
   ];
+
+  if (config.postUpdateOptions?.includes('dotnetWorkloadRestore')) {
+    cmds.unshift(
+      `dotnet workload restore --configfile ${quote(nugetConfigFile)}`,
+    );
+  }
+
   await exec(cmds, execOptions);
 }
 

--- a/lib/modules/manager/nuget/readme.md
+++ b/lib/modules/manager/nuget/readme.md
@@ -39,3 +39,14 @@ If you would like Renovate to disable updating of exact versions (warning: you m
   ]
 }
 ```
+
+### Workload restore
+
+Sometimes you need to run `dotnet workload restore` to ensure that all required workloads are installed before restoring the project.
+You can enable this behavior by adding `dotnetWorkloadRestore` to the `postUpdateOptions` in your Renovate configuration.
+
+```json
+{
+  "postUpdateOptions": ["dotnetWorkloadRestore"]
+}
+```


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Some projects need to restore dotnet workloads before you can restore packages.
It happens for `browser-wasm` projects.
<!-- Describe what behavior is changed by this PR. -->

## Context
- https://github.com/renovatebot/pgp/pull/7#issuecomment-3146189879
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
