### PR TITLE
fix(nuget): restore all projects if `global.json` changes

### DIFF
--- a/lib/modules/manager/nuget/artifacts.ts
+++ b/lib/modules/manager/nuget/artifacts.ts
@@ -21,6 +21,7 @@ import type {
 } from '../types';
 import { createNuGetConfigXml } from './config-formatter';
 import {
+  GLOBAL_JSON,
   MSBUILD_CENTRAL_FILE,
   NUGET_CENTRAL_FILE,
   getDependentPackageFiles,
@@ -98,8 +99,11 @@ export async function updateArtifacts({
     packageFileName.endsWith(`/${NUGET_CENTRAL_FILE}`) ||
     packageFileName.endsWith(`/${MSBUILD_CENTRAL_FILE}`);
 
+  const isGlobalJson = packageFileName === GLOBAL_JSON;
+
   if (
     !isCentralManagement &&
+    !isGlobalJson &&
     !regEx(/(?:cs|vb|fs)proj$/i).test(packageFileName)
   ) {
     // This could be implemented in the future if necessary.
@@ -116,6 +120,7 @@ export async function updateArtifacts({
   const deps = await getDependentPackageFiles(
     packageFileName,
     isCentralManagement,
+    isGlobalJson,
   );
   const packageFiles = deps.filter((d) => d.isLeaf).map((d) => d.name);
 
@@ -176,7 +181,6 @@ export async function updateArtifacts({
 
     return retArray.length > 0 ? retArray : null;
   } catch (err) {
-    // istanbul ignore if
     if (err.message === TEMPORARY_ERROR) {
       throw err;
     }

--- a/lib/modules/manager/nuget/extract.spec.ts
+++ b/lib/modules/manager/nuget/extract.spec.ts
@@ -6,6 +6,7 @@ import { DotnetVersionDatasource } from '../../datasource/dotnet-version';
 import type { ExtractConfig } from '../types';
 import { extractPackageFile } from '.';
 import { Fixtures } from '~test/fixtures';
+import { fs } from '~test/util';
 
 const config: ExtractConfig = {};
 
@@ -41,8 +42,10 @@ describe('modules/manager/nuget/extract', () => {
     it('extracts package file version', async () => {
       const packageFile = 'sample.csproj';
       const sample = Fixtures.get(packageFile);
+      vi.spyOn(fs, 'localPathExists').mockResolvedValueOnce(true);
       const res = await extractPackageFile(sample, packageFile, config);
       expect(res?.packageFileVersion).toBe('0.1.0');
+      expect(res?.lockFiles).toEqual(['packages.lock.json']);
     });
 
     it('does not fail on package file without version', async () => {

--- a/lib/modules/manager/nuget/extract.ts
+++ b/lib/modules/manager/nuget/extract.ts
@@ -216,7 +216,6 @@ export async function extractPackageFile(
 
   const res: PackageFileContent = { deps, packageFileVersion };
   const lockFileName = getSiblingFileName(packageFile, 'packages.lock.json');
-  // istanbul ignore if
   if (await localPathExists(lockFileName)) {
     res.lockFiles = [lockFileName];
   }

--- a/lib/modules/manager/nuget/package-tree.spec.ts
+++ b/lib/modules/manager/nuget/package-tree.spec.ts
@@ -94,6 +94,26 @@ describe('modules/manager/nuget/package-tree', () => {
       ]);
     });
 
+    it('returns project for two projects with one reference and global.json', async () => {
+      scm.getFileList.mockResolvedValue(['one/one.csproj', 'two/two.csproj']);
+      Fixtures.mock({
+        '/tmp/repo/one/one.csproj': Fixtures.get(
+          'two-one-reference-with-central-versions/one/one.csproj',
+        ),
+        '/tmp/repo/two/two.csproj': Fixtures.get(
+          'two-one-reference-with-central-versions/two/two.csproj',
+        ),
+        '/tmp/repo/global.json': '{}',
+      });
+
+      expect(
+        await getDependentPackageFiles('global.json', false, true),
+      ).toEqual([
+        { isLeaf: false, name: 'one/one.csproj' },
+        { isLeaf: true, name: 'two/two.csproj' },
+      ]);
+    });
+
     it('returns projects for three projects with two linear references', async () => {
       scm.getFileList.mockResolvedValue([
         'one/one.csproj',

--- a/lib/modules/manager/nuget/package-tree.ts
+++ b/lib/modules/manager/nuget/package-tree.ts
@@ -7,6 +7,7 @@ import { scm } from '../../platform/scm';
 import type { ProjectFile } from './types';
 import { readFileAsXmlDocument } from './util';
 
+export const GLOBAL_JSON = 'global.json';
 export const NUGET_CENTRAL_FILE = 'Directory.Packages.props';
 export const MSBUILD_CENTRAL_FILE = 'Packages.props';
 
@@ -16,6 +17,7 @@ export const MSBUILD_CENTRAL_FILE = 'Packages.props';
 export async function getDependentPackageFiles(
   packageFileName: string,
   isCentralManagement = false,
+  isGlobalJson = false,
 ): Promise<ProjectFile[]> {
   const packageFiles = await getAllPackageFiles();
   const graph = new Graph();
@@ -24,16 +26,24 @@ export async function getDependentPackageFiles(
     graph.addNode(packageFileName);
   }
 
+  if (isGlobalJson) {
+    graph.addNode(GLOBAL_JSON);
+  }
+
   const parentDir =
     packageFileName === NUGET_CENTRAL_FILE ||
-    packageFileName === MSBUILD_CENTRAL_FILE
+    packageFileName === MSBUILD_CENTRAL_FILE ||
+    packageFileName === GLOBAL_JSON
       ? ''
       : upath.dirname(packageFileName);
 
   for (const f of packageFiles) {
     graph.addNode(f);
 
-    if (isCentralManagement && upath.dirname(f).startsWith(parentDir)) {
+    if (
+      (isCentralManagement || isGlobalJson) &&
+      upath.dirname(f).startsWith(parentDir)
+    ) {
       graph.addEdge(packageFileName, f);
     }
   }
@@ -70,7 +80,7 @@ export async function getDependentPackageFiles(
   const deps = new Map<string, boolean>();
   recursivelyGetDependentPackageFiles(packageFileName, graph, deps);
 
-  if (isCentralManagement) {
+  if (isCentralManagement || isGlobalJson) {
     // remove props file, as we don't need it
     deps.delete(packageFileName);
   }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
In specific configurations all projects need to be restored when `global.json` changes, because it could add invisible dependencies like the `browser-wasm` target does.

fix missing coverage
<!-- Describe what behavior is changed by this PR. -->

## Context
- https://github.com/renovatebot/pgp/pull/5
- closes #28006
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
