### PR TITLE
fix(static-config): attempt migration before aborting

### DIFF
--- a/lib/workers/repository/init/merge.ts
+++ b/lib/workers/repository/init/merge.ts
@@ -198,20 +198,20 @@ export async function mergeRenovateConfig(
     };
   }
   const configFileParsed = repoConfig?.configFileParsed ?? {};
-  const configFileAndEnv = await resolveStaticRepoConfig(
+  const resolvedRepoConfig = await resolveStaticRepoConfig(
     configFileParsed,
     process.env.RENOVATE_X_STATIC_REPO_CONFIG_FILE,
   );
 
   if (is.nonEmptyArray(returnConfig.extends)) {
-    configFileAndEnv.extends = [
+    resolvedRepoConfig.extends = [
       ...returnConfig.extends,
-      ...(configFileAndEnv.extends ?? []),
+      ...(resolvedRepoConfig.extends ?? []),
     ];
     delete returnConfig.extends;
   }
   checkForRepoConfigError(repoConfig);
-  const migratedConfig = await migrateAndValidate(config, configFileAndEnv);
+  const migratedConfig = await migrateAndValidate(config, resolvedRepoConfig);
   if (migratedConfig.errors?.length) {
     const error = new Error(CONFIG_VALIDATION);
     error.validationSource = repoConfig.configFileName;

--- a/lib/workers/repository/init/merge.ts
+++ b/lib/workers/repository/init/merge.ts
@@ -385,23 +385,23 @@ export async function tryReadStaticRepoFileConfig(
     staticRepoConfigFile,
   ) as AllConfig;
 
-  const { errors } = await configValidation.validateConfig(
+  // validate and log issues here to preserve context, caller handles migration and full validation.
+  const { errors, warnings } = await configValidation.validateConfig(
     'repo',
     staticRepoConfig,
   );
 
   if (is.nonEmptyArray(errors)) {
-    logger.fatal(
-      { validationErrors: errors },
-      'static repository config validation errors',
+    logger.info(
+      { errors, warnings },
+      'Static repo config validation issues detected',
     );
-    throw new Error('Invalid renovate configuration in static config file');
+  } else {
+    logger.debug(
+      { staticRepoConfig },
+      'Static repository config file successfully parsed and validated',
+    );
   }
-
-  logger.debug(
-    { staticRepoConfig },
-    'Static repository config file successfully parsed and validated',
-  );
 
   return staticRepoConfig;
 }

--- a/lib/workers/repository/init/merge.ts
+++ b/lib/workers/repository/init/merge.ts
@@ -391,7 +391,7 @@ export async function tryReadStaticRepoFileConfig(
     staticRepoConfig,
   );
 
-  if (is.nonEmptyArray(errors)) {
+  if (is.nonEmptyArray(errors) || is.nonEmptyArray(warnings)) {
     logger.info(
       { errors, warnings },
       'Static repo config validation issues detected',


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Attempt static config migration before aborting due to invalid config that could otherwise be fixed.

<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
