### PR TITLE
feat(poetry): supersede `pep621`

### DIFF
--- a/lib/modules/manager/poetry/index.ts
+++ b/lib/modules/manager/poetry/index.ts
@@ -11,6 +11,7 @@ export { extractPackageFile } from './extract';
 export { updateArtifacts } from './artifacts';
 export { updateLockedDependency } from './update-locked';
 
+export const supersedesManagers = ['pep621'];
 export const supportsLockFileMaintenance = true;
 
 export const url = 'https://python-poetry.org/docs';

--- a/lib/workers/repository/extract/supersedes.spec.ts
+++ b/lib/workers/repository/extract/supersedes.spec.ts
@@ -31,6 +31,23 @@ describe('workers/repository/extract/supersedes', () => {
             },
           ],
         },
+        {
+          manager: 'pep621',
+          packageFiles: [
+            { packageFile: 'pyproject.toml', deps: [] },
+            { packageFile: 'some/pyproject.toml', deps: [] },
+          ],
+        },
+        {
+          manager: 'poetry',
+          packageFiles: [
+            {
+              packageFile: 'pyproject.toml',
+              deps: [],
+              lockFiles: ['poetry.lock'],
+            },
+          ],
+        },
       ];
       processSupersedesManagers(extractResults);
       expect(extractResults).toMatchObject([
@@ -56,6 +73,20 @@ describe('workers/repository/extract/supersedes', () => {
               deps: [],
               lockFiles: ['frontend/yarn.lock'],
               packageFile: 'frontend/package.json',
+            },
+          ],
+        },
+        {
+          manager: 'pep621',
+          packageFiles: [{ packageFile: 'some/pyproject.toml', deps: [] }],
+        },
+        {
+          manager: 'poetry',
+          packageFiles: [
+            {
+              packageFile: 'pyproject.toml',
+              deps: [],
+              lockFiles: ['poetry.lock'],
             },
           ],
         },


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Supercede extractions from pep621 manager by poetry.
`project.dependencies` and `project.optional-dependencies` are no longer extracted by `pep621`.
<!-- Describe what behavior is changed by this PR. -->

## Context
- closes #33961
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
