### PR TITLE
refactor: remove default radix from `parseInt`

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -98,6 +98,7 @@ export default tseslint.config(
       'no-negated-condition': 'error',
       'no-param-reassign': 'error',
       'no-template-curly-in-string': 'error',
+      radix: ['error', 'as-needed'], // on ES5+ the radix defaults to 10
 
       'sort-imports': [
         'error',

--- a/lib/modules/datasource/docker/dockerhub-cache.ts
+++ b/lib/modules/datasource/docker/dockerhub-cache.ts
@@ -71,7 +71,7 @@ export class DockerHubCache {
 
     if (earliestDate && latestDate) {
       for (const [key, item] of Object.entries(this.cache.items)) {
-        const id = parseInt(key, 10);
+        const id = parseInt(key);
 
         const itemDate = DateTime.fromISO(item.last_updated);
 

--- a/lib/modules/datasource/maven/index.spec.ts
+++ b/lib/modules/datasource/maven/index.spec.ts
@@ -67,7 +67,7 @@ function mockGenericPackage(opts: MockOpts = {}) {
       const [major, minor, patch] = latest
         .replace('-SNAPSHOT', '')
         .split('.')
-        .map(parseInt)
+        .map((x) => parseInt(x))
         .map((x) => (x < 10 ? `0${x}` : `${x}`));
       scope
         .get(

--- a/lib/modules/datasource/maven/index.spec.ts
+++ b/lib/modules/datasource/maven/index.spec.ts
@@ -67,14 +67,14 @@ function mockGenericPackage(opts: MockOpts = {}) {
       const [major, minor, patch] = latest
         .replace('-SNAPSHOT', '')
         .split('.')
-        .map((x) => parseInt(x, 10))
+        .map(parseInt)
         .map((x) => (x < 10 ? `0${x}` : `${x}`));
       scope
         .get(
           `/${packagePath}/${latest}/${artifact}-${latest.replace(
             '-SNAPSHOT',
             '',
-          )}-20200101.${major}${minor}${patch}-${parseInt(patch, 10)}.pom`,
+          )}-20200101.${major}${minor}${patch}-${parseInt(patch)}.pom`,
         )
         .reply(200, pom);
     } else {

--- a/lib/modules/datasource/nuget/common.ts
+++ b/lib/modules/datasource/nuget/common.ts
@@ -44,7 +44,7 @@ export function parseRegistryUrl(registryUrl: string): ParsedRegistryUrl {
   if (protocolVersionMatch) {
     const { protocol } = protocolVersionMatch;
     parsedUrl.hash = '';
-    protocolVersion = Number.parseInt(protocol, 10);
+    protocolVersion = Number.parseInt(protocol);
   } else if (parsedUrl.pathname.endsWith('.json')) {
     protocolVersion = 3;
   }

--- a/lib/modules/manager/npm/extract/yarn.ts
+++ b/lib/modules/manager/npm/extract/yarn.ts
@@ -20,7 +20,7 @@ export async function getYarnLock(filePath: string): Promise<LockFile> {
     for (const [key, val] of Object.entries(parsed)) {
       if (key === '__metadata') {
         // yarn 2
-        lockfileVersion = parseInt(val.cacheKey, 10);
+        lockfileVersion = parseInt(val.cacheKey);
         logger.once.debug(
           `yarn.lock ${filePath} has __metadata.cacheKey=${lockfileVersion}`,
         );

--- a/lib/modules/platform/gerrit/utils.ts
+++ b/lib/modules/platform/gerrit/utils.ts
@@ -141,7 +141,7 @@ export function mapBranchStatusToLabel(
   state: BranchStatus | 'UNKNOWN', // suppress default path code removal
   label: GerritLabelTypeInfo,
 ): number {
-  const numbers = Object.keys(label.values).map(parseInt);
+  const numbers = Object.keys(label.values).map((x) => parseInt(x));
   switch (state) {
     case 'green':
       return Math.max(...numbers);

--- a/lib/modules/platform/gerrit/utils.ts
+++ b/lib/modules/platform/gerrit/utils.ts
@@ -141,7 +141,7 @@ export function mapBranchStatusToLabel(
   state: BranchStatus | 'UNKNOWN', // suppress default path code removal
   label: GerritLabelTypeInfo,
 ): number {
-  const numbers = Object.keys(label.values).map((x) => parseInt(x, 10));
+  const numbers = Object.keys(label.values).map(parseInt);
   switch (state) {
     case 'green':
       return Math.max(...numbers);

--- a/lib/modules/versioning/conan/common.ts
+++ b/lib/modules/versioning/conan/common.ts
@@ -10,7 +10,7 @@ export function makeVersion(
   const prerelease = semver.prerelease(version, options);
 
   if (prerelease && !options.includePrerelease) {
-    if (!Number.isNaN(parseInt(prerelease.toString()[0], 10))) {
+    if (!Number.isNaN(parseInt(prerelease.toString()[0]))) {
       const stringVersion = `${splitVersion[0]}.${splitVersion[1]}.${splitVersion[2]}`;
       return semver.valid(stringVersion, options);
     }

--- a/lib/modules/versioning/deb/index.ts
+++ b/lib/modules/versioning/deb/index.ts
@@ -64,10 +64,10 @@ class DebVersioningApi extends GenericVersioningApi {
       return null;
     }
     const release = [...remainingVersion.matchAll(numericPattern)].map((m) =>
-      parseInt(m[0], 10),
+      parseInt(m[0]),
     );
     return {
-      epoch: parseInt(epochStr, 10),
+      epoch: parseInt(epochStr),
       upstreamVersion,
       debianRevision,
       release,

--- a/lib/modules/versioning/generic.spec.ts
+++ b/lib/modules/versioning/generic.spec.ts
@@ -43,7 +43,7 @@ describe('modules/versioning/generic', () => {
         }
         const { major, minor, patch, prerelease } = matchGroups;
         return {
-          release: [major, minor, patch].map((n) => parseInt(n, 10)),
+          release: [major, minor, patch].map(parseInt),
           prerelease,
         };
       }

--- a/lib/modules/versioning/generic.spec.ts
+++ b/lib/modules/versioning/generic.spec.ts
@@ -43,7 +43,7 @@ describe('modules/versioning/generic', () => {
         }
         const { major, minor, patch, prerelease } = matchGroups;
         return {
-          release: [major, minor, patch].map(parseInt),
+          release: [major, minor, patch].map((x) => parseInt(x)),
           prerelease,
         };
       }

--- a/lib/modules/versioning/gradle/compare.ts
+++ b/lib/modules/versioning/gradle/compare.ts
@@ -54,7 +54,7 @@ export function tokenize(versionStr: string): Token[] | null {
       if (regEx(/^\d+$/).test(val)) {
         result.push({
           type: TokenType.Number,
-          val: parseInt(val, 10),
+          val: parseInt(val),
         });
       } else {
         result.push({

--- a/lib/modules/versioning/hermit/index.ts
+++ b/lib/modules/versioning/hermit/index.ts
@@ -40,14 +40,14 @@ export class HermitVersioning extends RegExpVersioningApi {
       compatibility,
     } = groups;
     const release = [
-      Number.parseInt(major, 10),
-      typeof minor === 'undefined' ? 0 : Number.parseInt(minor, 10),
-      typeof patch === 'undefined' ? 0 : Number.parseInt(patch, 10),
-      typeof supplement === 'undefined' ? 0 : Number.parseInt(supplement, 10),
+      Number.parseInt(major),
+      typeof minor === 'undefined' ? 0 : Number.parseInt(minor),
+      typeof patch === 'undefined' ? 0 : Number.parseInt(patch),
+      typeof supplement === 'undefined' ? 0 : Number.parseInt(supplement),
     ];
 
     if (build) {
-      release.push(Number.parseInt(build, 10));
+      release.push(Number.parseInt(build));
     }
 
     return {
@@ -82,20 +82,20 @@ export class HermitVersioning extends RegExpVersioningApi {
     const release = [];
 
     if (major) {
-      release.push(Number.parseInt(major, 10));
+      release.push(Number.parseInt(major));
     }
 
     if (minor) {
-      release.push(Number.parseInt(minor, 10));
+      release.push(Number.parseInt(minor));
     }
     if (patch) {
-      release.push(Number.parseInt(patch, 10));
+      release.push(Number.parseInt(patch));
     }
     if (supplement) {
-      release.push(Number.parseInt(supplement, 10));
+      release.push(Number.parseInt(supplement));
     }
     if (build) {
-      release.push(Number.parseInt(build, 10));
+      release.push(Number.parseInt(build));
     }
 
     return {

--- a/lib/modules/versioning/maven/compare.ts
+++ b/lib/modules/versioning/maven/compare.ts
@@ -64,7 +64,7 @@ function iterateTokens(versionStr: string, cb: (token: Token) => void): void {
       cb({
         prefix: currentPrefix,
         type: TYPE_NUMBER,
-        val: parseInt(val, 10),
+        val: parseInt(val),
         isTransition: transition,
       });
     } else {

--- a/lib/modules/versioning/nixpkgs/index.ts
+++ b/lib/modules/versioning/nixpkgs/index.ts
@@ -27,11 +27,11 @@ export class NixPkgsVersioning extends RegExpVersioningApi {
     const release = [];
 
     if (major) {
-      release.push(Number.parseInt(major, 10));
+      release.push(Number.parseInt(major));
     }
 
     if (minor) {
-      release.push(Number.parseInt(minor, 10));
+      release.push(Number.parseInt(minor));
     }
 
     const compatibility = is.nonEmptyStringAndNotWhitespace(suffix)

--- a/lib/modules/versioning/nuget/parser.ts
+++ b/lib/modules/versioning/nuget/parser.ts
@@ -26,19 +26,19 @@ export function parseVersion(input: string): NugetVersion | null {
 
   const res: NugetVersion = {
     type: 'nuget-version',
-    major: Number.parseInt(major, 10),
+    major: Number.parseInt(major),
   };
 
   if (minor) {
-    res.minor = Number.parseInt(minor, 10);
+    res.minor = Number.parseInt(minor);
   }
 
   if (patch) {
-    res.patch = Number.parseInt(patch, 10);
+    res.patch = Number.parseInt(patch);
   }
 
   if (revision) {
-    res.revision = Number.parseInt(revision, 10);
+    res.revision = Number.parseInt(revision);
   }
 
   if (prerelease) {
@@ -58,7 +58,7 @@ const floatingRangeRegex = regEx(
 
 function parseFloatingComponent(input: string): number {
   const [int] = input.split('*');
-  return int ? 10 * Number.parseInt(int, 10) : 0;
+  return int ? 10 * Number.parseInt(int) : 0;
 }
 
 export function parseFloatingRange(input: string): NugetFloatingRange | null {
@@ -96,7 +96,7 @@ export function parseFloatingRange(input: string): NugetFloatingRange | null {
     };
   }
 
-  const majorNum = Number.parseInt(major, 10);
+  const majorNum = Number.parseInt(major);
   if (!Number.isNaN(majorNum)) {
     res = { ...res, major: majorNum };
   }
@@ -109,7 +109,7 @@ export function parseFloatingRange(input: string): NugetFloatingRange | null {
     };
   }
 
-  const minorNum = Number.parseInt(minor, 10);
+  const minorNum = Number.parseInt(minor);
   if (!Number.isNaN(minorNum)) {
     res = { ...res, minor: minorNum };
   }
@@ -122,9 +122,9 @@ export function parseFloatingRange(input: string): NugetFloatingRange | null {
     };
   }
 
-  const patchNum = Number.parseInt(patch, 10);
+  const patchNum = Number.parseInt(patch);
   if (!Number.isNaN(patchNum)) {
-    res = { ...res, patch: Number.parseInt(patch, 10) };
+    res = { ...res, patch: patchNum };
   }
 
   if (floating_revision) {
@@ -135,9 +135,9 @@ export function parseFloatingRange(input: string): NugetFloatingRange | null {
     };
   }
 
-  const revisionNum = Number.parseInt(revision, 10);
+  const revisionNum = Number.parseInt(revision);
   if (!Number.isNaN(revisionNum)) {
-    res = { ...res, revision: Number.parseInt(revision, 10) };
+    res = { ...res, revision: revisionNum };
   }
 
   if (res.prerelease) {

--- a/lib/modules/versioning/nuget/version.ts
+++ b/lib/modules/versioning/nuget/version.ts
@@ -8,7 +8,7 @@ function ensureNumber(input: string): number | null {
     return null;
   }
 
-  return Number.parseInt(input, 10);
+  return Number.parseInt(input);
 }
 
 function comparePrereleases(x: string, y: string): number {

--- a/lib/modules/versioning/perl/index.ts
+++ b/lib/modules/versioning/perl/index.ts
@@ -38,9 +38,9 @@ class PerlVersioningApi extends GenericVersioningApi {
           while (component.length < 3) {
             component += '0';
           }
-          return Number.parseInt(component, 10);
+          return Number.parseInt(component);
         }) ?? /* istanbul ignore next */ [];
-    const release = [Number.parseInt(intPart, 10), ...decimalComponents];
+    const release = [Number.parseInt(intPart), ...decimalComponents];
     return { release, prerelease };
   }
 

--- a/lib/modules/versioning/poetry/transform.ts
+++ b/lib/modules/versioning/poetry/transform.ts
@@ -51,7 +51,7 @@ export function poetry2semver(
   // trim leading zeros from valid numbers
   const releaseParts = matchGroups.release
     .split('.')
-    .map((segment) => parseInt(segment, 10));
+    .map((segment) => parseInt(segment));
   while (padRelease && releaseParts.length < 3) {
     releaseParts.push(0);
   }

--- a/lib/modules/versioning/pvp/util.ts
+++ b/lib/modules/versioning/pvp/util.ts
@@ -1,7 +1,7 @@
 import type { Parts } from './types';
 
 export function extractAllParts(version: string): number[] | null {
-  const parts = version.split('.').map((x) => parseInt(x, 10));
+  const parts = version.split('.').map(parseInt);
   const ret: number[] = [];
   for (const l of parts) {
     if (l < 0 || !isFinite(l)) {

--- a/lib/modules/versioning/pvp/util.ts
+++ b/lib/modules/versioning/pvp/util.ts
@@ -1,7 +1,7 @@
 import type { Parts } from './types';
 
 export function extractAllParts(version: string): number[] | null {
-  const parts = version.split('.').map(parseInt);
+  const parts = version.split('.').map((x) => parseInt(x));
   const ret: number[] = [];
   for (const l of parts) {
     if (l < 0 || !isFinite(l)) {

--- a/lib/modules/versioning/redhat/index.ts
+++ b/lib/modules/versioning/redhat/index.ts
@@ -21,15 +21,11 @@ class RedhatVersioningApi extends GenericVersioningApi {
 
     const { major, minor, patch, releaseMajor, releaseMinor } = matches;
     const release = [
-      Number.parseInt(major, 10),
-      typeof minor === 'undefined' ? 0 : Number.parseInt(minor, 10),
-      typeof patch === 'undefined' ? 0 : Number.parseInt(patch, 10),
-      typeof releaseMajor === 'undefined'
-        ? 0
-        : Number.parseInt(releaseMajor, 10),
-      typeof releaseMinor === 'undefined'
-        ? 0
-        : Number.parseInt(releaseMinor, 10),
+      Number.parseInt(major),
+      typeof minor === 'undefined' ? 0 : Number.parseInt(minor),
+      typeof patch === 'undefined' ? 0 : Number.parseInt(patch),
+      typeof releaseMajor === 'undefined' ? 0 : Number.parseInt(releaseMajor),
+      typeof releaseMinor === 'undefined' ? 0 : Number.parseInt(releaseMinor),
     ];
 
     return { release, prerelease: '' };

--- a/lib/modules/versioning/regex/index.ts
+++ b/lib/modules/versioning/regex/index.ts
@@ -64,15 +64,15 @@ export class RegExpVersioningApi extends GenericVersioningApi<RegExpVersion> {
     const { major, minor, patch, build, revision, prerelease, compatibility } =
       groups;
     const release = [
-      typeof major === 'undefined' ? 0 : Number.parseInt(major, 10),
-      typeof minor === 'undefined' ? 0 : Number.parseInt(minor, 10),
-      typeof patch === 'undefined' ? 0 : Number.parseInt(patch, 10),
+      typeof major === 'undefined' ? 0 : Number.parseInt(major),
+      typeof minor === 'undefined' ? 0 : Number.parseInt(minor),
+      typeof patch === 'undefined' ? 0 : Number.parseInt(patch),
     ];
 
     if (build) {
-      release.push(Number.parseInt(build, 10));
+      release.push(Number.parseInt(build));
       if (revision) {
-        release.push(Number.parseInt(revision, 10));
+        release.push(Number.parseInt(revision));
       }
     }
 

--- a/lib/modules/versioning/rpm/index.ts
+++ b/lib/modules/versioning/rpm/index.ts
@@ -61,7 +61,7 @@ class RpmVersioningApi extends GenericVersioningApi {
     if (epochIndex !== -1) {
       const epochStr = remainingVersion.slice(0, epochIndex);
       if (epochPattern.test(epochStr)) {
-        epoch = parseInt(epochStr, 10);
+        epoch = parseInt(epochStr);
       } else {
         return null;
       }
@@ -111,7 +111,7 @@ class RpmVersioningApi extends GenericVersioningApi {
     }
 
     const release = [...remainingVersion.matchAll(regEx(/\d+/g))].map((m) =>
-      parseInt(m[0], 10),
+      parseInt(m[0]),
     );
 
     return {

--- a/lib/modules/versioning/ruby/version.ts
+++ b/lib/modules/versioning/ruby/version.ts
@@ -58,7 +58,7 @@ const pgteUpperBound = (version: string): string => {
 // istanbul ignore next
 const incrementLastSegment = (version: string): string => {
   const segments = releaseSegments(version);
-  const nextLast = parseInt(segments.pop() as string, 10) + 1;
+  const nextLast = parseInt(segments.pop() as string) + 1;
 
   return [...segments, nextLast].join('.');
 };

--- a/lib/modules/versioning/ubuntu/common.ts
+++ b/lib/modules/versioning/ubuntu/common.ts
@@ -20,7 +20,7 @@ function getDatedContainerImageVersion(version: string): null | number {
     return null;
   }
 
-  return parseInt(groups.groups.date, 10);
+  return parseInt(groups.groups.date);
 }
 
 function getDatedContainerImageSuffix(version: string): null | string {

--- a/lib/modules/versioning/ubuntu/index.ts
+++ b/lib/modules/versioning/ubuntu/index.ts
@@ -74,7 +74,7 @@ function getMajor(version: string): null | number {
   const ver = getVersionByCodename(version);
   if (isValid(ver)) {
     const [major] = ver.split('.');
-    return parseInt(major, 10);
+    return parseInt(major);
   }
   return null;
 }
@@ -83,7 +83,7 @@ function getMinor(version: string): null | number {
   const ver = getVersionByCodename(version);
   if (isValid(ver)) {
     const [, minor] = ver.split('.');
-    return parseInt(minor, 10);
+    return parseInt(minor);
   }
   return null;
 }
@@ -92,7 +92,7 @@ function getPatch(version: string): null | number {
   const ver = getVersionByCodename(version);
   if (isValid(ver)) {
     const [, , patch] = ver.split('.');
-    return patch ? parseInt(patch, 10) : null;
+    return patch ? parseInt(patch) : null;
   }
   return null;
 }

--- a/lib/modules/versioning/unity3d-packages/index.ts
+++ b/lib/modules/versioning/unity3d-packages/index.ts
@@ -24,11 +24,7 @@ class Unity3dPackagesVersioningApi extends GenericVersioningApi {
     }
     const { major, minor, patch, label } = matches.groups;
 
-    const release = [
-      parseInt(major, 10),
-      parseInt(minor, 10),
-      parseInt(patch, 10),
-    ];
+    const release = [parseInt(major), parseInt(minor), parseInt(patch)];
     const isStable = !Unity3dPackagesVersioningApi.unstableRegex.test(label);
 
     return { release, prerelease: isStable ? undefined : label };

--- a/lib/modules/versioning/unity3d/index.ts
+++ b/lib/modules/versioning/unity3d/index.ts
@@ -33,11 +33,11 @@ class Unity3dVersioningApi extends GenericVersioningApi {
     const { major, minor, patch, releaseStream, build } = matches.groups;
 
     const release = [
-      parseInt(major, 10),
-      parseInt(minor, 10),
-      parseInt(patch, 10),
+      parseInt(major),
+      parseInt(minor),
+      parseInt(patch),
       Unity3dVersioningApi.ReleaseStreamType.indexOf(releaseStream),
-      parseInt(build, 10),
+      parseInt(build),
     ];
     const isStable =
       Unity3dVersioningApi.stableVersions.includes(releaseStream);

--- a/lib/util/git/auth.ts
+++ b/lib/util/git/auth.ts
@@ -41,7 +41,7 @@ export function getGitAuthenticatedEnvironmentVariables(
   let gitConfigCount = 0;
   if (gitConfigCountEnvVariable) {
     // passthrough the gitConfigCountEnvVariable environment variable as start value of the index count
-    gitConfigCount = parseInt(gitConfigCountEnvVariable, 10);
+    gitConfigCount = parseInt(gitConfigCountEnvVariable);
     if (Number.isNaN(gitConfigCount)) {
       logger.warn(
         {

--- a/lib/util/http/forgejo.ts
+++ b/lib/util/http/forgejo.ts
@@ -48,8 +48,8 @@ export class ForgejoHttp extends HttpBase<ForgejoHttpOptions> {
       opts.httpOptions.memCache = false;
 
       delete opts.httpOptions.paginate;
-      const total = parseInt(res.headers['x-total-count'] as string, 10);
-      let nextPage = parseInt(resolvedUrl.searchParams.get('page') ?? '1', 10);
+      const total = parseInt(res.headers['x-total-count'] as string);
+      let nextPage = parseInt(resolvedUrl.searchParams.get('page') ?? '1');
 
       while (total && pc.length < total) {
         nextPage += 1;

--- a/lib/util/http/gitea.ts
+++ b/lib/util/http/gitea.ts
@@ -48,8 +48,8 @@ export class GiteaHttp extends HttpBase<GiteaHttpOptions> {
       opts.httpOptions.memCache = false;
 
       delete opts.httpOptions.paginate;
-      const total = parseInt(res.headers['x-total-count'] as string, 10);
-      let nextPage = parseInt(resolvedUrl.searchParams.get('page') ?? '1', 10);
+      const total = parseInt(res.headers['x-total-count'] as string);
+      let nextPage = parseInt(resolvedUrl.searchParams.get('page') ?? '1');
 
       while (total && pc.length < total) {
         nextPage += 1;

--- a/lib/util/http/github.ts
+++ b/lib/util/http/github.ts
@@ -360,7 +360,7 @@ export class GithubHttp extends HttpBase<GithubHttpOptions> {
       const next = linkHeader?.next;
       const env = getEnv();
       if (next?.url && linkHeader?.last?.page) {
-        let lastPage = parseInt(linkHeader.last.page, 10);
+        let lastPage = parseInt(linkHeader.last.page);
         if (!env.RENOVATE_PAGINATE_ALL && httpOptions.paginate !== 'all') {
           lastPage = Math.min(pageLimit, lastPage);
         }

--- a/lib/util/http/retry-after.ts
+++ b/lib/util/http/retry-after.ts
@@ -102,7 +102,7 @@ export function getRetryAfter(err: unknown): number | null {
     return seconds;
   }
 
-  const seconds = parseInt(retryAfter, 10);
+  const seconds = parseInt(retryAfter);
   if (!Number.isNaN(seconds) && seconds >= 0) {
     return seconds;
   }

--- a/lib/util/number.ts
+++ b/lib/util/number.ts
@@ -26,6 +26,6 @@ export function parseInteger(
 ): number {
   // Number.parseInt returns NaN if the value is not a finite integer.
   const parsed =
-    is.string(val) && /^\d+$/.test(val) ? Number.parseInt(val, 10) : Number.NaN;
+    is.string(val) && /^\d+$/.test(val) ? Number.parseInt(val) : Number.NaN;
   return Number.isFinite(parsed) ? parsed : (def ?? 0);
 }

--- a/tools/utils/index.ts
+++ b/tools/utils/index.ts
@@ -75,7 +75,7 @@ export function parsePositiveInt(val: string | undefined): number {
   if (!val) {
     return 0;
   }
-  const r = Number.parseInt(val, 10);
+  const r = Number.parseInt(val);
   if (!Number.isFinite(r) || r < 0) {
     throw new Error(`Invalid number: ${val}`);
   }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
On ECMA 5+ the radix defaults to 10 and no longer special handling.
I learned that today.

<!-- Describe what behavior is changed by this PR. -->

## Context
- #37161
- - https://eslint.org/docs/latest/rules/radix
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
