### PR TITLE
docs: Change incorrect log remapping

### DIFF
--- a/lib/modules/datasource/custom/readme.md
+++ b/lib/modules/datasource/custom/readme.md
@@ -98,7 +98,7 @@ If you use the Mend Renovate app, use the [`logLevelRemap` config option](../../
 {
   "logLevelRemap": [
     {
-      "matchMessage": "/^Custom manager fetcher/",
+      "matchMessage": "/^Custom datasource/",
       "newLogLevel": "info"
     }
   ]


### PR DESCRIPTION


## Changes

The log remapping example for the custom datasource module is incorrect, and when applied provides no aditional logs

## Context

[This commit ](https://github.com/renovatebot/renovate/commit/fe360349c8c14aba929d6319dd68da3b06ada4fe) changes the log messages, I adapted the example to use the correct matcher


## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
