### PR TITLE
fix(bitbucket-server): getUsersFromReviewerGroup to return slugs, not emails

### DIFF
--- a/lib/modules/platform/bitbucket-server/index.spec.ts
+++ b/lib/modules/platform/bitbucket-server/index.spec.ts
@@ -2885,7 +2885,7 @@ Followed by some information.
           const users = await bitbucket.expandGroupMembers([
             '@reviewer-group/my-reviewer-group',
           ]);
-          expect(users).toEqual(['alice@alice.com', 'carol@carol.com']);
+          expect(users).toEqual(['alice', 'carol']);
         });
         it('returns empty array if group is not found', async () => {
           const scope = await initRepo();
@@ -2946,13 +2946,11 @@ Followed by some information.
                     {
                       slug: 'user1',
                       active: false,
-                      emailAddress: 'user1@user1.com',
                       displayName: 'user1',
                     },
                     {
                       slug: 'user2',
                       active: false,
-                      emailAddress: 'user2@user2.com',
                       displayName: 'user2',
                     },
                   ],
@@ -3009,7 +3007,7 @@ Followed by some information.
           const users = await bitbucket.expandGroupMembers([
             '@reviewer-group/my-group',
           ]);
-          expect(users).toEqual(['zoe@repo.com']);
+          expect(users).toEqual(['zoe']);
         });
 
         it('uses project-level group when repository-level group is not available', async () => {
@@ -3042,7 +3040,7 @@ Followed by some information.
           const users = await bitbucket.expandGroupMembers([
             '@reviewer-group/my-group',
           ]);
-          expect(users).toEqual(['jane@project.com']);
+          expect(users).toEqual(['jane']);
         });
 
         it('deals with not found groups correctly', async () => {
@@ -3116,7 +3114,7 @@ Followed by some information.
             '@reviewer-group/my-reviewer-group:random',
           ]);
           expect(users).toHaveLength(1);
-          expect(userArray.map((u) => u.emailAddress)).toContain(users[0]);
+          expect(userArray.map((u) => u.slug)).toContain(users[0]);
         });
         it('handles random with number correctly', async () => {
           const scope = await initRepo();
@@ -3163,7 +3161,7 @@ Followed by some information.
           ]);
           expect(users).toHaveLength(2);
           users.forEach((user) => {
-            expect(userArray.map((u) => u.emailAddress)).toContain(user);
+            expect(userArray.map((u) => u.slug)).toContain(user);
           });
         });
 
@@ -3212,7 +3210,7 @@ Followed by some information.
           ]);
           expect(users).toHaveLength(3);
           users.forEach((user) => {
-            expect(userArray.map((u) => u.emailAddress)).toContain(user);
+            expect(userArray.map((u) => u.slug)).toContain(user);
           });
         });
 
@@ -3276,7 +3274,7 @@ Followed by some information.
           const users = await bitbucket.expandGroupMembers([
             '@reviewer-group/my-reviewer-group',
           ]);
-          expect(users).toEqual(['alice@alice.com', 'bob@bob.com']);
+          expect(users).toEqual(['alice', 'bob']);
         });
       });
     });

--- a/lib/modules/platform/bitbucket-server/index.ts
+++ b/lib/modules/platform/bitbucket-server/index.ts
@@ -1305,7 +1305,7 @@ async function getUsersFromReviewerGroup(groupName: string): Promise<string[]> {
   if (repoGroup) {
     return repoGroup.users
       .filter((user) => user.active)
-      .map((user) => user.emailAddress);
+      .map((user) => user.slug);
   }
 
   // If no repo-level group, fall back to project-level group
@@ -1316,7 +1316,7 @@ async function getUsersFromReviewerGroup(groupName: string): Promise<string[]> {
   if (projectGroup) {
     return projectGroup.users
       .filter((user) => user.active)
-      .map((user) => user.emailAddress);
+      .map((user) => user.slug);
   }
 
   // Group not found at either level

--- a/lib/modules/platform/bitbucket-server/index.ts
+++ b/lib/modules/platform/bitbucket-server/index.ts
@@ -170,7 +170,7 @@ export async function initPlatform({
         )
       ).body;
 
-      if (!emailAddress?.length) {
+      if (!emailAddress.length) {
         throw new Error(`No email address configured for username ${username}`);
       }
 

--- a/lib/modules/platform/bitbucket-server/index.ts
+++ b/lib/modules/platform/bitbucket-server/index.ts
@@ -170,7 +170,7 @@ export async function initPlatform({
         )
       ).body;
 
-      if (!emailAddress.length) {
+      if (!emailAddress?.length) {
         throw new Error(`No email address configured for username ${username}`);
       }
 

--- a/lib/modules/platform/bitbucket-server/index.ts
+++ b/lib/modules/platform/bitbucket-server/index.ts
@@ -170,7 +170,7 @@ export async function initPlatform({
         )
       ).body;
 
-      if (!emailAddress || !emailAddress.length) {
+      if (!emailAddress.length) {
         throw new Error(`No email address configured for username ${username}`);
       }
 

--- a/lib/modules/platform/bitbucket-server/index.ts
+++ b/lib/modules/platform/bitbucket-server/index.ts
@@ -170,7 +170,7 @@ export async function initPlatform({
         )
       ).body;
 
-      if (!emailAddress.length) {
+      if (!emailAddress || !emailAddress.length) {
         throw new Error(`No email address configured for username ${username}`);
       }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Returns userSlugs instead of emailAddresses from getUsersFromReviewerGroup

## Context

It is waste to first fetch emailaddresses from groups, which aren't even required since #37512 to then call BitBucket and try to find a slug based on the emailaddress. Now we use the slug directly.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
