### PR TITLE
fix: use shared email type

### DIFF
--- a/lib/modules/platform/bitbucket-server/__snapshots__/index.spec.ts.snap
+++ b/lib/modules/platform/bitbucket-server/__snapshots__/index.spec.ts.snap
@@ -6,8 +6,6 @@ exports[`modules/platform/bitbucket-server/index > endpoint with no path > addRe
 
 exports[`modules/platform/bitbucket-server/index > endpoint with no path > addReviewers > throws 1`] = `[HTTPError: Response code 405 (Method Not Allowed)]`;
 
-exports[`modules/platform/bitbucket-server/index > endpoint with no path > addReviewers > throws on invalid reviewers 1`] = `[HTTPError: Response code 409 (Conflict)]`;
-
 exports[`modules/platform/bitbucket-server/index > endpoint with no path > deleteLAbel() > does not throw 1`] = `undefined`;
 
 exports[`modules/platform/bitbucket-server/index > endpoint with no path > findPr() > has pr 1`] = `
@@ -210,8 +208,6 @@ exports[`modules/platform/bitbucket-server/index > endpoint with path > addAssig
 exports[`modules/platform/bitbucket-server/index > endpoint with path > addReviewers > does not throw 1`] = `undefined`;
 
 exports[`modules/platform/bitbucket-server/index > endpoint with path > addReviewers > throws 1`] = `[HTTPError: Response code 405 (Method Not Allowed)]`;
-
-exports[`modules/platform/bitbucket-server/index > endpoint with path > addReviewers > throws on invalid reviewers 1`] = `[HTTPError: Response code 409 (Conflict)]`;
 
 exports[`modules/platform/bitbucket-server/index > endpoint with path > deleteLAbel() > does not throw 1`] = `undefined`;
 

--- a/lib/modules/platform/bitbucket-server/index.ts
+++ b/lib/modules/platform/bitbucket-server/index.ts
@@ -1305,7 +1305,7 @@ async function getUsersFromReviewerGroup(groupName: string): Promise<string[]> {
   if (repoGroup) {
     return repoGroup.users
       .filter((user) => user.active)
-      .map((user) => user.emailAddress ?? user.slug);
+      .map((user) => user.emailAddress);
   }
 
   // If no repo-level group, fall back to project-level group
@@ -1316,7 +1316,7 @@ async function getUsersFromReviewerGroup(groupName: string): Promise<string[]> {
   if (projectGroup) {
     return projectGroup.users
       .filter((user) => user.active)
-      .map((user) => user.emailAddress ?? user.slug);
+      .map((user) => user.emailAddress);
   }
 
   // Group not found at either level

--- a/lib/modules/platform/bitbucket-server/index.ts
+++ b/lib/modules/platform/bitbucket-server/index.ts
@@ -170,7 +170,7 @@ export async function initPlatform({
         )
       ).body;
 
-      if (!emailAddress.length) {
+      if (!emailAddress?.length) {
         throw new Error(`No email address configured for username ${username}`);
       }
 
@@ -1305,7 +1305,7 @@ async function getUsersFromReviewerGroup(groupName: string): Promise<string[]> {
   if (repoGroup) {
     return repoGroup.users
       .filter((user) => user.active)
-      .map((user) => user.emailAddress);
+      .map((user) => user.emailAddress ?? user.slug);
   }
 
   // If no repo-level group, fall back to project-level group
@@ -1316,7 +1316,7 @@ async function getUsersFromReviewerGroup(groupName: string): Promise<string[]> {
   if (projectGroup) {
     return projectGroup.users
       .filter((user) => user.active)
-      .map((user) => user.emailAddress);
+      .map((user) => user.emailAddress ?? user.slug);
   }
 
   // Group not found at either level

--- a/lib/modules/platform/bitbucket-server/index.ts
+++ b/lib/modules/platform/bitbucket-server/index.ts
@@ -25,6 +25,7 @@ import type { HttpOptions, HttpResponse } from '../../../util/http/types';
 import { newlineRegex, regEx } from '../../../util/regex';
 import { sampleSize } from '../../../util/sample';
 import { sanitize } from '../../../util/sanitize';
+import { isEmailAdress } from '../../../util/schema-utils';
 import { ensureTrailingSlash, getQueryString } from '../../../util/url';
 import type {
   BranchStatusConfig,
@@ -52,7 +53,7 @@ import type {
   PullRequestActivity,
   PullRequestCommentActivity,
 } from './schema';
-import { ReviewerGroups, User, Users, isEmail } from './schema';
+import { ReviewerGroups, User, Users } from './schema';
 import type {
   BbsConfig,
   BbsPr,
@@ -694,7 +695,7 @@ export async function addReviewers(
 
   for (const entry of reviewers) {
     // If entry is an email-address, resolve userslugs
-    if (isEmail(entry)) {
+    if (isEmailAdress(entry)) {
       const slugs = await getUserSlugsByEmail(entry);
       for (const slug of slugs) {
         reviewerSlugs.add(slug);

--- a/lib/modules/platform/bitbucket-server/schema.ts
+++ b/lib/modules/platform/bitbucket-server/schema.ts
@@ -1,8 +1,9 @@
 import { z } from 'zod';
+import { EmailAddress } from '../../../util/schema-utils';
 
 export const User = z.object({
   displayName: z.string(),
-  emailAddress: z.string(),
+  emailAddress: EmailAddress,
   active: z.boolean(),
   slug: z.string(),
 });
@@ -43,8 +44,3 @@ export const ReviewerGroup = z.object({
   }),
 });
 export const ReviewerGroups = z.array(ReviewerGroup);
-
-const Email = z.string().email();
-
-export const isEmail = (value: string): boolean =>
-  Email.safeParse(value).success;

--- a/lib/modules/platform/bitbucket-server/schema.ts
+++ b/lib/modules/platform/bitbucket-server/schema.ts
@@ -3,7 +3,7 @@ import { EmailAddress } from '../../../util/schema-utils';
 
 export const User = z.object({
   displayName: z.string(),
-  emailAddress: EmailAddress,
+  emailAddress: EmailAddress.nullish().catch(null),
   active: z.boolean(),
   slug: z.string(),
 });

--- a/lib/modules/platform/bitbucket-server/schema.ts
+++ b/lib/modules/platform/bitbucket-server/schema.ts
@@ -3,7 +3,7 @@ import { EmailAddress } from '../../../util/schema-utils';
 
 export const User = z.object({
   displayName: z.string(),
-  emailAddress: EmailAddress.nullish().catch(null),
+  emailAddress: EmailAddress.catch(''),
   active: z.boolean(),
   slug: z.string(),
 });

--- a/lib/modules/platform/forgejo/types.ts
+++ b/lib/modules/platform/forgejo/types.ts
@@ -1,4 +1,5 @@
 import type { LongCommitSha } from '../../../util/git/types';
+import type { EmailAddress } from '../../../util/schema-utils';
 import type { Pr, RepoSortMethod, SortMethod } from '../types';
 
 export interface PrReviewersParams {
@@ -67,7 +68,7 @@ export interface Issue {
 
 export interface User {
   id: number;
-  email: string;
+  email: EmailAddress;
   full_name?: string;
   username: string;
 }
@@ -136,7 +137,7 @@ export interface Commit {
 
 export interface CommitUser {
   name: string;
-  email: string;
+  email: EmailAddress;
   username: string;
 }
 

--- a/lib/modules/platform/gitea/types.ts
+++ b/lib/modules/platform/gitea/types.ts
@@ -1,4 +1,5 @@
 import type { LongCommitSha } from '../../../util/git/types';
+import type { EmailAddress } from '../../../util/schema-utils';
 import type { Pr, RepoSortMethod, SortMethod } from '../types';
 
 export interface PrReviewersParams {
@@ -67,7 +68,7 @@ export interface Issue {
 
 export interface User {
   id: number;
-  email: string;
+  email: EmailAddress;
   full_name?: string;
   username: string;
 }
@@ -136,7 +137,7 @@ export interface Commit {
 
 export interface CommitUser {
   name: string;
-  email: string;
+  email: EmailAddress;
   username: string;
 }
 

--- a/lib/modules/platform/github/types.ts
+++ b/lib/modules/platform/github/types.ts
@@ -1,4 +1,5 @@
 import type { LongCommitSha } from '../../../util/git/types';
+import type { EmailAddress } from '../../../util/schema-utils';
 import type { Pr, PrBodyStruct } from '../types';
 
 // https://developer.github.com/v3/repos/statuses
@@ -84,7 +85,7 @@ export interface PlatformConfig {
   isGHApp?: boolean;
   existingRepos?: string[];
   userDetails?: UserDetails;
-  userEmail?: string | null;
+  userEmail?: EmailAddress | null;
 }
 
 export interface LocalRepoConfig {

--- a/lib/modules/platform/github/user.ts
+++ b/lib/modules/platform/github/user.ts
@@ -1,5 +1,6 @@
 import { logger } from '../../../logger';
 import * as githubHttp from '../../../util/http/github';
+import type { EmailAddress } from '../../../util/schema-utils';
 import type { UserDetails } from './types';
 
 const githubApi = new githubHttp.GithubHttp();
@@ -54,10 +55,10 @@ export async function getUserDetails(
 export async function getUserEmail(
   endpoint: string,
   token: string,
-): Promise<string | null> {
+): Promise<EmailAddress | null> {
   try {
     const emails = (
-      await githubApi.getJsonUnchecked<{ email: string }[]>(
+      await githubApi.getJsonUnchecked<{ email: EmailAddress }[]>(
         endpoint + 'user/emails',
         {
           token,

--- a/lib/modules/platform/gitlab/index.ts
+++ b/lib/modules/platform/gitlab/index.ts
@@ -26,6 +26,7 @@ import { parseInteger } from '../../../util/number';
 import * as p from '../../../util/promises';
 import { regEx } from '../../../util/regex';
 import { sanitize } from '../../../util/sanitize';
+import type { EmailAddress } from '../../../util/schema-utils';
 import { ensureTrailingSlash, getQueryString } from '../../../util/url';
 import type {
   AutodiscoverConfig,
@@ -77,7 +78,7 @@ export { extractRulesFromCodeOwnersLines } from './code-owners';
 
 let config: {
   repository: string;
-  email: string;
+  email: EmailAddress;
   issueList: GitlabIssue[] | undefined;
   mergeMethod: MergeMethod;
   mergeTrainsEnabled: boolean;
@@ -125,10 +126,10 @@ export async function initPlatform({
     if (!gitAuthor) {
       const user = (
         await gitlabApi.getJsonUnchecked<{
-          email: string;
+          email: EmailAddress;
           name: string;
           id: number;
-          commit_email?: string;
+          commit_email?: EmailAddress;
         }>(`user`, { token })
       ).body;
       platformConfig.gitAuthor = `${user.name} <${

--- a/lib/util/git/types.ts
+++ b/lib/util/git/types.ts
@@ -1,5 +1,6 @@
 import type { PlatformCommitOptions } from '../../config/types';
 import type { GitOptions } from '../../types/git';
+import type { EmailAddress } from '../schema-utils';
 
 export type { DiffResult, StatusResult } from 'simple-git';
 
@@ -35,7 +36,7 @@ export interface LocalConfig extends StorageConfig {
   commitBranches: Record<string, string[]>;
   ignoredAuthors: string[];
   gitAuthorName?: string | null;
-  gitAuthorEmail?: string;
+  gitAuthorEmail?: EmailAddress;
 
   writeGitDone?: boolean;
 }

--- a/lib/util/schema-utils/index.ts
+++ b/lib/util/schema-utils/index.ts
@@ -362,3 +362,10 @@ export const NotCircular = z.unknown().superRefine((val, ctx) => {
     return z.NEVER;
   }
 });
+
+export const EmailAddress = z.string().email();
+export type EmailAddress = z.infer<typeof EmailAddress>;
+
+export function isEmailAdress(value: string): boolean {
+  return EmailAddress.safeParse(value).success;
+}


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Moved email type to schema utils and use the type for all emails (not validated)
<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
