### PR TITLE
feat(config): support base64-encoded privateKey

### DIFF
--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -769,6 +769,14 @@ Before the first commit in a repository, Renovate will:
 The `git` commands are run locally in the cloned repo instead of globally.
 This reduces the chance of unintended consequences with global Git configs on shared systems.
 
+<!-- prettier-ignore -->
+!!! tip
+    Renovate supports base64-encoded private keys for the `privateKey` config option. If your private key value is base64-encoded (for example, if it does not start with `-----BEGIN` and matches base64 format), Renovate will automatically decode it before use. This is useful if your configuration system or secrets manager only supports base64 values.
+
+    - You can provide either a PEM-formatted key or a base64-encoded PEM key.
+    - This does **not** apply to `privateKeyOld`, `privateKeyPath`, or `privateKeyPathOld`.
+    - If the decoded value does not look like a PEM key, Renovate will use the original value as-is.
+
 ## gitPrivateKeyPassphrase
 
 Passphrase for the `gitPrivateKey` when the private key is protected with a passphrase.

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -771,10 +771,10 @@ This reduces the chance of unintended consequences with global Git configs on sh
 
 <!-- prettier-ignore -->
 !!! tip
-    Renovate supports base64-encoded private keys for the `privateKey` config option. If your private key value is base64-encoded (for example, if it does not start with `-----BEGIN` and matches base64 format), Renovate will automatically decode it before use. This is useful if your configuration system or secrets manager only supports base64 values.
+    Renovate supports base64-encoded private keys for the `privateKey` and `privateKeyOld` config options. If your private key value is base64-encoded (for example, if it does not start with `-----BEGIN` and matches base64 format), Renovate will automatically decode it before use. This is useful if your configuration system or secrets manager only supports base64 values, or if configuring via environment variables.
 
-    - You can provide either a PEM-formatted key or a base64-encoded PEM key.
-    - This does **not** apply to `privateKeyOld`, `privateKeyPath`, or `privateKeyPathOld`.
+    - You can provide either a PEM-formatted key or a base64-encoded PEM key for both `privateKey` and `privateKeyOld`.
+    - This does **not** apply to `privateKeyPath` or `privateKeyPathOld`.
     - If the decoded value does not look like a PEM key, Renovate will use the original value as-is.
 
 ## gitPrivateKeyPassphrase

--- a/lib/config/decrypt.spec.ts
+++ b/lib/config/decrypt.spec.ts
@@ -327,4 +327,51 @@ describe('config/decrypt', () => {
       );
     });
   });
+
+  describe('setPrivateKeys (base64 support for privateKeyOld)', () => {
+    const pemKey =
+      '-----BEGIN PGP PRIVATE KEY BLOCK-----\nMIIB...END PGP PRIVATE KEY BLOCK-----';
+    const base64PemKey = Buffer.from(pemKey, 'utf-8').toString('base64');
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it('should use PEM as-is if provided for privateKeyOld', () => {
+      setPrivateKeys(undefined, pemKey);
+      expect(logger.logger.debug).toHaveBeenCalledWith(
+        'privateKeyOld: using value as-is (not base64 or already PEM)',
+      );
+    });
+
+    it('should decode base64 PEM and use decoded value for privateKeyOld', () => {
+      setPrivateKeys(undefined, base64PemKey);
+      expect(logger.logger.debug).toHaveBeenCalledWith(
+        'privateKeyOld: detected possible base64 encoding, attempting to decode',
+      );
+      expect(logger.logger.debug).toHaveBeenCalledWith(
+        'privateKeyOld: base64 decoded successfully, using decoded PEM',
+      );
+    });
+
+    it('should use original value if base64 decode does not yield PEM for privateKeyOld', () => {
+      const base64Garbage = Buffer.from('not-a-pem', 'utf-8').toString(
+        'base64',
+      );
+      setPrivateKeys(undefined, base64Garbage);
+      expect(logger.logger.debug).toHaveBeenCalledWith(
+        'privateKeyOld: detected possible base64 encoding, attempting to decode',
+      );
+      expect(logger.logger.debug).toHaveBeenCalledWith(
+        'privateKeyOld: base64 decoded but does not look like PEM, using original value',
+      );
+    });
+
+    it('should use original value if not base64 and not PEM for privateKeyOld', () => {
+      setPrivateKeys(undefined, 'not-base64-or-pem');
+      expect(logger.logger.debug).toHaveBeenCalledWith(
+        'privateKeyOld: using value as-is (not base64 or already PEM)',
+      );
+    });
+  });
 });


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds ability for privateKey to be base64-encoded

## Context

Closes #37517

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
