### PR TITLE
fix(config-migration): ignore `commitMessageSuffix` for `prTitle`

### DIFF
--- a/lib/workers/repository/config-migration/branch/commit-message.ts
+++ b/lib/workers/repository/config-migration/branch/commit-message.ts
@@ -17,6 +17,7 @@ export class ConfigMigrationCommitMessageFactory {
       semanticCommitScope: 'config',
       commitMessageExtra: '',
       commitMessageAction: '',
+      commitMessageSuffix: '',
       commitMessageTopic,
     };
 

--- a/lib/workers/repository/config-migration/branch/create.spec.ts
+++ b/lib/workers/repository/config-migration/branch/create.spec.ts
@@ -138,32 +138,6 @@ describe('workers/repository/config-migration/branch/create', () => {
       });
     });
 
-    describe('applies the commitMessageSuffix value', () => {
-      it('to the default commit message', async () => {
-        const suffix = 'SUFFIX';
-        config.commitMessageSuffix = suffix;
-
-        const message = `Migrate config renovate.json ${suffix}`;
-        await createConfigMigrationBranch(config, migratedConfigData);
-
-        expect(scm.checkoutBranch).toHaveBeenCalledWith(config.defaultBranch);
-        expect(scm.commitAndPush).toHaveBeenCalledWith({
-          branchName: 'renovate/migrate-config',
-          baseBranch: 'dev',
-          files: [
-            {
-              type: 'addition',
-              path: 'renovate.json',
-              contents: renovateConfig,
-            },
-          ],
-          message,
-          platformCommit: 'auto',
-          force: true,
-        });
-      });
-    });
-
     describe('applies semanticCommit prefix', () => {
       it('to the default commit message', async () => {
         const prefix = 'chore(config)';


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- Use emoty string as `commitMessageSuffix` for the pr title and commit message
<!-- Describe what behavior is changed by this PR. -->

## Context
- Ref: https://github.com/renovatebot/renovate/discussions/37061
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or https://github.com/Rahul-renovate-testing/renovate-repro-37061/pull/1
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
