### PR TITLE
fix(bitbucket-server): getUsersByEmail pagination zod error

### DIFF
--- a/lib/modules/platform/bitbucket-server/index.ts
+++ b/lib/modules/platform/bitbucket-server/index.ts
@@ -729,7 +729,7 @@ export async function getUserSlugsByEmail(
 
     const users = await bitbucketServerHttp.getJson(
       filterUrl,
-      { limit: 100 },
+      { paginate: true, limit: 100 },
       Users,
     );
 


### PR DESCRIPTION
Without the `paginate` option, no array but an object was returned, c…ausing errors. Explicitly added paginate again with a limit.

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds the `paginate: true` httpOption to the getUsersFiltered httpCall.

## Context

In #37199 the logic was added, to try to resolve emailAddresses to userSlugs when adding reviewers. This is done via a REST api call to BitBucket server. We concluded a limit op 100 results should be enough to match the requested user. However, in prod env, I get an error from ZOD on this call. It expects an array to be returned but it is an object. Debugging found that [my initial comment](https://github.com/renovatebot/renovate/pull/37199#discussion_r2252420195) was wrong. We need to explicitly add: `paginate: true` to the request, [for the logic of to parse the response into a valuesarray](https://github.com/renovatebot/renovate/blob/41.73.2/lib/util/http/bitbucket-server.ts#L54). This fixes the error.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
