### PR TITLE
feat(datasource/maven): set latest tag ignored by default

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -4250,6 +4250,12 @@ For `npm` manager when `replacementApproach=alias` then instead of replacing `"f
 Similar to `ignoreUnstable`, this option controls whether to update to versions that are greater than the version tagged as `latest` in the repository.
 By default, `renovate` will update to a version greater than `latest` only if the current version is itself past latest.
 
+<!-- prettier-ignore -->
+!!! note
+    By default, respectLatest will be set to `false` for Maven results if a `latest` tag is found.
+    This is because many Maven registries don't have a reliable `latest` tag - it just means whatever was last published.
+    You need to override this to `respectLatest=true` in `packageRules` in order to use it.
+
 ## reviewers
 
 Must be valid usernames.

--- a/lib/modules/datasource/clojure/__snapshots__/index.spec.ts.snap
+++ b/lib/modules/datasource/clojure/__snapshots__/index.spec.ts.snap
@@ -34,6 +34,7 @@ exports[`modules/datasource/clojure/index > falls back to next registry url 1`] 
       "version": "2.0.0",
     },
   ],
+  "respectLatest": false,
   "tags": {
     "latest": "2.0.0",
     "release": "2.0.0",
@@ -105,6 +106,7 @@ exports[`modules/datasource/clojure/index > returns releases from custom reposit
       "version": "2.0.0",
     },
   ],
+  "respectLatest": false,
   "tags": {
     "latest": "2.0.0",
     "release": "2.0.0",
@@ -146,6 +148,7 @@ exports[`modules/datasource/clojure/index > skips registry with invalid XML 1`] 
       "version": "2.0.0",
     },
   ],
+  "respectLatest": false,
   "tags": {
     "latest": "2.0.0",
     "release": "2.0.0",
@@ -187,6 +190,7 @@ exports[`modules/datasource/clojure/index > skips registry with invalid metadata
       "version": "2.0.0",
     },
   ],
+  "respectLatest": false,
   "tags": {
     "latest": "2.0.0",
     "release": "2.0.0",

--- a/lib/modules/datasource/clojure/__snapshots__/index.spec.ts.snap
+++ b/lib/modules/datasource/clojure/__snapshots__/index.spec.ts.snap
@@ -34,6 +34,10 @@ exports[`modules/datasource/clojure/index > falls back to next registry url 1`] 
       "version": "2.0.0",
     },
   ],
+  "tags": {
+    "latest": "2.0.0",
+    "release": "2.0.0",
+  },
 }
 `;
 
@@ -101,6 +105,10 @@ exports[`modules/datasource/clojure/index > returns releases from custom reposit
       "version": "2.0.0",
     },
   ],
+  "tags": {
+    "latest": "2.0.0",
+    "release": "2.0.0",
+  },
 }
 `;
 
@@ -138,6 +146,10 @@ exports[`modules/datasource/clojure/index > skips registry with invalid XML 1`] 
       "version": "2.0.0",
     },
   ],
+  "tags": {
+    "latest": "2.0.0",
+    "release": "2.0.0",
+  },
 }
 `;
 
@@ -175,5 +187,9 @@ exports[`modules/datasource/clojure/index > skips registry with invalid metadata
       "version": "2.0.0",
     },
   ],
+  "tags": {
+    "latest": "2.0.0",
+    "release": "2.0.0",
+  },
 }
 `;

--- a/lib/modules/datasource/maven/__snapshots__/index.spec.ts.snap
+++ b/lib/modules/datasource/maven/__snapshots__/index.spec.ts.snap
@@ -34,6 +34,10 @@ exports[`modules/datasource/maven/index > falls back to next registry url 1`] = 
       "version": "2.0.0",
     },
   ],
+  "tags": {
+    "latest": "2.0.0",
+    "release": "2.0.0",
+  },
 }
 `;
 
@@ -101,6 +105,10 @@ exports[`modules/datasource/maven/index > removes authentication header after re
       "version": "2.0.0",
     },
   ],
+  "tags": {
+    "latest": "2.0.0",
+    "release": "2.0.0",
+  },
 }
 `;
 
@@ -138,6 +146,10 @@ exports[`modules/datasource/maven/index > returns releases 1`] = `
       "version": "2.0.0",
     },
   ],
+  "tags": {
+    "latest": "2.0.0",
+    "release": "2.0.0",
+  },
 }
 `;
 
@@ -176,6 +188,10 @@ exports[`modules/datasource/maven/index > returns releases from custom repositor
       "version": "2.0.0",
     },
   ],
+  "tags": {
+    "latest": "2.0.0",
+    "release": "2.0.0",
+  },
 }
 `;
 
@@ -213,6 +229,10 @@ exports[`modules/datasource/maven/index > skips registry with invalid XML 1`] = 
       "version": "2.0.0",
     },
   ],
+  "tags": {
+    "latest": "2.0.0",
+    "release": "2.0.0",
+  },
 }
 `;
 
@@ -250,5 +270,9 @@ exports[`modules/datasource/maven/index > skips registry with invalid metadata s
       "version": "2.0.0",
     },
   ],
+  "tags": {
+    "latest": "2.0.0",
+    "release": "2.0.0",
+  },
 }
 `;

--- a/lib/modules/datasource/maven/__snapshots__/index.spec.ts.snap
+++ b/lib/modules/datasource/maven/__snapshots__/index.spec.ts.snap
@@ -34,6 +34,7 @@ exports[`modules/datasource/maven/index > falls back to next registry url 1`] = 
       "version": "2.0.0",
     },
   ],
+  "respectLatest": false,
   "tags": {
     "latest": "2.0.0",
     "release": "2.0.0",
@@ -105,6 +106,7 @@ exports[`modules/datasource/maven/index > removes authentication header after re
       "version": "2.0.0",
     },
   ],
+  "respectLatest": false,
   "tags": {
     "latest": "2.0.0",
     "release": "2.0.0",
@@ -146,6 +148,7 @@ exports[`modules/datasource/maven/index > returns releases 1`] = `
       "version": "2.0.0",
     },
   ],
+  "respectLatest": false,
   "tags": {
     "latest": "2.0.0",
     "release": "2.0.0",
@@ -188,6 +191,7 @@ exports[`modules/datasource/maven/index > returns releases from custom repositor
       "version": "2.0.0",
     },
   ],
+  "respectLatest": false,
   "tags": {
     "latest": "2.0.0",
     "release": "2.0.0",
@@ -229,6 +233,7 @@ exports[`modules/datasource/maven/index > skips registry with invalid XML 1`] = 
       "version": "2.0.0",
     },
   ],
+  "respectLatest": false,
   "tags": {
     "latest": "2.0.0",
     "release": "2.0.0",
@@ -270,6 +275,7 @@ exports[`modules/datasource/maven/index > skips registry with invalid metadata s
       "version": "2.0.0",
     },
   ],
+  "respectLatest": false,
   "tags": {
     "latest": "2.0.0",
     "release": "2.0.0",

--- a/lib/modules/datasource/maven/index.spec.ts
+++ b/lib/modules/datasource/maven/index.spec.ts
@@ -162,6 +162,10 @@ describe('modules/datasource/maven/index', () => {
       packageScope: 'org.example',
       registryUrl: 'https://repo.maven.apache.org/maven2',
       releases: [{ version: '1.0.3-SNAPSHOT' }],
+      tags: {
+        latest: '1.0.3-SNAPSHOT',
+        release: '1.0.3-SNAPSHOT',
+      },
     });
   });
 
@@ -193,6 +197,10 @@ describe('modules/datasource/maven/index', () => {
       packageScope: 'org.example',
       registryUrl: 'https://repo.maven.apache.org/maven2',
       releases: [{ version: '1.0.3-SNAPSHOT' }],
+      tags: {
+        latest: '1.0.3-SNAPSHOT',
+        release: '1.0.3-SNAPSHOT',
+      },
     });
   });
 
@@ -471,6 +479,10 @@ describe('modules/datasource/maven/index', () => {
         { version: '1.0.5-SNAPSHOT' },
         { version: '2.0.0' },
       ],
+      tags: {
+        latest: '2.0.0',
+        release: '2.0.0',
+      },
       isPrivate: true,
     });
     expect(googleAuth).toHaveBeenCalledTimes(2);
@@ -516,6 +528,10 @@ describe('modules/datasource/maven/index', () => {
         { version: '1.0.5-SNAPSHOT' },
         { version: '2.0.0' },
       ],
+      tags: {
+        latest: '2.0.0',
+        release: '2.0.0',
+      },
       isPrivate: true,
     });
     expect(googleAuth).toHaveBeenCalledTimes(2);

--- a/lib/modules/datasource/maven/index.spec.ts
+++ b/lib/modules/datasource/maven/index.spec.ts
@@ -162,6 +162,7 @@ describe('modules/datasource/maven/index', () => {
       packageScope: 'org.example',
       registryUrl: 'https://repo.maven.apache.org/maven2',
       releases: [{ version: '1.0.3-SNAPSHOT' }],
+      respectLatest: false,
       tags: {
         latest: '1.0.3-SNAPSHOT',
         release: '1.0.3-SNAPSHOT',
@@ -197,6 +198,7 @@ describe('modules/datasource/maven/index', () => {
       packageScope: 'org.example',
       registryUrl: 'https://repo.maven.apache.org/maven2',
       releases: [{ version: '1.0.3-SNAPSHOT' }],
+      respectLatest: false,
       tags: {
         latest: '1.0.3-SNAPSHOT',
         release: '1.0.3-SNAPSHOT',
@@ -479,6 +481,7 @@ describe('modules/datasource/maven/index', () => {
         { version: '1.0.5-SNAPSHOT' },
         { version: '2.0.0' },
       ],
+      respectLatest: false,
       tags: {
         latest: '2.0.0',
         release: '2.0.0',
@@ -528,6 +531,7 @@ describe('modules/datasource/maven/index', () => {
         { version: '1.0.5-SNAPSHOT' },
         { version: '2.0.0' },
       ],
+      respectLatest: false,
       tags: {
         latest: '2.0.0',
         release: '2.0.0',

--- a/lib/modules/datasource/maven/index.ts
+++ b/lib/modules/datasource/maven/index.ts
@@ -144,6 +144,10 @@ export class MavenDatasource extends Datasource {
     };
     if (metadata.tags) {
       result.tags = metadata.tags;
+      if (result.tags.latest) {
+        logger.debug(`Setting respectLatest=false for maven ${packageName}`);
+        result.respectLatest = false;
+      }
     }
 
     if (!this.defaultRegistryUrls.includes(registryUrl)) {

--- a/lib/modules/datasource/maven/index.ts
+++ b/lib/modules/datasource/maven/index.ts
@@ -49,6 +49,16 @@ function extractVersions(metadata: XmlDocument): MetadataResults {
     return res;
   }
   res.versions = elements.map((el) => el.val);
+  const latest = metadata.descendantWithPath('versioning.latest');
+  if (latest?.val) {
+    res.tags ??= {};
+    res.tags.latest = latest.val;
+  }
+  const release = metadata.descendantWithPath('versioning.release');
+  if (release?.val) {
+    res.tags ??= {};
+    res.tags.release = release.val;
+  }
 
   return res;
 }

--- a/lib/modules/datasource/maven/readme.md
+++ b/lib/modules/datasource/maven/readme.md
@@ -30,9 +30,5 @@ For example:
 
 #### latest and release tags
 
-Although a package's `maven-metadata.xml` may contain `latest` and `release` tags, we do not map them to `tags.latest` or `tags.release` in Renovate internal data.
-The reason for not doing this is that Maven registries don't use these tags as an indicator of stability - `latest` essentially means "the most recent version which was published".
-
-For more information on this, see the analysis done in [Discussion #36927](https://github.com/renovatebot/renovate/discussions/36927).
-
-As a result, neither `followTag` nor `respectLatest` concepts apply to Maven dependencies.
+When `latest` or `release` values are present in a package's `maven-metadata.xml`, Renovate will map these to its `tags` concept.
+This enables the use of Renovate's `followTag` feature.

--- a/lib/modules/datasource/maven/readme.md
+++ b/lib/modules/datasource/maven/readme.md
@@ -32,3 +32,6 @@ For example:
 
 When `latest` or `release` values are present in a package's `maven-metadata.xml`, Renovate will map these to its `tags` concept.
 This enables the use of Renovate's `followTag` feature.
+
+However, Renovate will set `respectLatest=false` whenever the `latest` tag is found, because many Maven registries have been found to populate the tag unreliably.
+You should use `packageRules` to set `respectLatest=true` if you wish to use this feature.

--- a/lib/modules/datasource/maven/s3.spec.ts
+++ b/lib/modules/datasource/maven/s3.spec.ts
@@ -65,6 +65,7 @@ describe('modules/datasource/maven/s3', () => {
           { version: '1.0.2' },
           { version: '1.0.3' },
         ],
+        respectLatest: false,
         tags: {
           latest: '1.0.2',
           release: '1.0.2',

--- a/lib/modules/datasource/maven/s3.spec.ts
+++ b/lib/modules/datasource/maven/s3.spec.ts
@@ -65,6 +65,10 @@ describe('modules/datasource/maven/s3', () => {
           { version: '1.0.2' },
           { version: '1.0.3' },
         ],
+        tags: {
+          latest: '1.0.2',
+          release: '1.0.2',
+        },
         isPrivate: true,
       });
     });

--- a/lib/modules/datasource/types.ts
+++ b/lib/modules/datasource/types.ts
@@ -97,6 +97,7 @@ export interface ReleaseResult {
   packageScope?: string;
   mostRecentTimestamp?: Timestamp;
   isAbandoned?: boolean;
+  respectLatest?: boolean;
 }
 
 export interface PostprocessReleaseConfig {

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -205,6 +205,7 @@ export async function lookupUpdates(
         'packageScope',
         'mostRecentTimestamp',
         'isAbandoned',
+        'respectLatest',
       ]);
 
       const latestVersion = dependency.tags?.latest;


### PR DESCRIPTION
Reintroduces latest/release tags for Maven datasource, but this time sets respectLatest to false if a latest tag is found. When this feature was released originally, there were too many situations where registry latest tags were unreliable (e.g. the most recent version pushed, not some "stable" latest). With this new approach, users have to explicitly opt in.