### PR TITLE
feat(bazel-module): Add support for rules_img

### DIFF
--- a/lib/modules/manager/bazel-module/extract.spec.ts
+++ b/lib/modules/manager/bazel-module/extract.spec.ts
@@ -593,6 +593,376 @@ describe('modules/manager/bazel-module/extract', () => {
       });
     });
 
+    it('handles a real-world MODULE.bazel file (rules_sh)', async () => {
+      const input = codeBlock`
+        module(
+            name = "rules_sh",
+            version = "0.5.0",
+            compatibility_level = 0,
+        )
+
+        bazel_dep(name = "bazel_skylib", version = "1.2.1")
+        bazel_dep(name = "platforms", version = "0.0.8")
+
+        bazel_dep(name = "stardoc", version = "0.6.2", dev_dependency = True, repo_name = "io_bazel_stardoc")
+
+        sh_configure = use_extension("//bzlmod:extensions.bzl", "sh_configure")
+        use_repo(sh_configure, "local_posix_config", "rules_sh_shim_exe")
+
+        register_toolchains("@local_posix_config//...")
+      `;
+
+      const result = await extractPackageFile(input, 'MODULE.bazel');
+
+      expect(result).toEqual({
+        deps: [
+          {
+            datasource: BazelDatasource.id,
+            depType: 'bazel_dep',
+            depName: 'bazel_skylib',
+            currentValue: '1.2.1',
+          },
+          {
+            datasource: BazelDatasource.id,
+            depType: 'bazel_dep',
+            depName: 'platforms',
+            currentValue: '0.0.8',
+          },
+          {
+            datasource: BazelDatasource.id,
+            depType: 'bazel_dep',
+            depName: 'stardoc',
+            currentValue: '0.6.2',
+          },
+        ],
+      });
+    });
+
+    it('handles every method available in MODULE.bazel files', async () => {
+      const input = codeBlock`
+        module(
+            name = "module_name",
+            version = "1.2.3",
+            compatibility_level = 0,
+            repo_name = "io_bazel_module_name",
+            bazel_compatibility = ["<=6.0.0", ">=8.2.0"],
+        )
+
+        bazel_dep(name = "bazel_skylib", version = "1.2.1")
+        bazel_dep(name = "platforms", version = "0.0.8")
+        bazel_dep(name = "rules_img", version = "0.1.5")
+
+        bazel_dep(name = "stardoc", version = "0.6.2", dev_dependency = True, repo_name = "io_bazel_stardoc")
+
+        pull = use_repo_rule("@rules_img//img:pull.bzl", "pull")
+        pull(
+            name = "ubuntu",
+            digest = "sha256:1e622c5f9ac0c0144d577702ba5f2cce79fc8e3cf89ec88291739cd4eee3b7b9",
+            registry = "index.docker.io",
+            repository = "library/ubuntu",
+            tag = "24.04",
+        )
+
+        multiple_version_override(
+            module_name = "overriden_module_a",
+            versions = ["1.2.3", "1.2.4"],
+            registry = "https://example.com/custom_registry",
+        )
+
+        git_override(
+            module_name = "overriden_module_c",
+            commit = "850cb49c8649e463b80ef7984e7c744279746170",
+            remote = "https://github.com/example/overriden_module_b.git",
+        )
+
+        archive_override(
+            module_name = "overriden_module_d",
+            urls = [
+                "https://example.com/archive.tar.gz",
+            ],
+        )
+
+        include("//:extra.MODULE.bazel")
+
+        sh_configure = use_extension("//bzlmod:extensions.bzl", "sh_configure")
+        use_repo(sh_configure, "local_posix_config", "rules_sh_shim_exe")
+
+        override_repo(
+            sh_configure,
+            com_github_foo_bar = "overriden_module_a",
+        )
+
+        register_execution_platforms(
+            "@overriden_module_a//:some_execution_platform",
+            dev_dependency = True,
+        )
+
+        register_toolchains(
+            "@overriden_module_a//:some_toolchain",
+            dev_dependency = True,
+        )
+
+        single_version_override(
+            module_name = "overriden_module_c",
+            version = "1.2.5",
+            registry = "https://example.com/custom_registry",
+            patch_cmds = [],
+            patch_strip = 8,
+        )
+
+        my_repo_rule = use_repo_rule("@my_repo//:my_repo.bzl", "my_repo_rule")
+
+        my_repo_rule(
+            name = "my_custom_repo",
+            url = "https://example.com/my_custom_repo.tar.gz",
+            sha256 = "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+        )
+      `;
+
+      const result = await extractPackageFile(input, 'MODULE.bazel');
+
+      expect(result).toEqual({
+        deps: [
+          {
+            datasource: BazelDatasource.id,
+            depType: 'bazel_dep',
+            depName: 'bazel_skylib',
+            currentValue: '1.2.1',
+          },
+          {
+            datasource: BazelDatasource.id,
+            depType: 'bazel_dep',
+            depName: 'platforms',
+            currentValue: '0.0.8',
+          },
+          {
+            datasource: BazelDatasource.id,
+            depType: 'bazel_dep',
+            depName: 'rules_img',
+            currentValue: '0.1.5',
+          },
+          {
+            datasource: BazelDatasource.id,
+            depType: 'bazel_dep',
+            depName: 'stardoc',
+            currentValue: '0.6.2',
+          },
+          {
+            datasource: DockerDatasource.id,
+            depType: 'rules_img_pull',
+            depName: 'ubuntu',
+            packageName: 'index.docker.io/library/ubuntu',
+            currentValue: '24.04',
+            currentDigest:
+              'sha256:1e622c5f9ac0c0144d577702ba5f2cce79fc8e3cf89ec88291739cd4eee3b7b9',
+            replaceString: codeBlock`
+              pull(
+                  name = "ubuntu",
+                  digest = "sha256:1e622c5f9ac0c0144d577702ba5f2cce79fc8e3cf89ec88291739cd4eee3b7b9",
+                  registry = "index.docker.io",
+                  repository = "library/ubuntu",
+                  tag = "24.04",
+              )
+            `,
+          },
+        ],
+      });
+    });
+
+    it('returns rules_img pull dependencies', async () => {
+      const input = codeBlock`
+        bazel_dep(name = "rules_img", version = "0.1.0")
+
+        pull = use_repo_rule("@rules_img//img:pull.bzl", "pull")
+
+        pull(
+            name = "ubuntu",
+            digest = "sha256:1e622c5f9ac0c0144d577702ba5f2cce79fc8e3cf89ec88291739cd4eee3b7b9",
+            registry = "index.docker.io",
+            repository = "library/ubuntu",
+            tag = "24.04",
+        )
+      `;
+
+      const result = await extractPackageFile(input, 'MODULE.bazel');
+
+      expect(result).toEqual({
+        deps: [
+          {
+            datasource: BazelDatasource.id,
+            depType: 'bazel_dep',
+            depName: 'rules_img',
+            currentValue: '0.1.0',
+          },
+          {
+            datasource: DockerDatasource.id,
+            depType: 'rules_img_pull',
+            depName: 'ubuntu',
+            packageName: 'index.docker.io/library/ubuntu',
+            currentValue: '24.04',
+            currentDigest:
+              'sha256:1e622c5f9ac0c0144d577702ba5f2cce79fc8e3cf89ec88291739cd4eee3b7b9',
+            replaceString: codeBlock`
+              pull(
+                  name = "ubuntu",
+                  digest = "sha256:1e622c5f9ac0c0144d577702ba5f2cce79fc8e3cf89ec88291739cd4eee3b7b9",
+                  registry = "index.docker.io",
+                  repository = "library/ubuntu",
+                  tag = "24.04",
+              )
+            `,
+          },
+        ],
+      });
+    });
+
+    it('returns rules_img pull dependencies with custom registry', async () => {
+      const input = codeBlock`
+        pull = use_repo_rule("@rules_img//img:pull.bzl", "pull")
+
+        pull(
+            name = "my_image",
+            registry = "my.registry.com",
+            repository = "myorg/myimage",
+            tag = "v1.2.3",
+        )
+      `;
+
+      const result = await extractPackageFile(input, 'MODULE.bazel');
+
+      expect(result).toEqual({
+        deps: [
+          {
+            datasource: DockerDatasource.id,
+            depType: 'rules_img_pull',
+            depName: 'my_image',
+            packageName: 'my.registry.com/myorg/myimage',
+            currentValue: 'v1.2.3',
+            replaceString: codeBlock`
+              pull(
+                  name = "my_image",
+                  registry = "my.registry.com",
+                  repository = "myorg/myimage",
+                  tag = "v1.2.3",
+              )
+            `,
+          },
+        ],
+      });
+    });
+
+    it('returns rules_img pull dependencies with multiple pulls', async () => {
+      const input = codeBlock`
+        pull = use_repo_rule("@rules_img//img:pull.bzl", "pull")
+
+        pull(
+            name = "ubuntu",
+            repository = "library/ubuntu",
+            tag = "24.04",
+        )
+
+        pull(
+            name = "nginx",
+            repository = "library/nginx",
+            tag = "1.27.1",
+            digest = "sha256:287ff321f9e3cde74b600cc26197424404157a72043226cbbf07ee8304a2c720",
+        )
+      `;
+
+      const result = await extractPackageFile(input, 'MODULE.bazel');
+
+      expect(result).toEqual({
+        deps: [
+          {
+            datasource: DockerDatasource.id,
+            depType: 'rules_img_pull',
+            depName: 'ubuntu',
+            packageName: 'library/ubuntu',
+            currentValue: '24.04',
+            replaceString: codeBlock`
+              pull(
+                  name = "ubuntu",
+                  repository = "library/ubuntu",
+                  tag = "24.04",
+              )
+            `,
+          },
+          {
+            datasource: DockerDatasource.id,
+            depType: 'rules_img_pull',
+            depName: 'nginx',
+            packageName: 'library/nginx',
+            currentValue: '1.27.1',
+            currentDigest:
+              'sha256:287ff321f9e3cde74b600cc26197424404157a72043226cbbf07ee8304a2c720',
+            replaceString: codeBlock`
+              pull(
+                  name = "nginx",
+                  repository = "library/nginx",
+                  tag = "1.27.1",
+                  digest = "sha256:287ff321f9e3cde74b600cc26197424404157a72043226cbbf07ee8304a2c720",
+              )
+            `,
+          },
+        ],
+      });
+    });
+
+    it('ignores rules_img pull without required fields', async () => {
+      const input = codeBlock`
+        pull = use_repo_rule("@rules_img//img:pull.bzl", "pull")
+
+        # Missing repository
+        pull(
+            name = "missing_repo",
+            tag = "1.0.0",
+        )
+
+        # Missing name
+        pull(
+            repository = "library/ubuntu",
+            tag = "24.04",
+        )
+      `;
+
+      const result = await extractPackageFile(input, 'MODULE.bazel');
+
+      expect(result).toBeNull();
+    });
+
+    it('handles rules_img with renamed variable', async () => {
+      const input = codeBlock`
+        my_pull = use_repo_rule("@rules_img//img:pull.bzl", "pull")
+
+        my_pull(
+            name = "ubuntu",
+            repository = "library/ubuntu",
+            tag = "24.04",
+        )
+      `;
+
+      const result = await extractPackageFile(input, 'MODULE.bazel');
+
+      expect(result).toEqual({
+        deps: [
+          {
+            datasource: DockerDatasource.id,
+            depType: 'rules_img_pull',
+            depName: 'ubuntu',
+            packageName: 'library/ubuntu',
+            currentValue: '24.04',
+            replaceString: codeBlock`
+              my_pull(
+                  name = "ubuntu",
+                  repository = "library/ubuntu",
+                  tag = "24.04",
+              )
+            `,
+          },
+        ],
+      });
+    });
+
     it('returns new_git_repository dependencies', async () => {
       const input = codeBlock`
         new_git_repository(

--- a/lib/modules/manager/bazel-module/extract.ts
+++ b/lib/modules/manager/bazel-module/extract.ts
@@ -8,6 +8,7 @@ import { parse } from './parser';
 import type { ResultFragment } from './parser/fragments';
 import { RuleToMavenPackageDep, fillRegistryUrls } from './parser/maven';
 import { RuleToDockerPackageDep } from './parser/oci';
+import { RulesImgPullToDockerPackageDep } from './parser/rules-img';
 import {
   GitRepositoryToPackageDep,
   RuleToBazelModulePackageDep,
@@ -24,6 +25,9 @@ export async function extractPackageFile(
     const gitRepositoryDeps = extractGitRepositoryDeps(records);
     const mavenDeps = extractMavenDeps(records);
     const dockerDeps = LooseArray(RuleToDockerPackageDep).parse(records);
+    const rulesImgDeps = LooseArray(RulesImgPullToDockerPackageDep).parse(
+      records,
+    );
 
     if (gitRepositoryDeps.length) {
       pfc.deps.push(...gitRepositoryDeps);
@@ -35,6 +39,10 @@ export async function extractPackageFile(
 
     if (dockerDeps.length) {
       pfc.deps.push(...dockerDeps);
+    }
+
+    if (rulesImgDeps.length) {
+      pfc.deps.push(...rulesImgDeps);
     }
 
     return pfc.deps.length ? pfc : null;

--- a/lib/modules/manager/bazel-module/parser/context.spec.ts
+++ b/lib/modules/manager/bazel-module/parser/context.spec.ts
@@ -56,5 +56,22 @@ describe('modules/manager/bazel-module/parser/context', () => {
         ),
       );
     });
+
+    it('throws CtxProcessingError with parent information', () => {
+      const ctx = new Ctx('');
+      // Create an invalid state where we try to add a string directly to a rule
+      // without wrapping it in an attribute
+      ctx.startRule('test_rule');
+      const error = new CtxProcessingError(
+        fragments.string('invalid'),
+        fragments.rule('test_rule'),
+      );
+      expect(error.message).toBe(
+        'Invalid context state. current: string, parent: rule',
+      );
+      expect(error.name).toBe('CtxProcessingError');
+      expect(error.current).toEqual(fragments.string('invalid'));
+      expect(error.parent).toEqual(fragments.rule('test_rule'));
+    });
   });
 });

--- a/lib/modules/manager/bazel-module/parser/fragments.ts
+++ b/lib/modules/manager/bazel-module/parser/fragments.ts
@@ -63,6 +63,15 @@ export const AttributeFragment = z.object({
   value: ValueFragments.optional(),
   isComplete: z.boolean(),
 });
+export const RepoRuleCallFragment = z.object({
+  type: z.literal('repoRuleCall'),
+  rule: z.string(), // The original rule name (e.g., 'pull')
+  functionName: z.string(), // The variable name used (e.g., 'pull' or 'my_pull')
+  module: z.string(), // The module path (e.g., '@rules_img//img:pull.bzl')
+  children: LooseRecord(ValueFragments),
+  isComplete: z.boolean(),
+  rawString: z.string().optional(), // Raw source string for replacements
+});
 export const AllFragments = z.discriminatedUnion('type', [
   ArrayFragment,
   AttributeFragment,
@@ -71,6 +80,7 @@ export const AllFragments = z.discriminatedUnion('type', [
   PreparedExtensionTagFragment,
   ExtensionTagFragment,
   StringFragment,
+  RepoRuleCallFragment,
 ]);
 
 export type AllFragments = z.infer<typeof AllFragments>;
@@ -86,7 +96,11 @@ export type PreparedExtensionTagFragment = z.infer<
 export type ExtensionTagFragment = z.infer<typeof ExtensionTagFragment>;
 export type StringFragment = z.infer<typeof StringFragment>;
 export type ValueFragments = z.infer<typeof ValueFragments>;
-export type ResultFragment = RuleFragment | ExtensionTagFragment;
+export type RepoRuleCallFragment = z.infer<typeof RepoRuleCallFragment>;
+export type ResultFragment =
+  | RuleFragment
+  | ExtensionTagFragment
+  | RepoRuleCallFragment;
 
 export function string(value: string): StringFragment {
   return {
@@ -184,4 +198,19 @@ export function isValue(data: unknown): data is ValueFragments {
 export function isPrimitive(data: unknown): data is PrimitiveFragments {
   const result = PrimitiveFragments.safeParse(data);
   return result.success;
+}
+
+export function repoRuleCall(
+  rule: string,
+  functionName: string,
+  module: string,
+): RepoRuleCallFragment {
+  return {
+    type: 'repoRuleCall',
+    rule,
+    functionName,
+    module,
+    children: {},
+    isComplete: false,
+  };
 }

--- a/lib/modules/manager/bazel-module/parser/index.ts
+++ b/lib/modules/manager/bazel-module/parser/index.ts
@@ -2,6 +2,7 @@ import { lang, query as q } from 'good-enough-parser';
 import { Ctx } from './context';
 import { extensionTags } from './extension-tags';
 import type { ResultFragment } from './fragments';
+import { extractRulesImgDependencies } from './post-process-rules-img';
 import { rules } from './rules';
 
 const rule = q.alt<Ctx>(rules, extensionTags);
@@ -16,5 +17,10 @@ const starlarkLang = lang.createLang('starlark');
 
 export function parse(input: string): ResultFragment[] {
   const parsedResult = starlarkLang.query(input, query, new Ctx(input));
-  return parsedResult?.results ?? [];
+  const results = parsedResult?.results ?? [];
+
+  // Post-process to find rules_img dependencies
+  const rulesImgDeps = extractRulesImgDependencies(input);
+
+  return [...results, ...rulesImgDeps];
 }

--- a/lib/modules/manager/bazel-module/parser/post-process-rules-img.spec.ts
+++ b/lib/modules/manager/bazel-module/parser/post-process-rules-img.spec.ts
@@ -1,0 +1,153 @@
+import { extractRulesImgDependencies } from './post-process-rules-img';
+import type { RepoRuleCallFragment, StringFragment } from './fragments';
+
+describe('modules/manager/bazel-module/parser/post-process-rules-img', () => {
+  describe('extractRulesImgDependencies', () => {
+    it('returns empty array when no rules_img dependencies found', () => {
+      const input = `
+        bazel_dep(name = "rules_foo", version = "1.0.0")
+        
+        some_other_function()
+      `;
+
+      const result = extractRulesImgDependencies(input);
+      expect(result).toEqual([]);
+    });
+
+    it('extracts basic rules_img pull dependency', () => {
+      const input = `
+        pull = use_repo_rule("@rules_img//img:pull.bzl", "pull")
+        
+        pull(
+            name = "ubuntu",
+            repository = "library/ubuntu",
+            tag = "24.04",
+        )
+      `;
+
+      const result = extractRulesImgDependencies(input);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        type: 'repoRuleCall',
+        rule: 'pull',
+        functionName: 'pull',
+        module: '@rules_img//img:pull.bzl',
+        children: {
+          name: { type: 'string', value: 'ubuntu' },
+          repository: { type: 'string', value: 'library/ubuntu' },
+          tag: { type: 'string', value: '24.04' },
+        },
+      });
+    });
+
+    it('handles renamed pull function', () => {
+      const input = `
+        my_pull = use_repo_rule("@rules_img//img:pull.bzl", "pull")
+        
+        my_pull(
+            name = "nginx",
+            repository = "library/nginx",
+            tag = "1.27.1",
+        )
+      `;
+
+      const result = extractRulesImgDependencies(input);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        type: 'repoRuleCall',
+        rule: 'pull',
+        functionName: 'my_pull',
+        module: '@rules_img//img:pull.bzl',
+      });
+    });
+
+    it('ignores calls to undefined functions', () => {
+      const input = `
+        pull = use_repo_rule("@rules_img//img:pull.bzl", "pull")
+        
+        # This call should be processed
+        pull(
+            name = "ubuntu",
+            repository = "library/ubuntu",
+            tag = "24.04",
+        )
+        
+        # This call should be ignored (undefined_function not registered)
+        undefined_function(
+            name = "something",
+            repository = "repo/something",
+        )
+      `;
+
+      const result = extractRulesImgDependencies(input);
+      expect(result).toHaveLength(1);
+      const fragment = result[0] as RepoRuleCallFragment;
+      expect((fragment.children.name as StringFragment).value).toBe('ubuntu');
+    });
+
+    it('handles multiple use_repo_rule assignments', () => {
+      const input = `
+        pull = use_repo_rule("@rules_img//img:pull.bzl", "pull")
+        other_pull = use_repo_rule("@rules_img//img:pull.bzl", "pull")
+        
+        pull(
+            name = "ubuntu",
+            repository = "library/ubuntu",
+            tag = "24.04",
+        )
+        
+        other_pull(
+            name = "nginx",
+            repository = "library/nginx",
+            tag = "1.27.1",
+        )
+      `;
+
+      const result = extractRulesImgDependencies(input);
+      expect(result).toHaveLength(2);
+      const fragment1 = result[0] as RepoRuleCallFragment;
+      const fragment2 = result[1] as RepoRuleCallFragment;
+      expect((fragment1.children.name as StringFragment).value).toBe('ubuntu');
+      expect((fragment2.children.name as StringFragment).value).toBe('nginx');
+    });
+
+    it('handles parameters with different quote styles', () => {
+      const input = `
+        pull = use_repo_rule('@rules_img//img:pull.bzl', 'pull')
+        
+        pull(
+            name = 'ubuntu',
+            repository = "library/ubuntu",
+            tag = '24.04',
+        )
+      `;
+
+      const result = extractRulesImgDependencies(input);
+      expect(result).toHaveLength(1);
+      expect((result[0] as RepoRuleCallFragment).children).toMatchObject({
+        name: { type: 'string', value: 'ubuntu' },
+        repository: { type: 'string', value: 'library/ubuntu' },
+        tag: { type: 'string', value: '24.04' },
+      });
+    });
+
+    it('correctly sets rawString for replaceString', () => {
+      const input = `
+        pull = use_repo_rule("@rules_img//img:pull.bzl", "pull")
+        
+        pull(
+            name = "ubuntu",
+            repository = "library/ubuntu",
+            tag = "24.04",
+        )
+      `;
+
+      const result = extractRulesImgDependencies(input);
+      expect((result[0] as RepoRuleCallFragment).rawString).toBe(`pull(
+            name = "ubuntu",
+            repository = "library/ubuntu",
+            tag = "24.04",
+        )`);
+    });
+  });
+});

--- a/lib/modules/manager/bazel-module/parser/post-process-rules-img.ts
+++ b/lib/modules/manager/bazel-module/parser/post-process-rules-img.ts
@@ -1,0 +1,66 @@
+import { regEx } from '../../../../util/regex';
+import type { RepoRuleCallFragment, ResultFragment } from './fragments';
+import * as fragments from './fragments';
+
+/**
+ * Post-process to extract rules_img dependencies.
+ * This is done separately to avoid interfering with the main parser.
+ */
+export function extractRulesImgDependencies(input: string): ResultFragment[] {
+  const results: RepoRuleCallFragment[] = [];
+
+  // First, find all use_repo_rule assignments for rules_img
+  const useRepoRuleRegex = regEx(
+    /(\w+)\s*=\s*use_repo_rule\s*\(\s*["'](@rules_img[^"']*["'])\s*,\s*["'](\w+)["']\s*\)/g,
+  );
+
+  const repoRules = new Map<string, { rule: string; module: string }>();
+  let match;
+
+  while ((match = useRepoRuleRegex.exec(input)) !== null) {
+    const [, varName, module, rule] = match;
+    repoRules.set(varName, { rule, module: module.replace(/["']/g, '') });
+  }
+
+  if (repoRules.size === 0) {
+    return [];
+  }
+
+  // Build regex to match repo rule calls
+  const varNames = Array.from(repoRules.keys());
+  const pullCallRegex = regEx(
+    `(${varNames.join('|')})\\s*\\(([^)]+)\\)`,
+    'gms',
+  );
+
+  while ((match = pullCallRegex.exec(input)) !== null) {
+    const [fullMatch, functionName, paramsStr] = match;
+    const ruleInfo = repoRules.get(functionName);
+
+    if (!ruleInfo) {
+      continue;
+    }
+
+    // Create a repo rule call fragment
+    const fragment = fragments.repoRuleCall(
+      ruleInfo.rule,
+      functionName,
+      ruleInfo.module,
+    );
+
+    // Extract parameters
+    const paramRegex = regEx(/(\w+)\s*=\s*["']([^"']+)["']/g);
+    let paramMatch;
+
+    while ((paramMatch = paramRegex.exec(paramsStr)) !== null) {
+      const [, key, value] = paramMatch;
+      fragment.children[key] = fragments.string(value);
+    }
+
+    fragment.isComplete = true;
+    fragment.rawString = fullMatch;
+    results.push(fragment);
+  }
+
+  return results;
+}

--- a/lib/modules/manager/bazel-module/parser/post-process-rules-img.ts
+++ b/lib/modules/manager/bazel-module/parser/post-process-rules-img.ts
@@ -37,6 +37,7 @@ export function extractRulesImgDependencies(input: string): ResultFragment[] {
     const [fullMatch, functionName, paramsStr] = match;
     const ruleInfo = repoRules.get(functionName);
 
+    // istanbul ignore if
     if (!ruleInfo) {
       continue;
     }

--- a/lib/modules/manager/bazel-module/parser/rules-img.ts
+++ b/lib/modules/manager/bazel-module/parser/rules-img.ts
@@ -1,0 +1,49 @@
+import { z } from 'zod';
+import { DockerDatasource } from '../../../datasource/docker';
+import type { PackageDependency } from '../../types';
+import { RepoRuleCallFragment, StringFragment } from './fragments';
+
+export const RulesImgPullToDockerPackageDep = RepoRuleCallFragment.extend({
+  rule: z.literal('pull'),
+  module: z.string().regex(/^@rules_img/),
+  children: z.object({
+    name: StringFragment,
+    repository: StringFragment,
+    registry: StringFragment.optional(),
+    tag: StringFragment.optional(),
+    digest: StringFragment.optional(),
+  }),
+}).transform(
+  ({
+    rawString,
+    children: { name, repository, registry, tag, digest },
+  }): PackageDependency => {
+    // Construct the full package name from registry and repository
+    let packageName: string;
+    if (registry?.value) {
+      // If registry is explicitly provided, use it
+      packageName = `${registry.value}/${repository.value}`;
+    } else {
+      // If no registry, use repository as-is (it might already include the registry)
+      packageName = repository.value;
+    }
+
+    const result: PackageDependency = {
+      datasource: DockerDatasource.id,
+      depType: 'rules_img_pull',
+      depName: name.value,
+      packageName,
+      replaceString: rawString,
+    };
+
+    if (tag?.value) {
+      result.currentValue = tag.value;
+    }
+
+    if (digest?.value) {
+      result.currentDigest = digest.value;
+    }
+
+    return result;
+  },
+);

--- a/lib/modules/manager/bazel-module/readme.md
+++ b/lib/modules/manager/bazel-module/readme.md
@@ -46,3 +46,17 @@ oci.pull(
     tag = "1.27.1",
 )
 ```
+
+It also supports Docker images pulled with [rules_img pull](https://github.com/tweag/rules_img/blob/main/docs/pull.md#pull):
+
+```
+pull = use_repo_rule("@rules_img//img:pull.bzl", "pull")
+
+pull(
+    name = "ubuntu",
+    digest = "sha256:1e622c5f9ac0c0144d577702ba5f2cce79fc8e3cf89ec88291739cd4eee3b7b9",
+    registry = "index.docker.io",
+    repository = "library/ubuntu",
+    tag = "24.04",
+)
+```


### PR DESCRIPTION
This PR adds support for `rules_img` pull dependencies in Bazel MODULE.bazel files, enabling Renovate to automatically update container image dependencies managed by the `rules_img` Bazel ruleset.

Previously, PR #37429 attempted to add this feature but was reverted due to a regression that broke parsing of basic Bazel MODULE.bazel files. This implementation uses a different approach that avoids modifying the core parser.

Instead of modifying the core parser (which caused the regression), this implementation uses a **post-processing approach**:

1. The main Bazel parser remains unchanged, ensuring existing functionality is preserved
2. A new post-processor (`post-process-rules-img.ts`) extracts `rules_img` patterns after the main parsing is complete
3. The post-processor identifies `use_repo_rule` assignments and their corresponding `pull()` calls
4. Results are merged with the main parser output

- **Added `RepoRuleCallFragment` type** to represent repository rule calls like `pull()`
- **Created `post-process-rules-img.ts`** for extracting rules_img dependencies without interfering with the main parser
- **Added `rules-img.ts`** to transform repository rule calls into Docker package dependencies
- **Updated `index.ts`** to include post-processing results
- **Added comprehensive test coverage** for various scenarios

```starlark
pull = use_repo_rule("@rules_img//img:pull.bzl", "pull")

pull(
    name = "ubuntu",
    repository = "library/ubuntu",
    tag = "24.04",
    digest = "sha256:abc123...",
)

my_pull = use_repo_rule("@rules_img//img:pull.bzl", "pull")

my_pull(
    name = "nginx",
    registry = "my.registry.com",
    repository = "myorg/nginx",
    tag = "1.27.1",
)
```

- All existing tests pass, including the regression test case
- Added comprehensive test coverage for rules_img scenarios:
  - Basic pull dependencies
  - Custom registries
  - Multiple image pulls
  - Renamed pull variables
  - Missing required fields (properly ignored)

- Enables automatic updates for container images in Bazel projects using `rules_img`
- Maintains backward compatibility with all existing Bazel module parsing
- Provides feature parity with the existing `rules_oci` support
- Follows Renovate's established patterns for Docker dependencies

- Closes https://github.com/tweag/rules_img/issues/8
- Fixes the regression from #37429

- [x] I have updated the documentation

I have verified these changes via:

- [x] Newly added/modified unit tests
- [x] Verified the regression test case passes
- [x] All existing Bazel module tests continue to pass

