### PR TITLE
fix(helmfile): align OCI `depName` with Flux OCIRepository `depName`

### DIFF
--- a/lib/modules/manager/helmfile/extract.spec.ts
+++ b/lib/modules/manager/helmfile/extract.spec.ts
@@ -344,7 +344,7 @@ describe('modules/manager/helmfile/extract', () => {
         deps: [
           {
             currentValue: '0.1.0',
-            depName: 'example',
+            depName: 'ghcr.io/example/oci-repo/example',
             datasource: 'docker',
             packageName: 'ghcr.io/example/oci-repo/example',
           },
@@ -355,7 +355,7 @@ describe('modules/manager/helmfile/extract', () => {
           },
           {
             currentValue: '0.4.2',
-            depName: 'url-example',
+            depName: 'ghcr.io/example/oci-repo/url-example',
             datasource: 'docker',
             packageName: 'ghcr.io/example/oci-repo/url-example',
           },
@@ -381,7 +381,7 @@ describe('modules/manager/helmfile/extract', () => {
         deps: [
           {
             currentValue: '1.2.3',
-            depName: 'nested/path/chart',
+            depName: 'ghcr.io/example/oci-repo/nested/path/chart',
             datasource: 'docker',
             packageName: 'ghcr.io/example/oci-repo/nested/path/chart',
           },
@@ -412,7 +412,7 @@ describe('modules/manager/helmfile/extract', () => {
         deps: [
           {
             currentValue: '0.1.0',
-            depName: 'example',
+            depName: 'ghcr.io/example/oci-repo/example',
             datasource: 'docker',
             packageName: 'ghcr.io/example/oci-repo/example',
           },
@@ -529,7 +529,7 @@ describe('modules/manager/helmfile/extract', () => {
           {
             currentValue: '0.4.2',
             datasource: 'docker',
-            depName: 'subgroup',
+            depName: 'gitlab.example.com:5000/group/subgroup',
             packageName: 'gitlab.example.com:5000/group/subgroup',
             registryUrls: [],
           },

--- a/lib/modules/manager/helmfile/extract.ts
+++ b/lib/modules/manager/helmfile/extract.ts
@@ -105,7 +105,7 @@ export async function extractPackageFile(
 
       const registryUrl = repoName ? registryData[repoName]?.url : undefined;
       const aliasUrl = repoName
-        ? (config.registryAliases?.[repoName] as string | undefined)
+        ? config.registryAliases?.[repoName]
         : undefined;
 
       const res: PackageDependency = {
@@ -128,8 +128,7 @@ export async function extractPackageFile(
         }
       } else if (repoName && registryData[repoName]?.oci) {
         const base =
-          registryData[repoName]?.url ??
-          (config.registryAliases?.[repoName] as string | undefined);
+          registryData[repoName]?.url ?? config.registryAliases?.[repoName];
         if (base) {
           const withoutPrefix = isOCIRegistry(base)
             ? base.replace(/^oci:\/\//, '')


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This PR aligns the depNames for Helmfile OCI and FLux OCI which will allow for auto grouping of these dependencies.

Current behavior:

PR Title for Flux OCI Repository:

> Update ghcr.io/controlplaneio-fluxcd/charts/flux-operator Docker tag to v0.21.0

PR Title for Helmfile OCI chart:

> Update flux-operator Docker tag to v0.21.0

This PR hopes to being these depNames and PR titles in alignment so they can automatically be grouped by Renovate.

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

I have a Helmfile that bootstraps apps into my Kubernetes cluster, and then I have Flux deployed to take over the apps. As of right now I need to manually group these packages together, but it is adding a lot of configuration that I would love to have to not maintain, see below

https://github.com/onedr0p/home-ops/blob/main/.renovate/groups.json5

As I didn't get any feedback in the discussion below I decided to update Helmfile OCI chart `depName` to match the Flux OCI `depName`

https://github.com/renovatebot/renovate/discussions/35005

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
