### PR TITLE
test(gitlab): add failing test to expose incorrect `/*` pattern handling in CODEOWNERS

### DIFF
--- a/lib/modules/platform/gitlab/code-owners.spec.ts
+++ b/lib/modules/platform/gitlab/code-owners.spec.ts
@@ -135,7 +135,7 @@ describe('modules/platform/gitlab/code-owners', () => {
       // Should match root level files (correct behavior)
       expect(match('README.md')).toBe(true);
       expect(match('package.json')).toBe(true);
-      
+
       // Should NOT match nested files according to GitLab spec, but currently does (bug)
       expect(match('src/index.js')).toBe(false);
       expect(match('docs/README.md')).toBe(false);

--- a/lib/modules/platform/gitlab/code-owners.spec.ts
+++ b/lib/modules/platform/gitlab/code-owners.spec.ts
@@ -127,5 +127,30 @@ describe('modules/platform/gitlab/code-owners', () => {
         },
       ]);
     });
+
+    it('should extract rules with /* pattern from root section and specific file pattern from another section', () => {
+      const lines = [
+        '[Root Section] @root-owner',
+        '/*',
+        '[Backend Team] @backend-team',
+        'src/backend.js',
+      ];
+      const rules = extractRulesFromCodeOwnersLines(lines);
+
+      expect(rules).toEqual([
+        {
+          pattern: '/*',
+          usernames: ['@root-owner'],
+          score: 2,
+          match: expect.any(Function),
+        },
+        {
+          pattern: 'src/backend.js',
+          usernames: ['@backend-team'],
+          score: 14,
+          match: expect.any(Function),
+        },
+      ]);
+    });
   });
 });

--- a/lib/modules/platform/gitlab/code-owners.spec.ts
+++ b/lib/modules/platform/gitlab/code-owners.spec.ts
@@ -128,29 +128,18 @@ describe('modules/platform/gitlab/code-owners', () => {
       ]);
     });
 
-    it('should extract rules with /* pattern from root section and specific file pattern from another section', () => {
-      const lines = [
-        '[Root Section] @root-owner',
-        '/*',
-        '[Backend Team] @backend-team',
-        'src/backend.js',
-      ];
-      const rules = extractRulesFromCodeOwnersLines(lines);
+    it('should only match root level with /* pattern according to GitLab spec', () => {
+      const rules = extractRulesFromCodeOwnersLines(['/* @root-owner']);
+      const match = rules[0].match;
 
-      expect(rules).toEqual([
-        {
-          pattern: '/*',
-          usernames: ['@root-owner'],
-          score: 2,
-          match: expect.any(Function),
-        },
-        {
-          pattern: 'src/backend.js',
-          usernames: ['@backend-team'],
-          score: 14,
-          match: expect.any(Function),
-        },
-      ]);
+      // Should match root level files (correct behavior)
+      expect(match('README.md')).toBe(true);
+      expect(match('package.json')).toBe(true);
+      
+      // Should NOT match nested files according to GitLab spec, but currently does (bug)
+      expect(match('src/index.js')).toBe(false);
+      expect(match('docs/README.md')).toBe(false);
+      expect(match('lib/utils/helper.js')).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Changes

Add failing test to expose incorrect `/*` handling

## Context

- #36982

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
