### PR TITLE
fix(pip-compile): add missing uv resolver flags

### DIFF
--- a/lib/modules/manager/pip-compile/common.ts
+++ b/lib/modules/manager/pip-compile/common.ts
@@ -128,6 +128,10 @@ const uvOptionsWithArguments = [
   '--constraints',
   '--python-version',
   '--no-emit-package',
+  '--resolution',
+  '--prerelease',
+  '--fork-strategy',
+  '--exclude-newer',
   ...commonOptionsWithArguments,
 ];
 export const optionsWithArguments = [

--- a/lib/modules/manager/pip-compile/common.ts
+++ b/lib/modules/manager/pip-compile/common.ts
@@ -131,13 +131,17 @@ const uvOptionsWithArguments = [
   '--resolution',
   '--prerelease',
   '--fork-strategy',
-  '--exclude-newer',
   ...commonOptionsWithArguments,
 ];
 export const optionsWithArguments = [
   ...pipOptionsWithArguments,
   ...uvOptionsWithArguments,
 ];
+const noArgumentOptions: Record<CommandType, string[]> = {
+  'pip-compile': [],
+  uv: ['--fork-strategy', '--exclude-newer'],
+  custom: [],
+};
 const allowedCommonOptions = [
   '-v',
   '--generate-hashes',
@@ -157,6 +161,8 @@ export const allowedOptions: Record<CommandType, string[]> = {
   uv: [
     '--no-strip-extras',
     '--universal',
+    '--exclude-newer',
+    '--no-emit-index-url',
     ...allowedCommonOptions,
     ...uvOptionsWithArguments,
   ],
@@ -217,6 +223,9 @@ export function extractHeaderCommand(
 
     if (arg.includes('=')) {
       const [option, value] = arg.split('=');
+      if (noArgumentOptions[commandType].includes(option)) {
+        throw new Error(`Option ${option} must not have an argument`);
+      }
       if (option === '--extra') {
         result.extra = result.extra ?? [];
         result.extra.push(value);
@@ -310,6 +319,7 @@ function throwForDisallowedOption(arg: string): void {
     throw new Error(`Option ${arg} not allowed for this manager`);
   }
 }
+
 function throwForNoEqualSignInOptionWithArgument(arg: string): void {
   if (optionsWithArguments.includes(arg)) {
     throw new Error(
@@ -317,6 +327,7 @@ function throwForNoEqualSignInOptionWithArgument(arg: string): void {
     );
   }
 }
+
 function throwForUnknownOption(commandType: CommandType, arg: string): void {
   if (arg.includes('=')) {
     const [option] = arg.split('=');


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Add resolver flags to fully support uv
<!-- Describe what behavior is changed by this PR. -->

## Context
UV has special resolver flags when running `uv pip compile`. Upon upgrade they're aded to requirements.txt and renovate crashes with them. This PR add those uv specific flags to list of allowed flags.
Reference: https://docs.astral.sh/uv/reference/cli/#uv-pip-compile

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required
