### PR TITLE
fix(workers): skip platform automerge reattempt in dry run

### DIFF
--- a/lib/workers/repository/update/branch/index.ts
+++ b/lib/workers/repository/update/branch/index.ts
@@ -649,10 +649,16 @@ export async function processBranch(
         platformPrOptions.usePlatformAutomerge &&
         platform.reattemptPlatformAutomerge
       ) {
-        await platform.reattemptPlatformAutomerge({
-          number: branchPr.number,
-          platformPrOptions,
-        });
+        if (GlobalConfig.get('dryRun')) {
+          logger.info(
+            `DRY-RUN: Would reattempt platform automerge for PR #${branchPr.number}`,
+          );
+        } else {
+          await platform.reattemptPlatformAutomerge({
+            number: branchPr.number,
+            platformPrOptions,
+          });
+        }
       }
       if (platform.refreshPr) {
         await platform.refreshPr(branchPr.number);


### PR DESCRIPTION
## Changes

Add the standard dry run check pattern before calling the platform method, consistent with the other occurrences in the branch worker.

:hammer_and_pick: with :heart: by [Siemens](https://opensource.siemens.com/)

## Context

- #37630

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
