### PR TITLE
fix(nuget): don't pin dotnet-tools versions

### DIFF
--- a/lib/modules/manager/nuget/extract.spec.ts
+++ b/lib/modules/manager/nuget/extract.spec.ts
@@ -525,6 +525,7 @@ describe('modules/manager/nuget/extract', () => {
                 datasource: 'nuget',
                 depName: 'minver-cli',
                 depType: 'nuget',
+                versioning: 'semver',
               },
             ],
           },
@@ -549,6 +550,7 @@ describe('modules/manager/nuget/extract', () => {
                 'https://api.nuget.org/v3/index.json#protocolVersion=3',
                 'https://contoso.com/packages/',
               ],
+              versioning: 'semver',
             },
           ],
         });

--- a/lib/modules/manager/nuget/extract.ts
+++ b/lib/modules/manager/nuget/extract.ts
@@ -5,6 +5,7 @@ import { logger } from '../../../logger';
 import { getSiblingFileName, localPathExists } from '../../../util/fs';
 import { regEx } from '../../../util/regex';
 import { NugetDatasource } from '../../datasource/nuget';
+import * as semver from '../../versioning/semver';
 import { getDep } from '../dockerfile/extract';
 import type {
   ExtractConfig,
@@ -186,6 +187,10 @@ export async function extractPackageFile(
         currentValue,
         datasource: NugetDatasource.id,
       };
+      if (is.string(currentValue) && semver.isVersion(currentValue)) {
+        // This is to avoid nuget versioning pinning to [1.2.3]
+        dep.versioning = 'semver';
+      }
 
       applyRegistries(dep, registries);
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Sets versioning=semver so that there's no pinning performed for dotnet-tools.json dependencies

## Context

- #35598 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
