### PR TITLE
refactor(manager/pep621): use abstract class for processors

### DIFF
--- a/lib/modules/manager/pep621/extract.spec.ts
+++ b/lib/modules/manager/pep621/extract.spec.ts
@@ -553,8 +553,12 @@ describe('modules/manager/pep621/extract', () => {
         Fixtures.get('pyproject_pdm_lockedversion.lock'),
       );
 
-      fs.localPathExists.mockResolvedValue(true);
-      fs.getSiblingFileName.mockReturnValue('pdm.lock');
+      fs.getSiblingFileName.mockReturnValueOnce('pdm.lock');
+
+      fs.getSiblingFileName.mockReturnValueOnce('pdm.lock');
+      fs.localPathExists.mockResolvedValueOnce(true);
+      fs.getSiblingFileName.mockReturnValueOnce('uv.lock');
+      fs.localPathExists.mockResolvedValueOnce(false);
 
       const res = await extractPackageFile(
         Fixtures.get('pyproject_pdm_lockedversion.toml'),
@@ -620,6 +624,11 @@ describe('modules/manager/pep621/extract', () => {
       );
 
       fs.findLocalSiblingOrParent.mockResolvedValue('uv.lock');
+
+      fs.getSiblingFileName.mockReturnValueOnce('pdm.lock');
+      fs.localPathExists.mockResolvedValueOnce(false);
+      fs.getSiblingFileName.mockReturnValueOnce('uv.lock');
+      fs.localPathExists.mockResolvedValueOnce(true);
 
       const res = await extractPackageFile(
         codeBlock`

--- a/lib/modules/manager/pep621/extract.spec.ts
+++ b/lib/modules/manager/pep621/extract.spec.ts
@@ -555,10 +555,7 @@ describe('modules/manager/pep621/extract', () => {
 
       fs.getSiblingFileName.mockReturnValueOnce('pdm.lock');
 
-      fs.getSiblingFileName.mockReturnValueOnce('pdm.lock');
-      fs.localPathExists.mockResolvedValueOnce(true);
-      fs.getSiblingFileName.mockReturnValueOnce('uv.lock');
-      fs.localPathExists.mockResolvedValueOnce(false);
+      fs.findLocalSiblingOrParent.mockResolvedValueOnce('pdm.lock');
 
       const res = await extractPackageFile(
         Fixtures.get('pyproject_pdm_lockedversion.toml'),
@@ -623,12 +620,9 @@ describe('modules/manager/pep621/extract', () => {
         `,
       );
 
-      fs.findLocalSiblingOrParent.mockResolvedValue('uv.lock');
-
-      fs.getSiblingFileName.mockReturnValueOnce('pdm.lock');
-      fs.localPathExists.mockResolvedValueOnce(false);
-      fs.getSiblingFileName.mockReturnValueOnce('uv.lock');
-      fs.localPathExists.mockResolvedValueOnce(true);
+      fs.findLocalSiblingOrParent.mockResolvedValueOnce(null);
+      fs.findLocalSiblingOrParent.mockResolvedValueOnce('uv.lock');
+      fs.findLocalSiblingOrParent.mockResolvedValueOnce('uv.lock');
 
       const res = await extractPackageFile(
         codeBlock`

--- a/lib/modules/manager/pep621/extract.ts
+++ b/lib/modules/manager/pep621/extract.ts
@@ -76,7 +76,7 @@ export async function extractPackageFile(
 
   // process specific tool sets
   let processedDeps = deps;
-  let lockFiles: string[] = [];
+  const lockFiles: string[] = [];
   for (const processor of processors) {
     processedDeps = processor.process(def, processedDeps);
     processedDeps = await processor.extractLockedVersions(
@@ -84,9 +84,9 @@ export async function extractPackageFile(
       processedDeps,
       packageFile,
     );
-    if (processor.getLockfiles) {
-      lockFiles = await processor.getLockfiles(def, lockFiles, packageFile);
-    }
+
+    const processedLockFiles = await processor.getLockfiles(def, packageFile);
+    lockFiles.push(...processedLockFiles);
   }
 
   const packageFileVersion = def.project?.version;

--- a/lib/modules/manager/pep621/processors/abstract.ts
+++ b/lib/modules/manager/pep621/processors/abstract.ts
@@ -1,0 +1,54 @@
+import { logger } from '../../../../logger';
+import { getSiblingFileName, localPathExists } from '../../../../util/fs';
+import type {
+  PackageDependency,
+  UpdateArtifact,
+  UpdateArtifactsResult,
+} from '../../types';
+import type { PyProject } from '../schema';
+import type { PyProjectProcessor } from './types';
+
+export abstract class BasePyProjectProcessor implements PyProjectProcessor {
+  // The name of the lockfiles to be searched for.
+  // This should be defined in the concrete processor classes.
+  // No lockfiles will be forwarded outside the manager implementation.
+  lockfileName: string | undefined;
+
+  abstract updateArtifacts(
+    updateArtifact: UpdateArtifact,
+    project: PyProject,
+  ): Promise<UpdateArtifactsResult[] | null>;
+
+  abstract process(
+    project: PyProject,
+    deps: PackageDependency[],
+  ): PackageDependency[];
+
+  abstract extractLockedVersions(
+    project: PyProject,
+    deps: PackageDependency[],
+    packageFile: string,
+  ): Promise<PackageDependency[]>;
+
+  async getLockfiles(
+    _project: PyProject,
+    packageFile: string,
+  ): Promise<string[]> {
+    if (!this.lockfileName) {
+      logger.trace(
+        { packageFile },
+        `No lockfile name defined for ${this.constructor.name}`,
+      );
+      return [];
+    }
+
+    const lockfilePath = getSiblingFileName(packageFile, this.lockfileName);
+    const lockfileExists = await localPathExists(lockfilePath);
+    if (lockfileExists) {
+      return [lockfilePath];
+    }
+
+    logger.debug({ packageFile }, `No ${this.lockfileName} found`);
+    return [];
+  }
+}

--- a/lib/modules/manager/pep621/processors/abstract.ts
+++ b/lib/modules/manager/pep621/processors/abstract.ts
@@ -1,5 +1,5 @@
 import { logger } from '../../../../logger';
-import { getSiblingFileName, localPathExists } from '../../../../util/fs';
+import { findLocalSiblingOrParent } from '../../../../util/fs';
 import type {
   PackageDependency,
   UpdateArtifact,
@@ -12,7 +12,7 @@ export abstract class BasePyProjectProcessor implements PyProjectProcessor {
   // The name of the lockfiles to be searched for.
   // This should be defined in the concrete processor classes.
   // No lockfiles will be forwarded outside the manager implementation.
-  lockfileName: string | undefined;
+  protected lockfileName: string | undefined;
 
   abstract updateArtifacts(
     updateArtifact: UpdateArtifact,
@@ -42,9 +42,11 @@ export abstract class BasePyProjectProcessor implements PyProjectProcessor {
       return [];
     }
 
-    const lockfilePath = getSiblingFileName(packageFile, this.lockfileName);
-    const lockfileExists = await localPathExists(lockfilePath);
-    if (lockfileExists) {
+    const lockfilePath = await findLocalSiblingOrParent(
+      packageFile,
+      this.lockfileName,
+    );
+    if (lockfilePath) {
       return [lockfilePath];
     }
 

--- a/lib/modules/manager/pep621/processors/hatch.ts
+++ b/lib/modules/manager/pep621/processors/hatch.ts
@@ -4,9 +4,9 @@ import type {
   UpdateArtifactsResult,
 } from '../../types';
 import type { PyProject } from '../schema';
-import type { PyProjectProcessor } from './types';
+import { BasePyProjectProcessor } from './abstract';
 
-export class HatchProcessor implements PyProjectProcessor {
+export class HatchProcessor extends BasePyProjectProcessor {
   process(
     pyproject: PyProject,
     deps: PackageDependency[],

--- a/lib/modules/manager/pep621/processors/types.ts
+++ b/lib/modules/manager/pep621/processors/types.ts
@@ -25,9 +25,5 @@ export interface PyProjectProcessor {
     packageFile: string,
   ): Promise<PackageDependency[]>;
 
-  getLockfiles?(
-    project: PyProject,
-    lockfiles: string[],
-    packageFile: string,
-  ): Promise<string[]>;
+  getLockfiles(project: PyProject, packageFile: string): Promise<string[]>;
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Refactoring processors to use abstract class for better re-usability of the `getLockFiles` method. 

<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
