### PR TITLE
fix(config): Replace secrets and variables globally

### DIFF
--- a/lib/config/secrets.spec.ts
+++ b/lib/config/secrets.spec.ts
@@ -72,6 +72,25 @@ describe('config/secrets', () => {
       });
     });
 
+    it('replaces all secrets and variables', () => {
+      const config = {
+        secrets: { FOO: 'foo', BAR: 'bar', BAZ: 'baz' },
+        variables: { FOO: 'foo', BAR: 'bar', BAZ: 'baz' },
+        customEnvVariables: {
+          SECRETS: '{{ secrets.FOO }} {{ secrets.BAR }} {{ secrets.BAZ }}',
+          VARIABLES:
+            '{{ variables.FOO }} {{ variables.BAR }} {{ variables.BAZ }}',
+        },
+      };
+      const result = applySecretsAndVariablesToConfig({ config });
+      expect(result).toEqual({
+        customEnvVariables: {
+          SECRETS: 'foo bar baz',
+          VARIABLES: 'foo bar baz',
+        },
+      });
+    });
+
     it('preserves secrets and variables if delete flags are false', () => {
       const config = {
         secrets: { TOKEN: 'secret123' },

--- a/lib/config/secrets.ts
+++ b/lib/config/secrets.ts
@@ -10,8 +10,8 @@ import type { AllConfig, RenovateConfig } from './types';
 
 const namePattern = '[A-Za-z][A-Za-z0-9_]*';
 const nameRegex = regEx(`^${namePattern}$`);
-const secretTemplateRegex = regEx(`{{ secrets\\.(${namePattern}) }}`);
-const variableTemplateRegex = regEx(`{{ variables\\.(${namePattern}) }}`);
+const secretTemplateRegex = regEx(`{{ secrets\\.(${namePattern}) }}`, 'g');
+const variableTemplateRegex = regEx(`{{ variables\\.(${namePattern}) }}`, 'g');
 
 export const options: Record<'secrets' | 'variables', InterpolatorOptions> = {
   secrets: {

--- a/lib/util/interpolator.ts
+++ b/lib/util/interpolator.ts
@@ -57,6 +57,9 @@ function replaceInterpolatedValuesInString(
   options: InterpolatorOptions,
 ): string {
   const { name, templateRegex } = options;
+  // Reset regex lastIndex for global regexes to ensure consistent behavior
+  templateRegex.lastIndex = 0;
+
   // do nothing if no interpolator template found
   if (!templateRegex.test(value)) {
     return value;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Applies the global modifier to `secretTemplateRegex` and `variableTemplateRegex`.

## Context

I have a `NIX_CONFIG` environment variable which contains multiple secrets. It was surprising to me that only the first secret has being interpolated.

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: Private repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
