### PR TITLE
fix(terraform): consider datasource array in docker image extractor preflight check

### DIFF
--- a/lib/modules/manager/terraform/extractors/resources/generic-docker-image-ref.spec.ts
+++ b/lib/modules/manager/terraform/extractors/resources/generic-docker-image-ref.spec.ts
@@ -1,4 +1,5 @@
 import { GenericDockerImageRefExtractor } from './generic-docker-image-ref';
+import { generic_image_datasource, generic_image_resource } from './utils';
 
 describe('modules/manager/terraform/extractors/resources/generic-docker-image-ref', () => {
   const extractor = new GenericDockerImageRefExtractor();
@@ -6,5 +7,14 @@ describe('modules/manager/terraform/extractors/resources/generic-docker-image-re
   it('return empty array if no resource is found', () => {
     const res = extractor.extract({}, [], {});
     expect(res).toBeArrayOfSize(0);
+  });
+
+  it('return resource and datasource types', () => {
+    const checkList = extractor.getCheckList();
+    expect(checkList).toBeArrayOfSize(
+      generic_image_datasource.length + generic_image_resource.length,
+    );
+    expect(checkList).toContain(`"${generic_image_datasource[0].type}"`);
+    expect(checkList).toContain(`"${generic_image_resource[0].type}"`);
   });
 });

--- a/lib/modules/manager/terraform/extractors/resources/generic-docker-image-ref.ts
+++ b/lib/modules/manager/terraform/extractors/resources/generic-docker-image-ref.ts
@@ -9,7 +9,9 @@ import { generic_image_datasource, generic_image_resource } from './utils';
 
 export class GenericDockerImageRefExtractor extends DependencyExtractor {
   getCheckList(): string[] {
-    return generic_image_resource.map((value) => `"${value.type}"`);
+    return [...generic_image_resource, ...generic_image_datasource].map(
+      (value) => `"${value.type}"`,
+    );
   }
 
   extract(


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

The check list of the GenericDockerImageRexExtractor which is used by the extractor's preflight check does not include all the dependencies it checks for.
This PR adds the second array to the list.

PR that introduced the bug: #35537

## Context

Please select one of the below:

- [x] This closes an existing Issue: #37742
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
