### PR TITLE
fix(terraform): update extractor to support gitlab dedicated

### DIFF
--- a/lib/modules/manager/terraform/extractors/others/modules.spec.ts
+++ b/lib/modules/manager/terraform/extractors/others/modules.spec.ts
@@ -1,3 +1,4 @@
+import type { PackageDependency } from '../../../types';
 import {
   ModuleExtractor,
   azureDevOpsSshRefMatchRegex,
@@ -6,6 +7,15 @@ import {
   githubRefMatchRegex,
   hostnameMatchRegex,
 } from './modules';
+
+function makeDep(source: string | undefined): PackageDependency {
+  return {
+    depName: 'foo',
+    depType: 'module',
+    currentValue: '0.0.0',
+    managerData: { source },
+  };
+}
 
 describe('modules/manager/terraform/extractors/others/modules', () => {
   const extractor = new ModuleExtractor();
@@ -338,5 +348,20 @@ describe('modules/manager/terraform/extractors/others/modules', () => {
         hostname: 'example.com',
       });
     });
+  });
+
+  test('Gitlab Dedicated URL', () => {
+    const dep = extractor.analyseTerraformModule(
+      makeDep(
+        'git::https://example.gitlab-dedicated.com/group/subgroup/repo.git?ref=v2.0.0',
+      ),
+    );
+    expect(dep.depName).toBe(
+      'example.gitlab-dedicated.com/group/subgroup/repo',
+    );
+    expect(dep.packageName).toBe(
+      'https://example.gitlab-dedicated.com/group/subgroup/repo',
+    );
+    expect(dep.currentValue).toBe('v2.0.0');
   });
 });

--- a/lib/modules/manager/terraform/extractors/others/modules.ts
+++ b/lib/modules/manager/terraform/extractors/others/modules.ts
@@ -60,7 +60,7 @@ export class ModuleExtractor extends DependencyExtractor {
     return dependencies;
   }
 
-  private analyseTerraformModule(dep: PackageDependency): PackageDependency {
+  public analyseTerraformModule(dep: PackageDependency): PackageDependency {
     // TODO #22198
     const source = dep.managerData!.source as string;
     const githubRefMatch = githubRefMatchRegex.exec(source);
@@ -93,8 +93,11 @@ export class ModuleExtractor extends DependencyExtractor {
       if (gitTagsRefMatch.groups.subfolder) {
         logger.debug('Terraform module contains subdirectory');
       }
-      dep.depName = gitTagsRefMatch.groups.path.replace('.git', '');
-      dep.packageName = gitTagsRefMatch.groups.url.replace('.git', '');
+      dep.depName = gitTagsRefMatch.groups.path.replace(/\.git(?=$|[/?])/g, '');
+      dep.packageName = gitTagsRefMatch.groups.url.replace(
+        /\.git(?=$|[/?])/g,
+        '',
+      );
       dep.currentValue = gitTagsRefMatch.groups.tag;
       dep.datasource = GitTagsDatasource.id;
     } else if (source) {


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Fixes terraform git tags extractor for Gitlab dedicated instances. Currently example.gitlab-dedicated.com is replaced with  examplelab.dedicated.com.

 <!-- Describe what behavior is changed by this PR. -->

## Context

See https://github.com/renovatebot/renovate/discussions/37221

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
