### PR TITLE
fix(platform): open or update issue correctly

### DIFF
--- a/lib/modules/platform/forgejo/index.spec.ts
+++ b/lib/modules/platform/forgejo/index.spec.ts
@@ -2331,12 +2331,11 @@ describe('modules/platform/forgejo/index', () => {
         .get('/repos/some/repo/issues')
         .query({ state: 'all', type: 'issues' })
         .reply(200, mockIssues)
-        .patch('/repos/some/repo/issues/2', {
+        .post('/repos/some/repo/issues', {
           body: closedIssue.body,
-          state: closedIssue.state,
-          title: 'closed-issue',
+          title: closedIssue.title,
         })
-        .reply(200, closedIssue);
+        .reply(200, { number: 42 });
       await initFakePlatform(scope);
       await initFakeRepo(scope);
 
@@ -2347,7 +2346,7 @@ describe('modules/platform/forgejo/index', () => {
         once: false,
       });
 
-      expect(res).toBe('updated');
+      expect(res).toBe('created');
     });
 
     it('should not update labels when not necessary', async () => {

--- a/lib/modules/platform/forgejo/index.ts
+++ b/lib/modules/platform/forgejo/index.ts
@@ -47,7 +47,6 @@ import { ForgejoPrCache } from './pr-cache';
 import type {
   CombinedCommitStatus,
   Comment,
-  IssueState,
   Label,
   PRMergeMethod,
   PRUpdateParams,
@@ -882,41 +881,42 @@ const platform: Platform = {
           return null;
         }
 
-        // Update issue body and re-open if enabled
-        // TODO: types (#22198)
-        logger.debug(`Updating Issue #${activeIssue.number!}`);
-        const existingIssue = await helper.updateIssue(
-          config.repository,
-          // TODO #22198
-          activeIssue.number!,
-          {
-            body,
-            title,
-            state: shouldReOpen ? 'open' : (activeIssue.state as IssueState),
-          },
-        );
-
-        // Test whether the issues need to be updated
-        const existingLabelIds = (existingIssue.labels ?? []).map(
-          (label) => label.id,
-        );
-        if (
-          labels &&
-          (labels.length !== existingLabelIds.length ||
-            labels.filter((labelId) => !existingLabelIds.includes(labelId))
-              .length !== 0)
-        ) {
-          await helper.updateIssueLabels(
+        if (shouldReOpen || activeIssue.state === 'open') {
+          // Update issue body and re-open
+          logger.debug(`Updating Issue #${activeIssue.number}`);
+          const existingIssue = await helper.updateIssue(
             config.repository,
             // TODO #22198
             activeIssue.number!,
             {
-              labels,
+              body,
+              title,
+              state: 'open',
             },
           );
-        }
 
-        return 'updated';
+          // Test whether the issues need to be updated
+          const existingLabelIds = (existingIssue.labels ?? []).map(
+            (label) => label.id,
+          );
+          if (
+            labels &&
+            (labels.length !== existingLabelIds.length ||
+              labels.filter((labelId) => !existingLabelIds.includes(labelId))
+                .length !== 0)
+          ) {
+            await helper.updateIssueLabels(
+              config.repository,
+              // TODO #22198
+              activeIssue.number!,
+              {
+                labels,
+              },
+            );
+          }
+
+          return 'updated';
+        }
       }
 
       // Create new issue and reset cache

--- a/lib/modules/platform/gitea/index.spec.ts
+++ b/lib/modules/platform/gitea/index.spec.ts
@@ -2331,12 +2331,11 @@ describe('modules/platform/gitea/index', () => {
         .get('/repos/some/repo/issues')
         .query({ state: 'all', type: 'issues' })
         .reply(200, mockIssues)
-        .patch('/repos/some/repo/issues/2', {
+        .post('/repos/some/repo/issues', {
           body: closedIssue.body,
-          state: closedIssue.state,
-          title: 'closed-issue',
+          title: closedIssue.title,
         })
-        .reply(200, closedIssue);
+        .reply(200, { number: 42 });
       await initFakePlatform(scope);
       await initFakeRepo(scope);
 
@@ -2347,7 +2346,7 @@ describe('modules/platform/gitea/index', () => {
         once: false,
       });
 
-      expect(res).toBe('updated');
+      expect(res).toBe('created');
     });
 
     it('should not update labels when not necessary', async () => {

--- a/lib/modules/platform/gitea/index.ts
+++ b/lib/modules/platform/gitea/index.ts
@@ -47,7 +47,6 @@ import { GiteaPrCache } from './pr-cache';
 import type {
   CombinedCommitStatus,
   Comment,
-  IssueState,
   Label,
   PRMergeMethod,
   PRUpdateParams,
@@ -890,41 +889,42 @@ const platform: Platform = {
           return null;
         }
 
-        // Update issue body and re-open if enabled
-        // TODO: types (#22198)
-        logger.debug(`Updating Issue #${activeIssue.number!}`);
-        const existingIssue = await helper.updateIssue(
-          config.repository,
-          // TODO #22198
-          activeIssue.number!,
-          {
-            body,
-            title,
-            state: shouldReOpen ? 'open' : (activeIssue.state as IssueState),
-          },
-        );
-
-        // Test whether the issues need to be updated
-        const existingLabelIds = (existingIssue.labels ?? []).map(
-          (label) => label.id,
-        );
-        if (
-          labels &&
-          (labels.length !== existingLabelIds.length ||
-            labels.filter((labelId) => !existingLabelIds.includes(labelId))
-              .length !== 0)
-        ) {
-          await helper.updateIssueLabels(
+        if (shouldReOpen || activeIssue.state === 'open') {
+          // Update issue body and re-open
+          logger.debug(`Updating Issue #${activeIssue.number}`);
+          const existingIssue = await helper.updateIssue(
             config.repository,
             // TODO #22198
             activeIssue.number!,
             {
-              labels,
+              body,
+              title,
+              state: 'open',
             },
           );
-        }
 
-        return 'updated';
+          // Test whether the issues need to be updated
+          const existingLabelIds = (existingIssue.labels ?? []).map(
+            (label) => label.id,
+          );
+          if (
+            labels &&
+            (labels.length !== existingLabelIds.length ||
+              labels.filter((labelId) => !existingLabelIds.includes(labelId))
+                .length !== 0)
+          ) {
+            await helper.updateIssueLabels(
+              config.repository,
+              // TODO #22198
+              activeIssue.number!,
+              {
+                labels,
+              },
+            );
+          }
+
+          return 'updated';
+        }
       }
 
       // Create new issue and reset cache

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -1328,7 +1328,7 @@ export async function ensureIssue({
         logger.debug('Issue is open and up to date - nothing to do');
         return null;
       }
-      if (shouldReOpen) {
+      if (shouldReOpen || issue.state === 'open') {
         logger.debug('Patching issue');
         const data: Record<string, unknown> = { body, state: 'open', title };
         if (labels) {

--- a/lib/workers/repository/error-config.ts
+++ b/lib/workers/repository/error-config.ts
@@ -83,7 +83,7 @@ async function raiseWarningIssue(
     shouldReOpen: config.configWarningReuseIssue,
     confidential: config.confidential,
   });
-  if (res === 'created') {
+  if (res === 'updated' || res === 'created') {
     logger.warn({ configError: error, res }, 'Configuration Warning');
   }
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- ensure warning log when config issue is updated (all platforms)
- properly update issue if open (github)
- properly create new issue if `configWarningReuseIssue=false` (gitea/forgejo)
<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
