### PR TITLE
fix(presets): use semantic commit type `chore` for lockfile updates with `:semanticPrefixFixDepsChoreOthers` preset

### DIFF
--- a/lib/config/presets/__snapshots__/index.spec.ts.snap
+++ b/lib/config/presets/__snapshots__/index.spec.ts.snap
@@ -103,6 +103,12 @@ exports[`config/presets/index > resolvePreset > migrates automerge in presets 1`
       "semanticCommitType": "fix",
     },
     {
+      "matchJsonata": [
+        "isLockfileUpdate = true",
+      ],
+      "semanticCommitType": "chore",
+    },
+    {
       "matchPackageNames": [
         "*",
       ],

--- a/lib/config/presets/internal/default.ts
+++ b/lib/config/presets/internal/default.ts
@@ -583,6 +583,10 @@ export const presets: Record<string, Preset> = {
         matchManagers: ['poetry'],
         semanticCommitType: 'fix',
       },
+      {
+        matchJsonata: ['isLockfileUpdate = true'],
+        semanticCommitType: 'chore',
+      },
     ],
   },
   separateMajorReleases: {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

I've extended the `:semanticPrefixFixDepsChoreOthers` preset to use the semantic commit type `chore` for lockfile updates (`rangeStrategy: 'update-lockfile'`). The rationale for this setting is as follows: Runtime dependencies of libraries typically have loose constraints (e.g., lower bounds). Yet, it's useful to lock also runtime dependencies for offering a reproducible development environment and deterministic/reproducible testing. Renovate's `rangeStrategy: 'update-lockfile'` setting allows updating only the locked version of a direct dependency without changing the version constraint in the manifest – independent of overall lockfile maintenance. With appropriate package rules, this range strategy can be applied only to runtime dependencies while, e.g., pinned versions of dev dependencies are bumped both in the manifest and lockfile. Now, the semantic commit type `fix` should only be used for changes that affect the consumers of a library, but updating only the locked version of a direct runtime dependency is a dev-only change, hence the semantic commit type should be `chore`. To achieve this behavior, I've added a package rule to the `:semanticPrefixFixDepsChoreOthers` preset at the end of the rules array to set the semantic commit type `chore` whenever the `isLockfileUpdate` attribute is `true`. This rule must come last to override any preceding rule that sets the semantic commit type to `fix`. Alternatively, we could add `matchJsonata: ['isLockfileUpdate != true']` to all package rules in this preset that set the semantic commit type to `fix`, but I felt that's too repetitive. I'm open to different opinions though. :slightly_smiling_face:

## Context

Please select one of the below:

- [x] This closes an existing Issue: #6791
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: https://github.com/sisp/test-renovate-lockfile-update-semanticprefixfixdepschoreothers

See the `main` branch for the current behavior of the `:semanticPrefixFixDepsChoreOthers` preset, the `fix` branch contains the package rule I've added in this PR, which is effectively equivalent to adding it to the preset. As you can see in this test project, the Renovate PR that targets the `main` branch uses the semantic commit type `fix` whereas the Renovate PR that targets the `fix` branch uses the semantic commit type `chore`.

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
