### PR TITLE
fix(nix): add `file` input type to Nix schema

### DIFF
--- a/lib/modules/manager/nix/extract.spec.ts
+++ b/lib/modules/manager/nix/extract.spec.ts
@@ -659,4 +659,51 @@ describe('modules/manager/nix/extract', () => {
       ],
     });
   });
+
+  it('ignores unsupported file type and still extracts other inputs', async () => {
+    const flakeLock = codeBlock`{
+      "nodes": {
+        "file": {
+          "flake": false,
+          "locked": {
+            "narHash": "sha256-55ZgnQaZD3uRr/Dom05x0K7ui4+Fnb6H30jW5Eu3ZE0=",
+            "type": "file",
+            "url": "https://raw.githubusercontent.com/NixOS/nixpkgs/a69c58b926f609e5b9c56b25b075d2af9a5b7dc5/README.md"
+          },
+          "original": {
+            "type": "file",
+            "url": "https://raw.githubusercontent.com/NixOS/nixpkgs/a69c58b926f609e5b9c56b25b075d2af9a5b7dc5/README.md"
+          }
+        },
+        "nixpkgs": {
+          "locked": {
+            "lastModified": 1757068644,
+            "narHash": "sha256-NOrUtIhTkIIumj1E/Rsv1J37Yi3xGStISEo8tZm3KW4=",
+            "owner": "NixOS",
+            "repo": "nixpkgs",
+            "rev": "8eb28adfa3dc4de28e792e3bf49fcf9007ca8ac9",
+            "type": "github"
+          },
+          "original": {
+            "owner": "NixOS",
+            "ref": "nixos-unstable",
+            "repo": "nixpkgs",
+            "type": "github"
+          }
+        },
+        "root": {
+          "inputs": {
+            "file": "file",
+            "nixpkgs": "nixpkgs"
+          }
+        }
+      },
+      "root": "root",
+      "version": 7
+    }`;
+    fs.readLocalFile.mockResolvedValueOnce(flakeLock);
+    const result = await extractPackageFile('', 'flake.nix');
+    expect(result?.deps).toHaveLength(1);
+    expect(result?.deps[0].depName).toBe('nixpkgs');
+  });
 });

--- a/lib/modules/manager/nix/schema.ts
+++ b/lib/modules/manager/nix/schema.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { Json } from '../../../util/schema-utils';
 
 const InputType = z.enum([
+  'file',
   'git',
   'github',
   'gitlab',
@@ -13,7 +14,7 @@ const InputType = z.enum([
 
 const LockedInput = z.object({
   ref: z.string().optional(),
-  rev: z.string(),
+  rev: z.string().optional(),
   type: InputType,
 });
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This change adds the `file` type to the Nix `flake.lock` schema. This is described by the [Nix Reference Manual](https://nix.dev/manual/nix/2.28/command-ref/new-cli/nix3-flake.html#types).

Without this change, the parser fails as soon as it encounters the `file` type, and fails to extract other inputs which _are_ supported.

<details>
<summary>Error message</summary>

```
DEBUG: invalid flake.lock file
{
  "packageLockFile": "flake.lock"
  "error": {
    "message": "Schema error",
    "stack": "ZodError: Schema error\n    at Object.get error [as error] (/usr/local/renovate/node_modules/.pnpm/zod@3.24.2/node_modules/zod/lib/types.js:55:31)\n    at Object.extractPackageFile (/usr/local/renovate/lib/modules/manager/nix/extract.ts:43:49)\n    at getManagerPackageFiles (/usr/local/renovate/lib/workers/repository/extract/manager-files.ts:58:19)\n    at /usr/local/renovate/lib/workers/repository/extract/index.ts:57:28\n    at async Promise.all (index 0)\n    at extractAllDependencies (/usr/local/renovate/lib/workers/repository/extract/index.ts:54:26)\n    at extract (/usr/local/renovate/lib/workers/repository/process/extract-update.ts:160:28)\n    at extractDependencies (/usr/local/renovate/lib/workers/repository/process/index.ts:158:26)\n    at Object.renovateRepository (/usr/local/renovate/lib/workers/repository/index.ts:72:9)\n    at attributes.repository (/usr/local/renovate/lib/workers/global/index.ts:206:11)\n    at start (/usr/local/renovate/lib/workers/global/index.ts:191:7)\n    at /usr/local/renovate/lib/renovate.ts:19:22",
    "issues": {
      "nodes": {
        "pubkeys": {
          "locked": {
            "rev": "Required",
            "type": "Invalid enum value. Expected 'git' | 'github' | 'gitlab' | 'indirect' | 'sourcehut' | 'tarball', received 'file'"
          },
          "original": {
            "type": "Invalid enum value. Expected 'git' | 'github' | 'gitlab' | 'indirect' | 'sourcehut' | 'tarball', received 'file'"
          }
        }
      }
    }
  }
}
```

</details>

This PR makes no attempt to support updating `file` dependencies or extracting them, and is only intended to prevent the parsing error which they cause to allow other inputs to continue working properly.

## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

This is relevant to #35345

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
