### PR TITLE
feat(datasource/go): improve source URL detection and fix direct sources

### DIFF
--- a/lib/modules/datasource/go/base.spec.ts
+++ b/lib/modules/datasource/go/base.spec.ts
@@ -24,8 +24,8 @@ describe('modules/datasource/go/base', () => {
       ${'dev.azure.com/foo/bar/_git/baz.git'}             | ${'git-tags'}       | ${'https://dev.azure.com/foo/bar/_git/baz'}
       ${'dev.azure.com/foo/bar/baz.git'}                  | ${'git-tags'}       | ${'https://dev.azure.com/foo/bar/_git/baz'}
       ${'gitea.com/go-chi/cache'}                         | ${'gitea-tags'}     | ${'go-chi/cache'}
-      ${'code.forgejo.org/go-chi/cache'}                  | ${'gitea-tags'}     | ${'go-chi/cache'}
-      ${'codeberg.org/eviedelta/detctime/durationparser'} | ${'gitea-tags'}     | ${'eviedelta/detctime'}
+      ${'code.forgejo.org/go-chi/cache'}                  | ${'forgejo-tags'}   | ${'go-chi/cache'}
+      ${'codeberg.org/eviedelta/detctime/durationparser'} | ${'forgejo-tags'}   | ${'eviedelta/detctime'}
     `(
       '$module -> $datasource: $packageName',
       async ({ module, datasource, packageName }) => {

--- a/lib/modules/datasource/go/base.ts
+++ b/lib/modules/datasource/go/base.ts
@@ -11,6 +11,7 @@ import {
   trimTrailingSlash,
 } from '../../../util/url';
 import { BitbucketTagsDatasource } from '../bitbucket-tags';
+import { ForgejoTagsDatasource } from '../forgejo-tags';
 import { GitTagsDatasource } from '../git-tags';
 import { GiteaTagsDatasource } from '../gitea-tags';
 import { GithubTagsDatasource } from '../github-tags';
@@ -110,7 +111,7 @@ export class BaseGoDatasource {
       const split = goModule.split('/');
       const packageName = `${split[1]}/${split[2]}`;
       return {
-        datasource: GiteaTagsDatasource.id,
+        datasource: ForgejoTagsDatasource.id,
         packageName,
         registryUrl: 'https://code.forgejo.org',
       };
@@ -120,7 +121,7 @@ export class BaseGoDatasource {
       const split = goModule.split('/');
       const packageName = `${split[1]}/${split[2]}`;
       return {
-        datasource: GiteaTagsDatasource.id,
+        datasource: ForgejoTagsDatasource.id,
         packageName,
         registryUrl: 'https://codeberg.org',
       };

--- a/lib/modules/datasource/go/common.spec.ts
+++ b/lib/modules/datasource/go/common.spec.ts
@@ -1,0 +1,21 @@
+import { getSourceUrl } from './common';
+
+describe('modules/datasource/go/common', () => {
+  describe('getSourceUrl', () => {
+    it.each`
+      expected                                   | datasource          | packageName
+      ${'https://bitbucket.org/foo/bar'}         | ${'bitbucket-tags'} | ${'foo/bar'}
+      ${'https://code.forgejo.org/go-chi/cache'} | ${'forgejo-tags'}   | ${'go-chi/cache'}
+      ${'https://gitea.com/go-chi/cache'}        | ${'gitea-tags'}     | ${'go-chi/cache'}
+      ${'https://github.com/go-foo/foo'}         | ${'github-tags'}    | ${'go-foo/foo'}
+      ${'https://gitlab.com/foo/bar'}            | ${'gitlab-tags'}    | ${'foo/bar'}
+      ${undefined}                               | ${'git-tags'}       | ${'https://dev.azure.com/foo/bar/_git/baz'}
+    `(
+      '($datasource, $packageName) => $expected',
+      ({ expected, datasource, packageName }) => {
+        const res = getSourceUrl({ datasource, packageName });
+        expect(res).toEqual(expected);
+      },
+    );
+  });
+});

--- a/lib/modules/datasource/go/common.ts
+++ b/lib/modules/datasource/go/common.ts
@@ -1,5 +1,7 @@
 import { getSourceUrl as githubSourceUrl } from '../../../util/github/url';
 import { BitbucketTagsDatasource } from '../bitbucket-tags';
+import { ForgejoTagsDatasource } from '../forgejo-tags';
+import { GiteaTagsDatasource } from '../gitea-tags';
 import { GithubTagsDatasource } from '../github-tags';
 import { GitlabTagsDatasource } from '../gitlab-tags';
 import { getSourceUrl as gitlabSourceUrl } from '../gitlab-tags/util';
@@ -16,19 +18,19 @@ export function getSourceUrl(
   if (dataSource) {
     const { datasource, registryUrl, packageName } = dataSource;
 
-    if (datasource === GithubTagsDatasource.id) {
-      return githubSourceUrl(packageName, registryUrl);
-    }
-
-    if (datasource === GitlabTagsDatasource.id) {
-      return gitlabSourceUrl(packageName, registryUrl);
-    }
-
-    if (datasource === BitbucketTagsDatasource.id) {
-      return BitbucketTagsDatasource.getSourceUrl(packageName, registryUrl);
+    switch (datasource) {
+      case ForgejoTagsDatasource.id:
+        return ForgejoTagsDatasource.getSourceUrl(packageName, registryUrl);
+      case GiteaTagsDatasource.id:
+        return GiteaTagsDatasource.getSourceUrl(packageName, registryUrl);
+      case GithubTagsDatasource.id:
+        return githubSourceUrl(packageName, registryUrl);
+      case GitlabTagsDatasource.id:
+        return gitlabSourceUrl(packageName, registryUrl);
+      case BitbucketTagsDatasource.id:
+        return BitbucketTagsDatasource.getSourceUrl(packageName, registryUrl);
     }
   }
 
-  // istanbul ignore next
   return undefined;
 }

--- a/lib/modules/datasource/go/index.spec.ts
+++ b/lib/modules/datasource/go/index.spec.ts
@@ -9,6 +9,7 @@ const hostRules = vi.mocked(_hostRules);
 
 const getReleasesDirectMock = vi.fn();
 
+const getDigestForgejoMock = vi.fn();
 const getDigestGiteaMock = vi.fn();
 const getDigestGithubMock = vi.fn();
 const getDigestGitlabMock = vi.fn();
@@ -18,6 +19,9 @@ vi.mock('./releases-direct', () => {
   return {
     GoDirectDatasource: vi.fn().mockImplementation(() => {
       return {
+        forgejo: {
+          getDigest: (...args: any[]) => getDigestForgejoMock(...args),
+        },
         git: { getDigest: (...args: any[]) => getDigestGitMock(...args) },
         gitea: { getDigest: (...args: any[]) => getDigestGiteaMock(...args) },
         github: { getDigest: (...args: any[]) => getDigestGithubMock(...args) },
@@ -187,6 +191,17 @@ describe('modules/datasource/go/index', () => {
       const res = await datasource.getDigest(
         {
           packageName: 'bitbucket.org/golang/text',
+        },
+        undefined,
+      );
+      expect(res).toBe('123');
+    });
+
+    it('support forgejo digest', async () => {
+      getDigestForgejoMock.mockResolvedValueOnce('123');
+      const res = await datasource.getDigest(
+        {
+          packageName: 'code.forgejo.org/go-chi/cache',
         },
         undefined,
       );

--- a/lib/modules/datasource/go/index.ts
+++ b/lib/modules/datasource/go/index.ts
@@ -8,6 +8,7 @@ import { parseUrl } from '../../../util/url';
 import { id as semverId } from '../../versioning/semver';
 import { BitbucketTagsDatasource } from '../bitbucket-tags';
 import { Datasource } from '../datasource';
+import { ForgejoTagsDatasource } from '../forgejo-tags';
 import { GitTagsDatasource } from '../git-tags';
 import { GiteaTagsDatasource } from '../gitea-tags';
 import { GithubTagsDatasource } from '../github-tags';
@@ -97,6 +98,9 @@ export class GoDatasource extends Datasource {
         : undefined;
 
     switch (source.datasource) {
+      case ForgejoTagsDatasource.id: {
+        return this.direct.forgejo.getDigest(source, tag);
+      }
       case GitTagsDatasource.id: {
         return this.direct.git.getDigest(source, tag);
       }
@@ -112,7 +116,7 @@ export class GoDatasource extends Datasource {
       case GitlabTagsDatasource.id: {
         return this.direct.gitlab.getDigest(source, tag);
       }
-      /* istanbul ignore next: can never happen, makes lint happy */
+      /* v8 ignore next 3: can never happen, makes lint happy */
       default: {
         return null;
       }
@@ -121,7 +125,7 @@ export class GoDatasource extends Datasource {
 }
 
 const env = getEnv();
-/* v8 ignore next 3 -- hard to test */
+/* v8 ignore start -- hard to test */
 if (is.string(env.GOPROXY)) {
   const uri = parseUrl(env.GOPROXY);
   if (uri?.password) {
@@ -130,3 +134,4 @@ if (is.string(env.GOPROXY)) {
     addSecretForSanitizing(uri.username, 'global');
   }
 }
+/* v8 ignore stop -- hard to test */

--- a/lib/modules/datasource/go/releases-direct.spec.ts
+++ b/lib/modules/datasource/go/releases-direct.spec.ts
@@ -66,6 +66,67 @@ describe('modules/datasource/go/releases-direct', () => {
       });
     });
 
+    it('support forgejo', async () => {
+      getDatasourceSpy.mockResolvedValueOnce({
+        datasource: 'forgejo-tags',
+        registryUrl: 'https://code.forgejo.org',
+        packageName: 'go-chi/cache',
+      });
+      httpMock
+        .scope('https://code.forgejo.org/')
+        .get('/api/v1/repos/go-chi/cache/tags')
+        .reply(200, [
+          {
+            name: 'v0.1.0',
+            commit: {
+              sha: 'd73d815ec22c421e7192a414594ac798c73c89e5',
+              created: '2022-05-15T16:29:42Z',
+            },
+          },
+          {
+            name: 'v0.2.0',
+            commit: {
+              sha: '3976707232cb68751ff2ddf42547ff95c6878a97',
+              created: '2022-05-15T17:23:28Z',
+            },
+          },
+          {
+            name: 'v0.2.1',
+            commit: {
+              sha: '2963b104773ead7ed28c00181c03318885d909dc',
+              created: '2024-09-06T23:44:34Z',
+            },
+          },
+        ]);
+      const res = await datasource.getReleases({
+        packageName: 'code.forgejo.org/go-chi/cache',
+      });
+      expect(res).toEqual({
+        registryUrl: 'https://code.forgejo.org',
+        releases: [
+          {
+            gitRef: 'v0.1.0',
+            newDigest: 'd73d815ec22c421e7192a414594ac798c73c89e5',
+            releaseTimestamp: '2022-05-15T16:29:42.000Z',
+            version: 'v0.1.0',
+          },
+          {
+            gitRef: 'v0.2.0',
+            newDigest: '3976707232cb68751ff2ddf42547ff95c6878a97',
+            releaseTimestamp: '2022-05-15T17:23:28.000Z',
+            version: 'v0.2.0',
+          },
+          {
+            gitRef: 'v0.2.1',
+            newDigest: '2963b104773ead7ed28c00181c03318885d909dc',
+            releaseTimestamp: '2024-09-06T23:44:34.000Z',
+            version: 'v0.2.1',
+          },
+        ],
+        sourceUrl: 'https://code.forgejo.org/go-chi/cache',
+      });
+    });
+
     it('support gitlab', async () => {
       getDatasourceSpy.mockResolvedValueOnce({
         datasource: 'gitlab-tags',
@@ -141,7 +202,7 @@ describe('modules/datasource/go/releases-direct', () => {
             version: 'v0.2.1',
           },
         ],
-        sourceUrl: null,
+        sourceUrl: 'https://gitea.com/go-chi/cache',
       });
     });
 

--- a/lib/modules/datasource/go/releases-direct.ts
+++ b/lib/modules/datasource/go/releases-direct.ts
@@ -3,6 +3,7 @@ import { cache } from '../../../util/cache/package/decorator';
 import { regEx } from '../../../util/regex';
 import { BitbucketTagsDatasource } from '../bitbucket-tags';
 import { Datasource } from '../datasource';
+import { ForgejoTagsDatasource } from '../forgejo-tags';
 import { GitTagsDatasource } from '../git-tags';
 import { GiteaTagsDatasource } from '../gitea-tags';
 import { GithubTagsDatasource } from '../github-tags';
@@ -60,6 +61,7 @@ function filterByPrefix(packageName: string, releases: Release[]): Release[] {
 export class GoDirectDatasource extends Datasource {
   static readonly id = 'go-direct';
 
+  readonly forgejo = new ForgejoTagsDatasource();
   git: GitTagsDatasource;
   readonly gitea = new GiteaTagsDatasource();
   github: GithubTagsDatasource;
@@ -106,6 +108,10 @@ export class GoDirectDatasource extends Datasource {
     }
 
     switch (source.datasource) {
+      case ForgejoTagsDatasource.id: {
+        res = await this.forgejo.getReleases(source);
+        break;
+      }
       case GitTagsDatasource.id: {
         res = await this.git.getReleases(source);
         break;
@@ -137,7 +143,7 @@ export class GoDirectDatasource extends Datasource {
       return null;
     }
 
-    const sourceUrl = getSourceUrl(source) ?? null;
+    const sourceUrl = res.sourceUrl ?? getSourceUrl(source) ?? null;
 
     return {
       ...res,

--- a/lib/modules/datasource/go/releases-goproxy.ts
+++ b/lib/modules/datasource/go/releases-goproxy.ts
@@ -203,7 +203,7 @@ export class GoProxyDatasource extends Datasource {
     const isGopkgin = packageName.startsWith('gopkg.in/');
     const majorSuffixSeparator = isGopkgin ? '.' : '/';
     const modParts = packageName.match(modRegex)?.groups;
-    const baseMod = modParts?.baseMod ?? /* istanbul ignore next */ packageName;
+    const baseMod = modParts?.baseMod ?? /* v8 ignore next */ packageName;
     const packageMajor = parseInt(modParts?.majorVersion ?? '0');
 
     const result: ReleaseResult = { releases: [] };


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- `codeberg.org` and `code.forgejo.org` are now using `forgejo-tags` on direct connection (technically breaking)
- reuse source URL from direct datasource if set
- add code coverage
<!-- Describe what behavior is changed by this PR. -->

## Context

- https://codeberg.org/forgejo/forgejo/pulls/9218
Previously the source URL from direct child datasources are hard overwritten, now they are reused.

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
