### PR TITLE
feat: Add Terraform Cloud authentication support for private modules

### DIFF
--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -1372,6 +1372,13 @@ It could then be used in a repository config or preset like so:
 
 Secret names must start with an upper or lower case character and can have only characters, digits, or underscores.
 
+## tfcToken
+
+API token for authenticating with Terraform Cloud/Enterprise private module registry.
+
+This token is used when Renovate needs to access private modules from `app.terraform.io`.
+You can also set this using the `RENOVATE_TFC_TOKEN` environment variable.
+
 ## token
 
 ## unicodeEmoji

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -983,6 +983,14 @@ const options: RenovateOptions[] = [
     globalOnly: true,
   },
   {
+    name: 'tfcToken',
+    description:
+      'Terraform Cloud/Enterprise API token for accessing private module registry.',
+    stage: 'repository',
+    type: 'string',
+    globalOnly: true,
+  },
+  {
     name: 'username',
     description: 'Username for authentication.',
     stage: 'repository',

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -176,6 +176,7 @@ export interface RepoGlobalConfig {
   s3PathStyle?: boolean;
   cachePrivatePackages?: boolean;
   ignorePrAuthor?: boolean;
+  tfcToken?: string;
 }
 
 export interface LegacyAdminConfig {


### PR DESCRIPTION

## Changes

Add TFC/TFE authentication to terraform-module datasource to support private module registries hosted on app.terraform.io.

Changes:
- Add tfcToken configuration option for TFC API authentication
- Enhance terraform-module datasource to detect TFC URLs and inject Bearer auth
- Support both config-based (tfcToken) and env-based (RENOVATE_TFC_TOKEN) tokens
- Add proper debug logging for TFC authentication flow

This is to fix

```
         "https://api.github.com/repositories/xxx/pulls": {"GET": {"200": 9}},
         "https://app.terraform.io/.well-known/terraform.json": {"GET": {"200": 1}},
         "https://app.terraform.io/api/registry/v1/modules/xxx/iam/aws": {
           "GET": {"401": 1}
         },
         "https://app.terraform.io/api/registry/v1/modules/xxx/s3/aws": {
           "GET": {"401": 1}
         }
```

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->


## Context

Please select one of the below:

- [ ] This closes an existing Issue: https://github.com/renovatebot/renovate/discussions/37926
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request? 

Yes, I used claude code to help with the changes

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
