### PR TITLE
feat(best-practices)!: provide default `minimumReleaseAge` for npm

### DIFF
--- a/lib/config/presets/internal/config.ts
+++ b/lib/config/presets/internal/config.ts
@@ -13,6 +13,7 @@ export const presets: Record<string, Preset> = {
       ':configMigration',
       ':pinDevDependencies',
       'abandonments:recommended',
+      'security:minimumReleaseAgeNpm',
     ],
   },
   'js-app': {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

As noted in #37952, we've seen a significant increase in recent years on
a number of package ecosystems being targeted with supply chain security
attacks.

We're in a particularly strong position to improve the level of security
across the world by setting a default for `minimumReleaseAge` in the
`best-practices` config preset.

To do this, we can introduce a new preset,
`security:minimum-release-age` to house these recommended options.

We use new presets `security:minimum-release-age` and
`security:minimum-release-age-npm`, to allow consumers to utilise
`ignorePresets` to undo this configuration, if they so wish.

As a first step towards securing our users, we can set a default for
npm, which as a large ecosystem with an increased number of packages
that depend on other packages (compared to other ecosystems), has been a
more targeted area.

In the future, we can expand this for other managers, as it makes sense,
and as support is added for them to use `minimumReleaseAge`.

- #37952.


## Context

Please select one of the below:

- [x] This closes an existing Issue: #37952
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

We've not yet decided if there's anything else (via https://github.com/renovatebot/renovate/discussions/37952) that needs updating

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: N/A

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
