### PR TITLE
feat(bazel-module): Add support for rules_img use_repo_rule

### DIFF
--- a/lib/modules/manager/bazel-module/extract.spec.ts
+++ b/lib/modules/manager/bazel-module/extract.spec.ts
@@ -618,5 +618,375 @@ describe('modules/manager/bazel-module/extract', () => {
         ],
       });
     });
+
+    it('handles a real-world MODULE.bazel file (rules_sh)', async () => {
+      const input = codeBlock`
+        module(
+            name = "rules_sh",
+            version = "0.5.0",
+            compatibility_level = 0,
+        )
+        bazel_dep(name = "bazel_skylib", version = "1.2.1")
+        bazel_dep(name = "platforms", version = "0.0.8")
+        bazel_dep(name = "stardoc", version = "0.6.2", dev_dependency = True, repo_name = "io_bazel_stardoc")
+        sh_configure = use_extension("//bzlmod:extensions.bzl", "sh_configure")
+        use_repo(sh_configure, "local_posix_config", "rules_sh_shim_exe")
+        register_toolchains("@local_posix_config//...")
+      `;
+
+      const result = await extractPackageFile(input, 'MODULE.bazel');
+
+      expect(result).toEqual({
+        deps: [
+          {
+            datasource: BazelDatasource.id,
+            depType: 'bazel_dep',
+            depName: 'bazel_skylib',
+            currentValue: '1.2.1',
+          },
+          {
+            datasource: BazelDatasource.id,
+            depType: 'bazel_dep',
+            depName: 'platforms',
+            currentValue: '0.0.8',
+          },
+          {
+            datasource: BazelDatasource.id,
+            depType: 'bazel_dep',
+            depName: 'stardoc',
+            currentValue: '0.6.2',
+          },
+        ],
+      });
+    });
+
+    it('handles every method available in MODULE.bazel files', async () => {
+      const input = codeBlock`
+        module(
+            name = "module_name",
+            version = "1.2.3",
+            compatibility_level = 0,
+            repo_name = "io_bazel_module_name",
+            bazel_compatibility = ["<=6.0.0", ">=8.2.0"],
+        )
+        bazel_dep(name = "bazel_skylib", version = "1.2.1")
+        bazel_dep(name = "platforms", version = "0.0.8")
+        bazel_dep(name = "rules_img", version = "0.1.5")
+        bazel_dep(name = "stardoc", version = "0.6.2", dev_dependency = True, repo_name = "io_bazel_stardoc")
+        pull = use_repo_rule("@rules_img//img:pull.bzl", "pull")
+        pull(
+            name = "ubuntu",
+            digest = "sha256:1e622c5f9ac0c0144d577702ba5f2cce79fc8e3cf89ec88291739cd4eee3b7b9",
+            registry = "index.docker.io",
+            repository = "library/ubuntu",
+            tag = "24.04",
+        )
+        multiple_version_override(
+            module_name = "overriden_module_a",
+            versions = ["1.2.3", "1.2.4"],
+            registry = "https://example.com/custom_registry",
+        )
+        git_override(
+            module_name = "overriden_module_c",
+            commit = "850cb49c8649e463b80ef7984e7c744279746170",
+            remote = "https://github.com/example/overriden_module_b.git",
+        )
+        archive_override(
+            module_name = "overriden_module_d",
+            urls = [
+                "https://example.com/archive.tar.gz",
+            ],
+        )
+        include("//:extra.MODULE.bazel")
+        sh_configure = use_extension("//bzlmod:extensions.bzl", "sh_configure")
+        use_repo(sh_configure, "local_posix_config", "rules_sh_shim_exe")
+        override_repo(
+            sh_configure,
+            com_github_foo_bar = "overriden_module_a",
+        )
+        register_execution_platforms(
+            "@overriden_module_a//:some_execution_platform",
+            dev_dependency = True,
+        )
+        register_toolchains(
+            "@overriden_module_a//:some_toolchain",
+            dev_dependency = True,
+        )
+        single_version_override(
+            module_name = "overriden_module_c",
+            version = "1.2.5",
+            registry = "https://example.com/custom_registry",
+            patch_cmds = [],
+            patch_strip = 8,
+        )
+        my_repo_rule = use_repo_rule("@my_repo//:my_repo.bzl", "my_repo_rule")
+        my_repo_rule(
+            name = "my_custom_repo",
+            url = "https://example.com/my_custom_repo.tar.gz",
+            sha256 = "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+        )
+      `;
+
+      const result = await extractPackageFile(input, 'MODULE.bazel');
+
+      expect(result).toEqual({
+        deps: [
+          {
+            datasource: BazelDatasource.id,
+            depType: 'bazel_dep',
+            depName: 'bazel_skylib',
+            currentValue: '1.2.1',
+          },
+          {
+            datasource: BazelDatasource.id,
+            depType: 'bazel_dep',
+            depName: 'platforms',
+            currentValue: '0.0.8',
+          },
+          {
+            datasource: BazelDatasource.id,
+            depType: 'bazel_dep',
+            depName: 'rules_img',
+            currentValue: '0.1.5',
+          },
+          {
+            datasource: BazelDatasource.id,
+            depType: 'bazel_dep',
+            depName: 'stardoc',
+            currentValue: '0.6.2',
+          },
+          {
+            datasource: DockerDatasource.id,
+            depType: 'rules_img_pull',
+            depName: 'ubuntu',
+            packageName: 'index.docker.io/library/ubuntu',
+            currentValue: '24.04',
+            currentDigest:
+              'sha256:1e622c5f9ac0c0144d577702ba5f2cce79fc8e3cf89ec88291739cd4eee3b7b9',
+            replaceString: codeBlock`
+              pull(
+                  name = "ubuntu",
+                  digest = "sha256:1e622c5f9ac0c0144d577702ba5f2cce79fc8e3cf89ec88291739cd4eee3b7b9",
+                  registry = "index.docker.io",
+                  repository = "library/ubuntu",
+                  tag = "24.04",
+              )
+            `,
+          },
+        ],
+      });
+    });
+
+    it('returns rules_img pull dependencies', async () => {
+      const input = codeBlock`
+        bazel_dep(name = "rules_img", version = "0.1.0")
+        pull = use_repo_rule("@rules_img//img:pull.bzl", "pull")
+        pull(
+            name = "ubuntu",
+            digest = "sha256:1e622c5f9ac0c0144d577702ba5f2cce79fc8e3cf89ec88291739cd4eee3b7b9",
+            registry = "index.docker.io",
+            repository = "library/ubuntu",
+            tag = "24.04",
+        )
+      `;
+
+      const result = await extractPackageFile(input, 'MODULE.bazel');
+
+      expect(result).toEqual({
+        deps: [
+          {
+            datasource: BazelDatasource.id,
+            depType: 'bazel_dep',
+            depName: 'rules_img',
+            currentValue: '0.1.0',
+          },
+          {
+            datasource: DockerDatasource.id,
+            depType: 'rules_img_pull',
+            depName: 'ubuntu',
+            packageName: 'index.docker.io/library/ubuntu',
+            currentValue: '24.04',
+            currentDigest:
+              'sha256:1e622c5f9ac0c0144d577702ba5f2cce79fc8e3cf89ec88291739cd4eee3b7b9',
+            replaceString: codeBlock`
+              pull(
+                  name = "ubuntu",
+                  digest = "sha256:1e622c5f9ac0c0144d577702ba5f2cce79fc8e3cf89ec88291739cd4eee3b7b9",
+                  registry = "index.docker.io",
+                  repository = "library/ubuntu",
+                  tag = "24.04",
+              )
+            `,
+          },
+        ],
+      });
+    });
+
+    it('returns rules_img pull dependencies with custom registry', async () => {
+      const input = codeBlock`
+        pull = use_repo_rule("@rules_img//img:pull.bzl", "pull")
+        pull(
+            name = "my_image",
+            registry = "my.registry.com",
+            repository = "myorg/myimage",
+            tag = "v1.2.3",
+        )
+      `;
+
+      const result = await extractPackageFile(input, 'MODULE.bazel');
+
+      expect(result).toEqual({
+        deps: [
+          {
+            datasource: DockerDatasource.id,
+            depType: 'rules_img_pull',
+            depName: 'my_image',
+            packageName: 'my.registry.com/myorg/myimage',
+            currentValue: 'v1.2.3',
+            replaceString: codeBlock`
+              pull(
+                  name = "my_image",
+                  registry = "my.registry.com",
+                  repository = "myorg/myimage",
+                  tag = "v1.2.3",
+              )
+            `,
+          },
+        ],
+      });
+    });
+
+    it('returns rules_img pull dependencies with multiple pulls', async () => {
+      const input = codeBlock`
+        pull = use_repo_rule("@rules_img//img:pull.bzl", "pull")
+        pull(
+            name = "ubuntu",
+            repository = "library/ubuntu",
+            tag = "24.04",
+        )
+        pull(
+            name = "nginx",
+            repository = "library/nginx",
+            tag = "1.27.1",
+            digest = "sha256:287ff321f9e3cde74b600cc26197424404157a72043226cbbf07ee8304a2c720",
+        )
+      `;
+
+      const result = await extractPackageFile(input, 'MODULE.bazel');
+
+      expect(result).toEqual({
+        deps: [
+          {
+            datasource: DockerDatasource.id,
+            depType: 'rules_img_pull',
+            depName: 'ubuntu',
+            packageName: 'library/ubuntu',
+            currentValue: '24.04',
+            replaceString: codeBlock`
+              pull(
+                  name = "ubuntu",
+                  repository = "library/ubuntu",
+                  tag = "24.04",
+              )
+            `,
+          },
+          {
+            datasource: DockerDatasource.id,
+            depType: 'rules_img_pull',
+            depName: 'nginx',
+            packageName: 'library/nginx',
+            currentValue: '1.27.1',
+            currentDigest:
+              'sha256:287ff321f9e3cde74b600cc26197424404157a72043226cbbf07ee8304a2c720',
+            replaceString: codeBlock`
+              pull(
+                  name = "nginx",
+                  repository = "library/nginx",
+                  tag = "1.27.1",
+                  digest = "sha256:287ff321f9e3cde74b600cc26197424404157a72043226cbbf07ee8304a2c720",
+              )
+            `,
+          },
+        ],
+      });
+    });
+
+    it('ignores rules_img pull without required fields', async () => {
+      const input = codeBlock`
+        pull = use_repo_rule("@rules_img//img:pull.bzl", "pull")
+        # Missing repository
+        pull(
+            name = "missing_repo",
+            tag = "1.0.0",
+        )
+        # Missing name
+        pull(
+            repository = "library/ubuntu",
+            tag = "24.04",
+        )
+      `;
+
+      const result = await extractPackageFile(input, 'MODULE.bazel');
+
+      expect(result).toBeNull();
+    });
+
+    it('handles rules_img with renamed variable', async () => {
+      const input = codeBlock`
+        my_pull = use_repo_rule("@rules_img//img:pull.bzl", "pull")
+        my_pull(
+            name = "ubuntu",
+            repository = "library/ubuntu",
+            tag = "24.04",
+        )
+      `;
+
+      const result = await extractPackageFile(input, 'MODULE.bazel');
+
+      expect(result).toEqual({
+        deps: [
+          {
+            datasource: DockerDatasource.id,
+            depType: 'rules_img_pull',
+            depName: 'ubuntu',
+            packageName: 'library/ubuntu',
+            currentValue: '24.04',
+            replaceString: codeBlock`
+              my_pull(
+                  name = "ubuntu",
+                  repository = "library/ubuntu",
+                  tag = "24.04",
+              )
+            `,
+          },
+        ],
+      });
+    });
+
+    it('ignores non-rules_img repo rules', async () => {
+      const input = codeBlock`
+        bazel_dep(name = "some_rules", version = "0.1.0")
+        
+        other_rule = use_repo_rule("@some_rules//some:rule.bzl", "other")
+        
+        other_rule(
+            name = "test",
+            value = "something",
+        )
+      `;
+
+      const result = await extractPackageFile(input, 'MODULE.bazel');
+
+      expect(result).toEqual({
+        deps: [
+          {
+            datasource: BazelDatasource.id,
+            depType: 'bazel_dep',
+            depName: 'some_rules',
+            currentValue: '0.1.0',
+          },
+        ],
+      });
+    });
   });
 });

--- a/lib/modules/manager/bazel-module/extract.spec.ts
+++ b/lib/modules/manager/bazel-module/extract.spec.ts
@@ -763,6 +763,7 @@ describe('modules/manager/bazel-module/extract', () => {
             currentValue: '24.04',
             currentDigest:
               'sha256:1e622c5f9ac0c0144d577702ba5f2cce79fc8e3cf89ec88291739cd4eee3b7b9',
+            registryUrls: ['https://index.docker.io'],
             replaceString: codeBlock`
               pull(
                   name = "ubuntu",
@@ -808,6 +809,7 @@ describe('modules/manager/bazel-module/extract', () => {
             currentValue: '24.04',
             currentDigest:
               'sha256:1e622c5f9ac0c0144d577702ba5f2cce79fc8e3cf89ec88291739cd4eee3b7b9',
+            registryUrls: ['https://index.docker.io'],
             replaceString: codeBlock`
               pull(
                   name = "ubuntu",
@@ -843,6 +845,7 @@ describe('modules/manager/bazel-module/extract', () => {
             depName: 'my_image',
             packageName: 'my.registry.com/myorg/myimage',
             currentValue: 'v1.2.3',
+            registryUrls: ['https://my.registry.com'],
             replaceString: codeBlock`
               pull(
                   name = "my_image",
@@ -882,6 +885,7 @@ describe('modules/manager/bazel-module/extract', () => {
             depName: 'ubuntu',
             packageName: 'library/ubuntu',
             currentValue: '24.04',
+            registryUrls: ['https://index.docker.io'],
             replaceString: codeBlock`
               pull(
                   name = "ubuntu",
@@ -898,6 +902,7 @@ describe('modules/manager/bazel-module/extract', () => {
             currentValue: '1.27.1',
             currentDigest:
               'sha256:287ff321f9e3cde74b600cc26197424404157a72043226cbbf07ee8304a2c720',
+            registryUrls: ['https://index.docker.io'],
             replaceString: codeBlock`
               pull(
                   name = "nginx",
@@ -951,6 +956,7 @@ describe('modules/manager/bazel-module/extract', () => {
             depName: 'ubuntu',
             packageName: 'library/ubuntu',
             currentValue: '24.04',
+            registryUrls: ['https://index.docker.io'],
             replaceString: codeBlock`
               my_pull(
                   name = "ubuntu",

--- a/lib/modules/manager/bazel-module/extract.spec.ts
+++ b/lib/modules/manager/bazel-module/extract.spec.ts
@@ -885,7 +885,6 @@ describe('modules/manager/bazel-module/extract', () => {
             depName: 'ubuntu',
             packageName: 'library/ubuntu',
             currentValue: '24.04',
-            registryUrls: ['https://index.docker.io'],
             replaceString: codeBlock`
               pull(
                   name = "ubuntu",
@@ -902,7 +901,6 @@ describe('modules/manager/bazel-module/extract', () => {
             currentValue: '1.27.1',
             currentDigest:
               'sha256:287ff321f9e3cde74b600cc26197424404157a72043226cbbf07ee8304a2c720',
-            registryUrls: ['https://index.docker.io'],
             replaceString: codeBlock`
               pull(
                   name = "nginx",
@@ -956,7 +954,6 @@ describe('modules/manager/bazel-module/extract', () => {
             depName: 'ubuntu',
             packageName: 'library/ubuntu',
             currentValue: '24.04',
-            registryUrls: ['https://index.docker.io'],
             replaceString: codeBlock`
               my_pull(
                   name = "ubuntu",
@@ -972,9 +969,9 @@ describe('modules/manager/bazel-module/extract', () => {
     it('ignores non-rules_img repo rules', async () => {
       const input = codeBlock`
         bazel_dep(name = "some_rules", version = "0.1.0")
-        
+
         other_rule = use_repo_rule("@some_rules//some:rule.bzl", "other")
-        
+
         other_rule(
             name = "test",
             value = "something",

--- a/lib/modules/manager/bazel-module/extract.ts
+++ b/lib/modules/manager/bazel-module/extract.ts
@@ -13,6 +13,7 @@ import {
   RuleToBazelModulePackageDep,
 } from './rules';
 import * as rules from './rules';
+import { transformRulesImgCalls } from './rules-img';
 
 export async function extractPackageFile(
   content: string,
@@ -24,6 +25,7 @@ export async function extractPackageFile(
     const gitRepositoryDeps = extractGitRepositoryDeps(records);
     const mavenDeps = extractMavenDeps(records);
     const dockerDeps = LooseArray(RuleToDockerPackageDep).parse(records);
+    const rulesImgDeps = transformRulesImgCalls(records);
 
     if (gitRepositoryDeps.length) {
       pfc.deps.push(...gitRepositoryDeps);
@@ -35,6 +37,10 @@ export async function extractPackageFile(
 
     if (dockerDeps.length) {
       pfc.deps.push(...dockerDeps);
+    }
+
+    if (rulesImgDeps.length) {
+      pfc.deps.push(...rulesImgDeps);
     }
 
     return pfc.deps.length ? pfc : null;

--- a/lib/modules/manager/bazel-module/parser/context.spec.ts
+++ b/lib/modules/manager/bazel-module/parser/context.spec.ts
@@ -56,5 +56,32 @@ describe('modules/manager/bazel-module/parser/context', () => {
         ),
       );
     });
+
+    it('throws if current use repo rule does not exist', () => {
+      const ctx = new Ctx('').startRule('foo');
+      expect(() => ctx.endUseRepoRule()).toThrow(
+        new Error('Requested current use repo rule, but does not exist.'),
+      );
+    });
+
+    it('throws if current repo rule call does not exist', () => {
+      const ctx = new Ctx('').startRule('foo');
+      expect(() => ctx.endRepoRuleCall(0)).toThrow(
+        new Error('Requested current repo rule call, but does not exist.'),
+      );
+    });
+
+    it('creates CtxProcessingError with parent type', () => {
+      const ctx = new Ctx('').startRule('parent');
+      ctx.startAttribute('name');
+      const parent = fragments.rule('parent');
+      const current = fragments.attribute('name');
+      const error = new CtxProcessingError(current, parent);
+      expect(error.message).toBe(
+        'Invalid context state. current: attribute, parent: rule',
+      );
+      expect(error.current).toBe(current);
+      expect(error.parent).toBe(parent);
+    });
   });
 });

--- a/lib/modules/manager/bazel-module/parser/context.ts
+++ b/lib/modules/manager/bazel-module/parser/context.ts
@@ -3,8 +3,10 @@ import type {
   ArrayFragment,
   ExtensionTagFragment,
   PreparedExtensionTagFragment,
+  RepoRuleCallFragment,
   ResultFragment,
   RuleFragment,
+  UseRepoRuleFragment,
 } from './fragments';
 import * as fragments from './fragments';
 
@@ -67,6 +69,22 @@ export class Ctx implements CtxCompatible {
     throw new Error('Requested current extension tag, but does not exist.');
   }
 
+  private get currentUseRepoRule(): UseRepoRuleFragment {
+    const current = this.current;
+    if (current.type === 'useRepoRule') {
+      return current;
+    }
+    throw new Error('Requested current use repo rule, but does not exist.');
+  }
+
+  private get currentRepoRuleCall(): RepoRuleCallFragment {
+    const current = this.current;
+    if (current.type === 'repoRuleCall') {
+      return current;
+    }
+    throw new Error('Requested current repo rule call, but does not exist.');
+  }
+
   private get currentArray(): ArrayFragment {
     const current = this.current;
     if (current.type === 'array') {
@@ -110,14 +128,21 @@ export class Ctx implements CtxCompatible {
         return true;
       }
       if (
-        (parent.type === 'rule' || parent.type === 'extensionTag') &&
+        (parent.type === 'rule' ||
+          parent.type === 'extensionTag' ||
+          parent.type === 'repoRuleCall') &&
         current.type === 'attribute' &&
         current.value !== undefined
       ) {
         parent.children[current.name] = current.value;
         return true;
       }
-    } else if (current.type === 'rule' || current.type === 'extensionTag') {
+    } else if (
+      current.type === 'rule' ||
+      current.type === 'extensionTag' ||
+      current.type === 'useRepoRule' ||
+      current.type === 'repoRuleCall'
+    ) {
       this.results.push(current);
       return true;
     }
@@ -185,6 +210,35 @@ export class Ctx implements CtxCompatible {
     const tag = this.currentExtensionTag;
     tag.isComplete = true;
     tag.rawString = this.source.slice(tag.offset, offset);
+    return this.processStack();
+  }
+
+  startUseRepoRule(
+    variableName: string,
+    bzlFile: string,
+    ruleName: string,
+  ): Ctx {
+    const useRepoRule = fragments.useRepoRule(variableName, bzlFile, ruleName);
+    this.stack.push(useRepoRule);
+    return this;
+  }
+
+  endUseRepoRule(): Ctx {
+    const useRepoRule = this.currentUseRepoRule;
+    useRepoRule.isComplete = true;
+    return this.processStack();
+  }
+
+  startRepoRuleCall(functionName: string, offset: number): Ctx {
+    const repoRuleCall = fragments.repoRuleCall(functionName, offset);
+    this.stack.push(repoRuleCall);
+    return this;
+  }
+
+  endRepoRuleCall(offset: number): Ctx {
+    const repoRuleCall = this.currentRepoRuleCall;
+    repoRuleCall.isComplete = true;
+    repoRuleCall.rawString = this.source.slice(repoRuleCall.offset, offset);
     return this.processStack();
   }
 

--- a/lib/modules/manager/bazel-module/parser/fragments.ts
+++ b/lib/modules/manager/bazel-module/parser/fragments.ts
@@ -57,6 +57,21 @@ export const ExtensionTagFragment = z.object({
   offset: z.number(), // start offset in the source string
   rawString: z.string().optional(), // raw source string
 });
+export const UseRepoRuleFragment = z.object({
+  type: z.literal('useRepoRule'),
+  variableName: z.string(),
+  bzlFile: z.string(),
+  ruleName: z.string(),
+  isComplete: z.boolean(),
+});
+export const RepoRuleCallFragment = z.object({
+  type: z.literal('repoRuleCall'),
+  functionName: z.string(),
+  children: LooseRecord(ValueFragments),
+  isComplete: z.boolean(),
+  offset: z.number(),
+  rawString: z.string().optional(),
+});
 export const AttributeFragment = z.object({
   type: z.literal('attribute'),
   name: z.string(),
@@ -70,6 +85,8 @@ export const AllFragments = z.discriminatedUnion('type', [
   RuleFragment,
   PreparedExtensionTagFragment,
   ExtensionTagFragment,
+  UseRepoRuleFragment,
+  RepoRuleCallFragment,
   StringFragment,
 ]);
 
@@ -84,9 +101,15 @@ export type PreparedExtensionTagFragment = z.infer<
   typeof PreparedExtensionTagFragment
 >;
 export type ExtensionTagFragment = z.infer<typeof ExtensionTagFragment>;
+export type UseRepoRuleFragment = z.infer<typeof UseRepoRuleFragment>;
+export type RepoRuleCallFragment = z.infer<typeof RepoRuleCallFragment>;
 export type StringFragment = z.infer<typeof StringFragment>;
 export type ValueFragments = z.infer<typeof ValueFragments>;
-export type ResultFragment = RuleFragment | ExtensionTagFragment;
+export type ResultFragment =
+  | RuleFragment
+  | ExtensionTagFragment
+  | UseRepoRuleFragment
+  | RepoRuleCallFragment;
 
 export function string(value: string): StringFragment {
   return {
@@ -145,6 +168,38 @@ export function extensionTag(
     extension,
     rawExtension,
     tag,
+    offset,
+    rawString,
+    isComplete,
+    children,
+  };
+}
+
+export function useRepoRule(
+  variableName: string,
+  bzlFile: string,
+  ruleName: string,
+  isComplete = false,
+): UseRepoRuleFragment {
+  return {
+    type: 'useRepoRule',
+    variableName,
+    bzlFile,
+    ruleName,
+    isComplete,
+  };
+}
+
+export function repoRuleCall(
+  functionName: string,
+  offset: number,
+  children: ChildFragments = {},
+  rawString?: string,
+  isComplete = false,
+): RepoRuleCallFragment {
+  return {
+    type: 'repoRuleCall',
+    functionName,
     offset,
     rawString,
     isComplete,

--- a/lib/modules/manager/bazel-module/parser/index.ts
+++ b/lib/modules/manager/bazel-module/parser/index.ts
@@ -2,9 +2,19 @@ import { lang, query as q } from 'good-enough-parser';
 import { Ctx } from './context';
 import { extensionTags } from './extension-tags';
 import type { ResultFragment } from './fragments';
+import {
+  clearRepoRuleVariables,
+  repoRuleCall,
+  useRepoRuleAssignment,
+} from './repo-rules';
 import { rules } from './rules';
 
-const rule = q.alt<Ctx>(rules, extensionTags);
+const rule = q.alt<Ctx>(
+  rules,
+  extensionTags,
+  useRepoRuleAssignment,
+  repoRuleCall,
+);
 
 const query = q.tree<Ctx>({
   type: 'root-tree',
@@ -15,6 +25,8 @@ const query = q.tree<Ctx>({
 const starlarkLang = lang.createLang('starlark');
 
 export function parse(input: string): ResultFragment[] {
+  clearRepoRuleVariables();
+
   const parsedResult = starlarkLang.query(input, query, new Ctx(input));
   return parsedResult?.results ?? [];
 }

--- a/lib/modules/manager/bazel-module/parser/repo-rules.ts
+++ b/lib/modules/manager/bazel-module/parser/repo-rules.ts
@@ -1,0 +1,84 @@
+import { query as q } from 'good-enough-parser';
+import type { parser } from 'good-enough-parser';
+import { regEx } from '../../../../util/regex';
+import { kvParams } from './common';
+import type { Ctx } from './context';
+
+// Store for tracking use_repo_rule assignments during parsing
+const repoRuleVariables = new Map<
+  string,
+  { bzlFile: string; ruleName: string }
+>();
+
+// Parser for use_repo_rule assignments:
+// pull = use_repo_rule("@rules_img//img:pull.bzl", "pull")
+export const useRepoRuleAssignment = q
+  .sym<Ctx>((ctx, token) => {
+    // Store the variable name for later use
+    (ctx as any)._tempVariableName = token.value;
+    return ctx;
+  })
+  .op('=')
+  .sym(regEx(/^use_repo_rule$/))
+  .tree({
+    type: 'wrapped-tree',
+    maxDepth: 1,
+    startsWith: '(',
+    endsWith: ')',
+    search: q.many(
+      q.str<Ctx>((ctx, token) => {
+        // Collect the string arguments
+        if (!(ctx as any)._tempStrings) {
+          (ctx as any)._tempStrings = [];
+        }
+        (ctx as any)._tempStrings.push(token.value);
+        return ctx;
+      }),
+    ),
+    postHandler: (ctx, tree) => {
+      const variableName = (ctx as any)._tempVariableName;
+      const strings = (ctx as any)._tempStrings;
+
+      if (variableName && strings.length >= 2) {
+        const bzlFile = strings[0];
+        const ruleName = strings[1];
+
+        // Store for later use by repoRuleCall parser
+        repoRuleVariables.set(variableName, { bzlFile, ruleName });
+
+        // Create the useRepoRule fragment
+        ctx.startUseRepoRule(variableName, bzlFile, ruleName);
+        ctx.endUseRepoRule();
+      }
+
+      // Clean up
+      delete (ctx as any)._tempVariableName;
+      delete (ctx as any)._tempStrings;
+
+      return ctx;
+    },
+  });
+
+// Parser for repository rule calls
+// This parser always creates repo rule call fragments, but they will be filtered
+// during extraction based on whether they correspond to known repo rule variables
+export const repoRuleCall = q
+  .sym<Ctx>(/^[a-zA-Z_]\w*$/, (ctx, token) => {
+    return ctx.startRepoRuleCall(token.value, token.offset);
+  })
+  .join(
+    q.tree({
+      type: 'wrapped-tree',
+      maxDepth: 1,
+      search: kvParams,
+      postHandler: (ctx, tree) => {
+        const { endsWith } = tree as parser.WrappedTree;
+        const endOffset = endsWith.offset + endsWith.value.length;
+        return ctx.endRepoRuleCall(endOffset);
+      },
+    }),
+  );
+
+export function clearRepoRuleVariables(): void {
+  repoRuleVariables.clear();
+}

--- a/lib/modules/manager/bazel-module/readme.md
+++ b/lib/modules/manager/bazel-module/readme.md
@@ -46,3 +46,16 @@ oci.pull(
     tag = "1.27.1",
 )
 ```
+
+It also supports Docker images pulled with [rules_img pull](https://github.com/tweag/rules_img/blob/main/docs/pull.md#pull):
+
+```
+pull = use_repo_rule("@rules_img//img:pull.bzl", "pull")
+pull(
+    name = "ubuntu",
+    digest = "sha256:1e622c5f9ac0c0144d577702ba5f2cce79fc8e3cf89ec88291739cd4eee3b7b9",
+    registry = "index.docker.io",
+    repository = "library/ubuntu",
+    tag = "24.04",
+)
+```

--- a/lib/modules/manager/bazel-module/rules-img.spec.ts
+++ b/lib/modules/manager/bazel-module/rules-img.spec.ts
@@ -1,0 +1,118 @@
+import { transformRulesImgCalls } from './rules-img';
+
+describe('modules/manager/bazel-module/rules-img', () => {
+  describe('transformRulesImgCalls()', () => {
+    it('ignores repo rule calls that are not rules_img', () => {
+      const fragments = [
+        {
+          type: 'useRepoRule',
+          variableName: 'other_rule',
+          bzlFile: '@other_rules//some:rule.bzl',
+          ruleName: 'other',
+          isComplete: true,
+        },
+        {
+          type: 'repoRuleCall',
+          functionName: 'other_rule',
+          children: {
+            name: { type: 'string', value: 'test', isComplete: true },
+            value: { type: 'string', value: 'something', isComplete: true },
+          },
+          isComplete: true,
+          offset: 0,
+          rawString: 'other_rule(name = "test", value = "something")',
+        },
+      ];
+
+      const result = transformRulesImgCalls(fragments);
+
+      expect(result).toEqual([]);
+    });
+
+    it('handles valid rules_img pull call', () => {
+      const fragments = [
+        {
+          type: 'useRepoRule',
+          variableName: 'pull',
+          bzlFile: '@rules_img//img:pull.bzl',
+          ruleName: 'pull',
+          isComplete: true,
+        },
+        {
+          type: 'repoRuleCall',
+          functionName: 'pull',
+          children: {
+            name: { type: 'string', value: 'ubuntu', isComplete: true },
+            repository: {
+              type: 'string',
+              value: 'library/ubuntu',
+              isComplete: true,
+            },
+            tag: { type: 'string', value: '24.04', isComplete: true },
+          },
+          isComplete: true,
+          offset: 0,
+          rawString:
+            'pull(name = "ubuntu", repository = "library/ubuntu", tag = "24.04")',
+        },
+      ];
+
+      const result = transformRulesImgCalls(fragments);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        datasource: 'docker',
+        depType: 'rules_img_pull',
+        depName: 'ubuntu',
+        packageName: 'library/ubuntu',
+        currentValue: '24.04',
+      });
+    });
+
+    it('skips repo rule calls without corresponding use_repo_rule', () => {
+      const fragments = [
+        {
+          type: 'repoRuleCall',
+          functionName: 'unknown_function',
+          children: {
+            name: { type: 'string', value: 'test', isComplete: true },
+          },
+          isComplete: true,
+          offset: 0,
+          rawString: 'unknown_function(name = "test")',
+        },
+      ];
+
+      const result = transformRulesImgCalls(fragments);
+
+      expect(result).toEqual([]);
+    });
+
+    it('skips malformed repo rule calls', () => {
+      const fragments = [
+        {
+          type: 'useRepoRule',
+          variableName: 'pull',
+          bzlFile: '@rules_img//img:pull.bzl',
+          ruleName: 'pull',
+          isComplete: true,
+        },
+        {
+          type: 'repoRuleCall',
+          functionName: 'pull',
+          children: {
+            // Missing required fields like 'name' and 'repository'
+            tag: { type: 'string', value: '24.04', isComplete: true },
+          },
+          isComplete: true,
+          offset: 0,
+          rawString: 'pull(tag = "24.04")',
+        },
+      ];
+
+      const result = transformRulesImgCalls(fragments);
+
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/lib/modules/manager/bazel-module/rules-img.spec.ts
+++ b/lib/modules/manager/bazel-module/rules-img.spec.ts
@@ -66,7 +66,6 @@ describe('modules/manager/bazel-module/rules-img', () => {
         depName: 'ubuntu',
         packageName: 'library/ubuntu',
         currentValue: '24.04',
-        registryUrls: ['https://index.docker.io'],
       });
     });
 

--- a/lib/modules/manager/bazel-module/rules-img.spec.ts
+++ b/lib/modules/manager/bazel-module/rules-img.spec.ts
@@ -66,6 +66,7 @@ describe('modules/manager/bazel-module/rules-img', () => {
         depName: 'ubuntu',
         packageName: 'library/ubuntu',
         currentValue: '24.04',
+        registryUrls: ['https://index.docker.io'],
       });
     });
 

--- a/lib/modules/manager/bazel-module/rules-img.ts
+++ b/lib/modules/manager/bazel-module/rules-img.ts
@@ -32,6 +32,9 @@ export const RulesImgPullCallToDep = RepoRuleCallFragment.extend({
       packageName,
       currentValue: tag?.value,
       currentDigest: digest?.value,
+      registryUrls: registry?.value
+        ? [`https://${registry.value}`]
+        : [`https://index.docker.io`],
       replaceString: rawString,
     };
   },

--- a/lib/modules/manager/bazel-module/rules-img.ts
+++ b/lib/modules/manager/bazel-module/rules-img.ts
@@ -1,0 +1,85 @@
+import { z } from 'zod';
+import { DockerDatasource } from '../../datasource/docker';
+import type { PackageDependency } from '../types';
+import { RepoRuleCallFragment, StringFragment } from './parser/fragments';
+
+export const RulesImgPullCallToDep = RepoRuleCallFragment.extend({
+  children: z.object({
+    name: StringFragment,
+    repository: StringFragment,
+    registry: StringFragment.optional(),
+    tag: StringFragment.optional(),
+    digest: StringFragment.optional(),
+  }),
+}).transform(
+  ({
+    rawString,
+    functionName,
+    children: { name, repository, registry, tag, digest },
+  }): PackageDependency => {
+    // Note: Validation that this is a rules_img pull call is done in transformRulesImgCalls
+
+    // Construct the package name
+    let packageName = repository.value;
+    if (registry?.value) {
+      packageName = `${registry.value}/${repository.value}`;
+    }
+
+    return {
+      datasource: DockerDatasource.id,
+      depType: 'rules_img_pull',
+      depName: name.value,
+      packageName,
+      currentValue: tag?.value,
+      currentDigest: digest?.value,
+      replaceString: rawString,
+    };
+  },
+);
+
+export function transformRulesImgCalls(fragments: any[]): PackageDependency[] {
+  const deps: PackageDependency[] = [];
+
+  // First, collect all use_repo_rule assignments to know which variables are repo rules
+  const repoRuleVariables = new Map<
+    string,
+    { bzlFile: string; ruleName: string }
+  >();
+
+  for (const fragment of fragments) {
+    if (fragment.type === 'useRepoRule') {
+      repoRuleVariables.set(fragment.variableName, {
+        bzlFile: fragment.bzlFile,
+        ruleName: fragment.ruleName,
+      });
+    }
+  }
+
+  // Then process repo rule calls, but only for known repo rule variables
+  for (const fragment of fragments) {
+    if (fragment.type === 'repoRuleCall') {
+      const functionName = fragment.functionName;
+
+      // Only process if this function name corresponds to a known repo rule variable
+      if (!repoRuleVariables.has(functionName)) {
+        continue;
+      }
+
+      // Check if it's a rules_img repo rule
+      const ruleInfo = repoRuleVariables.get(functionName);
+      if (!ruleInfo?.bzlFile.includes('@rules_img//img:pull.bzl')) {
+        continue;
+      }
+
+      try {
+        const dep = RulesImgPullCallToDep.parse(fragment);
+        deps.push(dep);
+      } catch {
+        // If parsing fails, it's not a rules_img pull call or is missing required fields
+        continue;
+      }
+    }
+  }
+
+  return deps;
+}

--- a/lib/modules/manager/bazel-module/rules-img.ts
+++ b/lib/modules/manager/bazel-module/rules-img.ts
@@ -25,18 +25,20 @@ export const RulesImgPullCallToDep = RepoRuleCallFragment.extend({
       packageName = `${registry.value}/${repository.value}`;
     }
 
-    return {
+    const result: PackageDependency = {
       datasource: DockerDatasource.id,
       depType: 'rules_img_pull',
       depName: name.value,
       packageName,
       currentValue: tag?.value,
       currentDigest: digest?.value,
-      registryUrls: registry?.value
-        ? [`https://${registry.value}`]
-        : [`https://index.docker.io`],
       replaceString: rawString,
     };
+    if (registry?.value) {
+      result.registryUrls = [`https://${registry.value}`];
+    }
+
+    return result;
   },
 );
 


### PR DESCRIPTION
## Changes

Added Mend Renovate support for `rules_img` container image dependencies in Bazel MODULE.bazel files using the `use_repo_rule` pattern. This enables automatic updates of container images for projects using the `rules_img` Bazel ruleset, addressing the functionality gap identified in https://github.com/tweag/rules_img/issues/8.

This new attempt contains a test to prevent a regression of https://github.com/renovatebot/renovate/discussions/37500.

### Technical Implementation:
- Extended the `bazel-module` parser with new fragment types: `UseRepoRuleFragment` and `RepoRuleCallFragment`
- Added proper parsing support for `use_repo_rule` assignments and repository rule function calls
- Created `rules-img.ts` transformer to convert repository rule calls into Docker package dependencies
- Integrated with existing Docker data source for seamless dependency management
- Enhanced parser context with methods to handle new fragment types
- Maintains full backward compatibility with existing Bazel module parsing

## Context

Closes https://github.com/tweag/rules_img/issues/8

This addresses the need for automatic dependency updates in projects using `rules_img` for container image management. The `rules_img` ruleset uses a different pattern than `rules_oci` - instead of extension tags like `oci.pull()`, it uses repository rules loaded via `use_repo_rule()` and called as regular functions.

Example usage pattern supported:
```starlark
bazel_dep(name = "rules_img", version = "0.1.5")

# Load the repository rule
pull = use_repo_rule("@rules_img//img:pull.bzl", "pull")

# Use the repository rule to pull an image
pull(
    name = "ubuntu",
    repository = "library/ubuntu",
    tag = "24.04",
    digest = "sha256:1e622c5f9ac0c0144d577702ba5f2cce79fc8e3cf89ec88291739cd4eee3b7b9",
)

# Support for renamed variables
my_pull = use_repo_rule("@rules_img//img:pull.bzl", "pull")
my_pull(
    name = "nginx",
    registry = "my.registry.com",
    repository = "myorg/nginx",
    tag = "1.27.1",
)
```

The implementation enables Renovate to:
- Detect container image dependencies defined via `rules_img` repository rule calls
- Automatically update image tags and digests when new versions are available
- Handle various configurations, including custom registries and renamed rule variables
- Filter out non-rules_img repository rule calls to avoid interference

## Documentation (please check one with an [x])

- [x] I have updated the documentation, though no user-facing documentation changes were needed as this extends existing Bazel module support

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Newly added/modified unit tests
