### PR TITLE
feat(datasource/rpm): support zstd-compressed data

### DIFF
--- a/lib/modules/datasource/rpm/index.ts
+++ b/lib/modules/datasource/rpm/index.ts
@@ -11,12 +11,12 @@ import { Datasource } from '../datasource';
 import type { GetReleasesConfig, Release, ReleaseResult } from '../types';
 
 const gunzipAsync = promisify(gunzip);
-const zstdDecompressAsync = promisify(zstdDecompress);
+const zstdDecompressAsync = zstdDecompress ? promisify(zstdDecompress) : null;
 
 function getDecompressor(
   contentType: string | undefined,
 ): (buf: Buffer) => Promise<Buffer> {
-  if (contentType === 'application/zstd') {
+  if (zstdDecompressAsync && contentType === 'application/zstd') {
     return zstdDecompressAsync;
   }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Add support for zstd-compressed `primary.xml` in rpm datasource.

## Context

`primary.xml` in Fedora 42 repositories is compressed with zstd: https://download.fedoraproject.org/pub/fedora/linux/releases/42/Everything/x86_64/os/repodata/

Also, Fedora 41 "updates" repository is compressed with zstd too: https://download.fedoraproject.org/pub/fedora/linux/updates/41/Everything/x86_64/repodata/

So, to get package versions from Fedora, the datasource must support zstd decompression in addition to gzip.

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/amezin/renovate-rpm-zstd

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
