### PR TITLE
fix(datasource/rpm): use zlib in stream mode to handle large files

### DIFF
--- a/lib/modules/datasource/rpm/index.spec.ts
+++ b/lib/modules/datasource/rpm/index.spec.ts
@@ -1,4 +1,5 @@
 import { gzipSync } from 'node:zlib';
+import { setTimeout } from 'timers/promises';
 import { RpmDatasource } from '.';
 import * as httpMock from '~test/http-mock';
 import { logger } from '~test/util';
@@ -184,6 +185,7 @@ describe('modules/datasource/rpm/index', () => {
         ],
       });
 
+      await setTimeout();
       expect(logger.logger.debug).not.toHaveBeenCalledWith(
         expect.stringMatching(/^Empty response body/),
       );
@@ -208,6 +210,7 @@ describe('modules/datasource/rpm/index', () => {
         rpmDatasource.getReleasesByPackageName(primaryXmlUrl, packageName),
       ).rejects.toThrow(`Response code 404 (Not Found)`);
 
+      await setTimeout();
       expect(logger.logger.debug).not.toHaveBeenCalledWith(
         expect.stringMatching(/^Empty response body/),
       );
@@ -234,6 +237,7 @@ describe('modules/datasource/rpm/index', () => {
         'Empty response body from getting ' + primaryXmlUrl + '.',
       );
 
+      await setTimeout();
       expect(logger.logger.debug).toHaveBeenLastCalledWith(
         `Empty response body from getting ${primaryXmlUrl}.`,
       );
@@ -383,6 +387,7 @@ describe('modules/datasource/rpm/index', () => {
       await expect(
         rpmDatasource.getReleasesByPackageName(primaryXmlUrl, packageName),
       ).rejects.toThrowError('Unencoded <');
+      await setTimeout();
       expect(logger.logger.debug).not.toHaveBeenCalledWith(
         expect.stringMatching(/^Empty response body/),
       );
@@ -437,6 +442,7 @@ describe('modules/datasource/rpm/index', () => {
       await expect(
         rpmDatasource.getReleasesByPackageName(primaryXmlUrl, packageName),
       ).rejects.toThrowError('unexpected end of file');
+      await setTimeout();
       expect(logger.logger.debug).not.toHaveBeenCalledWith(
         expect.stringMatching(/^Empty response body/),
       );


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Use Gunzip stream, instead of decompressing to a buffer.

## Context

Zlib splits the data into reasonably sized chunks during decompression.

Before this change, for `registryUrl=http://download.opensuse.org/update/leap/15.6/sle/repodata/`, Renovate terminates with the error:

```
Error: Cannot create a string longer than 0x1fffffe8 characters
    at StringDecoder.write (node:string_decoder:104:10)
    at SAXStream.write (/home/amezin/renovate/node_modules/.pnpm/sax@1.4.1/node_modules/sax/lib/sax.js:243:28)
    at Readable.ondata (node:internal/streams/readable:1009:22)
    at Readable.emit (node:events:519:28)
    at Readable.emit (node:domain:489:12)
    at Readable.read (node:internal/streams/readable:782:10)
    at flow (node:internal/streams/readable:1283:53)
    at resume_ (node:internal/streams/readable:1262:3)
    at processTicksAndRejections (node:internal/process/task_queues:90:21)
```

After this change, the same repository is processed successfully.

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: https://github.com/amezin/renovate-rpm-stream

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
