### PR TITLE
fix(forgejo): allow fallbacks in case default merge style not allowed

### DIFF
--- a/lib/modules/platform/forgejo/readme.md
+++ b/lib/modules/platform/forgejo/readme.md
@@ -47,3 +47,10 @@ Repositories are ignored when one of the following conditions is met:
 You can change the default server-side sort method and order for autodiscover API.
 Set those via [`autodiscoverRepoSort`](../../../self-hosted-configuration.md#autodiscoverreposort) and [`autodiscoverRepoOrder`](../../../self-hosted-configuration.md#autodiscoverrepoorder).
 Read the [Forgejo swagger docs](https://code.forgejo.org/api/swagger#/repository/repoSearch) for more details.
+
+## Merge style
+
+Renovate uses the repository's default merge style if allowed; if the default
+merge style is not an allowed merge style, renovate falls back to an allowed
+merge style as per an order chosen to minimize commits. If no merge style is
+allowed, the repository is blocked.

--- a/lib/modules/platform/forgejo/utils.ts
+++ b/lib/modules/platform/forgejo/utils.ts
@@ -1,6 +1,9 @@
 import is from '@sindresorhus/is';
 import type { MergeStrategy } from '../../../config/types';
-import { CONFIG_GIT_URL_UNAVAILABLE } from '../../../constants/error-messages';
+import {
+  CONFIG_GIT_URL_UNAVAILABLE,
+  REPOSITORY_BLOCKED,
+} from '../../../constants/error-messages';
 import { logger } from '../../../logger';
 import * as hostRules from '../../../util/host-rules';
 import { regEx } from '../../../util/regex';
@@ -168,4 +171,21 @@ export function usableRepo(repo: Repo): boolean {
     return false;
   }
   return true;
+}
+
+export function isAllowed(style: PRMergeMethod, repo: Repo): boolean {
+  switch (style) {
+    case 'merge':
+      return repo.allow_merge_commits;
+    case 'rebase':
+      return repo.allow_rebase;
+    case 'rebase-merge':
+      return repo.allow_rebase_explicit;
+    case 'squash':
+      return repo.allow_squash_merge;
+    case 'fast-forward-only':
+      return repo.allow_fast_forward_only_merge;
+  }
+  logger.debug('Repo has unknown merge style - aborting renovation');
+  throw new Error(REPOSITORY_BLOCKED);
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Changes as in https://github.com/renovatebot/renovate/pull/37768 for forgejo as requested in https://github.com/renovatebot/renovate/pull/37768#pullrequestreview-3197170914

Taken from https://github.com/renovatebot/renovate/pull/37768 - I understand the same is true of forgejo.

```
The default merge style in Gitea is always set, but it's possible that it is set to a merge style which 
is not allowed for the repo. Currently, Renovate blocks the repo in this case.

Gitea's handing of this is less strict; if the default merge style is not an allowed merge style, Gitea 
suggests one of the allowed merge styles based on an ordered list.

This change mirrors the behaviour of Gitea by permitting fallbacks in case the default merge style
is not an allowed merge style; the fallback is selected from an ordered list
```

## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

I did not use AI for this contribution, but I did have some AI assistance for #37768.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

