### PR TITLE
feat(presets): move netty monorepo from url to pattern

### DIFF
--- a/lib/data/monorepo.json
+++ b/lib/data/monorepo.json
@@ -453,7 +453,6 @@
       "https://github.com/nestjs/terminus"
     ],
     "nest-graphql": "https://github.com/nestjs/graphql",
-    "netty": "https://github.com/netty/netty",
     "neutrino": [
       "https://github.com/neutrinojs/neutrino",
       "https://github.com/mozilla-neutrino/neutrino-dev"
@@ -698,6 +697,7 @@
     "forge": "/^@forge//",
     "fullcalendar": "/^@fullcalendar//",
     "hotchocolate": "/^HotChocolate\\./",
+    "netty": "/^io.netty:/",
     "oracle-database": [
       "/^com.oracle.database.jdbc:/",
       "/^com.oracle.database.nls:/"


### PR DESCRIPTION
## Changes

netty maven packages doesn't contain `sourceUrl` in the fetch metadata. They are not being grouped according to netty `repoGroups`. This commits moves netty package from `repoGroups` to `patternGroups` matching package by `netty.io` organization name in order to allow monorepo rules to match and group packages

Example of netty dependency without `sourceUrl` in the metadata:
```
          {
            "currentValue": "4.2.4.Final",
            "currentVersion": "4.2.4.Final",
            "currentVersionAgeInDays": 34,
            "currentVersionTimestamp": "2025-08-13T12:45:42.000Z",
            "datasource": "sbt-package",
            "depName": "io.netty:netty-transport-native-unix-common",
            "dependencyUrl": "https://repo.maven.apache.org/maven2/io/netty",
            "fixedVersion": "4.2.4.Final",
            "isSingleVersion": true,
            "packageName": "io.netty:netty-transport-native-unix-common",
            "registryUrl": "https://repo.maven.apache.org/maven2",
            "registryUrls": [
              "https://repo.maven.apache.org/maven2"
            ],
            "versioning": "ivy",
            "warnings": [],
            "updates": [
                ...
            ]
          },
```

Example of netty package not providing `<url>` element in its pom.xml
```
<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
<modelVersion>4.0.0</modelVersion>
<parent>
</parent>
<artifactId>netty-codec</artifactId>
<packaging>jar</packaging>
<name>Netty/Codec</name>
<properties>
</properties>
<dependencies>
</dependencies>
<build>
</build>
</project>
```
https://repo.maven.apache.org/maven2/io/netty/netty-codec/4.2.6.Final/netty-codec-4.2.6.Final.pom


## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [X] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [X] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [X] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
