### PR TITLE
fix(jsonata): updates when version and digest changed (#36461)

### DIFF
--- a/lib/workers/repository/update/branch/auto-replace.spec.ts
+++ b/lib/workers/repository/update/branch/auto-replace.spec.ts
@@ -1347,6 +1347,69 @@ describe('workers/repository/update/branch/auto-replace', () => {
       );
     });
 
+    it('jsonata: update currentValue', async () => {
+      const source =
+        '[ { "version": "1.2.3", "digest": "abcdef", "package": "foo" } ]';
+      upgrade.manager = 'jsonata';
+      upgrade.depName = 'foo';
+      upgrade.currentValue = '1.2.3';
+      upgrade.newValue = '1.2.4';
+      upgrade.depIndex = 0;
+      upgrade.packageFile = 'deps.json';
+      upgrade.fileFormat = 'json';
+      upgrade.datasourceTemplate = 'github-releases';
+      upgrade.matchStrings = [
+        '*.{"depName": package, "currentDigest": digest, "currentValue": version }',
+      ];
+
+      const res = await doAutoReplace(upgrade, source, reuseExistingBranch);
+      expect(res).toBe(
+        '[ { "version": "1.2.4", "digest": "abcdef", "package": "foo" } ]',
+      );
+    });
+
+    it('jsonata: update currentDigest', async () => {
+      const source =
+        '[ { "version": "1.2.3", "digest": "abcdef", "package": "foo" } ]';
+      upgrade.manager = 'jsonata';
+      upgrade.depName = 'foo';
+      upgrade.currentDigest = 'abcdef';
+      upgrade.newDigest = 'badbeef';
+      upgrade.depIndex = 0;
+      upgrade.packageFile = 'deps.json';
+      upgrade.fileFormat = 'json';
+      upgrade.datasourceTemplate = 'github-releases';
+      upgrade.matchStrings = [
+        '*.{"depName": package, "currentDigest": digest, "currentValue": version }',
+      ];
+      const res = await doAutoReplace(upgrade, source, reuseExistingBranch);
+      expect(res).toBe(
+        '[ { "version": "1.2.3", "digest": "badbeef", "package": "foo" } ]',
+      );
+    });
+
+    it('jsonata: update currentValue and currentDigest', async () => {
+      const source =
+        '[ { "version": "1.2.3", "digest": "abcdef", "package": "foo" } ]';
+      upgrade.manager = 'jsonata';
+      upgrade.depName = 'foo';
+      upgrade.currentValue = '1.2.3';
+      upgrade.newValue = '1.2.4';
+      upgrade.currentDigest = 'abcdef';
+      upgrade.newDigest = 'badbeef';
+      upgrade.depIndex = 0;
+      upgrade.packageFile = 'deps.json';
+      upgrade.fileFormat = 'json';
+      upgrade.datasourceTemplate = 'github-releases';
+      upgrade.matchStrings = [
+        '*.{"depName": package, "currentDigest": digest, "currentValue": version }',
+      ];
+      const res = await doAutoReplace(upgrade, source, reuseExistingBranch);
+      expect(res).toBe(
+        '[ { "version": "1.2.4", "digest": "badbeef", "package": "foo" } ]',
+      );
+    });
+
     it('github-actions: updates with newValue only', async () => {
       const githubAction = codeBlock`
         jobs:

--- a/lib/workers/repository/update/branch/auto-replace.ts
+++ b/lib/workers/repository/update/branch/auto-replace.ts
@@ -196,6 +196,18 @@ async function checkExistingBranch(
   return existingContent;
 }
 
+// check if current !== newString and return 1 if it does or 0 if it doesn't
+function updatedToInt(
+  current: string | undefined,
+  newString: string | undefined,
+): number {
+  if (current && newString && newString !== current) {
+    return 1;
+  } else {
+    return 0;
+  }
+}
+
 export async function doAutoReplace(
   upgrade: BranchUpgradeConfig,
   existingContent: string,
@@ -225,11 +237,6 @@ export async function doAutoReplace(
     return await checkExistingBranch(upgrade, existingContent);
   }
 
-  // check if current !== newString and return 1 if it does or 0 if it doesn't
-  const updatedToInt = (
-    current: string | undefined,
-    newString: string | undefined,
-  ): number => (current && newString && newString !== current ? 1 : 0);
   // count how many strings need to be updated
   const changedCount =
     updatedToInt(depName, newName) +

--- a/lib/workers/repository/update/branch/auto-replace.ts
+++ b/lib/workers/repository/update/branch/auto-replace.ts
@@ -202,8 +202,8 @@ async function checkExistingBranch(
  * @remarks
  * Useful for counting the number of updates to do.
  *
- * @param {string|undefined} current The current value (if undefined then no update is required)
- * @param {string|undefined} newString The new value (if undefined then no update is required)
+ * @param current The current value (if undefined then no update is required)
+ * @param newString The new value (if undefined then no update is required)
  *
  * @returns 1 if `current !== newString` and 0 if they are equal or at least one is undefined.
  */

--- a/lib/workers/repository/update/branch/auto-replace.ts
+++ b/lib/workers/repository/update/branch/auto-replace.ts
@@ -224,11 +224,29 @@ export async function doAutoReplace(
   if (reuseExistingBranch) {
     return await checkExistingBranch(upgrade, existingContent);
   }
+
+  // check if current !== newString and return 1 if it does or 0 if it doesn't
+  const updatedToInt = (
+    current: string | undefined,
+    newString: string | undefined,
+  ): number => (current && newString && newString !== current ? 1 : 0);
+  // count how many strings need to be updated
+  const changedCount =
+    updatedToInt(depName, newName) +
+    updatedToInt(currentValue, newValue) +
+    updatedToInt(currentDigest, newDigest) +
+    updatedToInt(currentDigestShort, newDigest);
+  logger.debug(
+    { packageFile, depName, changedCount },
+    'N values changed and need to be updated',
+  );
+
   const replaceWithoutReplaceString =
-    is.string(newName) &&
-    newName !== depName &&
-    (is.undefined(upgrade.replaceString) ||
-      !upgrade.replaceString?.includes(depName!));
+    (is.string(newName) &&
+      newName !== depName &&
+      (is.undefined(upgrade.replaceString) ||
+        !upgrade.replaceString?.includes(depName!))) ||
+    (is.undefined(upgrade.replaceString) && changedCount > 1);
   const replaceString = upgrade.replaceString ?? currentValue ?? currentDigest;
   logger.trace({ depName, replaceString }, 'autoReplace replaceString');
   let searchIndex: number;

--- a/lib/workers/repository/update/branch/auto-replace.ts
+++ b/lib/workers/repository/update/branch/auto-replace.ts
@@ -196,7 +196,17 @@ async function checkExistingBranch(
   return existingContent;
 }
 
-// check if current !== newString and return 1 if it does or 0 if it doesn't
+/**
+ * Check if an update from `current` to `newString` should be performed and return 1 if so.
+ *
+ * @remarks
+ * Useful for counting the number of updates to do.
+ *
+ * @param {string|undefined} current The current value (if undefined then no update is required)
+ * @param {string|undefined} newString The new value (if undefined then no update is required)
+ *
+ * @returns 1 if `current !== newString` and 0 if they are equal or at least one is undefined.
+ */
 function updatedToInt(
   current: string | undefined,
   newString: string | undefined,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
- added a regression test for the issue discussed in #36461 (taken from #37976)
- changed the logic in `auto-replace` to consider the number of changes to be made.
    If more than one change needs to be made and `replaceString` is not set then also set `replaceWithoutReplaceString`.

## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
