### PR TITLE
feat(github): consider rulesets strict checks for rebaseWhen=auto

### DIFF
--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -1010,23 +1010,6 @@ describe('modules/platform/github/index', () => {
       expect(res).toBeTrue();
     });
 
-    it('should fallback to legacy branch protection when rulesets API fails', async () => {
-      httpMock
-        .scope(githubApiHost)
-        .get('/repos/undefined/rules/branches/main')
-        .reply(500);
-      httpMock
-        .scope(githubApiHost)
-        .get('/repos/undefined/branches/main/protection')
-        .reply(200, {
-          required_status_checks: {
-            strict: true,
-          },
-        });
-      const res = await github.getBranchForceRebase('main');
-      expect(res).toBeTrue();
-    });
-
     it('should return false when no force rebase rules found', async () => {
       httpMock
         .scope(githubApiHost)

--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -867,6 +867,10 @@ describe('modules/platform/github/index', () => {
     it('should detect repoForceRebase', async () => {
       httpMock
         .scope(githubApiHost)
+        .get('/repos/undefined/rules/branches/main')
+        .reply(404);
+      httpMock
+        .scope(githubApiHost)
         .get('/repos/undefined/branches/main/protection')
         .reply(200, {
           required_pull_request_reviews: {
@@ -897,6 +901,10 @@ describe('modules/platform/github/index', () => {
     it('should handle 404', async () => {
       httpMock
         .scope(githubApiHost)
+        .get('/repos/undefined/rules/branches/dev')
+        .reply(404);
+      httpMock
+        .scope(githubApiHost)
         .get('/repos/undefined/branches/dev/protection')
         .reply(404);
       const res = await github.getBranchForceRebase('dev');
@@ -906,6 +914,10 @@ describe('modules/platform/github/index', () => {
     it('should handle 403', async () => {
       httpMock
         .scope(githubApiHost)
+        .get('/repos/undefined/rules/branches/main')
+        .reply(404);
+      httpMock
+        .scope(githubApiHost)
         .get('/repos/undefined/branches/main/protection')
         .reply(403);
       const res = await github.getBranchForceRebase('main');
@@ -913,6 +925,10 @@ describe('modules/platform/github/index', () => {
     });
 
     it('should throw 401', async () => {
+      httpMock
+        .scope(githubApiHost)
+        .get('/repos/undefined/rules/branches/main')
+        .reply(404);
       httpMock
         .scope(githubApiHost)
         .get('/repos/undefined/branches/main/protection')
@@ -938,6 +954,98 @@ describe('modules/platform/github/index', () => {
         forkCreation: true,
       });
 
+      const res = await github.getBranchForceRebase('main');
+      expect(res).toBeFalse();
+    });
+
+    it('should detect non_fast_forward ruleset', async () => {
+      httpMock
+        .scope(githubApiHost)
+        .get('/repos/undefined/rules/branches/main')
+        .reply(200, [
+          {
+            type: 'non_fast_forward',
+            ruleset_source_type: 'Repository',
+            ruleset_source: 'owner/repo',
+            ruleset_id: 12345,
+          },
+        ]);
+      const res = await github.getBranchForceRebase('main');
+      expect(res).toBeTrue();
+    });
+
+    it('should detect strict required status checks ruleset', async () => {
+      httpMock
+        .scope(githubApiHost)
+        .get('/repos/undefined/rules/branches/main')
+        .reply(200, [
+          {
+            type: 'required_status_checks',
+            parameters: {
+              strict_required_status_checks_policy: true,
+            },
+            ruleset_source_type: 'Repository',
+            ruleset_source: 'owner/repo',
+            ruleset_id: 12345,
+          },
+        ]);
+      const res = await github.getBranchForceRebase('main');
+      expect(res).toBeTrue();
+    });
+
+    it('should fallback to legacy branch protection when rulesets not found', async () => {
+      httpMock
+        .scope(githubApiHost)
+        .get('/repos/undefined/rules/branches/main')
+        .reply(404);
+      httpMock
+        .scope(githubApiHost)
+        .get('/repos/undefined/branches/main/protection')
+        .reply(200, {
+          required_status_checks: {
+            strict: true,
+          },
+        });
+      const res = await github.getBranchForceRebase('main');
+      expect(res).toBeTrue();
+    });
+
+    it('should fallback to legacy branch protection when rulesets API fails', async () => {
+      httpMock
+        .scope(githubApiHost)
+        .get('/repos/undefined/rules/branches/main')
+        .reply(500);
+      httpMock
+        .scope(githubApiHost)
+        .get('/repos/undefined/branches/main/protection')
+        .reply(200, {
+          required_status_checks: {
+            strict: true,
+          },
+        });
+      const res = await github.getBranchForceRebase('main');
+      expect(res).toBeTrue();
+    });
+
+    it('should return false when no force rebase rules found', async () => {
+      httpMock
+        .scope(githubApiHost)
+        .get('/repos/undefined/rules/branches/main')
+        .reply(200, [
+          {
+            type: 'pull_request',
+            parameters: {
+              required_approving_review_count: 1,
+            },
+            ruleset_source_type: 'Repository',
+            ruleset_source: 'owner/repo',
+            ruleset_id: 12345,
+          },
+        ]);
+      httpMock
+        .scope(githubApiHost)
+        .get('/repos/undefined/branches/main/protection')
+        .reply(404);
       const res = await github.getBranchForceRebase('main');
       expect(res).toBeFalse();
     });

--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -1036,6 +1036,10 @@ describe('modules/platform/github/index', () => {
     it('should return cached result on subsequent calls', async () => {
       httpMock
         .scope(githubApiHost)
+        .get('/repos/undefined/rules/branches/main')
+        .reply(404);
+      httpMock
+        .scope(githubApiHost)
         .get('/repos/undefined/branches/main/protection')
         .reply(200, {
           required_status_checks: {
@@ -1055,6 +1059,10 @@ describe('modules/platform/github/index', () => {
     });
 
     it('should return cached false result on subsequent calls', async () => {
+      httpMock
+        .scope(githubApiHost)
+        .get('/repos/undefined/rules/branches/dev')
+        .reply(404);
       httpMock
         .scope(githubApiHost)
         .get('/repos/undefined/branches/dev/protection')

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -759,7 +759,9 @@ async function checkRulesetsForForceRebase(
 ): Promise<boolean> {
   try {
     const rulesets = await getBranchRulesets(branchName);
-    logger.debug(`Found ${rulesets.length} rulesets for branch ${branchName}`);
+    logger.trace(
+      `Ruleset: Found ${rulesets.length} rulesets for branch ${branchName}`,
+    );
 
     return rulesets.some((rule) => {
       if (rule.type === 'non_fast_forward') {
@@ -790,7 +792,7 @@ async function checkBranchProtectionForForceRebase(
 ): Promise<boolean> {
   try {
     const branchProtection = await getBranchProtection(branchName);
-    logger.debug(`Found branch protection for branch ${branchName}`);
+    logger.trace(`Found branch protection for branch ${branchName}`);
 
     const strictStatusChecks = branchProtection?.required_status_checks?.strict;
     if (strictStatusChecks) {

--- a/lib/modules/platform/github/schema.ts
+++ b/lib/modules/platform/github/schema.ts
@@ -102,3 +102,18 @@ export const GithubBranchProtection = z.object({
     .optional(),
 });
 export type GithubBranchProtection = z.infer<typeof GithubBranchProtection>;
+
+const GithubRulesetRule = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('non_fast_forward'),
+  }),
+  z.object({
+    type: z.literal('required_status_checks'),
+    parameters: z.object({
+      strict_required_status_checks_policy: z.boolean().optional(),
+    }),
+  }),
+]);
+
+export const GithubBranchRulesets = LooseArray(GithubRulesetRule);
+export type GithubBranchRulesets = z.infer<typeof GithubBranchRulesets>;

--- a/lib/modules/platform/github/schema.ts
+++ b/lib/modules/platform/github/schema.ts
@@ -113,6 +113,10 @@ const GithubRulesetRule = z.discriminatedUnion('type', [
       strict_required_status_checks_policy: z.boolean().optional(),
     }),
   }),
+  // prevents deletion
+  z.object({
+    type: z.literal('deletion'),
+  }),
 ]);
 
 export const GithubBranchRulesets = LooseArray(GithubRulesetRule);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds support for GitHub Rulesets which are planned to replace the existing BranchProtectionRules when detecting forced rebase when `rebaseWhen=auto` 

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/secustor/backstage-plugins

<details>
<summary>RuleSet Code</summary>

```json
{
  "id": 571127,
  "name": "main",
  "target": "branch",
  "source_type": "Repository",
  "source": "secustor/backstage-plugins",
  "enforcement": "active",
  "conditions": {
    "ref_name": {
      "exclude": [],
      "include": [
        "~DEFAULT_BRANCH"
      ]
    }
  },
  "rules": [
    {
      "type": "deletion"
    },
    {
      "type": "non_fast_forward"
    },
    {
      "type": "required_status_checks",
      "parameters": {
        "strict_required_status_checks_policy": true,
        "required_status_checks": [
          {
            "context": "check all required jobs"
          }
        ]
      }
    },
    {
      "type": "pull_request",
      "parameters": {
        "required_approving_review_count": 0,
        "dismiss_stale_reviews_on_push": true,
        "require_code_owner_review": false,
        "require_last_push_approval": false,
        "required_review_thread_resolution": true,
        "allowed_merge_methods": [
          "merge",
          "squash",
          "rebase"
        ]
      }
    }
  ],
  "bypass_actors": [
    {
      "actor_id": 5,
      "actor_type": "RepositoryRole",
      "bypass_mode": "always"
    }
  ]
}
```

</details

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
