### PR TITLE
fix(status-checks): do not set status checks in dry run

### DIFF
--- a/lib/workers/repository/update/branch/status-checks.spec.ts
+++ b/lib/workers/repository/update/branch/status-checks.spec.ts
@@ -1,3 +1,4 @@
+import { GlobalConfig } from '../../../../config/global';
 import { logger } from '../../../../logger';
 import type { ConfidenceConfig, StabilityConfig } from './status-checks';
 import {
@@ -19,6 +20,7 @@ describe('workers/repository/update/branch/status-checks', () => {
           minimumReleaseAge: 'renovate/stability-days',
         }),
       });
+      GlobalConfig.reset();
     });
 
     it('returns if not configured', async () => {
@@ -87,6 +89,16 @@ describe('workers/repository/update/branch/status-checks', () => {
       );
       expect(platform.setBranchStatus).not.toHaveBeenCalled();
     });
+
+    it('does not set status in dry mode', async () => {
+      GlobalConfig.set({ dryRun: 'full' });
+      config.stabilityStatus = 'green';
+      await setStability(config);
+      expect(logger.info).toHaveBeenCalledWith(
+        'DRY-RUN: Would update renovate/stability-days status check state to green',
+      );
+      expect(platform.setBranchStatus).not.toHaveBeenCalled();
+    });
   });
 
   describe('setConfidence', () => {
@@ -99,6 +111,7 @@ describe('workers/repository/update/branch/status-checks', () => {
           mergeConfidence: 'renovate/merge-confidence',
         }),
       };
+      GlobalConfig.reset();
     });
 
     it('returns if not configured', async () => {
@@ -170,6 +183,17 @@ describe('workers/repository/update/branch/status-checks', () => {
       });
       expect(logger.debug).toHaveBeenCalledWith(
         'Status check is null or an empty string, skipping status check addition.',
+      );
+      expect(platform.setBranchStatus).not.toHaveBeenCalled();
+    });
+
+    it('does not set status in dry mode', async () => {
+      GlobalConfig.set({ dryRun: 'full' });
+      config.minimumConfidence = 'high';
+      config.confidenceStatus = 'yellow';
+      await setConfidence(config);
+      expect(logger.info).toHaveBeenCalledWith(
+        'DRY-RUN: Would update renovate/merge-confidence status check state to yellow',
       );
       expect(platform.setBranchStatus).not.toHaveBeenCalled();
     });

--- a/lib/workers/repository/update/branch/status-checks.ts
+++ b/lib/workers/repository/update/branch/status-checks.ts
@@ -1,3 +1,4 @@
+import { GlobalConfig } from '../../../../config/global';
 import type { RenovateConfig } from '../../../../config/types';
 import { logger } from '../../../../logger';
 import { platform } from '../../../../modules/platform';
@@ -44,6 +45,12 @@ async function setStatusCheck(
   if (existingState === state) {
     logger.debug(`Status check ${context} is already up-to-date`);
   } else {
+    if (GlobalConfig.get('dryRun')) {
+      logger.info(
+        `DRY-RUN: Would update ${context} status check state to ${state}`,
+      );
+      return;
+    }
     logger.debug(`Updating ${context} status check state to ${state}`);
     await platform.setBranchStatus({
       branchName,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Do not set status checks in dry runs

## Context

Please select one of the below:

- [x] This closes an existing Issue: #38098
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
