### PR TITLE
feat(replacements): add `clang-format` maintenance fork 

### DIFF
--- a/lib/data/replacements.json
+++ b/lib/data/replacements.json
@@ -135,6 +135,17 @@
       }
     ]
   },
+  "clang-format-to-maintenance-fork": {
+    "description": "Maintenance fork of `clang-format`",
+    "packageRules": [
+      {
+        "matchDatasources": ["npm"],
+        "matchPackageNames": ["clang-format"],
+        "replacementName": "clang-format-node",
+        "replacementVersion": "2.0.0"
+      }
+    ]
+  },
   "containerbase": {
     "description": "Replace containerbase dependencies.",
     "packageRules": [


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Hello,

I've added the [`clang-format-node`](https://github.com/lumirlumir/npm-clang-format-node) package as a replacement for the deprecated [`clang-format`](https://github.com/angular/clang-format) package.

The `clang-format` package has been deprecated, as mentioned in https://github.com/angular/clang-format/issues/79#issuecomment-1335227896, https://github.com/angular/clang-format/issues/82#issuecomment-1748482685, and https://github.com/angular/clang-format/pull/83.

[`clang-format-node`](https://clang-format-node.lumir.page/) is a maintenance fork of `clang-format`, so I've added it to the `clang-format` replacement section.

## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: https://github.com/lumirlumir/npm-clang-format-node

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
