### PR TITLE
feat(manager/composer): Add support for `composer bump`

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -3817,6 +3817,7 @@ Table with options:
 | Name                         | Description                                                                                                                                                |
 | ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `bundlerConservative`        | Enable conservative mode for `bundler` (Ruby dependencies). This will only update the immediate dependency in the lockfile instead of all subdependencies. |
+| `composerBump`               | Run `composer bump` after `composer update` or `composer require` to update requirement constraints to currently installed versions.                       |
 | `composerWithAll`            | Run `composer update` with `--with-all-dependencies` flag instead of the default `--with-dependencies`.                                                    |
 | `dotnetWorkloadRestore`      | Run `dotnet workload restore` before `dotnet restore` commands.                                                                                            |
 | `gomodMassage`               | Enable massaging `replace` directives before calling `go` commands.                                                                                        |

--- a/docs/usage/php.md
+++ b/docs/usage/php.md
@@ -73,3 +73,8 @@ You may encrypt your `password` only, but you can encrypt your `username` as wel
 
 By default, Renovate will invoke `composer update` with the `--with-dependencies` flag.
 Add `composerWithAll` to your `postUpdateOptions` array to use the `--with-all-dependencies` flag instead.
+
+## Composer bump
+
+Add `composerBump` to your `postUpdateOptions` array to run `composer bump` after dependency updates.
+This command updates the requirement constraints in your `composer.json` to match the currently installed versions, preventing accidental downgrades and improving dependency resolution performance.

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -2540,6 +2540,7 @@ const options: RenovateOptions[] = [
     subType: 'string',
     allowedValues: [
       'bundlerConservative',
+      'composerBump',
       'composerWithAll',
       'dotnetWorkloadRestore',
       'gomodMassage',

--- a/lib/modules/manager/composer/artifacts.spec.ts
+++ b/lib/modules/manager/composer/artifacts.spec.ts
@@ -1234,4 +1234,33 @@ describe('modules/manager/composer/artifacts', () => {
       },
     ]);
   });
+
+  it('runs composer bump when composerBump is set in postUpdateOptions', async () => {
+    fs.readLocalFile.mockResolvedValueOnce('{}');
+    const execSnapshots = mockExecAll();
+    fs.readLocalFile.mockResolvedValueOnce('{}');
+    git.getRepoStatus.mockResolvedValueOnce(repoStatus);
+
+    expect(
+      await composer.updateArtifacts({
+        packageFileName: 'composer.json',
+        updatedDeps: [{ depName: 'foo', newVersion: '1.1.0' }],
+        newPackageFileContent: '{}',
+        config: {
+          ...config,
+          postUpdateOptions: ['composerBump'],
+        },
+      }),
+    ).toBeNull();
+    expect(execSnapshots).toMatchObject([
+      {
+        cmd: 'composer update foo:1.1.0 --with-dependencies --ignore-platform-reqs --no-ansi --no-interaction --no-scripts --no-autoloader --no-plugins',
+        options: { cwd: '/tmp/github/some/repo' },
+      },
+      {
+        cmd: 'composer bump --no-ansi --no-interaction',
+        options: { cwd: '/tmp/github/some/repo' },
+      },
+    ]);
+  });
 });

--- a/lib/modules/manager/composer/artifacts.ts
+++ b/lib/modules/manager/composer/artifacts.ts
@@ -198,6 +198,13 @@ export async function updateArtifacts({
     logger.trace({ cmd, args }, 'composer command');
     commands.push(`${cmd} ${args}`);
 
+    if (config.postUpdateOptions?.includes('composerBump')) {
+      const bumpCmd = 'composer bump';
+      const bumpArgs = '--no-ansi --no-interaction';
+      logger.trace({ cmd: bumpCmd, args: bumpArgs }, 'composer bump command');
+      commands.push(`${bumpCmd} ${bumpArgs}`);
+    }
+
     await exec(commands, execOptions);
     const status = await getRepoStatus();
     if (!status.modified.includes(lockFileName)) {

--- a/lib/modules/manager/composer/readme.md
+++ b/lib/modules/manager/composer/readme.md
@@ -13,3 +13,6 @@ For example, the package `acme/foo` would need an entry in [repositories](https:
 
 By default, Renovate will invoke `composer update` with the `--with-dependencies` flag.
 Add `composerWithAll` to your `postUpdateOptions` array to use the `--with-all-dependencies` flag instead.
+
+Add `composerBump` to your `postUpdateOptions` array to run `composer bump` after dependency updates.
+This updates requirement constraints in your `composer.json` to match currently installed versions.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This adds a way to trigger `composer bump` command for Renovate when `composer update` or `composer require` is run in order to bump the lower limit of composer.json requirements. 

This mainly is useful for projects and not libraries that don't use composer.lock file and support wider range of dependency versions.

E.q. when `composer require x/y -W` installs `"sentry/sentry-symfony": "^5"` the `bump` command makes it `"sentry/sentry-symfony": "^5.5"`.

## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
