### PR TITLE
feat(npm)!: support yarn catalogs

### DIFF
--- a/lib/modules/manager/npm/extract/index.spec.ts
+++ b/lib/modules/manager/npm/extract/index.spec.ts
@@ -1277,14 +1277,8 @@ describe('modules/manager/npm/extract/index', () => {
       const yarnrc = codeBlock`
         nodeLinker: node-modules
 
-        plugins:
-          - checksum: 4cb9601cfc0c71e5b0ffd0a85b78e37430b62257040714c2558298ce1fc058f4e918903f0d1747a4fef3f58e15722c35bd76d27492d9d08aa5b04e235bf43b22
-            path: .yarn/plugins/@yarnpkg/plugin-catalogs.cjs
-            spec: 'https://raw.githubusercontent.com/toss/yarn-plugin-catalogs/main/bundles/%40yarnpkg/plugin-catalogs.js'
-
-        catalogs:
-          list:
-            is-positive: 1.0.0
+        catalog:
+          is-positive: 1.0.0
       `;
       fs.readLocalFile.mockResolvedValueOnce(yarnrc);
 
@@ -1317,14 +1311,8 @@ describe('modules/manager/npm/extract/index', () => {
       const yarnrc = codeBlock`
         nodeLinker: node-modules
 
-        plugins:
-          - checksum: 4cb9601cfc0c71e5b0ffd0a85b78e37430b62257040714c2558298ce1fc058f4e918903f0d1747a4fef3f58e15722c35bd76d27492d9d08aa5b04e235bf43b22
-            path: .yarn/plugins/@yarnpkg/plugin-catalogs.cjs
-            spec: 'https://raw.githubusercontent.com/toss/yarn-plugin-catalogs/main/bundles/%40yarnpkg/plugin-catalogs.js'
-
-        catalogs:
-          list:
-            is-positive: 1.0.0
+        catalog:
+          is-positive: 1.0.0
       `;
 
       fs.readLocalFile.mockResolvedValueOnce(yarnrc);
@@ -1355,14 +1343,8 @@ describe('modules/manager/npm/extract/index', () => {
       const yarnrc = codeBlock`
         nodeLinker: node-modules
 
-        plugins:
-          - checksum: 4cb9601cfc0c71e5b0ffd0a85b78e37430b62257040714c2558298ce1fc058f4e918903f0d1747a4fef3f58e15722c35bd76d27492d9d08aa5b04e235bf43b22
-            path: .yarn/plugins/@yarnpkg/plugin-catalogs.cjs
-            spec: 'https://raw.githubusercontent.com/toss/yarn-plugin-catalogs/main/bundles/%40yarnpkg/plugin-catalogs.js'
-
-        catalogs:
-          list:
-            is-positive: 1.0.0
+        catalog:
+          is-positive: 1.0.0
       `;
 
       fs.readLocalFile.mockResolvedValueOnce(yarnrc);

--- a/lib/modules/manager/npm/extract/index.ts
+++ b/lib/modules/manager/npm/extract/index.ts
@@ -270,12 +270,12 @@ export async function extractAllPackageFiles(
 
           const yarnConfig = loadConfigFromYarnrcYml(content);
 
-          if (yarnConfig?.catalogs) {
+          if (yarnConfig?.catalogs || yarnConfig?.catalog) {
             const hasPackageManagerResult = await hasPackageManager(
               upath.dirname(packageFile),
             );
             const catalogsDeps = await extractYarnCatalogs(
-              yarnConfig.catalogs,
+              { catalog: yarnConfig.catalog, catalogs: yarnConfig.catalogs },
               packageFile,
               hasPackageManagerResult,
             );

--- a/lib/modules/manager/npm/extract/yarn.spec.ts
+++ b/lib/modules/manager/npm/extract/yarn.spec.ts
@@ -82,7 +82,7 @@ describe('modules/manager/npm/extract/yarn', () => {
   describe('.extractYarnCatalogs()', () => {
     it('handles empty catalog entries', async () => {
       expect(
-        await extractYarnCatalogs(undefined, 'package.json', false),
+        await extractYarnCatalogs({}, 'package.json', false),
       ).toMatchObject({
         deps: [],
       });
@@ -94,8 +94,10 @@ describe('modules/manager/npm/extract/yarn', () => {
       expect(
         await extractYarnCatalogs(
           {
-            list: {
+            catalog: {
               react: '18.3.0',
+            },
+            catalogs: {
               react17: {
                 react: '17.0.2',
               },
@@ -134,7 +136,7 @@ describe('modules/manager/npm/extract/yarn', () => {
       expect(
         await extractYarnCatalogs(
           {
-            list: {
+            catalog: {
               react: '18.3.1',
             },
           },

--- a/lib/modules/manager/npm/extract/yarn.ts
+++ b/lib/modules/manager/npm/extract/yarn.ts
@@ -127,7 +127,7 @@ export function getYarnVersionFromLock(lockfile: LockFile): string {
 }
 
 export async function extractYarnCatalogs(
-  catalogs: YarnCatalogs | undefined,
+  catalogs: YarnCatalogs,
   packageFile: string,
   hasPackageManager: boolean,
 ): Promise<PackageFileContent<NpmManagerData>> {
@@ -153,26 +153,25 @@ export async function extractYarnCatalogs(
   };
 }
 
-function yarnCatalogsToArray(catalogs: YarnCatalogs | undefined): Catalog[] {
+function yarnCatalogsToArray({
+  catalog: defaultCatalogDeps,
+  catalogs: namedCatalogs,
+}: YarnCatalogs): Catalog[] {
   const result: Catalog[] = [];
 
-  if (catalogs?.list !== undefined) {
-    for (const [
-      depNameOrCatalogName,
-      depsVersionOrNamedCatalog,
-    ] of Object.entries(catalogs.list)) {
-      if (is.object(depsVersionOrNamedCatalog)) {
-        result.push({
-          name: depNameOrCatalogName,
-          dependencies: depsVersionOrNamedCatalog,
-        });
-      } else {
-        result.push({
-          name: 'default',
-          dependencies: { [depNameOrCatalogName]: depsVersionOrNamedCatalog },
-        });
-      }
-    }
+  if (defaultCatalogDeps !== undefined) {
+    result.push({ name: 'default', dependencies: defaultCatalogDeps });
+  }
+
+  if (!namedCatalogs) {
+    return result;
+  }
+
+  for (const [name, dependencies] of Object.entries(namedCatalogs)) {
+    result.push({
+      name,
+      dependencies,
+    });
   }
 
   return result;

--- a/lib/modules/manager/npm/readme.md
+++ b/lib/modules/manager/npm/readme.md
@@ -11,7 +11,7 @@ The following `depTypes` are currently supported by the npm manager :
 - `resolutions`
 - `pnpm.overrides`
 - `pnpm.catalog.<name>`, such as `pnpm.catalog.default` and `pnpm.catalog.myCatalog`. [Matches any default and named pnpm catalogs](https://pnpm.io/catalogs#defining-catalogs).
-- `yarn.catalogs.list.<name>` if you are using the [yarn-plugin-catalogs](https://github.com/toss/yarn-plugin-catalogs)
+- `yarn.catalog.<name>`, such as `yarn.catalog.default` and `yarn.catalog.myCatalog`. [Matches any default and named yarn catalogs](https://yarnpkg.com/features/catalogs).
 
 ### npm problems and workarounds
 

--- a/lib/modules/manager/npm/readme.md
+++ b/lib/modules/manager/npm/readme.md
@@ -10,7 +10,7 @@ The following `depTypes` are currently supported by the npm manager :
 - `overrides`
 - `resolutions`
 - `pnpm.overrides`
-- `pnpm.catalog.<name>`, such as `pnpm.catalog.default` and `pnpm.catalog.myCatalog`. [Matches any default and named pnpm catalogs](https://pnpm.io/catalogs#defining-catalogs).
+- `pnpm.catalog` or `pnpm.catalog.<name>`. [Matches any default and named pnpm catalogs](https://pnpm.io/catalogs#defining-catalogs).
 - `yarn.catalog` or `yarn.catalogs.<name>`. [Matches any default and named yarn catalogs](https://yarnpkg.com/features/catalogs).
 
 ### npm problems and workarounds

--- a/lib/modules/manager/npm/readme.md
+++ b/lib/modules/manager/npm/readme.md
@@ -11,7 +11,7 @@ The following `depTypes` are currently supported by the npm manager :
 - `resolutions`
 - `pnpm.overrides`
 - `pnpm.catalog.<name>`, such as `pnpm.catalog.default` and `pnpm.catalog.myCatalog`. [Matches any default and named pnpm catalogs](https://pnpm.io/catalogs#defining-catalogs).
-- `yarn.catalog.<name>`, such as `yarn.catalog.default` and `yarn.catalog.myCatalog`. [Matches any default and named yarn catalogs](https://yarnpkg.com/features/catalogs).
+- `yarn.catalog` or `yarn.catalogs.<name>`. [Matches any default and named yarn catalogs](https://yarnpkg.com/features/catalogs).
 
 ### npm problems and workarounds
 

--- a/lib/modules/manager/npm/schema.ts
+++ b/lib/modules/manager/npm/schema.ts
@@ -7,23 +7,24 @@ export const PnpmCatalogs = z.object({
 });
 
 export const YarnCatalogs = z.object({
-  options: z.optional(z.union([z.string(), z.array(z.string())])),
-  list: z.record(z.union([z.string(), z.record(z.string())])),
+  catalog: z.optional(z.record(z.string())),
+  catalogs: z.optional(z.record(z.record(z.string()))).catch(undefined),
 });
 export type YarnCatalogs = z.infer<typeof YarnCatalogs>;
 
 export const YarnConfig = Yaml.pipe(
-  z.object({
-    npmRegistryServer: z.string().optional(),
-    npmScopes: z
-      .record(
-        z.object({
-          npmRegistryServer: z.string().optional(),
-        }),
-      )
-      .optional(),
-    catalogs: YarnCatalogs.optional().catch(undefined),
-  }),
+  z
+    .object({
+      npmRegistryServer: z.string().optional(),
+      npmScopes: z
+        .record(
+          z.object({
+            npmRegistryServer: z.string().optional(),
+          }),
+        )
+        .optional(),
+    })
+    .and(YarnCatalogs),
 );
 export type YarnConfig = z.infer<typeof YarnConfig>;
 

--- a/lib/modules/manager/npm/update/dependency/index.spec.ts
+++ b/lib/modules/manager/npm/update/dependency/index.spec.ts
@@ -430,25 +430,13 @@ describe('modules/manager/npm/update/dependency/index', () => {
       const overrideDependencies = `
         nodeLinker: node-modules
 
-        plugins:
-          - checksum: 4cb9601cfc0c71e5b0ffd0a85b78e37430b62257040714c2558298ce1fc058f4e918903f0d1747a4fef3f58e15722c35bd76d27492d9d08aa5b04e235bf43b22
-            path: .yarn/plugins/@yarnpkg/plugin-catalogs.cjs
-            spec: 'https://raw.githubusercontent.com/toss/yarn-plugin-catalogs/main/bundles/%40yarnpkg/plugin-catalogs.js'
-
-        catalogs:
-          list:
-            typescript: 0.0.5
+        catalog:
+          typescript: 0.0.5
       `;
       const expected = `nodeLinker: node-modules
 
-        plugins:
-          - checksum: 4cb9601cfc0c71e5b0ffd0a85b78e37430b62257040714c2558298ce1fc058f4e918903f0d1747a4fef3f58e15722c35bd76d27492d9d08aa5b04e235bf43b22
-            path: .yarn/plugins/@yarnpkg/plugin-catalogs.cjs
-            spec: 'https://raw.githubusercontent.com/toss/yarn-plugin-catalogs/main/bundles/%40yarnpkg/plugin-catalogs.js'
-
-        catalogs:
-          list:
-            typescript: 0.60.0
+        catalog:
+          typescript: 0.60.0
 `;
 
       const testContent = npmUpdater.updateDependency({

--- a/lib/modules/manager/npm/update/dependency/yarn.spec.ts
+++ b/lib/modules/manager/npm/update/dependency/yarn.spec.ts
@@ -15,14 +15,8 @@ describe('modules/manager/npm/update/dependency/yarn', () => {
       const yarnrcYaml = codeBlock`
       nodeLinker: node-modules
 
-      plugins:
-        - checksum: 4cb9601cfc0c71e5b0ffd0a85b78e37430b62257040714c2558298ce1fc058f4e918903f0d1747a4fef3f58e15722c35bd76d27492d9d08aa5b04e235bf43b22
-          path: .yarn/plugins/@yarnpkg/plugin-catalogs.cjs
-          spec: 'https://raw.githubusercontent.com/toss/yarn-plugin-catalogs/main/bundles/%40yarnpkg/plugin-catalogs.js'
-
-      catalogs:
-        list:
-          react: 18.3.1
+      catalog:
+        react: 18.3.1
     `;
       const testContent = updateYarnrcCatalogDependency({
         fileContent: yarnrcYaml,
@@ -45,15 +39,9 @@ describe('modules/manager/npm/update/dependency/yarn', () => {
       const yarnrcYaml = codeBlock`
       nodeLinker: node-modules
 
-      plugins:
-        - checksum: 4cb9601cfc0c71e5b0ffd0a85b78e37430b62257040714c2558298ce1fc058f4e918903f0d1747a4fef3f58e15722c35bd76d27492d9d08aa5b04e235bf43b22
-          path: .yarn/plugins/@yarnpkg/plugin-catalogs.cjs
-          spec: 'https://raw.githubusercontent.com/toss/yarn-plugin-catalogs/main/bundles/%40yarnpkg/plugin-catalogs.js'
-
       catalogs:
-        list:
-          react18:
-            react: 18.3.1
+        react18:
+          react: 18.3.1
     `;
       const testContent = updateYarnrcCatalogDependency({
         fileContent: yarnrcYaml,
@@ -72,15 +60,9 @@ describe('modules/manager/npm/update/dependency/yarn', () => {
       const yarnrcYaml = codeBlock`
       nodeLinker: node-modules
 
-      plugins:
-        - checksum: 4cb9601cfc0c71e5b0ffd0a85b78e37430b62257040714c2558298ce1fc058f4e918903f0d1747a4fef3f58e15722c35bd76d27492d9d08aa5b04e235bf43b22
-          path: .yarn/plugins/@yarnpkg/plugin-catalogs.cjs
-          spec: 'https://raw.githubusercontent.com/toss/yarn-plugin-catalogs/main/bundles/%40yarnpkg/plugin-catalogs.js'
-
       catalogs:
-        list:
-          react18:
-            react-dom: 18.3.1
+        react18:
+          react-dom: 18.3.1
     `;
 
       const testContent = updateYarnrcCatalogDependency({
@@ -100,14 +82,8 @@ describe('modules/manager/npm/update/dependency/yarn', () => {
       const yarnrcYaml = codeBlock`
       nodeLinker: node-modules
 
-      plugins:
-        - checksum: 4cb9601cfc0c71e5b0ffd0a85b78e37430b62257040714c2558298ce1fc058f4e918903f0d1747a4fef3f58e15722c35bd76d27492d9d08aa5b04e235bf43b22
-          path: .yarn/plugins/@yarnpkg/plugin-catalogs.cjs
-          spec: 'https://raw.githubusercontent.com/toss/yarn-plugin-catalogs/main/bundles/%40yarnpkg/plugin-catalogs.js'
-
-      catalogs:
-        list:
-          react: 18.3.1
+      catalog:
+        react: 18.3.1
     `;
       updateYarnrcCatalogDependency({
         fileContent: yarnrcYaml,
@@ -129,14 +105,8 @@ describe('modules/manager/npm/update/dependency/yarn', () => {
       const yarnrcYaml = codeBlock`
       nodeLinker: node-modules
 
-      plugins:
-        - checksum: 4cb9601cfc0c71e5b0ffd0a85b78e37430b62257040714c2558298ce1fc058f4e918903f0d1747a4fef3f58e15722c35bd76d27492d9d08aa5b04e235bf43b22
-          path: .yarn/plugins/@yarnpkg/plugin-catalogs.cjs
-          spec: 'https://raw.githubusercontent.com/toss/yarn-plugin-catalogs/main/bundles/%40yarnpkg/plugin-catalogs.js'
-
-      catalogs:
-        list:
-          react: 18.3.1
+      catalog:
+        react: 18.3.1
     `;
 
       const testContent = npmUpdater.updateDependency({
@@ -156,14 +126,8 @@ describe('modules/manager/npm/update/dependency/yarn', () => {
       const yarnrcYaml = codeBlock`
       nodeLinker: node-modules
 
-      plugins:
-        - checksum: 4cb9601cfc0c71e5b0ffd0a85b78e37430b62257040714c2558298ce1fc058f4e918903f0d1747a4fef3f58e15722c35bd76d27492d9d08aa5b04e235bf43b22
-          path: .yarn/plugins/@yarnpkg/plugin-catalogs.cjs
-          spec: 'https://raw.githubusercontent.com/toss/yarn-plugin-catalogs/main/bundles/%40yarnpkg/plugin-catalogs.js'
-
-      catalogs:
-        list:
-          react: 18.3.1
+      catalog:
+        react: 18.3.1
     `;
       const testContent = npmUpdater.updateDependency({
         fileContent: yarnrcYaml,
@@ -172,14 +136,8 @@ describe('modules/manager/npm/update/dependency/yarn', () => {
       expect(testContent).toEqual(codeBlock`
       nodeLinker: node-modules
 
-      plugins:
-        - checksum: 4cb9601cfc0c71e5b0ffd0a85b78e37430b62257040714c2558298ce1fc058f4e918903f0d1747a4fef3f58e15722c35bd76d27492d9d08aa5b04e235bf43b22
-          path: .yarn/plugins/@yarnpkg/plugin-catalogs.cjs
-          spec: 'https://raw.githubusercontent.com/toss/yarn-plugin-catalogs/main/bundles/%40yarnpkg/plugin-catalogs.js'
-
-      catalogs:
-        list:
-          react: 19.0.0
+      catalog:
+        react: 19.0.0
     `);
     });
 
@@ -192,15 +150,9 @@ describe('modules/manager/npm/update/dependency/yarn', () => {
       const yarnrcYaml = codeBlock`
       nodeLinker: node-modules
 
-      plugins:
-        - checksum: 4cb9601cfc0c71e5b0ffd0a85b78e37430b62257040714c2558298ce1fc058f4e918903f0d1747a4fef3f58e15722c35bd76d27492d9d08aa5b04e235bf43b22
-          path: .yarn/plugins/@yarnpkg/plugin-catalogs.cjs
-          spec: 'https://raw.githubusercontent.com/toss/yarn-plugin-catalogs/main/bundles/%40yarnpkg/plugin-catalogs.js'
-
       catalogs:
-        list:
-          react17:
-            react: 17.0.0
+        react17:
+          react: 17.0.0
     `;
       const testContent = npmUpdater.updateDependency({
         fileContent: yarnrcYaml,
@@ -209,15 +161,9 @@ describe('modules/manager/npm/update/dependency/yarn', () => {
       expect(testContent).toEqual(codeBlock`
       nodeLinker: node-modules
 
-      plugins:
-        - checksum: 4cb9601cfc0c71e5b0ffd0a85b78e37430b62257040714c2558298ce1fc058f4e918903f0d1747a4fef3f58e15722c35bd76d27492d9d08aa5b04e235bf43b22
-          path: .yarn/plugins/@yarnpkg/plugin-catalogs.cjs
-          spec: 'https://raw.githubusercontent.com/toss/yarn-plugin-catalogs/main/bundles/%40yarnpkg/plugin-catalogs.js'
-
       catalogs:
-        list:
-          react17:
-            react: 19.0.0
+        react17:
+          react: 19.0.0
     `);
     });
 
@@ -230,14 +176,8 @@ describe('modules/manager/npm/update/dependency/yarn', () => {
       const yarnrcYaml = codeBlock`
       nodeLinker: node-modules
 
-      plugins:
-        - checksum: 4cb9601cfc0c71e5b0ffd0a85b78e37430b62257040714c2558298ce1fc058f4e918903f0d1747a4fef3f58e15722c35bd76d27492d9d08aa5b04e235bf43b22
-          path: .yarn/plugins/@yarnpkg/plugin-catalogs.cjs
-          spec: 'https://raw.githubusercontent.com/toss/yarn-plugin-catalogs/main/bundles/%40yarnpkg/plugin-catalogs.js'
-
-      catalogs:
-        list:
-          react: 19.0.0
+      catalog:
+        react: 19.0.0
     `;
       const testContent = npmUpdater.updateDependency({
         fileContent: yarnrcYaml,
@@ -256,14 +196,8 @@ describe('modules/manager/npm/update/dependency/yarn', () => {
       const yarnrcYaml = codeBlock`
       nodeLinker: node-modules
 
-      plugins:
-        - checksum: 4cb9601cfc0c71e5b0ffd0a85b78e37430b62257040714c2558298ce1fc058f4e918903f0d1747a4fef3f58e15722c35bd76d27492d9d08aa5b04e235bf43b22
-          path: .yarn/plugins/@yarnpkg/plugin-catalogs.cjs
-          spec: 'https://raw.githubusercontent.com/toss/yarn-plugin-catalogs/main/bundles/%40yarnpkg/plugin-catalogs.js'
-
-      catalogs:
-        list:
-          config: 1.21.0
+      catalog:
+        config: 1.21.0
     `;
 
       const testContent = npmUpdater.updateDependency({
@@ -273,14 +207,8 @@ describe('modules/manager/npm/update/dependency/yarn', () => {
       expect(testContent).toEqual(codeBlock`
       nodeLinker: node-modules
 
-      plugins:
-        - checksum: 4cb9601cfc0c71e5b0ffd0a85b78e37430b62257040714c2558298ce1fc058f4e918903f0d1747a4fef3f58e15722c35bd76d27492d9d08aa5b04e235bf43b22
-          path: .yarn/plugins/@yarnpkg/plugin-catalogs.cjs
-          spec: 'https://raw.githubusercontent.com/toss/yarn-plugin-catalogs/main/bundles/%40yarnpkg/plugin-catalogs.js'
-
-      catalogs:
-        list:
-          abc: 2.0.0
+      catalog:
+        abc: 2.0.0
     `);
     });
 
@@ -295,14 +223,8 @@ describe('modules/manager/npm/update/dependency/yarn', () => {
       const yarnrcYaml = codeBlock`
       nodeLinker: node-modules
 
-      plugins:
-        - checksum: 4cb9601cfc0c71e5b0ffd0a85b78e37430b62257040714c2558298ce1fc058f4e918903f0d1747a4fef3f58e15722c35bd76d27492d9d08aa5b04e235bf43b22
-          path: .yarn/plugins/@yarnpkg/plugin-catalogs.cjs
-          spec: 'https://raw.githubusercontent.com/toss/yarn-plugin-catalogs/main/bundles/%40yarnpkg/plugin-catalogs.js'
-
-      catalogs:
-        list:
-          gulp: gulpjs/gulp#v4.0.0-alpha.2
+      catalog:
+        gulp: gulpjs/gulp#v4.0.0-alpha.2
     `;
       const testContent = npmUpdater.updateDependency({
         fileContent: yarnrcYaml,
@@ -311,14 +233,8 @@ describe('modules/manager/npm/update/dependency/yarn', () => {
       expect(testContent).toEqual(codeBlock`
       nodeLinker: node-modules
 
-      plugins:
-        - checksum: 4cb9601cfc0c71e5b0ffd0a85b78e37430b62257040714c2558298ce1fc058f4e918903f0d1747a4fef3f58e15722c35bd76d27492d9d08aa5b04e235bf43b22
-          path: .yarn/plugins/@yarnpkg/plugin-catalogs.cjs
-          spec: 'https://raw.githubusercontent.com/toss/yarn-plugin-catalogs/main/bundles/%40yarnpkg/plugin-catalogs.js'
-
-      catalogs:
-        list:
-          gulp: gulpjs/gulp#v4.0.0
+      catalog:
+        gulp: gulpjs/gulp#v4.0.0
     `);
     });
 
@@ -334,14 +250,8 @@ describe('modules/manager/npm/update/dependency/yarn', () => {
       const yarnrcYaml = codeBlock`
       nodeLinker: node-modules
 
-      plugins:
-        - checksum: 4cb9601cfc0c71e5b0ffd0a85b78e37430b62257040714c2558298ce1fc058f4e918903f0d1747a4fef3f58e15722c35bd76d27492d9d08aa5b04e235bf43b22
-          path: .yarn/plugins/@yarnpkg/plugin-catalogs.cjs
-          spec: 'https://raw.githubusercontent.com/toss/yarn-plugin-catalogs/main/bundles/%40yarnpkg/plugin-catalogs.js'
-
-      catalogs:
-        list:
-          hapi: npm:@hapi/hapi@18.3.0
+      catalog:
+        hapi: npm:@hapi/hapi@18.3.0
     `;
       const testContent = npmUpdater.updateDependency({
         fileContent: yarnrcYaml,
@@ -350,14 +260,8 @@ describe('modules/manager/npm/update/dependency/yarn', () => {
       expect(testContent).toEqual(codeBlock`
       nodeLinker: node-modules
 
-      plugins:
-        - checksum: 4cb9601cfc0c71e5b0ffd0a85b78e37430b62257040714c2558298ce1fc058f4e918903f0d1747a4fef3f58e15722c35bd76d27492d9d08aa5b04e235bf43b22
-          path: .yarn/plugins/@yarnpkg/plugin-catalogs.cjs
-          spec: 'https://raw.githubusercontent.com/toss/yarn-plugin-catalogs/main/bundles/%40yarnpkg/plugin-catalogs.js'
-
-      catalogs:
-        list:
-          hapi: npm:@hapi/hapi@18.3.1
+      catalog:
+        hapi: npm:@hapi/hapi@18.3.1
     `);
     });
 
@@ -372,14 +276,8 @@ describe('modules/manager/npm/update/dependency/yarn', () => {
       const yarnrcYaml = codeBlock`
       nodeLinker: node-modules
 
-      plugins:
-        - checksum: 4cb9601cfc0c71e5b0ffd0a85b78e37430b62257040714c2558298ce1fc058f4e918903f0d1747a4fef3f58e15722c35bd76d27492d9d08aa5b04e235bf43b22
-          path: .yarn/plugins/@yarnpkg/plugin-catalogs.cjs
-          spec: 'https://raw.githubusercontent.com/toss/yarn-plugin-catalogs/main/bundles/%40yarnpkg/plugin-catalogs.js'
-
-      catalogs:
-        list:
-          gulp: gulpjs/gulp#abcdef7
+      catalog:
+        gulp: gulpjs/gulp#abcdef7
     `;
       const testContent = npmUpdater.updateDependency({
         fileContent: yarnrcYaml,
@@ -388,14 +286,8 @@ describe('modules/manager/npm/update/dependency/yarn', () => {
       expect(testContent).toEqual(codeBlock`
       nodeLinker: node-modules
 
-      plugins:
-        - checksum: 4cb9601cfc0c71e5b0ffd0a85b78e37430b62257040714c2558298ce1fc058f4e918903f0d1747a4fef3f58e15722c35bd76d27492d9d08aa5b04e235bf43b22
-          path: .yarn/plugins/@yarnpkg/plugin-catalogs.cjs
-          spec: 'https://raw.githubusercontent.com/toss/yarn-plugin-catalogs/main/bundles/%40yarnpkg/plugin-catalogs.js'
-
-      catalogs:
-        list:
-          gulp: gulpjs/gulp#0000000
+      catalog:
+        gulp: gulpjs/gulp#0000000
     `);
     });
 
@@ -410,14 +302,8 @@ describe('modules/manager/npm/update/dependency/yarn', () => {
       const yarnrcYaml = codeBlock`
       nodeLinker: node-modules
 
-      plugins:
-        - checksum: 4cb9601cfc0c71e5b0ffd0a85b78e37430b62257040714c2558298ce1fc058f4e918903f0d1747a4fef3f58e15722c35bd76d27492d9d08aa5b04e235bf43b22
-          path: .yarn/plugins/@yarnpkg/plugin-catalogs.cjs
-          spec: 'https://raw.githubusercontent.com/toss/yarn-plugin-catalogs/main/bundles/%40yarnpkg/plugin-catalogs.js'
-
-      catalogs:
-        list:
-          n: git+https://github.com/owner/n#v1.0.0
+      catalog:
+        n: git+https://github.com/owner/n#v1.0.0
     `;
       const testContent = npmUpdater.updateDependency({
         fileContent: yarnrcYaml,
@@ -426,14 +312,8 @@ describe('modules/manager/npm/update/dependency/yarn', () => {
       expect(testContent).toEqual(codeBlock`
       nodeLinker: node-modules
 
-      plugins:
-        - checksum: 4cb9601cfc0c71e5b0ffd0a85b78e37430b62257040714c2558298ce1fc058f4e918903f0d1747a4fef3f58e15722c35bd76d27492d9d08aa5b04e235bf43b22
-          path: .yarn/plugins/@yarnpkg/plugin-catalogs.cjs
-          spec: 'https://raw.githubusercontent.com/toss/yarn-plugin-catalogs/main/bundles/%40yarnpkg/plugin-catalogs.js'
-
-      catalogs:
-        list:
-          n: git+https://github.com/owner/n#v1.1.0
+      catalog:
+        n: git+https://github.com/owner/n#v1.1.0
     `);
     });
 
@@ -446,16 +326,11 @@ describe('modules/manager/npm/update/dependency/yarn', () => {
       const yarnrcYaml = codeBlock`
       nodeLinker: node-modules
 
-      plugins:
-        - checksum: 4cb9601cfc0c71e5b0ffd0a85b78e37430b62257040714c2558298ce1fc058f4e918903f0d1747a4fef3f58e15722c35bd76d27492d9d08aa5b04e235bf43b22
-          path: .yarn/plugins/@yarnpkg/plugin-catalogs.cjs
-          spec: 'https://raw.githubusercontent.com/toss/yarn-plugin-catalogs/main/bundles/%40yarnpkg/plugin-catalogs.js'
+      catalog:
 
       catalogs:
-        list:
-
-      catalog:
-        react: 18.3.1
+        react18:
+          react: 18.3.1
     `;
       const testContent = npmUpdater.updateDependency({
         fileContent: yarnrcYaml,
@@ -472,11 +347,6 @@ describe('modules/manager/npm/update/dependency/yarn', () => {
       };
       const yarnrcYaml = codeBlock`
       nodeLinker: node-modules
-
-      plugins:
-        - checksum: 4cb9601cfc0c71e5b0ffd0a85b78e37430b62257040714c2558298ce1fc058f4e918903f0d1747a4fef3f58e15722c35bd76d27492d9d08aa5b04e235bf43b22
-          path: .yarn/plugins/@yarnpkg/plugin-catalogs.cjs
-          spec: 'https://raw.githubusercontent.com/toss/yarn-plugin-catalogs/main/bundles/%40yarnpkg/plugin-catalogs.js'
 
     `;
       const testContent = npmUpdater.updateDependency({
@@ -508,14 +378,8 @@ describe('modules/manager/npm/update/dependency/yarn', () => {
       const yarnrcYaml = codeBlock`
       nodeLinker: node-modules
 
-      plugins:
-        - checksum: 4cb9601cfc0c71e5b0ffd0a85b78e37430b62257040714c2558298ce1fc058f4e918903f0d1747a4fef3f58e15722c35bd76d27492d9d08aa5b04e235bf43b22
-          path: .yarn/plugins/@yarnpkg/plugin-catalogs.cjs
-          spec: 'https://raw.githubusercontent.com/toss/yarn-plugin-catalogs/main/bundles/%40yarnpkg/plugin-catalogs.js'
-
-      catalogs:
-        list:
-          react:    18.3.1
+      catalog:
+        react:    18.3.1
 
     `;
       const testContent = npmUpdater.updateDependency({
@@ -525,14 +389,8 @@ describe('modules/manager/npm/update/dependency/yarn', () => {
       expect(testContent).toEqual(codeBlock`
       nodeLinker: node-modules
 
-      plugins:
-        - checksum: 4cb9601cfc0c71e5b0ffd0a85b78e37430b62257040714c2558298ce1fc058f4e918903f0d1747a4fef3f58e15722c35bd76d27492d9d08aa5b04e235bf43b22
-          path: .yarn/plugins/@yarnpkg/plugin-catalogs.cjs
-          spec: 'https://raw.githubusercontent.com/toss/yarn-plugin-catalogs/main/bundles/%40yarnpkg/plugin-catalogs.js'
-
-      catalogs:
-        list:
-          react:    19.0.0
+      catalog:
+        react:    19.0.0
     `);
     });
 
@@ -545,14 +403,8 @@ describe('modules/manager/npm/update/dependency/yarn', () => {
       const yarnrcYaml = codeBlock`
       nodeLinker: node-modules
 
-      plugins:
-        - checksum: 4cb9601cfc0c71e5b0ffd0a85b78e37430b62257040714c2558298ce1fc058f4e918903f0d1747a4fef3f58e15722c35bd76d27492d9d08aa5b04e235bf43b22
-          path: .yarn/plugins/@yarnpkg/plugin-catalogs.cjs
-          spec: 'https://raw.githubusercontent.com/toss/yarn-plugin-catalogs/main/bundles/%40yarnpkg/plugin-catalogs.js'
-
-      catalogs:
-        list:
-          react: '18.3.1'
+      catalog:
+        react: '18.3.1'
     `;
       const testContent = npmUpdater.updateDependency({
         fileContent: yarnrcYaml,
@@ -561,14 +413,8 @@ describe('modules/manager/npm/update/dependency/yarn', () => {
       expect(testContent).toEqual(codeBlock`
       nodeLinker: node-modules
 
-      plugins:
-        - checksum: 4cb9601cfc0c71e5b0ffd0a85b78e37430b62257040714c2558298ce1fc058f4e918903f0d1747a4fef3f58e15722c35bd76d27492d9d08aa5b04e235bf43b22
-          path: .yarn/plugins/@yarnpkg/plugin-catalogs.cjs
-          spec: 'https://raw.githubusercontent.com/toss/yarn-plugin-catalogs/main/bundles/%40yarnpkg/plugin-catalogs.js'
-
-      catalogs:
-        list:
-          react: '19.0.0'
+      catalog:
+        react: '19.0.0'
     `);
     });
 
@@ -581,16 +427,10 @@ describe('modules/manager/npm/update/dependency/yarn', () => {
       const yarnrcYaml = codeBlock`
       nodeLinker: node-modules
 
-      plugins:
-        - checksum: 4cb9601cfc0c71e5b0ffd0a85b78e37430b62257040714c2558298ce1fc058f4e918903f0d1747a4fef3f58e15722c35bd76d27492d9d08aa5b04e235bf43b22
-          path: .yarn/plugins/@yarnpkg/plugin-catalogs.cjs
-          spec: 'https://raw.githubusercontent.com/toss/yarn-plugin-catalogs/main/bundles/%40yarnpkg/plugin-catalogs.js'
-
-      catalogs:
-        list:
-          react: 18.3.1 # This is a comment
-          # This is another comment
-          react-dom: 18.3.1
+      catalog:
+        react: 18.3.1 # This is a comment
+        # This is another comment
+        react-dom: 18.3.1
     `;
       const testContent = npmUpdater.updateDependency({
         fileContent: yarnrcYaml,
@@ -599,16 +439,10 @@ describe('modules/manager/npm/update/dependency/yarn', () => {
       expect(testContent).toEqual(codeBlock`
       nodeLinker: node-modules
 
-      plugins:
-        - checksum: 4cb9601cfc0c71e5b0ffd0a85b78e37430b62257040714c2558298ce1fc058f4e918903f0d1747a4fef3f58e15722c35bd76d27492d9d08aa5b04e235bf43b22
-          path: .yarn/plugins/@yarnpkg/plugin-catalogs.cjs
-          spec: 'https://raw.githubusercontent.com/toss/yarn-plugin-catalogs/main/bundles/%40yarnpkg/plugin-catalogs.js'
-
-      catalogs:
-        list:
-          react: 19.0.0 # This is a comment
-          # This is another comment
-          react-dom: 18.3.1
+      catalog:
+        react: 19.0.0 # This is a comment
+        # This is another comment
+        react-dom: 18.3.1
     `);
     });
 
@@ -621,14 +455,8 @@ describe('modules/manager/npm/update/dependency/yarn', () => {
       const yarnrcYaml = codeBlock`
       nodeLinker: node-modules
 
-      plugins:
-        - checksum: 4cb9601cfc0c71e5b0ffd0a85b78e37430b62257040714c2558298ce1fc058f4e918903f0d1747a4fef3f58e15722c35bd76d27492d9d08aa5b04e235bf43b22
-          path: .yarn/plugins/@yarnpkg/plugin-catalogs.cjs
-          spec: 'https://raw.githubusercontent.com/toss/yarn-plugin-catalogs/main/bundles/%40yarnpkg/plugin-catalogs.js'
-
-      catalogs:
-        list:
-          react: "18.3.1"
+      catalog:
+        react: "18.3.1"
     `;
       const testContent = npmUpdater.updateDependency({
         fileContent: yarnrcYaml,
@@ -637,14 +465,8 @@ describe('modules/manager/npm/update/dependency/yarn', () => {
       expect(testContent).toEqual(codeBlock`
       nodeLinker: node-modules
 
-      plugins:
-        - checksum: 4cb9601cfc0c71e5b0ffd0a85b78e37430b62257040714c2558298ce1fc058f4e918903f0d1747a4fef3f58e15722c35bd76d27492d9d08aa5b04e235bf43b22
-          path: .yarn/plugins/@yarnpkg/plugin-catalogs.cjs
-          spec: 'https://raw.githubusercontent.com/toss/yarn-plugin-catalogs/main/bundles/%40yarnpkg/plugin-catalogs.js'
-
-      catalogs:
-        list:
-          react: "19.0.0"
+      catalog:
+        react: "19.0.0"
     `);
     });
 
@@ -660,15 +482,9 @@ describe('modules/manager/npm/update/dependency/yarn', () => {
       const yarnrcYaml = codeBlock`
       nodeLinker: node-modules
 
-      plugins:
-        - checksum: 4cb9601cfc0c71e5b0ffd0a85b78e37430b62257040714c2558298ce1fc058f4e918903f0d1747a4fef3f58e15722c35bd76d27492d9d08aa5b04e235bf43b22
-          path: .yarn/plugins/@yarnpkg/plugin-catalogs.cjs
-          spec: 'https://raw.githubusercontent.com/toss/yarn-plugin-catalogs/main/bundles/%40yarnpkg/plugin-catalogs.js'
-
-      catalogs:
-        list:
-          react: &react 18.3.1
-          react-dom: *react
+      catalog:
+        react: &react 18.3.1
+        react-dom: *react
     `;
       const testContent = npmUpdater.updateDependency({
         fileContent: yarnrcYaml,
@@ -677,15 +493,9 @@ describe('modules/manager/npm/update/dependency/yarn', () => {
       expect(testContent).toEqual(codeBlock`
       nodeLinker: node-modules
 
-      plugins:
-        - checksum: 4cb9601cfc0c71e5b0ffd0a85b78e37430b62257040714c2558298ce1fc058f4e918903f0d1747a4fef3f58e15722c35bd76d27492d9d08aa5b04e235bf43b22
-          path: .yarn/plugins/@yarnpkg/plugin-catalogs.cjs
-          spec: 'https://raw.githubusercontent.com/toss/yarn-plugin-catalogs/main/bundles/%40yarnpkg/plugin-catalogs.js'
-
-      catalogs:
-        list:
-          react: &react 19.0.0
-          react-dom: *react
+      catalog:
+        react: &react 19.0.0
+        react-dom: *react
     `);
     });
 
@@ -698,14 +508,8 @@ describe('modules/manager/npm/update/dependency/yarn', () => {
       const yarnrcYaml = codeBlock`
       nodeLinker: node-modules
 
-      plugins:
-        - checksum: 4cb9601cfc0c71e5b0ffd0a85b78e37430b62257040714c2558298ce1fc058f4e918903f0d1747a4fef3f58e15722c35bd76d27492d9d08aa5b04e235bf43b22
-          path: .yarn/plugins/@yarnpkg/plugin-catalogs.cjs
-          spec: 'https://raw.githubusercontent.com/toss/yarn-plugin-catalogs/main/bundles/%40yarnpkg/plugin-catalogs.js'
-
-      catalogs:
-        list:
-          react: &react    18.3.1
+      catalog:
+        react: &react    18.3.1
     `;
       const testContent = npmUpdater.updateDependency({
         fileContent: yarnrcYaml,
@@ -714,14 +518,8 @@ describe('modules/manager/npm/update/dependency/yarn', () => {
       expect(testContent).toEqual(codeBlock`
       nodeLinker: node-modules
 
-      plugins:
-        - checksum: 4cb9601cfc0c71e5b0ffd0a85b78e37430b62257040714c2558298ce1fc058f4e918903f0d1747a4fef3f58e15722c35bd76d27492d9d08aa5b04e235bf43b22
-          path: .yarn/plugins/@yarnpkg/plugin-catalogs.cjs
-          spec: 'https://raw.githubusercontent.com/toss/yarn-plugin-catalogs/main/bundles/%40yarnpkg/plugin-catalogs.js'
-
-      catalogs:
-        list:
-          react: &react    19.0.0
+      catalog:
+        react: &react    19.0.0
     `);
     });
 
@@ -734,14 +532,8 @@ describe('modules/manager/npm/update/dependency/yarn', () => {
       const yarnrcYaml = codeBlock`
       nodeLinker: node-modules
 
-      plugins:
-        - checksum: 4cb9601cfc0c71e5b0ffd0a85b78e37430b62257040714c2558298ce1fc058f4e918903f0d1747a4fef3f58e15722c35bd76d27492d9d08aa5b04e235bf43b22
-          path: .yarn/plugins/@yarnpkg/plugin-catalogs.cjs
-          spec: 'https://raw.githubusercontent.com/toss/yarn-plugin-catalogs/main/bundles/%40yarnpkg/plugin-catalogs.js'
-
-      catalogs:
-        list:
-          react: &react "18.3.1"
+      catalog:
+        react: &react "18.3.1"
     `;
       const testContent = npmUpdater.updateDependency({
         fileContent: yarnrcYaml,
@@ -750,14 +542,8 @@ describe('modules/manager/npm/update/dependency/yarn', () => {
       expect(testContent).toEqual(codeBlock`
        nodeLinker: node-modules
 
-      plugins:
-        - checksum: 4cb9601cfc0c71e5b0ffd0a85b78e37430b62257040714c2558298ce1fc058f4e918903f0d1747a4fef3f58e15722c35bd76d27492d9d08aa5b04e235bf43b22
-          path: .yarn/plugins/@yarnpkg/plugin-catalogs.cjs
-          spec: 'https://raw.githubusercontent.com/toss/yarn-plugin-catalogs/main/bundles/%40yarnpkg/plugin-catalogs.js'
-
-      catalogs:
-        list:
-          react: &react "19.0.0"
+      catalog:
+        react: &react "19.0.0"
     `);
     });
 
@@ -770,16 +556,10 @@ describe('modules/manager/npm/update/dependency/yarn', () => {
       const yarnrcYaml = codeBlock`
       nodeLinker: node-modules
 
-      plugins:
-        - checksum: 4cb9601cfc0c71e5b0ffd0a85b78e37430b62257040714c2558298ce1fc058f4e918903f0d1747a4fef3f58e15722c35bd76d27492d9d08aa5b04e235bf43b22
-          path: .yarn/plugins/@yarnpkg/plugin-catalogs.cjs
-          spec: 'https://raw.githubusercontent.com/toss/yarn-plugin-catalogs/main/bundles/%40yarnpkg/plugin-catalogs.js'
-
-      catalogs:
-        list: {
-          # This is a comment
-          "react": "18.3.1"
-        }
+      catalog: {
+        # This is a comment
+        "react": "18.3.1"
+      }
     `;
       const testContent = npmUpdater.updateDependency({
         fileContent: yarnrcYaml,
@@ -788,16 +568,10 @@ describe('modules/manager/npm/update/dependency/yarn', () => {
       expect(testContent).toEqual(codeBlock`
       nodeLinker: node-modules
 
-      plugins:
-        - checksum: 4cb9601cfc0c71e5b0ffd0a85b78e37430b62257040714c2558298ce1fc058f4e918903f0d1747a4fef3f58e15722c35bd76d27492d9d08aa5b04e235bf43b22
-          path: .yarn/plugins/@yarnpkg/plugin-catalogs.cjs
-          spec: 'https://raw.githubusercontent.com/toss/yarn-plugin-catalogs/main/bundles/%40yarnpkg/plugin-catalogs.js'
-
-      catalogs:
-        list: {
-          # This is a comment
-          "react": "19.0.0"
-        }
+      catalog: {
+        # This is a comment
+        "react": "19.0.0"
+      }
     `);
     });
 
@@ -816,15 +590,9 @@ describe('modules/manager/npm/update/dependency/yarn', () => {
 
       nodeLinker: node-modules
 
-      plugins:
-        - checksum: 4cb9601cfc0c71e5b0ffd0a85b78e37430b62257040714c2558298ce1fc058f4e918903f0d1747a4fef3f58e15722c35bd76d27492d9d08aa5b04e235bf43b22
-          path: .yarn/plugins/@yarnpkg/plugin-catalogs.cjs
-          spec: 'https://raw.githubusercontent.com/toss/yarn-plugin-catalogs/main/bundles/%40yarnpkg/plugin-catalogs.js'
-
-      catalogs:
-        list:
-          react: *react
-          react-dom: *react
+      catalog:
+        react: *react
+        react-dom: *react
     `;
       const testContent = npmUpdater.updateDependency({
         fileContent: yarnrcYaml,
@@ -845,14 +613,8 @@ describe('modules/manager/npm/update/dependency/yarn', () => {
 
       nodeLinker: node-modules
 
-      plugins:
-        - checksum: 4cb9601cfc0c71e5b0ffd0a85b78e37430b62257040714c2558298ce1fc058f4e918903f0d1747a4fef3f58e15722c35bd76d27492d9d08aa5b04e235bf43b22
-          path: .yarn/plugins/@yarnpkg/plugin-catalogs.cjs
-          spec: 'https://raw.githubusercontent.com/toss/yarn-plugin-catalogs/main/bundles/%40yarnpkg/plugin-catalogs.js'
-
-      catalogs:
-        list:
-          *r: 18.0.0
+      catalog:
+        *r: 18.0.0
     `;
       const testContent = npmUpdater.updateDependency({
         fileContent: yarnrcYaml,

--- a/lib/modules/manager/npm/update/dependency/yarn.ts
+++ b/lib/modules/manager/npm/update/dependency/yarn.ts
@@ -49,10 +49,9 @@ export function updateYarnrcCatalogDependency({
 
   const oldVersion =
     catalogName === 'default'
-      ? parsedContents.catalogs?.list?.[depName!]
-      : is.object(parsedContents.catalogs?.list?.[catalogName]) &&
-          is.string(depName)
-        ? parsedContents.catalogs?.list?.[catalogName][depName]
+      ? parsedContents.catalog?.[depName!]
+      : is.object(parsedContents.catalogs?.[catalogName]) && is.string(depName)
+        ? parsedContents.catalogs?.[catalogName][depName]
         : undefined;
 
   if (oldVersion === newValue) {
@@ -135,8 +134,8 @@ function getDepPath({
   depName: string;
 }): string[] {
   if (catalogName === 'default') {
-    return ['catalogs', 'list', depName];
+    return ['catalog', depName];
   } else {
-    return ['catalogs', 'list', catalogName, depName];
+    return ['catalogs', catalogName, depName];
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: community plugin yarn-catalogs-plugin is not supported anymore

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

support of the yarn built-in catalogs implementation https://yarnpkg.com/features/catalogs

## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/MKruschke/renovate-yarn-workspaces-buit-in

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
