### PR TITLE
feat(presets): rename `npm:unpublishSafe` to `security:minimumReleaseAgeNpm`

### DIFF
--- a/lib/config/migration.spec.ts
+++ b/lib/config/migration.spec.ts
@@ -433,28 +433,28 @@ describe('config/migration', () => {
       res = configMigration.migrateConfig(config);
       expect(res.isMigrated).toBeTrue();
       expect(res.migratedConfig).toMatchObject({
-        extends: ['npm:unpublishSafe'],
+        extends: ['security:minimumReleaseAgeNpm'],
       });
 
       config = { unpublishSafe: true, extends: 'foo' } as never;
       res = configMigration.migrateConfig(config);
       expect(res.isMigrated).toBeTrue();
       expect(res.migratedConfig).toMatchObject({
-        extends: ['foo', 'npm:unpublishSafe'],
+        extends: ['foo', 'security:minimumReleaseAgeNpm'],
       });
 
       config = { unpublishSafe: true, extends: [] };
       res = configMigration.migrateConfig(config);
       expect(res.isMigrated).toBeTrue();
       expect(res.migratedConfig).toMatchObject({
-        extends: ['npm:unpublishSafe'],
+        extends: ['security:minimumReleaseAgeNpm'],
       });
 
       config = { unpublishSafe: true, extends: ['foo', 'bar'] };
       res = configMigration.migrateConfig(config);
       expect(res.isMigrated).toBeTrue();
       expect(res.migratedConfig).toMatchObject({
-        extends: ['foo', 'bar', 'npm:unpublishSafe'],
+        extends: ['foo', 'bar', 'security:minimumReleaseAgeNpm'],
       });
 
       config = {
@@ -464,7 +464,7 @@ describe('config/migration', () => {
       res = configMigration.migrateConfig(config);
       expect(res.isMigrated).toBeTrue();
       expect(res.migratedConfig).toMatchObject({
-        extends: ['foo', 'npm:unpublishSafe', 'bar'],
+        extends: ['foo', 'security:minimumReleaseAgeNpm', 'bar'],
       });
 
       config = {
@@ -474,7 +474,7 @@ describe('config/migration', () => {
       res = configMigration.migrateConfig(config);
       expect(res.isMigrated).toBeTrue();
       expect(res.migratedConfig).toMatchObject({
-        extends: ['foo', 'npm:unpublishSafe', 'bar'],
+        extends: ['foo', 'security:minimumReleaseAgeNpm', 'bar'],
       });
 
       config = {
@@ -494,7 +494,7 @@ describe('config/migration', () => {
       res = configMigration.migrateConfig(config);
       expect(res.isMigrated).toBeTrue();
       expect(res.migratedConfig).toMatchObject({
-        extends: ['foo', 'bar', 'npm:unpublishSafe'],
+        extends: ['foo', 'bar', 'security:minimumReleaseAgeNpm'],
       });
 
       config = {
@@ -504,7 +504,26 @@ describe('config/migration', () => {
       res = configMigration.migrateConfig(config);
       expect(res.isMigrated).toBeTrue();
       expect(res.migratedConfig).toMatchObject({
-        extends: [':unpublishSafeDisabled', 'npm:unpublishSafe'],
+        extends: [':unpublishSafeDisabled', 'security:minimumReleaseAgeNpm'],
+      });
+    });
+
+    it('migrates npm:unpublishSafe', () => {
+      let config: TestRenovateConfig;
+      let res: MigratedConfig;
+
+      config = { extends: ['npm:unpublishSafe'] };
+      res = configMigration.migrateConfig(config);
+      expect(res.isMigrated).toBeTrue();
+      expect(res.migratedConfig).toMatchObject({
+        extends: ['security:minimumReleaseAgeNpm'],
+      });
+
+      config = { extends: ['foo', 'npm:unpublishSafe'] } as never;
+      res = configMigration.migrateConfig(config);
+      expect(res.isMigrated).toBeTrue();
+      expect(res.migratedConfig).toMatchObject({
+        extends: ['foo', 'security:minimumReleaseAgeNpm'],
       });
     });
 

--- a/lib/config/migrations/custom/unpublish-safe-migration.spec.ts
+++ b/lib/config/migrations/custom/unpublish-safe-migration.spec.ts
@@ -7,7 +7,7 @@ describe('config/migrations/custom/unpublish-safe-migration', () => {
         unpublishSafe: true,
       },
       {
-        extends: ['npm:unpublishSafe'],
+        extends: ['security:minimumReleaseAgeNpm'],
       },
     );
   });
@@ -19,7 +19,7 @@ describe('config/migrations/custom/unpublish-safe-migration', () => {
         unpublishSafe: true,
       } as any,
       {
-        extends: ['test', 'npm:unpublishSafe'],
+        extends: ['test', 'security:minimumReleaseAgeNpm'],
       },
     );
   });
@@ -31,7 +31,7 @@ describe('config/migrations/custom/unpublish-safe-migration', () => {
         unpublishSafe: true,
       } as any,
       {
-        extends: ['npm:unpublishSafe'],
+        extends: ['security:minimumReleaseAgeNpm'],
       },
     );
   });
@@ -43,7 +43,7 @@ describe('config/migrations/custom/unpublish-safe-migration', () => {
         unpublishSafe: true,
       } as any,
       {
-        extends: ['foo', 'npm:unpublishSafe', 'bar'],
+        extends: ['foo', 'security:minimumReleaseAgeNpm', 'bar'],
       },
     );
 
@@ -53,17 +53,17 @@ describe('config/migrations/custom/unpublish-safe-migration', () => {
         unpublishSafe: true,
       } as any,
       {
-        extends: ['foo', 'npm:unpublishSafe', 'bar'],
+        extends: ['foo', 'security:minimumReleaseAgeNpm', 'bar'],
       },
     );
 
     await expect(UnpublishSafeMigration).toMigrate(
       {
-        extends: ['foo', 'npm:unpublishSafe', 'bar'],
+        extends: ['foo', 'security:minimumReleaseAgeNpm', 'bar'],
         unpublishSafe: true,
       } as any,
       {
-        extends: ['foo', 'npm:unpublishSafe', 'bar'],
+        extends: ['foo', 'security:minimumReleaseAgeNpm', 'bar'],
       },
     );
   });
@@ -83,12 +83,26 @@ describe('config/migrations/custom/unpublish-safe-migration', () => {
   it('prevent duplicates', async () => {
     await expect(UnpublishSafeMigration).toMigrate(
       {
-        extends: ['npm:unpublishSafe'],
+        extends: ['security:minimumReleaseAgeNpm'],
         unpublishSafe: true,
+      },
+      {
+        extends: ['security:minimumReleaseAgeNpm'],
+      },
+    );
+  });
+
+  it('should not migrate npm:unpublishSafe', async () => {
+    // NOTE that this preset name is now deprecated, but will be handled by `ExtendsMigration` instead of handled in this migration
+
+    await expect(UnpublishSafeMigration).toMigrate(
+      {
+        extends: ['npm:unpublishSafe'],
       },
       {
         extends: ['npm:unpublishSafe'],
       },
+      false,
     );
   });
 });

--- a/lib/config/migrations/custom/unpublish-safe-migration.ts
+++ b/lib/config/migrations/custom/unpublish-safe-migration.ts
@@ -6,6 +6,7 @@ export class UnpublishSafeMigration extends AbstractMigration {
     ':unpublishSafe',
     'default:unpublishSafe',
     'npm:unpublishSafe',
+    'security:minimumReleaseAgeNpm',
   ];
 
   override readonly deprecated = true;
@@ -21,14 +22,14 @@ export class UnpublishSafeMigration extends AbstractMigration {
       }
 
       if (newExtendsValue.every((item) => !this.isSupportedValue(item))) {
-        newExtendsValue.push('npm:unpublishSafe');
+        newExtendsValue.push('security:minimumReleaseAgeNpm');
       }
 
       this.setHard(
         'extends',
         newExtendsValue.map((item) => {
           if (this.isSupportedValue(item)) {
-            return 'npm:unpublishSafe';
+            return 'security:minimumReleaseAgeNpm';
           }
 
           return item;

--- a/lib/config/presets/common.ts
+++ b/lib/config/presets/common.ts
@@ -30,6 +30,7 @@ export const removedPresets: Record<string, string | null> = {
   'helpers:oddIsUnstablePackages': null,
   'group:jsTestMonMajor': 'group:jsTestNonMajor',
   'github>whitesource/merge-confidence:beta': 'mergeConfidence:all-badges',
+  'npm:unpublishSafe': 'security:minimumReleaseAgeNpm',
   'replacements:messageFormat-{{package}}-to-@messageformat/{{package}}':
     'replacements:messageFormat-to-scoped',
   'regexManagers:azurePipelinesVersions':


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

As noted in #37952, we've seen a significant increase in recent years on
a number of package ecosystems being targeted with supply chain security
attacks.

We're looking to introduce a default for `minimumReleaseAge` in the
`best-practices` config preset, which will use the `npm:unpublishSafe`.

However, we'd first like to rename `npm:unpublishSafe` to
`security:minimumReleaseAgeNpm` to fit within the new proposed naming
scheme.

This introduces a config migration to make sure that we can provide
folks a non-breaking path for the new preset name.

## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
