### PR TITLE
test: correctly call `toMigrate` with vitest

### DIFF
--- a/lib/config/migrations/custom/automerge-major-migration.spec.ts
+++ b/lib/config/migrations/custom/automerge-major-migration.spec.ts
@@ -1,8 +1,8 @@
 import { AutomergeMajorMigration } from './automerge-major-migration';
 
 describe('config/migrations/custom/automerge-major-migration', () => {
-  it('should migrate value to object', () => {
-    expect(AutomergeMajorMigration).toMigrate(
+  it('should migrate value to object', async () => {
+    await expect(AutomergeMajorMigration).toMigrate(
       {
         automergeMajor: 'some-value',
       },
@@ -14,8 +14,8 @@ describe('config/migrations/custom/automerge-major-migration', () => {
     );
   });
 
-  it('should migrate value to object and concat with existing minor object', () => {
-    expect(AutomergeMajorMigration).toMigrate(
+  it('should migrate value to object and concat with existing minor object', async () => {
+    await expect(AutomergeMajorMigration).toMigrate(
       {
         automergeMajor: 'some-value',
         major: {
@@ -31,8 +31,8 @@ describe('config/migrations/custom/automerge-major-migration', () => {
     );
   });
 
-  it('should ignore non object minor value', () => {
-    expect(AutomergeMajorMigration).toMigrate(
+  it('should ignore non object minor value', async () => {
+    await expect(AutomergeMajorMigration).toMigrate(
       {
         automergeMajor: 'some-value',
         major: null,

--- a/lib/config/migrations/custom/automerge-migration.spec.ts
+++ b/lib/config/migrations/custom/automerge-migration.spec.ts
@@ -1,8 +1,8 @@
 import { AutomergeMigration } from './automerge-migration';
 
 describe('config/migrations/custom/automerge-migration', () => {
-  it('should migrate none', () => {
-    expect(AutomergeMigration).toMigrate(
+  it('should migrate none', async () => {
+    await expect(AutomergeMigration).toMigrate(
       {
         automerge: 'none',
       } as any,
@@ -12,8 +12,8 @@ describe('config/migrations/custom/automerge-migration', () => {
     );
   });
 
-  it('should migrate patch', () => {
-    expect(AutomergeMigration).toMigrate(
+  it('should migrate patch', async () => {
+    await expect(AutomergeMigration).toMigrate(
       {
         automerge: 'patch',
       } as any,
@@ -31,8 +31,8 @@ describe('config/migrations/custom/automerge-migration', () => {
     );
   });
 
-  it('should migrate minor', () => {
-    expect(AutomergeMigration).toMigrate(
+  it('should migrate minor', async () => {
+    await expect(AutomergeMigration).toMigrate(
       {
         automerge: 'minor',
       } as any,
@@ -47,8 +47,8 @@ describe('config/migrations/custom/automerge-migration', () => {
     );
   });
 
-  it('should migrate any', () => {
-    expect(AutomergeMigration).toMigrate(
+  it('should migrate any', async () => {
+    await expect(AutomergeMigration).toMigrate(
       {
         automerge: 'any',
       } as any,

--- a/lib/config/migrations/custom/automerge-minor-migration.spec.ts
+++ b/lib/config/migrations/custom/automerge-minor-migration.spec.ts
@@ -1,8 +1,8 @@
 import { AutomergeMinorMigration } from './automerge-minor-migration';
 
 describe('config/migrations/custom/automerge-minor-migration', () => {
-  it('should migrate value to object', () => {
-    expect(AutomergeMinorMigration).toMigrate(
+  it('should migrate value to object', async () => {
+    await expect(AutomergeMinorMigration).toMigrate(
       {
         automergeMinor: 'some-value',
       },
@@ -14,8 +14,8 @@ describe('config/migrations/custom/automerge-minor-migration', () => {
     );
   });
 
-  it('should migrate value to object and concat with existing minor object', () => {
-    expect(AutomergeMinorMigration).toMigrate(
+  it('should migrate value to object and concat with existing minor object', async () => {
+    await expect(AutomergeMinorMigration).toMigrate(
       {
         automergeMinor: 'some-value',
         minor: {
@@ -31,8 +31,8 @@ describe('config/migrations/custom/automerge-minor-migration', () => {
     );
   });
 
-  it('should ignore non object minor value', () => {
-    expect(AutomergeMinorMigration).toMigrate(
+  it('should ignore non object minor value', async () => {
+    await expect(AutomergeMinorMigration).toMigrate(
       {
         automergeMinor: 'some-value',
         minor: null,

--- a/lib/config/migrations/custom/automerge-patch-migration.spec.ts
+++ b/lib/config/migrations/custom/automerge-patch-migration.spec.ts
@@ -1,8 +1,8 @@
 import { AutomergePatchMigration } from './automerge-patch-migration';
 
 describe('config/migrations/custom/automerge-patch-migration', () => {
-  it('should migrate value to object', () => {
-    expect(AutomergePatchMigration).toMigrate(
+  it('should migrate value to object', async () => {
+    await expect(AutomergePatchMigration).toMigrate(
       {
         automergePatch: 'some-value',
       },
@@ -14,8 +14,8 @@ describe('config/migrations/custom/automerge-patch-migration', () => {
     );
   });
 
-  it('should migrate value to object and concat with existing minor object', () => {
-    expect(AutomergePatchMigration).toMigrate(
+  it('should migrate value to object and concat with existing minor object', async () => {
+    await expect(AutomergePatchMigration).toMigrate(
       {
         automergePatch: 'some-value',
         patch: {
@@ -31,8 +31,8 @@ describe('config/migrations/custom/automerge-patch-migration', () => {
     );
   });
 
-  it('should ignore non object minor value', () => {
-    expect(AutomergePatchMigration).toMigrate(
+  it('should ignore non object minor value', async () => {
+    await expect(AutomergePatchMigration).toMigrate(
       {
         automergePatch: 'some-value',
         patch: null,

--- a/lib/config/migrations/custom/automerge-type-migration.spec.ts
+++ b/lib/config/migrations/custom/automerge-type-migration.spec.ts
@@ -1,8 +1,8 @@
 import { AutomergeTypeMigration } from './automerge-type-migration';
 
 describe('config/migrations/custom/automerge-type-migration', () => {
-  it('should migrate string like "branch-" to "branch"', () => {
-    expect(AutomergeTypeMigration).toMigrate(
+  it('should migrate string like "branch-" to "branch"', async () => {
+    await expect(AutomergeTypeMigration).toMigrate(
       {
         automergeType: 'branch-test',
       },
@@ -12,8 +12,8 @@ describe('config/migrations/custom/automerge-type-migration', () => {
     );
   });
 
-  it('should not migrate another string value', () => {
-    expect(AutomergeTypeMigration).toMigrate(
+  it('should not migrate another string value', async () => {
+    await expect(AutomergeTypeMigration).toMigrate(
       {
         automergeType: 'test',
       },
@@ -24,8 +24,8 @@ describe('config/migrations/custom/automerge-type-migration', () => {
     );
   });
 
-  it('should not migrate non string value', () => {
-    expect(AutomergeTypeMigration).toMigrate(
+  it('should not migrate non string value', async () => {
+    await expect(AutomergeTypeMigration).toMigrate(
       {
         automergeType: true,
       },

--- a/lib/config/migrations/custom/azure-gitlab-automerge-migration.spec.ts
+++ b/lib/config/migrations/custom/azure-gitlab-automerge-migration.spec.ts
@@ -1,8 +1,8 @@
 import { AzureGitLabAutomergeMigration } from './azure-gitlab-automerge-migration';
 
 describe('config/migrations/custom/azure-gitlab-automerge-migration', () => {
-  it('should migrate non undefined gitLabAutomerge', () => {
-    expect(AzureGitLabAutomergeMigration).toMigrate(
+  it('should migrate non undefined gitLabAutomerge', async () => {
+    await expect(AzureGitLabAutomergeMigration).toMigrate(
       {
         gitLabAutomerge: true,
       },
@@ -12,8 +12,8 @@ describe('config/migrations/custom/azure-gitlab-automerge-migration', () => {
     );
   });
 
-  it('should just remove undefined gitLabAutomerge', () => {
-    expect(AzureGitLabAutomergeMigration).toMigrate(
+  it('should just remove undefined gitLabAutomerge', async () => {
+    await expect(AzureGitLabAutomergeMigration).toMigrate(
       {
         gitLabAutomerge: undefined,
       },
@@ -21,8 +21,8 @@ describe('config/migrations/custom/azure-gitlab-automerge-migration', () => {
     );
   });
 
-  it('should override platformAutomerge when gitLabAutomerge defined', () => {
-    expect(AzureGitLabAutomergeMigration).toMigrate(
+  it('should override platformAutomerge when gitLabAutomerge defined', async () => {
+    await expect(AzureGitLabAutomergeMigration).toMigrate(
       {
         gitLabAutomerge: true,
         platformAutomerge: false,
@@ -33,8 +33,8 @@ describe('config/migrations/custom/azure-gitlab-automerge-migration', () => {
     );
   });
 
-  it('should migrate non undefined azureAutoComplete', () => {
-    expect(AzureGitLabAutomergeMigration).toMigrate(
+  it('should migrate non undefined azureAutoComplete', async () => {
+    await expect(AzureGitLabAutomergeMigration).toMigrate(
       {
         azureAutoComplete: true,
       },
@@ -44,8 +44,8 @@ describe('config/migrations/custom/azure-gitlab-automerge-migration', () => {
     );
   });
 
-  it('should just remove undefined azureAutoComplete', () => {
-    expect(AzureGitLabAutomergeMigration).toMigrate(
+  it('should just remove undefined azureAutoComplete', async () => {
+    await expect(AzureGitLabAutomergeMigration).toMigrate(
       {
         azureAutoComplete: undefined,
       },
@@ -53,8 +53,8 @@ describe('config/migrations/custom/azure-gitlab-automerge-migration', () => {
     );
   });
 
-  it('should override platformAutomerge when azureAutoComplete defined', () => {
-    expect(AzureGitLabAutomergeMigration).toMigrate(
+  it('should override platformAutomerge when azureAutoComplete defined', async () => {
+    await expect(AzureGitLabAutomergeMigration).toMigrate(
       {
         azureAutoComplete: true,
         platformAutomerge: false,

--- a/lib/config/migrations/custom/base-branch-migration.spec.ts
+++ b/lib/config/migrations/custom/base-branch-migration.spec.ts
@@ -1,8 +1,8 @@
 import { BaseBranchMigration } from './base-branch-migration';
 
 describe('config/migrations/custom/base-branch-migration', () => {
-  it('should migrate value to array', () => {
-    expect(BaseBranchMigration).toMigrate(
+  it('should migrate value to array', async () => {
+    await expect(BaseBranchMigration).toMigrate(
       {
         baseBranch: 'test',
       },
@@ -12,8 +12,8 @@ describe('config/migrations/custom/base-branch-migration', () => {
     );
   });
 
-  it('should migrate array', () => {
-    expect(BaseBranchMigration).toMigrate(
+  it('should migrate array', async () => {
+    await expect(BaseBranchMigration).toMigrate(
       {
         baseBranch: ['test'],
       } as any,
@@ -23,8 +23,8 @@ describe('config/migrations/custom/base-branch-migration', () => {
     );
   });
 
-  it('should push to existing bassBranchPatterns', () => {
-    expect(BaseBranchMigration).toMigrate(
+  it('should push to existing bassBranchPatterns', async () => {
+    await expect(BaseBranchMigration).toMigrate(
       {
         baseBranch: ['test'],
         baseBranchPatterns: ['base'],

--- a/lib/config/migrations/custom/binary-source-migration.spec.ts
+++ b/lib/config/migrations/custom/binary-source-migration.spec.ts
@@ -1,8 +1,8 @@
 import { BinarySourceMigration } from './binary-source-migration';
 
 describe('config/migrations/custom/binary-source-migration', () => {
-  it('should migrate "auto" to "global"', () => {
-    expect(BinarySourceMigration).toMigrate(
+  it('should migrate "auto" to "global"', async () => {
+    await expect(BinarySourceMigration).toMigrate(
       {
         binarySource: 'auto',
       },

--- a/lib/config/migrations/custom/branch-name-migration.spec.ts
+++ b/lib/config/migrations/custom/branch-name-migration.spec.ts
@@ -1,8 +1,8 @@
 import { BranchNameMigration } from './branch-name-migration';
 
 describe('config/migrations/custom/branch-name-migration', () => {
-  it('should replace pattern', () => {
-    expect(BranchNameMigration).toMigrate(
+  it('should replace pattern', async () => {
+    await expect(BranchNameMigration).toMigrate(
       {
         branchName: 'test {{managerBranchPrefix}} test',
       },
@@ -12,8 +12,8 @@ describe('config/migrations/custom/branch-name-migration', () => {
     );
   });
 
-  it('should not replace another string', () => {
-    expect(BranchNameMigration).toMigrate(
+  it('should not replace another string', async () => {
+    await expect(BranchNameMigration).toMigrate(
       {
         branchName: 'test',
       },
@@ -24,8 +24,8 @@ describe('config/migrations/custom/branch-name-migration', () => {
     );
   });
 
-  it('should not replace non string value', () => {
-    expect(BranchNameMigration).toMigrate(
+  it('should not replace non string value', async () => {
+    await expect(BranchNameMigration).toMigrate(
       {
         branchName: true,
       } as any,

--- a/lib/config/migrations/custom/branch-prefix-migration.spec.ts
+++ b/lib/config/migrations/custom/branch-prefix-migration.spec.ts
@@ -1,8 +1,8 @@
 import { BranchPrefixMigration } from './branch-prefix-migration';
 
 describe('config/migrations/custom/branch-prefix-migration', () => {
-  it('should migrate template', () => {
-    expect(BranchPrefixMigration).toMigrate(
+  it('should migrate template', async () => {
+    await expect(BranchPrefixMigration).toMigrate(
       {
         branchPrefix: 'renovate/{{parentDir}}-',
       },
@@ -13,8 +13,8 @@ describe('config/migrations/custom/branch-prefix-migration', () => {
     );
   });
 
-  it('should ignore string without template', () => {
-    expect(BranchPrefixMigration).toMigrate(
+  it('should ignore string without template', async () => {
+    await expect(BranchPrefixMigration).toMigrate(
       {
         branchPrefix: 'test',
       },
@@ -25,8 +25,8 @@ describe('config/migrations/custom/branch-prefix-migration', () => {
     );
   });
 
-  it('should ignore non string without template', () => {
-    expect(BranchPrefixMigration).toMigrate(
+  it('should ignore non string without template', async () => {
+    await expect(BranchPrefixMigration).toMigrate(
       {
         branchPrefix: true,
       } as any,

--- a/lib/config/migrations/custom/compatibility-migration.spec.ts
+++ b/lib/config/migrations/custom/compatibility-migration.spec.ts
@@ -1,8 +1,8 @@
 import { CompatibilityMigration } from './compatibility-migration';
 
 describe('config/migrations/custom/compatibility-migration', () => {
-  it('should migrate object', () => {
-    expect(CompatibilityMigration).toMigrate(
+  it('should migrate object', async () => {
+    await expect(CompatibilityMigration).toMigrate(
       {
         compatibility: {
           test: 'test',
@@ -16,8 +16,8 @@ describe('config/migrations/custom/compatibility-migration', () => {
     );
   });
 
-  it('should just remove property when compatibility is not an object', () => {
-    expect(CompatibilityMigration).toMigrate(
+  it('should just remove property when compatibility is not an object', async () => {
+    await expect(CompatibilityMigration).toMigrate(
       {
         compatibility: 'test',
       },

--- a/lib/config/migrations/custom/composer-ignore-platform-reqs-migration.spec.ts
+++ b/lib/config/migrations/custom/composer-ignore-platform-reqs-migration.spec.ts
@@ -1,8 +1,8 @@
 import { ComposerIgnorePlatformReqsMigration } from './composer-ignore-platform-reqs-migration';
 
 describe('config/migrations/custom/composer-ignore-platform-reqs-migration', () => {
-  it('should migrate true to empty array', () => {
-    expect(ComposerIgnorePlatformReqsMigration).toMigrate(
+  it('should migrate true to empty array', async () => {
+    await expect(ComposerIgnorePlatformReqsMigration).toMigrate(
       {
         composerIgnorePlatformReqs: true,
       },
@@ -12,8 +12,8 @@ describe('config/migrations/custom/composer-ignore-platform-reqs-migration', () 
     );
   });
 
-  it('should migrate false to null', () => {
-    expect(ComposerIgnorePlatformReqsMigration).toMigrate(
+  it('should migrate false to null', async () => {
+    await expect(ComposerIgnorePlatformReqsMigration).toMigrate(
       {
         composerIgnorePlatformReqs: false,
       },
@@ -23,8 +23,8 @@ describe('config/migrations/custom/composer-ignore-platform-reqs-migration', () 
     );
   });
 
-  it('should not change array value', () => {
-    expect(ComposerIgnorePlatformReqsMigration).toMigrate(
+  it('should not change array value', async () => {
+    await expect(ComposerIgnorePlatformReqsMigration).toMigrate(
       {
         composerIgnorePlatformReqs: [],
       },

--- a/lib/config/migrations/custom/custom-managers-migration.spec.ts
+++ b/lib/config/migrations/custom/custom-managers-migration.spec.ts
@@ -3,8 +3,8 @@ import { CustomManagersMigration } from './custom-managers-migration';
 import { partial } from '~test/util';
 
 describe('config/migrations/custom/custom-managers-migration', () => {
-  it('migrates', () => {
-    expect(CustomManagersMigration).toMigrate(
+  it('migrates', async () => {
+    await expect(CustomManagersMigration).toMigrate(
       {
         customManagers: partial<CustomManager>([
           {

--- a/lib/config/migrations/custom/datasource-migration.spec.ts
+++ b/lib/config/migrations/custom/datasource-migration.spec.ts
@@ -1,8 +1,8 @@
 import { DatasourceMigration } from './datasource-migration';
 
 describe('config/migrations/custom/datasource-migration', () => {
-  it('should migrate adoptium-java', () => {
-    expect(DatasourceMigration).toMigrate(
+  it('should migrate adoptium-java', async () => {
+    await expect(DatasourceMigration).toMigrate(
       {
         datasource: 'adoptium-java',
       },
@@ -12,8 +12,8 @@ describe('config/migrations/custom/datasource-migration', () => {
     );
   });
 
-  it('should migrate donet', () => {
-    expect(DatasourceMigration).toMigrate(
+  it('should migrate donet', async () => {
+    await expect(DatasourceMigration).toMigrate(
       {
         datasource: 'dotnet',
       },
@@ -23,8 +23,8 @@ describe('config/migrations/custom/datasource-migration', () => {
     );
   });
 
-  it('should migrate node', () => {
-    expect(DatasourceMigration).toMigrate(
+  it('should migrate node', async () => {
+    await expect(DatasourceMigration).toMigrate(
       {
         datasource: 'node',
       },

--- a/lib/config/migrations/custom/dep-types-migration.spec.ts
+++ b/lib/config/migrations/custom/dep-types-migration.spec.ts
@@ -1,8 +1,8 @@
 import { DepTypesMigration } from './dep-types-migration';
 
 describe('config/migrations/custom/dep-types-migration', () => {
-  it('should only add depTypes to packageRules', () => {
-    expect(DepTypesMigration).toMigrate(
+  it('should only add depTypes to packageRules', async () => {
+    await expect(DepTypesMigration).toMigrate(
       {
         peerDependencies: {
           versionStrategy: 'widen',

--- a/lib/config/migrations/custom/dry-run-migration.spec.ts
+++ b/lib/config/migrations/custom/dry-run-migration.spec.ts
@@ -1,8 +1,8 @@
 import { DryRunMigration } from './dry-run-migration';
 
 describe('config/migrations/custom/dry-run-migration', () => {
-  it('should migrate dryRun=true to dryRun=full', () => {
-    expect(DryRunMigration).toMigrate(
+  it('should migrate dryRun=true to dryRun=full', async () => {
+    await expect(DryRunMigration).toMigrate(
       {
         dryRun: true,
       },
@@ -12,8 +12,8 @@ describe('config/migrations/custom/dry-run-migration', () => {
     );
   });
 
-  it('should migrate dryRun=false to dryRun=null', () => {
-    expect(DryRunMigration).toMigrate(
+  it('should migrate dryRun=false to dryRun=null', async () => {
+    await expect(DryRunMigration).toMigrate(
       {
         dryRun: false,
       },

--- a/lib/config/migrations/custom/enabled-managers-migration.spec.ts
+++ b/lib/config/migrations/custom/enabled-managers-migration.spec.ts
@@ -1,8 +1,8 @@
 import { EnabledManagersMigration } from './enabled-managers-migration';
 
 describe('config/migrations/custom/enabled-managers-migration', () => {
-  it('migrates', () => {
-    expect(EnabledManagersMigration).toMigrate(
+  it('migrates', async () => {
+    await expect(EnabledManagersMigration).toMigrate(
       {
         enabledManagers: ['test1', 'yarn', 'test2', 'regex', 'custom.regex'],
       },
@@ -18,7 +18,7 @@ describe('config/migrations/custom/enabled-managers-migration', () => {
     );
 
     // coverage
-    expect(EnabledManagersMigration).not.toMigrate(
+    await expect(EnabledManagersMigration).not.toMigrate(
       {
         enabledManagers: undefined,
       },

--- a/lib/config/migrations/custom/extends-migration.spec.ts
+++ b/lib/config/migrations/custom/extends-migration.spec.ts
@@ -2,8 +2,8 @@ import { GlobalConfig } from '../../global';
 import { ExtendsMigration } from './extends-migration';
 
 describe('config/migrations/custom/extends-migration', () => {
-  it('migrates preset strings to array', () => {
-    expect(ExtendsMigration).toMigrate(
+  it('migrates preset strings to array', async () => {
+    await expect(ExtendsMigration).toMigrate(
       {
         extends: ':js-app',
       } as any,
@@ -12,7 +12,7 @@ describe('config/migrations/custom/extends-migration', () => {
       },
     );
 
-    expect(ExtendsMigration).toMigrate(
+    await expect(ExtendsMigration).toMigrate(
       {
         extends: 'foo',
       } as any,
@@ -22,8 +22,8 @@ describe('config/migrations/custom/extends-migration', () => {
     );
   });
 
-  it('migrates presets array', () => {
-    expect(ExtendsMigration).toMigrate(
+  it('migrates presets array', async () => {
+    await expect(ExtendsMigration).toMigrate(
       {
         extends: ['foo', ':js-app', 'bar'],
       },
@@ -33,8 +33,8 @@ describe('config/migrations/custom/extends-migration', () => {
     );
   });
 
-  it('should remove non string values', () => {
-    expect(ExtendsMigration).toMigrate(
+  it('should remove non string values', async () => {
+    await expect(ExtendsMigration).toMigrate(
       {
         extends: [{}],
       } as any,
@@ -44,8 +44,8 @@ describe('config/migrations/custom/extends-migration', () => {
     );
   });
 
-  it('should remove removed presets', () => {
-    expect(ExtendsMigration).toMigrate(
+  it('should remove removed presets', async () => {
+    await expect(ExtendsMigration).toMigrate(
       {
         extends: ['helpers:oddIsUnstable'],
       },
@@ -55,14 +55,14 @@ describe('config/migrations/custom/extends-migration', () => {
     );
   });
 
-  it('migrates presets', () => {
+  it('migrates presets', async () => {
     GlobalConfig.set({
       migratePresets: {
         '@org': 'local>org/renovate-config',
         '@org2/foo': '',
       },
     });
-    expect(ExtendsMigration).toMigrate(
+    await expect(ExtendsMigration).toMigrate(
       {
         extends: ['@org', '@org2/foo'],
       },
@@ -73,8 +73,8 @@ describe('config/migrations/custom/extends-migration', () => {
     GlobalConfig.reset();
   });
 
-  it('migrate merge confidence config preset to internal preset', () => {
-    expect(ExtendsMigration).toMigrate(
+  it('migrate merge confidence config preset to internal preset', async () => {
+    await expect(ExtendsMigration).toMigrate(
       {
         extends: ['github>whitesource/merge-confidence:beta'],
       },

--- a/lib/config/migrations/custom/fetch-release-notes-migration.spec.ts
+++ b/lib/config/migrations/custom/fetch-release-notes-migration.spec.ts
@@ -1,8 +1,8 @@
 import { FetchReleaseNotesMigration } from './fetch-release-notes-migration';
 
 describe('config/migrations/custom/fetch-release-notes-migration', () => {
-  it('migrates', () => {
-    expect(FetchReleaseNotesMigration).toMigrate(
+  it('migrates', async () => {
+    await expect(FetchReleaseNotesMigration).toMigrate(
       {
         fetchReleaseNotes: false as never,
       },
@@ -10,7 +10,7 @@ describe('config/migrations/custom/fetch-release-notes-migration', () => {
         fetchChangeLogs: 'off',
       },
     );
-    expect(FetchReleaseNotesMigration).toMigrate(
+    await expect(FetchReleaseNotesMigration).toMigrate(
       {
         fetchReleaseNotes: true as never,
       },
@@ -18,7 +18,7 @@ describe('config/migrations/custom/fetch-release-notes-migration', () => {
         fetchChangeLogs: 'pr',
       },
     );
-    expect(FetchReleaseNotesMigration).toMigrate(
+    await expect(FetchReleaseNotesMigration).toMigrate(
       {
         fetchReleaseNotes: 'pr',
       },
@@ -26,7 +26,7 @@ describe('config/migrations/custom/fetch-release-notes-migration', () => {
         fetchChangeLogs: 'pr',
       },
     );
-    expect(FetchReleaseNotesMigration).toMigrate(
+    await expect(FetchReleaseNotesMigration).toMigrate(
       {
         fetchReleaseNotes: 'off',
       },
@@ -34,7 +34,7 @@ describe('config/migrations/custom/fetch-release-notes-migration', () => {
         fetchChangeLogs: 'off',
       },
     );
-    expect(FetchReleaseNotesMigration).toMigrate(
+    await expect(FetchReleaseNotesMigration).toMigrate(
       {
         fetchReleaseNotes: 'branch',
       },

--- a/lib/config/migrations/custom/file-match-migration.spec.ts
+++ b/lib/config/migrations/custom/file-match-migration.spec.ts
@@ -1,8 +1,8 @@
 import { FileMatchMigration } from './file-match-migration';
 
 describe('config/migrations/custom/file-match-migration', () => {
-  it('migrates fileMatch of type string', () => {
-    expect(FileMatchMigration).toMigrate(
+  it('migrates fileMatch of type string', async () => {
+    await expect(FileMatchMigration).toMigrate(
       {
         fileMatch: 'filename',
       },
@@ -12,8 +12,8 @@ describe('config/migrations/custom/file-match-migration', () => {
     );
   });
 
-  it('migrates fileMatch of type array', () => {
-    expect(FileMatchMigration).toMigrate(
+  it('migrates fileMatch of type array', async () => {
+    await expect(FileMatchMigration).toMigrate(
       {
         fileMatch: ['filename1', 'filename2'],
       },
@@ -23,8 +23,8 @@ describe('config/migrations/custom/file-match-migration', () => {
     );
   });
 
-  it('concats fileMatch to managerFilePatterns', () => {
-    expect(FileMatchMigration).toMigrate(
+  it('concats fileMatch to managerFilePatterns', async () => {
+    await expect(FileMatchMigration).toMigrate(
       {
         fileMatch: ['filename1', 'filename2'],
         managerFilePatterns: ['filename3'],
@@ -35,8 +35,8 @@ describe('config/migrations/custom/file-match-migration', () => {
     );
   });
 
-  it('does nothing if fileMatch not defined', () => {
-    expect(FileMatchMigration).toMigrate(
+  it('does nothing if fileMatch not defined', async () => {
+    await expect(FileMatchMigration).toMigrate(
       {
         managerFilePatterns: ['filename3'],
       },

--- a/lib/config/migrations/custom/go-mod-tidy-migration.spec.ts
+++ b/lib/config/migrations/custom/go-mod-tidy-migration.spec.ts
@@ -1,8 +1,8 @@
 import { GoModTidyMigration } from './go-mod-tidy-migration';
 
 describe('config/migrations/custom/go-mod-tidy-migration', () => {
-  it('should add postUpdateOptions option when true', () => {
-    expect(GoModTidyMigration).toMigrate(
+  it('should add postUpdateOptions option when true', async () => {
+    await expect(GoModTidyMigration).toMigrate(
       {
         gomodTidy: true,
         postUpdateOptions: ['test'],
@@ -13,8 +13,8 @@ describe('config/migrations/custom/go-mod-tidy-migration', () => {
     );
   });
 
-  it('should handle case when postUpdateOptions is not defined', () => {
-    expect(GoModTidyMigration).toMigrate(
+  it('should handle case when postUpdateOptions is not defined', async () => {
+    await expect(GoModTidyMigration).toMigrate(
       {
         gomodTidy: true,
       },
@@ -24,8 +24,8 @@ describe('config/migrations/custom/go-mod-tidy-migration', () => {
     );
   });
 
-  it('should only remove when false', () => {
-    expect(GoModTidyMigration).toMigrate(
+  it('should only remove when false', async () => {
+    await expect(GoModTidyMigration).toMigrate(
       {
         gomodTidy: false,
       },

--- a/lib/config/migrations/custom/host-rules-migration.spec.ts
+++ b/lib/config/migrations/custom/host-rules-migration.spec.ts
@@ -2,8 +2,8 @@ import { CONFIG_VALIDATION } from '../../../constants/error-messages';
 import { HostRulesMigration } from './host-rules-migration';
 
 describe('config/migrations/custom/host-rules-migration', () => {
-  it('should migrate array', () => {
-    expect(HostRulesMigration).toMigrate(
+  it('should migrate array', async () => {
+    await expect(HostRulesMigration).toMigrate(
       {
         hostRules: [
           {

--- a/lib/config/migrations/custom/ignore-node-modules-migration.spec.ts
+++ b/lib/config/migrations/custom/ignore-node-modules-migration.spec.ts
@@ -1,8 +1,8 @@
 import { IgnoreNodeModulesMigration } from './ignore-node-modules-migration';
 
 describe('config/migrations/custom/ignore-node-modules-migration', () => {
-  it('should migrate to ignorePaths', () => {
-    expect(IgnoreNodeModulesMigration).toMigrate(
+  it('should migrate to ignorePaths', async () => {
+    await expect(IgnoreNodeModulesMigration).toMigrate(
       {
         ignoreNodeModules: true,
       },

--- a/lib/config/migrations/custom/ignore-npmrc-file-migration.spec.ts
+++ b/lib/config/migrations/custom/ignore-npmrc-file-migration.spec.ts
@@ -1,8 +1,8 @@
 import { IgnoreNpmrcFileMigration } from './ignore-npmrc-file-migration';
 
 describe('config/migrations/custom/ignore-npmrc-file-migration', () => {
-  it('should init npmrc field', () => {
-    expect(IgnoreNpmrcFileMigration).toMigrate(
+  it('should init npmrc field', async () => {
+    await expect(IgnoreNpmrcFileMigration).toMigrate(
       {
         ignoreNpmrcFile: true,
       },
@@ -12,8 +12,8 @@ describe('config/migrations/custom/ignore-npmrc-file-migration', () => {
     );
   });
 
-  it('should not change npmrc field if it represents string value', () => {
-    expect(IgnoreNpmrcFileMigration).toMigrate(
+  it('should not change npmrc field if it represents string value', async () => {
+    await expect(IgnoreNpmrcFileMigration).toMigrate(
       {
         ignoreNpmrcFile: true,
         npmrc: '',
@@ -24,8 +24,8 @@ describe('config/migrations/custom/ignore-npmrc-file-migration', () => {
     );
   });
 
-  it('should change npmrc field if it not represents string value', () => {
-    expect(IgnoreNpmrcFileMigration).toMigrate(
+  it('should change npmrc field if it not represents string value', async () => {
+    await expect(IgnoreNpmrcFileMigration).toMigrate(
       {
         ignoreNpmrcFile: true,
         npmrc: true,

--- a/lib/config/migrations/custom/include-forks-migration.spec.ts
+++ b/lib/config/migrations/custom/include-forks-migration.spec.ts
@@ -1,8 +1,8 @@
 import { IncludeForksMigration } from './include-forks-migration';
 
 describe('config/migrations/custom/include-forks-migration', () => {
-  it('should migrate true', () => {
-    expect(IncludeForksMigration).toMigrate(
+  it('should migrate true', async () => {
+    await expect(IncludeForksMigration).toMigrate(
       {
         includeForks: true,
       },
@@ -12,8 +12,8 @@ describe('config/migrations/custom/include-forks-migration', () => {
     );
   });
 
-  it('should migrate false', () => {
-    expect(IncludeForksMigration).toMigrate(
+  it('should migrate false', async () => {
+    await expect(IncludeForksMigration).toMigrate(
       {
         includeForks: false,
       },
@@ -23,8 +23,8 @@ describe('config/migrations/custom/include-forks-migration', () => {
     );
   });
 
-  it('should not migrate non boolean value', () => {
-    expect(IncludeForksMigration).toMigrate(
+  it('should not migrate non boolean value', async () => {
+    await expect(IncludeForksMigration).toMigrate(
       {
         includeForks: 'test',
       },

--- a/lib/config/migrations/custom/match-datasources-migration.spec.ts
+++ b/lib/config/migrations/custom/match-datasources-migration.spec.ts
@@ -1,8 +1,8 @@
 import { MatchDatasourcesMigration } from './match-datasources-migration';
 
 describe('config/migrations/custom/match-datasources-migration', () => {
-  it('should migrate properly', () => {
-    expect(MatchDatasourcesMigration).toMigrate(
+  it('should migrate properly', async () => {
+    await expect(MatchDatasourcesMigration).toMigrate(
       {
         matchDatasources: ['adoptium-java', 'dotnet', 'npm', 'node'],
       },

--- a/lib/config/migrations/custom/match-managers-migration.spec.ts
+++ b/lib/config/migrations/custom/match-managers-migration.spec.ts
@@ -1,8 +1,8 @@
 import { MatchManagersMigration } from './match-managers-migration';
 
 describe('config/migrations/custom/match-managers-migration', () => {
-  it('migrates old custom manager syntax to new one', () => {
-    expect(MatchManagersMigration).toMigrate(
+  it('migrates old custom manager syntax to new one', async () => {
+    await expect(MatchManagersMigration).toMigrate(
       {
         matchManagers: ['npm', 'regex', 'custom.regex', 'custom.someMgr'],
       },
@@ -18,8 +18,8 @@ describe('config/migrations/custom/match-managers-migration', () => {
   });
 
   // coverage
-  it('only migrates when necessary', () => {
-    expect(MatchManagersMigration).not.toMigrate(
+  it('only migrates when necessary', async () => {
+    await expect(MatchManagersMigration).not.toMigrate(
       {
         matchManagers: undefined,
       },

--- a/lib/config/migrations/custom/match-strings-migration.spec.ts
+++ b/lib/config/migrations/custom/match-strings-migration.spec.ts
@@ -1,8 +1,8 @@
 import { MatchStringsMigration } from './match-strings-migration';
 
 describe('config/migrations/custom/match-strings-migration', () => {
-  it('should migrate properly', () => {
-    expect(MatchStringsMigration).toMigrate(
+  it('should migrate properly', async () => {
+    await expect(MatchStringsMigration).toMigrate(
       {
         matchStrings: [
           undefined,

--- a/lib/config/migrations/custom/node-migration.spec.ts
+++ b/lib/config/migrations/custom/node-migration.spec.ts
@@ -1,8 +1,8 @@
 import { NodeMigration } from './node-migration';
 
 describe('config/migrations/custom/node-migration', () => {
-  it('should migrate node to travis', () => {
-    expect(NodeMigration).toMigrate(
+  it('should migrate node to travis', async () => {
+    await expect(NodeMigration).toMigrate(
       {
         node: { enabled: true },
       },
@@ -12,8 +12,8 @@ describe('config/migrations/custom/node-migration', () => {
     );
   });
 
-  it('should not delete node in case it has more than one property', () => {
-    expect(NodeMigration).toMigrate(
+  it('should not delete node in case it has more than one property', async () => {
+    await expect(NodeMigration).toMigrate(
       {
         node: { enabled: true, automerge: false },
       },

--- a/lib/config/migrations/custom/package-files-migration.spec.ts
+++ b/lib/config/migrations/custom/package-files-migration.spec.ts
@@ -1,8 +1,8 @@
 import { PackageFilesMigration } from './package-files-migration';
 
 describe('config/migrations/custom/package-files-migration', () => {
-  it('should migrate value to array', () => {
-    expect(PackageFilesMigration).toMigrate(
+  it('should migrate value to array', async () => {
+    await expect(PackageFilesMigration).toMigrate(
       {
         packageFiles: [
           {
@@ -18,8 +18,8 @@ describe('config/migrations/custom/package-files-migration', () => {
     );
   });
 
-  it('should handle multiple packageFile', () => {
-    expect(PackageFilesMigration).toMigrate(
+  it('should handle multiple packageFile', async () => {
+    await expect(PackageFilesMigration).toMigrate(
       {
         packageFiles: [['package.json', 'Chart.yaml']],
       },
@@ -29,8 +29,8 @@ describe('config/migrations/custom/package-files-migration', () => {
     );
   });
 
-  it('should still work for wrong config', () => {
-    expect(PackageFilesMigration).toMigrate(
+  it('should still work for wrong config', async () => {
+    await expect(PackageFilesMigration).toMigrate(
       {
         packageRules: [{ labels: ['lint'] }],
         packageFiles: [
@@ -53,8 +53,8 @@ describe('config/migrations/custom/package-files-migration', () => {
     );
   });
 
-  it('should work for non-object packageFiles', () => {
-    expect(PackageFilesMigration).toMigrate(
+  it('should work for non-object packageFiles', async () => {
+    await expect(PackageFilesMigration).toMigrate(
       {
         packageFiles: ['package.json'],
       },
@@ -64,8 +64,8 @@ describe('config/migrations/custom/package-files-migration', () => {
     );
   });
 
-  it('should work for nested rules', () => {
-    expect(PackageFilesMigration).toMigrate(
+  it('should work for nested rules', async () => {
+    await expect(PackageFilesMigration).toMigrate(
       {
         packageFiles: [
           {
@@ -96,8 +96,8 @@ describe('config/migrations/custom/package-files-migration', () => {
     );
   });
 
-  it('no change for empty packageFiles', () => {
-    expect(PackageFilesMigration).toMigrate(
+  it('no change for empty packageFiles', async () => {
+    await expect(PackageFilesMigration).toMigrate(
       {
         includePaths: ['package.json'],
         packageRules: [{ labels: ['linter'] }],

--- a/lib/config/migrations/custom/package-name-migration.spec.ts
+++ b/lib/config/migrations/custom/package-name-migration.spec.ts
@@ -1,8 +1,8 @@
 import { PackageNameMigration } from './package-name-migration';
 
 describe('config/migrations/custom/package-name-migration', () => {
-  it('should migrate value to array', () => {
-    expect(PackageNameMigration).toMigrate(
+  it('should migrate value to array', async () => {
+    await expect(PackageNameMigration).toMigrate(
       {
         packageName: 'test',
       },

--- a/lib/config/migrations/custom/package-pattern-migration.spec.ts
+++ b/lib/config/migrations/custom/package-pattern-migration.spec.ts
@@ -1,8 +1,8 @@
 import { PackagePatternMigration } from './package-pattern-migration';
 
 describe('config/migrations/custom/package-pattern-migration', () => {
-  it('should migrate value to array', () => {
-    expect(PackagePatternMigration).toMigrate(
+  it('should migrate value to array', async () => {
+    await expect(PackagePatternMigration).toMigrate(
       {
         packagePattern: 'test',
       },

--- a/lib/config/migrations/custom/package-rules-migration.spec.ts
+++ b/lib/config/migrations/custom/package-rules-migration.spec.ts
@@ -31,8 +31,8 @@ describe('config/migrations/custom/package-rules-migration', () => {
     expect(mappedProperties).toEqual(expectedMappedProperties);
   });
 
-  it('should not migrate nested packageRules', () => {
-    expect(PackageRulesMigration).toMigrate(
+  it('should not migrate nested packageRules', async () => {
+    await expect(PackageRulesMigration).toMigrate(
       {
         packageRules: [
           {
@@ -56,8 +56,8 @@ describe('config/migrations/custom/package-rules-migration', () => {
     );
   });
 
-  it('should migrate languages to categories', () => {
-    expect(PackageRulesMigration).toMigrate(
+  it('should migrate languages to categories', async () => {
+    await expect(PackageRulesMigration).toMigrate(
       {
         packageRules: [
           {
@@ -85,8 +85,8 @@ describe('config/migrations/custom/package-rules-migration', () => {
     );
   });
 
-  it('should migrate single match rule', () => {
-    expect(PackageRulesMigration).toMigrate(
+  it('should migrate single match rule', async () => {
+    await expect(PackageRulesMigration).toMigrate(
       {
         packageRules: [
           {
@@ -106,8 +106,8 @@ describe('config/migrations/custom/package-rules-migration', () => {
     );
   });
 
-  it('should migrate excludePackageNames to matchPackageNames', () => {
-    expect(PackageRulesMigration).toMigrate(
+  it('should migrate excludePackageNames to matchPackageNames', async () => {
+    await expect(PackageRulesMigration).toMigrate(
       {
         packageRules: [
           {
@@ -136,8 +136,8 @@ describe('config/migrations/custom/package-rules-migration', () => {
     );
   });
 
-  it('should migrate matchPackagePatterns to matchPackageNames', () => {
-    expect(PackageRulesMigration).toMigrate(
+  it('should migrate matchPackagePatterns to matchPackageNames', async () => {
+    await expect(PackageRulesMigration).toMigrate(
       {
         packageRules: [
           {
@@ -174,8 +174,8 @@ describe('config/migrations/custom/package-rules-migration', () => {
     );
   });
 
-  it('should migrate all match/exclude when value is of type string', () => {
-    expect(PackageRulesMigration).toMigrate(
+  it('should migrate all match/exclude when value is of type string', async () => {
+    await expect(PackageRulesMigration).toMigrate(
       {
         packageRules: [
           {
@@ -219,8 +219,8 @@ describe('config/migrations/custom/package-rules-migration', () => {
     );
   });
 
-  it('should migrate all match/exclude at once', () => {
-    expect(PackageRulesMigration).toMigrate(
+  it('should migrate all match/exclude at once', async () => {
+    await expect(PackageRulesMigration).toMigrate(
       {
         packageRules: [
           {

--- a/lib/config/migrations/custom/packages-migration.spec.ts
+++ b/lib/config/migrations/custom/packages-migration.spec.ts
@@ -1,8 +1,8 @@
 import { PackagesMigration } from './packages-migration';
 
 describe('config/migrations/custom/packages-migration', () => {
-  it('should migrate to package rules', () => {
-    expect(PackagesMigration).toMigrate(
+  it('should migrate to package rules', async () => {
+    await expect(PackagesMigration).toMigrate(
       {
         packages: [{ matchPackageNames: ['*'] }],
       },
@@ -12,8 +12,8 @@ describe('config/migrations/custom/packages-migration', () => {
     );
   });
 
-  it('should concat with existing package rules', () => {
-    expect(PackagesMigration).toMigrate(
+  it('should concat with existing package rules', async () => {
+    await expect(PackagesMigration).toMigrate(
       {
         packages: [{ matchPackageNames: ['*'] }],
         packageRules: [{ matchPackageNames: [] }],
@@ -24,8 +24,8 @@ describe('config/migrations/custom/packages-migration', () => {
     );
   });
 
-  it('should ignore non array value', () => {
-    expect(PackagesMigration).toMigrate(
+  it('should ignore non array value', async () => {
+    await expect(PackagesMigration).toMigrate(
       {
         packages: { matchPackageNames: ['*'] },
         packageRules: [{ matchPackageNames: [] }],

--- a/lib/config/migrations/custom/path-rules-migration.spec.ts
+++ b/lib/config/migrations/custom/path-rules-migration.spec.ts
@@ -1,8 +1,8 @@
 import { PathRulesMigration } from './path-rules-migration';
 
 describe('config/migrations/custom/path-rules-migration', () => {
-  it('should migrate to packageRules', () => {
-    expect(PathRulesMigration).toMigrate(
+  it('should migrate to packageRules', async () => {
+    await expect(PathRulesMigration).toMigrate(
       {
         pathRules: [
           {
@@ -22,8 +22,8 @@ describe('config/migrations/custom/path-rules-migration', () => {
     );
   });
 
-  it('should rewrite packageRules when it is not array', () => {
-    expect(PathRulesMigration).toMigrate(
+  it('should rewrite packageRules when it is not array', async () => {
+    await expect(PathRulesMigration).toMigrate(
       {
         packageRules: 'test',
         pathRules: [
@@ -44,8 +44,8 @@ describe('config/migrations/custom/path-rules-migration', () => {
     );
   });
 
-  it('should not migrate non array value', () => {
-    expect(PathRulesMigration).toMigrate(
+  it('should not migrate non array value', async () => {
+    await expect(PathRulesMigration).toMigrate(
       {
         pathRules: 'test',
       },
@@ -53,8 +53,8 @@ describe('config/migrations/custom/path-rules-migration', () => {
     );
   });
 
-  it('should concat with existing package rules', () => {
-    expect(PathRulesMigration).toMigrate(
+  it('should concat with existing package rules', async () => {
+    await expect(PathRulesMigration).toMigrate(
       {
         pathRules: [
           {

--- a/lib/config/migrations/custom/pin-versions-migration.spec.ts
+++ b/lib/config/migrations/custom/pin-versions-migration.spec.ts
@@ -1,8 +1,8 @@
 import { PinVersionsMigration } from './pin-versions-migration';
 
 describe('config/migrations/custom/pin-versions-migration', () => {
-  it('should migrate true', () => {
-    expect(PinVersionsMigration).toMigrate(
+  it('should migrate true', async () => {
+    await expect(PinVersionsMigration).toMigrate(
       {
         pinVersions: true,
       },
@@ -12,8 +12,8 @@ describe('config/migrations/custom/pin-versions-migration', () => {
     );
   });
 
-  it('should migrate false', () => {
-    expect(PinVersionsMigration).toMigrate(
+  it('should migrate false', async () => {
+    await expect(PinVersionsMigration).toMigrate(
       {
         pinVersions: false,
       },

--- a/lib/config/migrations/custom/platform-commit-migration.spec.ts
+++ b/lib/config/migrations/custom/platform-commit-migration.spec.ts
@@ -1,8 +1,8 @@
 import { PlatformCommitMigration } from './platform-commit-migration';
 
 describe('config/migrations/custom/platform-commit-migration', () => {
-  it('should migrate platformCommit=true to platformCommit=enabled', () => {
-    expect(PlatformCommitMigration).toMigrate(
+  it('should migrate platformCommit=true to platformCommit=enabled', async () => {
+    await expect(PlatformCommitMigration).toMigrate(
       {
         // @ts-expect-error: old type
         platformCommit: true,
@@ -13,8 +13,8 @@ describe('config/migrations/custom/platform-commit-migration', () => {
     );
   });
 
-  it('should migrate platformCommit=false to platformCommit=disabled', () => {
-    expect(PlatformCommitMigration).toMigrate(
+  it('should migrate platformCommit=false to platformCommit=disabled', async () => {
+    await expect(PlatformCommitMigration).toMigrate(
       {
         // @ts-expect-error: old type
         platformCommit: false,
@@ -25,8 +25,8 @@ describe('config/migrations/custom/platform-commit-migration', () => {
     );
   });
 
-  it('should not migrate platformCommit=auto', () => {
-    expect(PlatformCommitMigration).not.toMigrate(
+  it('should not migrate platformCommit=auto', async () => {
+    await expect(PlatformCommitMigration).not.toMigrate(
       {
         platformCommit: 'auto',
       },

--- a/lib/config/migrations/custom/post-update-options-migration.spec.ts
+++ b/lib/config/migrations/custom/post-update-options-migration.spec.ts
@@ -1,8 +1,8 @@
 import { PostUpdateOptionsMigration } from './post-update-options-migration';
 
 describe('config/migrations/custom/post-update-options-migration', () => {
-  it('should migrate properly', () => {
-    expect(PostUpdateOptionsMigration).toMigrate(
+  it('should migrate properly', async () => {
+    await expect(PostUpdateOptionsMigration).toMigrate(
       {
         postUpdateOptions: ['gomodTidy', 'gomodNoMassage'],
       },

--- a/lib/config/migrations/custom/rebase-conflicted-prs-migration.spec.ts
+++ b/lib/config/migrations/custom/rebase-conflicted-prs-migration.spec.ts
@@ -1,8 +1,8 @@
 import { RebaseConflictedPrs } from './rebase-conflicted-prs-migration';
 
 describe('config/migrations/custom/rebase-conflicted-prs-migration', () => {
-  it('should migrate false', () => {
-    expect(RebaseConflictedPrs).toMigrate(
+  it('should migrate false', async () => {
+    await expect(RebaseConflictedPrs).toMigrate(
       {
         rebaseConflictedPrs: false,
       },

--- a/lib/config/migrations/custom/rebase-stale-prs-migration.spec.ts
+++ b/lib/config/migrations/custom/rebase-stale-prs-migration.spec.ts
@@ -1,8 +1,8 @@
 import { RebaseStalePrsMigration } from './rebase-stale-prs-migration';
 
 describe('config/migrations/custom/rebase-stale-prs-migration', () => {
-  it('should migrate true', () => {
-    expect(RebaseStalePrsMigration).toMigrate(
+  it('should migrate true', async () => {
+    await expect(RebaseStalePrsMigration).toMigrate(
       {
         rebaseStalePrs: true,
       },
@@ -12,8 +12,8 @@ describe('config/migrations/custom/rebase-stale-prs-migration', () => {
     );
   });
 
-  it('should migrate false', () => {
-    expect(RebaseStalePrsMigration).toMigrate(
+  it('should migrate false', async () => {
+    await expect(RebaseStalePrsMigration).toMigrate(
       {
         rebaseStalePrs: false,
       },
@@ -23,8 +23,8 @@ describe('config/migrations/custom/rebase-stale-prs-migration', () => {
     );
   });
 
-  it('should migrate null', () => {
-    expect(RebaseStalePrsMigration).toMigrate(
+  it('should migrate null', async () => {
+    await expect(RebaseStalePrsMigration).toMigrate(
       {
         rebaseStalePrs: null,
       },

--- a/lib/config/migrations/custom/recreate-closed-migration.spec.ts
+++ b/lib/config/migrations/custom/recreate-closed-migration.spec.ts
@@ -1,8 +1,8 @@
 import { RecreateClosedMigration } from './recreate-closed-migration';
 
 describe('config/migrations/custom/recreate-closed-migration', () => {
-  it('should migrate true', () => {
-    expect(RecreateClosedMigration).toMigrate(
+  it('should migrate true', async () => {
+    await expect(RecreateClosedMigration).toMigrate(
       {
         recreateClosed: true,
       },
@@ -12,8 +12,8 @@ describe('config/migrations/custom/recreate-closed-migration', () => {
     );
   });
 
-  it('should migrate false', () => {
-    expect(RecreateClosedMigration).toMigrate(
+  it('should migrate false', async () => {
+    await expect(RecreateClosedMigration).toMigrate(
       {
         recreateClosed: false,
       },

--- a/lib/config/migrations/custom/renovate-fork-migration.spec.ts
+++ b/lib/config/migrations/custom/renovate-fork-migration.spec.ts
@@ -1,8 +1,8 @@
 import { RenovateForkMigration } from './renovate-fork-migration';
 
 describe('config/migrations/custom/renovate-fork-migration', () => {
-  it('should migrate true', () => {
-    expect(RenovateForkMigration).toMigrate(
+  it('should migrate true', async () => {
+    await expect(RenovateForkMigration).toMigrate(
       {
         renovateFork: true,
       },
@@ -12,8 +12,8 @@ describe('config/migrations/custom/renovate-fork-migration', () => {
     );
   });
 
-  it('should migrate false', () => {
-    expect(RenovateForkMigration).toMigrate(
+  it('should migrate false', async () => {
+    await expect(RenovateForkMigration).toMigrate(
       {
         renovateFork: false,
       },
@@ -23,8 +23,8 @@ describe('config/migrations/custom/renovate-fork-migration', () => {
     );
   });
 
-  it('should not migrate non boolean value', () => {
-    expect(RenovateForkMigration).toMigrate(
+  it('should not migrate non boolean value', async () => {
+    await expect(RenovateForkMigration).toMigrate(
       {
         renovateFork: 'test',
       },

--- a/lib/config/migrations/custom/require-config-migration.spec.ts
+++ b/lib/config/migrations/custom/require-config-migration.spec.ts
@@ -2,8 +2,8 @@ import type { RequiredConfig } from '../../types';
 import { RequireConfigMigration } from './require-config-migration';
 
 describe('config/migrations/custom/require-config-migration', () => {
-  it('should migrate requireConfig=true to requireConfig=required', () => {
-    expect(RequireConfigMigration).toMigrate(
+  it('should migrate requireConfig=true to requireConfig=required', async () => {
+    await expect(RequireConfigMigration).toMigrate(
       {
         requireConfig: 'true' as RequiredConfig,
       },
@@ -13,8 +13,8 @@ describe('config/migrations/custom/require-config-migration', () => {
     );
   });
 
-  it('should migrate requireConfig=false to requireConfig=optional', () => {
-    expect(RequireConfigMigration).toMigrate(
+  it('should migrate requireConfig=false to requireConfig=optional', async () => {
+    await expect(RequireConfigMigration).toMigrate(
       {
         requireConfig: 'false' as RequiredConfig,
       },

--- a/lib/config/migrations/custom/required-status-checks-migration.spec.ts
+++ b/lib/config/migrations/custom/required-status-checks-migration.spec.ts
@@ -1,8 +1,8 @@
 import { RequiredStatusChecksMigration } from './required-status-checks-migration';
 
 describe('config/migrations/custom/required-status-checks-migration', () => {
-  it('should migrate requiredStatusChecks=null to ignoreTests=true', () => {
-    expect(RequiredStatusChecksMigration).toMigrate(
+  it('should migrate requiredStatusChecks=null to ignoreTests=true', async () => {
+    await expect(RequiredStatusChecksMigration).toMigrate(
       {
         requiredStatusChecks: null,
       },

--- a/lib/config/migrations/custom/schedule-migration.spec.ts
+++ b/lib/config/migrations/custom/schedule-migration.spec.ts
@@ -1,8 +1,8 @@
 import { ScheduleMigration } from './schedule-migration';
 
 describe('config/migrations/custom/schedule-migration', () => {
-  it('migrates every friday', () => {
-    expect(ScheduleMigration).toMigrate(
+  it('migrates every friday', async () => {
+    await expect(ScheduleMigration).toMigrate(
       {
         schedule: 'every friday',
       } as any,
@@ -12,8 +12,8 @@ describe('config/migrations/custom/schedule-migration', () => {
     );
   });
 
-  it('does not migrate every weekday', () => {
-    expect(ScheduleMigration).toMigrate(
+  it('does not migrate every weekday', async () => {
+    await expect(ScheduleMigration).toMigrate(
       {
         schedule: 'every weekday',
       } as any,
@@ -24,8 +24,8 @@ describe('config/migrations/custom/schedule-migration', () => {
     );
   });
 
-  it('does not migrate multi days', () => {
-    expect(ScheduleMigration).toMigrate(
+  it('does not migrate multi days', async () => {
+    await expect(ScheduleMigration).toMigrate(
       {
         schedule: 'after 5:00pm on wednesday and thursday',
       } as any,
@@ -36,8 +36,8 @@ describe('config/migrations/custom/schedule-migration', () => {
     );
   });
 
-  it('does not migrate hour range', () => {
-    expect(ScheduleMigration).toMigrate(
+  it('does not migrate hour range', async () => {
+    await expect(ScheduleMigration).toMigrate(
       {
         schedule: 'after 1:00pm and before 5:00pm',
       } as any,
@@ -48,8 +48,8 @@ describe('config/migrations/custom/schedule-migration', () => {
     );
   });
 
-  it('does not migrate invalid range', () => {
-    expect(ScheduleMigration).toMigrate(
+  it('does not migrate invalid range', async () => {
+    await expect(ScheduleMigration).toMigrate(
       {
         schedule: 'after and before 5:00',
       } as any,

--- a/lib/config/migrations/custom/semantic-commits-migration.spec.ts
+++ b/lib/config/migrations/custom/semantic-commits-migration.spec.ts
@@ -1,8 +1,8 @@
 import { SemanticCommitsMigration } from './semantic-commits-migration';
 
 describe('config/migrations/custom/semantic-commits-migration', () => {
-  it('should migrate true to "enabled"', () => {
-    expect(SemanticCommitsMigration).toMigrate(
+  it('should migrate true to "enabled"', async () => {
+    await expect(SemanticCommitsMigration).toMigrate(
       {
         semanticCommits: true,
       } as any,
@@ -10,8 +10,8 @@ describe('config/migrations/custom/semantic-commits-migration', () => {
     );
   });
 
-  it('should migrate false to "disabled"', () => {
-    expect(SemanticCommitsMigration).toMigrate(
+  it('should migrate false to "disabled"', async () => {
+    await expect(SemanticCommitsMigration).toMigrate(
       {
         semanticCommits: false,
       } as any,
@@ -19,8 +19,8 @@ describe('config/migrations/custom/semantic-commits-migration', () => {
     );
   });
 
-  it('should migrate null to "auto"', () => {
-    expect(SemanticCommitsMigration).toMigrate(
+  it('should migrate null to "auto"', async () => {
+    await expect(SemanticCommitsMigration).toMigrate(
       {
         semanticCommits: null,
       } as any,
@@ -28,8 +28,8 @@ describe('config/migrations/custom/semantic-commits-migration', () => {
     );
   });
 
-  it('should migrate random string to "auto"', () => {
-    expect(SemanticCommitsMigration).toMigrate(
+  it('should migrate random string to "auto"', async () => {
+    await expect(SemanticCommitsMigration).toMigrate(
       {
         semanticCommits: 'test',
       } as any,
@@ -37,8 +37,8 @@ describe('config/migrations/custom/semantic-commits-migration', () => {
     );
   });
 
-  it('should not migrate valid enabled config', () => {
-    expect(SemanticCommitsMigration).toMigrate(
+  it('should not migrate valid enabled config', async () => {
+    await expect(SemanticCommitsMigration).toMigrate(
       {
         semanticCommits: 'enabled',
       } as any,
@@ -47,8 +47,8 @@ describe('config/migrations/custom/semantic-commits-migration', () => {
     );
   });
 
-  it('should not migrate valid disabled config', () => {
-    expect(SemanticCommitsMigration).toMigrate(
+  it('should not migrate valid disabled config', async () => {
+    await expect(SemanticCommitsMigration).toMigrate(
       {
         semanticCommits: 'disabled',
       } as any,

--- a/lib/config/migrations/custom/semantic-prefix-migration.spec.ts
+++ b/lib/config/migrations/custom/semantic-prefix-migration.spec.ts
@@ -1,8 +1,8 @@
 import { SemanticPrefixMigration } from './semantic-prefix-migration';
 
 describe('config/migrations/custom/semantic-prefix-migration', () => {
-  it('should work', () => {
-    expect(SemanticPrefixMigration).toMigrate(
+  it('should work', async () => {
+    await expect(SemanticPrefixMigration).toMigrate(
       {
         semanticPrefix: 'fix(deps): ',
       } as any,
@@ -10,8 +10,8 @@ describe('config/migrations/custom/semantic-prefix-migration', () => {
     );
   });
 
-  it('should remove non-string values', () => {
-    expect(SemanticPrefixMigration).toMigrate(
+  it('should remove non-string values', async () => {
+    await expect(SemanticPrefixMigration).toMigrate(
       {
         semanticPrefix: true,
       } as any,
@@ -19,8 +19,8 @@ describe('config/migrations/custom/semantic-prefix-migration', () => {
     );
   });
 
-  it('should migrate prefix with no-scope to null', () => {
-    expect(SemanticPrefixMigration).toMigrate(
+  it('should migrate prefix with no-scope to null', async () => {
+    await expect(SemanticPrefixMigration).toMigrate(
       {
         semanticPrefix: 'fix: ',
       } as any,
@@ -28,8 +28,8 @@ describe('config/migrations/custom/semantic-prefix-migration', () => {
     );
   });
 
-  it('works for random string', () => {
-    expect(SemanticPrefixMigration).toMigrate(
+  it('works for random string', async () => {
+    await expect(SemanticPrefixMigration).toMigrate(
       {
         semanticPrefix: 'test',
       } as any,

--- a/lib/config/migrations/custom/separate-major-release-migration.spec.ts
+++ b/lib/config/migrations/custom/separate-major-release-migration.spec.ts
@@ -1,8 +1,8 @@
 import { SeparateMajorReleasesMigration } from './separate-major-release-migration';
 
 describe('config/migrations/custom/separate-major-release-migration', () => {
-  it('should migrate', () => {
-    expect(SeparateMajorReleasesMigration).toMigrate(
+  it('should migrate', async () => {
+    await expect(SeparateMajorReleasesMigration).toMigrate(
       {
         separateMajorReleases: true,
       },

--- a/lib/config/migrations/custom/separate-multiple-major-migration.spec.ts
+++ b/lib/config/migrations/custom/separate-multiple-major-migration.spec.ts
@@ -1,8 +1,8 @@
 import { SeparateMultipleMajorMigration } from './separate-multiple-major-migration';
 
 describe('config/migrations/custom/separate-multiple-major-migration', () => {
-  it('should remove if separateMajorReleases exists', () => {
-    expect(SeparateMultipleMajorMigration).toMigrate(
+  it('should remove if separateMajorReleases exists', async () => {
+    await expect(SeparateMultipleMajorMigration).toMigrate(
       {
         separateMajorReleases: true,
         separateMultipleMajor: true,
@@ -13,8 +13,8 @@ describe('config/migrations/custom/separate-multiple-major-migration', () => {
     );
   });
 
-  it('should skip if separateMajorReleases does not exist', () => {
-    expect(SeparateMultipleMajorMigration).toMigrate(
+  it('should skip if separateMajorReleases does not exist', async () => {
+    await expect(SeparateMultipleMajorMigration).toMigrate(
       {
         separateMultipleMajor: true,
       },

--- a/lib/config/migrations/custom/stability-days-migration.spec.ts
+++ b/lib/config/migrations/custom/stability-days-migration.spec.ts
@@ -1,8 +1,8 @@
 import { StabilityDaysMigration } from './stability-days-migration';
 
 describe('config/migrations/custom/stability-days-migration', () => {
-  it('migrates', () => {
-    expect(StabilityDaysMigration).toMigrate(
+  it('migrates', async () => {
+    await expect(StabilityDaysMigration).toMigrate(
       {
         stabilityDays: 0,
       },
@@ -10,7 +10,7 @@ describe('config/migrations/custom/stability-days-migration', () => {
         minimumReleaseAge: null,
       },
     );
-    expect(StabilityDaysMigration).toMigrate(
+    await expect(StabilityDaysMigration).toMigrate(
       {
         stabilityDays: 2,
       },
@@ -18,7 +18,7 @@ describe('config/migrations/custom/stability-days-migration', () => {
         minimumReleaseAge: '2 days',
       },
     );
-    expect(StabilityDaysMigration).toMigrate(
+    await expect(StabilityDaysMigration).toMigrate(
       {
         stabilityDays: 1,
       },

--- a/lib/config/migrations/custom/suppress-notifications-migration.spec.ts
+++ b/lib/config/migrations/custom/suppress-notifications-migration.spec.ts
@@ -1,8 +1,8 @@
 import { SuppressNotificationsMigration } from './suppress-notifications-migration';
 
 describe('config/migrations/custom/suppress-notifications-migration', () => {
-  it('should remomve prEditNotification from array', () => {
-    expect(SuppressNotificationsMigration).toMigrate(
+  it('should remomve prEditNotification from array', async () => {
+    await expect(SuppressNotificationsMigration).toMigrate(
       {
         suppressNotifications: ['test', 'prEditNotification'],
       },
@@ -12,8 +12,8 @@ describe('config/migrations/custom/suppress-notifications-migration', () => {
     );
   });
 
-  it('should not migrate array without prEditNotification', () => {
-    expect(SuppressNotificationsMigration).toMigrate(
+  it('should not migrate array without prEditNotification', async () => {
+    await expect(SuppressNotificationsMigration).toMigrate(
       {
         suppressNotifications: ['test'],
       },
@@ -24,8 +24,8 @@ describe('config/migrations/custom/suppress-notifications-migration', () => {
     );
   });
 
-  it('should not migrate empty array', () => {
-    expect(SuppressNotificationsMigration).toMigrate(
+  it('should not migrate empty array', async () => {
+    await expect(SuppressNotificationsMigration).toMigrate(
       {
         suppressNotifications: [],
       },

--- a/lib/config/migrations/custom/trust-level-migration.spec.ts
+++ b/lib/config/migrations/custom/trust-level-migration.spec.ts
@@ -1,8 +1,8 @@
 import { TrustLevelMigration } from './trust-level-migration';
 
 describe('config/migrations/custom/trust-level-migration', () => {
-  it('should handle hight level', () => {
-    expect(TrustLevelMigration).toMigrate(
+  it('should handle hight level', async () => {
+    await expect(TrustLevelMigration).toMigrate(
       {
         trustLevel: 'high',
       },
@@ -14,8 +14,8 @@ describe('config/migrations/custom/trust-level-migration', () => {
     );
   });
 
-  it('should not rewrite provided properties', () => {
-    expect(TrustLevelMigration).toMigrate(
+  it('should not rewrite provided properties', async () => {
+    await expect(TrustLevelMigration).toMigrate(
       {
         allowCustomCrateRegistries: false,
         allowScripts: false,

--- a/lib/config/migrations/custom/unpublish-safe-migration.spec.ts
+++ b/lib/config/migrations/custom/unpublish-safe-migration.spec.ts
@@ -1,8 +1,8 @@
 import { UnpublishSafeMigration } from './unpublish-safe-migration';
 
 describe('config/migrations/custom/unpublish-safe-migration', () => {
-  it('should migrate true', () => {
-    expect(UnpublishSafeMigration).toMigrate(
+  it('should migrate true', async () => {
+    await expect(UnpublishSafeMigration).toMigrate(
       {
         unpublishSafe: true,
       },
@@ -12,8 +12,8 @@ describe('config/migrations/custom/unpublish-safe-migration', () => {
     );
   });
 
-  it('should migrate true and handle extends field', () => {
-    expect(UnpublishSafeMigration).toMigrate(
+  it('should migrate true and handle extends field', async () => {
+    await expect(UnpublishSafeMigration).toMigrate(
       {
         extends: 'test',
         unpublishSafe: true,
@@ -24,8 +24,8 @@ describe('config/migrations/custom/unpublish-safe-migration', () => {
     );
   });
 
-  it('should migrate true and handle empty extends field', () => {
-    expect(UnpublishSafeMigration).toMigrate(
+  it('should migrate true and handle empty extends field', async () => {
+    await expect(UnpublishSafeMigration).toMigrate(
       {
         extends: [],
         unpublishSafe: true,
@@ -36,8 +36,8 @@ describe('config/migrations/custom/unpublish-safe-migration', () => {
     );
   });
 
-  it('should migrate true and save order of items inside extends field', () => {
-    expect(UnpublishSafeMigration).toMigrate(
+  it('should migrate true and save order of items inside extends field', async () => {
+    await expect(UnpublishSafeMigration).toMigrate(
       {
         extends: ['foo', ':unpublishSafe', 'bar'],
         unpublishSafe: true,
@@ -47,7 +47,7 @@ describe('config/migrations/custom/unpublish-safe-migration', () => {
       },
     );
 
-    expect(UnpublishSafeMigration).toMigrate(
+    await expect(UnpublishSafeMigration).toMigrate(
       {
         extends: ['foo', 'default:unpublishSafe', 'bar'],
         unpublishSafe: true,
@@ -57,7 +57,7 @@ describe('config/migrations/custom/unpublish-safe-migration', () => {
       },
     );
 
-    expect(UnpublishSafeMigration).toMigrate(
+    await expect(UnpublishSafeMigration).toMigrate(
       {
         extends: ['foo', 'npm:unpublishSafe', 'bar'],
         unpublishSafe: true,
@@ -68,8 +68,8 @@ describe('config/migrations/custom/unpublish-safe-migration', () => {
     );
   });
 
-  it('should migrate false and save order of items inside extends field', () => {
-    expect(UnpublishSafeMigration).toMigrate(
+  it('should migrate false and save order of items inside extends field', async () => {
+    await expect(UnpublishSafeMigration).toMigrate(
       {
         extends: ['foo', 'bar'],
         unpublishSafe: false,
@@ -80,8 +80,8 @@ describe('config/migrations/custom/unpublish-safe-migration', () => {
     );
   });
 
-  it('prevent duplicates', () => {
-    expect(UnpublishSafeMigration).toMigrate(
+  it('prevent duplicates', async () => {
+    await expect(UnpublishSafeMigration).toMigrate(
       {
         extends: ['npm:unpublishSafe'],
         unpublishSafe: true,

--- a/lib/config/migrations/custom/update-lock-files-migration.spec.ts
+++ b/lib/config/migrations/custom/update-lock-files-migration.spec.ts
@@ -1,8 +1,8 @@
 import { UpdateLockFilesMigration } from './update-lock-files-migration';
 
 describe('config/migrations/custom/update-lock-files-migration', () => {
-  it('should replace false value', () => {
-    expect(UpdateLockFilesMigration).toMigrate(
+  it('should replace false value', async () => {
+    await expect(UpdateLockFilesMigration).toMigrate(
       {
         updateLockFiles: false,
       },
@@ -12,8 +12,8 @@ describe('config/migrations/custom/update-lock-files-migration', () => {
     );
   });
 
-  it('should not replace true value', () => {
-    expect(UpdateLockFilesMigration).toMigrate(
+  it('should not replace true value', async () => {
+    await expect(UpdateLockFilesMigration).toMigrate(
       {
         updateLockFiles: true,
       },
@@ -21,8 +21,8 @@ describe('config/migrations/custom/update-lock-files-migration', () => {
     );
   });
 
-  it('should not replace skipArtifactsUpdate', () => {
-    expect(UpdateLockFilesMigration).toMigrate(
+  it('should not replace skipArtifactsUpdate', async () => {
+    await expect(UpdateLockFilesMigration).toMigrate(
       {
         updateLockFiles: false,
         skipArtifactsUpdate: false,

--- a/lib/config/migrations/custom/upgrade-in-range-migration.spec.ts
+++ b/lib/config/migrations/custom/upgrade-in-range-migration.spec.ts
@@ -1,8 +1,8 @@
 import { UpgradeInRangeMigration } from './upgrade-in-range-migration';
 
 describe('config/migrations/custom/upgrade-in-range-migration', () => {
-  it('should migrate upgradeInRange=true to rangeStrategy="bump"', () => {
-    expect(UpgradeInRangeMigration).toMigrate(
+  it('should migrate upgradeInRange=true to rangeStrategy="bump"', async () => {
+    await expect(UpgradeInRangeMigration).toMigrate(
       {
         upgradeInRange: true,
       },
@@ -12,8 +12,8 @@ describe('config/migrations/custom/upgrade-in-range-migration', () => {
     );
   });
 
-  it('should just remove property when upgradeInRange not equals to true', () => {
-    expect(UpgradeInRangeMigration).toMigrate(
+  it('should just remove property when upgradeInRange not equals to true', async () => {
+    await expect(UpgradeInRangeMigration).toMigrate(
       {
         upgradeInRange: false,
       },

--- a/lib/config/migrations/custom/version-strategy-migration.spec.ts
+++ b/lib/config/migrations/custom/version-strategy-migration.spec.ts
@@ -1,8 +1,8 @@
 import { VersionStrategyMigration } from './version-strategy-migration';
 
 describe('config/migrations/custom/version-strategy-migration', () => {
-  it('should migrate versionStrategy="widen" to rangeStrategy="widen"', () => {
-    expect(VersionStrategyMigration).toMigrate(
+  it('should migrate versionStrategy="widen" to rangeStrategy="widen"', async () => {
+    await expect(VersionStrategyMigration).toMigrate(
       {
         versionStrategy: 'widen',
       },
@@ -12,8 +12,8 @@ describe('config/migrations/custom/version-strategy-migration', () => {
     );
   });
 
-  it('should just remove property when versionStrategy not equals to "widen"', () => {
-    expect(VersionStrategyMigration).toMigrate(
+  it('should just remove property when versionStrategy not equals to "widen"', async () => {
+    await expect(VersionStrategyMigration).toMigrate(
       {
         versionStrategy: 'test',
       },

--- a/test/to-migrate.ts
+++ b/test/to-migrate.ts
@@ -12,7 +12,7 @@ declare global {
         originalConfig: RenovateConfig,
         expectedConfig: RenovateConfig,
         isMigrated?: boolean,
-      ): R;
+      ): Promise<R>;
     }
   }
 }


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

While working on #38240, I noticed that the failing tests I was
writing didn't trigger.

It turns out that in https://github.com/renovatebot/renovate/pull/34475, when we
migrated to Vitest, and made some functions `async`, we missed out on
making the tests themselves `async`.

This correctly applies the `async` modifier to test functions, allowing
them to correctly pass/fail when running async code.

We can also make sure that `toMigrate` is returning a Promise to
indicate it's asynchronous.

## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
