### PR TITLE
feat(allowedMinimumReleaseAge): Add new allowedMinimumReleaseAge option

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2720,7 +2720,7 @@ The datasource that Renovate uses must have a release timestamp for the `minimum
 Some datasources may have a release timestamp, but in a format Renovate does not support.
 In those cases a feature request needs to be implemented.
 
-You might alsow want to look into the [`allowedMinimumReleaseAge`](#allowedminimumeeleaseage) packageRule that will only open with versions that are older than the specified duration.
+You might alsow want to look into the [`allowedMinimumReleaseAge`](#allowedminimumreleaseage) packageRule that will only open with versions that are older than the specified duration.
 
 <!-- prettier-ignore -->
 !!! warning "Warning for Maven users"
@@ -2943,6 +2943,34 @@ For example you have multiple `package.json` and want to use `dependencyDashboar
 !!! warning
     Avoid nesting any `object`-type configuration in a `packageRules` array, such as a `major` or `minor` block.
 
+### allowedMinimumReleaseAge
+
+You can use `allowedMinimumReleaseAge` - usually within a `packageRules` entry - to limit the allowed versions.
+
+For example if you only want NPM versions that are at least three days old at the moment of the Pull Request:
+
+```json
+{
+  "packageRules": [
+    {
+      "matchDatasources": ["npm"],
+      "allowedMinimumReleaseAge": "3 days"
+    }
+  ]
+}
+```
+
+This option is similar to `minimumReleaseAge`. Here is an example to illustrate the difference.
+
+Your application currently has a dependency on `@ctrl/tinycolor` at version `4.1.0`
+On the 15th of september 2025, version `4.1.1` was released.
+We're the 16th of september.
+
+Here's what happens with each setting;
+
+- `allowedMinimumReleaseAge: "3 days"` Will wait two more days to open a Pull Request.
+- `minimumReleaseAge: "3 days"` Will open a Pull Request as soon as it sees the new version but adds a "renovate/stability-days" pending status check.
+
 ### allowedVersions
 
 You can use `allowedVersions` - usually within a `packageRules` entry - to limit how far to upgrade a dependency.
@@ -2965,33 +2993,6 @@ Renovate calculates the valid syntax for this at runtime, because it depends on 
 <!-- prettier-ignore -->
 !!! warning
     `allowedVersions` and `matchUpdateTypes` cannot be used in the same package rule.
-
-### allowedMinimumReleaseAge
-
-You can use `allowedMinimumReleaseAge` - usually within a `packageRules` entry - to limit the allowed versions.
-
-For example if you only want NPM versions that are at least three days old at the moment of the Pull Request: 
-
-```json
-{
-  "packageRules": [
-    {
-      "matchDatasources": ["npm"],
-      "allowedMinimumReleaseAge": "3 days"
-    }
-  ]
-}
-```
-
-This option is similar to `minimumReleaseAge`. Here is an example to illustrate the difference.
-
-Your application currently has a dependency on `@ctrl/tinycolor` at version `4.1.0`
-On the 15th of september 2025, version `4.1.1` was released.
-We're the 16th of september. 
-
-Here's what happens with each setting;
-* `allowedMinimumReleaseAge: "3 days"` Will wait two more days to open a Pull Request.
-* `minimumReleaseAge: "3 days"` Will open a Pull Request as soon as it sees the new version but adds a "renovate/stability-days" pending status check.
 
 #### Using regular expressions
 

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2720,7 +2720,7 @@ The datasource that Renovate uses must have a release timestamp for the `minimum
 Some datasources may have a release timestamp, but in a format Renovate does not support.
 In those cases a feature request needs to be implemented.
 
-You might also want to look into the [`allowedMinimumReleaseAge`](#allowedminimumreleaseage) packageRule that will only create updates with versions that are older than the specified duration.
+You might also want to look into the [`allowedMinimumReleaseAge`](#allowedminimumreleaseage) configuration that will only create updates with versions that are older than the specified duration.
 
 <!-- prettier-ignore -->
 !!! warning "Warning for Maven users"

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2720,6 +2720,8 @@ The datasource that Renovate uses must have a release timestamp for the `minimum
 Some datasources may have a release timestamp, but in a format Renovate does not support.
 In those cases a feature request needs to be implemented.
 
+You might alsow want to look into the [`allowedMinimumReleaseAge`](#allowedminimumeeleaseage) packageRule that will only open with versions that are older than the specified duration.
+
 <!-- prettier-ignore -->
 !!! warning "Warning for Maven users"
     For `minimumReleaseAge` to work, the Maven source must return reliable `last-modified` headers.
@@ -2963,6 +2965,33 @@ Renovate calculates the valid syntax for this at runtime, because it depends on 
 <!-- prettier-ignore -->
 !!! warning
     `allowedVersions` and `matchUpdateTypes` cannot be used in the same package rule.
+
+### allowedMinimumReleaseAge
+
+You can use `allowedMinimumReleaseAge` - usually within a `packageRules` entry - to limit the allowed versions.
+
+For example if you only want NPM versions that are at least three days old at the moment of the Pull Request: 
+
+```json
+{
+  "packageRules": [
+    {
+      "matchDatasources": ["npm"],
+      "allowedMinimumReleaseAge": "3 days"
+    }
+  ]
+}
+```
+
+This option is similar to `minimumReleaseAge`. Here is an example to illustrate the difference.
+
+Your application currently has a dependency on `@ctrl/tinycolor` at version `4.1.0`
+On the 15th of september 2025, version `4.1.1` was released.
+We're the 16th of september. 
+
+Here's what happens with each setting;
+* `allowedMinimumReleaseAge: "3 days"` Will wait two more days to open a Pull Request.
+* `minimumReleaseAge: "3 days"` Will open a Pull Request as soon as it sees the new version but adds a "renovate/stability-days" pending status check.
 
 #### Using regular expressions
 

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2720,7 +2720,7 @@ The datasource that Renovate uses must have a release timestamp for the `minimum
 Some datasources may have a release timestamp, but in a format Renovate does not support.
 In those cases a feature request needs to be implemented.
 
-You might alsow want to look into the [`allowedMinimumReleaseAge`](#allowedminimumreleaseage) packageRule that will only open with versions that are older than the specified duration.
+You might also want to look into the [`allowedMinimumReleaseAge`](#allowedminimumreleaseage) packageRule that will only create updates with versions that are older than the specified duration.
 
 <!-- prettier-ignore -->
 !!! warning "Warning for Maven users"
@@ -2963,13 +2963,13 @@ For example if you only want NPM versions that are at least three days old at th
 This option is similar to `minimumReleaseAge`. Here is an example to illustrate the difference.
 
 Your application currently has a dependency on `@ctrl/tinycolor` at version `4.1.0`
-On the 15th of september 2025, version `4.1.1` was released.
-We're the 16th of september.
+On the 15th of September 2025, version `4.1.1` was released.
+We're the 16th of September.
 
-Here's what happens with each setting;
+Here's what happens with each setting:
 
-- `allowedMinimumReleaseAge: "3 days"` Will wait two more days to open a Pull Request.
-- `minimumReleaseAge: "3 days"` Will open a Pull Request as soon as it sees the new version but adds a "renovate/stability-days" pending status check.
+- `allowedMinimumReleaseAge: "3 days"` will wait two more days to open a Pull Request.
+- `minimumReleaseAge: "3 days"` will open a Pull Request as soon as it sees the new version, but adds a "renovate/stability-days" pending status check.
 
 ### allowedVersions
 

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -1648,6 +1648,15 @@ const options: RenovateOptions[] = [
     env: false,
   },
   {
+    name: 'allowedMinimumReleaseAge',
+    description: 'Time required before a new release is considered stable.',
+    type: 'string',
+    parents: ['packageRules'],
+    stage: 'package',
+    cli: false,
+    env: false,
+  },
+  {
     name: 'changelogUrl',
     description:
       'Set a custom URL for the changelog. Renovate will put this URL in the PR body text.',

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -423,6 +423,7 @@ export async function validateConfig(
                   // It's too late to apply any of these options once you already have updates determined
                   const preLookupOptions = [
                     'allowedVersions',
+                    'allowedMinimumReleaseAge',
                     'extractVersion',
                     'followTag',
                     'ignoreDeps',

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -422,8 +422,8 @@ export async function validateConfig(
                   }
                   // It's too late to apply any of these options once you already have updates determined
                   const preLookupOptions = [
-                    'allowedVersions',
                     'allowedMinimumReleaseAge',
+                    'allowedVersions',
                     'extractVersion',
                     'followTag',
                     'ignoreDeps',

--- a/lib/workers/repository/process/lookup/filter.spec.ts
+++ b/lib/workers/repository/process/lookup/filter.spec.ts
@@ -1,3 +1,4 @@
+import { CONFIG_VALIDATION } from '../../../../constants/error-messages';
 import type { Release } from '../../../../modules/datasource/types';
 import * as allVersioning from '../../../../modules/versioning';
 import type { Timestamp } from '../../../../util/timestamp';
@@ -103,6 +104,38 @@ describe('workers/repository/process/lookup/filter', () => {
           releaseTimestamp: lastWeek.toISOString() as Timestamp,
         },
       ]);
+    });
+
+    it('throws if allowedMinimumReleaseAge has an invalid value', () => {
+      const releases = [
+        {
+          version: '1.0.1',
+          releaseTimestamp: '2021-01-01T00:00:01.000Z' as Timestamp,
+        },
+        {
+          version: '1.2.0',
+          releaseTimestamp: '2021-01-03T00:00:00.000Z' as Timestamp,
+        },
+      ] satisfies Release[];
+
+      const config = partial<FilterConfig>({
+        ignoreUnstable: false,
+        ignoreDeprecated: false,
+        respectLatest: false,
+        allowedMinimumReleaseAge: 'not a duration',
+      });
+      const currentVersion = '1.0.0';
+      const latestVersion = '1.2.0';
+
+      expect(() =>
+        filterVersions(
+          config,
+          currentVersion,
+          latestVersion,
+          releases,
+          versioning,
+        ),
+      ).toThrow(CONFIG_VALIDATION);
     });
 
     it('allows unstable major upgrades', () => {

--- a/lib/workers/repository/process/lookup/filter.spec.ts
+++ b/lib/workers/repository/process/lookup/filter.spec.ts
@@ -66,17 +66,17 @@ describe('workers/repository/process/lookup/filter', () => {
 
       const releases = [
         {
-          version: '1.0.0'
+          version: '1.0.1',
           // No releaseTimestamp means we cannot filter it out
         },
         {
-          version: '1.0.1',
+          version: '1.0.2',
           releaseTimestamp: lastWeek.toISOString() as Timestamp,
         },
         {
           version: '1.2.0',
           releaseTimestamp: yesterday.toISOString() as Timestamp,
-        }
+        },
       ] satisfies Release[];
 
       const config = partial<FilterConfig>({
@@ -97,8 +97,11 @@ describe('workers/repository/process/lookup/filter', () => {
       );
 
       expect(filteredVersions).toEqual([
-        { version: '1.0.0' },
-        { version: '1.0.1', releaseTimestamp: lastWeek.toISOString() as Timestamp },
+        { version: '1.0.1' },
+        {
+          version: '1.0.2',
+          releaseTimestamp: lastWeek.toISOString() as Timestamp,
+        },
       ]);
     });
 

--- a/lib/workers/repository/process/lookup/filter.spec.ts
+++ b/lib/workers/repository/process/lookup/filter.spec.ts
@@ -57,6 +57,51 @@ describe('workers/repository/process/lookup/filter', () => {
       ]);
     });
 
+    it('should filter versions allowed by allowedMinimumReleaseAge', () => {
+      const yesterday = new Date();
+      yesterday.setDate(yesterday.getDate() - 1);
+
+      const lastWeek = new Date();
+      lastWeek.setDate(lastWeek.getDate() - 7);
+
+      const releases = [
+        {
+          version: '1.0.0'
+          // No releaseTimestamp means we cannot filter it out
+        },
+        {
+          version: '1.0.1',
+          releaseTimestamp: lastWeek.toISOString() as Timestamp,
+        },
+        {
+          version: '1.2.0',
+          releaseTimestamp: yesterday.toISOString() as Timestamp,
+        }
+      ] satisfies Release[];
+
+      const config = partial<FilterConfig>({
+        ignoreUnstable: false,
+        ignoreDeprecated: false,
+        respectLatest: false,
+        allowedMinimumReleaseAge: '3 days',
+      });
+      const currentVersion = '1.0.0';
+      const latestVersion = '1.2.0';
+
+      const filteredVersions = filterVersions(
+        config,
+        currentVersion,
+        latestVersion,
+        releases,
+        versioning,
+      );
+
+      expect(filteredVersions).toEqual([
+        { version: '1.0.0' },
+        { version: '1.0.1', releaseTimestamp: lastWeek.toISOString() as Timestamp },
+      ]);
+    });
+
     it('allows unstable major upgrades', () => {
       const nodeVersioning = allVersioning.get('node');
 

--- a/lib/workers/repository/process/lookup/filter.ts
+++ b/lib/workers/repository/process/lookup/filter.ts
@@ -1,5 +1,5 @@
-import semver from 'semver';
 import is from '@sindresorhus/is';
+import semver from 'semver';
 import { CONFIG_VALIDATION } from '../../../../constants/error-messages';
 import { logger } from '../../../../logger';
 import type { Release } from '../../../../modules/datasource/types';
@@ -7,11 +7,11 @@ import type { VersioningApi } from '../../../../modules/versioning';
 import * as npmVersioning from '../../../../modules/versioning/npm';
 import * as pep440 from '../../../../modules/versioning/pep440';
 import * as poetryVersioning from '../../../../modules/versioning/poetry';
+import { getElapsedMs } from '../../../../util/date';
+import { coerceNumber } from '../../../../util/number';
+import { toMs } from '../../../../util/pretty-time';
 import { getRegexPredicate } from '../../../../util/string-match';
 import type { FilterConfig } from './types';
-import { toMs } from '../../../../util/pretty-time';
-import { coerceNumber } from '../../../../util/number';
-import { getElapsedMs } from '../../../../util/date';
 
 function isReleaseStable(
   release: Release,
@@ -35,8 +35,13 @@ export function filterVersions(
   releases: Release[],
   versioningApi: VersioningApi,
 ): Release[] {
-  const { ignoreUnstable, ignoreDeprecated, respectLatest, allowedVersions, allowedMinimumReleaseAge } =
-    config;
+  const {
+    ignoreUnstable,
+    ignoreDeprecated,
+    respectLatest,
+    allowedVersions,
+    allowedMinimumReleaseAge,
+  } = config;
 
   // istanbul ignore if: shouldn't happen
   if (!currentVersion) {
@@ -123,7 +128,10 @@ export function filterVersions(
   }
 
   if (allowedMinimumReleaseAge) {
-    const allowedVersionsMinimumAge = coerceNumber(toMs(allowedMinimumReleaseAge), 0);
+    const allowedVersionsMinimumAge = coerceNumber(
+      toMs(allowedMinimumReleaseAge),
+      0,
+    );
 
     if (allowedVersionsMinimumAge <= 0) {
       const error = new Error(CONFIG_VALIDATION);
@@ -135,7 +143,7 @@ export function filterVersions(
       throw error;
     }
 
-    filteredReleases = filteredReleases.filter((r) =>{
+    filteredReleases = filteredReleases.filter((r) => {
       // If we don't have a release timestamp, then we cannot filter it out
       if (!r.releaseTimestamp || is.emptyString(r.releaseTimestamp)) {
         return true;

--- a/lib/workers/repository/process/lookup/types.ts
+++ b/lib/workers/repository/process/lookup/types.ts
@@ -11,8 +11,8 @@ import type { MergeConfidence } from '../../../../util/merge-confidence/types';
 import type { Timestamp } from '../../../../util/timestamp';
 
 export interface FilterConfig {
-  allowedVersions?: string;
   allowedMinimumReleaseAge?: string;
+  allowedVersions?: string;
   depName?: string;
   followTag?: string;
   ignoreDeprecated?: boolean;

--- a/lib/workers/repository/process/lookup/types.ts
+++ b/lib/workers/repository/process/lookup/types.ts
@@ -12,6 +12,7 @@ import type { Timestamp } from '../../../../util/timestamp';
 
 export interface FilterConfig {
   allowedVersions?: string;
+  allowedMinimumReleaseAge?: string;
   depName?: string;
   followTag?: string;
   ignoreDeprecated?: boolean;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

This PR introduces a new option `allowedMinimumReleaseAge` that's similar to `minimumReleaseAge` but behaves like `allowedVersions`: it filters out versions that are too young and only sends PRs for versions older than `allowedMinimumReleaseAge`.

The reason for this PR is that behaviour of Renovate's `minimumReleaseAge` clashes with Yarn's `npmMinimalAgeGate`.
If you set both `minimumReleaseAge` and `npmMinimalAgeGate` to 3 days; Renovate will create a PR immediately, and Yarn will refuse to install the package as it's too young.

`allowedMinimumReleaseAge` works with the same heuristic as `npmMinimalAgeGate`: only install/create PRs for packages older than X.

This is a complement to the comment I added to the discussion here: https://github.com/renovatebot/renovate/discussions/38247#discussioncomment-14530157

## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
