### PR TITLE
fix(gerrit): pass config labels to commitAndPush

### DIFF
--- a/lib/workers/repository/config-migration/branch/create.spec.ts
+++ b/lib/workers/repository/config-migration/branch/create.spec.ts
@@ -49,6 +49,7 @@ describe('workers/repository/config-migration/branch/create', () => {
         message: 'Migrate config renovate.json',
         platformCommit: 'auto',
         force: true,
+        labels: [],
       });
     });
 
@@ -73,6 +74,7 @@ describe('workers/repository/config-migration/branch/create', () => {
         message,
         platformCommit: 'auto',
         force: true,
+        labels: [],
       });
     });
 
@@ -109,6 +111,7 @@ describe('workers/repository/config-migration/branch/create', () => {
         message: 'Migrate config renovate.json',
         platformCommit: 'auto',
         force: true,
+        labels: [],
       });
     });
 
@@ -134,6 +137,7 @@ describe('workers/repository/config-migration/branch/create', () => {
           message,
           platformCommit: 'auto',
           force: true,
+          labels: [],
         });
       });
     });
@@ -161,6 +165,7 @@ describe('workers/repository/config-migration/branch/create', () => {
           message,
           platformCommit: 'auto',
           force: true,
+          labels: [],
         });
       });
 
@@ -187,6 +192,7 @@ describe('workers/repository/config-migration/branch/create', () => {
           message,
           platformCommit: 'auto',
           force: true,
+          labels: [],
         });
       });
     });

--- a/lib/workers/repository/config-migration/branch/create.ts
+++ b/lib/workers/repository/config-migration/branch/create.ts
@@ -74,5 +74,6 @@ export async function createConfigMigrationBranch(
     message: commitMessage.toString(),
     platformCommit: config.platformCommit,
     force: true,
+    labels: config.labels,
   });
 }

--- a/lib/workers/repository/config-migration/branch/rebase.spec.ts
+++ b/lib/workers/repository/config-migration/branch/rebase.spec.ts
@@ -106,6 +106,7 @@ describe('workers/repository/config-migration/branch/rebase', () => {
           message: `Migrate config ${filename}`,
           platformCommit: 'auto',
           baseBranch: 'dev',
+          labels: [],
         });
       },
     );

--- a/lib/workers/repository/config-migration/branch/rebase.ts
+++ b/lib/workers/repository/config-migration/branch/rebase.ts
@@ -54,6 +54,7 @@ export async function rebaseMigrationBranch(
     ],
     message: commitMessage.toString(),
     platformCommit: config.platformCommit,
+    labels: config.labels,
   });
 }
 

--- a/lib/workers/repository/onboarding/branch/create.spec.ts
+++ b/lib/workers/repository/onboarding/branch/create.spec.ts
@@ -32,6 +32,7 @@ describe('workers/repository/onboarding/branch/create', () => {
         force: true,
         message: 'Add renovate.json',
         platformCommit: 'auto',
+        labels: [],
       });
     });
 
@@ -55,6 +56,7 @@ describe('workers/repository/onboarding/branch/create', () => {
         force: true,
         message,
         platformCommit: 'auto',
+        labels: [],
       });
     });
 
@@ -76,6 +78,7 @@ describe('workers/repository/onboarding/branch/create', () => {
           force: true,
           message: `Add renovate.json\n\nsome commit body`,
           platformCommit: 'auto',
+          labels: [],
         });
       });
 
@@ -102,6 +105,7 @@ describe('workers/repository/onboarding/branch/create', () => {
           force: true,
           message: `We can Renovate if we want to, we can leave PRs in decline\n\nSigned Off: <Bot bot@botland.com>`,
           platformCommit: 'auto',
+          labels: [],
         });
       });
     });
@@ -127,6 +131,7 @@ describe('workers/repository/onboarding/branch/create', () => {
           force: true,
           message,
           platformCommit: 'auto',
+          labels: [],
         });
       });
 
@@ -155,6 +160,7 @@ describe('workers/repository/onboarding/branch/create', () => {
           force: true,
           message,
           platformCommit: 'auto',
+          labels: [],
         });
       });
     });
@@ -180,6 +186,7 @@ describe('workers/repository/onboarding/branch/create', () => {
           force: true,
           message,
           platformCommit: 'auto',
+          labels: [],
         });
       });
 
@@ -208,6 +215,7 @@ describe('workers/repository/onboarding/branch/create', () => {
           force: true,
           message,
           platformCommit: 'auto',
+          labels: [],
         });
       });
     });
@@ -234,6 +242,7 @@ describe('workers/repository/onboarding/branch/create', () => {
           force: true,
           message,
           platformCommit: 'auto',
+          labels: [],
         });
       });
 
@@ -258,6 +267,7 @@ describe('workers/repository/onboarding/branch/create', () => {
           force: true,
           message,
           platformCommit: 'auto',
+          labels: [],
         });
       });
 
@@ -283,6 +293,7 @@ describe('workers/repository/onboarding/branch/create', () => {
           force: true,
           message,
           platformCommit: 'auto',
+          labels: [],
         });
       });
 
@@ -302,6 +313,7 @@ describe('workers/repository/onboarding/branch/create', () => {
           message,
           force: true,
           platformCommit: 'auto',
+          labels: [],
         });
       });
     });

--- a/lib/workers/repository/onboarding/branch/create.ts
+++ b/lib/workers/repository/onboarding/branch/create.ts
@@ -52,5 +52,6 @@ export async function createOnboardingBranch(
     message: commitMessage,
     platformCommit: config.platformCommit,
     force: true,
+    labels: config.labels,
   });
 }

--- a/lib/workers/repository/onboarding/branch/rebase.ts
+++ b/lib/workers/repository/onboarding/branch/rebase.ts
@@ -59,5 +59,6 @@ export async function rebaseOnboardingBranch(
     ],
     message: commitMessage.toString(),
     platformCommit: config.platformCommit,
+    labels: config.labels,
   });
 }

--- a/lib/workers/repository/update/branch/commit.spec.ts
+++ b/lib/workers/repository/update/branch/commit.spec.ts
@@ -21,6 +21,7 @@ describe('workers/repository/update/branch/commit', () => {
         updatedArtifacts: [],
         upgrades: [],
         platformCommit: 'auto',
+        labels: ['label1', 'label2'],
       } satisfies BranchConfig;
       scm.commitAndPush.mockResolvedValueOnce('123test' as LongCommitSha);
       GlobalConfig.reset();
@@ -54,6 +55,7 @@ describe('workers/repository/update/branch/commit', () => {
             force: false,
             message: 'some commit message',
             platformCommit: 'auto',
+            labels: ['label1', 'label2'],
           },
         ],
       ]);

--- a/lib/workers/repository/update/branch/commit.ts
+++ b/lib/workers/repository/update/branch/commit.ts
@@ -64,6 +64,7 @@ export function commitFilesToBranch(
     prTitle: config.prTitle,
     // Only needed by Gerrit platform
     autoApprove: config.autoApprove,
+    // Only needed by Gerrit platform
     labels: config.labels,
   });
 }

--- a/lib/workers/repository/update/branch/commit.ts
+++ b/lib/workers/repository/update/branch/commit.ts
@@ -64,5 +64,6 @@ export function commitFilesToBranch(
     prTitle: config.prTitle,
     // Only needed by Gerrit platform
     autoApprove: config.autoApprove,
+    labels: config.labels,
   });
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Pass the config labels to commitAndPush so they get properly populated for gerrit.

This follows from https://github.com/renovatebot/renovate/pull/35900 which added label support for gerrit but didn't properly pass them along in all places.

## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

I ran on a private gerrit repository.

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
