### PR TITLE
fix(github-actions): uses-with action versions for ruby, deno, bun

### DIFF
--- a/lib/modules/manager/github-actions/community.ts
+++ b/lib/modules/manager/github-actions/community.ts
@@ -5,9 +5,11 @@ import { escapeRegExp, regEx } from '../../../util/regex';
 import { GithubReleasesDatasource } from '../../datasource/github-releases';
 import { NpmDatasource } from '../../datasource/npm';
 import { PypiDatasource } from '../../datasource/pypi';
+import { RubyVersionDatasource } from '../../datasource/ruby-version';
 import * as condaVersioning from '../../versioning/conda';
 import * as npmVersioning from '../../versioning/npm';
 import * as pep440versioning from '../../versioning/pep440';
+import * as rubyVersioning from '../../versioning/ruby';
 import type { PackageDependency } from '../types';
 
 function matchAction(action: string): z.Schema {
@@ -66,6 +68,87 @@ const SetupPnpm = z
       ...(skipStage && { skipStage }),
       ...(skipReason && { skipReason }),
       currentValue: val.version,
+      depType: 'uses-with',
+    };
+  });
+
+const SetupBun = z
+  .object({
+    uses: matchAction('oven-sh/setup-bun'),
+    with: z.object({
+      'bun-version': z.string().optional(),
+    }),
+  })
+  .transform(({ with: val }): PackageDependency => {
+    let skipStage: StageName | undefined;
+    let skipReason: SkipReason | undefined;
+    if (!val['bun-version']) {
+      skipStage = 'extract';
+      skipReason = 'unspecified-version';
+    }
+
+    return {
+      datasource: NpmDatasource.id,
+      depName: 'bun',
+      versioning: npmVersioning.id,
+      packageName: 'bun',
+      ...(skipStage && { skipStage }),
+      ...(skipReason && { skipReason }),
+      currentValue: val['bun-version'],
+      depType: 'uses-with',
+    };
+  });
+
+const SetupDeno = z
+  .object({
+    uses: matchAction('denoland/setup-deno'),
+    with: z.object({
+      'deno-version': z.string().optional(),
+    }),
+  })
+  .transform(({ with: val }): PackageDependency => {
+    let skipStage: StageName | undefined;
+    let skipReason: SkipReason | undefined;
+    if (!val['deno-version']) {
+      skipStage = 'extract';
+      skipReason = 'unspecified-version';
+    }
+
+    return {
+      datasource: NpmDatasource.id,
+      depName: 'deno',
+      versioning: npmVersioning.id,
+      packageName: 'deno',
+      ...(skipStage && { skipStage }),
+      ...(skipReason && { skipReason }),
+      currentValue: val['deno-version'],
+      depType: 'uses-with',
+    };
+  });
+
+const SetupRuby = z
+  .object({
+    uses: matchAction('ruby/setup-ruby'),
+    with: z.object({
+      'ruby-version': z.string().optional(),
+    }),
+  })
+  .transform(({ with: val }): PackageDependency => {
+    let skipStage: StageName | undefined;
+    let skipReason: SkipReason | undefined;
+    if (!val['ruby-version']) {
+      skipStage = 'extract';
+      skipReason = 'unspecified-version';
+    }
+
+    return {
+      datasource: RubyVersionDatasource.id,
+      depName: 'ruby',
+      versioning: rubyVersioning.id,
+      packageName: 'ruby',
+      ...(skipStage && { skipStage }),
+      ...(skipReason && { skipReason }),
+      currentValue: val['ruby-version'],
       depType: 'uses-with',
     };
   });
@@ -141,4 +224,7 @@ export const CommunityActions = z.union([
   SetupPixi,
   SetupPnpm,
   SetupUV,
+  SetupBun,
+  SetupDeno,
+  SetupRuby,
 ]);

--- a/lib/modules/manager/github-actions/extract.spec.ts
+++ b/lib/modules/manager/github-actions/extract.spec.ts
@@ -1077,7 +1077,7 @@ describe('modules/manager/github-actions/extract', () => {
     },
     {
       step: {
-        uses: 'over-sh/setup-bun@v2',
+        uses: 'oven-sh/setup-bun@v2',
         with: {},
       },
       expected: [
@@ -1094,7 +1094,7 @@ describe('modules/manager/github-actions/extract', () => {
     },
     {
       step: {
-        uses: 'over-sh/setup-bun@v2',
+        uses: 'oven-sh/setup-bun@v2',
         with: { 'bun-version': '1.2.0' },
       },
       expected: [
@@ -1150,7 +1150,7 @@ describe('modules/manager/github-actions/extract', () => {
         {
           skipStage: 'extract',
           skipReason: 'unspecified-version',
-          datasource: 'ruby',
+          datasource: 'ruby-version',
           depName: 'ruby',
           depType: 'uses-with',
           packageName: 'ruby',
@@ -1166,7 +1166,7 @@ describe('modules/manager/github-actions/extract', () => {
       expected: [
         {
           currentValue: '3.4',
-          datasource: 'ruby',
+          datasource: 'ruby-version',
           depName: 'ruby',
           depType: 'uses-with',
           packageName: 'ruby',

--- a/lib/modules/manager/github-actions/extract.spec.ts
+++ b/lib/modules/manager/github-actions/extract.spec.ts
@@ -606,18 +606,6 @@ describe('modules/manager/github-actions/extract', () => {
                 uses: actions/setup-node@v3
                 with:
                   node-version: 'latest'
-              - name: "Setup Deno"
-                uses: actions/setup-deno@v2
-                with:
-                  deno-version: '2.4.0'
-              - name: "Setup Bun"
-                uses: actions/setup-bun@v2
-                with:
-                  bun-version: '1.2.0'
-              - name: "Setup Ruby"
-                uses: actions/setup-ruby@v1
-                with:
-                  ruby-version: '3.4'
         `;
 
       const res = extractPackageFile(yamlContent, 'workflow.yml');
@@ -678,39 +666,6 @@ describe('modules/manager/github-actions/extract', () => {
           versioning: 'docker',
         },
         {
-          autoReplaceStringTemplate:
-            '{{depName}}@{{#if newDigest}}{{newDigest}}{{#if newValue}} # {{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}',
-          commitMessageTopic: '{{{depName}}} action',
-          currentValue: 'v2',
-          datasource: 'github-tags',
-          depName: 'actions/setup-deno',
-          depType: 'action',
-          replaceString: 'actions/setup-deno@v2',
-          versioning: 'docker',
-        },
-        {
-          autoReplaceStringTemplate:
-            '{{depName}}@{{#if newDigest}}{{newDigest}}{{#if newValue}} # {{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}',
-          commitMessageTopic: '{{{depName}}} action',
-          currentValue: 'v2',
-          datasource: 'github-tags',
-          depName: 'actions/setup-bun',
-          depType: 'action',
-          replaceString: 'actions/setup-bun@v2',
-          versioning: 'docker',
-        },
-        {
-          autoReplaceStringTemplate:
-            '{{depName}}@{{#if newDigest}}{{newDigest}}{{#if newValue}} # {{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}',
-          commitMessageTopic: '{{{depName}}} action',
-          currentValue: 'v1',
-          datasource: 'github-tags',
-          depName: 'actions/setup-ruby',
-          depType: 'action',
-          replaceString: 'actions/setup-ruby@v1',
-          versioning: 'docker',
-        },
-        {
           depName: 'node',
           packageName: 'actions/node-versions',
           currentValue: '16.x',
@@ -755,33 +710,6 @@ describe('modules/manager/github-actions/extract', () => {
           extractVersion: '^(?<version>\\d+\\.\\d+\\.\\d+)(-\\d+)?$',
           depType: 'uses-with',
         },
-        {
-          currentValue: '2.4.0',
-          datasource: 'github-releases',
-          depName: 'deno',
-          depType: 'uses-with',
-          extractVersion: '^(?<version>\\d+\\.\\d+\\.\\d+)(-\\d+)?$',
-          packageName: 'actions/deno-versions',
-          versioning: 'semver',
-        },
-        {
-          currentValue: '1.2.0',
-          datasource: 'github-releases',
-          depName: 'bun',
-          depType: 'uses-with',
-          extractVersion: '^(?<version>\\d+\\.\\d+\\.\\d+)(-\\d+)?$',
-          packageName: 'actions/bun-versions',
-          versioning: 'npm',
-        },
-        {
-          currentValue: '3.4',
-          datasource: 'github-releases',
-          depName: 'ruby',
-          depType: 'uses-with',
-          extractVersion: '^(?<version>\\d+\\.\\d+\\.\\d+)(-\\d+)?$',
-          packageName: 'actions/ruby-versions',
-          versioning: 'ruby',
-        },
       ]);
     });
 
@@ -810,18 +738,6 @@ describe('modules/manager/github-actions/extract', () => {
               uses: actions/setup-node@v3
               with:
                 node-version: 'latest'
-            - name: "Setup Deno"
-              uses: actions/setup-deno@v2
-              with:
-                deno-version: '2.4.0'
-            - name: "Setup Bun"
-              uses: actions/setup-bun@v2
-              with:
-                bun-version: '1.2.0'
-            - name: "Setup Ruby"
-              uses: actions/setup-ruby@v1
-              with:
-                ruby-version: '3.4'
         `;
 
       const res = extractPackageFile(yamlContent, 'action.yml');
@@ -882,39 +798,6 @@ describe('modules/manager/github-actions/extract', () => {
           versioning: 'docker',
         },
         {
-          autoReplaceStringTemplate:
-            '{{depName}}@{{#if newDigest}}{{newDigest}}{{#if newValue}} # {{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}',
-          commitMessageTopic: '{{{depName}}} action',
-          currentValue: 'v2',
-          datasource: 'github-tags',
-          depName: 'actions/setup-deno',
-          depType: 'action',
-          replaceString: 'actions/setup-deno@v2',
-          versioning: 'docker',
-        },
-        {
-          autoReplaceStringTemplate:
-            '{{depName}}@{{#if newDigest}}{{newDigest}}{{#if newValue}} # {{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}',
-          commitMessageTopic: '{{{depName}}} action',
-          currentValue: 'v2',
-          datasource: 'github-tags',
-          depName: 'actions/setup-bun',
-          depType: 'action',
-          replaceString: 'actions/setup-bun@v2',
-          versioning: 'docker',
-        },
-        {
-          autoReplaceStringTemplate:
-            '{{depName}}@{{#if newDigest}}{{newDigest}}{{#if newValue}} # {{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}',
-          commitMessageTopic: '{{{depName}}} action',
-          currentValue: 'v1',
-          datasource: 'github-tags',
-          depName: 'actions/setup-ruby',
-          depType: 'action',
-          replaceString: 'actions/setup-ruby@v1',
-          versioning: 'docker',
-        },
-        {
           depName: 'node',
           packageName: 'actions/node-versions',
           currentValue: '16.x',
@@ -958,33 +841,6 @@ describe('modules/manager/github-actions/extract', () => {
           versioning: 'node',
           extractVersion: '^(?<version>\\d+\\.\\d+\\.\\d+)(-\\d+)?$',
           depType: 'uses-with',
-        },
-        {
-          currentValue: '2.4.0',
-          datasource: 'github-releases',
-          depName: 'deno',
-          depType: 'uses-with',
-          extractVersion: '^(?<version>\\d+\\.\\d+\\.\\d+)(-\\d+)?$',
-          packageName: 'actions/deno-versions',
-          versioning: 'semver',
-        },
-        {
-          currentValue: '1.2.0',
-          datasource: 'github-releases',
-          depName: 'bun',
-          depType: 'uses-with',
-          extractVersion: '^(?<version>\\d+\\.\\d+\\.\\d+)(-\\d+)?$',
-          packageName: 'actions/bun-versions',
-          versioning: 'npm',
-        },
-        {
-          currentValue: '3.4',
-          datasource: 'github-releases',
-          depName: 'ruby',
-          depType: 'uses-with',
-          extractVersion: '^(?<version>\\d+\\.\\d+\\.\\d+)(-\\d+)?$',
-          packageName: 'actions/ruby-versions',
-          versioning: 'ruby',
         },
       ]);
     });
@@ -1216,6 +1072,105 @@ describe('modules/manager/github-actions/extract', () => {
           depType: 'uses-with',
           packageName: 'prefix-dev/pixi',
           versioning: 'conda',
+        },
+      ],
+    },
+    {
+      step: {
+        uses: 'over-sh/setup-bun@v2',
+        with: {},
+      },
+      expected: [
+        {
+          skipStage: 'extract',
+          skipReason: 'unspecified-version',
+          datasource: 'npm',
+          depName: 'bun',
+          depType: 'uses-with',
+          packageName: 'bun',
+          versioning: 'npm',
+        },
+      ],
+    },
+    {
+      step: {
+        uses: 'over-sh/setup-bun@v2',
+        with: { 'bun-version': '1.2.0' },
+      },
+      expected: [
+        {
+          currentValue: '1.2.0',
+          datasource: 'npm',
+          depName: 'bun',
+          depType: 'uses-with',
+          packageName: 'bun',
+          versioning: 'npm',
+        },
+      ],
+    },
+    {
+      step: {
+        uses: 'denoland/setup-deno@v2',
+        with: {},
+      },
+      expected: [
+        {
+          skipStage: 'extract',
+          skipReason: 'unspecified-version',
+          datasource: 'npm',
+          depName: 'deno',
+          depType: 'uses-with',
+          packageName: 'deno',
+          versioning: 'npm',
+        },
+      ],
+    },
+    {
+      step: {
+        uses: 'denoland/setup-deno@v2',
+        with: { 'deno-version': '2.4.0' },
+      },
+      expected: [
+        {
+          currentValue: '2.4.0',
+          datasource: 'npm',
+          depName: 'deno',
+          depType: 'uses-with',
+          packageName: 'deno',
+          versioning: 'npm',
+        },
+      ],
+    },
+    {
+      step: {
+        uses: 'ruby/setup-ruby@v1',
+        with: {},
+      },
+      expected: [
+        {
+          skipStage: 'extract',
+          skipReason: 'unspecified-version',
+          datasource: 'ruby',
+          depName: 'ruby',
+          depType: 'uses-with',
+          packageName: 'ruby',
+          versioning: 'ruby',
+        },
+      ],
+    },
+    {
+      step: {
+        uses: 'ruby/setup-ruby@v1',
+        with: { 'ruby-version': '3.4' },
+      },
+      expected: [
+        {
+          currentValue: '3.4',
+          datasource: 'ruby',
+          depName: 'ruby',
+          depType: 'uses-with',
+          packageName: 'ruby',
+          versioning: 'ruby',
         },
       ],
     },

--- a/lib/modules/manager/github-actions/extract.ts
+++ b/lib/modules/manager/github-actions/extract.ts
@@ -10,8 +10,6 @@ import { GithubTagsDatasource } from '../../datasource/github-tags';
 import * as dockerVersioning from '../../versioning/docker';
 import * as nodeVersioning from '../../versioning/node';
 import * as npmVersioning from '../../versioning/npm';
-import * as rubyVersioning from '../../versioning/ruby';
-import * as semanticVersioning from '../../versioning/semver';
 import { getDep } from '../dockerfile/extract';
 import type {
   ExtractConfig,
@@ -177,13 +175,11 @@ function extractRunner(runner: string): PackageDependency | null {
   return dependency;
 }
 
+// For official https://github.com/actions
 const versionedActions: Record<string, string> = {
-  bun: npmVersioning.id,
-  deno: semanticVersioning.id,
   go: npmVersioning.id,
   node: nodeVersioning.id,
   python: npmVersioning.id,
-  ruby: rubyVersioning.id,
 
   // Not covered yet because they use different datasources/packageNames:
   // - dotnet


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Refactor my previous contribution from #38132 to define deno, bun and ruby as community actions

<!-- Describe what behavior is changed by this PR. -->

## Context

This morning I noticed that #38132 wasn't behaving as expected, since these aren't official https://github.com/actions

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/setchy/renovate-useswith

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
