### PR TITLE
fix(github): skip non-fast-forward ruleset detection when rebaseWhen=auto

### DIFF
--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -958,7 +958,7 @@ describe('modules/platform/github/index', () => {
       expect(res).toBeFalse();
     });
 
-    it('should detect non_fast_forward ruleset', async () => {
+    it('should ignore non_fast_forward ruleset for determining rebase', async () => {
       httpMock
         .scope(githubApiHost)
         .get('/repos/undefined/rules/branches/main')
@@ -970,8 +970,16 @@ describe('modules/platform/github/index', () => {
             ruleset_id: 12345,
           },
         ]);
+      httpMock
+        .scope(githubApiHost)
+        .get('/repos/undefined/branches/main/protection')
+        .reply(200, {
+          required_status_checks: {
+            strict: false,
+          },
+        });
       const res = await github.getBranchForceRebase('main');
-      expect(res).toBeTrue();
+      expect(res).toBeFalse();
     });
 
     it('should detect strict required status checks ruleset', async () => {

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -764,11 +764,6 @@ async function checkRulesetsForForceRebase(
     );
 
     return rulesets.some((rule) => {
-      if (rule.type === 'non_fast_forward') {
-        logger.debug(`Ruleset: non_fast_forward rule found for ${branchName}`);
-        return true;
-      }
-
       if (
         rule.type === 'required_status_checks' &&
         rule.parameters?.strict_required_status_checks_policy === true


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
According to the [GitHub Docs](https://docs.github.com/en/rest/repos/rules?apiVersion=2022-11-28#get-rules-for-a-branch), the definition of the non_fast_forward ruleset is: “Prevent users with push access from force pushing to refs.”

Even if this ruleset is applied, a head branch that lags behind the base branch can still be merged normally. In other words, this ruleset has nothing to do with whether a rebase is required.

This issue was caused by the PR merged last week: https://github.com/renovatebot/renovate/pull/38072.

Our [repository](https://github.com/Flexget/Flexget) had no problems before, but **since last week I’ve noticed that Renovate has been unnecessarily rebasing all PRs**, leading to extra CI overhead.

## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
