### PR TITLE
fix: Reopen autoclosed PRs with new title

### DIFF
--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -1473,14 +1473,17 @@ describe('modules/platform/github/index', () => {
       vi.spyOn(branch, 'remoteBranchExists').mockResolvedValueOnce(false);
       git.getBranchCommit.mockReturnValueOnce('5678' as LongCommitSha);
 
-      const pr = await github.tryReuseAutoclosedPr({
-        number: 91,
-        title: 'old title - autoclosed',
-        state: 'closed',
-        closedAt: DateTime.now().minus({ days: 6 }).toISO(),
-        sourceBranch: 'somebranch',
-        sha: '1234' as LongCommitSha,
-      });
+      const pr = await github.tryReuseAutoclosedPr(
+        {
+          number: 91,
+          title: 'old title - autoclosed',
+          state: 'closed',
+          closedAt: DateTime.now().minus({ days: 6 }).toISO(),
+          sourceBranch: 'somebranch',
+          sha: '1234' as LongCommitSha,
+        },
+        'new title',
+      );
 
       expect(pr).toMatchObject({
         number: 91,

--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -1437,14 +1437,17 @@ describe('modules/platform/github/index', () => {
       await github.initRepo({ repository: 'some/repo' });
       vi.spyOn(branch, 'remoteBranchExists').mockResolvedValueOnce(false);
 
-      const pr = await github.tryReuseAutoclosedPr({
-        number: 91,
-        title: 'old title - autoclosed',
-        state: 'closed',
-        closedAt: DateTime.now().minus({ days: 6 }).toISO(),
-        sourceBranch: 'somebranch',
-        sha: '1234' as LongCommitSha,
-      });
+      const pr = await github.tryReuseAutoclosedPr(
+        {
+          number: 91,
+          title: 'old title - autoclosed',
+          state: 'closed',
+          closedAt: DateTime.now().minus({ days: 6 }).toISO(),
+          sourceBranch: 'somebranch',
+          sha: '1234' as LongCommitSha,
+        },
+        'new title',
+      );
 
       expect(pr).toMatchObject({ number: 91, sourceBranch: 'somebranch' });
     });
@@ -1463,14 +1466,17 @@ describe('modules/platform/github/index', () => {
 
       await github.initRepo({ repository: 'some/repo' });
 
-      const pr = await github.tryReuseAutoclosedPr({
-        number: 91,
-        title: 'old title - autoclosed',
-        state: 'closed',
-        closedAt: DateTime.now().minus({ days: 6 }).toISO(),
-        sourceBranch: 'somebranch',
-        sha: '1234' as LongCommitSha,
-      });
+      const pr = await github.tryReuseAutoclosedPr(
+        {
+          number: 91,
+          title: 'old title - autoclosed',
+          state: 'closed',
+          closedAt: DateTime.now().minus({ days: 6 }).toISO(),
+          sourceBranch: 'somebranch',
+          sha: '1234' as LongCommitSha,
+        },
+        'new title',
+      );
 
       expect(pr).toBeNull();
     });
@@ -1482,14 +1488,17 @@ describe('modules/platform/github/index', () => {
 
       await github.initRepo({ repository: 'some/repo' });
 
-      const pr = await github.tryReuseAutoclosedPr({
-        number: 91,
-        title: 'old title - autoclosed',
-        state: 'closed',
-        closedAt: DateTime.now().minus({ days: 6 }).toISO(),
-        sourceBranch: 'somebranch',
-        sha: '1234' as LongCommitSha,
-      });
+      const pr = await github.tryReuseAutoclosedPr(
+        {
+          number: 91,
+          title: 'old title - autoclosed',
+          state: 'closed',
+          closedAt: DateTime.now().minus({ days: 6 }).toISO(),
+          sourceBranch: 'somebranch',
+          sha: '1234' as LongCommitSha,
+        },
+        'new title',
+      );
 
       expect(pr).toBeNull();
     });

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -1036,6 +1036,7 @@ export async function getBranchPr(branchName: string): Promise<GhPr | null> {
 
 export async function tryReuseAutoclosedPr(
   autoclosedPr: Pr,
+  newTitle: string,
 ): Promise<Pr | null> {
   const { sha, number, sourceBranch: branchName } = autoclosedPr;
   try {
@@ -1050,18 +1051,17 @@ export async function tryReuseAutoclosedPr(
   }
 
   try {
-    const title = autoclosedPr.title.replace(regEx(/ - autoclosed$/), '');
     const { body: ghPr } = await githubApi.patchJson<GhRestPr>(
       `repos/${config.repository}/pulls/${number}`,
       {
         body: {
           state: 'open',
-          title,
+          title: newTitle,
         },
       },
     );
     logger.info(
-      { branchName, title, number },
+      { branchName, oldTitle: autoclosedPr.title, newTitle, number },
       'Successfully reopened autoclosed PR',
     );
     const result = coerceRestPr(ghPr);

--- a/lib/modules/platform/types.ts
+++ b/lib/modules/platform/types.ts
@@ -289,7 +289,7 @@ export interface Platform {
     internalChecksAsSuccess: boolean,
   ): Promise<BranchStatus>;
   getBranchPr(branchName: string, targetBranch?: string): Promise<Pr | null>;
-  tryReuseAutoclosedPr?(pr: Pr): Promise<Pr | null>;
+  tryReuseAutoclosedPr?(pr: Pr, newTitle: string): Promise<Pr | null>;
   initPlatform(config: PlatformParams): Promise<PlatformResult>;
   filterUnavailableUsers?(users: string[]): Promise<string[]>;
   commitFiles?(config: CommitFilesConfig): Promise<LongCommitSha | null>;

--- a/lib/workers/repository/update/pr/index.ts
+++ b/lib/workers/repository/update/pr/index.ts
@@ -173,7 +173,7 @@ export async function ensurePr(
   // Check if PR already exists
   const existingPr =
     (await platform.getBranchPr(branchName, config.baseBranch)) ??
-    (await tryReuseAutoclosedPr(branchName));
+    (await tryReuseAutoclosedPr(branchName, prTitle));
   const prCache = getPrCache(branchName);
   if (existingPr) {
     logger.debug('Found existing PR');

--- a/lib/workers/repository/update/pr/pr-reuse.spec.ts
+++ b/lib/workers/repository/update/pr/pr-reuse.spec.ts
@@ -21,7 +21,7 @@ describe('workers/repository/update/pr/pr-reuse', () => {
       writable: true,
     });
 
-    const res = await tryReuseAutoclosedPr('some-branch');
+    const res = await tryReuseAutoclosedPr('some-branch', 'PR Title');
 
     expect(res).toBeNull();
   });
@@ -29,7 +29,7 @@ describe('workers/repository/update/pr/pr-reuse', () => {
   it('returns null if PR is not found', async () => {
     platform.findPr.mockResolvedValueOnce(null);
 
-    const res = await tryReuseAutoclosedPr('some-branch');
+    const res = await tryReuseAutoclosedPr('some-branch', 'PR Title');
 
     expect(res).toBeNull();
   });
@@ -42,7 +42,7 @@ describe('workers/repository/update/pr/pr-reuse', () => {
       state: 'closed',
     });
 
-    const res = await tryReuseAutoclosedPr('some-branch');
+    const res = await tryReuseAutoclosedPr('some-branch', 'PR Title');
 
     expect(res).toBeNull();
   });
@@ -55,7 +55,7 @@ describe('workers/repository/update/pr/pr-reuse', () => {
       state: 'closed',
     });
 
-    const res = await tryReuseAutoclosedPr('some-branch');
+    const res = await tryReuseAutoclosedPr('some-branch', 'PR Title');
 
     expect(res).toBeNull();
   });
@@ -69,7 +69,7 @@ describe('workers/repository/update/pr/pr-reuse', () => {
       closedAt: DateTime.now().minus({ weeks: 1, seconds: 1 }).toISO(),
     });
 
-    const res = await tryReuseAutoclosedPr('some-branch');
+    const res = await tryReuseAutoclosedPr('some-branch', 'PR Title');
 
     expect(res).toBeNull();
   });
@@ -85,7 +85,7 @@ describe('workers/repository/update/pr/pr-reuse', () => {
       closedAt: DateTime.now().minus({ hours: 1 }).toISO(),
     });
 
-    const res = await tryReuseAutoclosedPr('some-branch');
+    const res = await tryReuseAutoclosedPr('some-branch', 'PR Title');
 
     expect(res).toBeNull();
     expect(tryReuseFn).not.toHaveBeenCalled();
@@ -107,7 +107,7 @@ describe('workers/repository/update/pr/pr-reuse', () => {
       state: 'open',
     });
 
-    const res = await tryReuseAutoclosedPr('some-branch');
+    const res = await tryReuseAutoclosedPr('some-branch', 'PR Title');
 
     expect(res).toEqual({
       number: 123,
@@ -129,7 +129,7 @@ describe('workers/repository/update/pr/pr-reuse', () => {
 
     tryReuseFn.mockRejectedValueOnce('oops');
 
-    const res = await tryReuseAutoclosedPr('some-branch');
+    const res = await tryReuseAutoclosedPr('some-branch', 'PR Title');
 
     expect(res).toBeNull();
     expect(tryReuseFn).toHaveBeenCalledOnce();

--- a/lib/workers/repository/update/pr/pr-reuse.ts
+++ b/lib/workers/repository/update/pr/pr-reuse.ts
@@ -8,6 +8,7 @@ const REOPEN_THRESHOLD_MILLIS = 1000 * 60 * 60 * 24 * 7;
 
 export async function tryReuseAutoclosedPr(
   branchName: string,
+  newTitle: string,
 ): Promise<Pr | null> {
   if (!platform.tryReuseAutoclosedPr) {
     return null;
@@ -49,7 +50,7 @@ export async function tryReuseAutoclosedPr(
   }
 
   try {
-    const pr = await platform.tryReuseAutoclosedPr(autoclosedPr);
+    const pr = await platform.tryReuseAutoclosedPr(autoclosedPr, newTitle);
     return pr;
   } catch (err) {
     logger.debug(


### PR DESCRIPTION
## Changes

This PR refactors the PR reopening logic to accept the new title as a parameter, allowing it to be updated in a single step instead of deriving it from the old title.

Previously, when reopening an autoclosed PR, the title was modified by removing the " - autoclosed" suffix. Now the new title is passed explicitly from the caller, reducing noise in PR history by updating the title in one step.

## Context

- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

- [x] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).

## Documentation

- [x] No documentation update is required

## How I've tested my work

- [x] Code inspection only