### PR TITLE
fix(pip-compile): Relative includes were handled incorrectly

### DIFF
--- a/lib/modules/manager/pip-compile/extract.spec.ts
+++ b/lib/modules/manager/pip-compile/extract.spec.ts
@@ -694,4 +694,32 @@ describe('modules/manager/pip-compile/extract', () => {
       { packageFile: 'dir/2.in', lockFiles: ['dir/2.txt'] },
     ]);
   });
+
+  it('handles -r dependency on file with relative path above with path', async () => {
+    fs.readLocalFile.mockImplementation((name): any => {
+      if (name === 'common/1.in') {
+        return 'foo';
+      } else if (name === 'dir/2.in') {
+        return '-r ../common/1.in\nbar';
+      } else if (name === 'common/1.txt') {
+        return getSimpleRequirementsFile(
+          'pip-compile --output-file=common/1.txt common/1.in',
+          ['foo==1.0.1'],
+        );
+      } else if (name === 'dir/2.txt') {
+        return getSimpleRequirementsFile(
+          'pip-compile --output-file=dir/2.txt dir/2.in',
+          ['foo==1.0.1', 'bar==2.0.0'],
+        );
+      }
+      return null;
+    });
+
+    const lockFiles = ['common/1.txt', 'dir/2.txt'];
+    const packageFiles = await extractAllPackageFiles({}, lockFiles);
+    expect(packageFiles).toMatchObject([
+      { packageFile: 'common/1.in', lockFiles: ['common/1.txt', 'dir/2.txt'] },
+      { packageFile: 'dir/2.in', lockFiles: ['dir/2.txt'] },
+    ]);
+  });
 });

--- a/lib/modules/manager/pip-compile/extract.ts
+++ b/lib/modules/manager/pip-compile/extract.ts
@@ -146,7 +146,8 @@ export async function extractAllPackageFiles(
         if (packageFileContent.managerData?.requirementsFiles) {
           packageFileContent.managerData.requirementsFiles =
             packageFileContent.managerData.requirementsFiles.map(
-              (file: string) => upath.normalize(upath.join(compileDir, file)),
+              (file: string) =>
+                upath.normalize(upath.join(upath.dirname(packageFile), file)),
             );
           for (const file of packageFileContent.managerData.requirementsFiles) {
             depsBetweenFiles.push({


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

When a requirements file includes another via the `-r` flag it's always treated as relative to the directory where the requirements file is, not the directory where the command is being run.  Those are often the same, but not always.
This fixes the path handling to handle the path correctly.

## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/mbudnek/renovate-pip-compile-test

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
