### PR TITLE
test(minimumReleaseAge): document `releaseTimestamp` leads to immediate PRs

### DIFF
--- a/lib/workers/repository/process/lookup/filter-checks.spec.ts
+++ b/lib/workers/repository/process/lookup/filter-checks.spec.ts
@@ -212,6 +212,40 @@ describe('workers/repository/process/lookup/filter-checks', () => {
       expect(res.release?.version).toBe('1.0.3');
     });
 
+    // TODO: will be fixed in https://github.com/renovatebot/renovate/discussions/38290 / https://github.com/renovatebot/renovate/discussions/38348
+    it('returns latest release if internalChecksFilter=strict, minimumReleaseAge is specified, but the latest release does not have a releaseTimestamp', async () => {
+      const releasesWithMissingReleaseTimestamp: Release[] = [
+        {
+          version: '1.0.1',
+          releaseTimestamp: '2021-01-01T00:00:01.000Z' as Timestamp,
+        },
+        {
+          version: '1.0.2',
+          releaseTimestamp: '2021-01-03T00:00:00.000Z' as Timestamp,
+        },
+        {
+          version: '1.0.3',
+          releaseTimestamp: '2021-01-05T00:00:00.000Z' as Timestamp,
+        },
+        {
+          version: '1.0.4',
+          // no releaseTimestamp
+        },
+      ];
+
+      config.internalChecksFilter = 'strict';
+      config.minimumReleaseAge = '100 days';
+      const res = await filterInternalChecks(
+        config,
+        versioning,
+        'patch',
+        releasesWithMissingReleaseTimestamp,
+      );
+      expect(res.pendingChecks).toBeFalse();
+      expect(res.pendingReleases).toHaveLength(0);
+      expect(res.release?.version).toBe('1.0.4');
+    });
+
     it('picks up minimumConfidence settings from updateType', async () => {
       config.internalChecksFilter = 'strict';
       config.minimumConfidence = 'high';

--- a/lib/workers/repository/update/branch/index.spec.ts
+++ b/lib/workers/repository/update/branch/index.spec.ts
@@ -238,6 +238,21 @@ describe('workers/repository/update/branch/index', () => {
       });
     });
 
+    // TODO: will be fixed in https://github.com/renovatebot/renovate/discussions/38290 / https://github.com/renovatebot/renovate/discussions/38348
+    it('does not skip branch if release is missing releaseTimestamp with minimumReleaseAge set', async () => {
+      schedule.isScheduledNow.mockReturnValueOnce(true);
+      config.prCreation = 'not-pending';
+      config.upgrades = partial<BranchUpgradeConfig>([
+        {
+          // no releaseTimestamp
+          minimumReleaseAge: '100 days',
+        },
+      ]);
+      scm.isBranchModified.mockResolvedValueOnce(false);
+      await branchWorker.processBranch(config);
+      expect(reuse.shouldReuseExistingBranch).toHaveBeenCalled();
+    });
+
     it('skips branch if minimumConfidence not met', async () => {
       schedule.isScheduledNow.mockReturnValueOnce(true);
       config.prCreation = 'not-pending';


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

As part of discussion in #38290, #38348 and #38324, the current
behaviour of `minimumReleaseAge` has been flagged as not particularly
great, as when we run with `minimumReleaseAge` enforced, a package that
does not return a `releaseTimestamp` will no longer be treated as
release that is bound by `minimumReleaseAge`'s checks to make it
pending.

As noted in the discussions, this can lead to cases where users are in a
"false sense of security", as they feel comfortable with
`minimumReleaseAge` in place, but it is not being enforced, only when
the `releaseTimestamp` is present.

Before we change this, we should add a test to document the existing
behaviour.

[0]: https://github.com/renovatebot/renovate/discussions/38290
[1]: https://github.com/renovatebot/renovate/discussions/38348

## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required - this is existing behaviour

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
