### PR TITLE
feat(minimumReleaseAge): optionally enforce presence of `releaseTimestamp`

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2707,7 +2707,7 @@ Example:
 
 This feature used to be called `stabilityDays`.
 
-If `minimumReleaseAge` is set to a time duration _and_ the update has a release timestamp header, then Renovate will check if the set duration has passed.
+If `minimumReleaseAge` is set to a time duration _and_ the update has a release timestamp header, then Renovate will check if the set duration has passed. This behaviour can be changed using [`minimumReleaseAgeBehaviour`](#minimumreleaseagebehaviour).
 
 Note: Renovate will wait for the set duration to pass for each **separate** version.
 Renovate does not wait until the package has seen no releases for x time-duration(`minimumReleaseAge`).
@@ -2774,6 +2774,16 @@ Renovate adds a "renovate/stability-days" pending status check to each branch/PR
 This pending check prevents the branch going green to automerge before the time has passed.
 
 <!-- markdownlint-enable MD001 -->
+
+## minimumReleaseAgeBehaviour
+
+When `minimumReleaseAge` is set to a time duration, the `minimumReleaseAgeBehaviour` will be used to control whether the release timestamp is required.
+
+When set to `timestamp-required`, this version is not treated stable unless there is release timestamp, and that release timestamp is past the [`minimumReleaseAge`](#minimumreleaseage).
+
+When set to `timestamp-optional`, Renovate will treat a release without a releaseTimestamp as stable.
+
+This only applies when used with [`minimumReleaseAge`](#minimumreleaseage).
 
 ## minor
 

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -1967,6 +1967,14 @@ const options: RenovateOptions[] = [
     default: null,
   },
   {
+    name: 'minimumReleaseAgeBehaviour',
+    description:
+      'When set in conjunction with `minimumReleaseAge`, controls whether the `releaseTimestamp` for a dependency update is required.',
+    type: 'string',
+    default: 'timestamp-optional',
+    allowedValues: ['timestamp-required', 'timestamp-optional'],
+  },
+  {
     name: 'abandonmentThreshold',
     description:
       'Flags packages that have not been updated within this period as abandoned.',

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -219,6 +219,9 @@ export type RenovateRepository =
 
 export type UseBaseBranchConfigType = 'merge' | 'none';
 export type ConstraintsFilter = 'strict' | 'none';
+export type MinimumReleaseAgeBehaviour =
+  | 'timestamp-optional'
+  | 'timestamp-required';
 
 export const allowedStatusCheckStrings = [
   'minimumReleaseAge',
@@ -326,6 +329,8 @@ export interface RenovateConfig
   additionalBranchPrefix?: string;
   sharedVariableName?: string;
   minimumGroupSize?: number;
+
+  minimumReleaseAgeBehaviour?: MinimumReleaseAgeBehaviour;
 }
 
 const CustomDatasourceFormats = [

--- a/lib/workers/repository/process/lookup/filter-checks.ts
+++ b/lib/workers/repository/process/lookup/filter-checks.ts
@@ -1,5 +1,6 @@
 import is from '@sindresorhus/is';
 import { mergeChildConfig } from '../../../../config';
+import type { MinimumReleaseAgeBehaviour } from '../../../../config/types';
 import { logger } from '../../../../logger';
 import type { Release } from '../../../../modules/datasource';
 import { postprocessRelease } from '../../../../modules/datasource/postprocess-release';
@@ -42,6 +43,14 @@ export async function filterInternalChecks(
     // Don't care if minimumReleaseAge or minimumConfidence are unmet
     release = sortedReleases.pop();
   } else {
+    const candidateVersionsWithoutReleaseTimestamp: Record<
+      MinimumReleaseAgeBehaviour,
+      string[]
+    > = {
+      'timestamp-required': [],
+      'timestamp-optional': [],
+    };
+
     // iterate through releases from highest to lowest, looking for the first which will pass checks if present
     for (let candidateRelease of sortedReleases.reverse()) {
       // merge the release data into dependency config
@@ -73,21 +82,44 @@ export async function filterInternalChecks(
       // Now check for a minimumReleaseAge config
       const { minimumConfidence, minimumReleaseAge, updateType } =
         releaseConfig;
-      if (
-        is.nonEmptyString(minimumReleaseAge) &&
-        candidateRelease.releaseTimestamp
-      ) {
-        if (
-          getElapsedMs(candidateRelease.releaseTimestamp) <
-          coerceNumber(toMs(minimumReleaseAge), 0)
+      if (is.nonEmptyString(minimumReleaseAge)) {
+        const minimumReleaseAgeBehaviour =
+          releaseConfig.minimumReleaseAgeBehaviour;
+
+        // if there is a releaseTimestamp, regardless of `minimumReleaseAgeBehaviour`, we should process it
+        if (candidateRelease.releaseTimestamp) {
+          // we should skip this if we have a timestamp that isn't passing checks:
+          if (
+            getElapsedMs(candidateRelease.releaseTimestamp) <
+            coerceNumber(toMs(minimumReleaseAge), 0)
+          ) {
+            // Skip it if it doesn't pass checks
+            logger.trace(
+              { depName, check: 'minimumReleaseAge' },
+              `Release ${candidateRelease.version} is pending status checks`,
+            );
+            pendingReleases.unshift(candidateRelease);
+            continue;
+          }
+        } // or if there is no timestamp, and we're running in `minimumReleaseAgeBehaviour=timestamp-required`
+        else if (
+          is.nullOrUndefined(candidateRelease.releaseTimestamp) &&
+          minimumReleaseAgeBehaviour === 'timestamp-required'
         ) {
-          // Skip it if it doesn't pass checks
-          logger.trace(
-            { depName, check: 'minimumReleaseAge' },
-            `Release ${candidateRelease.version} is pending status checks`,
-          );
+          // Skip it, as we require a timestamp
+          candidateVersionsWithoutReleaseTimestamp[
+            minimumReleaseAgeBehaviour
+          ].push(candidateRelease.version);
           pendingReleases.unshift(candidateRelease);
           continue;
+        } // if there is no timestamp, and we're running in `optional` mode, we can allow it
+        else if (
+          is.nullOrUndefined(candidateRelease.releaseTimestamp) &&
+          minimumReleaseAgeBehaviour === 'timestamp-optional'
+        ) {
+          candidateVersionsWithoutReleaseTimestamp[
+            minimumReleaseAgeBehaviour
+          ].push(candidateRelease.version);
         }
       }
 
@@ -115,6 +147,31 @@ export async function filterInternalChecks(
       release = candidateRelease;
       break;
     }
+
+    if (candidateVersionsWithoutReleaseTimestamp['timestamp-required'].length) {
+      logger.debug(
+        {
+          depName,
+          versions:
+            candidateVersionsWithoutReleaseTimestamp['timestamp-required'],
+          check: 'minimumReleaseAge',
+        },
+        `Marking ${candidateVersionsWithoutReleaseTimestamp['timestamp-required'].length} release(s) as pending, as they not have a releaseTimestamp and we're running with minimumReleaseAgeBehaviour=require-timestamp`,
+      );
+    }
+
+    if (candidateVersionsWithoutReleaseTimestamp['timestamp-optional'].length) {
+      logger.warn(
+        {
+          depName,
+          versions:
+            candidateVersionsWithoutReleaseTimestamp['timestamp-optional'],
+          check: 'minimumReleaseAge',
+        },
+        `${candidateVersionsWithoutReleaseTimestamp['timestamp-optional'].length} release(s) did not have a releaseTimestamp, but as we're running with minimumReleaseAgeBehaviour=optional-timestamp, proceeding`,
+      );
+    }
+
     if (!release) {
       if (pendingReleases.length) {
         // If all releases were pending then just take the highest

--- a/lib/workers/repository/update/branch/index.ts
+++ b/lib/workers/repository/update/branch/index.ts
@@ -1,7 +1,10 @@
 import is from '@sindresorhus/is';
 import { DateTime } from 'luxon';
 import { GlobalConfig } from '../../../../config/global';
-import type { RenovateConfig } from '../../../../config/types';
+import {
+  type MinimumReleaseAgeBehaviour,
+  type RenovateConfig,
+} from '../../../../config/types';
 import {
   CONFIG_VALIDATION,
   MANAGER_LOCKFILE_ERROR,
@@ -371,32 +374,56 @@ export async function processBranch(
     if (
       config.upgrades.some(
         (upgrade) =>
-          (is.nonEmptyString(upgrade.minimumReleaseAge) &&
-            is.nonEmptyString(upgrade.releaseTimestamp)) ||
+          is.nonEmptyString(upgrade.minimumReleaseAge) ||
           isActiveConfidenceLevel(upgrade.minimumConfidence!),
       )
     ) {
+      const depNamesWithoutReleaseTimestamp: Record<
+        MinimumReleaseAgeBehaviour,
+        string[]
+      > = {
+        'timestamp-required': [],
+        'timestamp-optional': [],
+      };
+
       // Only set a stability status check if one or more of the updates contain
       // both a minimumReleaseAge setting and a releaseTimestamp
       config.stabilityStatus = 'green';
       // Default to 'success' but set 'pending' if any update is pending
       for (const upgrade of config.upgrades) {
-        if (
-          is.nonEmptyString(upgrade.minimumReleaseAge) &&
-          upgrade.releaseTimestamp
-        ) {
-          const timeElapsed = getElapsedMs(upgrade.releaseTimestamp);
-          if (timeElapsed < coerceNumber(toMs(upgrade.minimumReleaseAge))) {
-            logger.debug(
-              {
-                depName: upgrade.depName,
-                timeElapsed,
-                minimumReleaseAge: upgrade.minimumReleaseAge,
-              },
-              'Update has not passed minimum release age',
-            );
-            config.stabilityStatus = 'yellow';
-            continue;
+        if (is.nonEmptyString(upgrade.minimumReleaseAge)) {
+          const minimumReleaseAgeBehaviour: MinimumReleaseAgeBehaviour =
+            upgrade.minimumReleaseAgeBehaviour ?? 'timestamp-optional';
+
+          // regardless of the value of `minimumReleaseAgeBehaviour`, if there is a timestamp, we will process it according to `minimumReleaseAge`
+          if (upgrade.releaseTimestamp) {
+            const timeElapsed = getElapsedMs(upgrade.releaseTimestamp);
+            if (timeElapsed < coerceNumber(toMs(upgrade.minimumReleaseAge))) {
+              logger.debug(
+                {
+                  depName: upgrade.depName,
+                  timeElapsed,
+                  minimumReleaseAge: upgrade.minimumReleaseAge,
+                },
+                'Update has not passed minimum release age',
+              );
+              config.stabilityStatus = 'yellow';
+              continue;
+            }
+          } else {
+            // if we're set to `minimumReleaseAgeBehaviour=timestamp-required`, and there isn't a timestamp, always mark the update as pending
+            if (minimumReleaseAgeBehaviour === 'timestamp-required') {
+              depNamesWithoutReleaseTimestamp['timestamp-required'].push(
+                upgrade.depName!,
+              );
+              config.stabilityStatus = 'yellow';
+              continue;
+            } else {
+              // if there is no timestamp, and we're running in `optional` mode, we can allow it, but make sure to warn the user
+              depNamesWithoutReleaseTimestamp['timestamp-optional'].push(
+                upgrade.depName!,
+              );
+            }
           }
         }
         const datasource = upgrade.datasource!;
@@ -427,6 +454,20 @@ export async function processBranch(
           }
         }
       }
+
+      if (depNamesWithoutReleaseTimestamp['timestamp-required'].length) {
+        logger.debug(
+          { depNames: depNamesWithoutReleaseTimestamp['timestamp-required'] },
+          `Marking ${depNamesWithoutReleaseTimestamp['timestamp-required'].length} release(s) as pending, as they not have a releaseTimestamp and we're running with minimumReleaseAgeBehaviour=require-timestamp`,
+        );
+      }
+      if (depNamesWithoutReleaseTimestamp['timestamp-optional'].length) {
+        logger.warn(
+          { depNames: depNamesWithoutReleaseTimestamp['timestamp-optional'] },
+          `${depNamesWithoutReleaseTimestamp['timestamp-optional'].length} upgrade(s) did not have a releaseTimestamp, but as we're running with minimumReleaseAgeBehaviour=timestamp-optional, proceeding`,
+        );
+      }
+
       // Don't create a branch if we know it will be status 'pending'
       if (
         !dependencyDashboardCheck &&


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

As noted in #38290, #38348, a "rough edge" of the current implementation
of `minimumReleaseAge` is that:

- if we have set `minimumReleaseAge` to apply to a given dependency
- and we have 3 dependencies that need an update
  - 2 of which have a `releaseTimestamp` that is not yet "stable"
  - 1 of which does not have a `releaseTimestamp`

The dependency update that does not have a `releaseTimestamp` will be
treated as "stable", and will receive an update immediately.

To make this a little more predictable, and explicit, we should add a
new configuration item, `minimumReleaseAgeBehaviour`, to control this
behaviour.

This adds the new configuration field, as well as making it available as
a strongly typed field in the codebase.

In the case that `minimumReleaseAgeBehaviour=timestamp-optional` is
being used, we will WARN on any packages that are being updated, but
maybe shouldn't be, as a way to proactively inform the user of possible
misconfiguration.

- #38290
- #38348.



<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the below:

- [ ] This closes an existing Issue: #38290, #38348
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
