### PR TITLE
fix: don't fetch repo config file when in fork mode

### DIFF
--- a/lib/workers/repository/onboarding/branch/check.spec.ts
+++ b/lib/workers/repository/onboarding/branch/check.spec.ts
@@ -66,4 +66,13 @@ describe('workers/repository/onboarding/branch/check', () => {
       REPOSITORY_CLOSED_ONBOARDING,
     );
   });
+
+  it('checks git file list for config file when in fork mode', async () => {
+    config.forkToken = 'token';
+    cache.getCache.mockReturnValue({ configFileName: 'renovate.json' });
+    scm.getFileList.mockResolvedValue([]);
+    await isOnboarded(config);
+    expect(platform.getJsonFile).not.toHaveBeenCalled();
+    expect(scm.getFileList).toHaveBeenCalled();
+  });
 });

--- a/lib/workers/repository/onboarding/branch/check.ts
+++ b/lib/workers/repository/onboarding/branch/check.ts
@@ -101,7 +101,9 @@ export async function isOnboarded(config: RenovateConfig): Promise<boolean> {
     return false;
   }
 
-  if (cache.configFileName) {
+  // when bot is ran is fork mode ... do not fetch file using api call instead use the git.fileList so we get sync first and get the latest config
+  // prevents https://github.com/renovatebot/renovate/discussions/37328
+  if (cache.configFileName && !config.forkToken) {
     logger.debug('Checking cached config file name');
     try {
       const configFileContent = await platform.getJsonFile(


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- When cached filename is available, check if bot is running in fork-mode before trying to fetch the repo config file uiing platform API. Instead, clone the repo and use the local file.
<!-- Describe what behavior is changed by this PR. -->

## Context
- We currently fetch the repo config using the platform API **before** syncing the fork with upstream. This causes a problem: the config file we fetch is the one from the fork, which may be outdated. If the user has updated the config file in upstream, we still end up using the outdated forked version because the HTTP request is cached. As a result, `mergeRenovateConfig` ends up working with stale configuration.

Please select one of the below:

- [x] This closes an existing Issue: #37328 
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository 
https://github.com/Rahul-renovate-testing/RahulGautamSingh-_-check-fork-sync


The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
