### PR TITLE
feat!: Decrease office hours for schedule presets from 10 to 8 hours

### DIFF
--- a/lib/config/presets/internal/schedule.ts
+++ b/lib/config/presets/internal/schedule.ts
@@ -6,7 +6,7 @@ const daily = ['* 0-3 * * *'];
 const earlyMondays = ['* 0-3 * * 1'];
 const monthly = ['* 0-3 1 * *'];
 const nonOfficeHours = ['* 0-4,22-23 * * 1-5', '* * * * 0,6'];
-const officeHours = ['* 8-16 * * 1-5'];
+const officeHours = ['* 9-16 * * 1-5'];
 const quarterly = ['* * 1 */3 *'];
 const weekdays = ['* * * * 1-5'];
 const weekends = ['* * * * 0,6'];
@@ -34,7 +34,7 @@ export const presets: Record<string, Preset> = {
   automergeOfficeHours: {
     automergeSchedule: officeHours,
     description:
-      'Schedule automerge during typical office hours on weekdays (i.e., 8 AM - 5 PM).',
+      'Schedule automerge during typical office hours on weekdays (i.e., 9 AM - 5 PM).',
   },
   automergeQuarterly: {
     automergeSchedule: quarterly,
@@ -78,7 +78,7 @@ export const presets: Record<string, Preset> = {
   },
   officeHours: {
     description:
-      'Schedule during typical office hours on weekdays (i.e., 8 AM - 5 PM).',
+      'Schedule during typical office hours on weekdays (i.e., 9 AM - 5 PM).',
     schedule: officeHours,
   },
   quarterly: {

--- a/lib/config/presets/internal/schedule.ts
+++ b/lib/config/presets/internal/schedule.ts
@@ -6,7 +6,7 @@ const daily = ['* 0-3 * * *'];
 const earlyMondays = ['* 0-3 * * 1'];
 const monthly = ['* 0-3 1 * *'];
 const nonOfficeHours = ['* 0-4,22-23 * * 1-5', '* * * * 0,6'];
-const officeHours = ['* 8-17 * * 1-5'];
+const officeHours = ['* 8-16 * * 1-5'];
 const quarterly = ['* * 1 */3 *'];
 const weekdays = ['* * * * 1-5'];
 const weekends = ['* * * * 0,6'];
@@ -34,7 +34,7 @@ export const presets: Record<string, Preset> = {
   automergeOfficeHours: {
     automergeSchedule: officeHours,
     description:
-      'Schedule automerge during typical office hours on weekdays (i.e., 8 AM - 6 PM).',
+      'Schedule automerge during typical office hours on weekdays (i.e., 8 AM - 5 PM).',
   },
   automergeQuarterly: {
     automergeSchedule: quarterly,
@@ -78,7 +78,7 @@ export const presets: Record<string, Preset> = {
   },
   officeHours: {
     description:
-      'Schedule during typical office hours on weekdays (i.e., 8 AM - 6 PM).',
+      'Schedule during typical office hours on weekdays (i.e., 8 AM - 5 PM).',
     schedule: officeHours,
   },
   quarterly: {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Office hours meaning is by its definition:

> Office hours are the times when an office is open for business. For example, office hours in Britain are usually between 9 o'clock and 5 o'clock from Monday to Friday.

However, the current configuration, covers from 8 AM to 6 PM. Hopefully, this is no ones office hours, as it'd entail someone working 10 hours per day. 🙂 

With this change, I propose to fix the configuration to go along with the general definition from 9 AM to 5 PM.

## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
