### PR TITLE
fix(merge-confidence): ensure that Maven coordinate lookups are URL escaped

### DIFF
--- a/lib/util/merge-confidence/index.spec.ts
+++ b/lib/util/merge-confidence/index.spec.ts
@@ -178,6 +178,32 @@ describe('util/merge-confidence/index', () => {
         ).toBe('high');
       });
 
+      it('escapes a partial Maven coordinate of groupId:artifactId from the packageName', async () => {
+        const datasource = 'maven';
+        const packageName =
+          'org.springframework.boot:org.springframework.boot.gradle.plugin';
+        const escapedPackageName =
+          'org.springframework.boot%3Aorg.springframework.boot.gradle.plugin';
+        const currentVersion = '2.6.2';
+        const newVersion = '2.7.2';
+        httpMock
+          .scope(apiBaseUrl)
+          .get(
+            `/api/mc/json/${datasource}/${escapedPackageName}/${currentVersion}/${newVersion}`,
+          )
+          .reply(200, { confidence: 'high' });
+
+        expect(
+          await getMergeConfidenceLevel(
+            datasource,
+            packageName,
+            currentVersion,
+            newVersion,
+            'major',
+          ),
+        ).toBe('high');
+      });
+
       it('returns neutral on invalid merge confidence response from api', async () => {
         const datasource = 'npm';
         const depName = 'renovate';

--- a/lib/util/merge-confidence/index.ts
+++ b/lib/util/merge-confidence/index.ts
@@ -140,7 +140,9 @@ async function queryApi(
     return 'neutral';
   }
 
-  const escapedPackageName = packageName.replace(regEx(/\//g), '%2f');
+  const escapedPackageName = packageName
+    .replace(regEx(/\//g), '%2f')
+    .replace(regEx(/:/g), '%3A');
   const url = joinUrlParts(
     apiBaseUrl,
     'api/mc/json',


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

This isn't technically needed, as right now the Merge Confidence API
allows URL-encoded or plain forms of the `:` symbol, but we should
perform our lookups more resiliently, to be safe.

Ideally we would use `encodeURIComponent`, but in keeping with the
existing escaping, we can use a regex replacement.

## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
