### PR TITLE
docs: add documentation on NO_PROXY variable

### DIFF
--- a/docs/usage/examples/self-hosting.md
+++ b/docs/usage/examples/self-hosting.md
@@ -441,3 +441,17 @@ USER 12021
 # OpenSSL
 ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
 ```
+
+## Proxy Environment Variable Configuration
+If your environment uses an HTTP proxy configured via environment variables (`HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`, and their lowercase variants), Renovate inherits these settings and prefers the lowercase variant.
+
+In some cases, you may need to adjust the `NO_PROXY` variable if Renovate encounters network or TLS errors when accessing internal or excluded domains.
+
+Renovate uses the [global-agent](https://github.com/gajus/global-agent) library to manage proxy connections.
+To exclude a domain and all its subdomains, you must use a wildcard — for example:
+```
+NO_PROXY=*.example.org
+```
+This configuration ensures that both `example.org` and `www.example.org` are accessed directly, bypassing the proxy for Renovate.
+
+If a tool that Renovate runs (such as git) still has proxy-related issues, note that different tools interpret NO_PROXY formats differently. See [GitLab’s detailed explanation](https://about.gitlab.com/blog/we-need-to-talk-no-proxy/#no_proxy-format) for guidance on tool-specific behavior.

--- a/docs/usage/examples/self-hosting.md
+++ b/docs/usage/examples/self-hosting.md
@@ -443,15 +443,19 @@ ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
 ```
 
 ## Proxy Environment Variable Configuration
+
 If your environment uses an HTTP proxy configured via environment variables (`HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`, and their lowercase variants), Renovate inherits these settings and prefers the lowercase variant.
 
 In some cases, you may need to adjust the `NO_PROXY` variable if Renovate encounters network or TLS errors when accessing internal or excluded domains.
 
 Renovate uses the [global-agent](https://github.com/gajus/global-agent) library to manage proxy connections.
+
 To exclude a domain and all its subdomains, you must use a wildcard — for example:
+
 ```
 NO_PROXY=*.example.org
 ```
+
 This configuration ensures that both `example.org` and `www.example.org` are accessed directly, bypassing the proxy for Renovate.
 
 If a tool that Renovate runs (such as git) still has proxy-related issues, note that different tools interpret NO_PROXY formats differently. See [GitLab’s detailed explanation](https://about.gitlab.com/blog/we-need-to-talk-no-proxy/#no_proxy-format) for guidance on tool-specific behavior.


### PR DESCRIPTION
see https://github.com/renovatebot/renovate/discussions/38420#discussioncomment-14622566

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds a new section on proxy environment varaible configuration to the self-hosting page.

## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### My Original Write-up
```markdown
## Proxy Environment Variable Configuration
If your environment has configured a http proxy using environment variables (`HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY` and lowercase variants ), you might need to tweak the `NO_PROXY` variables when Renovate encounters network or TLS errors.

Renovate uses the [global-agent](https://github.com/gajus/global-agent) library to setup a proxy connection.
To exclude a domain and all of its subdomains, you need to use a [wildcard](https://github.com/gajus/global-agent?tab=readme-ov-file#exclude-urls), e.g. `NO_PROXY=*.example.org` to exclude `example.org` and `www.example.org` for Renovate.

If a tool that Renovate instruments runs into problems (e.g. git), take a look at [GitLab's blog post](https://about.gitlab.com/blog/we-need-to-talk-no-proxy/#no_proxy-format) on how different tools interpret the variable.
```
## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
