### PR TITLE
fix(merge-confidence): use `packageName` for all lookups

### DIFF
--- a/lib/workers/repository/process/lookup/filter-checks.ts
+++ b/lib/workers/repository/process/lookup/filter-checks.ts
@@ -28,7 +28,13 @@ export async function filterInternalChecks(
   bucket: string,
   sortedReleases: Release[],
 ): Promise<InternalChecksResult> {
-  const { currentVersion, datasource, depName, internalChecksFilter } = config;
+  const {
+    currentVersion,
+    datasource,
+    depName,
+    packageName,
+    internalChecksFilter,
+  } = config;
   let release: Release | undefined = undefined;
   let pendingChecks = false;
   let pendingReleases: Release[] = [];
@@ -90,7 +96,7 @@ export async function filterInternalChecks(
         const confidenceLevel =
           (await getMergeConfidenceLevel(
             datasource!,
-            depName!,
+            packageName!,
             currentVersion!,
             candidateRelease.version,
             updateType!,

--- a/lib/workers/repository/update/branch/index.ts
+++ b/lib/workers/repository/update/branch/index.ts
@@ -401,6 +401,7 @@ export async function processBranch(
         }
         const datasource = upgrade.datasource!;
         const depName = upgrade.depName!;
+        const packageName = upgrade.packageName!;
         const minimumConfidence = upgrade.minimumConfidence!;
         const updateType = upgrade.updateType!;
         const currentVersion = upgrade.currentVersion!;
@@ -409,7 +410,7 @@ export async function processBranch(
           const confidence =
             (await getMergeConfidenceLevel(
               datasource,
-              depName,
+              packageName,
               currentVersion,
               newVersion,
               updateType,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

When performing lookups in Mend's Merge Confidence APIs, our contract
requires that we use the `packageName` not the `depName`.

In 9b7ae6aa9815c356935ee59a8cc26113a19b5a7a and
b67eae218061ecd70f9c4602c171ade7fc3e550f we made changes to make sure
that this wasn't the case, but we ended up missing a couple of cases.


## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: https://github.com/JamieTanna-Mend-testing/tka-mc-gradle/pull/4

Via `config.js`:

```javascript
module.exports = {
  "hostRules": [
    {
      "token": "...",
      "host-type": "merge-confidence",
    }
  ],
  "packageRules": [
    {
      "matchConfidence": ["high", "very high"],
      "groupName": "high merge confidence"
    }
  ]
}

```

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
