### PR TITLE
docs(aws-machine-image): clarify that currentImageName is updated by Renovate

### DIFF
--- a/lib/modules/datasource/aws-machine-image/readme.md
+++ b/lib/modules/datasource/aws-machine-image/readme.md
@@ -116,6 +116,10 @@ my_ami2: ami-0083e9407e275acf2
 # amiFilter=[{"Name":"owner-id","Values":["602401143452"]},{"Name":"name","Values":["amazon-eks-node-1.20-*"]},{"profile":"test","region":"eu-central-1"}]
 # currentImageName=amazon-eks-node-1.20-v20240615
 ami = "ami-0083e9407e275acf2"
+
+# Without currentImageName comment (also works!)
+# amiFilter=[{"Name":"owner-id","Values":["602401143452"]},{"Name":"name","Values":["amazon-eks-node-1.19-*"]}]
+my_ami3: ami-0a1b2c3d4e5f6g7h8
 ```
 
 ```typescript
@@ -127,7 +131,7 @@ const myConfigObject = {
 };
 
 /**
- * Only AMI, no AMI name mentioned
+ * AMI with name tracked in comment
  * amiFilter=[{"Name":"owner-id","Values":["602401143452"]},{"Name":"name","Values":["amazon-eks-node-1.20-*"]}]
  * currentImageName=amazon-eks-node-1.20-v20240615
  */
@@ -148,5 +152,13 @@ resource "aws_instance" "web" {
     connection {
         user = "root"
     }
+}
+
+resource "aws_instance" "app" {
+    # Without currentImageName comment
+    # amiFilter=[{"Name":"owner-id","Values":["602401143452"]},{"Name":"name","Values":["amazon-eks-node-1.19-*"]}]
+    ami = "ami-0a1b2c3d4e5f6g7h8"
+
+    count = 1
 }
 ```

--- a/lib/modules/datasource/aws-machine-image/readme.md
+++ b/lib/modules/datasource/aws-machine-image/readme.md
@@ -64,7 +64,7 @@ module.exports = {
       customType: 'regex',
       managerFilePatterns: ['/.*/'],
       matchStrings: [
-        '.*amiFilter=(?<packageName>.*?)\n(.*currentImageName=.*?\n)?(.*\n)?.*?(?<depName>[a-zA-Z0-9-_:]*)[ ]*?[:|=][ ]*?["|\']?(?<currentValue>ami-[a-z0-9]{17})["|\']?.*',
+        '.*amiFilter=(?<packageName>.*?)\n(.*currentImageName=(?<currentDigest>.*?)\n)?(.*\n)?.*?(?<depName>[a-zA-Z0-9-_:]*)[ ]*?[:|=][ ]*?["|\']?(?<currentValue>ami-[a-z0-9]{17})["|\']?.*',
       ],
       datasourceTemplate: 'aws-machine-image',
       versioningTemplate: 'aws-machine-image',
@@ -84,7 +84,7 @@ Or as JSON:
         'managerFilePatterns': ['/.*/'],
         'matchStrings':
           [
-            ".*amiFilter=(?<packageName>.*?)\n(.*currentImageName=.*?\n)?(.*\n)?.*?(?<depName>[a-zA-Z0-9-_:]*)[ ]*?[:|=][ ]*?[\"|']?(?<currentValue>ami-[a-z0-9]{17})[\"|']?.*",
+            ".*amiFilter=(?<packageName>.*?)\n(.*currentImageName=(?<currentDigest>.*?)\n)?(.*\n)?.*?(?<depName>[a-zA-Z0-9-_:]*)[ ]*?[:|=][ ]*?[\"|']?(?<currentValue>ami-[a-z0-9]{17})[\"|']?.*",
           ],
         'datasourceTemplate': 'aws-machine-image',
         'versioningTemplate': 'aws-machine-image',
@@ -93,21 +93,26 @@ Or as JSON:
 }
 ```
 
+**Note about `currentImageName`:**
+
+The optional `currentImageName` comment is automatically updated by Renovate to track the actual AMI name corresponding to the AMI ID. This provides human-readable context about which image version is being used. When Renovate finds a newer AMI, it will update both the AMI ID and the `currentImageName` comment.
+
 This would match every file, and would recognize the following lines:
 
 ```yaml
 # With AMI name mentioned in the comments
 # amiFilter=[{"Name":"owner-id","Values":["602401143452"]},{"Name":"name","Values":["amazon-eks-node-1.21-*"]}]
-# currentImageName=unknown
+# currentImageName=amazon-eks-node-1.21-v20240703
 my_ami1: ami-02ce3d9008cab69cb
+
 # Only AMI, no name mentioned
 # amiFilter=[{"Name":"owner-id","Values":["602401143452"]},{"Name":"name","Values":["amazon-eks-node-1.20-*"]}]
-# currentImageName=unknown
+# currentImageName=amazon-eks-node-1.20-v20240615
 my_ami2: ami-0083e9407e275acf2
 
 # Using custom aws profile and region
 # amiFilter=[{"Name":"owner-id","Values":["602401143452"]},{"Name":"name","Values":["amazon-eks-node-1.20-*"]},{"profile":"test","region":"eu-central-1"}]
-# currentImageName=unknown
+# currentImageName=amazon-eks-node-1.20-v20240615
 ami = "ami-0083e9407e275acf2"
 ```
 
@@ -115,14 +120,14 @@ ami = "ami-0083e9407e275acf2"
 const myConfigObject = {
   // With AMI name mentioned in the comments
   // amiFilter=[{"Name":"owner-id","Values":["602401143452"]},{"Name":"name","Values":["amazon-eks-node-1.21-*"]}]
-  // currentImageName=unknown
+  // currentImageName=amazon-eks-node-1.21-v20240703
   my_ami1: 'ami-02ce3d9008cab69cb',
 };
 
 /**
  * Only AMI, no AMI name mentioned
  * amiFilter=[{"Name":"owner-id","Values":["602401143452"]},{"Name":"name","Values":["amazon-eks-node-1.20-*"]}]
- * currentImageName=unknown
+ * currentImageName=amazon-eks-node-1.20-v20240615
  */
 const my_ami2 = 'ami-0083e9407e275acf2';
 ```
@@ -130,9 +135,9 @@ const my_ami2 = 'ami-0083e9407e275acf2';
 ```hcl
 resource "aws_instance" "web" {
 
-    # Only AMI, no name mentioned
+    # AMI with name tracked in comment
     # amiFilter=[{"Name":"owner-id","Values":["602401143452"]},{"Name":"name","Values":["amazon-eks-node-1.20-*"]}]
-    # currentImageName=unknown
+    # currentImageName=amazon-eks-node-1.20-v20240615
     ami = "ami-0083e9407e275acf2"
 
     count = 2

--- a/lib/modules/datasource/aws-machine-image/readme.md
+++ b/lib/modules/datasource/aws-machine-image/readme.md
@@ -84,7 +84,7 @@ Or as JSON:
         'managerFilePatterns': ['/.*/'],
         'matchStrings':
           [
-            ".*amiFilter=(?<packageName>.*?)\n(.*currentImageName=.*?\n)?(.*\n)?.*?(?<depName>[a-zA-Z0-9-_:]*)[ ]*?[:|=][ ]*?["|\']?(?<currentValue>ami-[a-z0-9]{17})["|\']?.*",
+            ".*amiFilter=(?<packageName>.*?)\n(.*currentImageName=.*?\n)?(.*\n)?.*?(?<depName>[a-zA-Z0-9-_:]*)[ ]*?[:|=][ ]*?[\"|']?(?<currentValue>ami-[a-z0-9]{17})[\"|']?.*",
           ],
         'datasourceTemplate': 'aws-machine-image',
         'versioningTemplate': 'aws-machine-image',

--- a/lib/modules/datasource/aws-machine-image/readme.md
+++ b/lib/modules/datasource/aws-machine-image/readme.md
@@ -136,6 +136,12 @@ const myConfigObject = {
  * currentImageName=amazon-eks-node-1.20-v20240615
  */
 const my_ami2 = 'ami-0083e9407e275acf2';
+
+/**
+ * Without currentImageName comment
+ * amiFilter=[{"Name":"owner-id","Values":["602401143452"]},{"Name":"name","Values":["amazon-eks-node-1.19-*"]}]
+ */
+const my_ami3 = 'ami-0a1b2c3d4e5f6g7h8';
 ```
 
 ```hcl

--- a/lib/modules/datasource/aws-machine-image/readme.md
+++ b/lib/modules/datasource/aws-machine-image/readme.md
@@ -95,7 +95,9 @@ Or as JSON:
 
 **Note about `currentImageName`:**
 
-The optional `currentImageName` comment is automatically updated by Renovate to track the actual AMI name corresponding to the AMI ID. This provides human-readable context about which image version is being used. When Renovate finds a newer AMI, it will update both the AMI ID and the `currentImageName` comment.
+The optional `currentImageName` comment is automatically updated by Renovate to track the actual AMI name corresponding to the AMI ID.
+This provides human-readable context about which image version is being used.
+When Renovate finds a newer AMI, it will update both the AMI ID and the `currentImageName` comment.
 
 This would match every file, and would recognize the following lines:
 

--- a/lib/modules/datasource/aws-machine-image/readme.md
+++ b/lib/modules/datasource/aws-machine-image/readme.md
@@ -64,7 +64,7 @@ module.exports = {
       customType: 'regex',
       managerFilePatterns: ['/.*/'],
       matchStrings: [
-        '.*amiFilter=(?<packageName>.*?)\n(.*currentImageName=(?<currentDigest>.*?)\n)?(.*\n)?.*?(?<depName>[a-zA-Z0-9-_:]*)[ ]*?[:|=][ ]*?["|\']?(?<currentValue>ami-[a-z0-9]{17})["|\']?.*',
+        '.*amiFilter=(?<packageName>.*?)\n(.*currentImageName=.*?\n)?(.*\n)?.*?(?<depName>[a-zA-Z0-9-_:]*)[ ]*?[:|=][ ]*?["|\']?(?<currentValue>ami-[a-z0-9]{17})["|\']?.*',
       ],
       datasourceTemplate: 'aws-machine-image',
       versioningTemplate: 'aws-machine-image',
@@ -84,7 +84,7 @@ Or as JSON:
         'managerFilePatterns': ['/.*/'],
         'matchStrings':
           [
-            ".*amiFilter=(?<packageName>.*?)\n(.*currentImageName=(?<currentDigest>.*?)\n)?(.*\n)?.*?(?<depName>[a-zA-Z0-9-_:]*)[ ]*?[:|=][ ]*?[\"|']?(?<currentValue>ami-[a-z0-9]{17})[\"|']?.*",
+            ".*amiFilter=(?<packageName>.*?)\n(.*currentImageName=.*?\n)?(.*\n)?.*?(?<depName>[a-zA-Z0-9-_:]*)[ ]*?[:|=][ ]*?["|\']?(?<currentValue>ami-[a-z0-9]{17})["|\']?.*",
           ],
         'datasourceTemplate': 'aws-machine-image',
         'versioningTemplate': 'aws-machine-image',


### PR DESCRIPTION
## Description

The example regex pattern incorrectly captures `currentImageName` into the `currentDigest` group, causing Renovate to update this comment field. The `currentImageName` field should remain static (typically "unknown") and not be modified during updates.

Remove the named capture group `<currentDigest>` from the `currentImageName` pattern so the comment line is preserved as-is while only the AMI ID is updated.

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Updated the example regex pattern in the AWS Machine Image datasource documentation to remove the `<currentDigest>` named capture group from the `currentImageName` line. This prevents Renovate from updating the `# currentImageName=unknown` comment, which should remain static.

Before: `(.*currentImageName=(?<currentDigest>.*?)\n)?`
After: `(.*currentImageName=.*?\n)?`

## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

AI was used to help identify the issue in the regex pattern.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
