### PR TITLE
chore(github): warn users without "Automatically delete head branches"

### DIFF
--- a/lib/modules/platform/github/graphql.ts
+++ b/lib/modules/platform/github/graphql.ts
@@ -14,6 +14,7 @@ query($owner: String!, $name: String!, $user: String) {
     mergeCommitAllowed
     rebaseMergeAllowed
     squashMergeAllowed
+    deleteBranchOnMerge
     defaultBranchRef {
       name
       target {

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -582,6 +582,19 @@ export async function initRepo({
       );
       throw new Error(REPOSITORY_ARCHIVED);
     }
+
+    // https://github.com/renovatebot/renovate/discussions/38325
+    if (!repo.deleteBranchOnMerge) {
+      logger.warn(
+        {
+          repo: repository,
+          documentationUrl:
+            'https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-the-automatic-deletion-of-branches',
+        },
+        'Repository does not have "Automatically delete head branches" set, which could cause Renovate to re-use a repository in some cases',
+      );
+    }
+
     // Use default branch as PR target unless later overridden.
     config.defaultBranch = repo.defaultBranchRef.name;
     // Base branch may be configured but defaultBranch is always fixed

--- a/lib/modules/platform/github/types.ts
+++ b/lib/modules/platform/github/types.ts
@@ -125,6 +125,7 @@ export interface GhRepo {
   mergeCommitAllowed: boolean;
   rebaseMergeAllowed: boolean;
   squashMergeAllowed: boolean;
+  deleteBranchOnMerge: boolean;
   defaultBranchRef: {
     name: string;
     target: {


### PR DESCRIPTION
## Changes

As noted in #38324, there could be a bug occur with branches not being
automagically deleted, where:

1. repository does not "Automatically delete head branches"
1. `minimumReleaseAge` is used to gate a release update, as the release
   is not passing that check
1. a group that includes that release is set up
1. a branch is created for all updates except the `minimumReleaseAge`
   (as expected)
1. the PR is merged
1. the branch is not deleted
1. next time Renovate runs, it sees the branch created - albeit out of
   date - so it treats this as permission to update the package gated by
   `minimumReleaseAge`

As a step towards fixing this long-term, we can introduce a log warning
to inform repo owners that they may be susceptible to issues.

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

Relates to #38325.

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
