### PR TITLE
fix(datasource/typst): explictly pass `registryUrl` as `baseUrl` to `githubHttp`

### DIFF
--- a/lib/modules/datasource/typst/index.ts
+++ b/lib/modules/datasource/typst/index.ts
@@ -13,7 +13,7 @@ import { SourceUrl, Versions } from './schema';
 export class TypstDatasource extends Datasource {
   static readonly id = 'typst';
 
-  override readonly defaultRegistryUrls = ['https://github.com'];
+  override readonly defaultRegistryUrls = ['https://api.github.com'];
 
   override defaultVersioning = semver;
 
@@ -21,9 +21,7 @@ export class TypstDatasource extends Datasource {
 
   constructor() {
     super(TypstDatasource.id);
-    this.githubHttp = new GithubHttp(TypstDatasource.id, {
-      baseUrl: 'https://api.github.com',
-    });
+    this.githubHttp = new GithubHttp(TypstDatasource.id);
   }
 
   @cache({
@@ -33,6 +31,7 @@ export class TypstDatasource extends Datasource {
   })
   override async getReleases({
     packageName,
+    registryUrl,
   }: GetReleasesConfig): Promise<ReleaseResult | null> {
     const [namespace, pkg] = packageName.split('/');
     if (namespace !== 'preview') {
@@ -51,7 +50,10 @@ export class TypstDatasource extends Datasource {
 
     const { body: versions } = await this.githubHttp.getJson(
       versionsUrl,
-      { cacheProvider },
+      {
+        cacheProvider,
+        baseUrl: registryUrl,
+      },
       Versions,
     );
 
@@ -68,7 +70,10 @@ export class TypstDatasource extends Datasource {
     const manifestUrl = `/repos/typst/packages/contents/packages/preview/${pkg}/${latestRelease}/typst.toml`;
     const { body: sourceUrl } = await this.githubHttp.getJson(
       manifestUrl,
-      { cacheProvider },
+      {
+        cacheProvider,
+        baseUrl: registryUrl,
+      },
       SourceUrl,
     );
 


### PR DESCRIPTION
## Changes

We noticed that the `typest` datasource lookups on GitHub Enterprise Server are done against that specific Enterprise Server rather than github.com causing the updates to fail as the repository doesn't exist on the GitHub Enterprise Server.
The new test `request package from github.com even on GitHub Enterprise Server` shows this behavior if you execute it without the changes.


This PR adjust the behavior of the `typst` datasource to expliclty pass the `registryUrl` as `baseUrl` to the `githubHttp` client. This would otherwise default to the GitHub Enterprise Server (even through the initial value is set to github.com, but this is later overwrriten during the platform/repo init steps as it is a global variable and not an instance attribute. Therefore I removed the inital setting of it completly). 
https://github.com/renovatebot/renovate/blob/a5f3956210f42637f7d15c5bbfa7f23bde7d033f/lib/util/http/github.ts#L32-L36

In order to support this change the registryUrl is updated from `https://github.com` to `https://api.github.com` as well and adjusted in the tests.

## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
