### PR TITLE
chore(instrumentation): add helpers for Git instrumentation

### DIFF
--- a/lib/instrumentation/types.ts
+++ b/lib/instrumentation/types.ts
@@ -3,6 +3,7 @@ import type { RenovateSplit } from '../config/types';
 import type { BunyanRecord } from '../logger/types';
 import type { PackageFile } from '../modules/manager/types';
 import type { BranchCache } from '../util/cache/repository/types';
+import type { GitOperationType } from '../util/git/types';
 
 export type RenovateSpanOptions = {
   attributes?: RenovateSpanAttributes;
@@ -10,6 +11,7 @@ export type RenovateSpanOptions = {
 
 export type RenovateSpanAttributes = {
   [ATTR_RENOVATE_SPLIT]?: RenovateSplit;
+  [ATTR_VCS_GIT_OPERATION_TYPE]?: GitOperationType;
 } & Attributes;
 
 /**
@@ -65,3 +67,14 @@ export interface DependencyStatus {
 }
 
 export const ATTR_RENOVATE_SPLIT = 'renovate.split';
+
+/**
+ * the Git Version Control System (VCS)'s Operation Type
+ *
+ * @see GitOperationType
+ *
+ */
+export const ATTR_VCS_GIT_OPERATION_TYPE = 'vcs.git.operation.type';
+
+/** the Git Version Control System (VCS)'s subcommand */
+export const ATTR_VCS_GIT_SUBCOMMAND = 'vcs.git.subcommand';

--- a/lib/util/git/instrument.ts
+++ b/lib/util/git/instrument.ts
@@ -1,0 +1,62 @@
+import type { RenovateSpanOptions } from '../../instrumentation/types';
+import {
+  ATTR_VCS_GIT_OPERATION_TYPE,
+  ATTR_VCS_GIT_SUBCOMMAND,
+} from '../../instrumentation/types';
+import type { GitOperationType } from './types';
+
+function isGitOperationType(
+  subcommand: string,
+): subcommand is GitOperationType {
+  return knownGitOperationTypesBySubcommand.includes(
+    subcommand as GitOperationType,
+  );
+}
+
+function gitOperationTypeForSubcommand(subcommand: string): GitOperationType {
+  let operationType: GitOperationType = 'other';
+  if (!isGitOperationType(subcommand)) {
+    if (subcommand === 'update-index') {
+      operationType = 'plumbing';
+    }
+
+    return operationType;
+  }
+
+  return subcommand;
+}
+
+/** single-command prefixes that correspond to an operation type */
+const knownGitOperationTypesBySubcommand: GitOperationType[] = [
+  'branch',
+  'checkout',
+  'clean',
+  'clone',
+  'commit',
+  'fetch',
+  'merge',
+  'pull',
+  'push',
+  'reset',
+  'submodule',
+];
+
+/** helper method for instrumentation of Git operations */
+export function prepareInstrumentation(
+  subcommand: string,
+  options: RenovateSpanOptions = {},
+): {
+  spanName: string;
+  options: RenovateSpanOptions;
+} {
+  const operationType = gitOperationTypeForSubcommand(subcommand);
+
+  options.attributes ??= {};
+  options.attributes[ATTR_VCS_GIT_OPERATION_TYPE] = operationType;
+  options.attributes[ATTR_VCS_GIT_SUBCOMMAND] = subcommand;
+
+  return {
+    spanName: `git ${subcommand}`,
+    options,
+  };
+}

--- a/lib/util/git/types.ts
+++ b/lib/util/git/types.ts
@@ -124,3 +124,73 @@ export interface AuthenticationRule {
   url: string;
   insteadOf: string;
 }
+
+export type GitOperationType =
+  /**
+   * The `git clone` sub-command.
+   */
+  | 'clone'
+  /**
+   * The `git reset` sub-command.
+   */
+  | 'reset'
+  /**
+   * The `git checkout` sub-command.
+   */
+  | 'checkout'
+  /**
+   * The `git fetch` sub-command.
+   */
+  | 'fetch'
+  /**
+   * The `git pull` sub-command.
+   */
+  | 'pull'
+  /**
+   * The `git push` sub-command.
+   */
+  | 'push'
+  /**
+   * The `git clean` sub-command.
+   */
+  | 'clean'
+  /**
+   * The `git merge` sub-command.
+   */
+  | 'merge'
+  /**
+   * The `git submodule` sub-command.
+   */
+  | 'submodule'
+  /**
+   * The `git commit` sub-command.
+   */
+  | 'commit'
+  /**
+   * The `git branch` sub-command.
+   */
+  | 'branch'
+  /**
+   * Any internal "plumbing" commands
+   *
+   * - `git update-index`
+   *
+   * See also: https://git-scm.com/book/en/v2/Git-Internals-Plumbing-and-Porcelain
+   */
+  | 'plumbing'
+  /**
+   * Any other operations i.e.
+   *
+   * - `git add`
+   * - `git branch`
+   * - `git config`
+   * - `git diff`
+   * - `git log`
+   * - `git ls-remote`
+   * - `git remote`
+   * - `git rev-parse`
+   * - `git status`
+   *
+   * See also: https://git-scm.com/book/en/v2/Git-Internals-Plumbing-and-Porcelain
+   */
+  | 'other';


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes



As part of being able to fully instrument our Git operations - using
SimpleGit - we can introduce some Git-specific instrumentation helpers.

These helpers will be used as part of a future change, where we will
instrument methods of SimpleGit that we're using.

This provides a set of types which will be used as OpenTelemetry
Attributes to categorise command types.

A number of subcommands that aren't currently deemed to be too important
are bucketed into an `other` category.

---

Note that it's worth reviewing this with the integration (https://github.com/renovatebot/renovate/pull/39591) in mind)


<!-- Describe what behavior is changed by this PR. -->

## Context


Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
