### PR TITLE
fix(npm): avoid updating lock files for `engines`, `packageManager`, and `volta` deps

### DIFF
--- a/lib/modules/manager/npm/extract/post/locked-versions.spec.ts
+++ b/lib/modules/manager/npm/extract/post/locked-versions.spec.ts
@@ -349,6 +349,8 @@ describe('modules/manager/npm/extract/post/locked-versions', () => {
       npm.getNpmLock.mockResolvedValue({
         lockedVersions: {
           npm: '10.9.4',
+          yarn: '1.2.3',
+          pnpm: '9.12.3',
         },
         lockfileVersion: 3,
       });
@@ -365,19 +367,31 @@ describe('modules/manager/npm/extract/post/locked-versions', () => {
             },
             {
               depName: 'yarn',
-              currentValue: '1.2.3',
-              depType: 'engines',
+              currentValue: '^1.0.0',
+              depType: 'devDependencies',
               datasource: 'npm',
             },
             {
               depName: 'pnpm',
-              currentValue: '9.12.3',
-              depType: 'packageManager',
+              currentValue: '^9.0.0',
+              depType: 'devDependencies',
               datasource: 'npm',
             },
             {
               depName: 'npm',
               currentValue: '10.9.3',
+              depType: 'engines',
+              datasource: 'npm',
+            },
+            {
+              depName: 'yarn',
+              currentValue: '1.2.3',
+              depType: 'packageManager',
+              datasource: 'npm',
+            },
+            {
+              depName: 'pnpm',
+              currentValue: '1.2.3',
               depType: 'volta',
               datasource: 'npm',
             },
@@ -399,21 +413,35 @@ describe('modules/manager/npm/extract/post/locked-versions', () => {
             },
             {
               depName: 'yarn',
-              currentValue: '1.2.3',
+              currentValue: '^1.0.0',
+              depType: 'devDependencies',
+              lockedVersion: '1.2.3',
+              datasource: 'npm',
+            },
+            {
+              depName: 'pnpm',
+              currentValue: '^9.0.0',
+              depType: 'devDependencies',
+              lockedVersion: '9.12.3',
+              datasource: 'npm',
+            },
+            {
+              depName: 'npm',
+              currentValue: '10.9.3',
               depType: 'engines',
               datasource: 'npm',
               // engines deps should NOT have lockedVersion
             },
             {
-              depName: 'pnpm',
-              currentValue: '9.12.3',
+              depName: 'yarn',
+              currentValue: '1.2.3',
               depType: 'packageManager',
               datasource: 'npm',
               // packageManager deps should NOT have lockedVersion
             },
             {
-              depName: 'npm',
-              currentValue: '10.9.3',
+              depName: 'pnpm',
+              currentValue: '1.2.3',
               depType: 'volta',
               datasource: 'npm',
               // volta deps should NOT have lockedVersion

--- a/lib/modules/manager/npm/extract/post/locked-versions.spec.ts
+++ b/lib/modules/manager/npm/extract/post/locked-versions.spec.ts
@@ -348,9 +348,9 @@ describe('modules/manager/npm/extract/post/locked-versions', () => {
     it('does not set locked versions for engines, packageManager, and volta deps', async () => {
       npm.getNpmLock.mockResolvedValue({
         lockedVersions: {
-          npm: '10.9.4',
-          yarn: '1.2.3',
-          pnpm: '9.12.3',
+          npm: '1.2.3',
+          yarn: '2.3.4',
+          pnpm: '3.4.5',
         },
         lockfileVersion: 3,
       });
@@ -361,37 +361,37 @@ describe('modules/manager/npm/extract/post/locked-versions', () => {
           deps: [
             {
               depName: 'npm',
-              currentValue: '^10.0.0',
-              depType: 'devDependencies',
-              datasource: 'npm',
-            },
-            {
-              depName: 'yarn',
               currentValue: '^1.0.0',
               depType: 'devDependencies',
               datasource: 'npm',
             },
             {
+              depName: 'yarn',
+              currentValue: '^2.0.0',
+              depType: 'devDependencies',
+              datasource: 'npm',
+            },
+            {
               depName: 'pnpm',
-              currentValue: '^9.0.0',
+              currentValue: '^3.0.0',
               depType: 'devDependencies',
               datasource: 'npm',
             },
             {
               depName: 'npm',
-              currentValue: '10.9.3',
+              currentValue: '2.0.0',
               depType: 'engines',
               datasource: 'npm',
             },
             {
               depName: 'yarn',
-              currentValue: '1.2.3',
+              currentValue: '3.0.0',
               depType: 'packageManager',
               datasource: 'npm',
             },
             {
               depName: 'pnpm',
-              currentValue: '1.2.3',
+              currentValue: '4.0.0',
               depType: 'volta',
               datasource: 'npm',
             },
@@ -406,42 +406,42 @@ describe('modules/manager/npm/extract/post/locked-versions', () => {
           deps: [
             {
               depName: 'npm',
-              currentValue: '^10.0.0',
-              depType: 'devDependencies',
-              lockedVersion: '10.9.4',
-              datasource: 'npm',
-            },
-            {
-              depName: 'yarn',
               currentValue: '^1.0.0',
               depType: 'devDependencies',
               lockedVersion: '1.2.3',
               datasource: 'npm',
             },
             {
-              depName: 'pnpm',
-              currentValue: '^9.0.0',
+              depName: 'yarn',
+              currentValue: '^2.0.0',
               depType: 'devDependencies',
-              lockedVersion: '9.12.3',
+              lockedVersion: '2.3.4',
+              datasource: 'npm',
+            },
+            {
+              depName: 'pnpm',
+              currentValue: '^3.0.0',
+              depType: 'devDependencies',
+              lockedVersion: '3.4.5',
               datasource: 'npm',
             },
             {
               depName: 'npm',
-              currentValue: '10.9.3',
+              currentValue: '2.0.0',
               depType: 'engines',
               datasource: 'npm',
               // engines deps should NOT have lockedVersion
             },
             {
               depName: 'yarn',
-              currentValue: '1.2.3',
+              currentValue: '3.0.0',
               depType: 'packageManager',
               datasource: 'npm',
               // packageManager deps should NOT have lockedVersion
             },
             {
               depName: 'pnpm',
-              currentValue: '1.2.3',
+              currentValue: '4.0.0',
               depType: 'volta',
               datasource: 'npm',
               // volta deps should NOT have lockedVersion

--- a/lib/modules/manager/npm/extract/post/locked-versions.spec.ts
+++ b/lib/modules/manager/npm/extract/post/locked-versions.spec.ts
@@ -345,7 +345,7 @@ describe('modules/manager/npm/extract/post/locked-versions', () => {
       ]);
     });
 
-    it('does not set locked versions for volta and packageManager dependencies', async () => {
+    it('does not set locked versions for engines, packageManager, and volta deps', async () => {
       npm.getNpmLock.mockResolvedValue({
         lockedVersions: {
           npm: '10.9.4',
@@ -364,15 +364,21 @@ describe('modules/manager/npm/extract/post/locked-versions', () => {
               datasource: 'npm',
             },
             {
-              depName: 'npm',
-              currentValue: '10.9.3',
-              depType: 'volta',
+              depName: 'yarn',
+              currentValue: '1.2.3',
+              depType: 'engines',
               datasource: 'npm',
             },
             {
               depName: 'pnpm',
               currentValue: '9.12.3',
               depType: 'packageManager',
+              datasource: 'npm',
+            },
+            {
+              depName: 'npm',
+              currentValue: '10.9.3',
+              depType: 'volta',
               datasource: 'npm',
             },
           ],
@@ -392,11 +398,11 @@ describe('modules/manager/npm/extract/post/locked-versions', () => {
               datasource: 'npm',
             },
             {
-              depName: 'npm',
-              currentValue: '10.9.3',
-              depType: 'volta',
+              depName: 'yarn',
+              currentValue: '1.2.3',
+              depType: 'engines',
               datasource: 'npm',
-              // volta deps should NOT have lockedVersion
+              // engines deps should NOT have lockedVersion
             },
             {
               depName: 'pnpm',
@@ -404,6 +410,13 @@ describe('modules/manager/npm/extract/post/locked-versions', () => {
               depType: 'packageManager',
               datasource: 'npm',
               // packageManager deps should NOT have lockedVersion
+            },
+            {
+              depName: 'npm',
+              currentValue: '10.9.3',
+              depType: 'volta',
+              datasource: 'npm',
+              // volta deps should NOT have lockedVersion
             },
           ],
           lockFiles: ['package-lock.json'],

--- a/lib/modules/manager/npm/extract/post/locked-versions.spec.ts
+++ b/lib/modules/manager/npm/extract/post/locked-versions.spec.ts
@@ -345,6 +345,74 @@ describe('modules/manager/npm/extract/post/locked-versions', () => {
       ]);
     });
 
+    it('does not set locked versions for volta and packageManager dependencies', async () => {
+      npm.getNpmLock.mockResolvedValue({
+        lockedVersions: {
+          npm: '10.9.4',
+        },
+        lockfileVersion: 3,
+      });
+      const packageFiles = [
+        {
+          managerData: { npmLock: 'package-lock.json' },
+          extractedConstraints: {},
+          deps: [
+            {
+              depName: 'npm',
+              currentValue: '^10.0.0',
+              depType: 'devDependencies',
+              datasource: 'npm',
+            },
+            {
+              depName: 'npm',
+              currentValue: '10.9.3',
+              depType: 'volta',
+              datasource: 'npm',
+            },
+            {
+              depName: 'pnpm',
+              currentValue: '9.12.3',
+              depType: 'packageManager',
+              datasource: 'npm',
+            },
+          ],
+          packageFile: 'package.json',
+        },
+      ];
+      await getLockedVersions(packageFiles);
+      expect(packageFiles).toEqual([
+        {
+          extractedConstraints: { npm: '>=7' },
+          deps: [
+            {
+              depName: 'npm',
+              currentValue: '^10.0.0',
+              depType: 'devDependencies',
+              lockedVersion: '10.9.4',
+              datasource: 'npm',
+            },
+            {
+              depName: 'npm',
+              currentValue: '10.9.3',
+              depType: 'volta',
+              datasource: 'npm',
+              // volta deps should NOT have lockedVersion
+            },
+            {
+              depName: 'pnpm',
+              currentValue: '9.12.3',
+              depType: 'packageManager',
+              datasource: 'npm',
+              // packageManager deps should NOT have lockedVersion
+            },
+          ],
+          lockFiles: ['package-lock.json'],
+          managerData: { npmLock: 'package-lock.json' },
+          packageFile: 'package.json',
+        },
+      ]);
+    });
+
     it('does nothing if managerData is not present', async () => {
       npm.getNpmLock.mockResolvedValue({
         lockedVersions: { a: '1.0.0', b: '2.0.0', c: '3.0.0' },

--- a/lib/modules/manager/npm/extract/post/locked-versions.ts
+++ b/lib/modules/manager/npm/extract/post/locked-versions.ts
@@ -109,6 +109,11 @@ export async function getLockedVersions(
       const relativeDir = upath.relative(npmRootDir, packageDir);
 
       for (const dep of packageFile.deps) {
+        // Skip dependencies that do not alter package-lock.json
+        if (dep.depType === 'volta' || dep.depType === 'packageManager') {
+          continue;
+        }
+
         // TODO: types (#22198)
         let lockedDepName = dep.depName!;
         if (relativeDir && relativeDir !== '.') {

--- a/lib/modules/manager/npm/extract/post/locked-versions.ts
+++ b/lib/modules/manager/npm/extract/post/locked-versions.ts
@@ -109,8 +109,12 @@ export async function getLockedVersions(
       const relativeDir = upath.relative(npmRootDir, packageDir);
 
       for (const dep of packageFile.deps) {
-        // Skip dependencies that do not alter package-lock.json
-        if (dep.depType === 'volta' || dep.depType === 'packageManager') {
+        // Skip dependency types which are not locked in the lock file
+        if (
+          dep.depType === 'engines' ||
+          dep.depType === 'packageManager' ||
+          dep.depType === 'volta'
+        ) {
           continue;
         }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

This fixes the issue where Renovate would attempt to update the lock files for `volta` and `packageManager` dependencies in `package.json`.

In most cases, this would be harmless, but in case there is a dependency with the same name as the package manager (e.g., `npm` or `pnpm`), Renovate would try to update the lock file with the new version of that dependency, which is incorrect.

## Context

Please select one of the below:

- [x] This closes an existing Issue: https://github.com/renovatebot/renovate/discussions/35792
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/felipecrs/renovate-repro-infinite-loop-npm

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
