### PR TITLE
build: use oidc auth for npmjs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -737,5 +737,5 @@ jobs:
         run: |
           pnpm semantic-release --dry-run ${{env.DRY_RUN}}
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LOG_LEVEL: debug

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -737,6 +737,5 @@ jobs:
         run: |
           pnpm semantic-release --dry-run ${{env.DRY_RUN}}
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }} # TODO: use action token?
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           LOG_LEVEL: debug

--- a/.npmrc
+++ b/.npmrc
@@ -5,4 +5,3 @@ provenance = true
 # https://pnpm.io/cli/run
 shell-emulator = true
 enable-pre-post-scripts = true
-strict-peer-dependencies = true

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -15,7 +15,7 @@
         ]
       }
     ],
-    "@semantic-release/npm",
+    "@containerbase/semantic-release-pnpm",
     [
       "@semantic-release/exec",
       {

--- a/package.json
+++ b/package.json
@@ -272,6 +272,7 @@
   },
   "devDependencies": {
     "@containerbase/eslint-plugin": "1.1.14",
+    "@containerbase/semantic-release-pnpm": "1.2.5",
     "@eslint/js": "9.35.0",
     "@hyrious/marshal": "0.3.3",
     "@ls-lint/ls-lint": "2.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -369,6 +369,9 @@ importers:
       '@containerbase/eslint-plugin':
         specifier: 1.1.14
         version: 1.1.14(eslint-plugin-import@2.32.0)(eslint-plugin-promise@7.2.1(eslint@9.35.0))(eslint@9.35.0)
+      '@containerbase/semantic-release-pnpm':
+        specifier: 1.2.5
+        version: 1.2.5(semantic-release@24.2.9(typescript@5.9.3))
       '@eslint/js':
         specifier: 9.35.0
         version: 9.35.0
@@ -927,6 +930,12 @@ packages:
       eslint: ^9.0.0
       eslint-plugin-import: ^2.31.0
       eslint-plugin-promise: ^7.0.0
+
+  '@containerbase/semantic-release-pnpm@1.2.5':
+    resolution: {integrity: sha512-1ez9THviisz/a6f/WR5gnVOVmdeUyx84V602h61MKKNZx/o3q15Sd5tcXR0C/+DFzd+XhtoATVHvQRzJDYSY6w==}
+    engines: {node: ^22.11.0 || ^24}
+    peerDependencies:
+      semantic-release: ^24.0.0
 
   '@emnapi/core@1.5.0':
     resolution: {integrity: sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg==}
@@ -7513,6 +7522,14 @@ snapshots:
       eslint: 9.35.0
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0)(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.35.0)
       eslint-plugin-promise: 7.2.1(eslint@9.35.0)
+
+  '@containerbase/semantic-release-pnpm@1.2.5(semantic-release@24.2.9(typescript@5.9.3))':
+    dependencies:
+      '@semantic-release/error': 4.0.0
+      aggregate-error: 5.0.0
+      execa: 9.6.0
+      semantic-release: 24.2.9(typescript@5.9.3)
+      semver: 7.7.2
 
   '@emnapi/core@1.5.0':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,1 +1,3 @@
 packages: []
+
+strictPeerDependencies: true


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- use oidc auth to publish to npmjs
- use built-in gh token to publish
<!-- Describe what behavior is changed by this PR. -->

## Context

Npmjs retires classic token and limits new token to 90 days which is impractical.
So use oidc auth instead which is already working on our other packages.

Also use built-in gh action token to publish github releases to reduce attack vector with additional accounts.

- https://gh.io/npm-token-changes
- sample https://github.com/renovatebot/detect-tools/commit/96ad71aa8fd004280328741421f3381c22fa57ac

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
