### PR TITLE
feat(poetry): support PEP735 dependency-groups

### DIFF
--- a/lib/modules/manager/pep621/schema.ts
+++ b/lib/modules/manager/pep621/schema.ts
@@ -27,7 +27,7 @@ function Pep508Dependency(depType: string): Pep508Dependency {
 
 type DependencyGroup = z.ZodType<PackageDependency<Record<string, any>>[]>;
 
-function DependencyGroup(depType: string): DependencyGroup {
+export function DependencyGroup(depType: string): DependencyGroup {
   return LooseRecord(LooseArray(Pep508Dependency(depType))).transform(
     (depGroups) => {
       const deps: PackageDependency[] = [];

--- a/lib/modules/manager/poetry/extract.spec.ts
+++ b/lib/modules/manager/poetry/extract.spec.ts
@@ -159,6 +159,53 @@ describe('modules/manager/poetry/extract', () => {
       ]);
     });
 
+    it('extracts dependencies from pep735 dependency groups', async () => {
+      const content = codeBlock`
+        [dependency-groups]
+        typing = ["mypy==1.13.0", "types-requests"]
+        coverage = ["pytest-cov==5.0.0"]
+        all = [{include-group = "typing"}, {include-group = "coverage"}, "click==8.1.7"]
+      `;
+      const res = await extractPackageFile(content, filename);
+      expect(res?.deps).toMatchObject([
+        {
+          packageName: 'mypy',
+          datasource: 'pypi',
+          depType: 'dependency-groups',
+          currentValue: '==1.13.0',
+          currentVersion: '1.13.0',
+          depName: 'mypy',
+          managerData: { depGroup: 'typing' },
+        },
+        {
+          packageName: 'types-requests',
+          datasource: 'pypi',
+          depType: 'dependency-groups',
+          skipReason: 'unspecified-version',
+          depName: 'types-requests',
+          managerData: { depGroup: 'typing' },
+        },
+        {
+          packageName: 'pytest-cov',
+          datasource: 'pypi',
+          depType: 'dependency-groups',
+          currentValue: '==5.0.0',
+          currentVersion: '5.0.0',
+          depName: 'pytest-cov',
+          managerData: { depGroup: 'coverage' },
+        },
+        {
+          packageName: 'click',
+          datasource: 'pypi',
+          depType: 'dependency-groups',
+          currentValue: '==8.1.7',
+          currentVersion: '8.1.7',
+          depName: 'click',
+          managerData: { depGroup: 'all' },
+        },
+      ]);
+    });
+
     it('resolves lockedVersions from the lockfile', async () => {
       fs.readLocalFile.mockResolvedValue(pyproject11tomlLock);
       const res = await extractPackageFile(pyproject11toml, filename);

--- a/lib/modules/manager/poetry/extract.spec.ts
+++ b/lib/modules/manager/poetry/extract.spec.ts
@@ -159,53 +159,6 @@ describe('modules/manager/poetry/extract', () => {
       ]);
     });
 
-    it('extracts dependencies from pep735 dependency groups', async () => {
-      const content = codeBlock`
-        [dependency-groups]
-        typing = ["mypy==1.13.0", "types-requests"]
-        coverage = ["pytest-cov==5.0.0"]
-        all = [{include-group = "typing"}, {include-group = "coverage"}, "click==8.1.7"]
-      `;
-      const res = await extractPackageFile(content, filename);
-      expect(res?.deps).toMatchObject([
-        {
-          packageName: 'mypy',
-          datasource: 'pypi',
-          depType: 'dependency-groups',
-          currentValue: '==1.13.0',
-          currentVersion: '1.13.0',
-          depName: 'mypy',
-          managerData: { depGroup: 'typing' },
-        },
-        {
-          packageName: 'types-requests',
-          datasource: 'pypi',
-          depType: 'dependency-groups',
-          skipReason: 'unspecified-version',
-          depName: 'types-requests',
-          managerData: { depGroup: 'typing' },
-        },
-        {
-          packageName: 'pytest-cov',
-          datasource: 'pypi',
-          depType: 'dependency-groups',
-          currentValue: '==5.0.0',
-          currentVersion: '5.0.0',
-          depName: 'pytest-cov',
-          managerData: { depGroup: 'coverage' },
-        },
-        {
-          packageName: 'click',
-          datasource: 'pypi',
-          depType: 'dependency-groups',
-          currentValue: '==8.1.7',
-          currentVersion: '8.1.7',
-          depName: 'click',
-          managerData: { depGroup: 'all' },
-        },
-      ]);
-    });
-
     it('resolves lockedVersions from the lockfile', async () => {
       fs.readLocalFile.mockResolvedValue(pyproject11tomlLock);
       const res = await extractPackageFile(pyproject11toml, filename);
@@ -615,5 +568,52 @@ describe('modules/manager/poetry/extract', () => {
         packageFileVersion: undefined,
       });
     });
+  });
+
+  it('extracts dependencies from pep735 dependency-groups', async () => {
+    const content = codeBlock`
+        [dependency-groups]
+        typing = ["mypy==1.13.0", "types-requests"]
+        coverage = ["pytest-cov==5.0.0"]
+        all = [{include-group = "typing"}, {include-group = "coverage"}, "click==8.1.7"]
+      `;
+    const res = await extractPackageFile(content, 'pyproject.toml');
+    expect(res?.deps).toMatchObject([
+      {
+        packageName: 'mypy',
+        datasource: 'pypi',
+        depType: 'dependency-groups',
+        currentValue: '==1.13.0',
+        currentVersion: '1.13.0',
+        depName: 'mypy',
+        managerData: { depGroup: 'typing' },
+      },
+      {
+        packageName: 'types-requests',
+        datasource: 'pypi',
+        depType: 'dependency-groups',
+        skipReason: 'unspecified-version',
+        depName: 'types-requests',
+        managerData: { depGroup: 'typing' },
+      },
+      {
+        packageName: 'pytest-cov',
+        datasource: 'pypi',
+        depType: 'dependency-groups',
+        currentValue: '==5.0.0',
+        currentVersion: '5.0.0',
+        depName: 'pytest-cov',
+        managerData: { depGroup: 'coverage' },
+      },
+      {
+        packageName: 'click',
+        datasource: 'pypi',
+        depType: 'dependency-groups',
+        currentValue: '==8.1.7',
+        currentVersion: '8.1.7',
+        depName: 'click',
+        managerData: { depGroup: 'all' },
+      },
+    ]);
   });
 });

--- a/lib/modules/manager/poetry/readme.md
+++ b/lib/modules/manager/poetry/readme.md
@@ -6,6 +6,7 @@ The following `depTypes` are supported by the Poetry manager:
 
 - `dependencies`
 - `dev-dependencies`
+- `dependency-groups`
 - `extras`
 - `<group-name>` (dynamic, based on the group name, per [dependency groups documentation](https://python-poetry.org/docs/managing-dependencies/#dependency-groups))
 

--- a/lib/modules/manager/poetry/schema.ts
+++ b/lib/modules/manager/poetry/schema.ts
@@ -19,7 +19,8 @@ import { normalizePythonDepName } from '../../datasource/pypi/common';
 import * as gitVersioning from '../../versioning/git';
 import * as pep440Versioning from '../../versioning/pep440';
 import * as poetryVersioning from '../../versioning/poetry';
-import { ProjectSection } from '../pep621/schema';
+import { DependencyGroup, ProjectSection } from '../pep621/schema';
+import { depTypes } from '../pep621/utils';
 import { dependencyPattern } from '../pip_requirements/extract';
 import type { PackageDependency, PackageFileContent } from '../types';
 
@@ -309,6 +310,7 @@ export const PoetryPyProject = Toml.pipe(
     .object({
       project: ProjectSection.optional().catch(undefined),
       tool: z.object({ poetry: PoetrySection }).optional().catch(undefined),
+      'dependency-groups': DependencyGroup(depTypes.dependencyGroups).catch([]),
       'build-system': z
         .object({
           'build-backend': z.string().refine(
@@ -329,7 +331,14 @@ export const PoetryPyProject = Toml.pipe(
         .optional()
         .catch(undefined),
     })
-    .transform(({ project, tool, 'build-system': poetryRequirement }) => {
+    .transform((pyproject) => {
+      const {
+        project,
+        tool,
+        'build-system': poetryRequirement,
+        'dependency-groups': dependencyGroups,
+      } = pyproject;
+
       const deps: PackageDependency[] = [];
 
       const projectDependencies = project?.dependencies;
@@ -341,6 +350,8 @@ export const PoetryPyProject = Toml.pipe(
       if (projectOptionalDependencies) {
         deps.push(...projectOptionalDependencies);
       }
+
+      deps.push(...dependencyGroups);
 
       const poetryDependencies = tool?.poetry?.dependencies;
       if (poetryDependencies) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
Supports PEP735 `dependency-groups` in the Poetry manager. Poetry supports PEP735 `dependency-groups` since version 2.2.

Related: https://github.com/renovatebot/renovate/discussions/38418

## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: <URL>

(the repo I tested on is private)

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
