### PR TITLE
feat: Support auto-discovery-buckets

### DIFF
--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -206,6 +206,61 @@ The sort method for autodiscover server side repository search.
 
 > If multiple `autodiscoverTopics` are used resulting order will be per topic not global.
 
+## autodiscoverShardCount
+
+Number of shards to use for autodiscover sharding. This allows you to split the set of autodiscovered repositories into multiple logical groups (shards) for parallel or distributed processing.
+
+For example, if you want to split your repositories into 8 shards:
+
+```json
+{
+  "autodiscoverShardCount": 8
+}
+```
+
+## autodiscoverShardSalt
+
+Salt to use for autodiscover sharding hash. This string is added to the hash function used to assign repositories to shards. Changing the salt will change the shard assignment for all repositories, which can be useful to rebalance workloads or avoid collisions.
+
+**Example:**
+
+```json
+{
+  "autodiscoverShardSalt": "my-salt-value"
+}
+```
+
+## autodiscoverShardSelector
+
+Which shard(s) to run for autodiscover sharding. This determines which subset of repositories will be processed in the current run. The value is a string expression that supports various syntax patterns for selecting shards.
+
+**Examples:**
+
+- To process only shard 0:
+
+  ```json
+  { "autodiscoverShardSelector": "0" }
+  ```
+
+- To process shards 0, 1, 2, and 3:
+
+  ```json
+  { "autodiscoverShardSelector": "0-3" }
+  ```
+
+- To process every 4th shard starting from 1:
+
+  ```json
+  { "autodiscoverShardSelector": "*/4+1" }
+  ```
+
+**Syntax:**
+
+- `n` — single shard
+- `a-b` — range from a to b (inclusive)
+- `*/k+o` — modular class: all i where i % k == o % k
+- Multiple selectors can be combined with commas: `"0-3,8-9,*/4+1"`
+
 ## autodiscoverTopics
 
 Some platforms allow you to add tags, or topics, to repositories and retrieve repository lists by specifying those

--- a/lib/config/global.ts
+++ b/lib/config/global.ts
@@ -39,6 +39,9 @@ export class GlobalConfig {
     's3PathStyle',
     'cachePrivatePackages',
     'ignorePrAuthor',
+    'autodiscoverShardCount',
+    'autodiscoverShardSelector',
+    'autodiscoverShardSalt',
   ];
 
   private static config: RepoGlobalConfig = {};

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -3242,6 +3242,30 @@ const options: RenovateOptions[] = [
     default: false,
     globalOnly: true,
   },
+  {
+    name: 'autodiscoverShardCount',
+    description: 'Number of shards to use for autodiscover sharding.',
+    type: 'integer',
+    default: null,
+    globalOnly: true,
+    stage: 'global',
+  },
+  {
+    name: 'autodiscoverShardSelector',
+    description: 'Which shard(s) to run for autodiscover sharding.',
+    type: 'string',
+    default: null,
+    globalOnly: true,
+    stage: 'global',
+  },
+  {
+    name: 'autodiscoverShardSalt',
+    description: 'Salt to use for autodiscover sharding hash.',
+    type: 'string',
+    default: '',
+    globalOnly: true,
+    stage: 'global',
+  },
 ];
 
 export function getOptions(): RenovateOptions[] {

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -134,6 +134,9 @@ export interface GlobalOnlyConfig {
   useCloudMetadataServices?: boolean;
   deleteConfigFile?: boolean;
   deleteAdditionalConfigFile?: boolean;
+  autodiscoverShardCount?: number;
+  autodiscoverShardSelector?: string;
+  autodiscoverShardSalt?: string;
 }
 
 // Config options used within the repository worker, but not user configurable
@@ -176,6 +179,9 @@ export interface RepoGlobalConfig {
   s3PathStyle?: boolean;
   cachePrivatePackages?: boolean;
   ignorePrAuthor?: boolean;
+  autodiscoverShardCount?: number;
+  autodiscoverShardSelector?: string;
+  autodiscoverShardSalt?: string;
 }
 
 export interface LegacyAdminConfig {

--- a/lib/workers/global/autodiscover.spec.ts
+++ b/lib/workers/global/autodiscover.spec.ts
@@ -1,8 +1,19 @@
+import { createHash } from 'node:crypto';
 import type { RenovateConfig } from '../../config/types';
 import * as platform from '../../modules/platform';
 import * as _ghApi from '../../modules/platform/github';
 import * as _hostRules from '../../util/host-rules';
-import { autodiscoverRepositories } from './autodiscover';
+import {
+  addModularClass,
+  addPlainInteger,
+  addToRange,
+  applyShard,
+  autodiscoverRepositories,
+  expandShardSelector,
+  parseInterval,
+  parseModularClass,
+  parsePlainInteger,
+} from './autodiscover';
 
 vi.mock('../../modules/platform/github');
 vi.mock('../../util/host-rules');
@@ -201,5 +212,184 @@ describe('workers/global/autodiscover', () => {
     );
     const res = await autodiscoverRepositories(config);
     expect(res.repositories).toEqual(['project/repo', 'PROJECT/repo2']);
+  });
+
+  describe('autodiscover shard sharding logic', () => {
+    describe('expandShardSelector', () => {
+      it('handles interval union: "0-3,8-9"', () => {
+        expect(expandShardSelector('0-3,8-9', 16)).toEqual([0, 1, 2, 3, 8, 9]);
+      });
+      it('handles modular class: "*/5+2"', () => {
+        expect(expandShardSelector('*/5+2', 16)).toEqual([2, 7, 12]);
+      });
+      it('handles mixed syntaxes: "1,3-4,*/8"', () => {
+        expect(expandShardSelector('1,3-4,*/8', 16)).toEqual([0, 1, 3, 4, 8]);
+      });
+      it('clips out-of-range: "14-99" with shards=16', () => {
+        expect(expandShardSelector('14-99', 16)).toEqual([14, 15]);
+      });
+      it('returns empty for empty parse: "900-901"', () => {
+        expect(expandShardSelector('900-901', 16)).toEqual([]);
+      });
+      it('returns empty when selector is undefined or shards <= 0', () => {
+        expect(expandShardSelector(undefined, 16)).toEqual([]);
+        expect(expandShardSelector('1,2', 0)).toEqual([]);
+        expect(expandShardSelector('1,2', -5)).toEqual([]);
+      });
+      it('skips empty tokens in selector', () => {
+        expect(expandShardSelector('1, ,3,, */8', 16)).toEqual([0, 1, 3, 8]);
+      });
+    });
+
+    describe('applyShard', () => {
+      const repos = Array.from({ length: 20 }, (_, i) => `repo${i}`);
+      it('returns all if no shards', () => {
+        expect(
+          applyShard(repos, { shards: undefined, shard: undefined }),
+        ).toEqual(repos);
+      });
+      it('returns empty if selector is empty', () => {
+        expect(applyShard(repos, { shards: 16, shard: '900-901' })).toEqual([]);
+      });
+      it('shards correctly for interval', () => {
+        const result = applyShard(repos, { shards: 16, shard: '0-3' });
+        expect(
+          result.every((r: string) => {
+            const hash = createHash('sha256').update('').update(r).digest();
+            const mod = hash.readUInt32BE(0) % 16;
+            return [0, 1, 2, 3].includes(mod);
+          }),
+        ).toBe(true);
+      });
+      it('shards correctly for modular class', () => {
+        const result = applyShard(repos, { shards: 16, shard: '*/4+1' });
+        expect(
+          result.every((r: string) => {
+            const hash = createHash('sha256').update('').update(r).digest();
+            const mod = hash.readUInt32BE(0) % 16;
+            return mod % 4 === 1 % 4;
+          }),
+        ).toBe(true);
+      });
+    });
+  });
+
+  describe('individual parser functions', () => {
+    describe('parseModularClass', () => {
+      it('parses modular class with offset', () => {
+        expect(parseModularClass('*/5+2')).toEqual({ modulus: 5, offset: 2 });
+      });
+      it('parses modular class without offset', () => {
+        expect(parseModularClass('*/3')).toEqual({ modulus: 3, offset: 0 });
+      });
+      it('returns null for invalid input', () => {
+        expect(parseModularClass('invalid')).toBeNull();
+        expect(parseModularClass('5+2')).toBeNull();
+      });
+    });
+
+    describe('parseInterval', () => {
+      it('parses interval without step', () => {
+        expect(parseInterval('5-15')).toEqual({ start: 5, end: 15 });
+      });
+      it('returns null for invalid input', () => {
+        expect(parseInterval('invalid')).toBeNull();
+        expect(parseInterval('5')).toBeNull();
+      });
+      it('returns null for step syntax', () => {
+        expect(parseInterval('0-10/3')).toBeNull();
+      });
+    });
+
+    describe('parsePlainInteger', () => {
+      it('parses valid integer', () => {
+        expect(parsePlainInteger('42')).toBe(42);
+        expect(parsePlainInteger('0')).toBe(0);
+      });
+      it('returns null for invalid input', () => {
+        expect(parsePlainInteger('abc')).toBeNull();
+        expect(parsePlainInteger('1.5')).toBeNull();
+        expect(parsePlainInteger('')).toBeNull();
+      });
+    });
+
+    describe('addModularClass', () => {
+      it('adds correct modular class indices', () => {
+        const picks = new Set<number>();
+        addModularClass(picks, 5, 2, 16);
+        expect([...picks].sort((a, b) => a - b)).toEqual([2, 7, 12]);
+      });
+      it('handles zero modulus gracefully', () => {
+        const picks = new Set<number>();
+        addModularClass(picks, 0, 2, 16);
+        expect([...picks]).toEqual([]);
+      });
+    });
+
+    describe('addToRange', () => {
+      it('adds range without step', () => {
+        const picks = new Set<number>();
+        addToRange(picks, 0, 10, 16);
+        expect([...picks].sort((a, b) => a - b)).toEqual([
+          0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+        ]);
+      });
+      it('clips to shard bounds', () => {
+        const picks = new Set<number>();
+        addToRange(picks, 14, 99, 16);
+        expect([...picks].sort((a, b) => a - b)).toEqual([14, 15]);
+      });
+    });
+
+    describe('addPlainInteger', () => {
+      it('adds valid integer within bounds', () => {
+        const picks = new Set<number>();
+        addPlainInteger(picks, 5, 16);
+        expect([...picks]).toEqual([5]);
+      });
+      it('ignores out-of-bounds integer', () => {
+        const picks = new Set<number>();
+        addPlainInteger(picks, 20, 16);
+        expect([...picks]).toEqual([]);
+      });
+      it('ignores negative integer', () => {
+        const picks = new Set<number>();
+        addPlainInteger(picks, -1, 16);
+        expect([...picks]).toEqual([]);
+      });
+    });
+  });
+
+  describe('autodiscoverRepositories advanced paths', () => {
+    it('applies sharding and returns empty when nothing selected', async () => {
+      config.autodiscover = true;
+      config.platform = 'github';
+      hostRules.find.mockImplementation(() => ({ token: 'abc' }));
+      ghApi.getRepos.mockImplementation(() =>
+        Promise.resolve(['a', 'b', 'c', 'd']),
+      );
+      config.autodiscoverShardCount = 16;
+      config.autodiscoverShardSelector = '900-901'; // selects nothing
+      const res = await autodiscoverRepositories(config);
+      expect(res.repositories).toEqual([]);
+    });
+
+    it('applies sharding and returns only selected repos', async () => {
+      config.autodiscover = true;
+      config.platform = 'github';
+      hostRules.find.mockImplementation(() => ({ token: 'abc' }));
+      const discovered = ['repo0', 'repo1', 'repo2', 'repo3', 'repo4', 'repo5'];
+      ghApi.getRepos.mockImplementation(() => Promise.resolve(discovered));
+      config.autodiscoverShardCount = 16;
+      config.autodiscoverShardSelector = '0-3';
+      config.autodiscoverShardSalt = '';
+      const res = await autodiscoverRepositories(config);
+      const expected = applyShard(discovered, {
+        shards: 16,
+        shard: '0-3',
+        salt: '',
+      });
+      expect(res.repositories).toEqual(expected);
+    });
   });
 });

--- a/lib/workers/global/autodiscover.ts
+++ b/lib/workers/global/autodiscover.ts
@@ -144,7 +144,7 @@ export function addToRange(
   const lo = Math.max(0, Math.min(start, end));
   const hi = Math.min(shards - 1, Math.max(start, end));
   for (let i = lo; i <= hi; i++) {
-    if (Number.isInteger(i) && i >= 0 && i < shards) {
+    if (i >= 0 && i < shards) {
       picks.add(i);
     }
   }

--- a/lib/workers/global/autodiscover.ts
+++ b/lib/workers/global/autodiscover.ts
@@ -1,4 +1,6 @@
+import { createHash } from 'node:crypto';
 import is from '@sindresorhus/is';
+
 import type { AllConfig } from '../../config/types';
 import { logger } from '../../logger';
 import { platform } from '../../modules/platform';
@@ -69,6 +71,32 @@ export async function autodiscoverRepositories(
     }
   }
 
+  // Apply sharding if configured
+  const {
+    autodiscoverShardCount,
+    autodiscoverShardSelector,
+    autodiscoverShardSalt,
+  } = config;
+  if (
+    autodiscoverShardCount &&
+    autodiscoverShardSelector !== undefined &&
+    autodiscoverShardSelector !== null
+  ) {
+    logger.debug(
+      { autodiscoverShardCount, autodiscoverShardSelector },
+      'Applying autodiscover sharding',
+    );
+    discovered = applyShard(discovered, {
+      shards: autodiscoverShardCount,
+      shard: autodiscoverShardSelector,
+      salt: autodiscoverShardSalt,
+    });
+    if (!discovered.length) {
+      logger.debug('No repositories remain after sharding');
+      return { ...config, repositories: [] };
+    }
+  }
+
   logger.info(
     { length: discovered.length, repositories: discovered },
     `Autodiscovered repositories`,
@@ -103,4 +131,149 @@ export async function autodiscoverRepositories(
 
 export function applyFilters(repos: string[], filters: string[]): string[] {
   return repos.filter((repo) => matchRegexOrGlobList(repo, filters));
+}
+
+type ShardSelector = string;
+
+export function addToRange(
+  picks: Set<number>,
+  start: number,
+  end: number,
+  shards: number,
+): void {
+  const lo = Math.max(0, Math.min(start, end));
+  const hi = Math.min(shards - 1, Math.max(start, end));
+  for (let i = lo; i <= hi; i++) {
+    if (Number.isInteger(i) && i >= 0 && i < shards) {
+      picks.add(i);
+    }
+  }
+}
+
+export function addModularClass(
+  picks: Set<number>,
+  modulus: number,
+  offset: number,
+  shards: number,
+): void {
+  if (modulus <= 0) {
+    return;
+  }
+  for (let i = 0; i < shards; i++) {
+    if (i % modulus === offset % modulus) {
+      picks.add(i);
+    }
+  }
+}
+
+export function addPlainInteger(
+  picks: Set<number>,
+  value: number,
+  shards: number,
+): void {
+  if (Number.isInteger(value) && value >= 0 && value < shards) {
+    picks.add(value);
+  }
+}
+
+export function parseModularClass(
+  part: string,
+): { modulus: number; offset: number } | null {
+  const match = /^\*\/(\d+)(?:\+(\d+))?$/.exec(part);
+  if (!match) {
+    return null;
+  }
+  const modulus = parseInt(match[1]);
+  const offset = match[2] ? parseInt(match[2]) : 0;
+  return { modulus, offset };
+}
+
+export function parseInterval(
+  part: string,
+): { start: number; end: number } | null {
+  const match = /^(\d+)-(\d+)$/.exec(part);
+  if (!match) {
+    return null;
+  }
+  const start = parseInt(match[1]);
+  const end = parseInt(match[2]);
+  return { start, end };
+}
+
+export function parsePlainInteger(part: string): number | null {
+  const match = /^\d+$/.exec(part);
+  if (!match) {
+    return null;
+  }
+  return parseInt(part);
+}
+
+export function expandShardSelector(
+  sel: ShardSelector | undefined,
+  shards: number,
+): number[] {
+  if (!sel || !shards || shards <= 0) {
+    return [];
+  }
+
+  const picks = new Set<number>();
+
+  for (const partRaw of sel.split(',')) {
+    const part = partRaw.trim();
+    if (!part) {
+      continue;
+    }
+
+    // Try modular class: "*/k+o"
+    const modularClass = parseModularClass(part);
+    if (modularClass) {
+      addModularClass(picks, modularClass.modulus, modularClass.offset, shards);
+      continue;
+    }
+
+    // Try interval: "a-b"
+    const interval = parseInterval(part);
+    if (interval) {
+      addToRange(picks, interval.start, interval.end, shards);
+      continue;
+    }
+
+    // Try plain integer
+    const plainInteger = parsePlainInteger(part);
+    if (plainInteger !== null) {
+      addPlainInteger(picks, plainInteger, shards);
+    }
+    // Unrecognised token → ignore
+  }
+
+  return [...picks].sort((x, y) => x - y);
+}
+
+export function applyShard(
+  repos: string[],
+  cfg: {
+    shards?: number;
+    shard?: ShardSelector;
+    salt?: string;
+  },
+): string[] {
+  const { shards, shard, salt } = cfg;
+  if (!shards || shards <= 0 || shard === undefined || shard === null) {
+    return repos;
+  }
+  const selected = new Set(expandShardSelector(shard, shards));
+  if (selected.size === 0) {
+    logger.debug(
+      'No shards selected after parsing autodiscoverShardSelector; returning empty list.',
+    );
+    return [];
+  }
+  return repos.filter((fullName) => {
+    const hash = createHash('sha256')
+      .update(salt ?? '')
+      .update(fullName)
+      .digest();
+    const mod = hash.readUInt32BE(0) % shards;
+    return selected.has(mod);
+  });
 }

--- a/lib/workers/global/config/parse/env.spec.ts
+++ b/lib/workers/global/config/parse/env.spec.ts
@@ -459,5 +459,32 @@ describe('workers/global/config/parse/env', () => {
       const config = await env.getConfig(envParam);
       expect(config.platformCommit).toBe('disabled');
     });
+
+    it('parses autodiscoverShardCount from env', async () => {
+      const envParam: NodeJS.ProcessEnv = {
+        RENOVATE_AUTODISCOVER_SHARD_COUNT: '8',
+      };
+      expect(await env.getConfig(envParam)).toMatchObject({
+        autodiscoverShardCount: 8,
+      });
+    });
+
+    it('parses autodiscoverShardSelector from env', async () => {
+      const envParam: NodeJS.ProcessEnv = {
+        RENOVATE_AUTODISCOVER_SHARD_SELECTOR: '0-3',
+      };
+      expect(await env.getConfig(envParam)).toMatchObject({
+        autodiscoverShardSelector: '0-3',
+      });
+    });
+
+    it('parses autodiscoverShardSalt from env', async () => {
+      const envParam: NodeJS.ProcessEnv = {
+        RENOVATE_AUTODISCOVER_SHARD_SALT: 'mysalt',
+      };
+      expect(await env.getConfig(envParam)).toMatchObject({
+        autodiscoverShardSalt: 'mysalt',
+      });
+    });
   });
 });


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Introduce a deterministic sharding mechanism for autodiscovered repositories so self-hosted Renovate can scale across large numbers of repos, either via parallel jobs or split serial runs, reducing pressure from CI time windows, access token lifetimes, and shared infra limits.

Add global config to shard the autodiscovered repository list:
- autodiscoverShardCount: number of shards (integer > 0)
- autodiscoverShardSelector: which shard(s) to run (string syntax below)
- autodiscoverShardSalt: optional salt used in hashing, to control the partitioning

## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [X] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [X] Yes — other (please describe): Used GPT-5 to find code entry points, and used Copilot code completion from IntelliJ. Apart from the unit test code, all code has been manually and substantially changed (renamed, refactored, rewritten). All code has been manually reviewed whether generated or not.

## Documentation (please check one with an [x])

- [X] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [X] Both unit tests + ran on a real repository

The public repository: <URL>

(only tested on private BitBucket repos)

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
