### PR TITLE
chore(json-schema)!: forbid global-only options in repo configuration

### DIFF
--- a/tools/docs/schema.ts
+++ b/tools/docs/schema.ts
@@ -197,6 +197,16 @@ export async function generateSchema(
     allowComments: true,
     type: 'object',
     properties: {},
+
+    /* any configuration items that should not be set - only used in inherited or repo config */
+    not: undefined as
+      | {
+          /* we have to use `anyOf` here with each rule, so any of the properties can be found in isolation, and will be excluded */
+          anyOf: {
+            required: string[];
+          }[];
+        }
+      | undefined,
   };
 
   if (isGlobal) {
@@ -205,25 +215,42 @@ export async function generateSchema(
     schema.title = `JSON schema for Renovate ${version} config files (with Inherit Config options) (https://renovatebot.com/)`;
   }
 
-  let configurationOptions = getOptions();
+  const configurationOptions = getOptions().filter((o) => {
+    // always allow non-global options
+    if (!o.globalOnly) {
+      return true;
+    }
 
-  if (!isGlobal) {
-    configurationOptions = configurationOptions.map((v) => {
-      if (v.globalOnly) {
-        if (!isInherit && v.inheritConfigSupport) {
-          // NOTE that the JSON Schema version we're using does not have support for deprecating, so we need to use the `description` field
-          return {
-            ...v,
-            description:
-              "Deprecated: This configuration option is only intended to be used with 'global' configuration when self-hosting, not used in a repository configuration file. Renovate likely won't use the configuration, and these fields will be removed from the repository configuration documentation in Renovate v43 (https://github.com/renovatebot/renovate/issues/38728)\n\n" +
-              v.description,
-          };
-        }
+    if (o.globalOnly && o.inheritConfigSupport) {
+      const allowed = isInherit || isGlobal;
+      if (!allowed) {
+        schema.not ??= {
+          anyOf: [],
+        };
+        // we have to use `anyOf` here with each rule, so any of the properties can be found in isolation, and will be excluded
+        schema.not.anyOf.push({
+          required: [o.name],
+        });
       }
+      return isInherit || isGlobal;
+    }
 
-      return v;
-    });
-  }
+    if (o.globalOnly) {
+      if (!isGlobal) {
+        schema.not ??= {
+          anyOf: [],
+        };
+        // we have to use `anyOf` here with each rule, so any of the properties can be found in isolation, and will be excluded
+        schema.not.anyOf.push({
+          required: [o.name],
+        });
+      }
+      return isGlobal;
+    }
+
+    // we don't currently have any config options that are hitting this, but to be safe, let's throw an error if we ever hit this
+    throw new Error(`Unhandled case for \`${o.name}\``);
+  });
 
   configurationOptions.sort((a, b) => {
     if (a.name < b.name) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes



As noted in #38728, we want to make sure that we only have repo level
configuration in repo configuration.

This makes sure that the resulting JSON Schemas are output with only the
configuration options that are relevant.



<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the below:

- [x] This closes an existing Issue: Closes #38728
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository:

1. In this repository, run `pnpm run test-schema`
1. Modify `renovate.json` to:

```json
{
  "$schema": "./renovate-schema.json",
  "onboarding": true,
  "baseDir": "fals",
  "extends": [
    "github>renovatebot/.github"
  ]
}
```

Notice that JSON Schema validation flags (i.e. in editor):

<img width="433" height="160" alt="Screenshot 2025-10-14 at 14 36 06" src="https://github.com/user-attachments/assets/5812b45b-d700-41a3-a988-a7f4ddc2c3d4" />

When running Renovate, we'd see:

```
 WARN: Found renovate config warnings (repository=local)
       "warnings": [
         {
           "topic": "Configuration Error",
           "message": "The \"baseDir\" option is a global option reserved only for Renovate's global configuration and cannot be configured within a repository's config file."
         },
         {
           "topic": "Configuration Error",
           "message": "The \"onboarding\" option is a global option reserved only for Renovate's global configuration and cannot be configured within a repository's config file."
         }
       ]
```

See also:

<img width="439" height="117" alt="Screenshot 2026-01-26 at 17 08 28" src="https://github.com/user-attachments/assets/45cf91ce-ad10-468f-a2dd-f1ed5e5774e1" />
<img width="375" height="118" alt="Screenshot 2026-01-26 at 17 08 34" src="https://github.com/user-attachments/assets/1888e16a-9308-46c3-a3d1-a1903e390142" />
<img width="471" height="124" alt="Screenshot 2026-01-26 at 17 08 40" src="https://github.com/user-attachments/assets/4c8522a2-18fc-4ae8-9c6c-c09702c098fb" />
<img width="462" height="136" alt="Screenshot 2026-01-26 at 17 08 48" src="https://github.com/user-attachments/assets/772d8f0a-d58c-4d18-94d2-a90aa6886437" />


But it doesn't fail

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
