### PR TITLE
fix(json-schema): correctly set version in generated JSON Schema

### DIFF
--- a/tools/docs/index.ts
+++ b/tools/docs/index.ts
@@ -14,7 +14,11 @@ import { generateSchema } from './schema';
 import { generateTemplates } from './templates';
 import { generateVersioning } from './versioning';
 
-export async function generateDocs(root = 'tmp', pack = true): Promise<void> {
+export async function generateDocs(
+  root = 'tmp',
+  pack = true,
+  version = undefined,
+): Promise<void> {
   try {
     const dist = `${root}/docs`;
     logger.info(`generating docs to '${dist}'`);
@@ -68,7 +72,7 @@ export async function generateDocs(root = 'tmp', pack = true): Promise<void> {
 
     // json-schema
     logger.info('* json-schema');
-    await generateSchema(dist);
+    await generateSchema(dist, version);
 
     if (pack) {
       await tar.create({ file: `${root}/docs.tgz`, cwd: dist, gzip: true }, [

--- a/tools/docs/schema.ts
+++ b/tools/docs/schema.ts
@@ -167,11 +167,14 @@ function createSchemaForChildConfigs(
   }
 }
 
-export async function generateSchema(dist: string): Promise<void> {
+export async function generateSchema(
+  dist: string,
+  version: string = pkg.version,
+): Promise<void> {
   const schema = {
-    title: `JSON schema for Renovate ${pkg.version} config files (https://renovatebot.com/)`,
+    title: `JSON schema for Renovate ${version} config files (https://renovatebot.com/)`,
     $schema: 'http://json-schema.org/draft-04/schema#',
-    'x-renovate-version': `${pkg.version}`,
+    'x-renovate-version': `${version}`,
     type: 'object',
     properties: {},
   };

--- a/tools/prepare-release.ts
+++ b/tools/prepare-release.ts
@@ -32,7 +32,7 @@ void (async () => {
   const opts = program.opts();
   logger.info(`Preparing v${opts.version} ...`);
   build();
-  await generateDocs();
+  await generateDocs(undefined, undefined, opts.version);
   await bake('build', opts);
 })();
 


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

In #38567 we tried to wire in the version of Renovate into the generated
JSON Schema. This unfortunately didn't work, as we don't have the
release number known at the time we're currently calling the JSON Schema
generation.

To fix this, we can make sure that at the point we're generating the
JSON Schema as part of the release process, we can wire in the version
as part of `generateSchema`.

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>



<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
