### PR TITLE
feat(git): make recursive cloning of submodules optional

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -661,7 +661,7 @@ This name will appear in Renovate logs, making it easier to debug or trace speci
 
 Enabling this option will mean that detected Git submodules will be cloned at time of repository clone.
 By default all will be cloned, but this can be customized by configuring `cloneSubmodulesFilter` too.
-Submodules are always cloned recursively.
+Submodules are always cloned recursively by default (see [`cloneSubmodulesRecursive`](#clonesubmodulesrecursive)).
 
 Important: private submodules aren't supported by Renovate, unless the underlying `ssh` layer already has the correct permissions.
 
@@ -671,6 +671,10 @@ Use this option together with `cloneSubmodules` if you wish to clone only a subs
 
 This config option supports regex and glob filters, including negative matches.
 For more details on this syntax see Renovate's [string pattern matching documentation](./string-pattern-matching.md).
+
+## cloneSubmodulesRecursive
+
+Defaults to `true`. Setting this to `false` will disable recursive cloning of submodules.
 
 ## commitBody
 

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -714,7 +714,7 @@ This name will appear in Renovate logs, making it easier to debug or trace speci
 
 Enabling this option will mean that detected Git submodules will be cloned at time of repository clone.
 By default all will be cloned, but this can be customized by configuring `cloneSubmodulesFilter` too.
-Submodules are always cloned recursively.
+Submodules are always cloned recursively by default (see [`cloneSubmodulesRecursive`](#clonesubmodulesrecursive)).
 
 Important: private submodules aren't supported by Renovate, unless the underlying `ssh` layer already has the correct permissions.
 
@@ -724,6 +724,10 @@ Use this option together with `cloneSubmodules` if you wish to clone only a subs
 
 This config option supports regex and glob filters, including negative matches.
 For more details on this syntax see Renovate's [string pattern matching documentation](./string-pattern-matching.md).
+
+## `cloneSubmodulesRecursive`
+
+Defaults to `true`. Setting this to `false` will disable recursive cloning of submodules.
 
 ## `commitBody`
 

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -3167,6 +3167,12 @@ const options: Readonly<RenovateOptions>[] = [
     default: false,
   },
   {
+    name: 'cloneSubmodulesRecursive',
+    description: 'Set to `false` to disable recursive cloning of submodules.',
+    type: 'boolean',
+    default: true,
+  },
+  {
     name: 'cloneSubmodulesFilter',
     description:
       'List of submodules names or patterns to clone when cloneSubmodules=true.',

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -3306,6 +3306,12 @@ const options: Readonly<RenovateOptions>[] = [
     default: false,
   },
   {
+    name: 'cloneSubmodulesRecursive',
+    description: 'Set to `false` to disable recursive cloning of submodules.',
+    type: 'boolean',
+    default: true,
+  },
+  {
     name: 'cloneSubmodulesFilter',
     description:
       'List of submodules names or patterns to clone when cloneSubmodules=true.',

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -377,6 +377,7 @@ export interface RenovateConfig
   defaultBranch?: string;
   branchList?: string[];
   cloneSubmodules?: boolean;
+  cloneSubmodulesRecursive?: boolean;
   cloneSubmodulesFilter?: string[];
   description?: string | string[];
   detectGlobalManagerConfig?: boolean;

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -400,6 +400,7 @@ export interface RenovateConfig
   defaultBranch?: string;
   branchList?: string[];
   cloneSubmodules?: boolean;
+  cloneSubmodulesRecursive?: boolean;
   cloneSubmodulesFilter?: string[];
   description?: string | string[];
   detectGlobalManagerConfig?: boolean;

--- a/lib/modules/platform/azure/index.ts
+++ b/lib/modules/platform/azure/index.ts
@@ -206,6 +206,7 @@ export async function getJsonFile(
 export async function initRepo({
   repository,
   cloneSubmodules,
+  cloneSubmodulesRecursive,
   cloneSubmodulesFilter,
 }: RepoParams): Promise<RepoResult> {
   logger.debug(`initRepo("${repository}")`);
@@ -254,6 +255,7 @@ export async function initRepo({
     url,
     extraCloneOpts: getStorageExtraCloneOpts(opts),
     cloneSubmodules,
+    cloneSubmodulesRecursive,
     cloneSubmodulesFilter,
   });
   const repoConfig: RepoResult = {

--- a/lib/modules/platform/azure/index.ts
+++ b/lib/modules/platform/azure/index.ts
@@ -201,6 +201,7 @@ export async function getJsonFile(
 export async function initRepo({
   repository,
   cloneSubmodules,
+  cloneSubmodulesRecursive,
   cloneSubmodulesFilter,
   azureWorkItemType,
 }: RepoParams): Promise<RepoResult> {
@@ -253,6 +254,7 @@ export async function initRepo({
     url,
     extraCloneOpts: getStorageExtraCloneOpts(opts),
     cloneSubmodules,
+    cloneSubmodulesRecursive,
     cloneSubmodulesFilter,
   });
   const repoConfig: RepoResult = {

--- a/lib/modules/platform/bitbucket-server/index.ts
+++ b/lib/modules/platform/bitbucket-server/index.ts
@@ -250,6 +250,7 @@ export async function getJsonFile(
 export async function initRepo({
   repository,
   cloneSubmodules,
+  cloneSubmodulesRecursive,
   cloneSubmodulesFilter,
   gitUrl,
 }: RepoParams): Promise<RepoResult> {
@@ -301,6 +302,7 @@ export async function initRepo({
       url,
       extraCloneOpts: getExtraCloneOpts(opts),
       cloneSubmodules,
+      cloneSubmodulesRecursive,
       cloneSubmodulesFilter,
       fullClone: semver.lte(defaults.version, '8.0.0'),
     });

--- a/lib/modules/platform/bitbucket/index.ts
+++ b/lib/modules/platform/bitbucket/index.ts
@@ -192,6 +192,7 @@ export async function getJsonFile(
 export async function initRepo({
   repository,
   cloneSubmodules,
+  cloneSubmodulesRecursive,
   cloneSubmodulesFilter,
 }: RepoParams): Promise<RepoResult> {
   logger.debug(`initRepo("${repository}")`);
@@ -274,6 +275,7 @@ export async function initRepo({
     ...config,
     url,
     cloneSubmodules,
+    cloneSubmodulesRecursive,
     cloneSubmodulesFilter,
   });
   const repoConfig: RepoResult = {

--- a/lib/modules/platform/bitbucket/index.ts
+++ b/lib/modules/platform/bitbucket/index.ts
@@ -230,6 +230,7 @@ export async function getJsonFile(
 export async function initRepo({
   repository,
   cloneSubmodules,
+  cloneSubmodulesRecursive,
   cloneSubmodulesFilter,
 }: RepoParams): Promise<RepoResult> {
   logger.debug(`initRepo("${repository}")`);
@@ -317,6 +318,7 @@ export async function initRepo({
     ...config,
     url,
     cloneSubmodules,
+    cloneSubmodulesRecursive,
     cloneSubmodulesFilter,
   });
   const repoConfig: RepoResult = {

--- a/lib/modules/platform/forgejo/index.ts
+++ b/lib/modules/platform/forgejo/index.ts
@@ -73,6 +73,7 @@ interface ForgejoRepoConfig {
   labelList: Promise<Label[]> | null;
   defaultBranch: string;
   cloneSubmodules: boolean;
+  cloneSubmodulesRecursive: boolean;
   cloneSubmodulesFilter: string[] | undefined;
   hasIssuesEnabled: boolean;
   isOrgRepo: boolean;
@@ -276,6 +277,7 @@ const platform: Platform = {
   async initRepo({
     repository,
     cloneSubmodules,
+    cloneSubmodulesRecursive,
     cloneSubmodulesFilter,
     gitUrl,
   }: RepoParams): Promise<RepoResult> {
@@ -284,6 +286,7 @@ const platform: Platform = {
     config = {} as any;
     config.repository = repository;
     config.cloneSubmodules = !!cloneSubmodules;
+    config.cloneSubmodulesRecursive = !!cloneSubmodulesRecursive;
     config.cloneSubmodulesFilter = cloneSubmodulesFilter;
     config.ignorePrAuthor = GlobalConfig.get('ignorePrAuthor', false);
 

--- a/lib/modules/platform/forgejo/index.ts
+++ b/lib/modules/platform/forgejo/index.ts
@@ -67,6 +67,7 @@ interface ForgejoRepoConfig {
   labelList: Promise<Label[]> | null;
   defaultBranch: string;
   cloneSubmodules: boolean;
+  cloneSubmodulesRecursive: boolean;
   cloneSubmodulesFilter: string[] | undefined;
   hasIssuesEnabled: boolean;
   isOrgRepo: boolean;
@@ -274,6 +275,7 @@ const platform: Platform = {
   async initRepo({
     repository,
     cloneSubmodules,
+    cloneSubmodulesRecursive,
     cloneSubmodulesFilter,
     gitUrl,
   }: RepoParams): Promise<RepoResult> {
@@ -282,6 +284,7 @@ const platform: Platform = {
     config = {} as any;
     config.repository = repository;
     config.cloneSubmodules = !!cloneSubmodules;
+    config.cloneSubmodulesRecursive = !!cloneSubmodulesRecursive;
     config.cloneSubmodulesFilter = cloneSubmodulesFilter;
     config.ignorePrAuthor = GlobalConfig.get('ignorePrAuthor');
 

--- a/lib/modules/platform/gerrit/index.spec.ts
+++ b/lib/modules/platform/gerrit/index.spec.ts
@@ -160,12 +160,14 @@ describe('modules/platform/gerrit/index', () => {
       await gerrit.initRepo({
         repository: 'test/repo',
         cloneSubmodules: true,
+        cloneSubmodulesRecursive: true,
         cloneSubmodulesFilter: ['test'],
       });
 
       expect(git.initRepo).toHaveBeenCalledExactlyOnceWith({
         url: 'https://user:pass@dev.gerrit.com/renovate/a/test%2Frepo',
         cloneSubmodules: true,
+        cloneSubmodulesRecursive: true,
         cloneSubmodulesFilter: ['test'],
         virtualBranches: {},
       });

--- a/lib/modules/platform/gerrit/index.ts
+++ b/lib/modules/platform/gerrit/index.ts
@@ -134,6 +134,7 @@ export async function getRepos(): Promise<string[]> {
 export async function initRepo({
   repository,
   cloneSubmodules,
+  cloneSubmodulesRecursive,
   cloneSubmodulesFilter,
   gitUrl,
 }: RepoParams): Promise<RepoResult> {
@@ -201,6 +202,7 @@ export async function initRepo({
   await git.initRepo({
     url,
     cloneSubmodules,
+    cloneSubmodulesRecursive,
     cloneSubmodulesFilter,
     virtualBranches,
   });

--- a/lib/modules/platform/gitea/index.ts
+++ b/lib/modules/platform/gitea/index.ts
@@ -73,6 +73,7 @@ interface GiteaRepoConfig {
   labelList: Promise<Label[]> | null;
   defaultBranch: string;
   cloneSubmodules: boolean;
+  cloneSubmodulesRecursive: boolean;
   cloneSubmodulesFilter: string[] | undefined;
   hasIssuesEnabled: boolean;
 }
@@ -279,6 +280,7 @@ const platform: Platform = {
   async initRepo({
     repository,
     cloneSubmodules,
+    cloneSubmodulesRecursive,
     cloneSubmodulesFilter,
     gitUrl,
   }: RepoParams): Promise<RepoResult> {
@@ -287,6 +289,7 @@ const platform: Platform = {
     config = {} as any;
     config.repository = repository;
     config.cloneSubmodules = !!cloneSubmodules;
+    config.cloneSubmodulesRecursive = !!cloneSubmodulesRecursive;
     config.cloneSubmodulesFilter = cloneSubmodulesFilter;
     config.ignorePrAuthor = GlobalConfig.get('ignorePrAuthor', false);
 

--- a/lib/modules/platform/gitea/index.ts
+++ b/lib/modules/platform/gitea/index.ts
@@ -73,6 +73,7 @@ interface GiteaRepoConfig {
   labelList: Promise<Label[]> | null;
   defaultBranch: string;
   cloneSubmodules: boolean;
+  cloneSubmodulesRecursive: boolean;
   cloneSubmodulesFilter: string[] | undefined;
   hasIssuesEnabled: boolean;
 }
@@ -280,6 +281,7 @@ const platform: Platform = {
   async initRepo({
     repository,
     cloneSubmodules,
+    cloneSubmodulesRecursive,
     cloneSubmodulesFilter,
     gitUrl,
   }: RepoParams): Promise<RepoResult> {
@@ -288,6 +290,7 @@ const platform: Platform = {
     config = {} as any;
     config.repository = repository;
     config.cloneSubmodules = !!cloneSubmodules;
+    config.cloneSubmodulesRecursive = !!cloneSubmodulesRecursive;
     config.cloneSubmodulesFilter = cloneSubmodulesFilter;
     config.ignorePrAuthor = GlobalConfig.get('ignorePrAuthor');
 

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -491,6 +491,7 @@ export async function initRepo({
   forkToken,
   renovateUsername,
   cloneSubmodules,
+  cloneSubmodulesRecursive,
   cloneSubmodulesFilter,
 }: RepoParams): Promise<RepoResult> {
   logger.debug(`initRepo("${repository}")`);
@@ -498,6 +499,7 @@ export async function initRepo({
   config = {
     repository,
     cloneSubmodules,
+    cloneSubmodulesRecursive,
     cloneSubmodulesFilter,
     ignorePrAuthor: GlobalConfig.get('ignorePrAuthor', false),
   } as any;

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -514,6 +514,7 @@ export async function initRepo({
   gitUrl,
   renovateUsername,
   cloneSubmodules,
+  cloneSubmodulesRecursive,
   cloneSubmodulesFilter,
 }: RepoParams): Promise<RepoResult> {
   logger.debug(`initRepo("${repository}")`);
@@ -521,6 +522,7 @@ export async function initRepo({
   config = {
     repository,
     cloneSubmodules,
+    cloneSubmodulesRecursive,
     cloneSubmodulesFilter,
     ignorePrAuthor: GlobalConfig.get('ignorePrAuthor'),
   } as any;

--- a/lib/modules/platform/gitlab/__snapshots__/index.spec.ts.snap
+++ b/lib/modules/platform/gitlab/__snapshots__/index.spec.ts.snap
@@ -144,6 +144,7 @@ exports[`modules/platform/gitlab/index > initRepo > should fall back respecting 
     {
       "cloneSubmodules": undefined,
       "cloneSubmodulesFilter": undefined,
+      "cloneSubmodulesRecursive": undefined,
       "defaultBranch": "master",
       "ignorePrAuthor": undefined,
       "mergeMethod": "merge",
@@ -161,6 +162,7 @@ exports[`modules/platform/gitlab/index > initRepo > should use ssh_url_to_repo i
     {
       "cloneSubmodules": undefined,
       "cloneSubmodulesFilter": undefined,
+      "cloneSubmodulesRecursive": undefined,
       "defaultBranch": "master",
       "ignorePrAuthor": undefined,
       "mergeMethod": "merge",

--- a/lib/modules/platform/gitlab/__snapshots__/index.spec.ts.snap
+++ b/lib/modules/platform/gitlab/__snapshots__/index.spec.ts.snap
@@ -144,6 +144,7 @@ exports[`modules/platform/gitlab/index > initRepo > should fall back respecting 
     {
       "cloneSubmodules": undefined,
       "cloneSubmodulesFilter": undefined,
+      "cloneSubmodulesRecursive": undefined,
       "defaultBranch": "master",
       "ignorePrAuthor": false,
       "mergeMethod": "merge",
@@ -161,6 +162,7 @@ exports[`modules/platform/gitlab/index > initRepo > should use ssh_url_to_repo i
     {
       "cloneSubmodules": undefined,
       "cloneSubmodulesFilter": undefined,
+      "cloneSubmodulesRecursive": undefined,
       "defaultBranch": "master",
       "ignorePrAuthor": false,
       "mergeMethod": "merge",

--- a/lib/modules/platform/gitlab/index.ts
+++ b/lib/modules/platform/gitlab/index.ts
@@ -86,6 +86,7 @@ let config: {
   mergeTrainsEnabled: boolean;
   defaultBranch: string;
   cloneSubmodules: boolean | undefined;
+  cloneSubmodulesRecursive: boolean | undefined;
   cloneSubmodulesFilter: string[] | undefined;
   ignorePrAuthor: boolean | undefined;
   squash: boolean;
@@ -265,12 +266,14 @@ export async function getJsonFile(
 export async function initRepo({
   repository,
   cloneSubmodules,
+  cloneSubmodulesRecursive,
   cloneSubmodulesFilter,
   gitUrl,
 }: RepoParams): Promise<RepoResult> {
   config = {} as any;
   config.repository = urlEscape(repository);
   config.cloneSubmodules = cloneSubmodules;
+  config.cloneSubmodulesRecursive = cloneSubmodulesRecursive;
   config.cloneSubmodulesFilter = cloneSubmodulesFilter;
   config.ignorePrAuthor = GlobalConfig.get('ignorePrAuthor');
 

--- a/lib/modules/platform/gitlab/index.ts
+++ b/lib/modules/platform/gitlab/index.ts
@@ -97,6 +97,7 @@ let config: {
   mergeTrainsEnabled: boolean;
   defaultBranch: string;
   cloneSubmodules: boolean | undefined;
+  cloneSubmodulesRecursive: boolean | undefined;
   cloneSubmodulesFilter: string[] | undefined;
   ignorePrAuthor: boolean | undefined;
   squash: boolean;
@@ -276,12 +277,14 @@ export async function getJsonFile(
 export async function initRepo({
   repository,
   cloneSubmodules,
+  cloneSubmodulesRecursive,
   cloneSubmodulesFilter,
   gitUrl,
 }: RepoParams): Promise<RepoResult> {
   config = {} as any;
   config.repository = urlEscape(repository);
   config.cloneSubmodules = cloneSubmodules;
+  config.cloneSubmodulesRecursive = cloneSubmodulesRecursive;
   config.cloneSubmodulesFilter = cloneSubmodulesFilter;
   config.ignorePrAuthor = GlobalConfig.get('ignorePrAuthor');
 

--- a/lib/modules/platform/types.ts
+++ b/lib/modules/platform/types.ts
@@ -51,6 +51,7 @@ export interface RepoParams {
   forkProcessing?: 'enabled' | 'disabled';
   renovateUsername?: string;
   cloneSubmodules?: boolean;
+  cloneSubmodulesRecursive?: boolean;
   cloneSubmodulesFilter?: string[];
 }
 

--- a/lib/modules/platform/types.ts
+++ b/lib/modules/platform/types.ts
@@ -43,6 +43,7 @@ export interface RepoParams {
   forkProcessing?: 'enabled' | 'disabled';
   renovateUsername?: string;
   cloneSubmodules?: boolean;
+  cloneSubmodulesRecursive?: boolean;
   cloneSubmodulesFilter?: string[];
   /** Azure only: work item type to use when creating issues. */
   azureWorkItemType?: string;

--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -263,6 +263,18 @@ describe('util/git/index', { timeout: 10000 }, () => {
       it('sets non-master base branch with submodule update', async () => {
         await git.initRepo({
           cloneSubmodules: true,
+          cloneSubmodulesRecursive: true,
+          url: base.path,
+        });
+        expect((await git.getRepoStatus()).isClean()).toBeTrue();
+        await git.checkoutBranch('stable');
+        expect((await git.getRepoStatus()).isClean()).toBeTrue();
+      });
+
+      it('clones submodules non-recursively when cloneSubmodulesRecursive is false', async () => {
+        await git.initRepo({
+          cloneSubmodules: true,
+          cloneSubmodulesRecursive: false,
           url: base.path,
         });
         expect((await git.getRepoStatus()).isClean()).toBeTrue();
@@ -298,6 +310,7 @@ describe('util/git/index', { timeout: 10000 }, () => {
       await repo.commit('Add submodules');
       await git.initRepo({
         cloneSubmodules: true,
+        cloneSubmodulesRecursive: true,
         cloneSubmodulesFilter: ['file'],
         url: base.path,
       });
@@ -1021,6 +1034,7 @@ describe('util/git/index', { timeout: 10000 }, () => {
       await repo.commit('Add submodule');
       await git.initRepo({
         cloneSubmodules: true,
+        cloneSubmodulesRecursive: true,
         url: base.path,
       });
       await git.syncGit();

--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -268,12 +268,27 @@ describe('util/git/index', { timeout: 30000 }, () => {
     });
 
     describe('submodules', () => {
+      let nestedSubmodule: tmp.DirectoryResult;
+
       beforeEach(async () => {
         const repo = simpleGit(base.path);
 
         auth.getGitEnvironmentVariables.mockReturnValue({
           GIT_ALLOW_PROTOCOL: 'file',
         });
+
+        // A separate repository referenced as a submodule of the submodule
+        // below, so recursion behaviour can be observed.
+        nestedSubmodule = await tmp.dir({ unsafeCleanup: true });
+        const nested = simpleGit(nestedSubmodule.path);
+        await nested.init();
+        await disableGitAutoMaintenance(nested);
+        await nested.addConfig('user.email', 'Jest@example.com');
+        await nested.addConfig('user.name', 'Jest');
+        await nested.addConfig('commit.gpgsign', 'false');
+        await fs.writeFile(`${nestedSubmodule.path}/nested_file`, 'nested');
+        await nested.add('nested_file');
+        await nested.commit('init nested submodule');
 
         const submoduleBasePath = `${base.path}/submodule`;
         await fs.mkdir(submoduleBasePath);
@@ -287,6 +302,9 @@ describe('util/git/index', { timeout: 30000 }, () => {
         await fs.writeFile(`${submoduleBasePath}/init_file`, 'init');
         await submodule.add('init_file');
         await submodule.commit('init submodule');
+
+        await submodule.submoduleAdd(nestedSubmodule.path, './nested');
+        await submodule.commit('add nested submodule');
 
         await repo.submoduleAdd('./submodule', './submodule');
         await repo.commit('add submodule');
@@ -309,11 +327,51 @@ describe('util/git/index', { timeout: 30000 }, () => {
       it('sets non-master base branch with submodule update', async () => {
         await git.initRepo({
           cloneSubmodules: true,
+          cloneSubmodulesRecursive: true,
           url: base.path,
         });
         expect((await git.getRepoStatus()).isClean()).toBeTrue();
         await git.checkoutBranch('stable');
         expect((await git.getRepoStatus()).isClean()).toBeTrue();
+        expect(
+          await fs.pathExists(`${tmpDir.path}/submodule/init_file`),
+        ).toBeTrue();
+        expect(
+          await fs.pathExists(`${tmpDir.path}/submodule/nested/nested_file`),
+        ).toBeTrue();
+      });
+
+      it('clones submodules non-recursively when cloneSubmodulesRecursive is false', async () => {
+        await git.initRepo({
+          cloneSubmodules: true,
+          cloneSubmodulesRecursive: false,
+          url: base.path,
+        });
+        expect((await git.getRepoStatus()).isClean()).toBeTrue();
+        await git.checkoutBranch('stable');
+        expect((await git.getRepoStatus()).isClean()).toBeTrue();
+        expect(
+          await fs.pathExists(`${tmpDir.path}/submodule/init_file`),
+        ).toBeTrue();
+        expect(
+          await fs.pathExists(`${tmpDir.path}/submodule/nested/nested_file`),
+        ).toBeFalse();
+      });
+
+      it('clones submodules recursively when cloneSubmodulesRecursive is undefined', async () => {
+        await git.initRepo({
+          cloneSubmodules: true,
+          url: base.path,
+        });
+        expect((await git.getRepoStatus()).isClean()).toBeTrue();
+        await git.checkoutBranch('stable');
+        expect((await git.getRepoStatus()).isClean()).toBeTrue();
+        expect(
+          await fs.pathExists(`${tmpDir.path}/submodule/init_file`),
+        ).toBeTrue();
+        expect(
+          await fs.pathExists(`${tmpDir.path}/submodule/nested/nested_file`),
+        ).toBeTrue();
       });
 
       afterEach(async () => {
@@ -324,6 +382,7 @@ describe('util/git/index', { timeout: 30000 }, () => {
         await repo.reset(['--hard', 'HEAD~2']);
         await repo.branch(['-D', 'stable']);
         await fs.rm(`${base.path}/submodule`, { recursive: true });
+        await nestedSubmodule?.cleanup();
       });
     });
   });
@@ -344,6 +403,7 @@ describe('util/git/index', { timeout: 30000 }, () => {
       await repo.commit('Add submodules');
       await git.initRepo({
         cloneSubmodules: true,
+        cloneSubmodulesRecursive: true,
         cloneSubmodulesFilter: ['file'],
         url: base.path,
       });
@@ -1408,6 +1468,7 @@ describe('util/git/index', { timeout: 30000 }, () => {
       await repo.commit('Add submodule');
       await git.initRepo({
         cloneSubmodules: true,
+        cloneSubmodulesRecursive: true,
         url: base.path,
       });
       await git.syncGit();

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -366,6 +366,7 @@ export async function getSubmodules(): Promise<string[]> {
 
 export async function cloneSubmodules(
   shouldClone: boolean,
+  cloneSubmodulesRecursive: boolean | undefined,
   cloneSubmodulesFilter: string[] | undefined,
 ): Promise<void> {
   if (!shouldClone || submodulesInitizialized) {
@@ -384,9 +385,18 @@ export async function cloneSubmodules(
       continue;
     }
     try {
-      logger.debug(`Cloning git submodule at ${submodule}`);
+      if (cloneSubmodulesRecursive) {
+        logger.debug(`Recursively cloning git submodule at ${submodule}`);
+      } else {
+        logger.debug(`Cloning git submodule at ${submodule}`);
+      }
+
       await gitRetry(() =>
-        git.env(gitEnv).submoduleUpdate(['--init', '--recursive', submodule]),
+        cloneSubmodulesRecursive
+          ? git
+              .env(gitEnv)
+              .submoduleUpdate(['--init', '--recursive', submodule])
+          : git.env(gitEnv).submoduleUpdate(['--init', submodule]),
       );
     } catch (err) {
       logger.warn({ err, submodule }, `Unable to initialise git submodule`);
@@ -497,7 +507,11 @@ export const syncGit = withInstrumenting(
     }
     // This will only happen now if set in global config
     await instrument('cloneSubmodules', () =>
-      cloneSubmodules(!!config.cloneSubmodules, config.cloneSubmodulesFilter),
+      cloneSubmodules(
+        !!config.cloneSubmodules,
+        config.cloneSubmodulesRecursive,
+        config.cloneSubmodulesFilter,
+      ),
     );
     try {
       const latestCommit = (await git.log({ n: 1 })).latest;

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -427,12 +427,14 @@ export async function getSubmodules(): Promise<string[]> {
 
 export async function cloneSubmodules(
   shouldClone: boolean,
+  cloneSubmodulesRecursive: boolean | undefined,
   cloneSubmodulesFilter: string[] | undefined,
 ): Promise<void> {
   if (!shouldClone || submodulesInitizialized) {
     return;
   }
   submodulesInitizialized = true;
+  const recursive = cloneSubmodulesRecursive ?? true;
   const gitEnv = getChildEnv({ env: getGitEnvironmentVariables() });
   await syncGit();
   const submodules = await getSubmodules();
@@ -445,9 +447,18 @@ export async function cloneSubmodules(
       continue;
     }
     try {
-      logger.debug(`Cloning git submodule at ${submodule}`);
+      if (recursive) {
+        logger.debug(`Recursively cloning git submodule at ${submodule}`);
+      } else {
+        logger.debug(`Cloning git submodule at ${submodule}`);
+      }
+
       await gitRetry(() =>
-        git.env(gitEnv).submoduleUpdate(['--init', '--recursive', submodule]),
+        recursive
+          ? git
+              .env(gitEnv)
+              .submoduleUpdate(['--init', '--recursive', submodule])
+          : git.env(gitEnv).submoduleUpdate(['--init', submodule]),
       );
     } catch (err) {
       logger.warn({ err, submodule }, `Unable to initialise git submodule`);
@@ -572,7 +583,11 @@ export const syncGit = withInstrumenting(
     }
     // This will only happen now if set in global config
     await instrument('cloneSubmodules', () =>
-      cloneSubmodules(!!config.cloneSubmodules, config.cloneSubmodulesFilter),
+      cloneSubmodules(
+        !!config.cloneSubmodules,
+        config.cloneSubmodulesRecursive,
+        config.cloneSubmodulesFilter,
+      ),
     );
     try {
       const latestCommit = (await git.log({ n: 1 })).latest;

--- a/lib/util/git/types.ts
+++ b/lib/util/git/types.ts
@@ -23,6 +23,7 @@ export interface StorageConfig {
   upstreamUrl?: string | undefined;
   extraCloneOpts?: GitOptions;
   cloneSubmodules?: boolean;
+  cloneSubmodulesRecursive?: boolean;
   cloneSubmodulesFilter?: string[];
   fullClone?: boolean;
 }

--- a/lib/util/git/types.ts
+++ b/lib/util/git/types.ts
@@ -31,6 +31,7 @@ export interface StorageConfig {
   upstreamUrl?: string | undefined;
   extraCloneOpts?: GitOptions;
   cloneSubmodules?: boolean;
+  cloneSubmodulesRecursive?: boolean;
   cloneSubmodulesFilter?: string[];
   fullClone?: boolean;
   /**

--- a/lib/workers/repository/init/index.ts
+++ b/lib/workers/repository/init/index.ts
@@ -78,6 +78,10 @@ export async function initRepo(
       'Full resolved config and hostRules including presets',
     );
   }
-  await cloneSubmodules(!!config.cloneSubmodules, config.cloneSubmodulesFilter);
+  await cloneSubmodules(
+    !!config.cloneSubmodules,
+    !!config.cloneSubmodulesRecursive,
+    config.cloneSubmodulesFilter,
+  );
   return config;
 }

--- a/lib/workers/repository/init/index.ts
+++ b/lib/workers/repository/init/index.ts
@@ -76,6 +76,10 @@ export async function initRepo(
       'Full resolved config and hostRules including presets',
     );
   }
-  await cloneSubmodules(!!config.cloneSubmodules, config.cloneSubmodulesFilter);
+  await cloneSubmodules(
+    !!config.cloneSubmodules,
+    config.cloneSubmodulesRecursive,
+    config.cloneSubmodulesFilter,
+  );
   return config;
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This PR introduces a small flag `cloneSubmodulesRecursive`, which defaults to `true`, to not alter existing behaviour, that allows the user to turn off the recursive checkout of submodules.

With https://github.com/renovatebot/renovate/commit/0e9e938112b9d6f411b2a3893a184e1be2937cde the `--recursive` flag for `git submodule` was hardcoded. That causes issues for us, where a submodule (`https://github.com/gravitational/teleport`) references another submodule (`https://github.com/gravitational/teleport.e` via `e`), we don't have access to.

## Context

Please select one of the below:

- [ ] This closes an existing Issue
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [X] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [X] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [X] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
