### PR TITLE
chore(telemetry): add span attribute for splits

### DIFF
--- a/lib/instrumentation/index.ts
+++ b/lib/instrumentation/index.ts
@@ -1,11 +1,5 @@
 import { ClientRequest } from 'node:http';
-import type {
-  Context,
-  Span,
-  SpanOptions,
-  Tracer,
-  TracerProvider,
-} from '@opentelemetry/api';
+import type { Context, Span, Tracer, TracerProvider } from '@opentelemetry/api';
 import * as api from '@opentelemetry/api';
 import { ProxyTracerProvider, SpanStatusCode } from '@opentelemetry/api';
 import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks';
@@ -47,6 +41,7 @@ import {
 } from '@opentelemetry/semantic-conventions';
 import { pkg } from '../expose.cjs';
 import { getEnv } from '../util/env';
+import type { RenovateSpanOptions } from './types';
 import {
   isTraceDebuggingEnabled,
   isTraceSendingEnabled,
@@ -170,18 +165,18 @@ export function instrument<F extends () => ReturnType<F>>(
 export function instrument<F extends () => ReturnType<F>>(
   name: string,
   fn: F,
-  options: SpanOptions,
+  options: RenovateSpanOptions,
 ): ReturnType<F>;
 export function instrument<F extends () => ReturnType<F>>(
   name: string,
   fn: F,
-  options: SpanOptions,
+  options: RenovateSpanOptions,
   context: Context,
 ): ReturnType<F>;
 export function instrument<F extends () => ReturnType<F>>(
   name: string,
   fn: F,
-  options: SpanOptions = {},
+  options: RenovateSpanOptions = {},
   context: Context = api.context.active(),
 ): ReturnType<F> {
   return getTracer().startActiveSpan(name, options, context, (span: Span) => {

--- a/lib/instrumentation/types.ts
+++ b/lib/instrumentation/types.ts
@@ -1,7 +1,16 @@
-import type { Attributes, SpanKind } from '@opentelemetry/api';
+import type { Attributes, SpanKind, SpanOptions } from '@opentelemetry/api';
+import type { RenovateSplit } from '../config/types';
 import type { BunyanRecord } from '../logger/types';
 import type { PackageFile } from '../modules/manager/types';
 import type { BranchCache } from '../util/cache/repository/types';
+
+export type RenovateSpanOptions = {
+  attributes?: RenovateSpanAttributes;
+} & SpanOptions;
+
+export type RenovateSpanAttributes = {
+  [ATTR_RENOVATE_SPLIT]?: RenovateSplit;
+} & Attributes;
 
 /**
  * The instrumentation decorator parameters.
@@ -54,3 +63,5 @@ export interface DependencyStatus {
   outdated: number;
   total: number;
 }
+
+export const ATTR_RENOVATE_SPLIT = 'renovate.split';

--- a/lib/workers/repository/index.ts
+++ b/lib/workers/repository/index.ts
@@ -10,6 +10,7 @@ import {
 import { pkg } from '../../expose.cjs';
 import { instrument } from '../../instrumentation';
 import { addExtractionStats } from '../../instrumentation/reporting';
+import { ATTR_RENOVATE_SPLIT } from '../../instrumentation/types';
 import { logger, setMeta } from '../../logger';
 import { resetRepositoryLogLevelRemaps } from '../../logger/remap';
 import { removeDanglingContainers } from '../../util/exec/docker';
@@ -95,6 +96,11 @@ export async function renovateRepository(
 
       return { config, localDir, errorRes };
     },
+    {
+      attributes: {
+        [ATTR_RENOVATE_SPLIT]: 'init',
+      },
+    },
   );
 
   try {
@@ -107,8 +113,15 @@ export async function renovateRepository(
       config.repoIsOnboarded! ||
       !OnboardingState.onboardingCacheValid ||
       OnboardingState.prUpdateRequested;
-    const extractResult = await instrument('extract', () =>
-      performExtract ? extractDependencies(config) : emptyExtract(config),
+    const extractResult = await instrument(
+      'extract',
+      () =>
+        performExtract ? extractDependencies(config) : emptyExtract(config),
+      {
+        attributes: {
+          [ATTR_RENOVATE_SPLIT]: 'extract',
+        },
+      },
     );
     addExtractionStats(config, extractResult);
 
@@ -122,12 +135,24 @@ export async function renovateRepository(
       GlobalConfig.get('dryRun') !== 'lookup' &&
       GlobalConfig.get('dryRun') !== 'extract'
     ) {
-      await instrument('onboarding', () =>
-        ensureOnboardingPr(config, packageFiles, branches),
+      await instrument(
+        'onboarding',
+        () => ensureOnboardingPr(config, packageFiles, branches),
+        {
+          attributes: {
+            [ATTR_RENOVATE_SPLIT]: 'onboarding',
+          },
+        },
       );
       addSplit('onboarding');
-      const res = await instrument('update', () =>
-        updateRepo(config, branches),
+      const res = await instrument(
+        'update',
+        () => updateRepo(config, branches),
+        {
+          attributes: {
+            [ATTR_RENOVATE_SPLIT]: 'update',
+          },
+        },
       );
       setMeta({ repository: config.repository });
       addSplit('update');


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

As part of a step towards better OpenTelemetry instrumentation as part
of #38609, we can start by introducing a known span attribute for the
repository "split" we're currently processing.

This requires a slight refactor of the `SpanOptions`, to use our custom
type, which enforces the `RenovateSplit` type when using the span name.

This adds it into each of the splits we currently instrument.

## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
