### PR TITLE
chore: disable pnpm `Update available!` notices

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,6 +1,9 @@
 save-exact = true
 provenance = true
 
+# updates are handled by Renovate itself
+update-notifier = false
+
 # pnpm run settings
 # https://pnpm.io/cli/run
 shell-emulator = true


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Every now and then, when running commands like `pnpm install` or even rebuilding the devcontainer, pnpm shows a notice that a new version is available:

```text
   ╭──────────────────────────────────────────╮
   │                                          │
   │   Update available! 10.18.1 → 10.18.3.   │
   │   Changelog: https://pnpm.io/v/10.18.3   │
   │     To update, run: pnpm add -g pnpm     │
   │                                          │
   ╰──────────────────────────────────────────╯
```

However, I don't think these notices are any helpful in this repository, since Renovate itself is already taking care of updating pnpm when needed. People are not meant to update pnpm manually here, nor take any action based on these notices.

So, this PR disables these `Update available!` notices. This is a [npm setting](https://docs.npmjs.com/cli/v11/using-npm/config#update-notifier) that pnpm respects.

## Context

Please select one of the below:

- [ ] This closes an existing Issue:
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
