### PR TITLE
docs: avoid editors flagging comments in `renovate.json`

### DIFF
--- a/tools/docs/schema.ts
+++ b/tools/docs/schema.ts
@@ -175,6 +175,7 @@ export async function generateSchema(
     title: `JSON schema for Renovate ${version} config files (https://renovatebot.com/)`,
     $schema: 'http://json-schema.org/draft-04/schema#',
     'x-renovate-version': `${version}`,
+    allowComments: true,
     type: 'object',
     properties: {},
   };


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Ever since https://github.com/renovatebot/renovate/issues/29535 Renovate supports comments in `renovate.json` files. However, editors like VS Code flag comments in JSON files as errors, which can be annoying.

This can also be misleading: users may go all the way to migrate to `renovate.json5` just because they want to add a comment line. That's a bummer, OOTB support for JSON5 in VS Code is very poor.

This PR fixes the JSON Schema for `renovate.json` files to allow comments, so that editors like VS Code no longer flag comments as errors.

https://github.com/user-attachments/assets/fe794104-8692-4741-9379-a7a16d126dc0

## Context

Please select one of the below:

- [ ] This closes an existing Issue:
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
