### PR TITLE
ci(tools/json-schema): validate JSON schemas are well-formed

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "test-e2e:pack": "pnpm pack",
     "test-e2e:install": "cd test/e2e && pnpm --ignore-workspace install --no-lockfile --prod",
     "test-e2e:run": "cd test/e2e && pnpm test",
-    "test-schema": "run-s create-json-schema",
+    "test-schema": "run-s create-json-schema && tsx tools/validate-schema.ts",
     "test:docs": "node --test tools/docs/test/**/*.mjs",
     "schedule-test-shards": "SCHEDULE_TEST_SHARDS=true tsx tools/test-shards.ts",
     "tsc": "tsc",

--- a/tools/validate-schema.ts
+++ b/tools/validate-schema.ts
@@ -1,0 +1,51 @@
+import { promises } from 'fs';
+import ajv from 'ajv';
+import draft4MetaSchema from 'ajv/lib/refs/json-schema-draft-04.json';
+import { glob } from 'glob';
+
+async function validateFileAgainstDraft04Schema(
+  validate: ajv.ValidateFunction,
+  filename: string,
+): Promise<ajv.ErrorObject[] | null | undefined> {
+  const schema = JSON.parse(await promises.readFile(filename, 'utf-8'));
+  const valid = await validate(schema);
+  if (!valid) {
+    return validate.errors;
+  }
+}
+
+async function validateDraft04Schemas(): Promise<void> {
+  const validator = new ajv({ schemaId: 'auto', meta: false });
+  validator.addMetaSchema(draft4MetaSchema);
+  const validate = validator.compile(draft4MetaSchema);
+
+  const failed: { filename: string; errors: ajv.ErrorObject[] }[] = [];
+
+  const fileGlobsToValidate = ['renovate-schema.json', 'tools/schemas/*.json'];
+  const expandedFiles: string[] = (
+    await Promise.all(
+      fileGlobsToValidate.map(async (pattern) => await glob(pattern)),
+    )
+  ).flat();
+
+  for (const filename of expandedFiles) {
+    const errors = await validateFileAgainstDraft04Schema(validate, filename);
+    if (errors) {
+      failed.push({ filename, errors });
+    } else {
+      console.log(`Schema in ${filename} is valid!`);
+    }
+  }
+
+  if (failed.length > 0) {
+    for (const f of failed) {
+      console.error(`Schema in ${f.filename} is invalid:`, f.errors);
+    }
+
+    process.exit(1);
+  }
+}
+
+void (async () => {
+  await validateDraft04Schemas();
+})();


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->



To ensure that our JSON Schema is always correctly formed, we can use
`ajv`'s inbuilt metaschema validation to perform.

We also wire this into the `test-schema` script, to make sure that we're
always validating it in CI.

This applies to both the core JSON Schema for configuration, and the
Replacements' JSON Schema.

The core of this - as little code as it is - was generated via GPT-4.1.

Co-authored-by: gpt-4.1

## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

Related to changes in https://github.com/renovatebot/renovate/pull/38640, I thought it'd be good for us to make sure that we're validating our JSON Schema on changes.

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->

Tested by breaking the JSON Schema in `renovate-schema.json`:

```json
{
  "title": "JSON schema for Renovate 0.0.0-semantic-release config files (https://renovatebot.com/)",
  "type": "string",
  "$schema": {
    ":": "http://json-schema.org/draft-04/schema#"
  }
}
```

Then running:

```sh
pnpm exec tsx tools/validate-schema.ts
```

Showing:

```console
Schema is invalid: [
  {
    keyword: 'type',
    dataPath: '.$schema',
    schemaPath: '#/properties/%24schema/type',
    params: { type: 'string' },
    message: 'should be string'
  }
]
```
