### PR TITLE
fix(workers/branch): skip branch update if `pendingChecks=true`

### DIFF
--- a/lib/workers/repository/update/branch/index.spec.ts
+++ b/lib/workers/repository/update/branch/index.spec.ts
@@ -723,6 +723,29 @@ describe('workers/repository/update/branch/index', () => {
       });
     });
 
+    it('returns if pending checks - but branch exists', async () => {
+      getUpdated.getUpdatedPackageFiles.mockResolvedValueOnce({
+        ...updatedPackageFiles,
+      });
+      npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
+        artifactErrors: [],
+        updatedArtifacts: [],
+      });
+      scm.branchExists.mockResolvedValue(true);
+      platform.getBranchPr.mockResolvedValueOnce(
+        partial<Pr>({
+          number: 5,
+          state: 'open',
+        }),
+      );
+      config.pendingChecks = true;
+      expect(await branchWorker.processBranch(config)).toEqual({
+        branchExists: true,
+        prNo: 5,
+        result: 'no-work',
+      });
+    });
+
     // automerge should respect only automergeSchedule
     // mock a case where branchPr does not exist, pr-creation is off-schedule, and the branch is configured for automerge
     it('automerges when there is no pr and, pr-creation is off-schedule', async () => {

--- a/lib/workers/repository/update/branch/index.spec.ts
+++ b/lib/workers/repository/update/branch/index.spec.ts
@@ -742,7 +742,7 @@ describe('workers/repository/update/branch/index', () => {
       expect(await branchWorker.processBranch(config)).toEqual({
         branchExists: true,
         prNo: 5,
-        result: 'no-work',
+        result: 'pending',
       });
     });
 

--- a/lib/workers/repository/update/branch/index.ts
+++ b/lib/workers/repository/update/branch/index.ts
@@ -282,7 +282,7 @@ export async function processBranch(
 
         if (config.pendingChecks) {
           logger.info(
-            'Branch updating is skipped because it contains updates with pendingChecks=true',
+            'Branch updating is skipped because internalChecksFilter was not met',
           );
           return {
             branchExists: true,

--- a/lib/workers/repository/update/branch/index.ts
+++ b/lib/workers/repository/update/branch/index.ts
@@ -268,8 +268,8 @@ export async function processBranch(
 
       const prRebaseChecked = !!branchPr?.bodyStruct?.rebaseRequested;
 
-      if (branchExists && !dependencyDashboardCheck) {
-        if (config.stopUpdating && !prRebaseChecked) {
+      if (branchExists && !dependencyDashboardCheck && !prRebaseChecked) {
+        if (config.stopUpdating) {
           logger.info(
             'Branch updating is skipped because stopUpdatingLabel is present in config',
           );
@@ -282,7 +282,7 @@ export async function processBranch(
 
         if (config.pendingChecks) {
           logger.info(
-            'Branch updating is skipped because it contains updates with unmet release age',
+            'Branch updating is skipped because it contains updates with pendingChecks=true',
           );
           return {
             branchExists: true,

--- a/lib/workers/repository/update/branch/index.ts
+++ b/lib/workers/repository/update/branch/index.ts
@@ -287,7 +287,7 @@ export async function processBranch(
           return {
             branchExists: true,
             prNo: branchPr?.number,
-            result: 'no-work',
+            result: 'pending',
           };
         }
       }

--- a/lib/workers/repository/update/branch/index.ts
+++ b/lib/workers/repository/update/branch/index.ts
@@ -268,10 +268,21 @@ export async function processBranch(
 
       const prRebaseChecked = !!branchPr?.bodyStruct?.rebaseRequested;
 
-      if (branchExists && !dependencyDashboardCheck && config.stopUpdating) {
-        if (!prRebaseChecked) {
+      if (branchExists && !dependencyDashboardCheck) {
+        if (config.stopUpdating && !prRebaseChecked) {
           logger.info(
             'Branch updating is skipped because stopUpdatingLabel is present in config',
+          );
+          return {
+            branchExists: true,
+            prNo: branchPr?.number,
+            result: 'no-work',
+          };
+        }
+
+        if (config.pendingChecks) {
+          logger.info(
+            'Branch updating is skipped because it contains updates with unmet release age',
           );
           return {
             branchExists: true,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- Skip updating an existing branch if `pendingChecks=true`
<!-- Describe what behavior is changed by this PR. -->

## Context

Closes: #38719 

Please select one of the below:

- [x] This closes an existing Issue: #38719
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/Rahul-renovate-testing/min-release-age-branch-update-old-behavior

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
