### PR TITLE
feat(hostRules): auto-wire a `hostRule` for `api.github.com`

### DIFF
--- a/lib/constants/platforms.ts
+++ b/lib/constants/platforms.ts
@@ -36,6 +36,7 @@ export const GITHUB_API_USING_HOST_TYPES = [
   'hermit',
   'github-changelog',
   'conan',
+  // DEPRECATED: do not add additional datasource-specific entries here, if they use `api.github.com` to look up new versions
 ];
 
 export const GITLAB_API_USING_HOST_TYPES = [

--- a/lib/util/http/host-rules.spec.ts
+++ b/lib/util/http/host-rules.spec.ts
@@ -371,6 +371,91 @@ describe('util/http/host-rules', () => {
       hostType: 'pod',
       token: 'token',
     });
+
+    // in the case that an API URL is used for GitHub.com, auto-detect it as a `hostType=github`, and use the `url`'s host to find a `matchHost: github.com`
+    {
+      const url = 'https://api.github.com/renovatebot/renovate';
+
+      {
+        opts = {};
+        hostRule = findMatchingRule(url, opts);
+        expect(hostRule).toEqual({
+          token: 'dotcom-api-token',
+        });
+        expect(applyHostRule(url, opts, hostRule)).toEqual({
+          context: {
+            authType: undefined,
+          },
+          token: 'dotcom-api-token',
+        });
+      }
+
+      // in the case a Datasource uses GitHub APIs, but doesn't have an explicit wiring in via GITHUB_API_USING_HOST_TYPES, we should also auto-detect
+      // See #30490 #38725
+      {
+        const url =
+          'https://api.github.com/repos/bitrise-io/bitrise-steplib/contents';
+
+        opts = { hostType: 'bitrise' };
+        hostRule = findMatchingRule(url, opts);
+        expect(hostRule).toEqual({
+          token: 'dotcom-api-token',
+        });
+        expect(applyHostRule(url, opts, hostRule)).toEqual({
+          context: {
+            authType: undefined,
+          },
+          hostType: 'bitrise',
+          token: 'dotcom-api-token',
+        });
+      }
+
+      // and validate that this has lowest precedence compared to other rules
+      {
+        hostRules.clear();
+        hostRules.add({
+          hostType: 'github-changelog',
+          token: 'changelogtoken',
+        });
+        hostRules.add({
+          hostType: 'github',
+          token: 'token',
+        });
+        hostRules.add({
+          matchHost: 'api.github.com',
+          token: 'dotcom-api-token',
+        });
+
+        // the specific `hostType` wins if we use it
+        opts = { hostType: 'github-changelog' };
+        hostRule = findMatchingRule('https://github.com/chalk/chalk', opts);
+        expect(hostRule).toEqual({
+          token: 'changelogtoken',
+        });
+        expect(
+          applyHostRule('https://github.com/chalk/chalk', opts, hostRule),
+        ).toEqual({
+          context: {
+            authType: undefined,
+          },
+          hostType: 'github-changelog',
+          token: 'changelogtoken',
+        });
+
+        // but if no `hostType` matching, we'll use our `hostType: github` for `github.com`
+        opts = {};
+        hostRule = findMatchingRule(url, opts);
+        expect(hostRule).toEqual({
+          token: 'dotcom-api-token',
+        });
+        expect(applyHostRule(url, opts, hostRule)).toEqual({
+          context: {
+            authType: undefined,
+          },
+          token: 'dotcom-api-token',
+        });
+      }
+    }
   });
 
   it('when multiple GitHub host types are set', () => {

--- a/lib/util/http/host-rules.ts
+++ b/lib/util/http/host-rules.ts
@@ -69,6 +69,17 @@ export function findMatchingRule<GotOptions extends HostRulesGotOptions>(
     };
   }
 
+  // in the case that an API URL is used for GitHub.com, fallback to `github` hostType, and use the `url`'s host to find a `matchHost: api.github.com` (or `matchHost: github.com`)
+  if (url.startsWith('https://api.github.com/')) {
+    res = {
+      ...hostRules.find({
+        hostType: 'github',
+        url,
+      }),
+      ...res,
+    };
+  }
+
   // Fallback to `gitlab` hostType
   if (
     hostType &&


### PR DESCRIPTION
## Changes

As noted in #38732, the Typst datasource performs API calls to the
GitHub APIs, but as we do not have explicit datasource mapping for the
API calls (via `GITHUB_API_USING_HOST_TYPES`), we end up sending
unauthenticated API calls, which then can result in rate limits.

We had previously attempted to fix this in #30490, for a different
datasource, and there are likely other datasources impacted.

To simplify this, we can auto-wire any `https://api.github.com/` API
calls with the `hostType: github` hostRule, when matching against the
hostname from the `url`.

This also adds a note to deprecate the usage of
`GITHUB_API_USING_HOST_TYPES`, unless it's explicitly needed.



## Context

Please select one of the below:


- [x] This closes an existing Issue: #38953.
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/jamietanna-Mend-testing/internships

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
