### PR TITLE
fix(replacements): correct `release-please` move to `googleapis` org

### DIFF
--- a/lib/data/replacements.json
+++ b/lib/data/replacements.json
@@ -686,8 +686,8 @@
     "description": "`google-github-action/release-please` was renamed to `googleapis/release-please`.",
     "packageRules": [
       {
-        "matchDatasources": ["github-actions"],
-        "matchPackageNames": ["google-github-action/release-please"],
+        "matchDatasources": ["github-tags"],
+        "matchPackageNames": ["google-github-actions/release-please-action"],
         "replacementName": "googleapis/release-please"
       }
     ]


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
In #38701, I had missed that this wasn't correctly wired in.

From some testing, it appears we need to use the `github-tags`
Datasource not the `github-actions` Manager, and make sure we correctly
note the `packageName`


## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: https://github.com/JamieTanna-Mend-testing/release-please-migration

With `config.js`:

```javascript
module.exports = {
  extends: [
    'replacements:google-github-action-release-please-to-googleapis',
  ],
  onboarding: false,
  requireConfig: 'ignored',
}
```

Raises https://github.com/JamieTanna-Mend-testing/release-please-migration/pull/3

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
