### PR TITLE
ci(tools/json-schema): validate data files against their JSON schemas

### DIFF
--- a/tools/schemas/abandonments-schema.json
+++ b/tools/schemas/abandonments-schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "Exceptions for abandoned packages",
   "description": "Community-sourced overrides for packages that appear abandoned but are still maintained",
   "type": "object",

--- a/tools/schemas/changelog-urls-schema.json
+++ b/tools/schemas/changelog-urls-schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "properties": {
     "$schema": { "type": "string" }

--- a/tools/schemas/monorepo-schema.json
+++ b/tools/schemas/monorepo-schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "properties": {
     "$schema": { "type": "string" },

--- a/tools/schemas/replacements-schema.json
+++ b/tools/schemas/replacements-schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "properties": {
     "$schema": { "type": "string" },
@@ -20,7 +20,7 @@
     }
   },
   "patternProperties": {
-    "^[a-zA-Z0-9-]+$": {
+    "^(?!all$)[a-zA-Z0-9-]+$": {
       "type": "object",
       "properties": {
         "description": { "type": "string" },

--- a/tools/schemas/source-urls-schema.json
+++ b/tools/schemas/source-urls-schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "properties": {
     "$schema": { "type": "string" }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

To ensure that our `lib/data` files match the JSON schemas that we have
defined, we can also introduce these into the `tools/validate-schema.ts`
file.

This loops through the known files and the JSON Schema that defines
them, then validates them with AJV.

Note that this also requires the following schema changes:

- using draft-04 everywhere (for ease, as we're not using draft-07
  functionality)
- using a consistent `$schema` identifier, to match the document `$id`

The core of this - as little code as it is - was generated via GPT-4.1,
based on existing code in this file.

Co-authored-by: gpt-4.1 <jamie.tanna+github-copilot@mend.io>


Co-authored-by: gpt-4.1

## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

Related to changes in https://github.com/renovatebot/renovate/pull/38640, I thought it'd be good for us to make sure that we're validating our JSON Schema on changes.

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->

Right now, this fails with:

```
Schema in renovate-schema.json is valid!
Schema in tools/schemas/source-urls-schema.json is valid!
Schema in tools/schemas/replacements-schema.json is valid!
Schema in tools/schemas/monorepo-schema.json is valid!
Schema in tools/schemas/changelog-urls-schema.json is valid!
Schema in tools/schemas/abandonments-schema.json is valid!
lib/data/abandonments.json validated correctly against schema from tools/schemas/abandonments-schema.json!
lib/data/changelog-urls.json failed to validate against schema from tools/schemas/changelog-urls-schema.json: [
  {
    keyword: 'additionalProperties',
    dataPath: '',
    schemaPath: '#/additionalProperties',
    params: { additionalProperty: '$schema' },
    message: 'should NOT have additional properties'
  }
]
lib/data/monorepo.json failed to validate against schema from tools/schemas/monorepo-schema.json: [
  {
    keyword: 'additionalProperties',
    dataPath: '',
    schemaPath: '#/additionalProperties',
    params: { additionalProperty: '$schema' },
    message: 'should NOT have additional properties'
  }
]
lib/data/replacements.json failed to validate against schema from tools/schemas/replacements-schema.json: [
  {
    keyword: 'additionalProperties',
    dataPath: '',
    schemaPath: '#/additionalProperties',
    params: { additionalProperty: '$schema' },
    message: 'should NOT have additional properties'
  }
]
lib/data/source-urls.json failed to validate against schema from tools/schemas/source-urls-schema.json: [
  {
    keyword: 'additionalProperties',
    dataPath: '',
    schemaPath: '#/additionalProperties',
    params: { additionalProperty: '$schema' },
    message: 'should NOT have additional properties'
  }
]
```

As we need to merge https://github.com/renovatebot/renovate/pull/38738 first.
