### PR TITLE
chore(tools/schema): upgrade internal schemas to JSON Schema draft-07

### DIFF
--- a/tools/schemas/abandonments-schema.json
+++ b/tools/schemas/abandonments-schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Exceptions for abandoned packages",
   "description": "Community-sourced overrides for packages that appear abandoned but are still maintained",
   "type": "object",

--- a/tools/schemas/changelog-urls-schema.json
+++ b/tools/schemas/changelog-urls-schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
     "$schema": { "type": "string" }

--- a/tools/schemas/monorepo-schema.json
+++ b/tools/schemas/monorepo-schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
     "$schema": { "type": "string" },

--- a/tools/schemas/replacements-schema.json
+++ b/tools/schemas/replacements-schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
     "$schema": { "type": "string" },

--- a/tools/schemas/source-urls-schema.json
+++ b/tools/schemas/source-urls-schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
     "$schema": { "type": "string" }

--- a/tools/validate-schema.ts
+++ b/tools/validate-schema.ts
@@ -1,9 +1,9 @@
 import { promises } from 'fs';
 import ajv from 'ajv';
-import draft4MetaSchema from 'ajv/lib/refs/json-schema-draft-04.json';
+import draft7MetaSchema from 'ajv/lib/refs/json-schema-draft-07.json';
 import { glob } from 'glob';
 
-async function validateFileAgainstDraft04Schema(
+async function validateFileAgainstDraft07Schema(
   validate: ajv.ValidateFunction,
   filename: string,
 ): Promise<ajv.ErrorObject[] | null | undefined> {
@@ -14,14 +14,14 @@ async function validateFileAgainstDraft04Schema(
   }
 }
 
-async function validateFileAgainstDraft04SchemaFromFile(
+async function validateFileAgainstDraft07SchemaFromFile(
   schemaFilename: string,
   filename: string,
 ): Promise<ajv.ErrorObject[] | null | undefined> {
   const data = JSON.parse(await promises.readFile(filename, 'utf-8'));
   const schema = JSON.parse(await promises.readFile(schemaFilename, 'utf-8'));
   const validator = new ajv({ schemaId: 'auto', meta: false });
-  validator.addMetaSchema(draft4MetaSchema);
+  validator.addMetaSchema(draft7MetaSchema);
   const validate = validator.compile(schema);
   const valid = await validate(data);
   if (!valid) {
@@ -29,10 +29,10 @@ async function validateFileAgainstDraft04SchemaFromFile(
   }
 }
 
-async function validateDraft04Schemas(): Promise<void> {
+async function validateDraft07Schemas(): Promise<void> {
   const validator = new ajv({ schemaId: 'auto', meta: false });
-  validator.addMetaSchema(draft4MetaSchema);
-  const validate = validator.compile(draft4MetaSchema);
+  validator.addMetaSchema(draft7MetaSchema);
+  const validate = validator.compile(draft7MetaSchema);
 
   const failed: { filename: string; errors: ajv.ErrorObject[] }[] = [];
 
@@ -44,7 +44,7 @@ async function validateDraft04Schemas(): Promise<void> {
   ).flat();
 
   for (const filename of expandedFiles) {
-    const errors = await validateFileAgainstDraft04Schema(validate, filename);
+    const errors = await validateFileAgainstDraft07Schema(validate, filename);
     if (errors) {
       failed.push({ filename, errors });
     } else {
@@ -95,7 +95,7 @@ async function validateDataFilesAgainstSchemas(): Promise<void> {
   }[] = [];
 
   for (const filename of filesAndSchemasToValidate) {
-    const errors = await validateFileAgainstDraft04SchemaFromFile(
+    const errors = await validateFileAgainstDraft07SchemaFromFile(
       filename.schemaFilename,
       filename.filename,
     );
@@ -121,6 +121,6 @@ async function validateDataFilesAgainstSchemas(): Promise<void> {
 }
 
 void (async () => {
-  await validateDraft04Schemas();
+  await validateDraft07Schemas();
   await validateDataFilesAgainstSchemas();
 })();


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
As noted in #38749, we need to upgrade to draft-07 of JSON Schema to
upgrade our dependency on AJV.

To do so, we "just" need to update the `$schema`, as we're not using
anything that's been deprecated/removed/changed as part of draft-07.

This doesn't impact anything user-facing (as these are schemas for
internal data files), and the schema doesn't change.

This appears to be supported by `vscode-json-languageservice`, which is
used by several IDEs (including VSCode) and editors to perform JSON
Schema validation in-editor.


## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

Part of #38749

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
