### PR TITLE
refactor(git): use non-capturing groups in SSH key regex

### DIFF
--- a/lib/util/git/private-key.ts
+++ b/lib/util/git/private-key.ts
@@ -12,7 +12,7 @@ import { fromBase64, toBase64 } from '../string';
 type PrivateKeyFormat = 'gpg' | 'ssh';
 
 const sshKeyRegex = regEx(
-  /-----BEGIN ([A-Z ]+ )?PRIVATE KEY-----.*?-----END ([A-Z]+ )?PRIVATE KEY-----/,
+  /-----BEGIN (?:[A-Z ]+ )?PRIVATE KEY-----.*?-----END (?:[A-Z]+ )?PRIVATE KEY-----/,
   's',
 );
 


### PR DESCRIPTION
## Changes

Refactored the SSH key regex pattern in `lib/util/git/private-key.ts` to use non-capturing groups (`(?:...)`) instead of capturing groups for optional parts that aren't being used. This makes the regex intent clearer and slightly more efficient.

## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).

## Documentation (please check one with an [x])

- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only