### PR TITLE
fix(release-notes): treat self-hosted GitLab like gitlab.com for skipping linkification

### DIFF
--- a/lib/util/markdown.spec.ts
+++ b/lib/util/markdown.spec.ts
@@ -35,6 +35,11 @@ describe('util/markdown', () => {
       expect(res).toEqual(after);
     });
 
+    it('works with base url without trailing slash', async () => {
+      const res = await linkify('https://github.com', 'some/repo', before);
+      expect(res).toEqual(after);
+    });
+
     it('works with gitlab', async () => {
       const res = await linkify(
         'https://company.gitlab.local',

--- a/lib/util/markdown.spec.ts
+++ b/lib/util/markdown.spec.ts
@@ -31,14 +31,15 @@ describe('util/markdown', () => {
     ` + '\n';
 
     it('works', async () => {
-      const res = await linkify(before, { repository: 'some/repo' });
+      const res = await linkify('https://github.com/', 'some/repo', before);
       expect(res).toEqual(after);
     });
 
     it('works with gitlab', async () => {
       const res = await linkify(
+        'https://company.gitlab.local',
+        'some/repo',
         `(https://company.gitlab.local/shared/scanner/-/merge_requests/1177)`,
-        { repository: 'some/repo' },
       );
       expect(res.toString()).toEqual(
         `(<https://company.gitlab.local/shared/scanner/-/merge_requests/1177>)\n`,

--- a/lib/util/markdown.ts
+++ b/lib/util/markdown.ts
@@ -1,9 +1,16 @@
 import { remark } from 'remark';
+import type { Processor } from 'unified';
+import type { Root } from 'mdast';
 import gfm from 'remark-gfm';
-import type { Options as RemarkGithubOptions } from 'remark-github';
-import github, { defaultBuildUrl } from 'remark-github';
-import { regEx } from './regex';
+import type {
+  Options as RemarkGithubOptions,
+  BuildUrlValues as BuildGithubUrlValues,
+} from 'remark-github';
+import github, {
+  defaultBuildUrl as defaultBuildGithubUrl,
+} from 'remark-github';
 import { detectPlatform } from './common';
+import { regEx } from './regex';
 
 // Generic replacements/link-breakers
 export function sanitizeMarkdown(markdown: string): string {
@@ -44,7 +51,7 @@ export async function linkify(
   // https://github.com/syntax-tree/mdast-util-to-markdown#optionsbullet
   let pipeline = remark()
     .use({ settings: { bullet: '-' } })
-    .use(gfm);
+    .use(gfm) as Processor<Root, Root, undefined, Root, string>;
 
   if (!baseUrl.endsWith('/')) {
     baseUrl = `${baseUrl}/`;
@@ -55,8 +62,11 @@ export async function linkify(
       mentionStrong: false,
       repository,
       // Override URL building to support GitHub Enterprise with custom domains
-      buildUrl: (values) =>
-        defaultBuildUrl(values).replace(/^https:\/\/github.com\//, baseUrl),
+      buildUrl: (values: Readonly<BuildGithubUrlValues>) =>
+        defaultBuildGithubUrl(values).replace(
+          /^https:\/\/github.com\//,
+          baseUrl,
+        ),
       ...(extraGithubOptions || {}),
     });
   }

--- a/lib/util/markdown.ts
+++ b/lib/util/markdown.ts
@@ -1,14 +1,14 @@
-import { remark } from 'remark';
-import type { Processor } from 'unified';
 import type { Root } from 'mdast';
+import { remark } from 'remark';
 import gfm from 'remark-gfm';
 import type {
-  Options as RemarkGithubOptions,
   BuildUrlValues as BuildGithubUrlValues,
+  Options as RemarkGithubOptions,
 } from 'remark-github';
 import github, {
   defaultBuildUrl as defaultBuildGithubUrl,
 } from 'remark-github';
+import type { Processor } from 'unified';
 import { detectPlatform } from './common';
 import { regEx } from './regex';
 
@@ -53,21 +53,18 @@ export async function linkify(
     .use({ settings: { bullet: '-' } })
     .use(gfm) as Processor<Root, Root, undefined, Root, string>;
 
-  if (!baseUrl.endsWith('/')) {
-    baseUrl = `${baseUrl}/`;
-  }
-
   if (detectPlatform(baseUrl) === 'github') {
     pipeline = pipeline.use(github, {
       mentionStrong: false,
       repository,
       // Override URL building to support GitHub Enterprise with custom domains
-      buildUrl: (values: Readonly<BuildGithubUrlValues>) =>
-        defaultBuildGithubUrl(values).replace(
+      buildUrl(values: Readonly<BuildGithubUrlValues>) {
+        return defaultBuildGithubUrl(values).replace(
           /^https:\/\/github.com\//,
-          baseUrl,
-        ),
-      ...(extraGithubOptions || {}),
+          baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`,
+        );
+      },
+      ...(extraGithubOptions ?? {}),
     });
   }
 

--- a/lib/workers/repository/update/pr/changelog/release-notes.spec.ts
+++ b/lib/workers/repository/update/pr/changelog/release-notes.spec.ts
@@ -912,7 +912,7 @@ describe('workers/repository/update/pr/changelog/release-notes', () => {
         partial<BranchUpgradeConfig>(),
       );
       expect(res).toEqual({
-        body: 'some body #123, [#124](https://gitlab.com/some/yet-other-repository/issues/124)',
+        body: 'some body #123, [#124](https://gitlab.com/some/yet-other-repository/issues/124)\n',
         name: undefined,
         notesSourceUrl:
           'https://api.gitlab.com/projects/some%2Fother-repository/releases',
@@ -949,7 +949,7 @@ describe('workers/repository/update/pr/changelog/release-notes', () => {
         partial<BranchUpgradeConfig>(),
       );
       expect(res).toEqual({
-        body: 'some body #123, [#124](https://gitlab.com/some/yet-other-repository/issues/124)',
+        body: 'some body #123, [#124](https://gitlab.com/some/yet-other-repository/issues/124)\n',
         name: undefined,
         notesSourceUrl:
           'https://api.gitlab.com/projects/some%2Fother-repository/releases',
@@ -986,7 +986,7 @@ describe('workers/repository/update/pr/changelog/release-notes', () => {
         partial<BranchUpgradeConfig>(),
       );
       expect(res).toEqual({
-        body: 'some body #123, [#124](https://gitlab.com/some/yet-other-repository/issues/124)',
+        body: 'some body #123, [#124](https://gitlab.com/some/yet-other-repository/issues/124)\n',
         name: undefined,
         notesSourceUrl:
           'https://api.gitlab.com/projects/some%2Fother-repository/releases',

--- a/lib/workers/repository/update/pr/changelog/release-notes.ts
+++ b/lib/workers/repository/update/pr/changelog/release-notes.ts
@@ -1,7 +1,6 @@
 import is from '@sindresorhus/is';
 import { DateTime } from 'luxon';
 import MarkdownIt from 'markdown-it';
-import { defaultBuildUrl as remarkBuildGitHubUrl } from 'remark-github';
 import { logger } from '../../../../../logger';
 import * as memCache from '../../../../../util/cache/memory';
 import * as packageCache from '../../../../../util/cache/package';
@@ -544,24 +543,10 @@ async function linkifyBody(
   bodyStr: string | undefined | null,
 ): Promise<string> {
   const body = massageBody(bodyStr, baseUrl);
-  const platform = detectPlatform(baseUrl);
-
-  // Remark only supports GitHub-style references to commits, mentions, etc.
-  if (platform !== 'github') {
-    return body;
-  }
 
   if (body?.length) {
     try {
-      return await linkify(body, {
-        // Override URL building to support GitHub Enterprise with custom domains
-        buildUrl: (values) =>
-          remarkBuildGitHubUrl(values).replace(
-            /^https:\/\/github.com\//,
-            baseUrl,
-          ),
-        repository,
-      });
+      return await linkify(baseUrl, repository, body);
     } catch (err) /* istanbul ignore next */ {
       logger.warn({ body, err, baseUrl, repository }, 'linkify error');
     }

--- a/lib/workers/repository/update/pr/changelog/release-notes.ts
+++ b/lib/workers/repository/update/pr/changelog/release-notes.ts
@@ -205,7 +205,8 @@ async function releaseNotesResult(
   }
   const { baseUrl, repository } = project;
   const releaseNotes: ChangeLogNotes = releaseMatch;
-  if (detectPlatform(baseUrl) === 'gitlab') {
+  const platform = detectPlatform(baseUrl);
+  if (platform === 'gitlab') {
     releaseNotes.url = `${baseUrl}${repository}/tags/${releaseMatch.tag!}`;
   } else {
     releaseNotes.url = releaseMatch.url
@@ -218,7 +219,7 @@ async function releaseNotesResult(
   releaseNotes.name = massageName(releaseNotes.name, releaseNotes.tag);
   if (releaseNotes.body.length || releaseNotes.name?.length) {
     try {
-      if (baseUrl !== 'https://gitlab.com/') {
+      if (platform !== 'gitlab') {
         releaseNotes.body = await linkify(releaseNotes.body, {
           repository: `${baseUrl}${repository}`,
         });


### PR DESCRIPTION
## Changes

Fixes release notes from self-hosted GitLab instances getting commit references, mentions etc. falsely linkified as GitHub links.

Potentially this should be changed to *only* perform linkification when the platform is GitHub, I'm not entirely certain.

## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
