### PR TITLE
chore(schema): deprecate `globalOnly` options in renovate-schema.json

### DIFF
--- a/tools/docs/schema.ts
+++ b/tools/docs/schema.ts
@@ -192,6 +192,21 @@ export async function generateSchema(
     properties: {},
   };
   const configurationOptions = getOptions();
+
+  if (!isGlobal) {
+    configurationOptions.map((v) => {
+      // TODO #38728 remove any global-only options in the repository configuration schema
+      if (v.globalOnly) {
+        // NOTE that the JSON Schema version we're using does not have support for deprecating, so we need to use the `description` field
+        v.description =
+          "Deprecated: This configuration option is only intended to be used with 'global' configuration when self-hosting, not used in a repository configuration file. Renovate likely won't use the configuration, and these fields will be removed from the repository configuration documentation in Renovate v43 (https://github.com/renovatebot/renovate/issues/38728)\n\n" +
+          v.description;
+      }
+
+      return v;
+    });
+  }
+
   configurationOptions.sort((a, b) => {
     if (a.name < b.name) {
       return -1;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->


Now we have a global schema for self-hosting configuration, we can
deprecate the use of global configuration in a repository configuration.

Unfortunately the JSON Schema version we use does not provide native
deprecation functionality, so we can prepend the deprecation notice to
the `description`.

Then, as part of #38728, we will remove this in the next major version
of Renovate.

Closes #38729.


## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
