### PR TITLE
feat(semver-partial): add support for v-prefixed versions

### DIFF
--- a/lib/modules/versioning/semver-partial/index.spec.ts
+++ b/lib/modules/versioning/semver-partial/index.spec.ts
@@ -3,14 +3,18 @@ import semverPartial from '.';
 describe('modules/versioning/semver-partial/index', () => {
   describe('.isValid()', () => {
     it.each`
-      version          | expected
-      ${'1'}           | ${true}
-      ${'1.2'}         | ${true}
-      ${'1.2.3'}       | ${true}
-      ${'~latest'}     | ${true}
-      ${'1.2.3-alpha'} | ${true}
-      ${'invalid'}     | ${false}
-      ${''}            | ${false}
+      version           | expected
+      ${'1'}            | ${true}
+      ${'1.2'}          | ${true}
+      ${'1.2.3'}        | ${true}
+      ${'~latest'}      | ${true}
+      ${'1.2.3-alpha'}  | ${true}
+      ${'v1'}           | ${true}
+      ${'v1.2'}         | ${true}
+      ${'v1.2.3'}       | ${true}
+      ${'v1.2.3-alpha'} | ${true}
+      ${'invalid'}      | ${false}
+      ${''}             | ${false}
     `('isValid("$version") === $expected', ({ version, expected }) => {
       expect(semverPartial.isValid(version)).toBe(expected);
     });
@@ -18,17 +22,22 @@ describe('modules/versioning/semver-partial/index', () => {
 
   describe('.isVersion()', () => {
     it.each`
-      version          | expected
-      ${'1'}           | ${false}
-      ${'1.2'}         | ${false}
-      ${'1.2.3'}       | ${true}
-      ${'~latest'}     | ${false}
-      ${'1.2.3-alpha'} | ${true}
-      ${'1.2.3-rc.1'}  | ${true}
-      ${'invalid'}     | ${false}
-      ${''}            | ${false}
-      ${'#1.0.0'}      | ${false}
-      ${'x1.0.0'}      | ${false}
+      version           | expected
+      ${'1'}            | ${false}
+      ${'1.2'}          | ${false}
+      ${'1.2.3'}        | ${true}
+      ${'~latest'}      | ${false}
+      ${'1.2.3-alpha'}  | ${true}
+      ${'1.2.3-rc.1'}   | ${true}
+      ${'v1'}           | ${false}
+      ${'v1.2'}         | ${false}
+      ${'v1.2.3'}       | ${true}
+      ${'v1.2.3-alpha'} | ${true}
+      ${'v1.2.3-rc.1'}  | ${true}
+      ${'invalid'}      | ${false}
+      ${''}             | ${false}
+      ${'#1.0.0'}       | ${false}
+      ${'x1.0.0'}       | ${false}
     `('isVersion("$version") === $expected', ({ version, expected }) => {
       expect(semverPartial.isVersion(version)).toBe(expected);
     });
@@ -48,6 +57,8 @@ describe('modules/versioning/semver-partial/index', () => {
       ${'1.0.0-1'}        | ${false}
       ${'1.0.0-build.1'}  | ${false}
       ${'1.0.0'}          | ${true}
+      ${'v1.0.0'}         | ${true}
+      ${'v1.0.0-alpha'}   | ${false}
       ${'1'}              | ${false}
       ${'not-a-version'}  | ${false}
     `('isStable("$version") === $expected', ({ version, expected }) => {
@@ -57,12 +68,16 @@ describe('modules/versioning/semver-partial/index', () => {
 
   describe('.isSingleVersion()', () => {
     it.each`
-      version          | expected
-      ${'1'}           | ${false}
-      ${'1.2'}         | ${false}
-      ${'1.2.3'}       | ${true}
-      ${'~latest'}     | ${false}
-      ${'1.2.3-alpha'} | ${true}
+      version           | expected
+      ${'1'}            | ${false}
+      ${'1.2'}          | ${false}
+      ${'1.2.3'}        | ${true}
+      ${'~latest'}      | ${false}
+      ${'1.2.3-alpha'}  | ${true}
+      ${'v1'}           | ${false}
+      ${'v1.2'}         | ${false}
+      ${'v1.2.3'}       | ${true}
+      ${'v1.2.3-alpha'} | ${true}
     `('isSingleVersion("$version") === $expected', ({ version, expected }) => {
       expect(semverPartial.isSingleVersion(version)).toBe(expected);
     });
@@ -96,6 +111,26 @@ describe('modules/versioning/semver-partial/index', () => {
       ${'not-semver-ver'} | ${'1'}       | ${false}
       ${'1.0.0-alpha'}    | ${'1'}       | ${false}
       ${'1.0.0-beta'}     | ${'1.0'}     | ${false}
+      ${'v1.0.0'}         | ${'v1'}      | ${true}
+      ${'v1.2.0'}         | ${'v1'}      | ${true}
+      ${'v1.1.0'}         | ${'v1.1'}    | ${true}
+      ${'v1.2.3'}         | ${'v1.2.3'}  | ${true}
+      ${'v2.0.0'}         | ${'v1'}      | ${false}
+      ${'v1.0.0'}         | ${'1'}       | ${true}
+      ${'1.0.0'}          | ${'v1'}      | ${true}
+      ${'v1.1.5'}         | ${'1.1'}     | ${true}
+      ${'1.1.5'}          | ${'v1.1'}    | ${true}
+      ${'v2.1.0'}         | ${'2'}       | ${true}
+      ${'2.1.0'}          | ${'v2'}      | ${true}
+      ${'v1.2.0'}         | ${'1.1'}     | ${false}
+      ${'1.2.0'}          | ${'v1.1'}    | ${false}
+      ${'v1.0.0-rc'}      | ${'v1'}      | ${false}
+      ${'1.0.0-rc'}       | ${'v1'}      | ${false}
+      ${'v1.0.0-rc'}      | ${'1'}       | ${false}
+      ${'v1.2.4'}         | ${'1.2.3'}   | ${false}
+      ${'1.2.4'}          | ${'v1.2.3'}  | ${false}
+      ${'v1.2.3'}         | ${'1.2.3'}   | ${true}
+      ${'1.2.3'}          | ${'v1.2.3'}  | ${true}
     `(
       'matches("$version", "$range") === $expected',
       ({ version, range, expected }) => {
@@ -127,6 +162,15 @@ describe('modules/versioning/semver-partial/index', () => {
       ${['not-valid', 'also-bad']}                                 | ${'1'}       | ${null}
       ${['1.0.0', '1.0.1-alpha', '1.0.2', '1.1.0-beta', '1.1.1']}  | ${'1'}       | ${'1.1.1'}
       ${['1.0.0', '1.0.1-alpha', '1.0.2', '1.1.0-beta', '1.1.1']}  | ${'1.0'}     | ${'1.0.2'}
+      ${['v1.0.0', 'v1.1.0', 'v1.1.1', 'v1.2.0', 'v2.0.0']}        | ${'v1'}      | ${'v1.2.0'}
+      ${['v1.0.0', 'v1.1.0', 'v1.1.1']}                            | ${'v1.1'}    | ${'v1.1.1'}
+      ${['v1.0.0', 'v2.0.0', 'v3.0.0']}                            | ${'v2'}      | ${'v2.0.0'}
+      ${['1.0.0', 'v1.1.0', '1.1.1', 'v1.2.0', '2.0.0']}           | ${'1'}       | ${'v1.2.0'}
+      ${['v1.0.0', '1.1.0', 'v1.1.1']}                             | ${'v1.1'}    | ${'v1.1.1'}
+      ${['1.0.0', 'v1.1.0', '1.1.1']}                              | ${'1'}       | ${'1.1.1'}
+      ${['v1.0.0', '1.1.0', 'v1.1.1']}                             | ${'1'}       | ${'v1.1.1'}
+      ${['1.0.0', '1.1.0', '1.2.0']}                               | ${'v1'}      | ${'1.2.0'}
+      ${['v1.0.0', 'v1.1.0', '1.2.0']}                             | ${'1'}       | ${'1.2.0'}
     `(
       'getSatisfyingVersion($versions, "$range") === $expected',
       ({ versions, range, expected }) => {
@@ -146,6 +190,11 @@ describe('modules/versioning/semver-partial/index', () => {
       ${['1.0.0', '1.1.0', '1.2.0', '2.0.0', '2.0.1', '2.1.0']} | ${'~latest'} | ${'1.0.0'}
       ${['1.0.0', '1.0.1-rc', '1.1.0']}                         | ${'1.0'}     | ${'1.0.0'}
       ${['0.5.0', '1.0.0', '2.0.0']}                            | ${'3'}       | ${null}
+      ${['v0.5.0', 'v1.0.0', 'v2.0.0']}                         | ${'v3'}      | ${null}
+      ${['v1.0.0', '1.1.0', 'v1.2.0']}                          | ${'1'}       | ${'v1.0.0'}
+      ${['1.0.0', 'v1.1.0', '1.2.0']}                           | ${'v1'}      | ${'1.0.0'}
+      ${['v1.0.0', 'v1.1.0', '1.2.0', 'v2.0.0']}                | ${'v1'}      | ${'v1.0.0'}
+      ${['1.0.0', '1.1.0', 'v1.2.0', '2.0.0']}                  | ${'1'}       | ${'1.0.0'}
     `(
       'minSatisfyingVersion($versions, "$range") === $expected',
       ({ versions, range, expected }) => {
@@ -170,6 +219,15 @@ describe('modules/versioning/semver-partial/index', () => {
       ${'1.0.0'}   | ${'~latest'} | ${false}
       ${'1.5.0'}   | ${'1'}       | ${false}
       ${'invalid'} | ${'1'}       | ${false}
+      ${'v0.9.0'}  | ${'v1'}      | ${true}
+      ${'v1.0.0'}  | ${'v1'}      | ${false}
+      ${'v1.0.0'}  | ${'v1.1'}    | ${true}
+      ${'0.9.0'}   | ${'v1'}      | ${true}
+      ${'v0.9.0'}  | ${'1'}       | ${true}
+      ${'1.0.0'}   | ${'v1.1'}    | ${true}
+      ${'v1.0.0'}  | ${'1.1'}     | ${true}
+      ${'v2.0.0'}  | ${'1'}       | ${false}
+      ${'2.0.0'}   | ${'v1'}      | ${false}
     `(
       'isLessThanRange("$version", "$range") === $expected',
       ({ version, range, expected }) => {
@@ -186,6 +244,12 @@ describe('modules/versioning/semver-partial/index', () => {
       ${'invalid'} | ${'1.0.0'}   | ${false}
       ${'1.0.0'}   | ${'invalid'} | ${false}
       ${'invalid'} | ${'invalid'} | ${false}
+      ${'v1.0.0'}  | ${'v1.0.0'}  | ${true}
+      ${'v1.0.0'}  | ${'v1.0.1'}  | ${false}
+      ${'v1.0.0'}  | ${'1.0.0'}   | ${true}
+      ${'1.0.0'}   | ${'v1.0.0'}  | ${true}
+      ${'v1.0.0'}  | ${'1.0.1'}   | ${false}
+      ${'1.0.1'}   | ${'v1.0.0'}  | ${false}
     `(
       'equals("$version", "$other") === $expected',
       ({ version, other, expected }) => {
@@ -199,6 +263,8 @@ describe('modules/versioning/semver-partial/index', () => {
       version      | expected
       ${'1.0.0'}   | ${1}
       ${'2.3.4'}   | ${2}
+      ${'v1.0.0'}  | ${1}
+      ${'v2.3.4'}  | ${2}
       ${'invalid'} | ${null}
     `('getMajor("$version") === $expected', ({ version, expected }) => {
       expect(semverPartial.getMajor(version)).toBe(expected);
@@ -210,6 +276,8 @@ describe('modules/versioning/semver-partial/index', () => {
       version      | expected
       ${'1.0.0'}   | ${0}
       ${'2.3.4'}   | ${3}
+      ${'v1.0.0'}  | ${0}
+      ${'v2.3.4'}  | ${3}
       ${'invalid'} | ${null}
     `('getMinor("$version") === $expected', ({ version, expected }) => {
       expect(semverPartial.getMinor(version)).toBe(expected);
@@ -221,6 +289,8 @@ describe('modules/versioning/semver-partial/index', () => {
       version      | expected
       ${'1.0.0'}   | ${0}
       ${'2.3.4'}   | ${4}
+      ${'v1.0.0'}  | ${0}
+      ${'v2.3.4'}  | ${4}
       ${'invalid'} | ${null}
     `('getPatch("$version") === $expected', ({ version, expected }) => {
       expect(semverPartial.getPatch(version)).toBe(expected);
@@ -235,6 +305,15 @@ describe('modules/versioning/semver-partial/index', () => {
       ${'2.0.0'}   | ${'1.9.9'}   | ${true}
       ${'invalid'} | ${'1.0.0'}   | ${false}
       ${'1.0.0'}   | ${'invalid'} | ${false}
+      ${'v1.0.1'}  | ${'v1.0.0'}  | ${true}
+      ${'v1.0.0'}  | ${'v1.0.1'}  | ${false}
+      ${'v2.0.0'}  | ${'v1.9.9'}  | ${true}
+      ${'v1.0.0'}  | ${'1.0.1'}   | ${false}
+      ${'1.0.1'}   | ${'v1.0.0'}  | ${true}
+      ${'v2.0.0'}  | ${'1.0.0'}   | ${true}
+      ${'2.0.0'}   | ${'v1.0.0'}  | ${true}
+      ${'v1.9.9'}  | ${'1.9.8'}   | ${true}
+      ${'1.9.9'}   | ${'v1.9.8'}  | ${true}
     `(
       'isGreaterThan("$version", "$other") === $expected',
       ({ version, other, expected }) => {
@@ -253,6 +332,13 @@ describe('modules/versioning/semver-partial/index', () => {
       ${'invalid'} | ${'1.0.0'}   | ${0}
       ${'1.0.0'}   | ${'invalid'} | ${0}
       ${'invalid'} | ${'invalid'} | ${0}
+      ${'v1.0.0'}  | ${'v1.0.0'}  | ${0}
+      ${'v1.0.0'}  | ${'v1.0.1'}  | ${-1}
+      ${'v1.0.1'}  | ${'v1.0.0'}  | ${1}
+      ${'v1.0.0'}  | ${'1.0.0'}   | ${0}
+      ${'1.0.0'}   | ${'v1.0.0'}  | ${0}
+      ${'v1.0.0'}  | ${'1.0.1'}   | ${-1}
+      ${'1.0.1'}   | ${'v1.0.0'}  | ${1}
     `('sortVersions("$a", "$b") === $expected', ({ a, b, expected }) => {
       expect(semverPartial.sortVersions(a, b)).toBe(expected);
     });
@@ -269,6 +355,15 @@ describe('modules/versioning/semver-partial/index', () => {
       ${'1.0.0'}   | ${'0.9.0'}   | ${true}
       ${'invalid'} | ${'1.0.0'}   | ${false}
       ${'1.0.0'}   | ${'invalid'} | ${false}
+      ${'v2.0.0'}  | ${'v1.0.0'}  | ${true}
+      ${'v1.1.0'}  | ${'v1.0.0'}  | ${false}
+      ${'v0.2.0'}  | ${'v0.1.0'}  | ${true}
+      ${'v2.0.0'}  | ${'1.0.0'}   | ${true}
+      ${'2.0.0'}   | ${'v1.0.0'}  | ${true}
+      ${'1.1.0'}   | ${'v1.0.0'}  | ${false}
+      ${'v1.1.0'}  | ${'1.0.0'}   | ${false}
+      ${'v1.0.0'}  | ${'0.9.0'}   | ${true}
+      ${'1.0.0'}   | ${'v0.9.0'}  | ${true}
     `(
       'isBreaking("$version", "$current") === $expected',
       ({ version, current, expected }) => {
@@ -283,6 +378,8 @@ describe('modules/versioning/semver-partial/index', () => {
       ${'1.0.0'}   | ${true}
       ${'1'}       | ${true}
       ${'~latest'} | ${true}
+      ${'v1.0.0'}  | ${true}
+      ${'v1'}      | ${true}
       ${'invalid'} | ${false}
     `('isCompatible("$version") === $expected', ({ version, expected }) => {
       expect(semverPartial.isCompatible(version)).toBe(expected);
@@ -300,6 +397,13 @@ describe('modules/versioning/semver-partial/index', () => {
       ${'10'}      | ${'pin'}      | ${'10.0.0'}    | ${'10.1.0'}  | ${'10.1.0'}
       ${'~latest'} | ${'pin'}      | ${'1.0.0'}     | ${'1.1.0'}   | ${'1.1.0'}
       ${'1.0.0'}   | ${'pin'}      | ${'1.0.0'}     | ${'1.1.0'}   | ${'1.1.0'}
+      ${'v1'}      | ${'pin'}      | ${'v1.0.0'}    | ${'v1.1.0'}  | ${'v1.1.0'}
+      ${'v1.2'}    | ${'pin'}      | ${'v1.2.0'}    | ${'v1.2.1'}  | ${'v1.2.1'}
+      ${'v1.2.3'}  | ${'pin'}      | ${'v1.2.3'}    | ${'v1.2.4'}  | ${'v1.2.4'}
+      ${'v1'}      | ${'pin'}      | ${'v1.0.0'}    | ${'1.1.0'}   | ${'1.1.0'}
+      ${'v1.2.3'}  | ${'pin'}      | ${'v1.2.3'}    | ${'1.2.4'}   | ${'1.2.4'}
+      ${'1'}       | ${'pin'}      | ${'1.0.0'}     | ${'v1.1.0'}  | ${'v1.1.0'}
+      ${'1.2.3'}   | ${'pin'}      | ${'1.2.3'}     | ${'v1.2.4'}  | ${'v1.2.4'}
       ${'1'}       | ${'replace'}  | ${'1.0.0'}     | ${'1.1.0'}   | ${'1'}
       ${'1'}       | ${'replace'}  | ${'1.0.0'}     | ${'2.0.0'}   | ${'2'}
       ${'1.2'}     | ${'replace'}  | ${'1.2.0'}     | ${'1.2.1'}   | ${'1.2'}
@@ -314,6 +418,20 @@ describe('modules/versioning/semver-partial/index', () => {
       ${'~latest'} | ${'replace'}  | ${'1.0.0'}     | ${'2.0.0'}   | ${'~latest'}
       ${'1.0.0'}   | ${'replace'}  | ${'1.0.0'}     | ${'1.1.0'}   | ${'1.1.0'}
       ${'1'}       | ${'replace'}  | ${'1.0.0'}     | ${'invalid'} | ${'invalid'}
+      ${'v1'}      | ${'replace'}  | ${'v1.0.0'}    | ${'v1.1.0'}  | ${'v1'}
+      ${'v1'}      | ${'replace'}  | ${'v1.0.0'}    | ${'v2.0.0'}  | ${'v2'}
+      ${'v1.2'}    | ${'replace'}  | ${'v1.2.0'}    | ${'v1.2.1'}  | ${'v1.2'}
+      ${'v1.2'}    | ${'replace'}  | ${'v1.2.0'}    | ${'v1.3.0'}  | ${'v1.3'}
+      ${'v1.2.3'}  | ${'replace'}  | ${'v1.2.3'}    | ${'v1.2.4'}  | ${'v1.2.4'}
+      ${'v1.2.3'}  | ${'replace'}  | ${'v1.2.3'}    | ${'v1.3.0'}  | ${'v1.3.0'}
+      ${'v1'}      | ${'replace'}  | ${'v1.0.0'}    | ${'v1.2.0'}  | ${'v1'}
+      ${'v2'}      | ${'replace'}  | ${'v2.0.0'}    | ${'v3.0.0'}  | ${'v3'}
+      ${'v1'}      | ${'replace'}  | ${'v1.0.0'}    | ${'1.1.0'}   | ${'v1'}
+      ${'v1'}      | ${'replace'}  | ${'v1.0.0'}    | ${'2.0.0'}   | ${'v2'}
+      ${'v1.2.3'}  | ${'replace'}  | ${'v1.2.3'}    | ${'1.2.4'}   | ${'1.2.4'}
+      ${'1'}       | ${'replace'}  | ${'1.0.0'}     | ${'v1.1.0'}  | ${'1'}
+      ${'1'}       | ${'replace'}  | ${'1.0.0'}     | ${'v2.0.0'}  | ${'2'}
+      ${'1.2.3'}   | ${'replace'}  | ${'1.2.3'}     | ${'v1.2.4'}  | ${'v1.2.4'}
     `(
       'getNewValue("$currentValue", "$rangeStrategy", "$currentVersion", "$newVersion") === "$expected"',
       ({

--- a/lib/modules/versioning/semver-partial/index.ts
+++ b/lib/modules/versioning/semver-partial/index.ts
@@ -16,8 +16,12 @@ function isLatest(input: string): boolean {
   return input === '~latest';
 }
 
+function massageValue(input: string): string {
+  return input.trim().replace(regEx(/^v/i), '');
+}
+
 function parseVersion(input: string): SemVer | null {
-  return semver.parse(input);
+  return semver.parse(massageValue(input));
 }
 
 interface Range {
@@ -26,13 +30,14 @@ interface Range {
 }
 
 function parseRange(input: string): Range | null {
-  const coerced = semver.coerce(input);
+  const stripped = massageValue(input);
+  const coerced = semver.coerce(stripped);
   if (!coerced) {
     return null;
   }
   const { major, minor } = coerced;
 
-  if (regEx(/^\d+$/).test(input)) {
+  if (regEx(/^\d+$/).test(stripped)) {
     return { major };
   }
 
@@ -218,11 +223,13 @@ function getNewValue({
     return newVersion;
   }
 
+  const [prefix] = currentValue.split(massageValue(currentValue));
+
   if (is.undefined(range.minor)) {
-    return `${newParsed.major}`;
+    return `${prefix}${newParsed.major}`;
   }
 
-  return `${newParsed.major}.${newParsed.minor}`;
+  return `${prefix}${newParsed.major}.${newParsed.minor}`;
 }
 
 function isCompatible(version: string): boolean {


### PR DESCRIPTION
## Changes

Added support for v-prefixed semantic versions (e.g., v1.2.3, v1.2, v1) in the semver-partial versioning scheme.

### Implementation Details:
- Added `massageValue()` function to strip the 'v' prefix from version strings
- Modified `parseVersion()` and `parseRange()` to handle v-prefixed versions
- Updated `getNewValue()` to preserve the original prefix format in the output
- Added comprehensive test coverage for all versioning API functions with v-prefixed versions

### Test Coverage:
Tests now verify that v-prefixed and non-prefixed versions can be used interchangeably across all operations including:
- Version validation, parsing, and comparison
- Range matching and satisfaction
- Version breaking detection
- Prefix preservation in version updates

## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: N/A