### PR TITLE
feat: add dynamic install for conan

### DIFF
--- a/lib/modules/manager/conan/artifacts.spec.ts
+++ b/lib/modules/manager/conan/artifacts.spec.ts
@@ -181,6 +181,54 @@ describe('modules/manager/conan/artifacts', () => {
     expect(execSnapshots).toMatchObject(expectedInSnapshot);
   });
 
+  it('supports install mode', async () => {
+    GlobalConfig.set({ ...adminConfig, binarySource: 'install' });
+    const updatedDeps = [
+      {
+        depName: 'dep',
+      },
+    ];
+
+    fs.findLocalSiblingOrParent.mockResolvedValueOnce('conan.lock');
+    fs.readLocalFile.mockResolvedValueOnce('Original conan.lock');
+    const execSnapshots = mockExecAll();
+    fs.readLocalFile.mockResolvedValueOnce('Updated conan.lock');
+
+    expect(
+      await conan.updateArtifacts({
+        packageFileName: 'conanfile.py',
+        updatedDeps,
+        newPackageFileContent: '',
+        config: {
+          ...config,
+          constraints: { conan: '2.0.5', python: '3.11.9' },
+        },
+      }),
+    ).toEqual([
+      {
+        file: {
+          contents: 'Updated conan.lock',
+          path: 'conan.lock',
+          type: 'addition',
+        },
+      },
+    ]);
+    expect(execSnapshots).toMatchObject([
+      {
+        cmd: 'install-tool python 3.11.9',
+      },
+      {
+        cmd: 'install-tool conan 2.0.5',
+      },
+      {
+        cmd: 'conan lock create conanfile.py',
+        options: {
+          cwd: '/tmp/github/some/repo',
+        },
+      },
+    ]);
+  });
+
   it('returns updated conan.lock when updateType are not empty', async () => {
     const updatedDeps = [
       {

--- a/lib/util/exec/containerbase.ts
+++ b/lib/util/exec/containerbase.ts
@@ -35,6 +35,11 @@ const allToolConfig: Record<string, ToolConfig> = {
     packageName: 'cocoapods',
     versioning: rubyVersioningId,
   },
+  conan: {
+    datasource: 'pypi',
+    packageName: 'conan',
+    versioning: pep440VersioningId,
+  },
   composer: {
     datasource: 'github-releases',
     packageName: 'containerbase/composer-prebuild',

--- a/lib/util/exec/containerbase.ts
+++ b/lib/util/exec/containerbase.ts
@@ -35,15 +35,15 @@ const allToolConfig: Record<string, ToolConfig> = {
     packageName: 'cocoapods',
     versioning: rubyVersioningId,
   },
-  conan: {
-    datasource: 'pypi',
-    packageName: 'conan',
-    versioning: pep440VersioningId,
-  },
   composer: {
     datasource: 'github-releases',
     packageName: 'containerbase/composer-prebuild',
     versioning: composerVersioningId,
+  },
+  conan: {
+    datasource: 'pypi',
+    packageName: 'conan',
+    versioning: pep440VersioningId,
   },
   copier: {
     datasource: 'pypi',


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This change enables dynamic installs for the conan tool for lock file updates.  
It installs Python in the latest (if no constraints are given) version and then installs conan.

## Context

Please select one of the below:

- [x] This closes an existing Issue: #38819
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [X] Yes — other (please describe): Understanding of the code flow. Not for writing the code.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The repository is internnal, but I can provide logs later.

logs:
```
...
DEBUG: User has requested rebase (repository=renovate-support/axle, branch=renovate/readline-8.x)
DEBUG: Using reuseExistingBranch: false (repository=renovate-support/axle, branch=renovate/readline-8.x)
DEBUG: Setting current branch to main (repository=renovate-support/axle, branch=renovate/readline-8.x)
DEBUG: latest commit (repository=renovate-support/axle, branch=renovate/readline-8.x)
       "branchName": "main",
       "latestCommitDate": "2025-10-17T12:29:23+02:00",
       "sha": "3d6ee32038011c6820e55d102684de3104dc54bc"
DEBUG: manager.getUpdatedPackageFiles() reuseExistingBranch=false (repository=renovate-support/axle, branch=renovate/readline-8.x)
DEBUG: Starting search at index 2429 (repository=renovate-support/axle, packageFile=conanfile.py, branch=renovate/readline-8.x)
       "depName": "readline"
DEBUG: Found match at index 2429 (repository=renovate-support/axle, packageFile=conanfile.py, branch=renovate/readline-8.x)
       "depName": "readline"
DEBUG: Contents updated (repository=renovate-support/axle, packageFile=conanfile.py, branch=renovate/readline-8.x)
       "depName": "readline"
DEBUG: updateArtifacts for updatedPackageFiles (repository=renovate-support/axle, branch=renovate/readline-8.x)
DEBUG: Setting CONTAINERBASE_CACHE_DIR to /tmp/renovate/cache/containerbase (repository=renovate-support/axle, branch=renovate/readline-8.x)
DEBUG: Using containerbase dynamic installs (repository=renovate-support/axle, branch=renovate/readline-8.x)
DEBUG: Resolved stable matching version (repository=renovate-support/axle, branch=renovate/readline-8.x)
       "toolName": "python",
       "constraint": undefined,
       "resolvedVersion": "3.14.0"
DEBUG: Using queue: host=pypi.org, concurrency=16 (repository=renovate-support/axle, branch=renovate/readline-8.x)
DEBUG: Resolved stable matching version (repository=renovate-support/axle, branch=renovate/readline-8.x)
       "toolName": "conan",
       "constraint": undefined,
       "resolvedVersion": "2.21.0"
DEBUG: Executing command (repository=renovate-support/axle, branch=renovate/readline-8.x)
       "command": "install-tool python 3.14.0"
DEBUG: exec completed (repository=renovate-support/axle, branch=renovate/readline-8.x)
       "durationMs": 11234,
       "stdout": "[19:24:48.687] DEBUG (712): discovered distro\n    distro: {\n      \"name\": \"Ubuntu\",\n      \"versionCode\": \"noble\",\n      \"versionId\": \"24.04\"\n    }\n[19:24:48.688] DEBUG (712): prepare commands\n[19:24:48.691] DEBUG (712): Try resolving version for python@3.14.0 ...\n[19:24:48.692] INFO (712): Installing tool python@3.14.0...\n[19:24:48.713] DEBUG (712): setting path mode\n    path: \"/opt/containerbase/data/state.nedb\"\n    mode: 436\n    s: 420\n[19:24:48.713] DEBUG (712): setting path mode\n    path: \"/opt/containerbase/data/versions.nedb\"\n    mode: 436\n    s: 420\n[19:24:48.713] DEBUG (712): setting path mode\n    path: \"/opt/containerbase/data/types.nedb\"\n    mode: 436\n    s: 420\n[19:24:48.713] DEBUG (712): setting path mode\n    path: \"/opt/containerbase/data/links.nedb\"\n    mode: 436\n    s: 420\n[19:24:48.717] DEBUG (712): ipc server started\n[19:24:48.717] DEBUG (712): validate tool\n    tool: \"python\"\n[19:24:48.717] DEBUG (712): Validating v2 tool python v3.14.0 ...\n[19:24:48.723] DEBUG (712): install tool\n    tool: \"python\"\n[19:24:48.723] DEBUG (712): Installing v2 tool python v3.14.0 ...\n[19:24:58.780] DEBUG (712): link tool\n    tool: \"python\"\n[19:24:58.780] DEBUG (712): Linking v2 tool python v3.14.0 ...\n[19:24:58.890] DEBUG (819): discovered distro\n    distro: {\n      \"name\": \"Ubuntu\",\n      \"versionCode\": \"noble\",\n      \"versionId\": \"24.04\"\n    }\n[19:24:58.890] DEBUG (819): prepare commands\n[19:24:58.896] DEBUG (819): Linking tool python (python)...\n[19:24:58.899] DEBUG (819): ipc client connected\n[19:24:58.903] DEBUG (819): ipc client link-tool done\n    data: {\n      \"success\": true\n    }\n[19:24:58.904] DEBUG (819): Linking tools python (python) succeded in 8ms.\n[19:24:58.901] DEBUG (712): link-tool ipc message received\n    data: {\n      \"tool\": \"python\",\n      \"config\": {\n        \"name\": \"python\",\n        \"srcDir\": \"/opt/containerbase/tools/python/3.14.0/bin/python\",\n        \"exports\": \"\",\n        \"args\": \"\",\n        \"body\": \"\"\n      }\n    }\n[19:24:58.902] DEBUG (712): setting path mode\n    path: \"/opt/containerbase/bin/python\"\n    mode: 509\n    s: 420\n[19:24:59.017] DEBUG (831): discovered distro\n    distro: {\n      \"name\": \"Ubuntu\",\n      \"versionCode\": \"noble\",\n      \"versionId\": \"24.04\"\n    }\n[19:24:59.018] DEBUG (831): prepare commands\n[19:24:59.024] DEBUG (831): Linking tool python3 (python)...\n[19:24:59.026] DEBUG (831): ipc client connected\n[19:24:59.030] DEBUG (831): ipc client link-tool done\n    data: {\n      \"success\": true\n    }\n[19:24:59.030] DEBUG (831): Linking tools python3 (python) succeded in 6ms.\n[19:24:59.028] DEBUG (712): link-tool ipc message received\n    data: {\n      \"tool\": \"python\",\n      \"config\": {\n        \"name\": \"python3\",\n        \"srcDir\": \"/opt/containerbase/tools/python/3.14.0/bin/python3\",\n        \"exports\": \"\",\n        \"args\": \"\",\n        \"body\": \"\"\n      }\n    }\n[19:24:59.029] DEBUG (712): setting path mode\n    path: \"/opt/containerbase/bin/python3\"\n    mode: 509\n    s: 420\n[19:24:59.144] DEBUG (843): discovered distro\n    distro: {\n      \"name\": \"Ubuntu\",\n      \"versionCode\": \"noble\",\n      \"versionId\": \"24.04\"\n    }\n[19:24:59.145] DEBUG (843): prepare commands\n[19:24:59.150] DEBUG (843): Linking tool python3.14 (python)...\n[19:24:59.153] DEBUG (843): ipc client connected\n[19:24:59.156] DEBUG (843): ipc client link-tool done\n    data: {\n      \"success\": true\n    }\n[19:24:59.157] DEBUG (843): Linking tools python3.14 (python) succeded in 6ms.\n[19:24:59.154] DEBUG (712): link-tool ipc message received\n    data: {\n      \"tool\": \"python\",\n      \"config\": {\n        \"name\": \"python3.14\",\n        \"srcDir\": \"/opt/containerbase/tools/python/3.14.0/bin/python3.14\",\n        \"exports\": \"\",\n        \"args\": \"\",\n        \"body\": \"\"\n      }\n    }\n[19:24:59.155] DEBUG (712): setting path mode\n    path: \"/opt/containerbase/bin/python3.14\"\n    mode: 509\n    s: 420\n[19:24:59.272] DEBUG (855): discovered distro\n    distro: {\n      \"name\": \"Ubuntu\",\n      \"versionCode\": \"noble\",\n      \"versionId\": \"24.04\"\n    }\n[19:24:59.272] DEBUG (855): prepare commands\n[19:24:59.281] DEBUG (855): Linking tool pip (python)...\n[19:24:59.283] DEBUG (855): ipc client connected\n[19:24:59.286] DEBUG (855): ipc client link-tool done\n    data: {\n      \"success\": true\n    }\n[19:24:59.287] DEBUG (855): Linking tools pip (python) succeded in 6ms.\n[19:24:59.284] DEBUG (712): link-tool ipc message received\n    data: {\n      \"tool\": \"python\",\n      \"config\": {\n        \"name\": \"pip\",\n        \"srcDir\": \"/opt/containerbase/tools/python/3.14.0/bin/pip\",\n        \"exports\": \"\",\n        \"args\": \"\",\n        \"body\": \"\"\n      }\n    }\n[19:24:59.285] DEBUG (712): setting path mode\n    path: \"/opt/containerbase/bin/pip\"\n    mode: 509\n    s: 420\n[19:24:59.394] DEBUG (867): discovered distro\n    distro: {\n      \"name\": \"Ubuntu\",\n      \"versionCode\": \"noble\",\n      \"versionId\": \"24.04\"\n    }\n[19:24:59.395] DEBUG (867): prepare commands\n[19:24:59.400] DEBUG (867): Linking tool pip3 (python)...\n[19:24:59.402] DEBUG (867): ipc client connected\n[19:24:59.405] DEBUG (867): ipc client link-tool done\n    data: {\n      \"success\": true\n    }\n[19:24:59.405] DEBUG (867): Linking tools pip3 (python) succeded in 5ms.\n[19:24:59.403] DEBUG (712): link-tool ipc message received\n    data: {\n      \"tool\": \"python\",\n      \"config\": {\n        \"name\": \"pip3\",\n        \"srcDir\": \"/opt/containerbase/tools/python/3.14.0/bin/pip3\",\n        \"exports\": \"\",\n        \"args\": \"\",\n        \"body\": \"\"\n      }\n    }\n[19:24:59.404] DEBUG (712): setting path mode\n    path: \"/opt/containerbase/bin/pip3\"\n    mode: 509\n    s: 420\n[19:24:59.515] DEBUG (879): discovered distro\n    distro: {\n      \"name\": \"Ubuntu\",\n      \"versionCode\": \"noble\",\n      \"versionId\": \"24.04\"\n    }\n[19:24:59.525] DEBUG (712): link-tool ipc message received\n    data: {\n      \"tool\": \"python\",\n      \"config\": {\n        \"name\": \"pip3.14\",\n        \"srcDir\": \"/opt/containerbase/tools/python/3.14.0/bin/pip3.14\",\n        \"exports\": \"\",\n        \"args\": \"\",\n        \"body\": \"\"\n      }\n    }\n[19:24:59.526] DEBUG (712): setting path mode\n    path: \"/opt/containerbase/bin/pip3.14\"\n    mode: 509\n    s: 420\n[19:24:59.516] DEBUG (879): prepare commands\n[19:24:59.521] DEBUG (879): Linking tool pip3.14 (python)...\n[19:24:59.524] DEBUG (879): ipc client connected\n[19:24:59.527] DEBUG (879): ipc client link-tool done\n    data: {\n      \"success\": true\n    }\n[19:24:59.528] DEBUG (879): Linking tools pip3.14 (python) succeded in 6ms.\n[19:24:59.537] DEBUG (712): post-install tool\n    tool: \"python\"\n[19:24:59.538] DEBUG (712): linked tools\n    tool: \"python\"\n    version: \"3.14.0\"\n    links: [\n      \"pip\",\n      \"pip3\",\n      \"pip3.14\",\n      \"python\",\n      \"python3\",\n      \"python3.14\"\n    ]\n[19:24:59.540] DEBUG (712): test tool\n    tool: \"python\"\n[19:24:59.540] DEBUG (712): Testing v2 tool python v3.14.0 ...\nPython 3.14.0\npip 25.2 from /opt/containerbase/tools/python/3.14.0/lib/python3.14/site-packages/pip (python 3.14)\n[19:24:59.793] INFO (712): Install tool python succeeded in 11.1s.\n",
       "stderr": ""
DEBUG: Executing command (repository=renovate-support/axle, branch=renovate/readline-8.x)
       "command": "install-tool conan 2.21.0"
DEBUG: exec completed (repository=renovate-support/axle, branch=renovate/readline-8.x)
       "durationMs": 6292,
       "stdout": "[19:24:59.928] DEBUG (919): discovered distro\n    distro: {\n      \"name\": \"Ubuntu\",\n      \"versionCode\": \"noble\",\n      \"versionId\": \"24.04\"\n    }\n[19:24:59.928] DEBUG (919): prepare commands\n[19:24:59.932] DEBUG (919): Try resolving version for conan@2.21.0 ...\n[19:24:59.933] INFO (919): Installing tool conan@2.21.0...\n[19:24:59.952] DEBUG (919): setting path mode\n    path: \"/opt/containerbase/data/versions.nedb\"\n    mode: 436\n    s: 420\n[19:24:59.953] DEBUG (919): setting path mode\n    path: \"/opt/containerbase/data/types.nedb\"\n    mode: 436\n    s: 420\n[19:24:59.953] DEBUG (919): setting path mode\n    path: \"/opt/containerbase/data/state.nedb\"\n    mode: 436\n    s: 420\n[19:24:59.953] DEBUG (919): setting path mode\n    path: \"/opt/containerbase/data/links.nedb\"\n    mode: 436\n    s: 420\n[19:24:59.957] DEBUG (919): ipc server started\n[19:24:59.957] DEBUG (919): tool not initialized\n    tool: \"conan\"\n[19:24:59.959] DEBUG (919): initialize tool\n    tool: \"conan\"\n[19:24:59.962] DEBUG (919): setting path mode\n    path: \"/tmp/containerbase/tool.init.d/conan\"\n    mode: 509\n    s: 420\n[19:24:59.962] DEBUG (919): validate tool\n    tool: \"conan\"\n[19:24:59.962] DEBUG (919): install tool\n    tool: \"conan\"\n[19:24:59.962] DEBUG (919): creating dir\n    path: \"/opt/containerbase/tools/conan/2.21.0\"\n[19:24:59.963] DEBUG (919): setting path mode\n    path: \"/opt/containerbase/tools/conan/2.21.0\"\n    mode: 509\n    s: 493\n[19:25:05.907] DEBUG (919): link tool\n    tool: \"conan\"\n[19:25:05.909] DEBUG (919): setting path mode\n    path: \"/opt/containerbase/bin/conan\"\n    mode: 509\n    s: 420\n[19:25:05.909] DEBUG (919): post-install tool\n    tool: \"conan\"\n[19:25:05.910] DEBUG (919): linked tools\n    tool: \"conan\"\n    version: \"2.21.0\"\n    links: [\n      \"conan\",\n      \"conan\"\n    ]\n[19:25:05.911] DEBUG (919): test tool\n    tool: \"conan\"\nConan version 2.21.0\n[19:25:06.069] INFO (919): Install tool conan succeeded in 6.1s.\n",
       "stderr": ""
DEBUG: Executing command (repository=renovate-support/axle, branch=renovate/readline-8.x)
       "command": "conan lock create conanfile.py"
...
```