### PR TITLE
feat(minimumReleaseAge)!: require a release timestamp by default

### DIFF
--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -1982,7 +1982,7 @@ const options: RenovateOptions[] = [
     description:
       'When set in conjunction with `minimumReleaseAge`, controls whether the `releaseTimestamp` for a dependency update is required.',
     type: 'string',
-    default: 'timestamp-optional',
+    default: 'timestamp-required',
     allowedValues: ['timestamp-required', 'timestamp-optional'],
   },
   {

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -221,8 +221,8 @@ export type RenovateRepository =
 export type UseBaseBranchConfigType = 'merge' | 'none';
 export type ConstraintsFilter = 'strict' | 'none';
 export type MinimumReleaseAgeBehaviour =
-  | 'timestamp-optional'
-  | 'timestamp-required';
+  | 'timestamp-required'
+  | 'timestamp-optional';
 
 export const allowedStatusCheckStrings = [
   'minimumReleaseAge',

--- a/lib/workers/repository/update/branch/index.ts
+++ b/lib/workers/repository/update/branch/index.ts
@@ -408,7 +408,7 @@ export async function processBranch(
       for (const upgrade of config.upgrades) {
         if (is.nonEmptyString(upgrade.minimumReleaseAge)) {
           const minimumReleaseAgeBehaviour: MinimumReleaseAgeBehaviour =
-            upgrade.minimumReleaseAgeBehaviour ?? 'timestamp-optional';
+            upgrade.minimumReleaseAgeBehaviour ?? 'timestamp-required';
 
           // regardless of the value of `minimumReleaseAgeBehaviour`, if there is a timestamp, we will process it according to `minimumReleaseAge`
           if (upgrade.releaseTimestamp) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
As noted in #38290, #38348, a "rough edge" of the current implementation
of `minimumReleaseAge` is that:

- if we have set `minimumReleaseAge` to apply to a given dependency
- and we have 3 dependencies that need an update
  - 2 of which have a `releaseTimestamp` that is not yet "stable"
  - 1 of which does not have a `releaseTimestamp`

The dependency update that does not have a `releaseTimestamp` will be
treated as "stable", and will receive an update immediately.

To provide safer "best practices" we will provide a default value for
`minimumReleaseAgeBehaviour` in `config:best-practices` to protect
users.

Note that this won't change anything unless there are already
dependencies being matched by `minimumReleaseAge`, but is still a
breaking change, as it will impact all users who are - now or in the
future - setting `minimumReleaseAge`.

## Context

Please select one of the below:

- [x] This closes an existing Issue: #38457
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
