### PR TITLE
fix(changelog): handle codeblocks in markdown

### DIFF
--- a/lib/workers/repository/update/pr/changelog/release-notes.spec.ts
+++ b/lib/workers/repository/update/pr/changelog/release-notes.spec.ts
@@ -11,6 +11,7 @@ import {
   getReleaseList,
   getReleaseNotes,
   getReleaseNotesMd,
+  massageBody,
   releaseNotesCacheMinutes,
   shouldSkipChangelogMd,
 } from './release-notes';
@@ -1628,6 +1629,27 @@ describe('workers/repository/update/pr/changelog/release-notes', () => {
       it('should continue for other repository', () => {
         expect(shouldSkipChangelogMd('some/repo')).toBeFalse();
       });
+    });
+  });
+
+  describe('massageBody()', () => {
+    it('does not modify # inside codeblocks', () => {
+      const str =
+        '  # Version 3.2.0' +
+        '\n' +
+        '* [Chore]: always publish build scans on CI. Optionally publish them locally.' +
+        '\n' +
+        '\n' +
+        'To publish build scans, add the following, as indicated:' +
+        '```' +
+        '\n' +
+        '# ~/.gradle/gradle.properties' +
+        '\n' +
+        'dependency.analysis.scans.publish=true' +
+        '```';
+      expect(massageBody(str, 'https://github.com/foo/bar/')).toBe(
+        str.replace('  # Version 3.2.0', '### Version 3.2.0'),
+      );
     });
   });
 });

--- a/lib/workers/repository/update/pr/changelog/release-notes.ts
+++ b/lib/workers/repository/update/pr/changelog/release-notes.ts
@@ -488,7 +488,7 @@ export async function addReleaseNotes(
   for (const v of input.versions) {
     let releaseNotes: ChangeLogNotes | null | undefined;
     const cacheKey = `${cacheKeyPrefix}:${v.version}`;
-    releaseNotes = undefined;
+    releaseNotes = await packageCache.get(cacheNamespace, cacheKey);
     releaseNotes ??= await getReleaseNotesMd(input.project, v);
     releaseNotes ??= await getReleaseNotes(input.project, v, config);
 

--- a/lib/workers/repository/update/pr/changelog/release-notes.ts
+++ b/lib/workers/repository/update/pr/changelog/release-notes.ts
@@ -111,9 +111,16 @@ export function massageBody(
   );
   // Reduce headings size
   body = body
-    .replace(regEx(/\n\s*####? /g), '\n##### ')
-    .replace(regEx(/\n\s*## /g), '\n#### ')
-    .replace(regEx(/\n\s*# /g), '\n### ');
+    .split(/(```[\s\S]*?```)/g)
+    .map((part) =>
+      part.startsWith('```') // do not modify # inside of codeblocks
+        ? part
+        : part
+            .replace(/\n\s*####? /g, '\n##### ')
+            .replace(/\n\s*## /g, '\n#### ')
+            .replace(/\n\s*# /g, '\n### '),
+    )
+    .join('');
   // Trim whitespace
   return body.trim();
 }
@@ -481,7 +488,7 @@ export async function addReleaseNotes(
   for (const v of input.versions) {
     let releaseNotes: ChangeLogNotes | null | undefined;
     const cacheKey = `${cacheKeyPrefix}:${v.version}`;
-    releaseNotes = await packageCache.get(cacheNamespace, cacheKey);
+    releaseNotes = undefined;
     releaseNotes ??= await getReleaseNotesMd(input.project, v);
     releaseNotes ??= await getReleaseNotes(input.project, v, config);
 

--- a/lib/workers/repository/update/pr/changelog/release-notes.ts
+++ b/lib/workers/repository/update/pr/changelog/release-notes.ts
@@ -111,14 +111,14 @@ export function massageBody(
   );
   // Reduce headings size
   body = body
-    .split(/(```[\s\S]*?```)/g)
+    .split(regEx(/(```[\s\S]*?```)/g))
     .map((part) =>
       part.startsWith('```') // do not modify # inside of codeblocks
         ? part
         : part
-            .replace(/\n\s*####? /g, '\n##### ')
-            .replace(/\n\s*## /g, '\n#### ')
-            .replace(/\n\s*# /g, '\n### '),
+            .replace(regEx(/\n\s*####? /g), '\n##### ')
+            .replace(regEx(/\n\s*## /g), '\n#### ')
+            .replace(regEx(/\n\s*# /g), '\n### '),
     )
     .join('');
   // Trim whitespace

--- a/lib/workers/repository/update/pr/changelog/release-notes.ts
+++ b/lib/workers/repository/update/pr/changelog/release-notes.ts
@@ -26,7 +26,7 @@ import type {
 } from './types';
 
 const markdown = new MarkdownIt('zero');
-markdown.enable(['heading', 'lheading']);
+markdown.enable(['heading', 'lheading', 'fence']);
 
 const repositoriesToSkipMdFetching = ['facebook/react-native'];
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- Enable `fence` section in the mardown it instance
- Prevent modifying heading sizes inside codeblock when we reduce heading sizes in `massageBody`
<!-- Describe what behavior is changed by this PR. -->

## Context
- Ref: #38799 
Please select one of the below:

- [x] This closes an existing Issue: #38799
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository https://github.com/Rahul-renovate-testing/net.twisterrob.libraries/pull/1

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
