### PR TITLE
fix(maven): normalize both sides of version comparison

### DIFF
--- a/lib/modules/versioning/maven/compare.spec.ts
+++ b/lib/modules/versioning/maven/compare.spec.ts
@@ -553,6 +553,7 @@ describe('modules/versioning/maven/compare', () => {
       ${'[1.2.3,1.2.4)'}         | ${'1.2.4'}   | ${'[1.2.4,1.2.5)'}
       ${'[1.2.1,1.2.4)'}         | ${'1.2.4'}   | ${'[1.2.1,1.2.5)'}
       ${'[1,1.2.3)'}             | ${'1.2.3'}   | ${'[1,1.2.4)'}
+      ${'[3,4-alpha)'}           | ${'4.3.2'}   | ${'[4,5-alpha)'}
     `(
       'autoExtendMavenRange("$range", "$version") === $expected',
       ({ range, version, expected }) => {

--- a/lib/modules/versioning/maven/compare.ts
+++ b/lib/modules/versioning/maven/compare.ts
@@ -518,7 +518,7 @@ function autoExtendMavenRange(
   if (
     leftValue !== null &&
     rightValue !== null &&
-    incrementRangeValue(leftValue) === rightValue
+    incrementRangeValue(leftValue) === coerceRangeValue(rightValue, rightValue)
   ) {
     if (compare(newValue, leftValue) !== -1) {
       interval.leftValue = coerceRangeValue(leftValue, newValue);

--- a/lib/modules/versioning/maven/compare.ts
+++ b/lib/modules/versioning/maven/compare.ts
@@ -524,6 +524,16 @@ function autoExtendMavenRange(
       interval.leftValue = coerceRangeValue(leftValue, newValue);
       interval.rightValue = incrementRangeValue(interval.leftValue);
     }
+  } else if (
+    leftValue !== null &&
+    rightValue !== null &&
+    incrementRangeValue(leftValue) + '-alpha' ===
+      coerceRangeValue(rightValue, rightValue)
+  ) {
+    if (compare(newValue, leftValue) !== -1) {
+      interval.leftValue = coerceRangeValue(leftValue, newValue);
+      interval.rightValue = incrementRangeValue(interval.leftValue) + '-alpha';
+    }
   } else if (rightValue !== null) {
     if (interval.rightType === INCLUDING_POINT) {
       const tokens = tokenize(rightValue);


### PR DESCRIPTION
> [!WARNING]  
> This PR is a follow-up to #38892, the first commit here is to be ignored

## Changes

Without this a leftValue of v3 is incremented to 4 and then compared to v4.

## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: https://github.com/Vampire/spock/

