### PR TITLE
chore(docs): render `allowedValues` as JSON

### DIFF
--- a/tools/docs/config.ts
+++ b/tools/docs/config.ts
@@ -120,10 +120,12 @@ function genTable(obj: [string, string][], type: string, def: any): string {
       ) {
         el[1] = `<code>${el[1]}</code>`;
       }
-      // objects and arrays should be printed in JSON notation
       if (
-        (type === 'object' || type === 'array') &&
-        (el[0] === 'default' || el[0] === 'additionalProperties')
+        // objects and arrays should be printed in JSON notation
+        ((type === 'object' || type === 'array') &&
+          (el[0] === 'default' || el[0] === 'additionalProperties')) ||
+        // enum values for `allowedValues` should be printed in JSON notation
+        el[0] === 'allowedValues'
       ) {
         // only show array and object defaults if they are not null and are not empty
         if (Object.keys(el[1] ?? []).length === 0) {
@@ -151,7 +153,7 @@ function genTable(obj: [string, string][], type: string, def: any): string {
 }
 
 function stringifyArrays(el: Record<string, any>): void {
-  const ignoredKeys = ['default', 'experimentalIssues'];
+  const ignoredKeys = ['allowedValues', 'default', 'experimentalIssues'];
 
   for (const [key, value] of Object.entries(el)) {
     if (!ignoredKeys.includes(key) && Array.isArray(value)) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
With `allowedValues`, we will almost always have multiple values. To
render them better, we can render this array as the JSON stringified
alternative, which reads a little better.

This requires we make sure that the array isn't pre-stringified, which
would JSON stringify as i.e. `"auto, enabled"`.

### Before

<!-- https://docs.renovatebot.com/configuration-options/#minimumreleaseagebehaviour -->

<img width="533" height="436" alt="Screenshot 2025-10-29 at 09 28 57" src="https://github.com/user-attachments/assets/8e79e424-b84c-4bdc-bb89-36aaf767fed1" />


### After

<img width="711" height="500" alt="Screenshot 2025-10-29 at 09 28 00" src="https://github.com/user-attachments/assets/6e2325a8-9d15-4f85-819b-72425289cd77" />


## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
