### PR TITLE
fix(gerrit): remove memCache to fix prNo coming as null when pr-created

### DIFF
--- a/lib/modules/platform/gerrit/client.spec.ts
+++ b/lib/modules/platform/gerrit/client.spec.ts
@@ -353,10 +353,7 @@ describe('modules/platform/gerrit/client', () => {
         .get('/a/changes/123456?o=CURRENT_REVISION&o=COMMIT_FOOTERS')
         .reply(200, gerritRestResponse(change), jsonResultHeader);
       await expect(
-        client.getChange(123456, undefined, [
-          'CURRENT_REVISION',
-          'COMMIT_FOOTERS',
-        ]),
+        client.getChange(123456, ['CURRENT_REVISION', 'COMMIT_FOOTERS']),
       ).resolves.toEqual(change);
     });
   });

--- a/lib/modules/platform/gerrit/index.spec.ts
+++ b/lib/modules/platform/gerrit/index.spec.ts
@@ -210,7 +210,6 @@ describe('modules/platform/gerrit/index', () => {
       );
       expect(clientMock.getChange).toHaveBeenCalledExactlyOnceWith(
         123456,
-        undefined,
         REQUEST_DETAILS_FOR_PRS,
       );
     });
@@ -368,7 +367,6 @@ describe('modules/platform/gerrit/index', () => {
           branchName: 'renovate/dependency-1.x',
           state: 'open',
           singleChange: true,
-          refreshCache: undefined,
           requestDetails: REQUEST_DETAILS_FOR_PRS,
         },
       );
@@ -424,18 +422,6 @@ describe('modules/platform/gerrit/index', () => {
           requestDetails: REQUEST_DETAILS_FOR_PRS,
         },
       ]);
-    });
-  });
-
-  describe('refreshPr()', () => {
-    it('refreshPr()', async () => {
-      clientMock.getChange.mockResolvedValueOnce(partial<GerritChange>({}));
-      await expect(gerrit.refreshPr(123456)).toResolve();
-      expect(clientMock.getChange).toHaveBeenCalledExactlyOnceWith(
-        123456,
-        true,
-        REQUEST_DETAILS_FOR_PRS,
-      );
     });
   });
 

--- a/lib/modules/platform/gerrit/index.ts
+++ b/lib/modules/platform/gerrit/index.ts
@@ -153,16 +153,9 @@ export async function findPr(findPRConfig: FindPRConfig): Promise<Pr | null> {
     : null;
 }
 
-export async function getPr(
-  number: number,
-  refreshCache?: boolean,
-): Promise<Pr | null> {
+export async function getPr(number: number): Promise<Pr | null> {
   try {
-    const change = await client.getChange(
-      number,
-      refreshCache,
-      REQUEST_DETAILS_FOR_PRS,
-    );
+    const change = await client.getChange(number, REQUEST_DETAILS_FOR_PRS);
     return mapGerritChangeToPr(change);
   } catch (err) {
     if (err.statusCode === 404) {
@@ -198,7 +191,6 @@ export async function createPr(prConfig: CreatePRConfig): Promise<Pr | null> {
       targetBranch: prConfig.targetBranch,
       state: 'open',
       singleChange: true,
-      refreshCache: true,
       requestDetails: REQUEST_DETAILS_FOR_PRS,
     })
   ).pop();
@@ -246,11 +238,6 @@ export async function getBranchPr(
     : null;
 }
 
-export async function refreshPr(number: number): Promise<void> {
-  // refresh cache
-  await getPr(number, true);
-}
-
 export async function getPrList(): Promise<Pr[]> {
   const changes = await client.findChanges(config.repository!, {
     branchName: '',
@@ -291,7 +278,6 @@ export async function getBranchStatus(
       state: 'open',
       branchName,
       singleChange: true,
-      refreshCache: true,
       requestDetails: ['LABELS', 'SUBMITTABLE', 'CHECK'],
     })
   ).pop();
@@ -330,7 +316,6 @@ export async function getBranchStatusCheck(
         branchName,
         state: 'open',
         singleChange: true,
-        refreshCache: true,
         requestDetails: ['LABELS'],
       })
     ).pop();

--- a/lib/modules/platform/gerrit/scm.spec.ts
+++ b/lib/modules/platform/gerrit/scm.spec.ts
@@ -31,7 +31,6 @@ describe('modules/platform/gerrit/scm', () => {
           state: 'open',
           targetBranch: 'baseBranch',
           singleChange: true,
-          refreshCache: true,
           requestDetails: ['CURRENT_REVISION', 'CURRENT_ACTIONS'],
         },
       );
@@ -87,7 +86,6 @@ describe('modules/platform/gerrit/scm', () => {
           state: 'open',
           targetBranch: 'master',
           singleChange: true,
-          refreshCache: true,
           requestDetails: ['CURRENT_REVISION', 'DETAILED_ACCOUNTS'],
         },
       );
@@ -183,7 +181,6 @@ describe('modules/platform/gerrit/scm', () => {
           branchName: 'myBranchName',
           state: 'open',
           singleChange: true,
-          refreshCache: true,
         },
       );
       expect(git.branchExists).toHaveBeenCalledExactlyOnceWith('myBranchName');
@@ -212,7 +209,6 @@ describe('modules/platform/gerrit/scm', () => {
           branchName: 'myBranchName',
           state: 'open',
           singleChange: true,
-          refreshCache: true,
           requestDetails: ['CURRENT_REVISION'],
         },
       );
@@ -244,7 +240,6 @@ describe('modules/platform/gerrit/scm', () => {
           branchName: 'nonExistingChange',
           state: 'open',
           singleChange: true,
-          refreshCache: true,
           requestDetails: ['CURRENT_REVISION'],
         },
       );
@@ -273,7 +268,6 @@ describe('modules/platform/gerrit/scm', () => {
           branchName: 'existingChange',
           state: 'open',
           singleChange: true,
-          refreshCache: true,
           requestDetails: ['CURRENT_REVISION'],
         },
       );
@@ -304,7 +298,6 @@ describe('modules/platform/gerrit/scm', () => {
           state: 'open',
           targetBranch: 'main',
           singleChange: true,
-          refreshCache: true,
           requestDetails: ['CURRENT_REVISION'],
         },
       );

--- a/lib/modules/platform/gerrit/scm.ts
+++ b/lib/modules/platform/gerrit/scm.ts
@@ -20,7 +20,6 @@ export class GerritScm extends DefaultGitScm {
       state: 'open',
       branchName,
       singleChange: true,
-      refreshCache: true,
     };
     const change = (await client.findChanges(repository, searchConfig)).pop();
     if (change) {
@@ -36,7 +35,6 @@ export class GerritScm extends DefaultGitScm {
       state: 'open',
       branchName,
       singleChange: true,
-      refreshCache: true,
       requestDetails: ['CURRENT_REVISION'],
     };
     const change = (await client.findChanges(repository, searchConfig)).pop();
@@ -55,7 +53,6 @@ export class GerritScm extends DefaultGitScm {
       branchName,
       targetBranch: baseBranch,
       singleChange: true,
-      refreshCache: true,
       requestDetails: ['CURRENT_REVISION', 'CURRENT_ACTIONS'],
     };
     const change = (await client.findChanges(repository, searchConfig)).pop();
@@ -98,7 +95,6 @@ export class GerritScm extends DefaultGitScm {
       branchName,
       targetBranch: baseBranch,
       singleChange: true,
-      refreshCache: true,
       requestDetails: ['CURRENT_REVISION', 'DETAILED_ACCOUNTS'],
     };
     const change = (await client.findChanges(repository, searchConfig)).pop();
@@ -118,7 +114,6 @@ export class GerritScm extends DefaultGitScm {
       branchName: commit.branchName,
       targetBranch: commit.baseBranch,
       singleChange: true,
-      refreshCache: true,
       requestDetails: ['CURRENT_REVISION'],
     };
     const existingChange = (
@@ -184,7 +179,6 @@ export class GerritScm extends DefaultGitScm {
       state: 'open',
       branchName,
       singleChange: true,
-      refreshCache: true,
       requestDetails: ['CURRENT_REVISION'],
     };
     const change = (await client.findChanges(repository, searchConfig)).pop();


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

As per my investigation, the only place where a cached request was being reused for the Gerrit platform was in `getBranchPr()`.

Even there, it was incorrect. It was causing `prNo` to come as `null` in the report for `pr-created` branches, because it was reusing stale cache even after the change was created.

While this does increase the number of requests per execution, it fixes the bug above.

A smarter cache implementation is being worked on in https://github.com/renovatebot/renovate/pull/35676. Additionally, I'll rework the Gerrit SCM implementation to dramatically reduce API calls. Together, those two changes should yield an 80%+ reduction in requests to the Gerrit platform.

Therefore, this change also serves as a code cleanup to simplify the review of https://github.com/renovatebot/renovate/pull/35676.

## Context

Please select one of the below:

- [ ] This closes an existing Issue:
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://review.gerrithub.io/admin/repos/felipecrs/renovate-tutorial

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
