### PR TITLE
fix(presets): update repository URL for wasm-bindgen

### DIFF
--- a/lib/data/monorepo.json
+++ b/lib/data/monorepo.json
@@ -558,7 +558,7 @@
     "ruby-on-rails": "https://github.com/rails/rails",
     "rust-analyzer": "https://github.com/rust-lang/rust-analyzer",
     "rust-futures": "https://github.com/rust-lang/futures-rs",
-    "rust-wasm-bindgen": "https://github.com/rustwasm/wasm-bindgen",
+    "rust-wasm-bindgen": "https://github.com/wasm-bindgen/wasm-bindgen",
     "sanity": "https://github.com/sanity-io/sanity",
     "serilog-ui": "https://github.com/serilog-contrib/serilog-ui",
     "scaffdog": "https://github.com/scaffdog/scaffdog",


### PR DESCRIPTION
The `rustwasm` org was [sunsetted in September 2025][blog] and the repository was transferred to a new `wasm-bindgen` org. Update the URL accordingly.

[blog]: https://blog.rust-lang.org/inside-rust/2025/07/21/sunsetting-the-rustwasm-github-org/
