### PR TITLE
feat: Cleanup mutexes before each run

### DIFF
--- a/lib/modules/datasource/deb/index.spec.ts
+++ b/lib/modules/datasource/deb/index.spec.ts
@@ -274,6 +274,7 @@ describe('modules/datasource/deb/index', () => {
     });
 
     it('should not lead to a race condition on parallel lookups', async () => {
+      vi.unmock('../../../util/mutex');
       const packages = [
         'album',
         'album-data',

--- a/lib/util/mutex.spec.ts
+++ b/lib/util/mutex.spec.ts
@@ -1,5 +1,7 @@
 import { acquireLock, getMutex } from './mutex';
 
+vi.unmock('./mutex');
+
 describe('util/mutex', () => {
   describe('getMutex', () => {
     it('returns mutex with default namespace', () => {

--- a/lib/util/mutex.ts
+++ b/lib/util/mutex.ts
@@ -1,7 +1,11 @@
 import { Mutex, type MutexInterface, withTimeout } from 'async-mutex';
 
 const DEFAULT_NAMESPACE = 'default';
-const mutexes: Record<string, Record<string, MutexInterface>> = {};
+let mutexes: Record<string, Record<string, MutexInterface>> = {};
+
+export function initMutexes(): void {
+  mutexes = {};
+}
 
 export function getMutex(
   key: string,

--- a/lib/workers/repository/init/index.spec.ts
+++ b/lib/workers/repository/init/index.spec.ts
@@ -19,6 +19,7 @@ vi.mock('../../../modules/platform', () => ({
   platform: { initRepo: vi.fn() },
   getPlatformList: vi.fn(),
 }));
+vi.unmock('../../../util/mutex');
 
 const apis = vi.mocked(_apis);
 const config = vi.mocked(_config);

--- a/lib/workers/repository/init/index.ts
+++ b/lib/workers/repository/init/index.ts
@@ -8,6 +8,7 @@ import * as memCache from '../../../util/cache/memory';
 import { clone } from '../../../util/clone';
 import { cloneSubmodules, setUserRepoConfig } from '../../../util/git';
 import { getAll } from '../../../util/host-rules';
+import { initMutexes } from '../../../util/mutex';
 import { checkIfConfigured } from '../configured';
 import { PackageFiles } from '../package-files';
 import type { WorkerPlatformConfig } from './apis';
@@ -53,6 +54,7 @@ export async function initRepo(
   await resetCaches();
   logger.once.reset();
   memCache.init();
+  initMutexes();
   config = await initApis(config);
   await initializeCaches(config as WorkerPlatformConfig);
   config = await getRepoConfig(config);

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -31,3 +31,7 @@ Object.defineProperty(global, 'fixtures', { value: _fixtures });
 declare global {
   const fixtures: typeof _fixtures;
 }
+
+vi.mock('../lib/util/mutex', () => ({
+  acquireLock: () => Promise.resolve(() => undefined),
+}));

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -33,5 +33,6 @@ declare global {
 }
 
 vi.mock('../lib/util/mutex', () => ({
-  acquireLock: () => Promise.resolve(() => undefined),
+  initMutexes: () => vi.fn(),
+  acquireLock: () => vi.fn().mockImplementation(() => () => undefined),
 }));


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

I'm planning to use it for locking the same HTTP requests.
I want to avoid growing the size of mutex storage for the long-running processes.

Also, this PR disables locks from being used in tests.

## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
