### PR TITLE
chore: add separate input for version requirement on "request help"

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/request-help.yml
+++ b/.github/DISCUSSION_TEMPLATE/request-help.yml
@@ -7,6 +7,30 @@ body:
         - 'A Mend.io-hosted app'
         - 'Self-hosted Renovate'
 
+  - type: dropdown
+    id: self-hosted-platform
+    attributes:
+      label: Which platform you running Renovate on?
+      options:
+        - 'GitHub.com'
+        - 'GitHub Enterprise Server'
+        - 'GitLab (.com or self-hosted)'
+        - 'Gitea'
+        - 'Forgejo'
+        - 'Other (please specify)'
+    validations:
+      required: false
+
+  - type: input
+    id: self-hosted-version
+    attributes:
+      label: |
+        Which version of Renovate are you using?
+        Please do not say "latest" version (as Renovate ships many updates daily), but instead note the exact version.
+        You can find it by checking the `INFO: Repository started` log line.
+    validations:
+      required: false
+
   - type: input
     id: self-hosted-version
     attributes:


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
We end up getting quite a few Discussions where the version is indicated
as "latest", which can be hard to determine, as that version changes
fairly regularly.

Sometimes we also get Docker image digest, which are more easy to
determine what they pin to, but still less straightforward than an exact
version.

To save some back-and-forth with confirming with users, let's make this
clearer in the "Request Help" template, by creating a separate "which
platform are you self hosting with" and "what version are you using".

## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

As an alternative to https://github.com/renovatebot/renovate/pull/38983

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
