### PR TITLE
feat(manager/gradle): add support for variables in plugin names

### DIFF
--- a/lib/modules/manager/gradle/parser.spec.ts
+++ b/lib/modules/manager/gradle/parser.spec.ts
@@ -617,12 +617,14 @@ describe('modules/manager/gradle/parser', () => {
         ${''}               | ${'id("foo.bar").version("1.2.3")'}        | ${{ depName: 'foo.bar', packageName: 'foo.bar:foo.bar.gradle.plugin', currentValue: '1.2.3' }}
         ${''}               | ${'id(["foo.bar"]) version "1.2.3"'}       | ${null}
         ${''}               | ${'id("foo", "bar") version "1.2.3"'}      | ${null}
+        ${''}               | ${'id(foo) version "1.2.3"'}               | ${null}
         ${''}               | ${'id "foo".version("1.2.3")'}             | ${null}
         ${''}               | ${'id("foo.bar") version("1.2.3")'}        | ${{ depName: 'foo.bar', packageName: 'foo.bar:foo.bar.gradle.plugin', currentValue: '1.2.3' }}
         ${''}               | ${'id("foo.bar") version "1.2.3"'}         | ${{ depName: 'foo.bar', packageName: 'foo.bar:foo.bar.gradle.plugin', currentValue: '1.2.3' }}
         ${''}               | ${'id "foo.bar" version "$baz"'}           | ${{ depName: 'foo.bar', skipReason: 'unspecified-version', currentValue: 'baz' }}
         ${'baz = "1.2.3"'}  | ${'id "foo.bar" version "$baz"'}           | ${{ depName: 'foo.bar', packageName: 'foo.bar:foo.bar.gradle.plugin', currentValue: '1.2.3', sharedVariableName: 'baz' }}
         ${'baz = "1.2.3"'}  | ${'id("foo.bar") version "$baz"'}          | ${{ depName: 'foo.bar', packageName: 'foo.bar:foo.bar.gradle.plugin', currentValue: '1.2.3' }}
+        ${'foo = "bar"'}    | ${'id(foo + ".baz") version "1.2.3"'}      | ${{ depName: 'bar.baz', packageName: 'bar.baz:bar.baz.gradle.plugin', currentValue: '1.2.3' }}
         ${''}               | ${'id "foo.bar" version "x${ab}cd"'}       | ${{ depName: 'foo.bar', skipReason: 'unspecified-version' }}
         ${''}               | ${'id("foo.bar") version "$baz"'}          | ${{ depName: 'foo.bar', skipReason: 'unspecified-version', currentValue: 'baz' }}
         ${''}               | ${'id("foo.bar") version "x${ab}cd"'}      | ${{ depName: 'foo.bar', skipReason: 'unspecified-version' }}

--- a/lib/modules/manager/gradle/parser/handlers.ts
+++ b/lib/modules/manager/gradle/parser/handlers.ts
@@ -226,10 +226,14 @@ export function handleLongFormDep(ctx: Ctx): Ctx {
 
 export function handlePlugin(ctx: Ctx): Ctx {
   const methodName = loadFromTokenMap(ctx, 'methodName')[0];
-  const pluginName = loadFromTokenMap(ctx, 'pluginName')[0];
+  const pluginNameTokens = loadFromTokenMap(ctx, 'pluginName');
   const pluginVersion = loadFromTokenMap(ctx, 'version');
 
-  const plugin = pluginName.value;
+  const plugin = interpolateString(pluginNameTokens, ctx);
+  if (!plugin) {
+    return ctx;
+  }
+
   const depName =
     methodName.value === 'kotlin' ? `org.jetbrains.kotlin.${plugin}` : plugin;
   const packageName = `${depName}:${depName}.gradle.plugin`;

--- a/lib/modules/manager/gradle/parser/plugins.ts
+++ b/lib/modules/manager/gradle/parser/plugins.ts
@@ -4,6 +4,7 @@ import type { Ctx } from '../types';
 import {
   cleanupTempVars,
   qStringValue,
+  qValueMatcher,
   qVersion,
   storeInTokenMap,
   storeVarToken,
@@ -26,7 +27,7 @@ export const qPlugins = q
         maxDepth: 1,
         startsWith: '(',
         endsWith: ')',
-        search: q.begin<Ctx>().join(qStringValue).end(),
+        search: q.begin<Ctx>().join(qValueMatcher).end(),
       })
       .handler((ctx) => storeInTokenMap(ctx, 'pluginName'))
       .alt(


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Enables the interpolation of variables and templated strings in gradle plugin definitions.

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the below:

- [x] This closes an existing Issue: https://github.com/renovatebot/renovate/discussions/38984
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/renovate-demo/38984-renovate-gradle-plugin-by-variables/pull/2

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
