### PR TITLE
feat(logger): support custom serializers

### DIFF
--- a/lib/logger/renovate-logger.ts
+++ b/lib/logger/renovate-logger.ts
@@ -67,6 +67,10 @@ export class RenovateLogger implements Logger {
     this.log('fatal', p1, p2);
   }
 
+  addSerializers(serializers: bunyan.Serializers): void {
+    this.bunyanLogger.addSerializers(serializers);
+  }
+
   addStream(stream: bunyan.Stream): void {
     this.bunyanLogger.addStream(withSanitizer(stream));
   }


### PR DESCRIPTION
## Changes
We use the Renovate logger internally in some of our Renovate OSS wrapper projects.
In certain cases, we need to support custom serialization of logger metadata.

This change adds support for registering custom logger serializers.


<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, **grammar fixes**).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
