### PR TITLE
feat(manager/sbt): support replacement

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -3644,7 +3644,6 @@ Managers which do not support replacement:
 - `gradle`
 - `homebrew`
 - `regex`
-- `sbt`
 
 Use the `replacementName` config option to set the name of a replacement package.
 

--- a/lib/modules/manager/sbt/index.ts
+++ b/lib/modules/manager/sbt/index.ts
@@ -6,7 +6,7 @@ import { SbtPluginDatasource } from '../../datasource/sbt-plugin';
 import * as ivyVersioning from '../../versioning/ivy';
 
 export { extractAllPackageFiles, extractPackageFile } from './extract';
-export { bumpPackageVersion } from './update';
+export { bumpPackageVersion, updateDependency } from './update';
 
 export const displayName = 'sbt';
 export const url = 'https://www.scala-sbt.org';

--- a/lib/modules/manager/sbt/update.spec.ts
+++ b/lib/modules/manager/sbt/update.spec.ts
@@ -48,4 +48,88 @@ describe('modules/manager/sbt/update', () => {
       expect(bumpedContent).toEqual(content);
     });
   });
+
+  describe('.updateDependency()', () => {
+    it('should do replacement with new value', async () => {
+      const simpleContent = `libraryDependencies += "org.scalatestplus" %% "mockito-3-12" % "3.2.10.0"`;
+
+      const res = await sbtUpdater.updateDependency({
+        fileContent: simpleContent,
+        upgrade: {
+          updateType: 'replacement',
+          depName: 'org.scalatestplus:mockito-3-12',
+          currentValue: '3.2.10.0',
+          newName: 'org.scalatestplus.new:mockito-4-11',
+          newValue: '3.3.0.0',
+        },
+      });
+
+      expect(res).toEqual(
+        'libraryDependencies += "org.scalatestplus.new" %% "mockito-4-11" % "3.3.0.0"',
+      );
+    });
+
+    it('should do replacement without a new value', async () => {
+      const simpleContent = `libraryDependencies += "org.scalatestplus" %% "mockito-3-12" % "3.2.10.0"`;
+
+      const res = await sbtUpdater.updateDependency({
+        fileContent: simpleContent,
+        upgrade: {
+          updateType: 'replacement',
+          depName: 'org.scalatestplus:mockito-3-12',
+          currentValue: '3.2.10.0',
+          newName: 'org.scalatestplus.new:mockito-4-11',
+        },
+      });
+
+      expect(res).toEqual(
+        'libraryDependencies += "org.scalatestplus.new" %% "mockito-4-11" % "3.2.10.0"',
+      );
+    });
+
+    it('should do replacement for Java library as well (single %)', async () => {
+      const simpleContent = `libraryDependencies += "com.fasterxml.jackson" % "jackson-bom" % "2.20.0"`;
+
+      const res = await sbtUpdater.updateDependency({
+        fileContent: simpleContent,
+        upgrade: {
+          updateType: 'replacement',
+          depName: 'com.fasterxml.jackson:jackson-bom',
+          currentValue: '2.20.0',
+          newName: 'tools.jackson:jackson-bom-new',
+          newValue: '3.0.0',
+        },
+      });
+
+      expect(res).toEqual(
+        'libraryDependencies += "tools.jackson" % "jackson-bom-new" % "3.0.0"',
+      );
+    });
+
+    it('should do replacement with version as shared variable', async () => {
+      const simpleContent = `
+      val someVersion = "3.2.10.0"
+      libraryDependencies += "org.scalatestplus" %% "mockito-3-12" % someVersion
+      `;
+
+      const res = await sbtUpdater.updateDependency({
+        fileContent: simpleContent,
+        upgrade: {
+          updateType: 'replacement',
+          depName: 'org.scalatestplus:mockito-3-12',
+          currentValue: '3.2.10.0',
+          newName: 'org.scalatestplus.new:mockito-4-11',
+          newValue: '3.3.0.0',
+          sharedVariableName: 'someVersion',
+        },
+      });
+
+      expect(res).toEqual(
+        `
+      val someVersion = "3.3.0.0"
+      libraryDependencies += "org.scalatestplus.new" %% "mockito-4-11" % someVersion
+      `,
+      );
+    });
+  });
 });

--- a/lib/modules/manager/sbt/update.ts
+++ b/lib/modules/manager/sbt/update.ts
@@ -1,8 +1,13 @@
 import type { ReleaseType } from 'semver';
 import semver from 'semver';
 import { logger } from '../../../logger';
-import { regEx } from '../../../util/regex';
-import type { BumpPackageVersionResult } from '../types';
+import { escapeRegExp, regEx } from '../../../util/regex';
+import { doAutoReplace } from '../../../workers/repository/update/branch/auto-replace';
+import type { BranchUpgradeConfig } from '../../../workers/types';
+import type {
+  BumpPackageVersionResult,
+  UpdateDependencyConfig,
+} from '../types';
 
 export function bumpPackageVersion(
   content: string,
@@ -31,4 +36,45 @@ export function bumpPackageVersion(
   }
 
   return { bumpedContent };
+}
+
+export async function updateDependency({
+  fileContent,
+  upgrade,
+}: UpdateDependencyConfig): Promise<string | null> {
+  const { depName, newName } = upgrade;
+
+  let updatedContent = fileContent;
+
+  if (upgrade.updateType === 'replacement') {
+    if (newName) {
+      const [oldGroupId, oldArtifactId] = depName!.split(':', 2);
+      const [newGroupId, newArtifactId] = newName.split(':', 2);
+      const pattern = new RegExp(
+        `"${escapeRegExp(oldGroupId)}"\\s*(%%?)\\s*"${escapeRegExp(oldArtifactId)}"`,
+        'g',
+      );
+
+      updatedContent = fileContent.replace(pattern, (match, percentSigns) => {
+        return `"${newGroupId}" ${percentSigns} "${newArtifactId}"`;
+      });
+    }
+  }
+
+  if (newName) {
+    // Replace the depName so that doAutoReplace works with the new name that has been updated above
+    return await doAutoReplace(
+      { ...upgrade, depName: newName } as BranchUpgradeConfig,
+      updatedContent,
+      false,
+      true,
+    );
+  } else {
+    return await doAutoReplace(
+      upgrade as BranchUpgradeConfig,
+      updatedContent,
+      false,
+      true,
+    );
+  }
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

**UPDATE 2025-11-10:** new proposal at https://github.com/renovatebot/renovate/pull/39202, I'm keeping this one opened just in case until one of them is accepted.

Attempts to solve https://github.com/renovatebot/renovate/issues/25643, that is support the replacement feature in sbt.

:warning: **It's a draft because I need help to:**
- know if this is the right direction, especially there's a dependency cycle raised by eslint (because auto-replace -> sbt/update -> auto-replace I guess)
- make the tests work, they fail on the `writeLocalFile` in `auto-replace` but I don't understand how to mock it

## Context

Please select one of the below:

- [x] This closes an existing Issue: #25643 
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: https://github.com/gaeljw/renovate-maven-sbt-replacement/pulls

For the record, I tested with the following package file:
```scala
libraryDependencies += "org.scalatestplus" %% "mockito-3-12" % "3.2.10.0"

// Using a shared variable
val junitVersion = "3.12.19.1"
libraryDependencies += "org.scalatestplus" %% "junit-4-13" % junitVersion

// A regular update without replacement
libraryDependencies += "org.scalatest" %% "scalatest-core" % "3.2.18"

// Both a replacement and a regular upgrade
libraryDependencies += "org.scalatestplus" %% "testng-6-7" % "3.2.9.0"
```

And following config:
```json
{
"packageRules": [
    {
      "matchDatasources": [
        "sbt-package"
      ],
      "matchDepNames": [
        "org.scalatestplus:mockito-3-12"
      ],
      "replacementName": "org.scalatestplus:mockito-4-11",
      "replacementVersion": "3.12.16.0"
    },
    {
      "matchDatasources": [
        "sbt-package"
      ],
      "matchDepNames": [
        "org.scalatestplus:junit-4-13"
      ],
      "replacementName": "org.scalatestplus:junit-5-13",
      "replacementVersion": "3.12.19.0"
    },
    {
      "matchDatasources": [
        "sbt-package"
      ],
      "matchDepNames": [
        "org.scalatestplus:testng-6-7"
      ],
      "replacementName": "org.scalatestplus:testng-7-9",
      "replacementVersion": "3.12.18.0"
    }
  ]
}
```

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
