### PR TITLE
feat(minimumReleaseAge): allow enforcing which `updateType`s to check release timestamps

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2796,6 +2796,16 @@ When set to `timestamp-optional`, Renovate will treat a release without a releas
 
 This only applies when used with [`minimumReleaseAge`](#minimumreleaseage).
 
+## minimumReleaseAgeEnforcedUpdateTypes
+
+????????
+
+????
+
+???
+
+TODO
+
 ## minor
 
 Add to this object if you wish to define rules that apply only to minor updates.

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -1987,9 +1987,11 @@ const options: RenovateOptions[] = [
   },
   {
     name: 'minimumReleaseAgeEnforcedUpdateTypes',
-    description: '....... TODO', // TODO
+    description:
+      'When set in conjunction with `minimumReleaseAge`, controls which `updateType`s will have the `releaseTimestamp` check enforced.',
     type: 'array',
     subType: 'string',
+    allowedValues: [...UpdateTypesOptions],
     default: ['major', 'minor', 'patch'],
   },
   {

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -1986,6 +1986,13 @@ const options: RenovateOptions[] = [
     allowedValues: ['timestamp-required', 'timestamp-optional'],
   },
   {
+    name: 'minimumReleaseAgeEnforcedUpdateTypes',
+    description: '....... TODO', // TODO
+    type: 'array',
+    subType: 'string',
+    default: ['major', 'minor', 'patch'],
+  },
+  {
     name: 'abandonmentThreshold',
     description:
       'Flags packages that have not been updated within this period as abandoned.',

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -334,6 +334,7 @@ export interface RenovateConfig
   minimumGroupSize?: number;
   configFileNames?: string[];
   minimumReleaseAgeBehaviour?: MinimumReleaseAgeBehaviour;
+  minimumReleaseAgeEnforcedUpdateTypes?: UpdateType[];
 }
 
 const CustomDatasourceFormats = [

--- a/lib/workers/repository/update/branch/index.spec.ts
+++ b/lib/workers/repository/update/branch/index.spec.ts
@@ -247,6 +247,7 @@ describe('workers/repository/update/branch/index', () => {
             releaseTimestamp: undefined,
             minimumReleaseAge: '100 days',
             minimumReleaseAgeBehaviour: 'timestamp-required',
+            updateType: 'major',
           },
         ]);
 
@@ -266,8 +267,28 @@ describe('workers/repository/update/branch/index', () => {
             releaseTimestamp: undefined,
             minimumReleaseAge: '100 days',
             minimumReleaseAgeBehaviour: 'timestamp-optional',
+            updateType: 'major',
           },
         ]);
+        scm.isBranchModified.mockResolvedValueOnce(false);
+        await branchWorker.processBranch(config);
+        expect(reuse.shouldReuseExistingBranch).toHaveBeenCalled();
+      });
+
+      it('does not skip branch if minimumReleaseAgeBehaviour=timestamp-required, if updateType is not in minimumReleaseAgeEnforcedUpdateTypes', async () => {
+        schedule.isScheduledNow.mockReturnValueOnce(true);
+        config.prCreation = 'not-pending';
+        config.upgrades = partial<BranchUpgradeConfig>([
+          {
+            releaseTimestamp: undefined,
+            minimumReleaseAge: '100 days',
+            minimumReleaseAgeBehaviour: 'timestamp-required',
+
+            updateType: 'digest',
+            minimumReleaseAgeEnforcedUpdateTypes: ['major'],
+          },
+        ]);
+
         scm.isBranchModified.mockResolvedValueOnce(false);
         await branchWorker.processBranch(config);
         expect(reuse.shouldReuseExistingBranch).toHaveBeenCalled();
@@ -396,7 +417,7 @@ describe('workers/repository/update/branch/index', () => {
       await branchWorker.processBranch(config);
       expect(reuse.shouldReuseExistingBranch).toHaveBeenCalledTimes(0);
 
-      expect(logger.debug).toHaveBeenCalledWith(
+      expect(logger.debug).toHaveBeenCalledExactlyOnceWith(
         `Matching PR #${pr.number} was merged previously`,
       );
     });
@@ -453,7 +474,7 @@ describe('workers/repository/update/branch/index', () => {
         result: 'pr-edited',
       });
 
-      expect(logger.debug).toHaveBeenCalledWith(
+      expect(logger.debug).toHaveBeenCalledExactlyOnceWith(
         `PR has been edited, PrNo:${pr.number}`,
       );
       expect(platform.ensureComment).toHaveBeenCalledExactlyOnceWith(
@@ -485,7 +506,7 @@ describe('workers/repository/update/branch/index', () => {
         result: 'pr-edited',
       });
 
-      expect(logger.debug).toHaveBeenCalledWith(
+      expect(logger.debug).toHaveBeenCalledExactlyOnceWith(
         `PR has been edited, PrNo:${pr.number}`,
       );
       expect(platform.ensureComment).toHaveBeenCalledExactlyOnceWith(
@@ -511,7 +532,7 @@ describe('workers/repository/update/branch/index', () => {
         result: 'pr-edited',
       });
 
-      expect(logger.debug).toHaveBeenCalledWith(
+      expect(logger.debug).toHaveBeenCalledExactlyOnceWith(
         `PR has been edited, PrNo:${pr.number}`,
       );
       expect(platform.ensureComment).toHaveBeenCalledTimes(0);
@@ -545,7 +566,7 @@ describe('workers/repository/update/branch/index', () => {
         result: 'pr-edited',
       });
 
-      expect(logger.debug).toHaveBeenCalledWith(
+      expect(logger.debug).toHaveBeenCalledExactlyOnceWith(
         `PR has been edited, PrNo:${pr.number}`,
       );
       expect(platform.ensureComment).toHaveBeenCalledExactlyOnceWith(
@@ -1195,7 +1216,7 @@ describe('workers/repository/update/branch/index', () => {
         commitSha: null,
       });
 
-      expect(logger.debug).toHaveBeenCalledWith(
+      expect(logger.debug).toHaveBeenCalledExactlyOnceWith(
         'Branch cannot automerge now because automergeSchedule is off schedule - skipping',
       );
       expect(prWorker.ensurePr).toHaveBeenCalledTimes(0);
@@ -1492,7 +1513,7 @@ describe('workers/repository/update/branch/index', () => {
         cacheFingerprintMatch: 'matched',
       });
 
-      expect(logger.debug).toHaveBeenCalledWith(
+      expect(logger.debug).toHaveBeenCalledExactlyOnceWith(
         'Base branch changed by user, rebasing the branch onto new base',
       );
       expect(commit.commitFilesToBranch).toHaveBeenCalled();
@@ -1531,7 +1552,7 @@ describe('workers/repository/update/branch/index', () => {
         cacheFingerprintMatch: 'no-fingerprint',
       });
 
-      expect(logger.debug).toHaveBeenCalledWith(
+      expect(logger.debug).toHaveBeenCalledExactlyOnceWith(
         'Existing branch needs updating. Restarting processBranch() with a clean branch',
       );
       expect(commit.commitFilesToBranch).toHaveBeenCalled();
@@ -1567,7 +1588,7 @@ describe('workers/repository/update/branch/index', () => {
         cacheFingerprintMatch: 'no-fingerprint',
       });
 
-      expect(logger.debug).toHaveBeenCalledWith(
+      expect(logger.debug).toHaveBeenCalledExactlyOnceWith(
         'Existing branch needs updating. Restarting processBranch() with a clean branch',
       );
       expect(commit.commitFilesToBranch).toHaveBeenCalled();
@@ -1630,7 +1651,7 @@ describe('workers/repository/update/branch/index', () => {
         result: 'pr-edited',
       });
 
-      expect(logger.info).toHaveBeenCalledWith(
+      expect(logger.info).toHaveBeenCalledExactlyOnceWith(
         `DRY-RUN: Would ensure edited/blocked PR comment in PR #${pr.number}`,
       );
       expect(platform.updatePr).toHaveBeenCalledTimes(0);
@@ -1676,7 +1697,7 @@ describe('workers/repository/update/branch/index', () => {
         commitSha: null,
       });
 
-      expect(logger.info).toHaveBeenCalledWith(
+      expect(logger.info).toHaveBeenCalledExactlyOnceWith(
         `DRY-RUN: Would remove edited/blocked PR comment in PR #${pr.number}`,
       );
     });
@@ -1724,7 +1745,7 @@ describe('workers/repository/update/branch/index', () => {
         commitSha: null,
       });
 
-      expect(logger.info).toHaveBeenCalledWith(
+      expect(logger.info).toHaveBeenCalledExactlyOnceWith(
         'DRY-RUN: Would ensure comment removal in PR #undefined',
       );
     });
@@ -2827,9 +2848,11 @@ describe('workers/repository/update/branch/index', () => {
         commitSha: '123test',
       });
 
-      expect(logger.debug).toHaveBeenCalledWith('Found existing branch PR');
+      expect(logger.debug).toHaveBeenCalledExactlyOnceWith(
+        'Found existing branch PR',
+      );
 
-      expect(logger.debug).toHaveBeenCalledWith(
+      expect(logger.debug).toHaveBeenCalledExactlyOnceWith(
         'No package files need updating',
       );
     });
@@ -2866,7 +2889,9 @@ describe('workers/repository/update/branch/index', () => {
         commitSha: null,
       });
 
-      expect(logger.debug).toHaveBeenCalledWith('Found existing branch PR');
+      expect(logger.debug).toHaveBeenCalledExactlyOnceWith(
+        'Found existing branch PR',
+      );
       expect(logger.debug).not.toHaveBeenCalledWith(
         'No package files need updating',
       );
@@ -3050,7 +3075,7 @@ describe('workers/repository/update/branch/index', () => {
       await branchWorker.processBranch(config);
       expect(platform.reattemptPlatformAutomerge).not.toHaveBeenCalled();
 
-      expect(logger.info).toHaveBeenCalledWith(
+      expect(logger.info).toHaveBeenCalledExactlyOnceWith(
         'DRY-RUN: Would reattempt platform automerge for PR #123',
       );
     });


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the below:

- [ ] This closes an existing Issue:
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

Discussion: https://github.com/renovatebot/renovate/discussions/39058

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
