### PR TITLE
fix(config/validation): validate `allowedValues`

### DIFF
--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -325,7 +325,7 @@ export type UpdateConfig<
 
 export type RenovateRepository =
   | string
-  | (RenovateConfig & {
+  | (AllConfig & {
       repository: string;
     });
 

--- a/lib/config/validation.spec.ts
+++ b/lib/config/validation.spec.ts
@@ -2,7 +2,7 @@ import { partial } from '~test/util.ts';
 import type { HostRule } from '../types/index.ts';
 import { getConfigFileNames } from './app-strings.ts';
 import { GlobalConfig } from './global.ts';
-import type { RenovateConfig } from './types.ts';
+import type { AllConfig, RenovateConfig } from './types.ts';
 import * as configValidation from './validation.ts';
 
 describe('config/validation', () => {
@@ -718,9 +718,13 @@ describe('config/validation', () => {
         true,
       );
       expect(warnings).toHaveLength(0);
-      expect(errors).toHaveLength(1);
+      expect(errors).toHaveLength(2);
       expect(errors).toMatchInlineSnapshot(`
         [
+          {
+            "message": "Invalid customManagers[0].customType: customType had a value \`"unknown"\` which was not part of the allowedValues: ["jsonata","regex"]",
+            "topic": "Configuration Error",
+          },
           {
             "message": "Invalid customType: unknown. Key is not a custom manager",
             "topic": "Configuration Error",
@@ -1621,6 +1625,47 @@ describe('config/validation', () => {
       expect(warnings).toBeEmptyArray();
     });
 
+    it('errors if a value does not match the allowedValues', async () => {
+      const config: Partial<RenovateConfig> = {
+        // for a single value
+        // @ts-expect-error: contains invalid values
+        mode: 'not-valid',
+        // for an array
+        postUpdateOptions: ['invalid', 'another'],
+        hostRules: [
+          {
+            // this is allowed, as it's the default value
+            artifactAuth: null,
+          },
+        ],
+        packageRules: [
+          {
+            matchDepNames: ['/.*/'],
+            versioning: 'regex:^(?<major>1)',
+          },
+        ],
+      };
+      const { warnings, errors } = await configValidation.validateConfig(
+        'repo',
+        config,
+        true,
+      );
+      expect(warnings).toHaveLength(0);
+      expect(errors).toHaveLength(2);
+      expect(errors).toMatchObject([
+        {
+          message:
+            'Invalid mode: mode had a value `"not-valid"` which was not part of the allowedValues: ["full","silent"]',
+          topic: 'Configuration Error',
+        },
+        {
+          message:
+            'Invalid postUpdateOptions: postUpdateOptions had invalid values `["invalid","another"]` which are not part of the allowedValues: ["bundlerConservative","composerWithAll","composerNoMinimalChanges","dotnetWorkloadRestore","gomodMassage","gomodTidy","gomodTidy1.17","gomodTidyE","gomodUpdateImportPaths","gomodSkipVendor","gomodVendor","goGenerate","helmUpdateSubChartArchives","kustomizeInflateHelmCharts","npmDedupe","npmInstallTwice","pnpmDedupe","yarnDedupeFewer","yarnDedupeHighest"]',
+          topic: 'Configuration Error',
+        },
+      ]);
+    });
+
     it('errors if no bumpVersion filePattern is provided', async () => {
       // @ts-expect-error -- TODO: fix test
       const config = partial<RenovateConfig>({
@@ -1644,7 +1689,7 @@ describe('config/validation', () => {
         true,
       );
       expect(warnings).toHaveLength(0);
-      expect(errors).toHaveLength(2);
+      expect(errors).toHaveLength(4);
     });
 
     it('errors if no matchStrings are provided for bumpVersion', async () => {
@@ -1668,7 +1713,7 @@ describe('config/validation', () => {
         true,
       );
       expect(warnings).toHaveLength(0);
-      expect(errors).toHaveLength(2);
+      expect(errors).toHaveLength(4);
     });
 
     it('allow bumpVersion', async () => {
@@ -1692,7 +1737,7 @@ describe('config/validation', () => {
         true,
       );
       expect(warnings).toHaveLength(0);
-      expect(errors).toHaveLength(2);
+      expect(errors).toHaveLength(4);
     });
   });
 
@@ -2373,6 +2418,35 @@ describe('config/validation', () => {
       ]);
       expect(warnings).toHaveLength(2);
       expect(errors).toHaveLength(1);
+    });
+
+    it('errors if a value does not match the allowedValues', async () => {
+      const config: Partial<AllConfig> = {
+        // for a single value
+        // @ts-expect-error: contains invalid values
+        autodiscoverRepoOrder: 'middle-out',
+
+        // for an array
+        mergeConfidenceDatasources: ['some', 'value'],
+      };
+      const { warnings, errors } = await configValidation.validateConfig(
+        'global',
+        config,
+      );
+      expect(warnings).toHaveLength(2); // 2 * mergeConfidenceDatasources warnings
+      expect(errors).toHaveLength(2);
+      expect(errors).toMatchObject([
+        {
+          message:
+            'Invalid autodiscoverRepoOrder: autodiscoverRepoOrder had a value `"middle-out"` which was not part of the allowedValues: ["asc","desc"]',
+          topic: 'Configuration Error',
+        },
+        {
+          message:
+            'Invalid mergeConfidenceDatasources: mergeConfidenceDatasources had invalid values `["some","value"]` which are not part of the allowedValues: ["go","maven","npm","nuget","packagist","pypi","rubygems"]',
+          topic: 'Configuration Error',
+        },
+      ]);
     });
   });
 });

--- a/lib/config/validation.spec.ts
+++ b/lib/config/validation.spec.ts
@@ -3062,7 +3062,7 @@ describe('config/validation', () => {
     });
 
     describe('repositories', () => {
-      it('is not validated', async () => {
+      it('is validated', async () => {
         const config: AllConfig = {
           repositories: [
             {
@@ -3079,7 +3079,12 @@ describe('config/validation', () => {
         );
 
         expect(warnings).toBeEmptyArray();
-        expect(errors).toBeEmptyArray();
+        expect(errors).toMatchObject([
+          {
+            message:
+              'Configuration option `repositories[0].dependencyDashboardHeader` should be a string',
+          },
+        ]);
       });
     });
   });

--- a/lib/config/validation.spec.ts
+++ b/lib/config/validation.spec.ts
@@ -3060,5 +3060,27 @@ describe('config/validation', () => {
         expect(errors).toBeEmptyArray();
       });
     });
+
+    describe('repositories', () => {
+      it('is not validated', async () => {
+        const config: AllConfig = {
+          repositories: [
+            {
+              repository: 'valid/name',
+              // @ts-expect-error -- invalid config
+              dependencyDashboardHeader: true,
+            },
+          ],
+        };
+
+        const { errors, warnings } = await configValidation.validateConfig(
+          'global',
+          config,
+        );
+
+        expect(warnings).toBeEmptyArray();
+        expect(errors).toBeEmptyArray();
+      });
+    });
   });
 });

--- a/lib/config/validation.spec.ts
+++ b/lib/config/validation.spec.ts
@@ -954,6 +954,10 @@ describe('config/validation', () => {
       expect(errors).toMatchInlineSnapshot(`
         [
           {
+            "message": "Invalid customManagers[0].customType: customType had a value \`"unknown"\` which was not part of the allowedValues: ["jsonata","regex"]",
+            "topic": "Configuration Error",
+          },
+          {
             "message": "Invalid customType: unknown. Key is not a custom manager",
             "topic": "Configuration Error",
           },
@@ -2426,7 +2430,12 @@ describe('config/validation', () => {
           topic: 'Configuration Error',
         },
       ]);
-      expect(errors).toBeEmptyArray();
+      expect(errors).toMatchObject([
+        {
+          message:
+            'Invalid binarySource: binarySource had a value `"invalid"` which was not part of the allowedValues: ["global","docker","install","hermit"]',
+        },
+      ]);
     });
 
     describe('validates string type options', () => {
@@ -2445,7 +2454,12 @@ describe('config/validation', () => {
             topic: 'Configuration Error',
           },
         ]);
-        expect(errors).toBeEmptyArray();
+        expect(errors).toMatchObject([
+          {
+            message:
+              'Invalid binarySource: binarySource had a value `"invalid"` which was not part of the allowedValues: ["global","docker","install","hermit"]',
+          },
+        ]);
       });
 
       it('baseDir', async () => {
@@ -2480,7 +2494,12 @@ describe('config/validation', () => {
             topic: 'Configuration Error',
           },
         ]);
-        expect(errors).toBeEmptyArray();
+        expect(errors).toMatchObject([
+          {
+            message:
+              'Invalid requireConfig: requireConfig had a value `"invalid"` which was not part of the allowedValues: ["required","optional","ignored"]',
+          },
+        ]);
       });
 
       it('dryRun', async () => {
@@ -2498,7 +2517,12 @@ describe('config/validation', () => {
             topic: 'Configuration Error',
           },
         ]);
-        expect(errors).toBeEmptyArray();
+        expect(errors).toMatchObject([
+          {
+            message:
+              'Invalid dryRun: dryRun had a value `"invalid"` which was not part of the allowedValues: ["extract","lookup","full"]',
+          },
+        ]);
       });
 
       it('repositoryCache', async () => {
@@ -2516,7 +2540,12 @@ describe('config/validation', () => {
             topic: 'Configuration Error',
           },
         ]);
-        expect(errors).toBeEmptyArray();
+        expect(errors).toMatchObject([
+          {
+            message:
+              'Invalid repositoryCache: repositoryCache had a value `"invalid"` which was not part of the allowedValues: ["disabled","enabled","reset"]',
+          },
+        ]);
       });
 
       it('onboardingConfigFileName', async () => {
@@ -2597,14 +2626,19 @@ describe('config/validation', () => {
           'global',
           config,
         );
-        expect(warnings).toEqual([
+        expect(warnings).toMatchObject([
           {
             message:
               'Invalid value `invalid` for `gitUrl`. The allowed values are default, ssh, endpoint.',
+          },
+        ]);
+        expect(errors).toMatchObject([
+          {
+            message:
+              'Invalid gitUrl: gitUrl had a value `"invalid"` which was not part of the allowedValues: ["default","ssh","endpoint"]',
             topic: 'Configuration Error',
           },
         ]);
-        expect(errors).toBeEmptyArray();
       });
     });
 
@@ -2674,12 +2708,18 @@ describe('config/validation', () => {
             'Invalid value `1` for `mergeConfidenceDatasources`. The allowed values are go, maven, npm, nuget, packagist, pypi, rubygems.',
         },
         {
+          topic: 'Configuration Error',
           message:
             'Invalid value for `gitNoVerify`. The allowed values are commit, push.',
+        },
+      ]);
+      expect(errors).toMatchObject([
+        {
+          message:
+            'Invalid gitNoVerify: gitNoVerify had invalid values `["invalid"]` which are not part of the allowedValues: ["commit","push"]',
           topic: 'Configuration Error',
         },
       ]);
-      expect(errors).toBeEmptyArray();
     });
 
     it('validates object type options', async () => {
@@ -2964,6 +3004,109 @@ describe('config/validation', () => {
           topic: 'Configuration Error',
         },
       ]);
+    });
+
+    describe('allowedValues are validated', () => {
+      it('with repo config', async () => {
+        const config: Partial<RenovateConfig> = {
+          // for a single value
+          // @ts-expect-error: contains invalid values
+          mode: 'not-valid',
+          // for an array
+          postUpdateOptions: ['invalid', 'another'],
+          hostRules: [
+            {
+              // this is allowed, as it's the default value
+              artifactAuth: null,
+            },
+          ],
+          packageRules: [
+            // valid and a regex: versioning scheme
+            {
+              matchDepNames: ['/.*/'],
+              versioning: 'regex:^(?<major>1)',
+            },
+            // valid and part of allowedValues
+            {
+              matchDepNames: ['/.*/'],
+              versioning: 'maven',
+            },
+            // invalid, using an unknown option
+            {
+              matchDepNames: ['/.*/'],
+              versioning: 'not-ever-valid-scheme',
+            },
+          ],
+          bumpVersions: [
+            {
+              filePatterns: [],
+              matchStrings: [],
+              bumpType: '{{#if isPatch}}patch{{else}}minor{{/if}}',
+            },
+          ],
+        };
+        const { warnings, errors } = await configValidation.validateConfig(
+          'repo',
+          config,
+          true,
+        );
+        expect(warnings).toBeEmptyArray();
+        expect(errors).toMatchObject([
+          {
+            message:
+              'Invalid mode: mode had a value `"not-valid"` which was not part of the allowedValues: ["full","silent"]',
+            topic: 'Configuration Error',
+          },
+          {
+            message:
+              'Invalid packageRules[2].versioning: versioning had invalid value `"not-ever-valid-scheme"`. versioning can only be a known versioning scheme, or be a string starting with `regex:` for custom regular expression versioning',
+            topic: 'Configuration Error',
+          },
+          {
+            message:
+              'Invalid postUpdateOptions: postUpdateOptions had invalid values `["invalid","another"]` which are not part of the allowedValues: ["bundlerConservative","composerWithAll","composerNoMinimalChanges","dotnetWorkloadRestore","gomodMassage","gomodTidy","gomodTidy1.17","gomodTidyE","gomodUpdateImportPaths","gomodSkipVendor","gomodVendor","goGenerate","helmUpdateSubChartArchives","kustomizeInflateHelmCharts","npmDedupe","npmInstallTwice","pnpmDedupe","yarnDedupeFewer","yarnDedupeHighest"]',
+            topic: 'Configuration Error',
+          },
+        ]);
+      });
+
+      it('with global config', async () => {
+        const config: Partial<AllConfig> = {
+          // for a single value
+          // @ts-expect-error: contains invalid values
+          autodiscoverRepoOrder: 'middle-out',
+
+          // for an array
+          // @ts-expect-error: contains invalid values
+          allowedUnsafeExecutions: ['some', 'value'],
+
+          repositories: [
+            {
+              // @ts-expect-error: contains invalid values
+              allowedUnsafeExecutions: ['some', 'value'],
+            },
+          ],
+        };
+        const { warnings, errors } = await configValidation.validateConfig(
+          'global',
+          config,
+        );
+        expect(warnings).toBeEmptyArray();
+        expect(errors).toMatchObject([
+          {
+            message:
+              'Invalid allowedUnsafeExecutions: allowedUnsafeExecutions had invalid values `["some","value"]` which are not part of the allowedValues: ["bazelModDeps","goGenerate","gradleWrapper","mise"]',
+          },
+          {
+            message:
+              'Invalid autodiscoverRepoOrder: autodiscoverRepoOrder had a value `"middle-out"` which was not part of the allowedValues: ["asc","desc"]',
+          },
+          {
+            message:
+              'Invalid repositories[0].allowedUnsafeExecutions: allowedUnsafeExecutions had invalid values `["some","value"]` which are not part of the allowedValues: ["bazelModDeps","goGenerate","gradleWrapper","mise"]',
+          },
+        ]);
+      });
     });
 
     describe('cacheTtlOverride', () => {

--- a/lib/config/validation.spec.ts
+++ b/lib/config/validation.spec.ts
@@ -151,40 +151,6 @@ describe('config/validation', () => {
       expect(errors).toBeEmptyArray();
     });
 
-    it('does not warn for valid platformConfig', async () => {
-      const config = {
-        platformConfig: 'auto',
-      };
-      const { warnings, errors } = await configValidation.validateConfig(
-        'repo',
-        // @ts-expect-error -- TODO: What is `platformConfig` type?
-        config,
-      );
-      expect(warnings).toBeEmptyArray();
-      expect(errors).toMatchObject([
-        {
-          message: 'Invalid configuration option: platformConfig',
-        },
-      ]);
-    });
-
-    it('warns for invalid platformConfig', async () => {
-      const config = {
-        platformConfig: 'invalid',
-      };
-      const { errors, warnings } = await configValidation.validateConfig(
-        'repo',
-        // @ts-expect-error -- TODO: What is `platformConfig` type?
-        config,
-      );
-      expect(errors).toMatchObject([
-        {
-          message: 'Invalid configuration option: platformConfig',
-        },
-      ]);
-      expect(warnings).toBeEmptyArray();
-    });
-
     it('catches invalid templates', async () => {
       const config = {
         commitMessage: '{{{something}}',

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -820,6 +820,8 @@ export async function validateConfig(
         }
       }
     }
+
+    validateAllowedValues(key, val, currentPath, errors);
   }
 
   function sortAll(a: ValidationMessage, b: ValidationMessage): number {
@@ -1036,6 +1038,40 @@ async function validateGlobalConfig(
           message: `Configuration option \`${currentPath}\` should be a JSON object.`,
         });
       }
+    }
+  }
+
+  validateAllowedValues(key, val, currentPath, errors);
+}
+
+function validateAllowedValues(
+  key: string,
+  val: any,
+  currentPath: string | undefined,
+  errors: ValidationMessage[],
+): void {
+  const option = options.find((o) => o.name === key);
+  if (!option) {
+    return;
+  }
+
+  const allowedValues = option?.allowedValues;
+  if (allowedValues?.length) {
+    if (val === null && option.default === null) {
+      // do nothing
+    } else if (isArray(val, isString)) {
+      const invalidOptions = val.filter((v) => !allowedValues.includes(v));
+      if (invalidOptions.length) {
+        errors.push({
+          topic: 'Configuration Error',
+          message: `Invalid ${currentPath}: ${option.name} had invalid values \`${JSON.stringify(invalidOptions)}\` which are not part of the allowedValues: ${JSON.stringify(option.allowedValues)}`,
+        });
+      }
+    } else if (key !== 'versioning' && !allowedValues.includes(val)) {
+      errors.push({
+        topic: 'Configuration Error',
+        message: `Invalid ${currentPath}: ${option.name} had a value \`${JSON.stringify(val)}\` which was not part of the allowedValues: ${JSON.stringify(option.allowedValues)}`,
+      });
     }
   }
 }

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -1056,6 +1056,19 @@ async function validateGlobalConfig(
       }
     } else if (type === 'array') {
       if (isArray(val)) {
+        for (const [subIndex, subval] of val.entries()) {
+          if (isObject(subval)) {
+            const subValidation = await validateConfig(
+              'global',
+              subval as AllConfig,
+              false,
+              `${currentPath}[${subIndex}]`,
+            );
+            warnings.push(...subValidation.warnings);
+            errors.push(...subValidation.errors);
+          }
+        }
+
         if (isRegexOrGlobOption(key)) {
           warnings.push(
             ...regexOrGlobValidator.check({

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -922,6 +922,8 @@ export async function validateConfig(
         }
       }
     }
+
+    validateAllowedValues(key, val, currentPath, errors);
   }
 
   function sortAll(a: ValidationMessage, b: ValidationMessage): number {
@@ -1166,6 +1168,8 @@ async function validateGlobalConfig(
       }
     }
   }
+
+  validateAllowedValues(key, val, currentPath, errors);
 }
 
 function getPossibleConfigFileNames({
@@ -1181,4 +1185,45 @@ function getPossibleConfigFileNames({
   }
 
   return filenames;
+}
+
+function validateAllowedValues(
+  key: string,
+  val: any,
+  currentPath: string | undefined,
+  errors: ValidationMessage[],
+): void {
+  const option = options.find((o) => o.name === key);
+  if (!option) {
+    return;
+  }
+
+  const allowedValues = option?.allowedValues;
+  if (allowedValues?.length) {
+    if (val === null && option.default === null) {
+      // do nothing
+    } else if (isArray(val, isString)) {
+      const invalidOptions = val.filter((v) => !allowedValues.includes(v));
+      if (invalidOptions.length) {
+        errors.push({
+          topic: 'Configuration Error',
+          message: `Invalid ${currentPath}: ${option.name} had invalid values \`${JSON.stringify(invalidOptions)}\` which are not part of the allowedValues: ${JSON.stringify(option.allowedValues)}`,
+        });
+      }
+    } else if (isString(val)) {
+      if (key === 'versioning') {
+        if (!allowedValues.includes(val) && !val.startsWith('regex:')) {
+          errors.push({
+            topic: 'Configuration Error',
+            message: `Invalid ${currentPath}: ${option.name} had invalid value \`${JSON.stringify(val)}\`. ${option.name} can only be a known versioning scheme, or be a string starting with \`regex:\` for custom regular expression versioning`,
+          });
+        }
+      } else if (!allowedValues.includes(val) && !option.supportsTemplating) {
+        errors.push({
+          topic: 'Configuration Error',
+          message: `Invalid ${currentPath}: ${option.name} had a value \`${JSON.stringify(val)}\` which was not part of the allowedValues: ${JSON.stringify(option.allowedValues)}`,
+        });
+      }
+    }
+  }
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes







To make sure that we provide faster feedback for users, we should
validate that for options that have an `allowedValues` set, we validate
the option according to the value.

We also need to:

- handle a single option value
- handle an array of option values
- handle when a default (`null`) option is used, as that won't match
  `allowedValues`
- handle when a `supportsTemplating` config option is used alongside
  `allowedValues`
- add a special case to handle `packageRule.versioning` differently, as
  it may have a `regex:` value which isn't technically in the
  `allowedValues`

This adds a number of extra errors for some validation that is already
happening for specific options' values, which we'll follow-up and remove
the duplication for.

This also makes sure that we validate this for both repository config
and global config.






## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
