### PR TITLE
feat(pip-compile): Support more `uv pip compile` options

### DIFF
--- a/lib/modules/manager/pip-compile/common.spec.ts
+++ b/lib/modules/manager/pip-compile/common.spec.ts
@@ -45,6 +45,30 @@ describe('modules/manager/pip-compile/common', () => {
       expect(logger.warn).toHaveBeenCalledTimes(0);
     });
 
+    it.each([
+      '-v',
+      '--all-extras',
+      '--generate-hashes',
+      '--output-file=reqs.txt',
+      '--extra-index-url=https://pypi.org/simple',
+      // uv-specific options
+      `--no-strip-extras`,
+      '--universal',
+      '--constraints=constraints.txt',
+      '--python-version=3.13',
+      '--no-emit-package=cffi',
+      '--prerelease=if-necessary',
+      '--format=pylock.toml',
+    ])('returns object on correct uv options', (argument: string) => {
+      expect(
+        extractHeaderCommand(
+          getCommandInHeader(`uv pip compile ${argument} reqs.in`),
+          'reqs.txt',
+        ),
+      ).toBeObject();
+      expect(logger.warn).toHaveBeenCalledTimes(0);
+    });
+
     it.each(['--resolver', '--output-file reqs.txt', '--extra = jupyter'])(
       'errors on malformed options with argument',
       (argument: string) => {

--- a/lib/modules/manager/pip-compile/common.spec.ts
+++ b/lib/modules/manager/pip-compile/common.spec.ts
@@ -59,6 +59,10 @@ describe('modules/manager/pip-compile/common', () => {
       '--no-emit-package=cffi',
       '--prerelease=if-necessary',
       '--format=pylock.toml',
+      '--resolution=lowest',
+      '--fork-strategy=fewest',
+      '--exclude-newer=2025-11-01',
+      '--exclude-newer-package="tqdm=2022-04-04T00:00:00Z"',
     ])('returns object on correct uv options', (argument: string) => {
       expect(
         extractHeaderCommand(

--- a/lib/modules/manager/pip-compile/common.ts
+++ b/lib/modules/manager/pip-compile/common.ts
@@ -128,6 +128,8 @@ const uvOptionsWithArguments = [
   '--constraints',
   '--python-version',
   '--no-emit-package',
+  '--prerelease',
+  '--format',
   ...commonOptionsWithArguments,
 ];
 export const optionsWithArguments = [
@@ -139,10 +141,10 @@ const allowedCommonOptions = [
   '--generate-hashes',
   '--emit-index-url',
   '--index-url',
+  '--all-extras',
 ];
 export const allowedOptions: Record<CommandType, string[]> = {
   'pip-compile': [
-    '--all-extras',
     '--allow-unsafe',
     '--generate-hashes',
     '--no-emit-index-url',

--- a/lib/modules/manager/pip-compile/common.ts
+++ b/lib/modules/manager/pip-compile/common.ts
@@ -130,6 +130,10 @@ const uvOptionsWithArguments = [
   '--no-emit-package',
   '--prerelease',
   '--format',
+  '--resolution',
+  '--fork-strategy',
+  '--exclude-newer',
+  '--exclude-newer-package',
   ...commonOptionsWithArguments,
 ];
 export const optionsWithArguments = [


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Namely: `--prerelease`, `--format` and `--all-extras` (this last one previous only specific to `pip-compile`).

UPDATE: I also added `--resolution`, `--fork-strategy`, `--exclude-newer` and `exclude-newer-package` (https://github.com/renovatebot/renovate/pull/37608 was closed for some reason).

<details><summary>Full uv 0.9.7 uv pip compile options</summary>
<p>

```
Compile a `requirements.in` file to a `requirements.txt` or `pylock.toml` file

Usage: uv pip compile [OPTIONS] <SRC_FILE|--group <GROUP>>

Arguments:
  [SRC_FILE]...  Include the packages listed in the given files

Options:
  -c, --constraints <CONSTRAINTS>
          Constrain versions using the given requirements files [env: UV_CONSTRAINT=]
      --overrides <OVERRIDES>
          Override versions using the given requirements files [env: UV_OVERRIDE=]
  -b, --build-constraints <BUILD_CONSTRAINTS>
          Constrain build dependencies using the given requirements files when building source
          distributions [env: UV_BUILD_CONSTRAINT=]
      --extra <EXTRA>
          Include optional dependencies from the specified extra name; may be provided more than
          once
      --all-extras
          Include all optional dependencies
      --group <GROUP>
          Install the specified dependency group from a `pyproject.toml`
      --no-deps
          Ignore package dependencies, instead only add those packages explicitly listed on the
          command line to the resulting requirements file
  -o, --output-file <OUTPUT_FILE>
          Write the compiled requirements to the given `requirements.txt` or `pylock.toml` file
      --format <FORMAT>
          The format in which the resolution should be output [possible values: requirements.txt,
          pylock.toml]
      --no-strip-extras
          Include extras in the output file
      --no-strip-markers
          Include environment markers in the output file
      --no-annotate
          Exclude comment annotations indicating the source of each package
      --no-header
          Exclude the comment header at the top of the generated output file
      --annotation-style <ANNOTATION_STYLE>
          The style of the annotation comments included in the output file, used to indicate the
          source of each package [possible values: line, split]
      --custom-compile-command <CUSTOM_COMPILE_COMMAND>
          The header comment to include at the top of the output file generated by `uv pip compile`
          [env: UV_CUSTOM_COMPILE_COMMAND=]
      --system
          Install packages into the system Python environment [env: UV_SYSTEM_PYTHON=]
      --generate-hashes
          Include distribution hashes in the output file
      --no-build
          Don't build source distributions
      --no-binary <NO_BINARY>
          Don't install pre-built wheels
      --only-binary <ONLY_BINARY>
          Only use pre-built wheels; don't build source distributions
      --python-platform <PYTHON_PLATFORM>
          The platform for which requirements should be resolved [possible values: windows, linux,
          macos, x86_64-pc-windows-msvc, aarch64-pc-windows-msvc, i686-pc-windows-msvc,
          x86_64-unknown-linux-gnu, aarch64-apple-darwin, x86_64-apple-darwin,
          aarch64-unknown-linux-gnu, aarch64-unknown-linux-musl, x86_64-unknown-linux-musl,
          riscv64-unknown-linux, x86_64-manylinux2014, x86_64-manylinux_2_17,
          x86_64-manylinux_2_28, x86_64-manylinux_2_31, x86_64-manylinux_2_32,
          x86_64-manylinux_2_33, x86_64-manylinux_2_34, x86_64-manylinux_2_35,
          x86_64-manylinux_2_36, x86_64-manylinux_2_37, x86_64-manylinux_2_38,
          x86_64-manylinux_2_39, x86_64-manylinux_2_40, aarch64-manylinux2014,
          aarch64-manylinux_2_17, aarch64-manylinux_2_28, aarch64-manylinux_2_31,
          aarch64-manylinux_2_32, aarch64-manylinux_2_33, aarch64-manylinux_2_34,
          aarch64-manylinux_2_35, aarch64-manylinux_2_36, aarch64-manylinux_2_37,
          aarch64-manylinux_2_38, aarch64-manylinux_2_39, aarch64-manylinux_2_40,
          aarch64-linux-android, x86_64-linux-android, wasm32-pyodide2024, arm64-apple-ios,
          arm64-apple-ios-simulator, x86_64-apple-ios-simulator]
      --universal
          Perform a universal resolution, attempting to generate a single `requirements.txt` output
          file that is compatible with all operating systems, architectures, and Python
          implementations
      --no-emit-package <NO_EMIT_PACKAGE>
          Specify a package to omit from the output resolution. Its dependencies will still be
          included in the resolution. Equivalent to pip-compile's `--unsafe-package` option
      --emit-index-url
          Include `--index-url` and `--extra-index-url` entries in the generated output file
      --emit-find-links
          Include `--find-links` entries in the generated output file
      --emit-build-options
          Include `--no-binary` and `--only-binary` entries in the generated output file
      --emit-index-annotation
          Include comment annotations indicating the index used to resolve each package (e.g., `#
          from https://pypi.org/simple`)
      --torch-backend <TORCH_BACKEND>
          The backend to use when fetching packages in the PyTorch ecosystem (e.g., `cpu`, `cu126`,
          or `auto`) [env: UV_TORCH_BACKEND=] [possible values: auto, cpu, cu130, cu129, cu128,
          cu126, cu125, cu124, cu123, cu122, cu121, cu120, cu118, cu117, cu116, cu115, cu114,
          cu113, cu112, cu111, cu110, cu102, cu101, cu100, cu92, cu91, cu90, cu80, rocm6.3,
          rocm6.2.4, rocm6.2, rocm6.1, rocm6.0, rocm5.7, rocm5.6, rocm5.5, rocm5.4.2, rocm5.4,
          rocm5.3, rocm5.2, rocm5.1.1, rocm4.2, rocm4.1, rocm4.0.1, xpu]

Index options:
      --index <INDEX>
          The URLs to use when resolving dependencies, in addition to the default index [env:
          UV_INDEX=]
      --default-index <DEFAULT_INDEX>
          The URL of the default package index (by default: <https://pypi.org/simple>) [env:
          UV_DEFAULT_INDEX=]
  -i, --index-url <INDEX_URL>
          (Deprecated: use `--default-index` instead) The URL of the Python package index (by
          default: <https://pypi.org/simple>) [env: UV_INDEX_URL=]
      --extra-index-url <EXTRA_INDEX_URL>
          (Deprecated: use `--index` instead) Extra URLs of package indexes to use, in addition to
          `--index-url` [env: UV_EXTRA_INDEX_URL=]
  -f, --find-links <FIND_LINKS>
          Locations to search for candidate distributions, in addition to those found in the
          registry indexes [env: UV_FIND_LINKS=]
      --no-index
          Ignore the registry index (e.g., PyPI), instead relying on direct URL dependencies and
          those provided via `--find-links`
      --index-strategy <INDEX_STRATEGY>
          The strategy to use when resolving against multiple index URLs [env: UV_INDEX_STRATEGY=]
          [possible values: first-index, unsafe-first-match, unsafe-best-match]
      --keyring-provider <KEYRING_PROVIDER>
          Attempt to use `keyring` for authentication for index URLs [env: UV_KEYRING_PROVIDER=]
          [possible values: disabled, subprocess]

Resolver options:
  -U, --upgrade
          Allow package upgrades, ignoring pinned versions in any existing output file. Implies
          `--refresh`
  -P, --upgrade-package <UPGRADE_PACKAGE>
          Allow upgrades for a specific package, ignoring pinned versions in any existing output
          file. Implies `--refresh-package`
      --resolution <RESOLUTION>
          The strategy to use when selecting between the different compatible versions for a given
          package requirement [env: UV_RESOLUTION=] [possible values: highest, lowest,
          lowest-direct]
      --prerelease <PRERELEASE>
          The strategy to use when considering pre-release versions [env: UV_PRERELEASE=] [possible
          values: disallow, allow, if-necessary, explicit, if-necessary-or-explicit]
      --fork-strategy <FORK_STRATEGY>
          The strategy to use when selecting multiple versions of a given package across Python
          versions and platforms [env: UV_FORK_STRATEGY=] [possible values: fewest,
          requires-python]
      --exclude-newer <EXCLUDE_NEWER>
          Limit candidate packages to those that were uploaded prior to the given date [env:
          UV_EXCLUDE_NEWER=]
      --exclude-newer-package <EXCLUDE_NEWER_PACKAGE>
          Limit candidate packages for a specific package to those that were uploaded prior to the
          given date
      --no-sources
          Ignore the `tool.uv.sources` table when resolving dependencies. Used to lock against the
          standards-compliant, publishable package metadata, as opposed to using any workspace,
          Git, URL, or local path sources

Build options:
  -C, --config-setting <CONFIG_SETTING>
          Settings to pass to the PEP 517 build backend, specified as `KEY=VALUE` pairs
      --config-settings-package <CONFIG_SETTINGS_PACKAGE>
          Settings to pass to the PEP 517 build backend for a specific package, specified as
          `PACKAGE:KEY=VALUE` pairs
      --no-build-isolation
          Disable isolation when building source distributions [env: UV_NO_BUILD_ISOLATION=]
      --no-build-isolation-package <NO_BUILD_ISOLATION_PACKAGE>
          Disable isolation when building source distributions for a specific package

Installer options:
      --link-mode <LINK_MODE>  The method to use when installing packages from the global cache
                               [env: UV_LINK_MODE=] [possible values: clone, copy, hardlink,
                               symlink]

Cache options:
  -n, --no-cache
          Avoid reading from or writing to the cache, instead using a temporary directory for the
          duration of the operation [env: UV_NO_CACHE=]
      --cache-dir <CACHE_DIR>
          Path to the cache directory [env: UV_CACHE_DIR=]
      --refresh
          Refresh all cached data
      --refresh-package <REFRESH_PACKAGE>
          Refresh cached data for a specific package

Python options:
  -p, --python <PYTHON>
          The Python interpreter to use during resolution.
      --python-version <PYTHON_VERSION>
          The Python version to use for resolution
      --managed-python
          Require use of uv-managed Python versions [env: UV_MANAGED_PYTHON=]
      --no-managed-python
          Disable use of uv-managed Python versions [env: UV_NO_MANAGED_PYTHON=]
      --no-python-downloads
          Disable automatic downloads of Python. [env: "UV_PYTHON_DOWNLOADS=never"]

Global options:
  -q, --quiet...
          Use quiet output
  -v, --verbose...
          Use verbose output
      --color <COLOR_CHOICE>
          Control the use of color in output [possible values: auto, always, never]
      --native-tls
          Whether to load TLS certificates from the platform's native certificate store [env:
          UV_NATIVE_TLS=]
      --offline
          Disable network access [env: UV_OFFLINE=]
      --allow-insecure-host <ALLOW_INSECURE_HOST>
          Allow insecure connections to a host [env: UV_INSECURE_HOST=]
      --no-progress
          Hide all progress outputs [env: UV_NO_PROGRESS=]
      --directory <DIRECTORY>
          Change to the given directory prior to running the command [env: UV_WORKING_DIRECTORY=]
      --project <PROJECT>
          Run the command within the given project directory [env: UV_PROJECT=]
      --config-file <CONFIG_FILE>
          The path to a `uv.toml` file to use for configuration [env: UV_CONFIG_FILE=]
  -h, --help
          Display the concise help for this command

Use `uv help pip compile` for more details.
```

</p>
</details> 

## Context

Please select one of the below:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
