### PR TITLE
feat: add configValidationError option to log config validation errors as errors instead of warnings

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -798,6 +798,10 @@ After we changed the [`baseBranchPatterns`](#basebranchpatterns) feature, the Re
 
 For more details, read the [config migration documentation](./config-migration.md).
 
+## configValidationError
+
+If enabled, config validation errors will be reported as errors instead of warnings, and Renovate will exit with a non-zero exit code.
+
 ## configWarningReuseIssue
 
 If no existing issue is found, Renovate's default behavior is to create a new Config Warning issue.

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -798,10 +798,6 @@ After we changed the [`baseBranchPatterns`](#basebranchpatterns) feature, the Re
 
 For more details, read the [config migration documentation](./config-migration.md).
 
-## configValidationError
-
-If enabled, config validation errors will be reported as errors instead of warnings, and Renovate will exit with a non-zero exit code.
-
 ## configWarningReuseIssue
 
 If no existing issue is found, Renovate's default behavior is to create a new Config Warning issue.

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -486,6 +486,10 @@ Example:
 !!! note
     If you want renovate to use a custom filename for the onboarding branch you also need to change the [`onboardingConfigFileName`](#onboardingconfigfilename).
 
+## configValidationError
+
+If enabled, config validation errors will be reported as errors instead of warnings, and Renovate will exit with a non-zero exit code.
+
 ## containerbaseDir
 
 This directory is used to cache downloads when `binarySource=docker` or `binarySource=install`.

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -3261,6 +3261,14 @@ const options: RenovateOptions[] = [
     default: false,
     globalOnly: true,
   },
+  {
+    name: 'configValidationError',
+    description:
+      'If enabled, config validation errors will be reported as errors instead of warnings, and Renovate will exit with a non-zero exit code.',
+    type: 'boolean',
+    default: false,
+    globalOnly: true,
+  },
 ];
 
 export function getOptions(): RenovateOptions[] {

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -50,6 +50,7 @@ export interface RenovateSharedConfig {
   commitMessagePrefix?: string;
   commitMessageTopic?: string;
   confidential?: boolean;
+  configValidationError?: boolean;
   changelogUrl?: string;
   dependencyDashboardApproval?: boolean;
   draftPR?: boolean;

--- a/lib/workers/repository/error.ts
+++ b/lib/workers/repository/error.ts
@@ -130,7 +130,11 @@ export default async function handleError(
   }
   if (err.message === CONFIG_VALIDATION) {
     delete config.branchList;
-    logger.warn({ error: err }, 'Repository has invalid config');
+    if (config.configValidationError) {
+      logger.error({ error: err }, 'Repository has invalid config');
+    } else {
+      logger.warn({ error: err }, 'Repository has invalid config');
+    }
     await raiseConfigWarningIssue(config, err);
     return err.message;
   }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Added an option called `configValidationError`. When this is set to true, config validation errors will be logged as errors instead of warnings. As a result, if there are config validation errors, Renovate will exit with a non-zero exit code.

## Context

Please select one of the below:

- [x] This closes an existing Issue, Closes: #24891
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: N/A (repository was private)

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
