### PR TITLE
fix(presets): set source url for timberio/vector

### DIFF
--- a/lib/data/source-urls.json
+++ b/lib/data/source-urls.json
@@ -30,6 +30,7 @@
     "mcr.microsoft.com/dotnet/sdk": "https://github.com/dotnet/sdk",
     "node": "https://github.com/nodejs/node",
     "registry": "https://github.com/distribution/distribution",
+    "timberio/vector": "https://github.com/vectordotdev/vector",
     "traefik": "https://github.com/containous/traefik",
     "kudobuilder/kuttl": "https://github.com/kudobuilder/kuttl",
     "prom/blackbox-exporter": "https://github.com/prometheus/blackbox_exporter",


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Add an explicit rule for Vector changelog.  `latest` is not provided and even after my PR for adding the OCI label, it does not work.  Ref. the output under that did not find a newer tag.

Notice it's from 2023.  However, there is a `latest-debian` tag that is updated regularly.  But, we don't look for ut.

## Context

```
DEBUG: getLabels(https://index.docker.io, timberio/vector, 2023-01-27_backport_dd_metrics_interval_fix-distroless-libc) (repository=local)
DEBUG: getManifestResponse(https://index.docker.io, timberio/vector, 2023-01-27_backport_dd_metrics_interval_fix-distroless-libc, getText) (repository=local)
DEBUG: http cache: saving https://auth.docker.io/token?scope=repository%3Atimberio%2Fvector%3Apull&service=registry.docker.io (etag=undefined, lastModified=undefined) (repository=local)
DEBUG: http cache: saving https://index.docker.io/v2/timberio/vector/manifests/2023-01-27_backport_dd_metrics_interval_fix-distroless-libc (etag="sha256:65c2addba58b34ce459bada3a2b7e2e69bb4ce2d6cb0145235597535a2d86317", lastModified=undefined) (repository=local)
DEBUG: found labels in manifest (repository=local)
       "labels": {}
```       

### Diff in runs:

```json
                 "versioning": "docker",
                 "warnings": [],
                 "sourceUrl": "https://github.com/vectordotdev/vector",
                 "registryUrl": "https://index.docker.io",
                 "changelogUrl": "https://github.com/vectordotdev/vector",
                 "currentVersion": "0.50.0",
                 "currentVersionTimestamp": "2025-09-23T15:06:25.450Z",
                 "currentVersionAgeInDays": 46,
                 "isSingleVersion": true,
                 "fixedVersion": "0.50.0-debian"
```

vs. 

```json
                 "versioning": "docker",
                 "warnings": [],
                 "registryUrl": "https://index.docker.io",
                 "currentVersion": "0.50.0",
                 "currentVersionTimestamp": "2025-09-23T15:06:25.450Z",
                 "currentVersionAgeInDays": 46,
                 "isSingleVersion": true,
                 "fixedVersion": "0.50.0-debian"
```

I don't of there is really another way to doing it without adding a rule in every user repo. 🤷🏻‍♂️ 

Please select one of the below:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/MindTooth/renovate-docker-test/blob/master/Containerfile

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
