### PR TITLE
fix: ignore .npmrc when the npmrc configuration is being used

### DIFF
--- a/lib/workers/repository/update/branch/execute-post-upgrade-commands.spec.ts
+++ b/lib/workers/repository/update/branch/execute-post-upgrade-commands.spec.ts
@@ -303,6 +303,54 @@ describe('workers/repository/update/branch/execute-post-upgrade-commands', () =>
       );
     });
 
+    it('excludes .npmrc files when npmrc config is present', async () => {
+      const commands = partial<BranchUpgradeConfig>([
+        {
+          manager: 'npm',
+          branchName: 'main',
+          postUpgradeTasks: {
+            executionMode: 'update',
+            commands: ['echo test'],
+            fileFilters: ['**/*'],
+          },
+        },
+      ]);
+      const config: BranchConfig = {
+        manager: 'npm',
+        updatedPackageFiles: [
+          { type: 'addition', path: 'package.json', contents: '{}' },
+        ],
+        npmrc: 'registry=https://example.com',
+        upgrades: [],
+        branchName: 'main',
+        baseBranch: 'base',
+      };
+
+      git.getRepoStatus.mockResolvedValueOnce(
+        partial<StatusResult>({
+          modified: [],
+          not_added: ['.npmrc', 'other-file.txt'],
+          deleted: [],
+        }),
+      );
+
+      const localDir = upath.join(tmpDir.path, 'local');
+      GlobalConfig.set({ localDir, allowedCommands: ['echo test'] });
+
+      fs.localPathIsFile.mockResolvedValue(true);
+      fs.localPathExists.mockResolvedValue(true);
+      fs.readLocalFile.mockResolvedValueOnce('some content');
+
+      const res = await postUpgradeCommands.postUpgradeCommandsExecutor(
+        commands,
+        config,
+      );
+
+      expect(res.updatedArtifacts).toHaveLength(1);
+      expect(res.updatedArtifacts[0].path).toBe('other-file.txt');
+      expect(res.updatedArtifacts[0].type).toBe('addition');
+    });
+
     it('handles previously-deleted files which are re-added', async () => {
       const commands = partial<BranchUpgradeConfig>([
         {

--- a/lib/workers/repository/update/branch/execute-post-upgrade-commands.ts
+++ b/lib/workers/repository/update/branch/execute-post-upgrade-commands.ts
@@ -217,7 +217,20 @@ export async function postUpgradeCommandsExecutor(
         `Checking ${addedOrModifiedFiles.length} added or modified files for post-upgrade changes`,
       );
 
+      const fileExcludes: string[] = [];
+      if (config.npmrc) {
+        fileExcludes.push('.npmrc');
+      }
+
       for (const relativePath of addedOrModifiedFiles) {
+        if (
+          fileExcludes.some((pattern) =>
+            minimatch(pattern, { dot: true }).match(relativePath),
+          )
+        ) {
+          continue;
+        }
+
         let fileMatched = false;
         for (const pattern of fileFilters) {
           if (minimatch(pattern, { dot: true }).match(relativePath)) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Skip adding .npmrc file if the `npmrc` option is deteced

## Context

Please select one of the below:

- [x] This closes an existing Issue, Closes: #38794
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
