### PR TITLE
fix(config/validation): don't allow `global:` presets outside of global configuration

### DIFF
--- a/lib/config/validation.spec.ts
+++ b/lib/config/validation.spec.ts
@@ -1213,6 +1213,58 @@ describe('config/validation', () => {
       expect(warnings).toHaveLength(1);
     });
 
+    it('does not error on use of `global:` presets in `globalExtends`', async () => {
+      const config = {
+        globalExtends: ['global:safeEnv'],
+      };
+      const { warnings, errors } = await configValidation.validateConfig(
+        'global',
+        config,
+        true,
+      );
+      expect(errors).toHaveLength(0);
+      expect(warnings).toHaveLength(0);
+    });
+
+    it('does not error on use of `global:` presets in global `extends`', async () => {
+      const config = {
+        extends: ['global:safeEnv'],
+      };
+      const { warnings, errors } = await configValidation.validateConfig(
+        'global',
+        config,
+        true,
+      );
+      expect(errors).toHaveLength(0);
+      expect(warnings).toHaveLength(0);
+    });
+
+    it('errors on use of `global:` presets in inherit `extends`', async () => {
+      const config = {
+        extends: ['global:safeEnv'],
+      };
+      const { warnings, errors } = await configValidation.validateConfig(
+        'inherit',
+        config,
+        true,
+      );
+      expect(errors).toHaveLength(1);
+      expect(warnings).toHaveLength(0);
+    });
+
+    it('errors on use of `global:` presets in repo `extends`', async () => {
+      const config = {
+        extends: ['global:safeEnv'],
+      };
+      const { warnings, errors } = await configValidation.validateConfig(
+        'repo',
+        config,
+        true,
+      );
+      expect(errors).toHaveLength(1);
+      expect(warnings).toHaveLength(0);
+    });
+
     // adding this test explicitly because we used to validate the customEnvVariables inside repo config previously
     it('warns if customEnvVariables are found in repo config', async () => {
       const config = {

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -341,6 +341,13 @@ export async function validateConfig(
             if (key === 'extends') {
               for (const subval of val) {
                 if (isString(subval)) {
+                  if (configType !== 'global' && subval.startsWith('global:')) {
+                    errors.push({
+                      topic: 'Configuration Error',
+                      message: `${currentPath}: you cannot extend from "global:" presets in a repository config's "extends"`,
+                    });
+                  }
+
                   if (
                     parentName === 'packageRules' &&
                     subval.startsWith('group:')


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
Right now, the `global:safeEnv` preset is the only "global" preset we
have, which allows providing a means to share common used global
self-hosting configuration.

In the future, we will introduce some new global presets, which will
have more (possibly dangerous) configuration that administrators will
need to make sure they are informed of the pros and cons before
enabling.

Before we make this available, we should make sure that there is no
possibility for a repo configuration to extend from `global:`, ensuring
that this can only be set in global configuration's `extends` or
`globalExtends`.

There is currently no gap in security allowing this to be bypassed, or a
way to leverage this right now without making a number of code changes
(to remove other sets of validation).

We mark this as an error to make sure that the repo cannot proceed.


## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
