### PR TITLE
fix(datasource/pypi): sponsors URL vs `sponsors` in project name mixup

### DIFF
--- a/lib/modules/datasource/pypi/common.ts
+++ b/lib/modules/datasource/pypi/common.ts
@@ -1,9 +1,10 @@
 import { regEx } from '../../../util/regex';
 
-const githubRepoPattern = regEx(/^https?:\/\/github\.com\/[^/]+\/[^/]+$/);
+const githubRepoPattern = regEx(/^https?:\/\/github\.com\/([^/]+)\/[^/]+$/);
 
 export function isGitHubRepo(url: string): boolean {
-  return !url.includes('sponsors') && githubRepoPattern.test(url);
+  const m = url.match(githubRepoPattern);
+  return !!m && m[1] !== 'sponsors';
 }
 
 // https://packaging.python.org/en/latest/specifications/name-normalization/

--- a/lib/modules/datasource/pypi/index.spec.ts
+++ b/lib/modules/datasource/pypi/index.spec.ts
@@ -306,6 +306,25 @@ describe('modules/datasource/pypi/index', () => {
       expect(result?.sourceUrl).toBeUndefined();
     });
 
+    it('does not mistake sponsors in project name as sponsors url', async () => {
+      const info = {
+        name: 'example',
+        home_page: 'https://example.com',
+        project_urls: {
+          random: 'https://github.com/renovatebot/example-sponsors',
+        },
+      };
+      httpMock
+        .scope(baseUrl)
+        .get('/example/json')
+        .reply(200, { ...JSON.parse(res1), info });
+      const result = await getPkgReleases({
+        datasource,
+        packageName: 'example',
+      });
+      expect(result?.sourceUrl).toBe(info.project_urls.random);
+    });
+
     it('normalizes the package name according to PEP 503', async () => {
       const expectedHttpCall = httpMock
         .scope(baseUrl)


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Make GitHub project URL sniffing to check user/organization part for `sponsors` only. There are a few PyPI projects for which the previous implementation currently produces false positives.

https://pypi.org/search/?q=sponsors

## Context

Please select one of the below:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
