### PR TITLE
feat(presets): add global preset to allow unsafe actions

### DIFF
--- a/lib/config/presets/internal/global.ts
+++ b/lib/config/presets/internal/global.ts
@@ -3,6 +3,16 @@ import type { GlobalPreset } from '../types';
 /* eslint sort-keys: ["error", "asc", {caseSensitive: false, natural: true}] */
 
 export const presets: Record<string, GlobalPreset> = {
+  allowAllUnsafe: {
+    allowCustomCrateRegistries: true,
+    allowedCommands: ['/.*/'],
+    allowedEnv: ['/.*/'],
+    allowedHeaders: ['/.*/'],
+    allowPlugins: true,
+    allowScripts: true,
+    description:
+      'Set all `allow*` and `allowed*` settings to true. Administrators should think carefully before enabling this for their self-hosted usages, as it will introduce all possible avenues for remote code execution from packages and repo owners alike.',
+  },
   safeEnv: {
     allowedEnv: ['GO*', 'GRADLE_OPTS', 'RUSTC_BOOTSTRAP'],
     description:


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
As a means to more easily support self-hosted administrators who wish
to allowlist certain configuration, we can introduce a new preset,
`global:allowAllUnsafe`, to turn the configuration all on.

We can add a warning - both in the description and the name - to hint to
administrators that they should be /very/ careful when enabling this due
to the additional remote code execution this allows.

Requires #39211 first.

## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
