### PR TITLE
fix(bitbucket-server): better empty pr-cache handling

### DIFF
--- a/lib/modules/platform/bitbucket-server/pr-cache.spec.ts
+++ b/lib/modules/platform/bitbucket-server/pr-cache.spec.ts
@@ -64,7 +64,7 @@ describe('modules/platform/bitbucket-server/pr-cache', () => {
     cache = getCache();
   });
 
-  it('fetches cache', async () => {
+  it('fetches cache - author defined', async () => {
     httpMock
       .scope(urlHost)
       .get(`${urlPath}/rest/api/1.0/projects/SOME/repos/repo/pull-requests`)
@@ -97,6 +97,49 @@ describe('modules/platform/bitbucket-server/pr-cache', () => {
         bitbucketServer: {
           pullRequestsCache: {
             author: 'some-author',
+            items: {
+              '1': prInfo(pr1),
+              '2': prInfo(pr2),
+            },
+            updatedDate: 1547853840016,
+          },
+        },
+      },
+    });
+  });
+
+  it('fetches cache - author undefined', async () => {
+    httpMock
+      .scope(urlHost)
+      .get(`${urlPath}/rest/api/1.0/projects/SOME/repos/repo/pull-requests`)
+      .query(true)
+      .reply(200, { values: [pr1], nextPageStart: 2 })
+      .get(`${urlPath}/rest/api/1.0/projects/SOME/repos/repo/pull-requests`)
+      .query(true)
+      .reply(200, { values: [pr2] });
+
+    const res = await BbsPrCache.getPrs(
+      http,
+      'SOME',
+      'repo',
+      ignorePrAuthor,
+      undefined as never,
+    );
+
+    expect(res).toMatchObject([
+      {
+        number: 2,
+        title: 'title',
+      },
+      {
+        number: 1,
+        title: 'title',
+      },
+    ]);
+    expect(cache).toEqual({
+      platform: {
+        bitbucketServer: {
+          pullRequestsCache: {
             items: {
               '1': prInfo(pr1),
               '2': prInfo(pr2),

--- a/lib/modules/platform/bitbucket-server/pr-cache.ts
+++ b/lib/modules/platform/bitbucket-server/pr-cache.ts
@@ -1,4 +1,4 @@
-import { isString } from '@sindresorhus/is';
+import { isNullOrUndefined, isString } from '@sindresorhus/is';
 import { dequal } from 'dequal';
 import { DateTime } from 'luxon';
 import { logger } from '../../../logger';
@@ -24,7 +24,10 @@ export class BbsPrCache {
     repoCache.platform.bitbucketServer ??= {};
     let pullRequestCache = repoCache.platform.bitbucketServer
       .pullRequestsCache as BbsPrCacheData;
-    if (pullRequestCache?.author !== author) {
+    if (
+      isNullOrUndefined(pullRequestCache) ||
+      pullRequestCache.author !== author
+    ) {
       pullRequestCache = {
         items: {},
         updatedDate: null,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- Init new cache object incase pr cache is not defined, doesn't have defined author
- Add test for this case 
<!-- Describe what behavior is changed by this PR. -->

## Context
- Branched this off from [main PR](https://github.com/renovatebot/renovate/pull/39230) cause some users are already facing issues and the main PR could take some time to get merged. And, this smaller PR can get merged early to fix the issue for users.

- Ref: https://github.com/renovatebot/renovate/discussions/39228
- Ref: https://github.com/renovatebot/renovate/discussions/39237

Please select one of the below:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
