### PR TITLE
feat(bumpVersions): support short versions

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -597,6 +597,14 @@ All messages are prefixed with `bumpVersions` or `bumpVersions(<name>)` to help 
 }
 ```
 
+**short versions**
+
+It's possible to bump short versions:
+
+- `1` -> `2` (major)
+- `1.1` -> `2.0` (major)
+- `1.2` -> `1.3` (minor)
+
 ### bumpType
 
 The `bumpType` field specifies the type of version bump to apply.

--- a/lib/workers/repository/update/branch/bump-versions.spec.ts
+++ b/lib/workers/repository/update/branch/bump-versions.spec.ts
@@ -564,5 +564,133 @@ describe('workers/repository/update/branch/bump-versions', () => {
         ],
       });
     });
+
+    it('should bump major version', async () => {
+      const config = partial<BranchConfig>({
+        bumpVersions: [
+          {
+            filePatterns: ['\\.release-version'],
+            bumpType: 'major',
+            matchStrings: ['^(?<version>.+)$'],
+          },
+        ],
+        updatedPackageFiles: [
+          {
+            type: 'addition',
+            path: 'foo',
+            contents: 'bar',
+          },
+        ],
+      });
+      scm.getFileList.mockResolvedValueOnce(['foo', '.release-version']);
+      fs.readLocalFile.mockResolvedValueOnce('1');
+      await bumpVersions(config);
+
+      expect(config).toMatchObject({
+        updatedArtifacts: [
+          {
+            type: 'addition',
+            path: '.release-version',
+            contents: '2',
+          },
+        ],
+      });
+    });
+
+    it('should bump major/minor version', async () => {
+      const config = partial<BranchConfig>({
+        bumpVersions: [
+          {
+            filePatterns: ['\\.release-version'],
+            bumpType: 'major',
+            matchStrings: ['^(?<version>.+)$'],
+          },
+        ],
+        updatedPackageFiles: [
+          {
+            type: 'addition',
+            path: 'foo',
+            contents: 'bar',
+          },
+        ],
+      });
+      scm.getFileList.mockResolvedValueOnce(['foo', '.release-version']);
+      fs.readLocalFile.mockResolvedValueOnce('1.1');
+      await bumpVersions(config);
+
+      expect(config).toMatchObject({
+        updatedArtifacts: [
+          {
+            type: 'addition',
+            path: '.release-version',
+            contents: '2.0',
+          },
+        ],
+      });
+    });
+
+    it('should bump minor version', async () => {
+      const config = partial<BranchConfig>({
+        bumpVersions: [
+          {
+            filePatterns: ['\\.release-version'],
+            bumpType: 'minor',
+            matchStrings: ['^(?<version>.+)$'],
+          },
+        ],
+        updatedPackageFiles: [
+          {
+            type: 'addition',
+            path: 'foo',
+            contents: 'bar',
+          },
+        ],
+      });
+      scm.getFileList.mockResolvedValueOnce(['foo', '.release-version']);
+      fs.readLocalFile.mockResolvedValueOnce('1.0');
+      await bumpVersions(config);
+
+      expect(config).toMatchObject({
+        updatedArtifacts: [
+          {
+            type: 'addition',
+            path: '.release-version',
+            contents: '1.1',
+          },
+        ],
+      });
+    });
+
+    it('throws for invalid bump type and short version', async () => {
+      const config = partial<BranchConfig>({
+        bumpVersions: [
+          {
+            filePatterns: ['\\.release-version'],
+            bumpType: 'patch',
+            matchStrings: ['^(?<version>.+)$'],
+          },
+        ],
+        updatedPackageFiles: [
+          {
+            type: 'addition',
+            path: 'foo',
+            contents: 'bar',
+          },
+        ],
+      });
+      scm.getFileList.mockResolvedValueOnce(['foo', '.release-version']);
+      fs.readLocalFile.mockResolvedValueOnce('1.0');
+      await bumpVersions(config);
+
+      expect(config).toMatchObject({
+        artifactErrors: [
+          {
+            fileName: '.release-version',
+            stderr:
+              'Failed to calculate new version for bumpVersions: Unsupported bump type for {major}.{minor} version: patch',
+          },
+        ],
+      });
+    });
   });
 });

--- a/lib/workers/repository/update/branch/bump-versions.ts
+++ b/lib/workers/repository/update/branch/bump-versions.ts
@@ -143,7 +143,23 @@ async function bumpVersion(
       let newVersion: string | null = null;
       try {
         const bumpType = compile(rawBumpType, branchConfig);
-        newVersion = inc(version, bumpType as ReleaseType);
+        const parts = regEx('^(?<major>\\d+)(?:\\.(?<minor>\\d+))?$').exec(
+          version,
+        );
+        if (parts?.groups) {
+          const { major, minor } = parts.groups;
+          if (bumpType === 'major') {
+            newVersion = `${parseInt(major) + 1}${minor ? `.0` : ''}`;
+          } else if (bumpType === 'minor') {
+            newVersion = `${major}.${parseInt(minor) + 1}`;
+          } else {
+            throw new Error(
+              `Unsupported bump type for {major}.{minor} version: ${bumpType}`,
+            );
+          }
+        } else {
+          newVersion = inc(version, bumpType as ReleaseType);
+        }
       } catch (e) {
         addArtifactError(
           branchConfig,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Allow bumping short versions:

- `1` -> `2` (major)
- `1.1` -> `2.0` (major)
- `1.2` -> `1.3` (minor)

<!-- Describe what behavior is changed by this PR. -->

## Context
I need this to bump major version of jenkins plugins.

- https://github.com/jenkinsci/gitea-checks-plugin/pull/286
- https://github.com/visualon/renovate-config/blob/main/jenkins.json#L24-L35

Please select one of the below:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
