### PR TITLE
fix(presets): remove `npm` preset file

### DIFF
--- a/lib/config/presets/internal/index.ts
+++ b/lib/config/presets/internal/index.ts
@@ -9,7 +9,6 @@ import * as groupPreset from './group';
 import * as helpersPreset from './helpers';
 import * as mergeConfidence from './merge-confidence';
 import * as monorepoPreset from './monorepos';
-import * as npm from './npm';
 import * as packagesPreset from './packages';
 import * as previewPreset from './preview';
 import * as replacements from './replacements';
@@ -30,7 +29,6 @@ export const groups: Record<string, Record<string, Preset>> = {
   helpers: helpersPreset.presets,
   mergeConfidence: mergeConfidence.presets,
   monorepo: monorepoPreset.presets,
-  npm: npm.presets,
   packages: packagesPreset.presets,
   preview: previewPreset.presets,
   replacements: replacements.presets,

--- a/lib/config/presets/internal/npm.ts
+++ b/lib/config/presets/internal/npm.ts
@@ -1,5 +1,0 @@
-import type { Preset } from '../types';
-
-/* eslint sort-keys: ["error", "asc", {caseSensitive: false, natural: true}] */
-
-export const presets: Record<string, Preset> = {};


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

As we removed the only preset for npm in #38310, it's been flagged by @RahulGautamSingh 
the autogenerated docs page for this preset is now blank:

<img width="1633" height="947" alt="image" src="https://github.com/user-attachments/assets/65d7b35a-9ea0-481e-940c-846156a14ab1" />


The simpler change is to remove the wiring in of the `npm:` presets.

## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
