### PR TITLE
fix: remove references to "bot"

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,4 +2,4 @@ blank_issues_enabled: false
 contact_links:
   - name: Start a discussion
     url: https://github.com/renovatebot/renovate/discussions/new/choose
-    about: Our preferred starting point if you have any questions or suggestions about bot configuration, features or behavior.
+    about: Our preferred starting point if you have any questions or suggestions about configuration, features or behavior.

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -128,4 +128,4 @@ runs:
         git config --global core.autocrlf false
         git config --global core.symlinks true
         git config --global user.email 'renovate@whitesourcesoftware.com'
-        git config --global user.name  'Renovate Bot'
+        git config --global user.name  'Renovate'

--- a/docs/development/configuration.md
+++ b/docs/development/configuration.md
@@ -14,7 +14,7 @@ The above are listed in **_reverse order_** of preference. e.g. CLI values will 
 ### Default Configuration
 
 The default configuration values can be found in [lib/config/options/index.ts](../../lib/config/options/index.ts).
-Options which have `"globalOnly": true` are reserved only for bot global configuration and cannot be configured within repository config files.
+Options which have `"globalOnly": true` are reserved only for global self-hosted configuration and cannot be configured within repository config files.
 
 ### Configuration File
 

--- a/docs/development/issue-labeling.md
+++ b/docs/development/issue-labeling.md
@@ -221,7 +221,7 @@ Add a label `auto:retry-latest` to any Discussion where the user should retry th
 
 </details>
 
-Apply the `self-hosted` label when an issue is applicable only to users who self-administer their own bot.
+Apply the `self-hosted` label when an issue is applicable only to users who self-administer their own Renovate instance.
 
 ## Automated check for Issues with missing labels
 

--- a/docs/development/style-guide.md
+++ b/docs/development/style-guide.md
@@ -4,7 +4,7 @@ This document describes the correct style for user-facing text in the:
 
 - Documentation
 - Error and debug messages
-- Texts created by the bot in issues and pull requests
+- Texts created by Renovate in issues and pull requests
 
 ## Use American English
 

--- a/docs/usage/config-overview.md
+++ b/docs/usage/config-overview.md
@@ -41,9 +41,12 @@ The default config is loaded first, and may be superseded/overridden by the conf
 
 ### Global config
 
-Global config means: the config defined by the person or team responsible for running the bot.
-This is also referred to as "bot config", because it's the config passed to the bot by the person running it.
+Global config means: the config defined by the person or team responsible for running the deployment of Renovate.
+
 Global config can contain config which is "global only" as well as any configuration options which are valid in Inherited config or Repository config.
+
+Previously, this may have been referred to as "bot config", because it is the config passed to Renovate by the person running it.
+We no longer use "bot" terminology, so it is now called "global self-hosted configuration".
 
 If you are an end user of Renovate, for example if you're using the Mend Renovate App, then you don't need to care as much about any global config.
 As a end-user you can not change some settings because those settings are global-only.

--- a/docs/usage/config-presets.md
+++ b/docs/usage/config-presets.md
@@ -132,7 +132,7 @@ It mostly uses Renovate config defaults but adds a few smart customizations such
 ## How to Use Preset Configs
 
 By default, Renovate App's onboarding PR suggests the `["config:recommended"]` preset.
-If you're self hosting, and want to use the `config:recommended` preset, then you must add `"onboardingConfig": { "extends": ["config:recommended"] }` to your bot's config.
+If you're self hosting, and want to use the `config:recommended` preset, then you must add `"onboardingConfig": { "extends": ["config:recommended"] }` to your self-hosted config.
 
 Read the [Full Config Presets](./presets-config.md) page to learn more about our `config:` presets.
 

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -499,7 +499,7 @@ e.g. instead of `renovate/{{parentDir}}-`, configure the template part in `addit
 
 !!! note
   This setting does not change the default _onboarding_ branch name, i.e. `renovate/configure`.
-  If you wish to change that too, you need to also configure the field `onboardingBranch` in your global bot config.
+  If you wish to change that too, you need to also configure the field `onboardingBranch` in your global self-hosted config.
 
 ## `branchPrefixOld`
 
@@ -878,7 +878,7 @@ If enabled, all issues created by Renovate are set as confidential, even in a pu
 If enabled, Renovate raises a pull request when it needs to migrate the Renovate config file.
 Renovate only performs `configMigration` on `.json` and `.json5` files.
 
-We're adding new features to Renovate bot often.
+We're adding new features to Renovate often.
 Often you can keep using your Renovate config and use the new features right away.
 But sometimes you need to update your Renovate configuration.
 To help you with this, Renovate will create config migration pull requests, when you enable `configMigration`.
@@ -1596,7 +1596,7 @@ The Dependency Dashboard categories are only used to visually organize updates w
 ## `dependencyDashboardLabels`
 
 The labels only get updated when the Dependency Dashboard issue updates its content and/or title.
-It is pointless to edit the labels, as Renovate bot restores the labels on each run.
+It is pointless to edit the labels, as Renovate restores the labels on each run.
 
 ## `dependencyDashboardOSVVulnerabilitySummary`
 
@@ -1764,7 +1764,7 @@ This option allows users to specify explicit environment variables values.
 It is valid only as a top-level configuration option and not, for example, within `packageRules`.
 
 !!! warning
-  The bot administrator must configure a list of allowed environment names in the [`allowedEnv`](./self-hosted-configuration.md#allowedenv) config option, before users can use those allowed names in the `env` option.
+  The administrator of your Renovate deployment must configure a list of allowed environment names in the [`allowedEnv`](./self-hosted-configuration.md#allowedenv) config option, before users can use those allowed names in the `env` option.
 
 Behavior:
 
@@ -2024,7 +2024,7 @@ For more details on the syntax and supported patterns, see Renovate's [string pa
 
 ## `gitLabIgnoreApprovals`
 
-Ignore the default project level approval(s), so that Renovate bot can automerge its merge requests, without needing approval(s).
+Ignore the default project level approval(s), so that Renovate can automerge its merge requests, without needing approval(s).
 Under the hood, it creates a MR-level approval rule where `approvals_required` is set to `0`.
 This option works only when `automerge=true` and either `automergeType=pr` or `automergeType=branch`.
 Also, approval rules overriding should not be [prevented in GitLab settings](https://docs.gitlab.com/ee/user/project/merge_requests/approvals/settings.html#prevent-editing-approval-rules-in-merge-requests).
@@ -2177,7 +2177,7 @@ To match specific ports you have to add a protocol to `matchHost`:
 
 !!! note
   Disabling a host is only 100% effective if added to self-hosted config.
-  Renovate currently still checks its _cache_ for results first before trying to connect, so if a public host is blocked in your repository config (e.g. `renovate.json`) then it's possible you may get cached _results_ from that host if another repository using the same bot has successfully queried for the same dependency recently.
+  Renovate currently still checks its _cache_ for results first before trying to connect, so if a public host is blocked in your repository config (e.g. `renovate.json`) then it's possible you may get cached _results_ from that host if another repository using the same Renovate deployment has successfully queried for the same dependency recently.
 
 ### `hostRules.abortIgnoreStatusCodes`
 
@@ -2344,9 +2344,9 @@ Enable got [http2](https://github.com/sindresorhus/got/blob/v11.5.2/readme.md#ht
 You can provide a `headers` object that includes fields to be forwarded to the HTTP request headers.
 By default, all headers starting with "X-" are allowed.
 
-A bot administrator may configure an override for [`allowedHeaders`](./self-hosted-configuration.md#allowedheaders) to configure more permitted headers.
+A self-hosted administrator may configure an override for [`allowedHeaders`](./self-hosted-configuration.md#allowedheaders) to configure more permitted headers.
 
-`headers` value(s) configured in the bot admin `hostRules` (for example in a `config.js` file) are _not_ validated, so it may contain any header regardless of `allowedHeaders`.
+`headers` value(s) configured in the self-hosted configuration's `hostRules` (for example in a `config.js` file) are _not_ validated, so it may contain any header regardless of `allowedHeaders`.
 
 For example:
 
@@ -2617,7 +2617,7 @@ Please ask Mend.io sales about "Renovate Enterprise Cloud".
 
 If you are self-hosting Renovate, and want to allow Renovate to run any scripts:
 
-1. Set the self-hosted config option [`allowScripts`](./self-hosted-configuration.md#allowscripts) to `true` in your bot/admin configuration
+1. Set the self-hosted config option [`allowScripts`](./self-hosted-configuration.md#allowscripts) to `true` in your admin configuration
 1. Set `ignoreScripts` to `false` for the package managers you want to allow to run scripts (only works for the supportedManagers listed in the table above)
 
 ## `ignoreTests`
@@ -2848,7 +2848,7 @@ We do not want Renovate to parse every YAML file in every repository, just in ca
 Therefore Renovate's default `managerFilePatterns` for the `kubernetes` manager is an empty array (`[]`).
 Because the array is empty, you as user must tell Renovate which directories/files to check.
 
-Finally, there are cases where Renovate's default `managerFilePatterns` is good, but you may be using file patterns that a bot couldn't possibly guess.
+Finally, there are cases where Renovate's default `managerFilePatterns` is good, but you may be using non-standard filenames.
 For example, Renovate's default `managerFilePatterns` for `Dockerfile` is `['/(^|/|\\.)([Dd]ocker|[Cc]ontainer)file$/', '/(^|/)([Dd]ocker|[Cc]ontainer)file[^/]*$/']`.
 This will catch files like `backend/Dockerfile`, `prefix.Dockerfile` or `Dockerfile-suffix`, but it will miss files like `ACTUALLY_A_DOCKERFILE.template`.
 Because `managerFilePatterns` is "mergeable", you can add the missing file to the `filePattern` like this:
@@ -3013,7 +3013,7 @@ See [Private npm module support](./getting-started/private-packages.md) for deta
 
 This option exists to provide flexibility about whether `npmrc` strings in config should override `.npmrc` files in the repo, or be merged with them.
 In some situations you need the ability to force override `.npmrc` contents in a repo (`npmrcMerge=false`) while in others you might want to simply supplement the settings already in the `.npmrc` (`npmrcMerge=true`).
-A use case for the latter is if you are a Renovate bot admin and wish to provide a default token for `npmjs.org` without removing any other `.npmrc` settings which individual repositories have configured (such as scopes/registries).
+A use case for the latter is if you are a Renovate admin and wish to provide a default token for `npmjs.org` without removing any other `.npmrc` settings which individual repositories have configured (such as scopes/registries).
 
 If `false` (default), it means that defining `config.npmrc` will result in any `.npmrc` file in the repo being overridden and its values ignored.
 If configured to `true`, it means that any `.npmrc` file in the repo will have `config.npmrc` prepended to it before running `npm`.
@@ -4479,7 +4479,7 @@ What may happen if you don't set a `prHourlyLimit`:
 
 The above may cause:
 
-- Renovate bot's PRs to overwhelm your CI systems
+- Renovate's PRs to overwhelm your CI systems
 - a lot of test runs, because branches are rebased each time you merge a PR
 
 To prevent these problems you can set `prHourlyLimit` to a value like `1` or `2`.
@@ -4926,7 +4926,7 @@ When this option is set, Renovate won't attempt to update artifacts such as lock
 
 ## `skipInstalls`
 
-By default, Renovate will use the most efficient approach to updating package files and lock files, which in most cases skips the need to perform a full module install by the bot.
+By default, Renovate will use the most efficient approach to updating package files and lock files, which in most cases skips the need to perform a full module install.
 If this is set to false, then a full install of modules will be done.
 This is currently applicable to `npm` only, and only used in cases where bugs in `npm` result in incorrect lock files being updated.
 

--- a/docs/usage/configuration-templates.md
+++ b/docs/usage/configuration-templates.md
@@ -10,7 +10,7 @@ This document describes how you can edit branch names, commit messages, PR title
 ## Branch Name
 
 The branch name is very important for Renovate because it helps determine "grouping" of updates, and also makes it efficient when an existing PR needs to be updated when a newer version of a package is released.
-If you change the `branchPrefix` while you have ignored some upgrades (closed PR without merging), you might get a duplicate PR after the new `branchPrefix` setting is picked up by the bot.
+If you change the `branchPrefix` while you have ignored some upgrades (closed PR without merging), you might get a duplicate PR after the new `branchPrefix` setting is picked up by Renovate.
 
 `branchName` default value is `{{{branchPrefix}}}{{{additionalBranchPrefix}}}{{{branchTopic}}}`.
 

--- a/docs/usage/examples/self-hosting.md
+++ b/docs/usage/examples/self-hosting.md
@@ -5,7 +5,7 @@
 
 !!! warning
   Most Open Source packages are hosted on github.com, including a number of tools that Renovate may pull at run-time.
-  GitHub greatly rate limits unauthenticated API requests, so you need to configure credentials for `github.com` or the bot will get rate limited quickly.
+  GitHub greatly rate limits unauthenticated API requests, so you need to configure credentials for `github.com` or your deployment will get rate limited quickly.
   &nbsp;
   Read [Running Renovate, GitHub.com token for changelogs](../getting-started/running.md#githubcom-token-for-changelogs-and-tools) to learn more.
 
@@ -96,7 +96,7 @@ stringData:
   # You can set RENOVATE_AUTODISCOVER to true to run Renovate on all repos you have push access to
   RENOVATE_AUTODISCOVER: 'false'
   RENOVATE_ENDPOINT: 'https://github.company.com/api/v3'
-  RENOVATE_GIT_AUTHOR: 'Renovate Bot <bot@renovateapp.com>'
+  RENOVATE_GIT_AUTHOR: 'Renovate <bot@renovateapp.com>'
   RENOVATE_PLATFORM: 'github'
   RENOVATE_TOKEN: 'your-github-enterprise-renovate-user-token'
 ```
@@ -237,7 +237,7 @@ If you want to override the cache directory then set your own value for `cacheDi
 
 The following example uses the Renovate CLI tool, which you can install by running `npm i -g renovate`.
 
-If running your own Renovate bot then you will need a user account that Renovate will run as.
+If running your own Renovate deployment, then you will need a user account that Renovate will run as.
 We recommend you create and use a dedicated account for the bot, e.g. name it `renovate-bot` if on your own instance.
 Create and save a PAT for this account.
 
@@ -281,7 +281,7 @@ Only add the script to `cron` after you checked it works.
 
 !!! note
   The GitHub.com token as an environment variable is needed to fetch changelogs that are usually hosted on github.com.
-  You don't need to add it if you are already running the bot against github.com, but you do need to add it if you're using GitHub Enterprise Server, GitLab, Azure DevOps, or Bitbucket.
+  You don't need to add it if you are already running Renovate against github.com, but you do need to add it if you're using GitHub Enterprise Server, GitLab, Azure DevOps, or Bitbucket.
 
 ## Kubernetes for GitLab, using Git over SSH
 
@@ -340,7 +340,7 @@ stringData:
   RENOVATE_GITHUB_COM_TOKEN: 'any-personal-user-token-for-github-com-for-fetching-changelogs'
   RENOVATE_AUTODISCOVER: 'false'
   RENOVATE_ENDPOINT: 'https://github.company.com/api/v3'
-  RENOVATE_GIT_AUTHOR: 'Renovate Bot <bot@renovateapp.com>'
+  RENOVATE_GIT_AUTHOR: 'Renovate <bot@renovateapp.com>'
   RENOVATE_PLATFORM: 'github'
   RENOVATE_TOKEN: 'your-github-enterprise-renovate-user-token'
 ---

--- a/docs/usage/faq.md
+++ b/docs/usage/faq.md
@@ -97,7 +97,7 @@ The basic idea is that you create a new `packageRules` entry and describe what k
 }
 ```
 
-You may even configure Renovate bot to ask for approval for _all_ updates.
+You may even configure Renovate to ask for approval for _all_ updates.
 The `dependencyDashboardApproval` config option is outside of a `packageRules` array, and so applies to all updates:
 
 ```json

--- a/docs/usage/getting-started/installing-onboarding.md
+++ b/docs/usage/getting-started/installing-onboarding.md
@@ -18,7 +18,7 @@ If the administrator has configured a fixed list of repositories then the only w
 
 Otherwise, the process for adding new repositories to a Renovate installation can vary:
 
-- Most commonly, you run Renovate as a dedicated "bot user" with global config option `autodiscover` set to `true`, meaning that it will run on every repository which it's been granted access to
+- Most commonly, you run Renovate as a dedicated account with global config option `autodiscover` set to `true`, meaning that it will run on every repository which it's been granted access to
 - If using a GitHub App (including the Mend Renovate App) then you can install the app into a user or organization account and select either "All repositories", or "Select repositories" and pick them manually
 
 ### Hosted GitHub.com App
@@ -57,7 +57,7 @@ You can do this by running this Git command:
 git config --global core.autocrlf input
 ```
 
-This prevents the carriage return `\r\n` which may confuse Renovate bot.
+This prevents the carriage return `\r\n` which may confuse Renovate.
 You can also set the line endings in your repository by adding `* text=auto eol=lf` to your `.gitattributes` file.
 
 ## Repository onboarding
@@ -100,7 +100,7 @@ If you don't want a `renovate.json` file in your repository you can use one of t
 - `package.json` (deprecated)
 
 Or in a custom file present within the [`configFileNames`](../self-hosted-configuration.md#configfilenames).
-The bot first checks all the files in the `configFileNames` array before checking from the above file list.
+Renovate first checks all the files in the `configFileNames` array before checking from the above file list.
 
 #### package.json
 
@@ -152,7 +152,7 @@ If you want to make config edits directly, follow these steps:
 1. Create a pull request from the `renovate/reconfigure` branch
 1. Run renovate on your repository(if self-hosted), or wait for the hosted app to process the changes
 1. Renovate will comment on your PR, outlining the expected changes from your modified configuration
-1. You can continue to edit the configuration file in the same PR, and the bot will update its comment accordingly
+1. You can continue to edit the configuration file in the same PR, and Renovate will update its comment accordingly
 1. If you only want to validate your configuration changes, check out: [Validate your config](../config-validation.md)
 
 ### Nuke config and re-onboard

--- a/docs/usage/getting-started/private-packages.md
+++ b/docs/usage/getting-started/private-packages.md
@@ -31,7 +31,7 @@ There are four times in Renovate's behavior when it may need credentials:
 Renovate supports config presets, including those which are private.
 
 Although npm presets were the first type supported, they are now deprecated and it is recommend that all users migrate to git-hosted "local" presets instead.
-However if you do still use them, private modules should work if you configure `hostRules` (recommended) or `npmrc` including token credentials in your bot global config.
+However if you do still use them, private modules should work if you configure `hostRules` (recommended) or `npmrc` including token credentials in your global self-hosted config.
 It is strongly recommended not to use private modules on a private registry and a warning will be logged if that is found.
 Credentials stored on disk (e.g. in `~/.npmrc`) are no longer supported.
 
@@ -147,7 +147,7 @@ When Renovate creates Pull Requests, its default behavior is to locate and embed
 These release notes are fetched from the source repository of packages and not from the registries themselves, so if they are private then they will require different credentials.
 
 When it comes to open source, most packages host their source on `github.com` in public repositories.
-GitHub greatly rate limits unauthenticated API requests, so you need to configure credentials for `github.com` or the bot will get rate limited quickly.
+GitHub greatly rate limits unauthenticated API requests, so you need to configure credentials for `github.com` or your deployment will get rate limited quickly.
 It can be confusing for people who host their own source code privately to be asked to configure a `github.com` token but without it changelogs for most open source packages will be blocked.
 
 Currently the preferred way to configure `github.com` credentials for self-hosted Renovate is:
@@ -231,13 +231,13 @@ If you need to configure per-repository credentials then you can also configure 
 
 The recommended approaches in order of preference are:
 
-1. **Self-hosted hostRules**: Configure a hostRules entry in the bot's `config.js` with the `hostType`, `matchHost` and `token` specified
+1. **Self-hosted hostRules**: Configure a hostRules entry in your self-hosted `config.js` with the `hostType`, `matchHost` and `token` specified
 1. **The Mend Renovate App with private modules from npmjs.org**: Add an encrypted `npmToken` to your Renovate config
 1. **The Mend Renovate App with a private registry**: Add an plaintext `npmrc` plus an encrypted `npmToken` in config
 
 These approaches are described in full below.
 
-#### Add hostRule to bots config
+#### Add hostRule to self-hosted config
 
 Define `hostRules` like this:
 
@@ -603,7 +603,7 @@ The solution to this is that you should break your presets into public and priva
 ### Encrypting secrets
 
 It is strongly recommended that you avoid committing secrets to repositories, including private ones, and this includes secrets needed by Renovate to access private modules.
-The preferred approach to secrets is that the bot administrator configures them as `hostRules` which are then applied to all repositories which the bot accesses.
+The preferred approach to secrets is that the administrator configures them as `hostRules` which are then applied to all repositories which Renovate accesses.
 
 !!! warning "Store secrets for your Mend-hosted app via the web UI"
   Mend no longer supports putting encrypted secrets in the Renovate config file on your repository.
@@ -639,9 +639,9 @@ The Mend Renovate App does not run using GitHub Actions, but such secrets would 
 - The app would be granted access to _all_ the repository/org secrets, not just the ones you want
 - If Renovate wants access to such secrets, it would need to ask for them from every user, not just the ones who want to use this approach (GitHub does not support the concept of optional permissions for Apps, so people do not have the option to decline)
 
-## Admin/Bot config vs User/Repository config for Self-hosted users
+## Admin config vs User/Repository config for Self-hosted users
 
-"Admin/Bot config" refers to the config which the Renovate Bot administrator provides at bot startup, e.g. using environment variables, CLI parameters, or the `config.js` configuration file.
+"Admin config" refers to the config which the Renovate administrator provides at startup, e.g. using environment variables, CLI parameters, or the `config.js` configuration file.
 User/Repository config refers to the in-repository config file which defaults to `renovate.json` but has a large number of alternative filenames supported.
 
 If there is a need to supply custom rules for certain repository, it can still be done using the `config.js` file and the `repositories` array.
@@ -656,7 +656,7 @@ For instructions on this, see the above section on encrypting secrets for the Me
 - Configure the app to run with `privateKey` set to the private key you generated above
 
 !!! note
-  Encrypted values can't be used in the "Admin/Bot config".
+  Encrypted values can't be used in the "Admin config".
 
 ### hostRules configuration using environment variables
 

--- a/docs/usage/getting-started/running.md
+++ b/docs/usage/getting-started/running.md
@@ -10,14 +10,14 @@ If you're using the Mend Renovate App, or if someone else is hosting Renovate fo
 
 ## Self-Hosting Renovate
 
-When self-hosting Renovate you're the "administrator" of the bot, this means you:
+When self-hosting Renovate you're the "administrator" of that deployment, this means you:
 
 - provide the infrastructure that Renovate runs on,
 - provision Renovate's global config,
-- make sure Renovate bot runs regularly,
-- make sure Renovate bot itself is updated
+- make sure Renovate runs regularly,
+- make sure Renovate itself is updated
 
-If you're self-hosting Renovate on Windows, read [Self-hosting on Windows](./installing-onboarding.md#self-hosting-on-windows) to prevent line endings from confusing Renovate bot.
+If you're self-hosting Renovate on Windows, read [Self-hosting on Windows](./installing-onboarding.md#self-hosting-on-windows) to prevent line endings from confusing Renovate.
 
 If you're running Renovate Community Edition or Renovate Enterprise Edition, refer to the documentation on the [`mend/renovate-ce-ee` GitHub repository](https://github.com/mend/renovate-ce-ee).
 
@@ -164,11 +164,11 @@ Any other (`*.js`, `*.ts`, `*.json`, `*.json5`, `*.yaml` or `*.yml`) file is sup
 Renovate checks for the additional config file only if the `RENOVATE_ADDITIONAL_CONFIG_FILE` is set.
 Behaviour wise this config is similar to the file config, except that it has higher priority than the default config file.
 
-Some config is global-only, meaning that either it is only applicable to the bot administrator or it can only be controlled by the administrator and not repository users.
+Some config is global-only, meaning that either it is only applicable to the administrator or it can only be controlled by the administrator and not repository users.
 Those are documented in [Self-hosted Configuration](../self-hosted-configuration.md).
-Your bot's global config can include both global as well as non-global configuration options, while user/repo config can only include non-global options.
+Your global config can include both global as well as non-global configuration options, while user/repo config can only include non-global options.
 We recommend that you keep as much of the non-global config as possible in repository config files.
-This way the Renovate end users can see as much of the bot's configuration as possible.
+This way the Renovate end users can see as much of the configuration as possible.
 
 If you are configuring Renovate using environment variables, there are two possibilities:
 
@@ -226,10 +226,10 @@ The `.mts` extension is always treated as an ES module, and `.cts` is always tre
 
 Regardless of platform, you need to select a user account for `renovate` to assume the identity of, and generate a Personal Access Token.
 We recommend you use `@renovate-bot` as username if you're on a self-hosted server where you can set all usernames.
-We also recommend you configure `config.gitAuthor` with the same identity as your Renovate user, for example: `"gitAuthor": "Renovate Bot <renovate@some.domain.test>"`.
+We also recommend you configure `config.gitAuthor` with the same identity as your Renovate user, for example: `"gitAuthor": "Renovate <renovate@some.domain.test>"`.
 
 !!! warning
-  We recommend you use a single, dedicated username for your Renovate bot.
+  We recommend you use a single, dedicated username for your Renovate.
   Never share the Renovate username with your other bots, as this can cause flip-flopping.
 
 #### Docs

--- a/docs/usage/gitlab-bot-security.md
+++ b/docs/usage/gitlab-bot-security.md
@@ -32,7 +32,7 @@ This was a useful feature to leverage for a shared service.
 If you are running a self-hosted Renovate service, we recommend you:
 
 - Run a shared service only within projects which have shared visibility/security within the users, or which have a low risk that a user would try to gain access to a private project they don't otherwise have access to
-- If running with `autodiscover`, also configure a value for `autodiscoverFilter` so that the bot can't be invited to projects or groups you don't intend
+- If running with `autodiscover`, also configure a value for `autodiscoverFilter` so that Renovate can't be invited to projects or groups you don't intend
 
 ## Security solutions and workarounds
 
@@ -44,7 +44,7 @@ If you only run a bot service on _public_ projects, the risk of unauthorized use
 But malicious users can still spoof or spam packages to any other public project they are not a member of, this rules out this approach for a public hosted service.
 
 A public-visibility-only bot service should be low risk for most self-hosted GitLab instances.
-But you _can't stop users_ from inviting the bot into _private_ projects by accident, which is risky.
+But you _can't stop users_ from inviting Renovate into _private_ projects by accident, which is risky.
 
 ### Project Access Tokens
 
@@ -80,7 +80,7 @@ The above solution/workaround will be actively researched in collaboration with 
 ### OAuth
 
 An alternative to a bot service running with a bot PAT would be to have it run using user OAuth tokens.
-In this scenario, an OAuth app would be needed to allow users to "install" the bot into projects with members they trust not to exploit them, and then commits and Merge Requests would appear to be authored by the _user_, not any bot.
+In this scenario, an OAuth app would be needed to allow users to "install" Renovate into projects with members they trust not to exploit them, and then commits and Merge Requests would appear to be authored by the _user_, not any bot.
 Bot services are better if they are provisioned with a "bot identity" so that users can quickly distinguish bot activity from real user activity.
 
 ## Recommended migration

--- a/docs/usage/golang.md
+++ b/docs/usage/golang.md
@@ -32,7 +32,7 @@ To learn what these variables do, read the [Go Modules Reference about the`GOPRO
 ## Enabling Go Modules Updating
 
 Renovate updates Go Modules by default.
-To install Renovate Bot itself, either enable the [Renovate App](https://github.com/apps/renovate) on GitHub, or check out [Renovate OSS](https://github.com/renovatebot/renovate) for self-hosted.
+To install Renovate itself, either enable the [Renovate App](https://github.com/apps/renovate) on GitHub, or check out [Renovate OSS](https://github.com/renovatebot/renovate) for self-hosted.
 
 ## Technical Details
 

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -34,7 +34,7 @@ Multi-platform and multi-language.
 
   ---
 
-  You can customize the bot's behavior with configuration files.
+  You can customize Renovate's behavior with configuration files.
 
 -   :octicons-share-24:{ .lg .middle } __Share your configuration__
 

--- a/docs/usage/java.md
+++ b/docs/usage/java.md
@@ -117,7 +117,7 @@ The manager for Gradle makes use of the `maven` datasource.
 Renovate can be configured to access more repositories and access repositories authenticated.
 
 This example shows how you can use a `config.js` file to configure Renovate for use with Artifactory.
-We're using environment variables to pass the Artifactory username and password to Renovate bot.
+We're using environment variables to pass the Artifactory username and password to Renovate.
 
 ```js title="config.js"
 module.exports = {

--- a/docs/usage/key-concepts/presets.md
+++ b/docs/usage/key-concepts/presets.md
@@ -14,7 +14,7 @@ To learn how to create and host them, read the [Shareable Config Presets](../con
 
 Use presets to:
 
-- Set up the bot with good default settings
+- Set up Renovate with good default settings
 - Avoid duplicating your configuration
 - Share your configuration with others
 - Use somebody else's configuration as-is, or extend it with your own rules

--- a/docs/usage/key-concepts/scheduling.md
+++ b/docs/usage/key-concepts/scheduling.md
@@ -7,7 +7,7 @@ This document describes Renovate's scheduling.
 
 ## Default behavior
 
-On the backend side, Renovate bot runs as often as its administrator has configured Renovate to run.
+On the backend side, Renovate runs as often as its administrator has configured Renovate to run.
 For example, the administrator configure Renovate to begin its runs hourly, daily, or outside office hours only.
 How often Renovate runs per-repository subsequently depends on how many repositories there are to check, and how many updates are pending for each repository at the time.
 If the backend configuration for Renovate means it runs scheduled jobs per-repo approximately every X hours, it is not possible for _repository configuration_ to reduce that to less than X, or to force Renovate to run at exact times on specific repos.
@@ -39,10 +39,10 @@ The table below shows how the number of dependencies and repositories affect Ren
 
 At a high level, you have two ways to schedule Renovate, a "global way" and a "specific way":
 
-| Way to schedule Renovate | What this does                                                                                           | Notes                                                                                                                                  |
-| ------------------------ | -------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| Global                   | Decides when Renovate runs.                                                                              | This schedule is usually controlled by your organization's bot administor. For the Mend Renovate app, Mend decides when Renovate runs. |
-| Specific                 | When Renovate runs it checks the schedule to see if it should look for updates to a specific dependency. | Usually set in the `renovate.json` config file, or similar config file.                                                                |
+| Way to schedule Renovate | What this does                                                                                           | Notes                                                                                                                                 |
+| ------------------------ | -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Global                   | Decides when Renovate runs.                                                                              | This schedule is usually controlled by your organization's administrator. For the Mend Renovate app, Mend decides when Renovate runs. |
+| Specific                 | When Renovate runs it checks the schedule to see if it should look for updates to a specific dependency. | Usually set in the `renovate.json` config file, or similar config file.                                                               |
 
 Renovate can only update a dependency if _both_ of these conditions are true:
 
@@ -63,7 +63,7 @@ You can use the scheduling tools to:
 
 - Run Renovate outside office hours, to free up continous integration resources for your developers
 - Get updates for certain packages on a regular interval, instead of right away
-- Reduce Renovate bot PR notifications during the day
+- Reduce Renovate PR notifications during the day
 
 ## Customizing the schedule
 
@@ -136,7 +136,7 @@ The `@breejs/later` library also controls the interpretation of "days", time_bef
 
 ### In-repository schedule configuration
 
-Important: _when_ the Renovate process runs is usually controlled by the bot admin, using tools such as `cron`.
+Important: _when_ the Renovate process runs is usually controlled by the administrator, using tools such as `cron`.
 For the Mend Renovate App, the Mend maintainers control when the Renovate process runs, usually hourly.
 
 If you control the hardware that Renovate runs on, we recommend you:

--- a/docs/usage/known-limitations.md
+++ b/docs/usage/known-limitations.md
@@ -1,6 +1,6 @@
 # Known limitations
 
-Learn about the limitations of Renovate bot.
+Learn about the limitations of Renovate.
 
 ## Introduction
 
@@ -14,11 +14,11 @@ This document tries to list out the most commonly seen limitations and describe 
 
 When a user configures a schedule in their repo config, they may think that this schedule "controls" when Renovate runs.
 In actuality, Renovate may be running frequently, but skipping updates to the repo if the configured schedule is not met.
-Additionally, the Renovate admin may have put the bot on its own schedule, or the job queue may be too long, so Renovate doesn't even get a chance to run on your repository during a certain scheduled time window.
+Additionally, the Renovate admin may have put Renovate on its own schedule, or the job queue may be too long, so Renovate doesn't even get a chance to run on your repository during a certain scheduled time window.
 
 For scheduled action to take place, both these need to happen:
 
-- The bot needs to run against your repository
+- Renovate needs to run against your repository
 - The current time needs to fall within your repository's configured schedule
 
 ### The Mend Renovate app and scheduled jobs
@@ -26,7 +26,7 @@ For scheduled action to take place, both these need to happen:
 The Mend Renovate App checks each active repository roughly every three hours, if no activity has been seen before then (merged PRs, etc).
 
 For this reason, you should set your schedule window to at least three or four hours.
-This makes it likely that Renovate bot checks your repository at least once during the schedule.
+This makes it likely that Renovate checks your repository at least once during the schedule.
 
 ## Automerge limitations
 

--- a/docs/usage/logo-brand-guidelines.md
+++ b/docs/usage/logo-brand-guidelines.md
@@ -24,7 +24,7 @@ You are allowed to use our logo as:
 
 - an icon in your repository readme, that says you are using Renovate
 - part of a badge in your repository readme, that says you are using Renovate
-- an avatar image for your self-hosted version of Renovate, but give your bot a _different_ name
+- an avatar image for your self-hosted version of Renovate, but give it a _different_ name
 
 ## Allowed uses of the Renovate branding
 

--- a/docs/usage/modules/versioning/index.md
+++ b/docs/usage/modules/versioning/index.md
@@ -28,7 +28,7 @@ For example, `npm` uses `1.0.0-beta.1` while `pip` uses `1.0.0b1`.
 
 Renovate interprets versions correctly out-of-the-box most of the time.
 But Renovate can't automatically detect **all** versioning schemes.
-So sometimes you need to tell the bot what versioning scheme it should use.
+So sometimes you need to tell Renovate what versioning scheme it should use.
 
 For some ecosystems, automatic version selection works nearly every time (e.g. for npm-compliant managers, use `npm` versioning).
 For other ecosystems such as Docker or GitHub tags, there is no consistent convention for versions, so the default choice may not always work.

--- a/docs/usage/node.md
+++ b/docs/usage/node.md
@@ -29,7 +29,7 @@ Renovate can manage the Node.js version in the following files:
 When `binarySource=install`, such as in the Mend Renovate App, Renovate will choose and install an `npm` version dynamically.
 
 To control which version or constraint is installed, you should use the `engines.npm` property in your `package.json` file.
-Renovate bot will then use that version constraint for npm when it creates a pull request.
+Renovate will then use that version constraint for npm when it creates a pull request.
 
 For example, if you want to use at least npm `8.1.0` and also allow newer versions of npm in the `8.x` range, you would put this in your `package.json` file:
 

--- a/docs/usage/noise-reduction.md
+++ b/docs/usage/noise-reduction.md
@@ -54,7 +54,7 @@ Grouping dependencies versus single PRs:
 
 ## Scheduling Renovate
 
-For a high level overview of scheduling when Renovate bot runs, read the [key concepts, scheduling](./key-concepts/scheduling.md) docs.
+For a high level overview of scheduling when Renovate runs, read the [key concepts, scheduling](./key-concepts/scheduling.md) docs.
 
 On its own, the Renovate CLI tool runs once and then exits.
 Hence, it only runs as often as its administrator sets it to (e.g. via `cron`).

--- a/docs/usage/php.md
+++ b/docs/usage/php.md
@@ -41,7 +41,7 @@ If you are using a [privately hosted Composer package](https://getcomposer.org/d
 }
 ```
 
-This host rule is best added to the bot's `config.js` config so that it is not visible to users of the repository.
+This host rule is best added to the self-hosted `config.js` config so that it is not visible to users of the repository.
 If you are using the Mend Renovate App then you can encrypt it with Renovate's public key instead, so that only Renovate can decrypt it.
 
 Go to [https://app.renovatebot.com/encrypt](https://app.renovatebot.com/encrypt), paste in the secret string you wish to encrypt, select _Encrypt_, then copy the encrypted result.

--- a/docs/usage/python.md
+++ b/docs/usage/python.md
@@ -10,7 +10,7 @@ See [all supported managers](./modules/manager/index.md).
 
 ## Versioning support
 
-We've written a JavaScript version of the [PEP440 specification](https://www.python.org/dev/peps/pep-0440/) so we can use it in Renovate bot.
+We've written a JavaScript version of the [PEP440 specification](https://www.python.org/dev/peps/pep-0440/) so we can use it in Renovate.
 You can find this project in our [`renovatebot/pep440` repository](https://github.com/renovatebot/pep440).
 
 Our PEP440 implementation supports pinned versions and ranges.

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -9,7 +9,7 @@ Only use these configuration options when you _self-host_ Renovate.
 
 Do _not_ put the self-hosted config options listed on this page in your "repository config" file (`renovate.json` for example), because Renovate will ignore those config options, and may also create a config error issue.
 
-The config options below _must_ be configured in the bot/admin config, so in either a environment variable, CLI option, or a special file like `config.js`.
+The config options below _must_ be configured in the admin config, so in either an environment variable, CLI option, or a special file like `config.js`.
 
 !!! note
   Renovate supports `JSONC` for `.json` files and any config files without file extension (e.g. `.renovaterc`).
@@ -82,7 +82,7 @@ This configuration option was formerly known as `allowedPostUpgradeCommands`.
 
 ## `allowedEnv`
 
-Bot administrators can allow users to configure custom environment variables within repo config.
+Administrators can allow users to configure custom environment variables within repo config.
 Only environment variables matching the list will be accepted in the [`env`](./configuration-options.md#env) configuration.
 
 Examples:
@@ -167,12 +167,12 @@ Allowed options:
 
 ## `autodiscover`
 
-When you enable `autodiscover`, by default, Renovate runs on _every_ repository that the bot account can access.
+When you enable `autodiscover`, by default, Renovate runs on _every_ repository that the Renovate account can access.
 You can limit which repositories Renovate can access by using the `autodiscoverFilter` config option.
 
 ## `autodiscoverFilter`
 
-You can use this option to filter the list of repositories that the Renovate bot account can access through `autodiscover`.
+You can use this option to filter the list of repositories that the Renovate account can access through `autodiscover`.
 The pattern matches against the organization/repo path.
 
 This option supports an array of minimatch-compatible globs or RE2-compatible regex strings.
@@ -508,7 +508,7 @@ The process that runs Renovate must have the correct permissions to delete the c
 
 ## `detectGlobalManagerConfig`
 
-The purpose of this config option is to allow you (as a bot admin) to configure manager-specific files such as a global `.npmrc` file, instead of configuring it in Renovate config.
+The purpose of this config option is to allow you (as an administrator) to configure manager-specific files such as a global `.npmrc` file, instead of configuring it in Renovate config.
 
 This config option is disabled by default because it may prove surprising or undesirable for some users who don't expect Renovate to go into their home directory and import registry or credential information.
 
@@ -701,7 +701,7 @@ If you must expose all environment variables to package managers, you can set th
   Always consider the security implications of using `exposeAllEnv`!
   Secrets and other confidential information stored in environment variables could be leaked by a malicious script, that enumerates all environment variables.
 
-Set `exposeAllEnv` to `true` only if you have reviewed, and trust, the repositories which Renovate bot runs against.
+Set `exposeAllEnv` to `true` only if you have reviewed, and trust, the repositories which Renovate runs against.
 Alternatively, you can use the [`customEnvVariables`](./self-hosted-configuration.md#customenvvariables) config option to handpick a set of variables you need to expose.
 
 Setting this to `true` also allows for variable substitution in `.npmrc` files.
@@ -761,7 +761,7 @@ To learn more about Git hooks, read the [Pro Git 2 book, section on Git Hooks](h
 This is a private PGP or SSH key for signing Git commits.
 
 For PGP, it should be an armored private key, so the type you get from running `gpg --export-secret-keys --armor 92066A17F0D1707B4E96863955FEF5171C45FAE5 > private.key`.
-Replace the newlines with `\n` before adding the resulting single-line value to your bot's config.
+Replace the newlines with `\n` before adding the resulting single-line value to your self-hosted config.
 
 !!! note
   The private key can't be protected with a passphrase if running in a headless environment. Renovate will not be able to handle entering the passphrase.
@@ -836,13 +836,13 @@ Value of `0` means no caching.
 
 ## `ignorePrAuthor`
 
-This is usually needed if someone needs to migrate bot accounts, including from the Mend Renovate App to self-hosted.
+This is usually needed if someone needs to migrate the account Renovate runs as, including from the Mend Renovate App to self-hosted.
 An additional use case is for GitLab users of project or group access tokens who need to rotate them.
 
 If `ignorePrAuthor` is configured to true, it means Renovate will fetch the entire list of repository PRs instead of optimizing to fetch only those PRs which it created itself.
-You should only want to enable this if you are changing the bot account (e.g. from `@old-bot` to `@new-bot`) and want `@new-bot` to find and update any existing PRs created by `@old-bot`.
+You should only want to enable this if you are changing the account Renovate runs as (e.g. from `@old-bot` to `@new-bot`) and want `@new-bot` to find and update any existing PRs created by `@old-bot`.
 
-Setting this field to `true` in Github or GitLab will also mean that all Issues will be fetched instead of only those by the bot itself.
+Setting this field to `true` in Github or GitLab will also mean that all Issues will be fetched instead of only those by Renovate itself.
 
 ## `includeMirrors`
 
@@ -963,8 +963,8 @@ In the above example any reference to the `@company` preset will be replaced wit
 
 Only set this to `false` if all three statements are true:
 
-- You've configured Renovate entirely on the bot side (e.g. empty `renovate.json` in repositories)
-- You want to run Renovate on every repository the bot has access to
+- You've configured Renovate entirely on the admin side (e.g. empty `renovate.json` in repositories)
+- You want to run Renovate on every repository Renovate has access to
 - You want to skip all onboarding PRs
 
 ## `onboardingAutoCloseAge`
@@ -1026,7 +1026,7 @@ Otherwise, it will continue as normal.
 
 `optimizeForDisabled` can make initialization quicker in cases where most repositories are disabled, but it uses an extra API call for enabled repositories.
 
-A second, advanced, use also exists when the bot global config has `extends: [":disableRenovate"]`.
+A second, advanced, use also exists when the global config has `extends: [":disableRenovate"]`.
 In that case, Renovate searches the repository config file for any of these configurations:
 
 - `extends: [":enableRenovate"]`
@@ -1108,11 +1108,11 @@ Is this correct? (y/N) y
 
 GnuPG needs to construct a user ID to identify your key.
 
-Real name: Renovate Bot
+Real name: Renovate
 Email address: renovate@whitesourcesoftware.com
 Comment:
 You selected this USER-ID:
-    "Renovate Bot <renovate@whitesourcesoftware.com>"
+    "Renovate <renovate@whitesourcesoftware.com>"
 
 Change (N)ame, (C)omment, (E)mail or (O)kay/(Q)uit? O
 
@@ -1122,7 +1122,7 @@ public and secret key created and signed.
 
 pub   rsa4096 2021-09-10 [SC]
       794B820F34B34A8DF32AADB20649CEXAMPLEONLY
-uid                      Renovate Bot <renovate@whitesourcesoftware.com>
+uid                      Renovate <renovate@whitesourcesoftware.com>
 sub   rsa4096 2021-09-10 [E]
 ```
 
@@ -1137,7 +1137,7 @@ sub   rsa4096 2021-09-10 [E]
 ```bash
 ❯ gpg --edit-key renovate@whitesourcesoftware.com
 gpg> showpref
-[ultimate] (1). Renovate Bot <renovate@whitesourcesoftware.com>
+[ultimate] (1). Renovate <renovate@whitesourcesoftware.com>
      Cipher: AES256, AES192, AES, 3DES
      AEAD: OCB, EAX
      Digest: SHA512, SHA384, SHA256, SHA224, SHA1
@@ -1161,7 +1161,7 @@ gpg> save
 - Run `gpg --armor --export-secret-keys YOUR_NEW_KEY_ID > renovate-private-key.asc` to generate an armored (text-based) private key file
 - Run `gpg --armor --export YOUR_NEW_KEY_ID > renovate-public-key.asc` to generate an armored (text-based) public key file
 
-The private key should then be added to your Renovate Bot global config (either using `privateKeyPath` or exporting it to the `RENOVATE_PRIVATE_KEY` environment variable).
+The private key should then be added to your Renovate global config (either using `privateKeyPath` or exporting it to the `RENOVATE_PRIVATE_KEY` environment variable).
 The public key can be used to replace the existing key in <https://app.renovatebot.com/encrypt> for your own use.
 
 !!! note "Base64 Encoding Support"
@@ -1365,7 +1365,7 @@ Read the [AWS S3 docs, Interface BucketEndpointInputConfig](https://docs.aws.ama
 
 ## `secrets`
 
-Secrets may be configured by a bot admin in `config.js`, which will then make them available for templating within repository configs.
+Secrets may be configured by an administrator in `config.js`, which will then make them available for templating within repository configs.
 For example, to configure a `GOOGLE_TOKEN` to be accessible by all repositories:
 
 ```js
@@ -1434,7 +1434,7 @@ Renovate will use the token to discover its username on the platform, including 
 
 ## `variables`
 
-Variables may be configured by a bot admin in `config.js`, which will then make them available for templating within repository configs.
+Variables may be configured by an administrator in `config.js`, which will then make them available for templating within repository configs.
 This config option behaves exactly like [secrets](#secrets), except that it won't be masked in the logs.
 For example, to configure a `SOME_VARIABLE` to be accessible by all repositories:
 
@@ -1480,7 +1480,7 @@ By default, Renovate processes each repository that it finds.
 You can use this optional parameter so Renovate writes the discovered repositories to a JSON file and exits.
 
 Known use cases consist, among other things, of horizontal scaling setups.
-See [Scaling Renovate Bot on self-hosted GitLab](https://github.com/renovatebot/renovate/discussions/13172).
+See [Scaling Renovate on self-hosted GitLab](https://github.com/renovatebot/renovate/discussions/13172).
 
 Usage: `renovate --write-discovered-repos=/tmp/renovate-repos.json`
 

--- a/docs/usage/self-hosted-experimental.md
+++ b/docs/usage/self-hosted-experimental.md
@@ -7,7 +7,7 @@ The following environment variables are "experimental" because they:
 - can be removed at any time
 - are variables for Renovate's internal use to validate they work as intended
 
-Experimental variables which are commonly used and for which there is no external solution in sight can be converted to an official configuration option by the Renovate bot developers.
+Experimental variables which are commonly used and for which there is no external solution in sight can be converted to an official configuration option by the Renovate developers.
 
 Use these experimental variables at your own risk.
 We do not follow Semantic Versioning for any experimental variables.

--- a/docs/usage/updating-rebasing.md
+++ b/docs/usage/updating-rebasing.md
@@ -14,7 +14,7 @@ Here is a list of the most common cases where Renovate must update/rebase the br
 - When you have manually told Renovate to rebase when behind the base branch with `"rebaseWhen": "behind-base-branch"`
 - When you have set `keepUpdatedLabel` and included the label on a PR
 - When a newer version of the dependency is released
-- When you request a manual rebase from the Renovate bot
+- When you request a manual rebase from Renovate
 - When you use `"automerge": true` and `"rebaseWhen": "auto"` on a branch / pr
 
 Renovate uses its own version of "rebasing", which is _not the same_ as doing a `git rebase` with Git.

--- a/docs/usage/user-stories/swissquote.md
+++ b/docs/usage/user-stories/swissquote.md
@@ -186,7 +186,7 @@ On our side, we’re not using the on-premise but rather a custom scheduler usin
 
 > The figures here have been updated in November 2023
 
-We started using Renovate Bot in 2019, using the (now deprecated) `renovate/pro` Docker image.
+We started using Renovate in 2019, using the (now deprecated) `renovate/pro` Docker image.
 We installed it as a GitHub app and some early adopters started to use it.
 
 Pretty quickly, we ran into the biggest limitation; this Docker image runs all repositories one after another.

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -1029,7 +1029,7 @@ const options: Readonly<RenovateOptions>[] = [
     type: 'boolean',
     default: true,
   },
-  // Bot administration
+  // Admin/self-hosted administration
   {
     name: 'persistRepoData',
     description:
@@ -2132,7 +2132,7 @@ const options: Readonly<RenovateOptions>[] = [
   },
   {
     name: 'rebaseLabel',
-    description: 'Label to request a rebase from Renovate bot.',
+    description: 'Label to request a rebase from Renovate.',
     type: 'string',
     default: 'rebase',
   },

--- a/lib/config/validation-helpers/utils.ts
+++ b/lib/config/validation-helpers/utils.ts
@@ -63,7 +63,7 @@ export function validateNumber(
 
 /**  An option is a false global if it has the same name as a global only option
  *   but is actually just the field of a non global option or field an children of the non global option
- *   eg. token: it's global option used as the bot's token as well and
+ *   eg. token: it's global option used as Renovate's token as well and
  *   also it can be the token used for a platform inside the hostRules configuration
  */
 export function isFalseGlobal(

--- a/lib/config/validation.spec.ts
+++ b/lib/config/validation.spec.ts
@@ -2323,7 +2323,7 @@ describe('config/validation', () => {
       expect(errors).toMatchObject([
         {
           message:
-            "hostRules header `unallowedHeader` is not allowed by this bot's `allowedHeaders`.",
+            "hostRules header `unallowedHeader` is not allowed by this Renovate instance's `allowedHeaders`.",
           topic: 'Configuration Error',
         },
       ]);
@@ -2378,7 +2378,7 @@ describe('config/validation', () => {
       expect(errors).toMatchObject([
         {
           message:
-            "hostRules header `X-Auth-Token` is not allowed by this bot's `allowedHeaders`.",
+            "hostRules header `X-Auth-Token` is not allowed by this Renovate instance's `allowedHeaders`.",
           topic: 'Configuration Error',
         },
       ]);
@@ -2401,7 +2401,7 @@ describe('config/validation', () => {
       expect(errors).toMatchObject([
         {
           message:
-            "Env variable name `randomKey` is not allowed by this bot's `allowedEnv`.",
+            "Env variable name `randomKey` is not allowed by this Renovate instance's `allowedEnv`.",
         },
         {
           message:
@@ -2576,7 +2576,7 @@ describe('config/validation', () => {
       expect(errors).toMatchObject([
         {
           message:
-            "hostRules header `X-Auth-Token` is not allowed by this bot's `allowedHeaders`.",
+            "hostRules header `X-Auth-Token` is not allowed by this Renovate instance's `allowedHeaders`.",
           topic: 'Configuration Error',
         },
       ]);
@@ -2638,7 +2638,7 @@ describe('config/validation', () => {
       expect(errors).toMatchObject([
         {
           message:
-            "Env variable name `SOME_VAR` is not allowed by this bot's `allowedEnv`.",
+            "Env variable name `SOME_VAR` is not allowed by this Renovate instance's `allowedEnv`.",
           topic: 'Configuration Error',
         },
       ]);
@@ -3158,7 +3158,7 @@ describe('config/validation', () => {
         {
           topic: 'Configuration Error',
           message:
-            "Env variable name `NOT_ALLOWED` is not allowed by this bot's `allowedEnv`.",
+            "Env variable name `NOT_ALLOWED` is not allowed by this Renovate instance's `allowedEnv`.",
         },
       ]);
     });
@@ -3229,7 +3229,7 @@ describe('config/validation', () => {
         {
           topic: 'Configuration Error',
           message:
-            "hostRules header `Authorization` is not allowed by this bot's `allowedHeaders`.",
+            "hostRules header `Authorization` is not allowed by this Renovate instance's `allowedHeaders`.",
         },
       ]);
     });

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -799,7 +799,7 @@ export async function validateConfig(
                     if (!matchRegexOrGlobList(envVarName, allowedEnvVars)) {
                       errors.push({
                         topic: ConfigValidationTopic.Error,
-                        message: `Env variable name \`${envVarName}\` is not allowed by this bot's \`allowedEnv\`.`,
+                        message: `Env variable name \`${envVarName}\` is not allowed by this Renovate instance's \`allowedEnv\`.`,
                       });
                     }
                   }
@@ -1045,7 +1045,7 @@ export async function validateConfig(
               if (!matchRegexOrGlobList(header, allowedHeaders)) {
                 errors.push({
                   topic: ConfigValidationTopic.Error,
-                  message: `hostRules header \`${header}\` is not allowed by this bot's \`allowedHeaders\`.`,
+                  message: `hostRules header \`${header}\` is not allowed by this Renovate instance's \`allowedHeaders\`.`,
                 });
               }
             }

--- a/lib/modules/manager/bundler/readme.md
+++ b/lib/modules/manager/bundler/readme.md
@@ -30,5 +30,5 @@ Important notes:
 
 To avoid committing raw secrets to your repository, either:
 
-- If self-hosting: add the `hostRules` to your bot config file, instead of the repository configuration file, or
+- If self-hosting: add the `hostRules` to your self-hosted config file, instead of the repository configuration file, or
 - If using the Mend Renovate App: use the [`encrypted`](../../../configuration-options.md#encrypted) config option

--- a/lib/modules/manager/copier/extract.ts
+++ b/lib/modules/manager/copier/extract.ts
@@ -20,7 +20,7 @@ function stripGitPrefix(url: string): string {
 /**
  * Convert SSH-style template URLs to their HTTPS equivalent for the
  * datasource lookup, like the git-submodules manager does.
- * This way the lookup can be authenticated via `hostRules` on bots
+ * This way the lookup can be authenticated via `hostRules` on accounts
  * which access the Git host over HTTPS only.
  * The answers file itself keeps the original URL.
  */

--- a/lib/modules/manager/github-actions/__fixtures__/workflow_3.yml
+++ b/lib/modules/manager/github-actions/__fixtures__/workflow_3.yml
@@ -12,9 +12,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@1e204e9a9253d643386038d443f96446fa156a97 # renovate: tag=v2.3.5 # Comment that Renovate bot has moved Comment that Renovate bot will remove later on
-      - uses: actions/checkout@v1 # Comment that Renovate bot will remove later on
-      - uses: "actions/checkout@v1.1.2" # Comment that Renovate bot will remove later on
+      - uses: actions/checkout@1e204e9a9253d643386038d443f96446fa156a97 # renovate: tag=v2.3.5 # Comment that Renovate has moved Comment that Renovate will remove later on
+      - uses: actions/checkout@v1 # Comment that Renovate will remove later on
+      - uses: "actions/checkout@v1.1.2" # Comment that Renovate will remove later on
 
       - name: Run a one-line script
         run: echo Hello, world!

--- a/lib/modules/platform/azure/readme.md
+++ b/lib/modules/platform/azure/readme.md
@@ -4,7 +4,7 @@
 
 ### Personal Access Token (PAT)
 
-First, [create a Personal Access Token](https://learn.microsoft.com/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate) for the bot account.
+First, [create a Personal Access Token](https://learn.microsoft.com/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate) for the Renovate account.
 Let Renovate use your PAT by doing _one_ of the following:
 
 - Set your PAT as a `token` in your `config.js` file
@@ -117,7 +117,7 @@ steps:
 
   - bash: |
       git config --global user.email 'bot@renovateapp.com'
-      git config --global user.name 'Renovate Bot'
+      git config --global user.name 'Renovate'
       npx --userconfig .npmrc renovate
     env:
       RENOVATE_PLATFORM: azure

--- a/lib/modules/platform/bitbucket-server/readme.md
+++ b/lib/modules/platform/bitbucket-server/readme.md
@@ -2,7 +2,7 @@
 
 ## Authentication
 
-First, create a [HTTP access token](https://confluence.atlassian.com/bitbucketserver/personal-access-tokens-939515499.html) for the bot account.
+First, create a [HTTP access token](https://confluence.atlassian.com/bitbucketserver/personal-access-tokens-939515499.html) for the Renovate account.
 Let Renovate use your HTTP access token by doing _one_ of the following:
 
 - Set your HTTP access token as a `token` in your `config.js` file
@@ -13,9 +13,9 @@ If you use project or repository based HTTP access tokens, it can only be used a
 
 Remember to set `platform=bitbucket-server` somewhere in your Renovate config file.
 
-If you're not using `@renovate-bot` as username then set your custom `username` for the bot account.
+If you're not using `@renovate-bot` as username then set your custom `username` for the Renovate account.
 
-If you use MySQL or MariaDB you must set `unicodeEmoji` to `false` in the global bot config (`RENOVATE_CONFIG_FILE`) to prevent issues with emojis.
+If you use MySQL or MariaDB you must set `unicodeEmoji` to `false` in the global self-hosted config (`RENOVATE_CONFIG_FILE`) to prevent issues with emojis.
 
 ## Unsupported platform features/concepts
 

--- a/lib/modules/platform/bitbucket/readme.md
+++ b/lib/modules/platform/bitbucket/readme.md
@@ -12,7 +12,7 @@ When you use the app, Mend will:
 - maintain and update the Renovate version used
 
 If you self-host Renovate you must do the things listed above yourself.
-Self-hosting is meant for users with advanced use cases, or who want to be in full control of the bot and the environment it runs in.
+Self-hosting is meant for users with advanced use cases, or who want to be in full control of Renovate and the environment it runs in.
 We recommend most users install the Mend app.
 
 Read the [Security and Permissions](../../../security-and-permissions.md) page to learn about the Security and Permissions needed for the Mend app.
@@ -21,8 +21,8 @@ After you installed the hosted app, please read the [reading list](../../../read
 
 ## Authentication
 
-First, [create an API token](https://support.atlassian.com/bitbucket-cloud/docs/create-an-api-token/) for the bot account.
-Give the bot API token the following permission scopes:
+First, [create an API token](https://support.atlassian.com/bitbucket-cloud/docs/create-an-api-token/) for the Renovate account.
+Give the API token the following permission scopes:
 
 | Permission                                                                                                               | Scope                |
 | ------------------------------------------------------------------------------------------------------------------------ | -------------------- |
@@ -33,7 +33,7 @@ Give the bot API token the following permission scopes:
 | [`read:user:bitbucket`](https://developer.atlassian.com/cloud/bitbucket/rest/intro/#read-user-bitbucket)                 | User: Read           |
 | [`read:workspace:bitbucket`](https://developer.atlassian.com/cloud/bitbucket/rest/intro/#read-workspace-bitbucket)       | Workspace: Read      |
 
-The bot also needs to validate the workspace membership status of pull-request reviewers, for that, [create a new user group](https://support.atlassian.com/bitbucket-cloud/docs/organize-workspace-members-into-groups/) in the workspace with the **Create repositories** permission and add the bot user to it.
+Renovate also needs to validate the workspace membership status of pull-request reviewers, for that, [create a new user group](https://support.atlassian.com/bitbucket-cloud/docs/organize-workspace-members-into-groups/) in the workspace with the **Create repositories** permission and add the Renovate user to it.
 
 Let Renovate use your API token by doing _one_ of the following:
 
@@ -43,7 +43,7 @@ Let Renovate use your API token by doing _one_ of the following:
 
 Remember to:
 
-- Set the `username` for the bot account, which is your Atlassian account email. You can find your email through "Personal Bitbucket settings" on the "Email aliases" page for your account
+- Set the `username` for the Renovate account, which is your Atlassian account email. You can find your email through "Personal Bitbucket settings" on the "Email aliases" page for your account
 - Set `platform=bitbucket` somewhere in your Renovate config file
 
 ## Unsupported platform features/concepts

--- a/lib/modules/platform/forgejo/index.ts
+++ b/lib/modules/platform/forgejo/index.ts
@@ -542,7 +542,7 @@ const platform: Platform = {
   }: FindPRConfig): Promise<Pr | null> {
     logger.debug(`findPr(${branchName}, ${title!}, ${state})`);
     if (includeOtherAuthors && isString(targetBranch)) {
-      // do not use pr cache as it only fetches prs created by the bot account
+      // do not use pr cache as it only fetches prs created by the Renovate account
       const pr = await helper.getPRByBranch(
         config.repository,
         targetBranch,

--- a/lib/modules/platform/forgejo/readme.md
+++ b/lib/modules/platform/forgejo/readme.md
@@ -4,8 +4,8 @@ Renovate supports [Forgejo](https://forgejo.org).
 
 ## Authentication
 
-First, [create a Personal Access Token (PAT)](https://forgejo.org/docs/latest/user/api-usage/#authentication) for the bot account.
-The bot account should have full name and email address configured.
+First, [create a Personal Access Token (PAT)](https://forgejo.org/docs/latest/user/api-usage/#authentication) for the Renovate account.
+The Renovate account should have full name and email address configured.
 Then let Renovate use your PAT by doing _one_ of the following:
 
 - Set your PAT as a `token` in your `config.js` file

--- a/lib/modules/platform/gerrit/readme.md
+++ b/lib/modules/platform/gerrit/readme.md
@@ -31,7 +31,7 @@ If you use the "Code-Review" label and want to get `automerge` working then you 
 Renovate will now add the _Code-Review_ label with the value "+2" to each of its "pull requests" (Gerrit-Change).
 
 !!! note
-  The bot's user account must have permission to give +2 for the Code-Review label.
+  The Renovate user account must have permission to give +2 for the Code-Review label.
 
 The Renovate option `automergeType: "branch"` makes no sense for Gerrit, because there are no branches used to create pull requests.
 It works similar to the default option `"pr"`.

--- a/lib/modules/platform/gitea/index.ts
+++ b/lib/modules/platform/gitea/index.ts
@@ -549,7 +549,7 @@ const platform: Platform = {
   }: FindPRConfig): Promise<Pr | null> {
     logger.debug(`findPr(${branchName}, ${title!}, ${state})`);
     if (includeOtherAuthors && isString(targetBranch)) {
-      // do not use pr cache as it only fetches prs created by the bot account
+      // do not use pr cache as it only fetches prs created by the Renovate account
       const pr = await helper.getPRByBranch(
         config.repository,
         targetBranch,

--- a/lib/modules/platform/gitea/readme.md
+++ b/lib/modules/platform/gitea/readme.md
@@ -8,8 +8,8 @@ Renovate supports [Gitea](https://gitea.io).
 
 ## Authentication
 
-First, [create a Personal Access Token (PAT)](https://docs.gitea.io/en-us/api-usage/#authentication) for the bot account.
-The bot account should have full name and email address configured.
+First, [create a Personal Access Token (PAT)](https://docs.gitea.io/en-us/api-usage/#authentication) for the Renovate account.
+The Renovate account should have full name and email address configured.
 Then let Renovate use your PAT by doing _one_ of the following:
 
 - Set your PAT as a `token` in your `config.js` file

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -686,7 +686,7 @@ export async function initRepo({
   config.prList = null;
 
   if (forkToken) {
-    logger.debug('Bot is in fork mode');
+    logger.debug('Renovate is in fork mode');
     if (repo.isFork) {
       logger.debug(
         `Forked repos cannot be processed when running with a forkToken, so this repo will be skipped`,

--- a/lib/modules/platform/github/readme.md
+++ b/lib/modules/platform/github/readme.md
@@ -12,7 +12,7 @@ When you use the app, Mend will:
 - maintain and update the Renovate version used
 
 If you self-host Renovate you must do the things listed above yourself.
-Self-hosting is meant for users with advanced use cases, or who want to be in full control of the bot and the environment it runs in.
+Self-hosting is meant for users with advanced use cases, or who want to be in full control of Renovate and the environment it runs in.
 We recommend most users install the Mend Renovate app.
 
 Read the [Security and Permissions](../../../security-and-permissions.md) page to learn about the Security and Permissions needed for the Mend Renovate app.
@@ -62,12 +62,12 @@ A fine-grained token must have these permissions:
 | `Pull requests`     | `Read and write` | _Repository_ or _Organization_ |
 | `Workflows`         | `Read and write` | _Repository_ or _Organization_ |
 
-!!! tip "Use a bot role account"
+!!! tip "Use a dedicated role account"
   Consider creating a GitHub App to use instead of using your own GitHub user account.
 
 ## Running as a GitHub App
 
-Instead of a bot account with a Personal Access Token you can run `renovate` as a self-hosted [GitHub App](https://docs.github.com/en/developers/apps/getting-started-with-apps).
+Instead of a dedicated account with a Personal Access Token you can run `renovate` as a self-hosted [GitHub App](https://docs.github.com/en/developers/apps/getting-started-with-apps).
 
 When creating the GitHub App give it the following permissions:
 
@@ -117,9 +117,9 @@ The GitHub App installation token is scoped at most to a single organization and
 
 The slug name of your app with `[bot]` appended
 
-**`gitAuthor:"Self-hosted Renovate Bot <123456+self-hosted-renovate[bot]@users.noreply.github.enterprise.com>"`** (optional, autodetected if not supplied)
+**`gitAuthor:"Self-hosted Renovate <123456+self-hosted-renovate[bot]@users.noreply.github.enterprise.com>"`** (optional, autodetected if not supplied)
 
-The [GitHub App associated email](https://github.community/t/logging-into-git-as-a-github-app/115916/2) to match commits to the bot.
+The [GitHub App associated email](https://github.community/t/logging-into-git-as-a-github-app/115916/2) to match commits to Renovate.
 It needs to have the user id _and_ the username followed by the `users.noreply.`-domain of either github.com or the GitHub Enterprise Server.
 A way to get the user id of a GitHub app is to [query the user API](https://docs.github.com/en/rest/reference/users#get-a-user) at `api.github.com/users/self-hosted-renovate[bot]` (github.com) or `github.enterprise.com/api/v3/users/self-hosted-renovate[bot]` (GitHub Enterprise Server).
 

--- a/lib/modules/platform/gitlab/readme.md
+++ b/lib/modules/platform/gitlab/readme.md
@@ -12,22 +12,22 @@ You can authenticate Renovate to GitLab, with _one_ of these methods:
 
 To start, create either:
 
-- a [Personal Access Token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html#create-a-personal-access-token) for the bot account
+- a [Personal Access Token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html#create-a-personal-access-token) for the Renovate account
 - or a [Project Access Token](https://docs.gitlab.com/ee/user/project/settings/project_access_tokens.html#create-a-project-access-token) if Renovate only needs to check and update _one_ project. We do not recommend Project Access Tokens, as you need to configure Renovate, and the token, for _each_ project
 - or a [Group Access Token](https://docs.gitlab.com/ee/user/group/settings/group_access_tokens.html#create-a-group-access-token-using-ui) to the group Renovate will be working on
 
-#### Bot or token must have at least developer role
+#### Renovate account or token must have at least developer role
 
-The bot account, or token, must have at least the Developer role.
+The Renovate account, or token, must have at least the Developer role.
 The developer role allows Renovate to [create issues and merge requests](https://docs.gitlab.com/ee/user/permissions.html#project-members-permissions).
 
 #### If you want Renovate to automerge, give appropriate permissions
 
-If you are using automerge, the bot account, or token, must have the appropriate ["Allowed to merge" permission on the protected branch](https://docs.gitlab.com/ee/user/project/protected_branches.html#require-everyone-to-submit-merge-requests-for-a-protected-branch) of your projects.
+If you are using automerge, the Renovate account, or token, must have the appropriate ["Allowed to merge" permission on the protected branch](https://docs.gitlab.com/ee/user/project/protected_branches.html#require-everyone-to-submit-merge-requests-for-a-protected-branch) of your projects.
 
 #### If only maintainers are allowed to merge, give Maintainer role
 
-If merging is restricted to Maintainers, the bot account or token must have the Maintainer role.
+If merging is restricted to Maintainers, the Renovate account or token must have the Maintainer role.
 
 #### Setting up Project Access Tokens or Group Access Tokens
 

--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -1570,6 +1570,18 @@ describe('util/git/index', { timeout: 30000 }, () => {
     it('throws for invalid', () => {
       expect(() => git.setGitAuthor('invalid')).toThrow(CONFIG_VALIDATION);
     });
+
+    it('defaults to "Renovate Bot" when undefined', async () => {
+      git.setGitAuthor(undefined);
+      await git.writeGitAuthor();
+      const local = simpleGit(tmpDir.path);
+      expect((await local.raw(['config', 'user.name'])).trim()).toBe(
+        'Renovate Bot',
+      );
+      expect((await local.raw(['config', 'user.email'])).trim()).toBe(
+        'renovate@whitesourcesoftware.com',
+      );
+    });
   });
 
   describe('isBranchConflicted', () => {

--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -1571,12 +1571,12 @@ describe('util/git/index', { timeout: 30000 }, () => {
       expect(() => git.setGitAuthor('invalid')).toThrow(CONFIG_VALIDATION);
     });
 
-    it('defaults to "Renovate Bot" when undefined', async () => {
+    it('defaults to "Renovate" when undefined', async () => {
       git.setGitAuthor(undefined);
       await git.writeGitAuthor();
       const local = simpleGit(tmpDir.path);
       expect((await local.raw(['config', 'user.name'])).trim()).toBe(
-        'Renovate Bot',
+        'Renovate',
       );
       expect((await local.raw(['config', 'user.email'])).trim()).toBe(
         'renovate@whitesourcesoftware.com',

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -360,7 +360,7 @@ async function cleanLocalBranches(): Promise<void> {
 
 export function setGitAuthor(gitAuthor: string | undefined): void {
   const gitAuthorParsed = parseGitAuthor(
-    gitAuthor ?? 'Renovate Bot <renovate@whitesourcesoftware.com>',
+    gitAuthor ?? 'Renovate <renovate@whitesourcesoftware.com>',
   );
   if (!gitAuthorParsed) {
     const error = new Error(CONFIG_VALIDATION);
@@ -605,7 +605,7 @@ export const syncGit = withInstrumenting(
     /* v8 ignore next -- TODO: add test #40625 */
     delete getCache()?.semanticCommits;
 
-    // If upstreamUrl is set then the bot is running in fork mode
+    // If upstreamUrl is set then Renovate is running in fork mode
     // The "upstream" remote is the original repository which was forked from
     if (config.upstreamUrl) {
       const { upstreamUrl } = config;

--- a/lib/workers/repository/init/apis.ts
+++ b/lib/workers/repository/init/apis.ts
@@ -34,8 +34,8 @@ async function validateOptimizeForDisabled(
     }
     /*
      * The following is to support a use case within Mend customers where:
-     *  - Bot admins configure install the bot into every repo
-     *  - Bot admins configure `extends: [':disableRenovate'] in order to skip repos by default
+     *  - Admins configure and install Renovate into every repo
+     *  - Admins configure `extends: [':disableRenovate'] in order to skip repos by default
      *  - Repo users can push a `renovate.json` containing `extends: [':enableRenovate']` to re-enable Renovate
      */
     if (config.extends?.includes(':disableRenovate')) {

--- a/lib/workers/repository/onboarding/branch/check.ts
+++ b/lib/workers/repository/onboarding/branch/check.ts
@@ -107,7 +107,7 @@ export async function isOnboarded(config: RenovateConfig): Promise<boolean> {
     return false;
   }
 
-  // when bot is ran is fork mode ... do not fetch file using api call instead use the git.fileList so we get sync first and get the latest config
+  // when Renovate is running in fork mode ... do not fetch file using api call instead use the git.fileList so we get sync first and get the latest config
   // prevents https://github.com/renovatebot/renovate/discussions/37328
   if (cache.configFileName && !config.forkToken) {
     logger.debug('Checking cached config file name');

--- a/lib/workers/repository/reconfigure/comment.ts
+++ b/lib/workers/repository/reconfigure/comment.ts
@@ -46,7 +46,7 @@ const SUMMARY_SECTION_ORDER = [
 function buildReconfigurePrCommentTemplate(
   sectionOrder: readonly string[],
 ): string {
-  let prCommentTemplate = `This is a reconfigure PR comment to help you understand and re-configure your renovate bot settings. If this Reconfigure PR were to be merged, we'd expect to see the following outcome:\n\n`;
+  let prCommentTemplate = `This is a reconfigure PR comment to help you understand and re-configure your renovate settings. If this Reconfigure PR were to be merged, we'd expect to see the following outcome:\n\n`;
 
   // TODO #22198
   prCommentTemplate += `

--- a/lib/workers/repository/update/branch/get-updated.ts
+++ b/lib/workers/repository/update/branch/get-updated.ts
@@ -284,7 +284,7 @@ export async function getUpdatedPackageFiles(
       }
       if (newContent !== packageFileContent) {
         if (reuseExistingBranch) {
-          // This ensure it's always 1 commit from the bot
+          // This ensure it's always 1 commit from Renovate
           logger.debug(
             { packageFile, depName },
             'Need to update package file so will rebase first',

--- a/tools/docs/config.ts
+++ b/tools/docs/config.ts
@@ -391,9 +391,12 @@ function generateToolsForInstallTools(): string {
   return output;
 }
 
-export async function generateConfig(dist: string, bot = false): Promise<void> {
+export async function generateConfig(
+  dist: string,
+  globalOnly = false,
+): Promise<void> {
   let configFile = `configuration-options.md`;
-  if (bot) {
+  if (globalOnly) {
     configFile = `self-hosted-configuration.md`;
   }
 
@@ -405,7 +408,8 @@ export async function generateConfig(dist: string, bot = false): Promise<void> {
 
   options
     .filter(
-      (option) => !!option.globalOnly === bot && !managers.has(option.name),
+      (option) =>
+        !!option.globalOnly === globalOnly && !managers.has(option.name),
     )
     .forEach((option) => {
       // TODO: fix types (#22198,#9610)
@@ -464,7 +468,7 @@ export async function generateConfig(dist: string, bot = false): Promise<void> {
 
   let content = configOptionsRaw.join('\n');
 
-  if (bot) {
+  if (globalOnly) {
     content = replaceContent(
       content,
       generateCacheNamespacesList(),
@@ -472,7 +476,7 @@ export async function generateConfig(dist: string, bot = false): Promise<void> {
     );
   }
 
-  if (!bot) {
+  if (!globalOnly) {
     content = replaceContent(
       content,
       generateLockFileTable(),
@@ -480,7 +484,7 @@ export async function generateConfig(dist: string, bot = false): Promise<void> {
     );
   }
 
-  if (!bot) {
+  if (!globalOnly) {
     content = replaceContent(
       content,
       generateConfigFileNames(),
@@ -488,7 +492,7 @@ export async function generateConfig(dist: string, bot = false): Promise<void> {
     );
   }
 
-  if (!bot) {
+  if (!globalOnly) {
     content = replaceContent(
       content,
       generateToolsForConstraints(),
@@ -496,7 +500,7 @@ export async function generateConfig(dist: string, bot = false): Promise<void> {
     );
   }
 
-  if (!bot) {
+  if (!globalOnly) {
     content = replaceContent(
       content,
       generateAdditionalConstraints(),
@@ -504,7 +508,7 @@ export async function generateConfig(dist: string, bot = false): Promise<void> {
     );
   }
 
-  if (!bot) {
+  if (!globalOnly) {
     content = replaceContent(
       content,
       generateToolsForInstallTools(),
@@ -512,7 +516,7 @@ export async function generateConfig(dist: string, bot = false): Promise<void> {
     );
   }
 
-  if (!bot) {
+  if (!globalOnly) {
     content = replaceContent(
       content,
       generateStatusCheckWhenTable(),

--- a/tools/docs/manager.ts
+++ b/tools/docs/manager.ts
@@ -112,7 +112,7 @@ export async function generateManagers(
       md += `Renovate supports updating ${nameWithUrl} dependencies.\n\n`;
       if (defaultConfig.enabled === false) {
         md += '## Enabling\n\n';
-        md += `${displayName} functionality is currently in beta testing, so you must opt-in to test it. To enable it, add a configuration like this to either your bot config or your \`renovate.json\`:\n\n`;
+        md += `${displayName} functionality is currently in beta testing, so you must opt-in to test it. To enable it, add a configuration like this to either your self-hosted config or your \`renovate.json\`:\n\n`;
         md += '```\n';
         md += `{\n  "${manager}": {\n    "enabled": true\n  }\n}`;
         md += '\n```\n\n';


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
We dropped the "bot" from our terminology long ago (as with #37535), but it
looks like we've got some outdated docs + code that reference it.

We should remove this to keep things consistent.

Fix as it changes some user-facing things like logs, and changes the default commit author.


## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
