### PR TITLE
feat(presets): log the resolved configuration (without internal presets)

### DIFF
--- a/lib/config/presets/index.spec.ts
+++ b/lib/config/presets/index.spec.ts
@@ -568,6 +568,565 @@ describe('config/presets/index', () => {
         PLATFORM_RATE_LIMIT_EXCEEDED,
       );
     });
+
+    describe('when using mergeInternalPresets=true', () => {
+      describe('when resolving an internal preset', () => {
+        it('merges `extends`', async () => {
+          config.extends = ['security:openssf-scorecard'];
+          config.packageRules = [
+            {
+              extends: ['packages:eslint'],
+              groupName: 'eslint',
+            },
+          ];
+
+          const { config: res } = await presets.resolveConfigPresets(
+            config,
+            undefined,
+            undefined,
+            undefined,
+            true,
+          );
+
+          expect(res).toEqual({
+            description: ['Show OpenSSF badge on pull requests.'],
+            packageRules: [
+              {
+                matchSourceUrls: ['https://github.com/**'],
+                prBodyColumns: [
+                  'Package',
+                  'Type',
+                  'Update',
+                  'Change',
+                  'Pending',
+                  'OpenSSF',
+                ],
+                prBodyDefinitions: {
+                  OpenSSF:
+                    '[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/{{sourceRepo}}/badge)](https://securityscorecards.dev/viewer/?uri=github.com/{{sourceRepo}})',
+                },
+              },
+              {
+                groupName: 'eslint',
+                matchPackageNames: [
+                  '*/eslint-plugin',
+                  '@babel/eslint-parser',
+                  '@eslint/**',
+                  '@eslint-community/**',
+                  '@stylistic/eslint-plugin**',
+                  '@types/eslint',
+                  '@types/eslint__**',
+                  '@typescript-eslint/**',
+                  'babel-eslint',
+                  'eslint**',
+                  'typescript-eslint',
+                ],
+              },
+            ],
+          });
+        });
+
+        it('does not return any unmerged presets', async () => {
+          config.extends = ['security:openssf-scorecard'];
+          config.packageRules = [
+            {
+              extends: ['packages:eslint'],
+              groupName: 'eslint',
+            },
+          ];
+
+          const {
+            visitedPresets: { unmerged },
+          } = await presets.resolveConfigPresets(
+            config,
+            undefined,
+            undefined,
+            undefined,
+            true,
+          );
+
+          expect(unmerged).toBeEmptyArray();
+        });
+      });
+
+      // NOTE that this is a **??**
+      describe('when resolving an internal preset which includes many other internal presets', () => {
+        it('merges `extends`, recursively', async () => {
+          config.extends = [':assignAndReview(jamietanna)'];
+
+          const { config: res } = await presets.resolveConfigPresets(
+            config,
+            undefined,
+            undefined,
+            undefined,
+            true,
+          );
+
+          expect(res).toEqual({
+            assignees: ['jamietanna'],
+            description: [
+              'Assign PRs to `jamietanna`.',
+              'Add `jamietanna` as reviewer for PRs.',
+            ],
+            reviewers: ['jamietanna'],
+          });
+        });
+
+        it('does not return any unmerged presets', async () => {
+          config.extends = [':assignAndReview(jamietanna)'];
+
+          const {
+            visitedPresets: { merged, unmerged },
+          } = await presets.resolveConfigPresets(
+            config,
+            undefined,
+            undefined,
+            undefined,
+            true,
+          );
+
+          expect(merged).toEqual([
+            ':assignAndReview(jamietanna)',
+            ':assignee(jamietanna)',
+            ':reviewer(jamietanna)',
+          ]);
+          expect(unmerged).toEqual([]);
+        });
+      });
+
+      describe('when resolving an external preset which references an internal preset', () => {
+        it('merges internal `extends`', async () => {
+          config.extends = ['local>username/preset-repo'];
+          local.getPreset.mockResolvedValueOnce({
+            extends: ['security:openssf-scorecard'],
+            labels: ['self-hosted resolved'],
+          });
+
+          const { config: res } = await presets.resolveConfigPresets(
+            config,
+            undefined,
+            undefined,
+            undefined,
+            true,
+          );
+
+          expect(res).toEqual({
+            description: ['Show OpenSSF badge on pull requests.'],
+            labels: ['self-hosted resolved'],
+            packageRules: [
+              {
+                matchSourceUrls: ['https://github.com/**'],
+                prBodyColumns: [
+                  'Package',
+                  'Type',
+                  'Update',
+                  'Change',
+                  'Pending',
+                  'OpenSSF',
+                ],
+                prBodyDefinitions: {
+                  OpenSSF:
+                    '[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/{{sourceRepo}}/badge)](https://securityscorecards.dev/viewer/?uri=github.com/{{sourceRepo}})',
+                },
+              },
+            ],
+          });
+        });
+
+        it('does not return any unmerged presets', async () => {
+          config.extends = ['local>username/preset-repo'];
+          local.getPreset.mockResolvedValueOnce({
+            extends: ['security:openssf-scorecard'],
+            labels: ['self-hosted resolved'],
+          });
+
+          const {
+            visitedPresets: { unmerged },
+          } = await presets.resolveConfigPresets(
+            config,
+            undefined,
+            undefined,
+            undefined,
+            true,
+          );
+
+          expect(unmerged).toBeEmptyArray();
+        });
+      });
+
+      describe('when resolving mixed internal and external presets', () => {
+        it('merges internal `extends`', async () => {
+          config.extends = [
+            'security:openssf-scorecard',
+            'local>username/preset-repo',
+          ];
+          local.getPreset.mockResolvedValueOnce({
+            labels: ['self-hosted resolved'],
+          });
+          config.packageRules = [
+            {
+              extends: ['packages:eslint'],
+              groupName: 'eslint',
+            },
+          ];
+
+          const { config: res } = await presets.resolveConfigPresets(
+            config,
+            undefined,
+            undefined,
+            undefined,
+            true,
+          );
+
+          expect(res).toEqual({
+            description: ['Show OpenSSF badge on pull requests.'],
+            labels: ['self-hosted resolved'],
+            packageRules: [
+              {
+                matchSourceUrls: ['https://github.com/**'],
+                prBodyColumns: [
+                  'Package',
+                  'Type',
+                  'Update',
+                  'Change',
+                  'Pending',
+                  'OpenSSF',
+                ],
+                prBodyDefinitions: {
+                  OpenSSF:
+                    '[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/{{sourceRepo}}/badge)](https://securityscorecards.dev/viewer/?uri=github.com/{{sourceRepo}})',
+                },
+              },
+              {
+                groupName: 'eslint',
+                matchPackageNames: [
+                  '*/eslint-plugin',
+                  '@babel/eslint-parser',
+                  '@eslint/**',
+                  '@eslint-community/**',
+                  '@stylistic/eslint-plugin**',
+                  '@types/eslint',
+                  '@types/eslint__**',
+                  '@typescript-eslint/**',
+                  'babel-eslint',
+                  'eslint**',
+                  'typescript-eslint',
+                ],
+              },
+            ],
+          });
+        });
+
+        it('does not return any unmerged presets', async () => {
+          config.extends = [
+            'security:openssf-scorecard',
+            'local>username/preset-repo',
+          ];
+          local.getPreset.mockResolvedValueOnce({
+            labels: ['self-hosted resolved'],
+          });
+          config.packageRules = [
+            {
+              extends: ['packages:eslint'],
+              groupName: 'eslint',
+            },
+          ];
+
+          const {
+            visitedPresets: { unmerged },
+          } = await presets.resolveConfigPresets(
+            config,
+            undefined,
+            undefined,
+            undefined,
+            true,
+          );
+
+          expect(unmerged).toBeEmptyArray();
+        });
+      });
+    });
+
+    describe('when using mergeInternalPresets=false', () => {
+      describe('when resolving an internal preset', () => {
+        it('does not merge `extends`', async () => {
+          config.extends = ['security:openssf-scorecard'];
+          config.packageRules = [
+            {
+              extends: ['packages:eslint'],
+              groupName: 'eslint',
+            },
+          ];
+
+          const { config: res } = await presets.resolveConfigPresets(
+            config,
+            undefined,
+            undefined,
+            undefined,
+            false,
+          );
+
+          expect(res).toEqual({
+            packageRules: [
+              {
+                groupName: 'eslint',
+              },
+            ],
+          });
+        });
+
+        it('returns the presets in the unmerged array', async () => {
+          config.extends = ['security:openssf-scorecard'];
+          config.packageRules = [
+            {
+              extends: ['packages:eslint'],
+              groupName: 'eslint',
+            },
+          ];
+
+          const {
+            visitedPresets: { unmerged },
+          } = await presets.resolveConfigPresets(
+            config,
+            undefined,
+            undefined,
+            undefined,
+            false,
+          );
+
+          expect(unmerged).toEqual([
+            'security:openssf-scorecard',
+            'packages:eslint',
+          ]);
+        });
+      });
+
+      describe('when resolving an internal, parameterised preset', () => {
+        it('does not merge `extends`', async () => {
+          config.extends = [':assignee(renovate-tests)'];
+
+          const { config: res } = await presets.resolveConfigPresets(
+            config,
+            undefined,
+            undefined,
+            undefined,
+            false,
+          );
+
+          expect(res).toEqual({});
+        });
+
+        it('returns the preset in the unmerged array', async () => {
+          config.extends = [':assignee(renovate-tests)'];
+
+          const {
+            visitedPresets: { unmerged },
+          } = await presets.resolveConfigPresets(
+            config,
+            undefined,
+            undefined,
+            undefined,
+            false,
+          );
+
+          expect(unmerged).toEqual([':assignee(renovate-tests)']);
+        });
+      });
+
+      describe('when resolving an internal preset which includes many other internal presets', () => {
+        it('does not merge `extends`', async () => {
+          config.extends = ['config:recommended'];
+
+          const { config: res } = await presets.resolveConfigPresets(
+            config,
+            undefined,
+            undefined,
+            undefined,
+            false,
+          );
+
+          expect(res).toEqual({});
+        });
+
+        it('returns the unmerged internal presets', async () => {
+          config.extends = ['config:recommended'];
+
+          const {
+            visitedPresets: { merged, unmerged },
+          } = await presets.resolveConfigPresets(
+            config,
+            undefined,
+            undefined,
+            undefined,
+            false,
+          );
+
+          expect(merged).toEqual([]);
+          expect(unmerged).toEqual(['config:recommended']);
+        });
+      });
+
+      describe('when resolving an external preset which references an internal preset', () => {
+        it('does not merge `extends`', async () => {
+          config.extends = ['local>username/preset-repo'];
+          local.getPreset.mockResolvedValueOnce({
+            extends: ['security:openssf-scorecard'],
+            labels: ['self-hosted resolved'],
+          });
+
+          const { config: res } = await presets.resolveConfigPresets(
+            config,
+            undefined,
+            undefined,
+            undefined,
+            false,
+          );
+
+          expect(res).toEqual({
+            labels: ['self-hosted resolved'],
+          });
+        });
+
+        it('returns the unmerged internal presets', async () => {
+          config.extends = ['local>username/preset-repo'];
+          local.getPreset.mockResolvedValueOnce({
+            extends: ['security:openssf-scorecard'],
+            labels: ['self-hosted resolved'],
+          });
+
+          const {
+            visitedPresets: { unmerged },
+          } = await presets.resolveConfigPresets(
+            config,
+            undefined,
+            undefined,
+            undefined,
+            false,
+          );
+
+          expect(unmerged).toEqual(['security:openssf-scorecard']);
+        });
+      });
+
+      describe('when resolving mixed internal and external presets', () => {
+        it('does not expand internal `extends`', async () => {
+          config.extends = [
+            'security:openssf-scorecard',
+            'local>username/preset-repo',
+          ];
+          local.getPreset.mockResolvedValueOnce({
+            labels: ['self-hosted resolved'],
+          });
+          config.packageRules = [
+            {
+              extends: ['packages:eslint'],
+              groupName: 'eslint',
+            },
+          ];
+
+          const { config: res } = await presets.resolveConfigPresets(
+            config,
+            undefined,
+            undefined,
+            undefined,
+            false,
+          );
+
+          expect(res).toEqual({
+            labels: ['self-hosted resolved'],
+            packageRules: [
+              {
+                groupName: 'eslint',
+              },
+            ],
+          });
+        });
+
+        it('returns the unmerged internal presets', async () => {
+          config.extends = [
+            'security:openssf-scorecard',
+            'local>username/preset-repo',
+          ];
+          local.getPreset.mockResolvedValueOnce({
+            labels: ['self-hosted resolved'],
+          });
+          config.packageRules = [
+            {
+              extends: ['packages:eslint'],
+              groupName: 'eslint',
+            },
+          ];
+
+          const {
+            visitedPresets: { unmerged },
+          } = await presets.resolveConfigPresets(
+            config,
+            undefined,
+            undefined,
+            undefined,
+            false,
+          );
+
+          expect(unmerged).toEqual([
+            'security:openssf-scorecard',
+            'packages:eslint',
+          ]);
+        });
+      });
+
+      describe('when resolving an internal preset inside a nested object config value', () => {
+        it('returns the unmerged internal presets from a datasource', async () => {
+          config.extends = ['local>username/preset-repo'];
+          local.getPreset.mockResolvedValueOnce({
+            artifactory: {
+              extends: ['security:openssf-scorecard'],
+              enabled: true,
+            },
+          });
+
+          const {
+            visitedPresets: { unmerged },
+          } = await presets.resolveConfigPresets(
+            config,
+            undefined,
+            undefined,
+            undefined,
+            false,
+          );
+
+          expect(unmerged).toEqual(['security:openssf-scorecard']);
+        });
+      });
+
+      describe('when duplicate internal presets are found', () => {
+        it('they are de-duplicated when returned as unmerged', async () => {
+          config.extends = [
+            'security:openssf-scorecard',
+            'local>username/preset-repo',
+          ];
+          local.getPreset.mockResolvedValueOnce({
+            extends: ['security:openssf-scorecard'],
+          });
+          config.packageRules = [
+            {
+              extends: ['security:openssf-scorecard'],
+            },
+          ];
+
+          const {
+            visitedPresets: { unmerged },
+          } = await presets.resolveConfigPresets(
+            config,
+            undefined,
+            undefined,
+            undefined,
+            false,
+          );
+
+          expect(unmerged).toEqual(['security:openssf-scorecard']);
+        });
+      });
+    });
   });
 
   describe('replaceArgs', () => {

--- a/lib/config/presets/index.ts
+++ b/lib/config/presets/index.ts
@@ -200,17 +200,26 @@ export interface ResolveConfigPresetsResult {
   visitedPresets: {
     /** which internal/shared presets were merged into the final config */
     merged: string[];
+    /** which internal/shared presets were not merged into the final config */
+    unmerged: string[];
   };
 }
 
+/**
+ * @param [mergeInternalPresets=true] when resolving the config presets, whether to merge Renovate internal presets into the resulting configuration.
+ *   When set to `false`, this will resolve these internal presets (recursively), but not merge them.
+ *   This is primarily intended to be used by "shallow config" resolution (for logging purposes).
+ */
 export async function resolveConfigPresets(
   inputConfig: AllConfig,
   baseConfig?: RenovateConfig,
   _ignorePresets?: string[],
   existingPresets: string[] = [],
+  mergeInternalPresets = true,
 ): Promise<ResolveConfigPresetsResult> {
   const allVisitedPresets = {
     merged: new Set<string>(),
+    unmerged: new Set<string>(),
   };
 
   let ignorePresets = clone(_ignorePresets);
@@ -218,9 +227,10 @@ export async function resolveConfigPresets(
     ignorePresets = inputConfig.ignorePresets ?? [];
   }
   logger.trace(
-    { config: inputConfig, existingPresets },
+    { config: inputConfig, existingPresets, mergeInternalPresets },
     'resolveConfigPresets',
   );
+
   let config: AllConfig = {};
   // First, merge all the preset configs from left to right
   if (inputConfig.extends?.length) {
@@ -229,6 +239,17 @@ export async function resolveConfigPresets(
       template.compile(tmpl, {}),
     );
     for (const preset of inputConfig.extends) {
+      // don't attempt to merge any internal presets if we're not expecting to
+      if (!mergeInternalPresets && internal.isInternal(preset)) {
+        logger.once.trace(
+          { ignoredPreset: preset, mergeInternalPresets },
+          'Not merging preset',
+        );
+        // ... but make sure we note that we haven't resolved it
+        allVisitedPresets.unmerged.add(preset);
+        continue;
+      }
+
       if (shouldResolvePreset(preset, existingPresets, ignorePresets)) {
         logger.trace(`Resolving preset "${preset}"`);
         const fetchedPreset = await fetchPreset(
@@ -243,15 +264,22 @@ export async function resolveConfigPresets(
             baseConfig ?? inputConfig,
             ignorePresets,
             existingPresets.concat([preset]),
+            mergeInternalPresets,
           );
         if (inputConfig?.ignoreDeps?.length === 0) {
           delete presetConfig.description;
         }
+
         config = mergeChildConfig(config, presetConfig);
         allVisitedPresets.merged.add(preset);
+
         // then also make sure we've noted any nested presets we've merged
         for (const mergedPreset of visitedPresets.merged) {
           allVisitedPresets.merged.add(mergedPreset);
+        }
+        // ... or not merged
+        for (const unmergedPreset of visitedPresets.unmerged) {
+          allVisitedPresets.unmerged.add(unmergedPreset);
         }
       }
     }
@@ -278,11 +306,17 @@ export async function resolveConfigPresets(
               baseConfig,
               ignorePresets,
               existingPresets,
+              mergeInternalPresets,
             );
           (config[key] as RenovateConfig[]).push(presetConfig);
 
+          // then also make sure we've noted any nested presets we've merged
           for (const mergedPreset of visited.merged) {
             allVisitedPresets.merged.add(mergedPreset);
+          }
+          // ... or not merged
+          for (const unmergedPreset of visited.unmerged) {
+            allVisitedPresets.unmerged.add(unmergedPreset);
           }
         } else {
           (config[key] as unknown[]).push(element);
@@ -297,11 +331,17 @@ export async function resolveConfigPresets(
           baseConfig,
           ignorePresets,
           existingPresets,
+          mergeInternalPresets,
         );
       config[key] = presetConfig as never; // type can't be narrowed
 
+      // then also make sure we've noted any nested presets we've merged
       for (const mergedPreset of visited.merged) {
         allVisitedPresets.merged.add(mergedPreset);
+      }
+      // ... or not merged
+      for (const unmergedPreset of visited.unmerged) {
+        allVisitedPresets.unmerged.add(unmergedPreset);
       }
     }
   }
@@ -315,6 +355,7 @@ export async function resolveConfigPresets(
     config,
     visitedPresets: {
       merged: Array.from(allVisitedPresets.merged),
+      unmerged: Array.from(allVisitedPresets.unmerged),
     },
   };
 }

--- a/lib/workers/repository/init/inherited.spec.ts
+++ b/lib/workers/repository/init/inherited.spec.ts
@@ -191,6 +191,7 @@ describe('workers/repository/init/inherited', () => {
       },
       visitedPresets: {
         merged: [],
+        unmerged: [],
       },
     });
     const res = await mergeInheritedConfig(config);
@@ -229,6 +230,7 @@ describe('workers/repository/init/inherited', () => {
       },
       visitedPresets: {
         merged: [],
+        unmerged: [],
       },
     });
     const res = await mergeInheritedConfig(config);
@@ -272,6 +274,7 @@ describe('workers/repository/init/inherited', () => {
       },
       visitedPresets: {
         merged: [],
+        unmerged: [],
       },
     });
     await expect(mergeInheritedConfig(config)).rejects.toThrow(
@@ -307,6 +310,7 @@ describe('workers/repository/init/inherited', () => {
       },
       visitedPresets: {
         merged: [],
+        unmerged: [],
       },
     });
     const res = await mergeInheritedConfig(config);

--- a/lib/workers/repository/init/merge.ts
+++ b/lib/workers/repository/init/merge.ts
@@ -18,6 +18,7 @@ import {
   CONFIG_VALIDATION,
   REPOSITORY_CHANGED,
 } from '../../../constants/error-messages.ts';
+import { pkg } from '../../../expose.ts';
 import { logger } from '../../../logger/index.ts';
 import * as npmApi from '../../../modules/datasource/npm/index.ts';
 import { platform } from '../../../modules/platform/index.ts';
@@ -25,6 +26,7 @@ import { scm } from '../../../modules/platform/scm.ts';
 import { ExternalHostError } from '../../../types/errors/external-host-error.ts';
 import { coerceArray } from '../../../util/array.ts';
 import { getCache } from '../../../util/cache/repository/index.ts';
+import { clone } from '../../../util/clone.ts';
 import { getInheritedOrGlobal, parseJson } from '../../../util/common.ts';
 import { setUserEnv } from '../../../util/env.ts';
 import { readLocalFile, readSystemFile } from '../../../util/fs/index.ts';
@@ -283,6 +285,11 @@ export async function mergeRenovateConfig(
   // Decrypt before resolving in case we need npm authentication for any presets
   const decryptedConfig = await decryptConfig(migratedConfig, repository);
   applyNpmrc(decryptedConfig, 'decrypted');
+
+  // NOTE that this should not be used with any other configuration (`resolvedConfig`, etc) below, as they will include addditionally merged configuration
+  // Decrypted secrets are sanitised, so should be safe to log
+  await logShallowConfig(decryptedConfig, config);
+
   // Decrypt after resolving in case the preset contains npm authentication instead
   const { config: configToDecrypt } = await presets.resolveConfigPresets(
     decryptedConfig,
@@ -479,4 +486,39 @@ export function mergeStaticConfig(
 
   // renovate repo config overrides RENOVATE_STATIC_REPO_CONFIG[_FILE]
   return mergeChildConfig(staticRepoConfig, config);
+}
+
+/**
+ * Resolve everything but internal Renovate presets and log it out.
+ *
+* This allows users to understand the fully resolved configuration, including any `github>`, `local>`, etc presets, but excluding anything that's internal to Renovate (which can be verbose and/or less relevant), and provides useful output for debugging purposes.
+
+* This is also known as the "shallow" config.
+
+* Due to caching, this doesn't add any additional requests.
+ */
+async function logShallowConfig(
+  _decryptedConfig: RenovateConfig,
+  _config: RepositoryWorkerConfig,
+): Promise<void> {
+  // make sure we clone the existing config, so we don't modify the existing settings when resolving this in a shallow fashion
+  const decryptedConfig = clone(_decryptedConfig);
+  const config = clone(_config);
+
+  const { config: resolvedConfig, visitedPresets } =
+    await presets.resolveConfigPresets(
+      clone(decryptedConfig),
+      clone(config),
+      [],
+      [],
+      false,
+    );
+  logger.debug(
+    {
+      renovateVersion: pkg.version,
+      config: resolvedConfig,
+      visitedPresets,
+    },
+    'Resolved shallow config, without merging internal presets',
+  );
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

As noted in #15827, it would be useful to log the "shallow"
configuration for a given repository - that is, the resolved
configuration, but without any Renovate internal presets being included.

This will be very useful for debugging, as it shows the final resulting
configuration, but without the - often very - verbose internal presets.

In the case that only this log line is shared, we can make sure to
reference the version of the Renovate CLI in the log line.

This requires building on top of changes in
6a4fa3f245dd8976fc8477c4d72f7aae32adab34 to be able to return a `merged`
and `unmerged` list of presets, and uses helpers from
c8f42e86b4f182a6c4c530250b2b1d2a0fb20e22, and
66b84dd12bd9a638b914883fa2781e2def601e9a to process the internal presets
accordingly.

Since we first worked on this, we've worked on improvements to caching
which should provide a require no additional performance overhead
performing this resolution twice.

This can also lead to being able to understand more clearly how Renovate
configuration is being used[0], as we have the final resolved configuration.

[0]: https://www.jvt.me/posts/2024/04/14/renovate-config-sql/

Other notes:

- I've not validated what happens with environment config
- This will be super useful for "Request Help" questions
## Context

Please select one of the below:

- [x] This closes an existing Issue: Closes #15827
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
