### PR TITLE
feat(datasource/jsr): Support `releaseTimestamp`

### DIFF
--- a/docs/usage/key-concepts/minimum-release-age.md
+++ b/docs/usage/key-concepts/minimum-release-age.md
@@ -183,22 +183,23 @@ Note that you will also need to [verify if the registry you're using](#which-reg
 
 The below is a non-exhaustive list of public registries which support release timestamps:
 
-| Datasource           | Registry URL                                       | Supported | Notes                                                         |
-| -------------------- | -------------------------------------------------- | --------- | ------------------------------------------------------------- |
-| `docker`             | `https://ghcr.io`                                  | ❌        | [Issue](https://github.com/renovatebot/renovate/issues/39064) |
-| `rubygems`           | `https://rubygems.org`                             | ✅        |                                                               |
-| `docker`             | `https://index.docker.io`                          | ✅        |                                                               |
-| `docker`             | `https://quay.io`                                  | ❌        | [Issue](https://github.com/renovatebot/renovate/issues/38572) |
-| `github-releases`    | `https://github.com`                               | ✅        |                                                               |
-| `terraform-provider` | `https://registry.terraform.io`                    | ✅        | Not always returned                                           |
-| `github-tags`        | `https://github.com`                               | ✅        |                                                               |
-| `go`                 | `https://proxy.golang.org,`                        | ✅        |                                                               |
-| `golang-version`     | `https://raw.githubusercontent.com/golang/website` | ✅        |                                                               |
-| `maven`              | `https://repo1.maven.org/maven2`                   | ✅        |                                                               |
-| `node-version`       | `https://nodejs.org/dist`                          | ✅        |                                                               |
-| `npm`                | `https://registry.npmjs.org`                       | ✅        |                                                               |
-| `pypi`               | `https://pypi.org/pypi/`                           | ✅        |                                                               |
-| `ruby-version`       | `https://www.ruby-lang.org`                        | ✅        |                                                               |
+| Datasource           | Registry URL                                       | Supported | Notes                                                            |
+| -------------------- | -------------------------------------------------- | --------- | ---------------------------------------------------------------- |
+| `docker`             | `https://ghcr.io`                                  | ❌        | [Issue](https://github.com/renovatebot/renovate/issues/39064)    |
+| `rubygems`           | `https://rubygems.org`                             | ✅        |                                                                  |
+| `docker`             | `https://index.docker.io`                          | ✅        |                                                                  |
+| `docker`             | `https://quay.io`                                  | ❌        | [Issue](https://github.com/renovatebot/renovate/issues/38572)    |
+| `github-releases`    | `https://github.com`                               | ✅        |                                                                  |
+| `terraform-provider` | `https://registry.terraform.io`                    | ✅        | Not always returned                                              |
+| `github-tags`        | `https://github.com`                               | ✅        |                                                                  |
+| `go`                 | `https://proxy.golang.org,`                        | ✅        |                                                                  |
+| `golang-version`     | `https://raw.githubusercontent.com/golang/website` | ✅        |                                                                  |
+| `maven`              | `https://repo1.maven.org/maven2`                   | ✅        |                                                                  |
+| `node-version`       | `https://nodejs.org/dist`                          | ✅        |                                                                  |
+| `npm`                | `https://registry.npmjs.org`                       | ✅        |                                                                  |
+| `pypi`               | `https://pypi.org/pypi/`                           | ✅        |                                                                  |
+| `ruby-version`       | `https://www.ruby-lang.org`                        | ✅        |                                                                  |
+| `jsr`                | `https://jsr.io`                                   | ✅        | For packages without explicit timestamps, defaults to 2025-09-18 |
 
 It is _likely_ that if you are using a public registry (i.e. `registry.npmjs.org`, `repo1.maven.org`, etc) the release timestamp data will be present.
 We welcome user contributions to this table.

--- a/lib/modules/datasource/jsr/index.spec.ts
+++ b/lib/modules/datasource/jsr/index.spec.ts
@@ -1,5 +1,6 @@
 import * as httpMock from '../../../../test/http-mock';
 import type { Timestamp } from '../../../util/timestamp';
+import { MINIMUM_RELEASE_TIMESTAMP } from './schema';
 import { JsrDatasource } from '.';
 
 const jsrPackageMetadataResponse = {
@@ -55,7 +56,7 @@ describe('modules/datasource/jsr/index', () => {
       releases: [
         {
           version: '0.0.1',
-          releaseTimestamp: '2025-09-18T00:00:00.000Z' as Timestamp,
+          releaseTimestamp: MINIMUM_RELEASE_TIMESTAMP,
         },
         {
           isLatest: true,
@@ -83,7 +84,7 @@ describe('modules/datasource/jsr/index', () => {
         {
           isDeprecated: true,
           version: '0.0.1',
-          releaseTimestamp: '2025-09-18T00:00:00.000Z' as Timestamp,
+          releaseTimestamp: MINIMUM_RELEASE_TIMESTAMP,
         },
         {
           isLatest: true,

--- a/lib/modules/datasource/jsr/index.spec.ts
+++ b/lib/modules/datasource/jsr/index.spec.ts
@@ -6,7 +6,11 @@ import { JsrDatasource } from '.';
 const jsrPackageMetadataResponse = {
   latest: '0.0.2',
   versions: {
+    // Mixed createdAt fields for testing:
+    // Actually, it's either all there or none.
+    // has no createdAt (should use fallback MINIMUM_RELEASE_TIMESTAMP)
     '0.0.1': {},
+    // has explicit createdAt (should use actual timestamp)
     '0.0.2': { createdAt: '2025-11-15T00:00:00.000Z' },
   },
 } as {

--- a/lib/modules/datasource/jsr/index.spec.ts
+++ b/lib/modules/datasource/jsr/index.spec.ts
@@ -1,13 +1,17 @@
 import * as httpMock from '../../../../test/http-mock';
+import type { Timestamp } from '../../../util/timestamp';
 import { JsrDatasource } from '.';
 
 const jsrPackageMetadataResponse = {
   latest: '0.0.2',
   versions: {
     '0.0.1': {},
-    '0.0.2': {},
+    '0.0.2': { createdAt: '2025-11-15T00:00:00.000Z' },
   },
-} as { latest: string; versions: Record<string, { yanked?: boolean }> };
+} as {
+  latest: string;
+  versions: Record<string, { createdAt?: string; yanked?: boolean }>;
+};
 
 describe('modules/datasource/jsr/index', () => {
   const jsr = new JsrDatasource();
@@ -51,10 +55,12 @@ describe('modules/datasource/jsr/index', () => {
       releases: [
         {
           version: '0.0.1',
+          releaseTimestamp: '2025-09-18T00:00:00.000Z' as Timestamp,
         },
         {
           isLatest: true,
           version: '0.0.2',
+          releaseTimestamp: '2025-11-15T00:00:00.000Z' as Timestamp,
         },
       ],
     });
@@ -77,10 +83,12 @@ describe('modules/datasource/jsr/index', () => {
         {
           isDeprecated: true,
           version: '0.0.1',
+          releaseTimestamp: '2025-09-18T00:00:00.000Z' as Timestamp,
         },
         {
           isLatest: true,
           version: '0.0.2',
+          releaseTimestamp: '2025-11-15T00:00:00.000Z' as Timestamp,
         },
       ],
     });

--- a/lib/modules/datasource/jsr/index.ts
+++ b/lib/modules/datasource/jsr/index.ts
@@ -23,7 +23,7 @@ export class JsrDatasource extends Datasource {
   // use npm compatible registry api url due to returns
   override readonly defaultRegistryUrls = defaultRegistryUrls;
 
-  override readonly releaseTimestampSupport = false;
+  override readonly releaseTimestampSupport = true;
 
   constructor() {
     super(JsrDatasource.id);

--- a/lib/modules/datasource/jsr/index.ts
+++ b/lib/modules/datasource/jsr/index.ts
@@ -24,6 +24,8 @@ export class JsrDatasource extends Datasource {
   override readonly defaultRegistryUrls = defaultRegistryUrls;
 
   override readonly releaseTimestampSupport = true;
+  override readonly releaseTimestampNote =
+    'The release timestamp is determined from the `createdAt` field in the results. For packages without explicit timestamps, defaults to 2025-09-18.';
 
   constructor() {
     super(JsrDatasource.id);

--- a/lib/modules/datasource/jsr/schema.ts
+++ b/lib/modules/datasource/jsr/schema.ts
@@ -2,6 +2,18 @@ import { z } from 'zod';
 import { MaybeTimestamp } from '../../../util/timestamp';
 import type { Release } from '../types';
 
+/**
+ * In the JSR.io API, if a package has had any version published on or after 2025-09-18,
+ * the createdAt field will be returned for all versions of that package, including historical ones.
+ * If a package has not been published at all since this date,
+ * the createdAt field will be omitted entirely from the API response.
+ * Therefore, we can assume that it published no less than that date for older versions
+ * https://github.com/jsr-io/jsr/pull/1194#issuecomment-3522729482
+ */
+export const MINIMUM_RELEASE_TIMESTAMP = MaybeTimestamp.parse(
+  '2025-09-18T00:00:00.000Z',
+);
+
 // https://github.com/jsr-io/jsr/blob/b8d753f4ed96f032bc494e8809065cfe8df5c641/api/src/metadata.rs#L30-L35
 export const JsrPackageMetadata = z
   .object({
@@ -18,14 +30,7 @@ export const JsrPackageMetadata = z
     return Object.entries(versions).map(([version, val]) => ({
       version,
       ...{
-        releaseTimestamp:
-          // In the JSR.io API, if a package has had any version published on or after 2025-09-18,
-          // the createdAt field will be returned for all versions of that package, including historical ones.
-          // If a package has not been published at all since this date,
-          // the createdAt field will be omitted entirely from the API response.
-          // Therefore, we can assume that it published no less than that date for older versions
-          // https://github.com/jsr-io/jsr/pull/1194#issuecomment-3522729482
-          val.createdAt ?? MaybeTimestamp.parse('2025-09-18T00:00:00.000Z'),
+        releaseTimestamp: val.createdAt ?? MINIMUM_RELEASE_TIMESTAMP,
       },
       ...(val.yanked && { isDeprecated: true }),
       ...(latest === version && { isLatest: true }),

--- a/lib/modules/datasource/jsr/schema.ts
+++ b/lib/modules/datasource/jsr/schema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { MaybeTimestamp } from '../../../util/timestamp';
 import type { Release } from '../types';
 
 // https://github.com/jsr-io/jsr/blob/b8d753f4ed96f032bc494e8809065cfe8df5c641/api/src/metadata.rs#L30-L35
@@ -8,6 +9,7 @@ export const JsrPackageMetadata = z
     versions: z.record(
       z.string(),
       z.object({
+        createdAt: MaybeTimestamp,
         yanked: z.boolean().optional(),
       }),
     ),
@@ -15,6 +17,16 @@ export const JsrPackageMetadata = z
   .transform(({ versions, latest }): Release[] => {
     return Object.entries(versions).map(([version, val]) => ({
       version,
+      ...{
+        releaseTimestamp:
+          // In the JSR.io API, if a package has had any version published on or after 2025-09-18,
+          // the createdAt field will be returned for all versions of that package, including historical ones.
+          // If a package has not been published at all since this date,
+          // the createdAt field will be omitted entirely from the API response.
+          // Therefore, we can assume that it published no less than that date for older versions
+          // https://github.com/jsr-io/jsr/pull/1194#issuecomment-3522729482
+          val.createdAt ?? MaybeTimestamp.parse('2025-09-18T00:00:00.000Z'),
+      },
       ...(val.yanked && { isDeprecated: true }),
       ...(latest === version && { isLatest: true }),
     }));


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

This PR adds support for `releaseTimestamp` in the JSR data source, as the JSR API recently added a package creation date field(`createdAt`) to its response.

## Context

Please select one of the below:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
