### PR TITLE
docs(manager/ocb): add example for otel's dual versioning

### DIFF
--- a/lib/modules/manager/ocb/readme.md
+++ b/lib/modules/manager/ocb/readme.md
@@ -29,13 +29,13 @@ To allow Renovate to pin digests for these dependencies, the following `packageR
 
 ```json
 {
-  matchManagers: ["ocb"],
-  matchPackageNames: [
-    "/^go\\.opentelemetry\\.io\\/collector\\/confmap\\/provider\\/\\w+provider$/",
+  "matchManagers": ["ocb"],
+  "matchPackageNames": [
+    "/^go\\.opentelemetry\\.io\\/collector\\/confmap\\/provider\\/\\w+provider$/"
   ],
-  overrideDatasource: "github-tags",
-  overridePackageName: "open-telemetry/opentelemetry-collector",
-  extractVersion: "^confmap\\/(?<version>.+)"
+  "overrideDatasource": "github-tags",
+  "overridePackageName": "open-telemetry/opentelemetry-collector",
+  "extractVersion": "^confmap\\/(?<version>.+)"
 }
 ```
 

--- a/lib/modules/manager/ocb/readme.md
+++ b/lib/modules/manager/ocb/readme.md
@@ -23,19 +23,20 @@ Supported dependencies and their respective `depType`s are:
 | processors     | `processors` |
 
 ### OpenTelemetry Collector's dual-versioning scheme and pinning digests
+
 OpenTelemetry uses a dual-versioning scheme. For example, confmap providers may be on `v1.45.0`, while the release tag is `v0.139.0`.
 To allow Renovate to pin digests for these dependencies, the following `packageRule` is needed:
 
 ```json
-    {
-      matchManagers: ["ocb"],
-      matchPackageNames: [
-        "/^go\\.opentelemetry\\.io\\/collector\\/confmap\\/provider\\/\\w+provider$/",
-      ],
-      overrideDatasource: "github-tags",
-      overridePackageName: "open-telemetry/opentelemetry-collector",
-      extractVersion: "^confmap\\/(?<version>.+)"
-    }
+{
+  matchManagers: ["ocb"],
+  matchPackageNames: [
+    "/^go\\.opentelemetry\\.io\\/collector\\/confmap\\/provider\\/\\w+provider$/",
+  ],
+  overrideDatasource: "github-tags",
+  overridePackageName: "open-telemetry/opentelemetry-collector",
+  extractVersion: "^confmap\\/(?<version>.+)"
+}
 ```
 
 Using this packageRule, Renovate will use the GitHub tags on [the opentelemetry-collector repository](https://github.com/open-telemetry/opentelemetry-collector) 

--- a/lib/modules/manager/ocb/readme.md
+++ b/lib/modules/manager/ocb/readme.md
@@ -39,5 +39,5 @@ To allow Renovate to pin digests for these dependencies, the following `packageR
 }
 ```
 
-Using this packageRule, Renovate will use the GitHub tags on [the opentelemetry-collector repository](https://github.com/open-telemetry/opentelemetry-collector) 
+Using this packageRule, Renovate will use the GitHub tags on [the opentelemetry-collector repository](https://github.com/open-telemetry/opentelemetry-collector)
 as a datasource instead of using the `go` datasource. In this GitHub repository, it will look for the latest `confmap/v...` tag.

--- a/lib/modules/manager/ocb/readme.md
+++ b/lib/modules/manager/ocb/readme.md
@@ -21,3 +21,22 @@ Supported dependencies and their respective `depType`s are:
 | exports        | `exports`    |
 | extensions     | `extensions` |
 | processors     | `processors` |
+
+### OpenTelemetry Collector's dual-versioning scheme and pinning digests
+OpenTelemetry uses a dual-versioning scheme. For example, confmap providers may be on `v1.45.0`, while the release tag is `v0.139.0`.
+To allow Renovate to pin digests for these dependencies, the following `packageRule` is needed:
+
+```json
+    {
+      matchManagers: ["ocb"],
+      matchPackageNames: [
+        "/^go\\.opentelemetry\\.io\\/collector\\/confmap\\/provider\\/\\w+provider$/",
+      ],
+      overrideDatasource: "github-tags",
+      overridePackageName: "open-telemetry/opentelemetry-collector",
+      extractVersion: "^confmap\\/(?<version>.+)"
+    }
+```
+
+Using this packageRule, Renovate will use the GitHub tags on [the opentelemetry-collector repository](https://github.com/open-telemetry/opentelemetry-collector) 
+as a datasource instead of using the `go` datasource. In this GitHub repository, it will look for the latest `confmap/v...` tag.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
OpenTelemetry-Collector has a dual-versioning repository. Most components follow the "base" version (the latest at the time of writing is "0.139.0"), but some components have a "stable" version instead (v1.45.0 at the time of writing). The release name is called v1.45.0/v0.139.0, but is only tagged as v0.139.0. Because of this, Renovate is unable to do digest pinning, as it cannot look up the tag for the "stable" version components.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

I ran Renovate locally to look at the debug logs.

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
