### PR TITLE
fix(manager/kustomize): prevent setting replaceString for OCI chart extraction with registry aliases

### DIFF
--- a/lib/modules/manager/kustomize/extract.spec.ts
+++ b/lib/modules/manager/kustomize/extract.spec.ts
@@ -247,6 +247,25 @@ describe('modules/manager/kustomize/extract', () => {
       });
       expect(pkg).toEqual(sample);
     });
+
+    it('should correctly extract an OCI chart with registryAliases', () => {
+      const sample = {
+        depName: 'redis',
+        packageName: 'registry-1.docker.io/bitnamicharts/redis',
+        currentValue: '18.12.1',
+        datasource: DockerDatasource.id,
+        pinDigests: false,
+      };
+      const pkg = extractHelmChart(
+        {
+          name: sample.depName,
+          version: sample.currentValue,
+          repo: 'oci://localhost:5000/bitnamicharts',
+        },
+        { 'localhost:5000': 'registry-1.docker.io' },
+      );
+      expect(pkg).toEqual(sample);
+    });
   });
 
   describe('image extraction', () => {

--- a/lib/modules/manager/kustomize/extract.ts
+++ b/lib/modules/manager/kustomize/extract.ts
@@ -164,9 +164,9 @@ export function extractHelmChart(
       false,
       aliases,
     );
-    const { replaceString, ...rest } = dep;
+    delete dep.replaceString;
     return {
-      ...rest,
+      ...dep,
       depName: helmChart.name,
       // https://github.com/helm/helm/issues/10312
       // https://github.com/helm/helm/issues/10678

--- a/lib/modules/manager/kustomize/extract.ts
+++ b/lib/modules/manager/kustomize/extract.ts
@@ -164,8 +164,9 @@ export function extractHelmChart(
       false,
       aliases,
     );
+    const { replaceString, ...rest } = dep;
     return {
-      ...dep,
+      ...rest,
       depName: helmChart.name,
       // https://github.com/helm/helm/issues/10312
       // https://github.com/helm/helm/issues/10678


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

When using the kustomize manager, Helm charts may be referenced using OCI registries. However, if registry aliases are used, `replaceString` is set by the `dockerfile` manager, leading to a failure while replacing the version key of the existing context. In this PR, the object key `replaceString` is deleted using a destruction.

The issue has already been described in the following discussion: https://github.com/renovatebot/renovate/discussions/37638

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [X] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [X] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [X] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
