### PR TITLE
fix(presets): allow `lockFileMaintenance` to not be governed by `minimumReleaseAge`

### DIFF
--- a/lib/config/presets/internal/security.ts
+++ b/lib/config/presets/internal/security.ts
@@ -44,5 +44,15 @@ export const presets: Record<string, Preset> = {
       internalChecksFilter: 'strict',
       prCreation: 'not-pending',
     },
+    packageRules: [
+      {
+        description:
+          'Do not require Minimum Release Age for update types that are controlled by the package manager',
+        matchUpdateTypes: ['lockFileMaintenance'],
+        prBodyNotes: [
+          "⚠️ Renovate's lock file maintenance functionality does not support validating Minimum Release Age, as the package manager performs the required changes to update package(s). Confirm whether your package manager perform its own validation for the Minimum Release Age of packages.",
+        ],
+      },
+    ],
   },
 };


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
As noted in #39352, with Renovate 42's default enforcement of all npm
datasource package updates requiring `minimumReleaseAge` checks to
succeed, we're seeing that lock file maintenance updates are also being
blocked by this, despite Renovate itself delegating the logic to the
package manager.

We can opt-out the `lockFileMaintenance` updates from Minimum Release
Age checks, but make sure that we warn users of the risks.

## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
