### PR TITLE
fix(crow): support array notation in `steps:` spec

### DIFF
--- a/lib/modules/manager/crow/extract.ts
+++ b/lib/modules/manager/crow/extract.ts
@@ -37,11 +37,16 @@ export function extractPackageFile(
 
   // Image name/tags for services are only eligible for update if they don't
   // use variables and if the image is not built locally
-  const deps = pipelineKeys.flatMap((pipelineKey) =>
-    Object.values(coerceObject(config[pipelineKey]))
+  const deps = pipelineKeys.flatMap((pipelineKey) => {
+    const pipelineValue = config[pipelineKey];
+    // Handle both object and array formats
+    const steps = Array.isArray(pipelineValue)
+      ? pipelineValue
+      : Object.values(coerceObject(pipelineValue));
+    return steps
       .filter((step) => isString(step?.image))
-      .map((step) => getDep(step.image, true, extractConfig.registryAliases)),
-  );
+      .map((step) => getDep(step.image, true, extractConfig.registryAliases));
+  });
 
   logger.trace({ deps }, 'Crow Configuration image');
   return deps.length ? { deps } : null;

--- a/lib/modules/manager/crow/schema.ts
+++ b/lib/modules/manager/crow/schema.ts
@@ -5,10 +5,18 @@ export const CrowStep = z.object({
   image: z.string().optional(),
 });
 
+export const CrowStepWithName = CrowStep.extend({
+  name: z.string(),
+});
+
 export const CrowConfig = Yaml.pipe(
   z.object({
-    pipeline: z.record(z.string(), CrowStep).optional(),
-    steps: z.record(z.string(), CrowStep).optional(),
+    pipeline: z
+      .union([z.record(z.string(), CrowStep), z.array(CrowStepWithName)])
+      .optional(),
+    steps: z
+      .union([z.record(z.string(), CrowStep), z.array(CrowStepWithName)])
+      .optional(),
     clone: z.record(z.string(), CrowStep).optional(),
     services: z.record(z.string(), CrowStep).optional(),
   }),


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Until now, the `steps:` spec only works in map notation and fails with the following when using arrays:

```
DEBUG: Invalid Crow Configuration schema (repository=crowci/autoscaler, packageFile=.crow/changelog.yaml)
       "err": {
         "message": "Schema error",
         "stack": "ZodError: Schema error\n    at Object.get error [as error] (/usr/local/renovate/node_modules/.pnpm/zod@3.25.76/node_modules/zod/v3/types.cjs:45:31)\n    at Object.extractPackageFile (/usr/local/renovate/lib/modules/manager/crow/extract.ts:24:34)\n    at extractPackageFile (/usr/local/renovate/lib/modules/manager/index.ts:74:9)\n    at getManagerPackageFiles (/usr/local/renovate/lib/workers/repository/extract/manager-files.ts:58:43)\n    at /usr/local/renovate/lib/workers/repository/extract/index.ts:57:28\n    at async Promise.all (index 0)\n    at extractAllDependencies (/usr/local/renovate/lib/workers/repository/extract/index.ts:54:26)\n    at extract (/usr/local/renovate/lib/workers/repository/process/extract-update.ts:165:28)\n    at extractDependencies (/usr/local/renovate/lib/workers/repository/process/index.ts:190:26)\n    at Object.renovateRepository (/usr/local/renovate/lib/workers/repository/index.ts:110:27)\n    at attributes.repository (/usr/local/renovate/lib/workers/global/index.ts:188:11)\n    at start (/usr/local/renovate/lib/workers/global/index.ts:173:7)\n    at /usr/local/renovate/lib/renovate.ts:19:22",
         "issues": {"steps": "Expected object, received array"}
       }
```

Example array notation:

```yaml
steps:
  - name: 'name'
    image: node:lts
```

This PR adds support for array notation which should have been included since the beginning, which is why I labelled it as a fix.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
