### PR TITLE
feat(instrumentation): use OTEL_NODE_RESOURCE_DETECTORS env to disabl…

### DIFF
--- a/lib/instrumentation/index.ts
+++ b/lib/instrumentation/index.ts
@@ -92,7 +92,11 @@ export function getResourceDetectorsFromEnv(
   ]);
   const resourceDetectorsFromEnv = env.OTEL_NODE_RESOURCE_DETECTORS?.split(
     ',',
-  ) ?? ['all'];
+  ) ?? [
+    env.RENOVATE_USE_CLOUD_METADATA_SERVICES?.toLocaleLowerCase() === 'false'
+      ? 'env'
+      : 'all',
+  ];
 
   if (resourceDetectorsFromEnv.includes('all')) {
     return [...resourceDetectors.values()].flat();


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Enable selective loading of resource detectors via the OTEL_NODE_RESOURCE_DETECTORS environment variable. Default: `OTEL_NODE_RESOURCE_DETECTORS=all` (all detectors loaded)

Examples:
`OTEL_NODE_RESOURCE_DETECTORS=none` (no detectors loaded)
`OTEL_NODE_RESOURCE_DETECTORS=aws,env` (only aws and env detectors loaded)
`OTEL_NODE_RESOURCE_DETECTORS=gcp` (only gcp detector loaded)

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #38604
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
