### PR TITLE
feat(platform/pr-body): add note if body is truncated

### DIFF
--- a/lib/modules/platform/utils/__snapshots__/pr-body.spec.ts.snap
+++ b/lib/modules/platform/utils/__snapshots__/pr-body.spec.ts.snap
@@ -1,7 +1,9 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`modules/platform/utils/pr-body > .smartTruncate > truncates to 300 not smart 1`] = `
-"This PR contains the following updates:
+"> **Note:** This PR body was truncated due to platform limits.
+
+This PR contains the following updates:
 
 | Package | Type | Update | Change |
 |---|---|---|---|
@@ -9,16 +11,13 @@ exports[`modules/platform/utils/pr-body > .smartTruncate > truncates to 300 not 
 
 ---
 
-### Release Notes
-
-<details>
-<summary>renovatebot/renovate</summary>
-
-### [\`v19."
+### Release Note"
 `;
 
 exports[`modules/platform/utils/pr-body > .smartTruncate > truncates to 1000 1`] = `
-"This PR contains the following updates:
+"> **Note:** This PR body was truncated due to platform limits.
+
+This PR contains the following updates:
 
 | Package | Type | Update | Change |
 |---|---|---|---|
@@ -31,9 +30,7 @@ exports[`modules/platform/utils/pr-body > .smartTruncate > truncates to 1000 1`]
 <details>
 <summary>renovatebot/renovate</summary>
 
-### [\`v19.47.0\`](https://togithub.com/renovatebot/renovate/releases/19.47.0)
-
-##### Feat
+### [\`v19.47.0\`](https:/
 
 </details>
 

--- a/lib/modules/platform/utils/pr-body.spec.ts
+++ b/lib/modules/platform/utils/pr-body.spec.ts
@@ -1,5 +1,6 @@
 import { smartTruncate } from './pr-body';
 import { Fixtures } from '~test/fixtures';
+import { logger } from '~test/util';
 
 const prBody = Fixtures.get('pr-body.txt');
 
@@ -9,17 +10,26 @@ describe('modules/platform/utils/pr-body', () => {
       const body = smartTruncate(prBody, 1000);
       expect(body).toMatchSnapshot();
       expect(body.length < prBody.length).toBe(true);
+      expect(logger.logger.warn).toHaveBeenCalledWith(
+        'Truncating PR body due to platform limitation of 1000 characters',
+      );
     });
 
     it('truncates to 300 not smart', () => {
       const body = smartTruncate(prBody, 300);
       expect(body).toMatchSnapshot();
       expect(body).toHaveLength(300);
+      expect(logger.logger.warn).toHaveBeenCalledWith(
+        'Truncating PR body due to platform limitation of 300 characters',
+      );
     });
 
     it('truncates to 10', () => {
       const body = smartTruncate('Lorem ipsum dolor sit amet', 10);
-      expect(body).toBe('Lorem ipsu');
+      expect(body).toBe('> **Note:*');
+      expect(logger.logger.warn).toHaveBeenCalledWith(
+        'Truncating PR body due to platform limitation of 10 characters',
+      );
     });
 
     it('does not truncate', () => {

--- a/lib/modules/platform/utils/pr-body.spec.ts
+++ b/lib/modules/platform/utils/pr-body.spec.ts
@@ -10,7 +10,7 @@ describe('modules/platform/utils/pr-body', () => {
       const body = smartTruncate(prBody, 1000);
       expect(body).toMatchSnapshot();
       expect(body.length < prBody.length).toBe(true);
-      expect(logger.logger.warn).toHaveBeenCalledWith(
+      expect(logger.logger.debug).toHaveBeenCalledWith(
         'Truncating PR body due to platform limitation of 1000 characters',
       );
     });
@@ -19,7 +19,7 @@ describe('modules/platform/utils/pr-body', () => {
       const body = smartTruncate(prBody, 300);
       expect(body).toMatchSnapshot();
       expect(body).toHaveLength(300);
-      expect(logger.logger.warn).toHaveBeenCalledWith(
+      expect(logger.logger.debug).toHaveBeenCalledWith(
         'Truncating PR body due to platform limitation of 300 characters',
       );
     });
@@ -27,7 +27,7 @@ describe('modules/platform/utils/pr-body', () => {
     it('truncates to 10', () => {
       const body = smartTruncate('Lorem ipsum dolor sit amet', 10);
       expect(body).toBe('> **Note:*');
-      expect(logger.logger.warn).toHaveBeenCalledWith(
+      expect(logger.logger.debug).toHaveBeenCalledWith(
         'Truncating PR body due to platform limitation of 10 characters',
       );
     });

--- a/lib/modules/platform/utils/pr-body.ts
+++ b/lib/modules/platform/utils/pr-body.ts
@@ -1,3 +1,4 @@
+import { logger } from '../../../logger';
 import { regEx } from '../../../util/regex';
 
 const re = regEx(
@@ -9,10 +10,16 @@ export function smartTruncate(input: string, len: number): string {
   if (input.length < len) {
     return input;
   }
+  logger.warn(
+    `Truncating PR body due to platform limitation of ${len} characters`,
+  );
 
-  const reMatch = re.exec(input);
+  const note = `> **Note:** This PR body was truncated due to platform limits.\n\n`;
+  const truncatedInput = note + input;
+
+  const reMatch = re.exec(truncatedInput);
   if (!reMatch?.groups) {
-    return input.substring(0, len);
+    return truncatedInput.substring(0, len);
   }
 
   const divider = `\n\n</details>\n\n---\n\n### Configuration`;
@@ -24,7 +31,7 @@ export function smartTruncate(input: string, len: number): string {
     len - (preNotes.length + postNotes.length + divider.length);
 
   if (availableLength <= 0) {
-    return input.substring(0, len);
+    return truncatedInput.substring(0, len);
   } else {
     return (
       preNotes + releaseNotes.slice(0, availableLength) + divider + postNotes

--- a/lib/modules/platform/utils/pr-body.ts
+++ b/lib/modules/platform/utils/pr-body.ts
@@ -10,7 +10,7 @@ export function smartTruncate(input: string, len: number): string {
   if (input.length < len) {
     return input;
   }
-  logger.warn(
+  logger.debug(
     `Truncating PR body due to platform limitation of ${len} characters`,
   );
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- Adds a warning/note on top of PR body incase it has been truncated due to platform char limits
- Warning log for the same
<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #39426 
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/Rahul-renovate-testing/pr-body-trunc/pull/2

> First I ran without changes and the pr body waa truncated (release notes shortened) but no note added. Then, I ran with this branch and the note was added.

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
