### PR TITLE
fix(monorepos): fix cedar source url

### DIFF
--- a/lib/data/monorepo.json
+++ b/lib/data/monorepo.json
@@ -91,7 +91,7 @@
     "cake": "https://github.com/cake-build/cake",
     "cake-issues": "https://github.com/cake-contrib/Cake.Issues",
     "capacitor": "https://github.com/ionic-team/capacitor",
-    "cedar": "https://github.com/cedarjs/cedar/",
+    "cedar": "https://github.com/cedarjs/cedar",
     "chakra-ui": "https://github.com/chakra-ui/chakra-ui",
     "chromely": "https://github.com/chromelyapps/Chromely",
     "citation-js": "https://github.com/citation-js/citation-js",


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

It seems, like cedarjs doesn't get grouped for us, even after waiting four month.

Looking at this again, I found the trailing backslash to be suspicious, so I've removed it. Hopefully maintainers can chip in with concrete knowledge.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
