### PR TITLE
fix(presets): don't override `prCreation` on `security:minimumReleaseAgeNpm`

### DIFF
--- a/docs/usage/key-concepts/minimum-release-age.md
+++ b/docs/usage/key-concepts/minimum-release-age.md
@@ -26,7 +26,6 @@ The following configuration options can be used to enable and tune the functiona
 - [`minimumReleaseAge`](../configuration-options.md#minimumreleaseage) (previously known as `stabilityDays`)
 - [`minimumReleaseAgeBehaviour`](../configuration-options.md#minimumreleaseagebehaviour)
 - [`internalChecksFilter`](../configuration-options.md#internalchecksfilter)
-- [`prCreation`](../configuration-options.md#prcreation)
 
 ## FAQs
 
@@ -54,12 +53,7 @@ As time goes on, if the 2 updates with a release timestamp are now passed the mi
 
 ### What happens when an update is not yet passing the minimum release age checks?
 
-For this question, consider two key aspects to Renovate updating a dependency:
-
-- the creation of the branch ([`internalChecksFilter`](../configuration-options.md#internalchecksfilter))
-- the creation of the PR ([`prCreation`](../configuration-options.md#prcreation))
-
-Based on the values of `internalChecksFilter` and `prCreation`, different behaviour will occur.
+Renovate will decide whether it will create a branch for a dependency update using [`internalChecksFilter`](../configuration-options.md#internalchecksfilter).
 
 #### `internalChecksFilter=strict`
 
@@ -79,32 +73,19 @@ DEBUG: Branch renovate/actions-checkout-5.x creation is disabled because interna
 
 In this case, no branch is created.
 
-<!-- prettier-ignore -->
-!!! warning
-    However, depending on the value of `prCreation`, the branch may still be created, even if it's pending status checks.
-
-#### `prCreation=immediate` (default)
-
-If you have not configured [`prCreation`](../configuration-options.md#prcreation), Renovate will use `prCreation=immediate` as the default.
-
-If an update is pending the minimum release age checks, Renovate will create a PR.
-When raising this PR, a `renovate/stability-days` status check will be added to the branch, marked as pending.
-
-Renovate will not perform automerge until that check has passed.
-
-If you do not wish Renovate to raise a PR until this status check has passed, you will want to set `prCreation=not-pending`, for instance using a package rule targeting the datasource you're enforcing this functionality on.
-
-#### `prCreation=not-pending`
-
-If an update is pending the minimum release age checks, Renovate will not create a branch, nor raise a PR.
-
 If you have a Dependency Dashboard enabled, it will be found in the Dependency Dashboard in the "Pending Status Checks".
 
 You can force the dependency update by requesting it via the Dependency Dashboard, or if you are self-hosting, you can use the [`checkedBranches`](../self-hosted-configuration.md#checkedbranches) to force the branch creation.
 
+<!-- prettier-ignore -->
+!!! note
+    A previous version of the documentation (up until Renovate 42.19.9) recommended configuring [`prCreation`](../configuration-options.md#prcreation). This is no longer the case.
+
+If no branch is created, Renovate will not raise a PR, regardless of [`prCreation`](../configuration-options.md#prcreation)'s settings.
+
 #### Recommended settings
 
-The recommendation is to set `internalChecksFilter=strict` and `prCreation=not-pending` when using `minimumReleaseAge`, so Renovate will create neither branches nor PRs on updates that haven't yet met minimum release age checks.
+The recommendation is to set `internalChecksFilter=strict` when using `minimumReleaseAge`, so Renovate will create neither branches (nor PRs) on updates that haven't yet met minimum release age checks.
 
 ### Which update types take `minimumReleaseAge` into account?
 

--- a/lib/config/presets/internal/security.ts
+++ b/lib/config/presets/internal/security.ts
@@ -42,7 +42,6 @@ export const presets: Record<string, Preset> = {
     npm: {
       minimumReleaseAge: '3 days',
       internalChecksFilter: 'strict',
-      prCreation: 'not-pending',
     },
     packageRules: [
       {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
Since rolling out the v42 Renovate release to the Mend Developer
Platform, we've been watching out for user reports for issues following
the addition of `security:minimumReleaseAgeNpm` in
`config:best-practices`.

In particular, two Discussions #39525 and #39477 are interesting cases
where a change from #39066 around `prCreation` has inadvertently caused
impact to PRs being created, as the CI needs to pass on the branch
before a PR is created (as intended by `prCreation=not-pending`).

However, these branches do not get CI running until there is a PR, which
means PRs will never be raised.

This partially reverts changes from #39066, #39116 and #38873, which
have been re-investigated since the reports.

Slightly surprising is the fact that the changes from #39066 have been
live on the Mend Developer Platform for a few weeks, but it wasn't
noticed until now, after the full rollout of v42.

## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: https://github.com/JamieTanna-Mend-testing/mra-testing-digest

I have:

- https://github.com/JamieTanna-Mend-testing/mra-testing-digest/blob/65a004dca497af4ae7b64a4e02cc132a62f78b26/renovate.json
- Running with this version of the presets
- I can see that branches are not created (https://github.com/JamieTanna-Mend-testing/mra-testing-digest/branches/all) for i.e. contentful, or other dependencies in https://github.com/JamieTanna-Mend-testing/mra-testing-digest/issues/1 in `Pending Status Checks`

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
