### PR TITLE
fix(devbox): Allow for pre and post release versioning

### DIFF
--- a/lib/modules/versioning/devbox/index.spec.ts
+++ b/lib/modules/versioning/devbox/index.spec.ts
@@ -12,20 +12,25 @@ describe('modules/versioning/devbox/index', () => {
     ${'v1.4'}         | ${false}
     ${'V0.5'}         | ${false}
     ${'3.5.0'}        | ${true}
-    ${'4.2.21.Final'} | ${false}
+    ${'4.2.21.Final'} | ${true}
     ${'1234'}         | ${false}
     ${'foo'}          | ${false}
     ${'latest'}       | ${false}
     ${''}             | ${false}
-    ${'3.5.0-beta.3'} | ${false}
+    ${'3.5.0-beta.3'} | ${true}
     ${'*'}            | ${false}
     ${'x'}            | ${false}
     ${'X'}            | ${false}
     ${'~1.2.3'}       | ${false}
     ${'>1.2.3'}       | ${false}
     ${'^1.2.3'}       | ${false}
-    ${'1.2.3-foo'}    | ${false}
-    ${'1.2.3foo'}     | ${false}
+    ${'1.2.3-foo'}    | ${true}
+    ${'1.2.3-'}       | ${false}
+    ${'1.2.3.'}       | ${false}
+    ${'1.2.3+'}       | ${false}
+    ${'1.2.3+8'}      | ${true}
+    ${'1.2.3a1'}      | ${true}
+    ${'1.2.3rc3'}     | ${true}
   `('isVersion("$version") === $expected', ({ version, expected }) => {
     expect(!!devbox.isVersion(version)).toBe(expected);
   });
@@ -41,37 +46,46 @@ describe('modules/versioning/devbox/index', () => {
     ${'v1.4'}         | ${false}
     ${'V0.5'}         | ${false}
     ${'3.5.0'}        | ${true}
-    ${'4.2.21.Final'} | ${false}
+    ${'4.2.21.Final'} | ${true}
     ${'1234'}         | ${true}
     ${'foo'}          | ${false}
     ${'latest'}       | ${true}
     ${''}             | ${false}
-    ${'3.5.0-beta.3'} | ${false}
+    ${'3.5.0-beta.3'} | ${true}
     ${'*'}            | ${false}
     ${'x'}            | ${false}
     ${'X'}            | ${false}
     ${'~1.2.3'}       | ${false}
     ${'>1.2.3'}       | ${false}
     ${'^1.2.3'}       | ${false}
-    ${'1.2.3-foo'}    | ${false}
-    ${'1.2.3foo'}     | ${false}
+    ${'1.2.3-foo'}    | ${true}
+    ${'1.2.3foo'}     | ${true}
+    ${'1.2.3+8'}      | ${true}
+    ${'1.2.3a1'}      | ${true}
+    ${'1.2.3rc3'}     | ${true}
+    ${'1.2.3-'}       | ${false}
+    ${'1.2.3.'}       | ${false}
+    ${'1.2.3+'}       | ${false}
   `('isValid("$version") === $isValid', ({ version, isValid }) => {
     expect(!!devbox.isValid(version)).toBe(isValid);
   });
 
   it.each`
-    version      | range        | expected
-    ${'1'}       | ${'1'}       | ${false}
-    ${'1'}       | ${'0'}       | ${false}
-    ${'1.2.3'}   | ${'1'}       | ${true}
-    ${'1.2'}     | ${'1'}       | ${false}
-    ${'1.0.0'}   | ${'1'}       | ${true}
-    ${'1.2.0'}   | ${'1.2'}     | ${true}
-    ${'1.2.3'}   | ${'1.2'}     | ${true}
-    ${'0'}       | ${'latest'}  | ${false}
-    ${'1.2.3'}   | ${'latest'}  | ${true}
-    ${'1.2.3.5'} | ${'1.2.3.5'} | ${false}
-    ${'1.2'}     | ${'1.2.3'}   | ${false}
+    version       | range         | expected
+    ${'1'}        | ${'1'}        | ${false}
+    ${'1'}        | ${'0'}        | ${false}
+    ${'1.2.3'}    | ${'1'}        | ${true}
+    ${'1.2'}      | ${'1'}        | ${false}
+    ${'1.0.0'}    | ${'1'}        | ${true}
+    ${'1.2.0'}    | ${'1.2'}      | ${true}
+    ${'1.2.3'}    | ${'1.2'}      | ${true}
+    ${'0'}        | ${'latest'}   | ${false}
+    ${'1.2.3'}    | ${'latest'}   | ${true}
+    ${'1.2.3.5'}  | ${'1.2.3.5'}  | ${true}
+    ${'1.2'}      | ${'1.2.3'}    | ${false}
+    ${'1.2.3rc3'} | ${'1.2.3rc3'} | ${true}
+    ${'1.2.3rc3'} | ${'1.2.3rc4'} | ${false}
+    ${'1.2.3+7'}  | ${'1.2.3+8'}  | ${false}
   `(
     'matches("$version", "$range") === $expected',
     ({ version, range, expected }) => {
@@ -80,24 +94,95 @@ describe('modules/versioning/devbox/index', () => {
   );
 
   it.each`
-    version      | range        | expected
-    ${'1'}       | ${'1'}       | ${true}
-    ${'1'}       | ${'0'}       | ${false}
-    ${'1.2.3'}   | ${'1'}       | ${true}
-    ${'1.2'}     | ${'1'}       | ${true}
-    ${'1.0.0'}   | ${'1'}       | ${true}
-    ${'1.2.0'}   | ${'1.2'}     | ${true}
-    ${'1.2.3'}   | ${'1.2'}     | ${true}
-    ${'0'}       | ${'latest'}  | ${true}
-    ${'1.2.3'}   | ${'latest'}  | ${true}
-    ${'1.2.3.5'} | ${'1.2.3.5'} | ${false}
-    ${'latest'}  | ${'latest'}  | ${false}
-    ${'latest'}  | ${'1.2.3'}   | ${false}
-    ${'1.2'}     | ${'1.2.3'}   | ${true}
+    version       | range         | expected
+    ${'1'}        | ${'1'}        | ${true}
+    ${'1'}        | ${'0'}        | ${false}
+    ${'1.2.3'}    | ${'1'}        | ${true}
+    ${'1.2'}      | ${'1'}        | ${true}
+    ${'1.0.0'}    | ${'1'}        | ${true}
+    ${'1.2.0'}    | ${'1.2'}      | ${true}
+    ${'1.2.3'}    | ${'1.2'}      | ${true}
+    ${'0'}        | ${'latest'}   | ${true}
+    ${'1.2.3'}    | ${'latest'}   | ${true}
+    ${'1.2.3.5'}  | ${'1.2.3.5'}  | ${true}
+    ${'latest'}   | ${'latest'}   | ${false}
+    ${'latest'}   | ${'1.2.3'}    | ${false}
+    ${'1.2'}      | ${'1.2.3'}    | ${true}
+    ${'1.2.3rc3'} | ${'1.2.3rc3'} | ${true}
+    ${'1.2.3rc3'} | ${'1.2.3rc4'} | ${false}
+    ${'1.2.3+7'}  | ${'1.2.3+8'}  | ${false}
   `(
     'equals("$version", "$range") === $expected',
     ({ version, range, expected }) => {
       expect(devbox.equals(version, range)).toBe(expected);
+    },
+  );
+
+  it.each`
+    version        | expected
+    ${'1.2.3'}     | ${true}
+    ${'1.2.3-foo'} | ${false}
+    ${'1.2.3+8'}   | ${true}
+    ${'1.2.3a1'}   | ${false}
+    ${'1.2.3rc3'}  | ${false}
+  `('isStable("$version") === $expected', ({ version, expected }) => {
+    expect(devbox.isStable(version)).toBe(expected);
+  });
+
+  it.each`
+    version              | other                | expected
+    ${'1.2.3'}           | ${'1.2.2'}           | ${true}
+    ${'1.2.3'}           | ${'1.2.4'}           | ${false}
+    ${'1.2.3'}           | ${'1.2.3'}           | ${false}
+    ${'1.0.0'}           | ${'1.0.0'}           | ${false}
+    ${'2.0.0'}           | ${'1.9.9'}           | ${true}
+    ${'1.2'}             | ${'1.2.0'}           | ${false}
+    ${'1.2.0'}           | ${'1.2'}             | ${false}
+    ${'1.2.3-foo'}       | ${'1.2.2'}           | ${true}
+    ${'1.2.3-foo'}       | ${'1.2.3'}           | ${true}
+    ${'1.2.3-foo'}       | ${'1.2.4'}           | ${false}
+    ${'1.2.3-foo'}       | ${'1.2.3-bar'}       | ${true}
+    ${'1.2.3+8'}         | ${'1.2.2'}           | ${true}
+    ${'1.2.3+8'}         | ${'1.2.3'}           | ${true}
+    ${'1.2.3+8'}         | ${'1.2.4'}           | ${false}
+    ${'1.2.3+8'}         | ${'1.2.3+7'}         | ${true}
+    ${'1.2.3+8'}         | ${'1.2.3rc1'}        | ${true}
+    ${'1.2.3+8'}         | ${'1.2.3a1'}         | ${true}
+    ${'1.2.3+8'}         | ${'1.2.3b1'}         | ${true}
+    ${'1.2.3a1'}         | ${'1.2.2'}           | ${true}
+    ${'1.2.3a1'}         | ${'1.2.3'}           | ${false}
+    ${'1.2.3a1'}         | ${'1.2.3a2'}         | ${false}
+    ${'1.2.3rc3'}        | ${'1.2.2'}           | ${true}
+    ${'1.2.3rc3'}        | ${'1.2.3'}           | ${false}
+    ${'1.2.3rc1'}        | ${'1.2.3a2'}         | ${true}
+    ${'3.5.0-beta.3'}    | ${'3.4.9'}           | ${true}
+    ${'3.5.0-beta.3'}    | ${'3.5.0'}           | ${false}
+    ${'4.2.21.Final'}    | ${'4.2.20'}          | ${true}
+    ${'4.2.21.Final'}    | ${'4.2.21'}          | ${true}
+    ${'4.2.21'}          | ${'4.2.21.Final'}    | ${false}
+    ${'1.2.3'}           | ${'1.2.3-foo'}       | ${false}
+    ${'1.2.3'}           | ${'1.2.3.5'}         | ${false}
+    ${'1.2.3'}           | ${'1.2.3rc1'}        | ${true}
+    ${'1.2.3'}           | ${'1.2.3a1'}         | ${true}
+    ${'1.2.3alpha1'}     | ${'1.2.3a1'}         | ${false}
+    ${'1.2.3beta1'}      | ${'1.2.3b1'}         | ${false}
+    ${'1.2.3c1'}         | ${'1.2.3rc1'}        | ${false}
+    ${'1.2.3rc1'}        | ${'1.2.3b1'}         | ${true}
+    ${'1.2.3b1'}         | ${'1.2.3a1'}         | ${true}
+    ${'1.2.3something1'} | ${'1.2.3a1'}         | ${true}
+    ${'1.2.3a1'}         | ${'1.2.3something1'} | ${false}
+    ${'1.2.3something1'} | ${'1.2.3+8'}         | ${false}
+    ${'1.2.3a1.dev'}     | ${'1.2.3a1'}         | ${true}
+    ${'invalid'}         | ${'1.2.3'}           | ${true}
+    ${'1.2.3'}           | ${'invalid'}         | ${true}
+    ${'1.2.3.5'}         | ${'1.2.3'}           | ${true}
+    ${'1.2.3-bar'}       | ${'1.2.3-baz'}       | ${false}
+    ${'1.2.3.5'}         | ${'1.2.3.4'}         | ${true}
+    ${'1.2.3-x'}         | ${'1.2.3-y'}         | ${false}
+  `(
+    'isGreaterThan("$version", "$other") === $expected',
+    ({ version, other, expected }) => {
+      expect(devbox.isGreaterThan(version, other)).toBe(expected);
     },
   );
 });

--- a/lib/modules/versioning/devbox/index.spec.ts
+++ b/lib/modules/versioning/devbox/index.spec.ts
@@ -6,27 +6,28 @@ describe('modules/versioning/devbox/index', () => {
     ${'1'}            | ${false}
     ${'01'}           | ${false}
     ${'1.01'}         | ${false}
+    ${'1.1.01'}       | ${false}
     ${'1.1'}          | ${false}
     ${'1.3.0'}        | ${true}
     ${'2.1.20'}       | ${true}
     ${'v1.4'}         | ${false}
     ${'V0.5'}         | ${false}
     ${'3.5.0'}        | ${true}
-    ${'4.2.21.Final'} | ${true}
     ${'1234'}         | ${false}
     ${'foo'}          | ${false}
     ${'latest'}       | ${false}
     ${''}             | ${false}
-    ${'3.5.0-beta.3'} | ${true}
     ${'*'}            | ${false}
     ${'x'}            | ${false}
     ${'X'}            | ${false}
     ${'~1.2.3'}       | ${false}
     ${'>1.2.3'}       | ${false}
     ${'^1.2.3'}       | ${false}
-    ${'1.2.3-foo'}    | ${true}
     ${'1.2.3-'}       | ${false}
+    ${'1.2.3-foo'}    | ${true}
+    ${'3.5.0-beta.3'} | ${true}
     ${'1.2.3.'}       | ${false}
+    ${'4.2.21.Final'} | ${true}
     ${'1.2.3+'}       | ${false}
     ${'1.2.3+8'}      | ${true}
     ${'1.2.3a1'}      | ${true}
@@ -40,29 +41,30 @@ describe('modules/versioning/devbox/index', () => {
     ${'1'}            | ${true}
     ${'01'}           | ${false}
     ${'1.01'}         | ${false}
+    ${'1.1.01'}       | ${false}
     ${'1.1'}          | ${true}
     ${'1.3.0'}        | ${true}
     ${'2.1.20'}       | ${true}
     ${'v1.4'}         | ${false}
     ${'V0.5'}         | ${false}
     ${'3.5.0'}        | ${true}
-    ${'4.2.21.Final'} | ${true}
     ${'1234'}         | ${true}
     ${'foo'}          | ${false}
     ${'latest'}       | ${true}
     ${''}             | ${false}
-    ${'3.5.0-beta.3'} | ${true}
     ${'*'}            | ${false}
     ${'x'}            | ${false}
     ${'X'}            | ${false}
     ${'~1.2.3'}       | ${false}
     ${'>1.2.3'}       | ${false}
     ${'^1.2.3'}       | ${false}
-    ${'1.2.3-foo'}    | ${true}
     ${'1.2.3foo'}     | ${true}
-    ${'1.2.3+8'}      | ${true}
     ${'1.2.3a1'}      | ${true}
     ${'1.2.3rc3'}     | ${true}
+    ${'1.2.3-foo'}    | ${true}
+    ${'3.5.0-beta.3'} | ${true}
+    ${'4.2.21.Final'} | ${true}
+    ${'1.2.3+8'}      | ${true}
     ${'1.2.3-'}       | ${false}
     ${'1.2.3.'}       | ${false}
     ${'1.2.3+'}       | ${false}
@@ -104,9 +106,9 @@ describe('modules/versioning/devbox/index', () => {
     ${'1.2.3'}    | ${'1.2'}      | ${true}
     ${'0'}        | ${'latest'}   | ${true}
     ${'1.2.3'}    | ${'latest'}   | ${true}
-    ${'1.2.3.5'}  | ${'1.2.3.5'}  | ${true}
     ${'latest'}   | ${'latest'}   | ${false}
     ${'latest'}   | ${'1.2.3'}    | ${false}
+    ${'1.2.3.5'}  | ${'1.2.3.5'}  | ${true}
     ${'1.2'}      | ${'1.2.3'}    | ${true}
     ${'1.2.3rc3'} | ${'1.2.3rc3'} | ${true}
     ${'1.2.3rc3'} | ${'1.2.3rc4'} | ${false}

--- a/lib/modules/versioning/devbox/index.ts
+++ b/lib/modules/versioning/devbox/index.ts
@@ -11,7 +11,9 @@ export const supportsRanges = false;
 const validPattern = regEx(/^((\d|[1-9]\d*)(\.(\d|[1-9]\d*)){0,2})(.+)?$/);
 const versionPattern = regEx(/^((\d|[1-9]\d*)(\.(\d|[1-9]\d*)){2})(.+)?$/);
 const stablePattern = regEx(/^((\d|[1-9]\d*)(\.(\d|[1-9]\d*)){2})(\+.+)?$/);
+const prereleasePattern = regEx(/^[-+.]?(a|alpha|b|beta|rc|c)?(\d+)?(.*)$/);
 const rangeOperatorPattern = regEx(/^[~>^]/);
+
 const preReleaseOrder: Record<string, number> = {
   a: 1,
   alpha: 1,
@@ -46,7 +48,7 @@ class DevboxVersioningApi extends GenericVersioningApi {
   } {
     // Match patterns like: -alpha1, a1, rc3, +8, -beta.3, .5
     // This regex always matches due to all-optional groups and trailing (.*)
-    const match = /^[-+.]?(a|alpha|b|beta|rc|c)?(\d+)?(.*)$/.exec(suffix)!;
+    const match = prereleasePattern.exec(suffix)!;
     const type = match[1] || '';
     const num = match[2] ? parseInt(match[2]) : 0;
     const rest = match[3] || '';
@@ -132,6 +134,10 @@ class DevboxVersioningApi extends GenericVersioningApi {
     }
     // Reject versions with empty suffixes (e.g., '1.2.3-', '1.2.3.')
     if (regEx(/[-+.]$/).test(version)) {
+      return false;
+    }
+    // Reject versions with leading zeros
+    if (this._hasLeadingZero(version)) {
       return false;
     }
     const matches = versionPattern.exec(version);

--- a/lib/modules/versioning/devbox/index.ts
+++ b/lib/modules/versioning/devbox/index.ts
@@ -8,8 +8,18 @@ export const displayName = 'devbox';
 export const urls = [];
 export const supportsRanges = false;
 
-const validPattern = regEx(/^((\d|[1-9]\d*)(\.(\d|[1-9]\d*)){0,2})$/);
-const versionPattern = regEx(/^((\d|[1-9]\d*)(\.(\d|[1-9]\d*)){2})$/);
+const validPattern = regEx(/^((\d|[1-9]\d*)(\.(\d|[1-9]\d*)){0,2})(.+)?$/);
+const versionPattern = regEx(/^((\d|[1-9]\d*)(\.(\d|[1-9]\d*)){2})(.+)?$/);
+const stablePattern = regEx(/^((\d|[1-9]\d*)(\.(\d|[1-9]\d*)){2})(\+.+)?$/);
+const rangeOperatorPattern = regEx(/^[~>^]/);
+const preReleaseOrder: Record<string, number> = {
+  a: 1,
+  alpha: 1,
+  b: 2,
+  beta: 2,
+  rc: 3,
+  c: 3,
+};
 
 class DevboxVersioningApi extends GenericVersioningApi {
   protected _parse(version: string): GenericVersion | null {
@@ -17,13 +27,101 @@ class DevboxVersioningApi extends GenericVersioningApi {
     if (!matches) {
       return null;
     }
-    const release = matches[0].split('.').map(Number);
+    // Extract only the numeric part (matches[1]) before any suffix
+    const release = matches[1].split('.').map(Number);
     return { release };
+  }
+
+  private _getSuffix(version: string): string {
+    const matches = validPattern.exec(version);
+    return matches?.[5] ?? '';
+  }
+
+  private _parsePreRelease(suffix: string): {
+    type: string;
+    order: number;
+    num: number;
+    rest: string;
+    isPreRelease: boolean;
+  } {
+    // Match patterns like: -alpha1, a1, rc3, +8, -beta.3, .5
+    // This regex always matches due to all-optional groups and trailing (.*)
+    const match = /^[-+.]?(a|alpha|b|beta|rc|c)?(\d+)?(.*)$/.exec(suffix)!;
+    const type = match[1] || '';
+    const num = match[2] ? parseInt(match[2]) : 0;
+    const rest = match[3] || '';
+
+    // + prefix means build metadata (treated as higher than no suffix)
+    if (suffix.startsWith('+')) {
+      return { type: 'build', order: 1000, num, rest, isPreRelease: false };
+    }
+
+    // Check if this is a recognized pre-release identifier
+    const isPreRelease = type in preReleaseOrder;
+    const order = isPreRelease ? preReleaseOrder[type] : 999;
+
+    return { type, order, num, rest, isPreRelease };
+  }
+
+  private _compareSuffixes(suffix1: string, suffix2: string): number {
+    // Extract pre-release type and number from suffixes
+    const pre1 = this._parsePreRelease(suffix1);
+    const pre2 = this._parsePreRelease(suffix2);
+
+    // Handle comparison with no suffix (base version)
+    if (!suffix1) {
+      return pre2.isPreRelease ? 1 : -1; // base > pre-release, base < other
+    }
+    if (!suffix2) {
+      return pre1.isPreRelease ? -1 : 1; // pre-release < base, other > base
+    }
+
+    // Compare pre-release order (a < b < rc)
+    if (pre1.order !== pre2.order) {
+      return pre1.order - pre2.order;
+    }
+
+    // Same pre-release type, compare numbers
+    if (pre1.num !== pre2.num) {
+      return pre1.num - pre2.num;
+    }
+
+    // If there's more to compare, do lexicographic comparison
+    if (pre1.rest || pre2.rest) {
+      return pre1.rest.localeCompare(pre2.rest);
+    }
+
+    return 0;
+  }
+
+  private _hasLeadingZero(version: string): boolean {
+    // Check for leading zeros in any numeric part
+    // Extract just the numeric version part before any suffix
+    const numericPart = version.split(/[-+]/)[0];
+    const parts = numericPart.split('.');
+    for (const part of parts) {
+      if (part.length > 1 && part.startsWith('0')) {
+        return true;
+      }
+    }
+    return false;
   }
 
   override isValid(version: string): boolean {
     if (version === 'latest') {
       return true;
+    }
+    // Reject versions starting with ~, >, or ^
+    if (rangeOperatorPattern.test(version)) {
+      return false;
+    }
+    // Reject versions with leading zeros
+    if (this._hasLeadingZero(version)) {
+      return false;
+    }
+    // Reject versions with empty suffixes (e.g., '1.2.3-', '1.2.3.')
+    if (regEx(/[-+.]$/).test(version)) {
+      return false;
     }
     return this._parse(version) !== null;
   }
@@ -32,22 +130,39 @@ class DevboxVersioningApi extends GenericVersioningApi {
     if (version === 'latest') {
       return false;
     }
+    // Reject versions with empty suffixes (e.g., '1.2.3-', '1.2.3.')
+    if (regEx(/[-+.]$/).test(version)) {
+      return false;
+    }
     const matches = versionPattern.exec(version);
     return !!matches;
   }
 
+  override isStable(version: string): boolean {
+    const matches = stablePattern.exec(version);
+    return !!matches;
+  }
+
   override matches(version: string, range: string): boolean {
+    if (range === 'latest') {
+      return this.isVersion(version);
+    }
     return this.isVersion(version) && this.equals(version, range);
   }
 
   protected override _compare(version: string, other: string): number {
-    const parsed1 = this._parse(version);
-    const parsed2 = this._parse(other);
+    // If version is "latest", it never equals anything (even itself)
+    if (version === 'latest') {
+      return 1;
+    }
 
-    // Treat "latest" as * and always return equal
-    if (other === 'latest' && parsed1) {
+    // If other (range) is "latest", any valid version equals it
+    if (other === 'latest') {
       return 0;
     }
+
+    const parsed1 = this._parse(version);
+    const parsed2 = this._parse(other);
 
     // If either version is invalid, return unequal
     if (!(parsed1 && parsed2)) {
@@ -65,6 +180,15 @@ class DevboxVersioningApi extends GenericVersioningApi {
         return part1 - part2;
       }
     }
+
+    // If numeric parts are equal, compare suffixes using PEP 440 ordering
+    const suffix1 = this._getSuffix(version);
+    const suffix2 = this._getSuffix(other);
+
+    if (suffix1 !== suffix2) {
+      return this._compareSuffixes(suffix1, suffix2);
+    }
+
     return 0;
   }
 }

--- a/lib/modules/versioning/devbox/readme.md
+++ b/lib/modules/versioning/devbox/readme.md
@@ -1,2 +1,8 @@
 Devbox's Nixhub uses fairly strict versioning, characters such as ~, ^ and >= are not allowed.
+
 The semver values must not include "\*" or "x". "1.2.3" "1.2" and "1" are the only valid formats.
+
+Common pre-release and post-release formats are supported e.g. 1.2.3rc1 1.2.3-beta 1.2.3+4.
+
+Due to the wide range of version formats allowed in nix packages this is a best effort,
+contributions are welcome if the current versioning isn't working for a particular nix package you rely on.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

I have had some engineers at Culture Amp telling me that some versions are being missed for JDK and go.

I initially implemented the versioning very simply to only allow for versions like `1.2.3` but because Devbox installs many different tools from Nix there are a lot of different version schemes that need to be supported. I don't think we will ever cover them fully but we can keep iterating and it can be "good enough".

This PR adds support for:
- Python pre release versions (not stable)
- JDK versions like `1.2.3+4` (these are stable)
  - Not sure if this is the right approach, it could cause unstable versions of other tools to be installed erroneously.
- Go versions which only contain 2 numbers `1.2`
- 4 number versions `1.2.3.4`
- Tagged versions like `1.2.3.Tag`

For the python prerelease versions I have added some ordering to make sure comparisons are correct.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/burritobill/renovate-testing/pulls

I have run this both with --ignore-unstable=false set and unset.

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
