### PR TITLE
docs: add Renovate CLI version to docs footer

### DIFF
--- a/tools/mkdocs/mkdocs.yml
+++ b/tools/mkdocs/mkdocs.yml
@@ -26,6 +26,8 @@ hooks:
 # General site info
 
 # Metadata
+extra:
+  version: !ENV RENOVATE_VERSION
 
 # Set the main title for the project.
 # Required setting.

--- a/tools/mkdocs/overrides/partials/copyright.html
+++ b/tools/mkdocs/overrides/partials/copyright.html
@@ -1,0 +1,19 @@
+<div class="md-copyright">
+  {% if config.extra.version %}
+  <p>
+    These docs correspond to Mend Renovate
+    <a
+      href="https://github.com/renovatebot/renovate/releases/tag/{{ config.extra.version }}"
+      >{{ config.extra.version }}</a
+    >.
+  </p>
+  {% endif %} {% if not config.extra.generator == false %} Made with
+  <a
+    href="https://squidfunk.github.io/mkdocs-material/"
+    target="_blank"
+    rel="noopener"
+  >
+    Material for MkDocs
+  </a>
+  {% endif %}
+</div>


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
As part of wiring in the version of the CLI into the docs build process,
we should also show this version to users, so they're aware what version
of the docs they're looking at.

To put this into the footer, the simplest place is to overwrite the
existing `copyright.html`[0], and remove the (unused) copyright
configuration.

We make the inclusion of the version optional, to make it possible to
merge + release this before the docs site has the version wired in.

[0]: https://github.com/squidfunk/mkdocs-material/blob/9.7.0/material/templates/partials/copyright.html
## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
