### PR TITLE
fix(bitbucket-server): fix schema to work with tags on bitbucket server 9.x

### DIFF
--- a/lib/modules/datasource/bitbucket-server-tags/schema.spec.ts
+++ b/lib/modules/datasource/bitbucket-server-tags/schema.spec.ts
@@ -19,6 +19,13 @@ describe('modules/datasource/bitbucket-server-tags/schema', () => {
         latestChangeset: '3566b84b24a7e8cf24badac73ea1d20a0851924e',
         hash: null,
       },
+      {
+        id: 'refs/tags/v17.7.1',
+        displayId: 'v17.7.1',
+        type: 'TAG',
+        latestCommit: '3566b84b24a7e8cf24badac73ea1d20a0851924e',
+        latestChangeset: '3566b84b24a7e8cf24badac73ea1d20a0851924e',
+      },
     ];
     expect(BitbucketServerTags.parse(response)).toMatchObject([
       {
@@ -26,6 +33,7 @@ describe('modules/datasource/bitbucket-server-tags/schema', () => {
         hash: '430f18aa2968b244fc91ecd9f374f62301af4b63',
       },
       { displayId: 'v17.7.2', hash: null },
+      { displayId: 'v17.7.1' },
     ]);
   });
 

--- a/lib/modules/datasource/bitbucket-server-tags/schema.ts
+++ b/lib/modules/datasource/bitbucket-server-tags/schema.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 export const BitbucketServerTag = z.object({
   displayId: z.string(),
-  hash: z.string().nullable(),
+  hash: z.string().nullish(),
 });
 
 export const BitbucketServerTags = z.array(BitbucketServerTag);


### PR DESCRIPTION
## Changes

In Bitbucket Server 9.x, `hash` in a Bitbucket Server Tag response can be `undefined`. This causes zod-validation to fail and renovate is unable to retrieve available versions.

## Context

Please select one of the following:

- [X] This closes an existing Issue: #39537
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [X] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [X] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
