### PR TITLE
fix(platform): `includeMirrors` is a global only option

### DIFF
--- a/lib/config/global.ts
+++ b/lib/config/global.ts
@@ -32,6 +32,7 @@ export class GlobalConfig {
     'gitTimeout',
     'httpCacheTtlDays',
     'ignorePrAuthor',
+    'includeMirrors',
     'localDir',
     'migratePresets',
     'platform',

--- a/lib/modules/platform/gitlab/index.spec.ts
+++ b/lib/modules/platform/gitlab/index.spec.ts
@@ -2,6 +2,7 @@
 import _timers from 'timers/promises';
 import { mockDeep } from 'vitest-mock-extended';
 import type { RepoParams } from '..';
+import { GlobalConfig } from '../../../config/global';
 import {
   CONFIG_GIT_URL_UNAVAILABLE,
   REPOSITORY_ARCHIVED,
@@ -31,6 +32,7 @@ const gitlabApiHost = 'https://gitlab.com';
 
 describe('modules/platform/gitlab/index', () => {
   beforeEach(() => {
+    GlobalConfig.reset();
     git.branchExists.mockReturnValue(true);
     git.isBranchBehindBase.mockResolvedValue(true);
     git.getBranchCommit.mockReturnValue(
@@ -341,10 +343,10 @@ describe('modules/platform/gitlab/index', () => {
           default_branch: 'master',
           mirror: true,
         });
+      GlobalConfig.set({ includeMirrors: true });
       expect(
         await gitlab.initRepo({
           repository: 'some/repo',
-          includeMirrors: true,
         }),
       ).toEqual({
         defaultBranch: 'master',

--- a/lib/modules/platform/gitlab/index.ts
+++ b/lib/modules/platform/gitlab/index.ts
@@ -264,7 +264,6 @@ export async function initRepo({
   cloneSubmodules,
   cloneSubmodulesFilter,
   gitUrl,
-  includeMirrors,
 }: RepoParams): Promise<RepoResult> {
   config = {} as any;
   config.repository = urlEscape(repository);
@@ -284,7 +283,7 @@ export async function initRepo({
       throw new Error(REPOSITORY_ARCHIVED);
     }
 
-    if (res.body.mirror && includeMirrors !== true) {
+    if (res.body.mirror && GlobalConfig.get('includeMirrors') !== true) {
       logger.debug(
         'Repository is a mirror - throwing error to abort renovation',
       );

--- a/lib/modules/platform/types.spec.ts
+++ b/lib/modules/platform/types.spec.ts
@@ -1,0 +1,19 @@
+import type { RepoGlobalConfig } from '../../config/types';
+import type { RepoParams } from './types';
+
+describe('modules/platform/types', () => {
+  it('`RepoParams` and `RepoGlobalConfig` types should be incompatible', () => {
+    type RequiredRepoGlobalConfig = Required<RepoGlobalConfig>;
+    type RequiredRepoParams = Required<RepoParams>;
+
+    const globalConfig: Omit<
+      RequiredRepoGlobalConfig,
+      keyof RequiredRepoParams
+    > = {} as any;
+    const repoConfig: Omit<RequiredRepoParams, keyof RequiredRepoGlobalConfig> =
+      {} as any;
+
+    expectTypeOf(globalConfig).toEqualTypeOf<RequiredRepoGlobalConfig>();
+    expectTypeOf(repoConfig).toEqualTypeOf<RequiredRepoParams>();
+  });
+});

--- a/lib/modules/platform/types.ts
+++ b/lib/modules/platform/types.ts
@@ -48,7 +48,6 @@ export interface RepoParams {
   cloneSubmodules?: boolean;
   cloneSubmodulesFilter?: string[];
   bbUseDevelopmentBranch?: boolean;
-  includeMirrors?: boolean;
 }
 
 export interface PrDebugData {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
`includeMirrors` is already on `RepoGlobalConfig` and while testing i found it was missing on `GlobalConfig.OPTIONS`
<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
