### PR TITLE
refactor(splits): add a type for repository splits

### DIFF
--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -17,6 +17,13 @@ export type RenovateConfigStage =
   | 'branch'
   | 'pr';
 
+export type RenovateSplit =
+  | 'init'
+  | 'onboarding'
+  | 'extract'
+  | 'lookup'
+  | 'update';
+
 export type RepositoryCacheConfig = 'disabled' | 'enabled' | 'reset';
 // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
 export type RepositoryCacheType = 'local' | string;

--- a/lib/util/split.spec.ts
+++ b/lib/util/split.spec.ts
@@ -2,11 +2,18 @@ import { addSplit, getSplits, splitInit } from './split';
 
 describe('util/split', () => {
   it('adds splits and returns results', () => {
+    vi.setSystemTime(0);
     splitInit();
-    addSplit('one');
-    addSplit('two');
+
+    vi.setSystemTime(1000);
+    addSplit('init');
+
+    vi.setSystemTime(3000);
+    addSplit('lookup');
+
     const res = getSplits();
     expect(res.total).toBeDefined();
-    expect(Object.keys(res.splits)).toHaveLength(2);
+    expect(res.splits.init).toEqual(1000);
+    expect(res.splits.lookup).toEqual(2000);
   });
 });

--- a/lib/util/split.ts
+++ b/lib/util/split.ts
@@ -1,16 +1,31 @@
+import type { RenovateSplit } from '../config/types';
+
 let startTime = 0;
 let lastTime = 0;
-let splits: Record<string, number> = {};
+let splits: Record<RenovateSplit, number> = {
+  init: 0,
+  onboarding: 0,
+  extract: 0,
+  lookup: 0,
+  update: 0,
+};
 
 export function splitInit(): void {
-  splits = {};
+  splits = {
+    init: 0,
+    onboarding: 0,
+    extract: 0,
+    lookup: 0,
+    update: 0,
+  };
   startTime = Date.now();
   lastTime = startTime;
 }
 
-export function addSplit(name: string): void {
-  splits[name] = Date.now() - lastTime;
-  lastTime = Date.now();
+export function addSplit(name: RenovateSplit): void {
+  const now = Date.now();
+  splits[name] = now - lastTime;
+  lastTime = now;
 }
 
 export function getSplits(): any {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->


As part of future changes to add an OpenTelemetry attribute for the
splits, we should make sure that we have a common type for the splits,
which can be used with `addSplit`.

This refactors - with some help from GPT-4.1 - to use Vitest's timer
mocking.

This also requires a slight refactor of the implementation to test more
appropriately, without duplicate calls to `Date.now`.





## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
