### PR TITLE
fix(git): report Git operation statistics at end of run

### DIFF
--- a/lib/instrumentation/index.spec.ts
+++ b/lib/instrumentation/index.spec.ts
@@ -1,6 +1,7 @@
 import { ProxyTracerProvider } from '@opentelemetry/api';
 import * as api from '@opentelemetry/api';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import { GitOperationSpanProcessor } from '../util/git/span-processor';
 import {
   disableInstrumentations,
   getTracerProvider,
@@ -73,6 +74,7 @@ describe('instrumentation/index', () => {
               },
             },
           },
+          new GitOperationSpanProcessor(),
         ],
       },
     });
@@ -106,6 +108,7 @@ describe('instrumentation/index', () => {
               },
             },
           },
+          new GitOperationSpanProcessor(),
         ],
       },
     });

--- a/lib/instrumentation/index.ts
+++ b/lib/instrumentation/index.ts
@@ -42,6 +42,7 @@ import {
 import { isPromise } from '@sindresorhus/is';
 import { pkg } from '../expose.cjs';
 import { getEnv } from '../util/env';
+import { GitOperationSpanProcessor } from '../util/git/span-processor';
 import type { RenovateSpanOptions } from './types';
 import {
   isTraceDebuggingEnabled,
@@ -69,6 +70,7 @@ export function init(): void {
   if (isTraceSendingEnabled()) {
     const exporter = new OTLPTraceExporter();
     spanProcessors.push(new BatchSpanProcessor(exporter));
+    spanProcessors.push(new GitOperationSpanProcessor());
   }
 
   const env = getEnv();

--- a/lib/util/git/span-processor.ts
+++ b/lib/util/git/span-processor.ts
@@ -1,0 +1,41 @@
+import type { Context } from '@opentelemetry/api';
+import type {
+  ReadableSpan,
+  Span,
+  SpanProcessor,
+} from '@opentelemetry/sdk-trace-base';
+import { ATTR_VCS_GIT_OPERATION_TYPE } from '../../instrumentation/types';
+import { GitOperationStats } from '../stats';
+import type { GitOperationType } from './types';
+
+export class GitOperationSpanProcessor implements SpanProcessor {
+  async forceFlush(): Promise<void> {
+    // no implementation
+  }
+  onStart(span: Span, parentContext: Context): void {
+    // no implementation
+  }
+  onEnd(span: ReadableSpan): void {
+    if (!span.ended) {
+      return;
+    }
+
+    if (!span.attributes[ATTR_VCS_GIT_OPERATION_TYPE]) {
+      return;
+    }
+
+    const start = span.startTime; // [seconds, nanos]
+    const end = span.endTime; // [seconds, nanos]
+    const startNs = start[0] * 1e9 + start[1];
+    const endNs = end[0] * 1e9 + end[1];
+    const ns = endNs - startNs;
+
+    GitOperationStats.write(
+      span.attributes[ATTR_VCS_GIT_OPERATION_TYPE] as GitOperationType,
+      ns / 1_000_000,
+    );
+  }
+  async shutdown(): Promise<void> {
+    // no implementation
+  }
+}

--- a/lib/workers/repository/index.ts
+++ b/lib/workers/repository/index.ts
@@ -23,6 +23,7 @@ import { addSplit, getSplits, splitInit } from '../../util/split';
 import {
   AbandonedPackageStats,
   DatasourceCacheStats,
+  GitOperationStats,
   HttpCacheStats,
   HttpStats,
   LookupStats,
@@ -207,6 +208,7 @@ export async function renovateRepository(
   LookupStats.report();
   ObsoleteCacheHitLogger.report();
   AbandonedPackageStats.report();
+  GitOperationStats.report();
   const cloned = isCloned();
   /* v8 ignore next 11 -- coverage not required of these `undefined` checks, as we're happy receiving an `undefined` in the logs */
   logger.info(


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Now we have instrumented our Git operations with tracing, we can make
sure that users who are not using OpenTelemetry still get insights into
their Git operation usage using a debug log output.

Following how other insights are produced, we can introduce a new type
in `lib/util/stats` for `GitOperationStats`, which will track the
overall execution for each operation type, and output them in the same
style as we use for other timing reports.

At the end of a Renovate run, we'll then make sure that this is logged
into a debug log for further investigation.

To create the report, we can make sure that we introduce a new
OpenTelemetry `SpanProcessor`, which will run when we end our Run, and
store any Git operations in `GitOperationStats`.

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->

## Evidence

When tested with:

```javascript
/**
 * @typedef {import('renovate/dist/config/types').AllConfig} AllConfig
 */

const fs = require('fs')

/** @type {AllConfig} */
let config = {
  onboarding: false,
  requireConfig: 'ignored',

  // branchConcurrentLimit: 100,
  // prConcurrentLimit: 100,
  // // make sure that **??**
  // prHourlyLimit: 1000,

  extends: ['config:best-practices'],
  logLevelRemap: [
    {
      matchMessage: "/Git operations statistics/",
      "newLogLevel": "info"
    },
  ]
}

module.exports = config;
```

With:

```
env npm run compile:ts && env OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 node ../dist/renovate.js --token $(gh auth token) $repo --dry-run=full 
```

### [backstage/backstage](https://github.com/backstage/backstage)

<img width="798" height="103" alt="Screenshot 2025-12-01 at 15 43 49" src="https://github.com/user-attachments/assets/2a76743c-b4c4-4ecd-862b-fc02ad618e4d" />


A large repository, with many possible branches, let's see how long it takes to run.

```
 INFO: Git operations statistics (repository=backstage/backstage)
       "other": {
         "count": 29,
         "avgMs": 36,
         "medianMs": 17.72544,
         "maxMs": 359.779328,
         "totalMs": 1032
       },
       "clone": {
         "count": 1,
         "avgMs": 32537,
         "medianMs": 32537.324032,
         "maxMs": 32537.324032,
         "totalMs": 32538
       },
       "checkout": {
         "count": 1,
         "avgMs": 194,
         "medianMs": 194.338048,
         "maxMs": 194.338048,
         "totalMs": 195
       },
       "reset": {
         "count": 1,
         "avgMs": 152,
         "medianMs": 152.2048,
         "maxMs": 152.2048,
         "totalMs": 153
       },
       "oldLevel": "debug",
       "trace_id": "5c81f7938635a648ad360eef90fa7b77",
       "span_id": "ba9b6e3aa9976d0c",
       "trace_flags": "01"
```

### [JamieTanna-Mend-testing/elastic-poetry-1-forced-csp-security-policies](https://github.com/JamieTanna-Mend-testing/elastic-poetry-1-forced-csp-security-policies) (fork of https://github.com/elastic/csp-security-policies/)

A smaller repository, where we'd need to invoke `poetry` (although not tested in dry-run mode)

```
 INFO: Git operations statistics (repository=JamieTanna-Mend-testing/elastic-poetry-1-forced-csp-security-policies)
       "other": {
         "count": 93,
         "avgMs": 18,
         "medianMs": 12.624896,
         "maxMs": 358.847232,
         "totalMs": 1695
       },
       "clone": {
         "count": 1,
         "avgMs": 1250,
         "medianMs": 1249.728768,
         "maxMs": 1249.728768,
         "totalMs": 1250
       },
       "checkout": {
         "count": 23,
         "avgMs": 26,
         "medianMs": 25.03808,
         "maxMs": 114.301184,
         "totalMs": 595
       },
       "reset": {
         "count": 33,
         "avgMs": 18,
         "medianMs": 16.93696,
         "maxMs": 31.168256,
         "totalMs": 593
       },
       "merge": {
         "count": 20,
         "avgMs": 230,
         "medianMs": 349.608448,
         "maxMs": 443.538432,
         "totalMs": 4608
       },
       "oldLevel": "debug",
       "trace_id": "3d152da3d3ab4b97b4ae90b410cea4ef",
       "span_id": "e1ee2ef83ffdb686",
       "trace_flags": "01"
```
