### PR TITLE
fix(instrumentation): wrap branches in spans

### DIFF
--- a/lib/workers/repository/process/write.ts
+++ b/lib/workers/repository/process/write.ts
@@ -1,5 +1,11 @@
+import {
+  ATTR_VCS_REF_BASE_TYPE,
+  ATTR_VCS_REF_HEAD_NAME,
+  ATTR_VCS_REF_TYPE,
+} from '@opentelemetry/semantic-conventions/incubating';
 import { isString } from '@sindresorhus/is';
 import type { RenovateConfig } from '../../../config/types';
+import { instrument } from '../../../instrumentation';
 import { addMeta, logger, removeMeta } from '../../../logger';
 import { hashMap } from '../../../modules/manager';
 import { scm } from '../../../modules/platform/scm';
@@ -141,50 +147,66 @@ export async function writeUpdates(
 
   for (const branch of branches) {
     const { baseBranch, branchName } = branch;
-    const meta: Record<string, string> = { branch: branchName };
-    if (config.baseBranchPatterns?.length && baseBranch) {
-      meta.baseBranch = baseBranch;
-    }
-    addMeta(meta);
-    const branchExisted = await scm.branchExists(branchName);
-    const branchState = await syncBranchState(branchName, baseBranch);
+    const res = await instrument(
+      branchName,
+      async () => {
+        const meta: Record<string, string> = { branch: branchName };
+        if (config.baseBranchPatterns?.length && baseBranch) {
+          meta.baseBranch = baseBranch;
+        }
+        addMeta(meta);
+        const branchExisted = await scm.branchExists(branchName);
+        const branchState = await syncBranchState(branchName, baseBranch);
 
-    const managers = [
-      ...new Set(
-        branch.upgrades
-          .map((upgrade) => hashMap.get(upgrade.manager) ?? upgrade.manager)
-          .filter(isString),
-      ),
-    ].sort();
-    const commitFingerprint = fingerprint({
-      commitFingerprintConfig: generateCommitFingerprintConfig(branch),
-      managers,
-    });
-    branch.cacheFingerprintMatch = compareCacheFingerprint(
-      branchState,
-      commitFingerprint,
+        const managers = [
+          ...new Set(
+            branch.upgrades
+              .map((upgrade) => hashMap.get(upgrade.manager) ?? upgrade.manager)
+              .filter(isString),
+          ),
+        ].sort();
+        const commitFingerprint = fingerprint({
+          commitFingerprintConfig: generateCommitFingerprintConfig(branch),
+          managers,
+        });
+        branch.cacheFingerprintMatch = compareCacheFingerprint(
+          branchState,
+          commitFingerprint,
+        );
+
+        const res = await processBranch(branch);
+        branch.prBlockedBy = res?.prBlockedBy;
+        branch.prNo = res?.prNo;
+        branch.result = res?.result;
+        branch.commitFingerprint = res?.updatesVerified
+          ? commitFingerprint
+          : branchState.commitFingerprint;
+
+        if (res?.commitSha) {
+          setBranchNewCommit(branchName, baseBranch, res.commitSha);
+        }
+        if (
+          branch.result === 'automerged' &&
+          branch.automergeType !== 'pr-comment'
+        ) {
+          // Stop processing other branches because base branch has been changed
+          return 'automerged';
+        }
+        if (!branchExisted && (await scm.branchExists(branch.branchName))) {
+          incCountValue('Branches');
+        }
+      },
+      {
+        attributes: {
+          [ATTR_VCS_REF_TYPE]: 'branch',
+          [ATTR_VCS_REF_BASE_TYPE]: 'branch',
+          [ATTR_VCS_REF_HEAD_NAME]: branchName,
+        },
+      },
     );
 
-    const res = await processBranch(branch);
-    branch.prBlockedBy = res?.prBlockedBy;
-    branch.prNo = res?.prNo;
-    branch.result = res?.result;
-    branch.commitFingerprint = res?.updatesVerified
-      ? commitFingerprint
-      : branchState.commitFingerprint;
-
-    if (res?.commitSha) {
-      setBranchNewCommit(branchName, baseBranch, res.commitSha);
-    }
-    if (
-      branch.result === 'automerged' &&
-      branch.automergeType !== 'pr-comment'
-    ) {
-      // Stop processing other branches because base branch has been changed
-      return 'automerged';
-    }
-    if (!branchExisted && (await scm.branchExists(branch.branchName))) {
-      incCountValue('Branches');
+    if (res !== undefined) {
+      return res;
     }
   }
   removeMeta(['branch', 'baseBranch']);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
As part of ongoing work to improve OpenTelemetry instrumentation of
Renovate in #38609, we can instrument our branch creation with the
branch name (and relevant Semantic Convention attributes) for
visibility.
## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: https://github.com/JamieTanna-Mend-testing/elastic-poetry-2-cortado

<img width="1920" height="1283" alt="Screenshot 2025-11-28 at 10-39-37 🐔 d762fa2 run (renovate) — Jaeger UI" src="https://github.com/user-attachments/assets/7576b6f5-2c35-4f52-a6bf-20fff9d6a954" />


<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
