### PR TITLE
chore(instrumentation): add a decorator for functions

### DIFF
--- a/lib/instrumentation/decorator.spec.ts
+++ b/lib/instrumentation/decorator.spec.ts
@@ -1,44 +1,78 @@
-import { instrument } from './decorator';
+import { instrument, instrumentStandalone } from './decorator';
 import { disableInstrumentations } from '.';
 
 afterAll(disableInstrumentations);
 
 describe('instrumentation/decorator', () => {
-  const spy = vi.fn(() => Promise.resolve());
+  describe('instrument', () => {
+    const spy = vi.fn(() => Promise.resolve());
 
-  it('should instrument async function', async () => {
-    class MyClass {
-      @instrument({ name: 'getNumber' })
-      public async getNumber(): Promise<number> {
-        await spy();
-        return Math.random();
+    it('should instrument async function', async () => {
+      class MyClass {
+        @instrument({ name: 'getNumber' })
+        public async getNumber(): Promise<number> {
+          await spy();
+          return Math.random();
+        }
       }
-    }
-    const myClass = new MyClass();
-    const result = await myClass.getNumber();
+      const myClass = new MyClass();
+      const result = await myClass.getNumber();
 
-    expect(result).toBeDefined();
-    expect(result).toBeNumber();
+      expect(result).toBeDefined();
+      expect(result).toBeNumber();
 
-    expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should instrument multiple async function calls', async () => {
+      class MyClass {
+        @instrument({ name: 'getNumber' })
+        public async getNumber(): Promise<number> {
+          await spy();
+          return Math.random();
+        }
+      }
+      const myClass = new MyClass();
+      await myClass.getNumber();
+      await myClass.getNumber();
+      const result = await myClass.getNumber();
+
+      expect(result).toBeDefined();
+      expect(result).toBeNumber();
+
+      expect(spy).toHaveBeenCalledTimes(3);
+    });
   });
 
-  it('should instrument multiple async function calls', async () => {
-    class MyClass {
-      @instrument({ name: 'getNumber' })
-      public async getNumber(): Promise<number> {
-        await spy();
-        return Math.random();
-      }
-    }
-    const myClass = new MyClass();
-    await myClass.getNumber();
-    await myClass.getNumber();
-    const result = await myClass.getNumber();
+  describe('instrumentStandalone', () => {
+    const spy = vi.fn(() => Promise.resolve('ok'));
 
-    expect(result).toBeDefined();
-    expect(result).toBeNumber();
+    it('should instrument a standalone async function', async () => {
+      const fn = instrumentStandalone(
+        { name: 'standaloneTest' },
+        async function testFn(arg: string) {
+          await spy();
+          return `hello ${arg}`;
+        },
+      );
 
-    expect(spy).toHaveBeenCalledTimes(3);
+      const result = await fn('world');
+      expect(result).toBe('hello world');
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should pass all arguments to the wrapped function', async () => {
+      const fn = instrumentStandalone(
+        { name: 'multiArgTest' },
+        async function testFn(a: number, b: number) {
+          await spy();
+          return a + b;
+        },
+      );
+
+      const result = await fn(2, 3);
+      expect(result).toBe(5);
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/lib/instrumentation/decorator.ts
+++ b/lib/instrumentation/decorator.ts
@@ -21,3 +21,21 @@ export function instrument<T>({
     });
   });
 }
+
+export function instrumentStandalone<T extends (...args: any[]) => any>(
+  {
+    name,
+    attributes,
+    ignoreParentSpan,
+    kind = SpanKind.INTERNAL,
+  }: SpanParameters,
+  fn: T,
+): T {
+  return async function (...args: any[]) {
+    return await instrumentFunc(name, () => fn(...args), {
+      attributes,
+      root: ignoreParentSpan,
+      kind,
+    });
+  } as T;
+}


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
As the current method only allows decorating on a class method, but it's
convenient to be able to wrap a whole function.

This isn't technically a decorator, but is a wrapper function.


<!-- Describe what behavior is changed by this PR. -->
## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

GPT-4.1 (GitHub Copilot)

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
