### PR TITLE
feat(replacements): add `ojdbc-to-ojdbc11` and `ojdbc10-to-ojdbc11`

### DIFF
--- a/lib/data/replacements.json
+++ b/lib/data/replacements.json
@@ -27,6 +27,8 @@
       "replacements:middie-to-scoped",
       "replacements:now-to-vercel",
       "replacements:npm-run-all-to-maintenance-fork",
+      "replacements:ojdbc-to-ojdbc11",
+      "replacements:ojdbc10-to-ojdbc11",
       "replacements:opencost-registry-move",
       "replacements:parcel-css-to-lightningcss",
       "replacements:passport-saml",
@@ -805,6 +807,28 @@
         "matchPackageNames": ["npm-run-all"],
         "replacementName": "npm-run-all2",
         "replacementVersion": "5.0.0"
+      }
+    ]
+  },
+  "ojdbc-to-ojdbc11": {
+    "description": "`ojdbc:ojdbc` was moved to `com.oracle.database.jdbc:ojdbc11`.",
+    "packageRules": [
+      {
+        "matchDatasources": ["maven"],
+        "matchPackageNames": ["ojdbc:ojdbc"],
+        "replacementName": "com.oracle.database.jdbc:ojdbc11",
+        "replacementVersion": "21.1.0.0"
+      }
+    ]
+  },
+  "ojdbc10-to-ojdbc11": {
+    "description": "`com.oracle.database.jdbc:ojdbc10` was moved to `com.oracle.database.jdbc:ojdbc11`.",
+    "packageRules": [
+      {
+        "matchDatasources": ["maven"],
+        "matchPackageNames": ["com.oracle.database.jdbc:ojdbc10"],
+        "replacementName": "com.oracle.database.jdbc:ojdbc11",
+        "replacementVersion": "21.1.0.0"
       }
     ]
   },


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

This PR adds two replacements:

1. `ojdcb:ojdbc` to `com.oracle.database.jdbc:ojdbc11` ([ref](https://mvnrepository.com/artifact/ojdbc/ojdbc))
   - Note: `ojdcb:ojdbc` was originally moved to `com.oracle.database.jdbc:ojdbc10`, which was then moved to `com.oracle.database.jdbc:ojdbc11` (see below).
2. `com.oracle.database.jdbc:ojdbc10` to `com.oracle.database.jdbc:ojdbc11` ([ref](https://mvnrepository.com/artifact/com.oracle.database.jdbc/ojdbc10))

<img width="400" height="965" alt="image" src="https://github.com/user-attachments/assets/8b9ee09e-3013-456d-ba10-e4eefdf8575a" />

<img width="400" height="968" alt="image" src="https://github.com/user-attachments/assets/578fc3c2-ac7d-454e-a932-49340773b4e8" />


## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: N/A

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
