### PR TITLE
feat(github): add support for pinning dependency dashboard issue

### DIFF
--- a/lib/modules/platform/github/graphql.ts
+++ b/lib/modules/platform/github/graphql.ts
@@ -26,6 +26,7 @@ query($owner: String!, $name: String!, $user: String) {
       first: 5
     ) {
       nodes {
+        id
         number
         state
         title
@@ -57,6 +58,7 @@ query(
         hasNextPage
       }
       nodes {
+        id
         number
         state
         title
@@ -80,6 +82,38 @@ mutation EnablePullRequestAutoMerge(
     }
   ) {
     pullRequest {
+      number
+    }
+  }
+}
+`;
+
+export const pinIssueMutation = `
+mutation PinIssue(
+  $issueId: ID!,
+) {
+  pinIssue(
+    input: {
+      issueId: $issueId,
+    }
+  ) {
+    issue {
+      number
+    }
+  }
+}
+`;
+
+export const unpinIssueMutation = `
+mutation UnpinIssue(
+  $issueId: ID!,
+) {
+  unpinIssue(
+    input: {
+      issueId: $issueId,
+    }
+  ) {
+    issue {
       number
     }
   }

--- a/lib/modules/platform/github/issue.ts
+++ b/lib/modules/platform/github/issue.ts
@@ -18,7 +18,7 @@ interface TransformedIssue {
   title: string;
   body: string;
   lastModified: string;
-  node_id: string | undefined;
+  node_id?: string;
 }
 
 const GithubGraphqlIssue = GithubIssueBase.extend({

--- a/lib/modules/platform/github/issue.ts
+++ b/lib/modules/platform/github/issue.ts
@@ -12,14 +12,14 @@ const GithubIssueBase = z.object({
   node_id: z.string().optional(),
 });
 
-type TransformedIssue = {
+interface TransformedIssue {
   number: number;
   state: string;
   title: string;
   body: string;
   lastModified: string;
   node_id: string | undefined;
-};
+}
 
 const GithubGraphqlIssue = GithubIssueBase.extend({
   id: z.string().optional(),
@@ -42,7 +42,7 @@ const GithubRestIssue = GithubIssueBase.extend({
 export const GithubIssue = z.union([GithubGraphqlIssue, GithubRestIssue]);
 export type GithubIssue = z.infer<typeof GithubIssue>;
 
-type CacheData = Record<number, GithubIssue>;
+interface CacheData extends Record<number, GithubIssue> {}
 
 export class GithubIssueCache {
   private static reset(cacheData: CacheData | null): void {

--- a/lib/modules/platform/github/issue.ts
+++ b/lib/modules/platform/github/issue.ts
@@ -9,22 +9,34 @@ const GithubIssueBase = z.object({
   state: z.string().transform((val) => val.toLowerCase()),
   title: z.string(),
   body: z.string(),
+  node_id: z.string().optional(),
 });
 
+type TransformedIssue = {
+  number: number;
+  state: string;
+  title: string;
+  body: string;
+  lastModified: string;
+  node_id: string | undefined;
+};
+
 const GithubGraphqlIssue = GithubIssueBase.extend({
+  id: z.string().optional(),
   updatedAt: z.string(),
-}).transform((issue) => {
+}).transform((issue): TransformedIssue => {
   const lastModified = issue.updatedAt;
-  const { number, state, title, body } = issue;
-  return { number, state, title, body, lastModified };
+  const { number, state, title, body, id } = issue;
+  const node_id = id ?? issue.node_id;
+  return { number, state, title, body, lastModified, node_id };
 });
 
 const GithubRestIssue = GithubIssueBase.extend({
   updated_at: z.string(),
-}).transform((issue) => {
+}).transform((issue): TransformedIssue => {
   const lastModified = issue.updated_at;
-  const { number, state, title, body } = issue;
-  return { number, state, title, body, lastModified };
+  const { number, state, title, body, node_id } = issue;
+  return { number, state, title, body, lastModified, node_id };
 });
 
 export const GithubIssue = z.union([GithubGraphqlIssue, GithubRestIssue]);

--- a/lib/modules/platform/types.ts
+++ b/lib/modules/platform/types.ts
@@ -160,6 +160,7 @@ export interface EnsureIssueConfig {
   once?: boolean;
   shouldReOpen?: boolean;
   confidential?: boolean;
+  isPinned?: boolean;
 }
 export interface BranchStatusConfig {
   branchName: string;

--- a/lib/workers/repository/dependency-dashboard.ts
+++ b/lib/workers/repository/dependency-dashboard.ts
@@ -624,6 +624,7 @@ export async function ensureDependencyDashboard(
       body: platform.massageMarkdown(issueBody, config.rebaseLabel),
       labels: config.dependencyDashboardLabels,
       confidential: config.confidential,
+      isPinned: true,
     });
   }
 }


### PR DESCRIPTION
Adds ability to pin GitHub issues via the platform API and configures the dependency dashboard to be pinned by default. This makes the dependency dashboard more visible by pinning it at the top of the repository's Issues page.

Changes:
- Add `isPinned` optional parameter to `EnsureIssueConfig` interface
- Implement GraphQL mutations for pinning/unpinning issues
- Add `node_id` field to GitHub issue schema to support pinning
- Update GitHub platform `ensureIssue()` to pin issues when requested
- Configure dependency dashboard to set `isPinned: true` by default

The implementation uses GitHub's GraphQL API `pinIssue` mutation, which requires the issue's global node ID. Issue pinning is only performed when the `isPinned` parameter is explicitly set to true, maintaining backward compatibility with existing code.

---

This PR was written primarily by Claude Code.

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [X] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [X] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [X] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
