### PR TITLE
fix(github-actions): handling of quoted Docker image references

### DIFF
--- a/lib/modules/manager/github-actions/__fixtures__/workflow_3.yml
+++ b/lib/modules/manager/github-actions/__fixtures__/workflow_3.yml
@@ -18,3 +18,6 @@ jobs:
 
       - name: Run a one-line script
         run: echo Hello, world!
+
+      - name: Quoted Docker image reference
+        uses: "docker://busybox:1.37.0-glibc"

--- a/lib/modules/manager/github-actions/extract.spec.ts
+++ b/lib/modules/manager/github-actions/extract.spec.ts
@@ -188,6 +188,13 @@ describe('modules/manager/github-actions/extract', () => {
           versioning: 'docker',
         },
         {
+          currentValue: '1.37.0-glibc',
+          datasource: 'docker',
+          depName: 'busybox',
+          depType: 'docker',
+          replaceString: 'busybox:1.37.0-glibc',
+        },
+        {
           currentValue: 'latest',
           datasource: 'github-runners',
           depName: 'ubuntu',

--- a/lib/modules/manager/github-actions/extract.ts
+++ b/lib/modules/manager/github-actions/extract.ts
@@ -20,7 +20,7 @@ import { CommunityActions } from './community';
 import type { Steps } from './schema';
 import { Workflow } from './schema';
 
-const dockerActionRe = regEx(/^\s+uses\s*: ['"]?docker:\/\/([^'"]+)\s*$/);
+const dockerActionRe = regEx(/^\s+uses\s*: ['"]?docker:\/\/([^'"]+).*$/);
 const actionRe = regEx(
   /^\s+-?\s+?uses\s*: (?<replaceString>['"]?(?<depName>(?<registryUrl>https:\/\/[.\w-]+\/)?(?<packageName>[\w-]+\/[.\w-]+))(?<path>\/.*)?@(?<currentValue>[^\s'"]+)['"]?(?:(?<commentWhiteSpaces>\s+)#\s*(((?:renovate\s*:\s*)?(?:pin\s+|tag\s*=\s*)?|(?:ratchet:[\w-]+\/[.\w-]+)?)@?(?<tag>([\w-]*[-/])?v?\d+(?:\.\d+(?:\.\d+)?)?)|(?:ratchet:exclude)))?)/,
 );

--- a/lib/modules/manager/github-actions/extract.ts
+++ b/lib/modules/manager/github-actions/extract.ts
@@ -20,7 +20,7 @@ import { CommunityActions } from './community';
 import type { Steps } from './schema';
 import { Workflow } from './schema';
 
-const dockerActionRe = regEx(/^\s+uses\s*: ['"]?docker:\/\/([^'"]+).*$/);
+const dockerActionRe = regEx(/^\s+uses\s*: ['"]?docker:\/\/([^'"\s]+)/);
 const actionRe = regEx(
   /^\s+-?\s+?uses\s*: (?<replaceString>['"]?(?<depName>(?<registryUrl>https:\/\/[.\w-]+\/)?(?<packageName>[\w-]+\/[.\w-]+))(?<path>\/.*)?@(?<currentValue>[^\s'"]+)['"]?(?:(?<commentWhiteSpaces>\s+)#\s*(((?:renovate\s*:\s*)?(?:pin\s+|tag\s*=\s*)?|(?:ratchet:[\w-]+\/[.\w-]+)?)@?(?<tag>([\w-]*[-/])?v?\d+(?:\.\d+(?:\.\d+)?)?)|(?:ratchet:exclude)))?)/,
 );


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

The problem with the use of `\s` is that it swallows the newline at the end of the line, meaning the $ anchor doesn't have anything to match against, which results in it failing to match quoted entries. By simply switching to a dot (which doesn't match newlines), the issue is resolved for all references.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
