### PR TITLE
feat(presets): add helper to add changelog for digest updates for GitHub-based packages

### DIFF
--- a/lib/config/presets/index.spec.ts
+++ b/lib/config/presets/index.spec.ts
@@ -579,6 +579,7 @@ describe('config/presets/index', () => {
           'mergeConfidence:age-confidence-badges',
           'replacements:all',
           'workarounds:all',
+          'helpers:githubDigestChangelogs',
         ],
       });
     });

--- a/lib/config/presets/internal/config.ts
+++ b/lib/config/presets/internal/config.ts
@@ -36,6 +36,7 @@ export const presets: Record<string, Preset> = {
       'mergeConfidence:age-confidence-badges',
       'replacements:all',
       'workarounds:all',
+      'helpers:githubDigestChangelogs',
     ],
   },
   semverAllMonthly: {

--- a/lib/config/presets/internal/helpers.ts
+++ b/lib/config/presets/internal/helpers.ts
@@ -27,7 +27,7 @@ export const presets: Record<string, Preset> = {
     packageRules: [
       {
         changelogUrl: '{{sourceUrl}}/compare/{{currentDigest}}..{{newDigest}}',
-        matchSourceUrls: ['https://github.com/**/*'],
+        matchSourceUrls: ['https://github.com/**'],
         matchUpdateTypes: ['digest'],
       },
     ],

--- a/lib/config/presets/internal/helpers.ts
+++ b/lib/config/presets/internal/helpers.ts
@@ -21,6 +21,17 @@ export const presets: Record<string, Preset> = {
     description: 'Keep `typescript` version in sync with the `rc` tag.',
     extends: [':followTag(typescript, rc)'],
   },
+  githubDigestChangelogs: {
+    description:
+      'Ensure that every dependency pinned by digest and sourced from GitHub.com contains a link to the commit-to-commit diff',
+    packageRules: [
+      {
+        changelogUrl: '{{sourceUrl}}/compare/{{currentDigest}}..{{newDigest}}',
+        matchSourceUrls: ['https://github.com/**/*'],
+        matchUpdateTypes: ['digest'],
+      },
+    ],
+  },
   pinGitHubActionDigests: {
     description: 'Pin `github-action` digests.',
     packageRules: [


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
As noted in #39646, this would be useful to provide changelogs for
digest updates.

Via [0].

[0]: https://www.jvt.me/posts/2025/05/08/renovate-digest-changelog/


## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

Relates to #39646

## Context

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
