### PR TITLE
fix(instrumentation): correctly `async` / `await` Git operations

### DIFF
--- a/lib/util/git/instrument.ts
+++ b/lib/util/git/instrument.ts
@@ -5,6 +5,7 @@ import type {
   DiffResult,
   LogOptions,
   LogResult,
+  MergeResult,
   Options,
   RemoteWithRefs,
   RemoteWithoutRefs,
@@ -97,10 +98,10 @@ export class InstrumentedSimpleGit {
     return this.git.version();
   }
 
-  raw(args: string[]): Response<string> {
+  raw(args: string[]): Promise<string> {
     const { spanName, options } = prepareInstrumentation(args[0]);
 
-    return instrument(spanName, () => this.git.raw(args), options);
+    return instrument(spanName, async () => await this.git.raw(args), options);
   }
 
   async checkout(whatOrOptions: string | TaskOptions): Promise<string> {
@@ -119,71 +120,99 @@ export class InstrumentedSimpleGit {
     );
   }
 
-  async checkoutBranch(branch: string, startPoint: string): Promise<void> {
+  checkoutBranch(branch: string, startPoint: string): Promise<void> {
     const { spanName, options } = prepareInstrumentation('checkout');
 
-    await instrument(
+    return instrument(
       spanName,
-      () => this.git.checkoutBranch(branch, startPoint),
+      async () => await this.git.checkoutBranch(branch, startPoint),
       options,
     );
   }
-  async branch(args: string[]): Promise<BranchSummary> {
+  branch(args: string[]): Promise<BranchSummary> {
     const { spanName, options } = prepareInstrumentation('branch');
 
-    return await instrument(spanName, () => this.git.branch(args), options);
+    return instrument(
+      spanName,
+      async () => await this.git.branch(args),
+      options,
+    );
   }
-  async branchLocal(): Promise<BranchSummary> {
+  branchLocal(): Promise<BranchSummary> {
     const { spanName, options } = prepareInstrumentation('branch');
 
-    return await instrument(spanName, () => this.git.branchLocal(), options);
+    return instrument(
+      spanName,
+      async () => await this.git.branchLocal(),
+      options,
+    );
   }
-  async add(files: string | string[]): Promise<string> {
+  add(files: string | string[]): Promise<string> {
     const { spanName, options } = prepareInstrumentation('add');
 
-    return await instrument(spanName, () => this.git.add(files), options);
+    return instrument(spanName, async () => await this.git.add(files), options);
   }
-  async addConfig(key: string, value: string): Promise<void> {
+  addConfig(key: string, value: string): Promise<string> {
     const { spanName, options } = prepareInstrumentation('config');
 
-    await instrument(spanName, () => this.git.addConfig(key, value), options);
+    return instrument(
+      spanName,
+      async () => await this.git.addConfig(key, value),
+      options,
+    );
   }
-  async rm(files: string | string[]): Promise<void> {
+  rm(files: string | string[]): Promise<void> {
     const { spanName, options } = prepareInstrumentation('rm');
 
-    await instrument(spanName, () => this.git.rm(files), options);
+    return instrument(spanName, async () => await this.git.rm(files), options);
   }
-  async reset(modeOrOptions: any): Promise<void> {
+  reset(modeOrOptions: any): Promise<string> {
     const { spanName, options } = prepareInstrumentation('reset');
 
-    await instrument(spanName, () => this.git.reset(modeOrOptions), options);
+    return instrument(
+      spanName,
+      async () => await this.git.reset(modeOrOptions),
+      options,
+    );
   }
-  async merge(args: string[]): Promise<void> {
+  merge(args: string[]): Promise<MergeResult> {
     const { spanName, options } = prepareInstrumentation('merge');
 
-    await instrument(spanName, () => this.git.merge(args), options);
+    return instrument(
+      spanName,
+      async () => await this.git.merge(args),
+      options,
+    );
   }
-  async push(...args: any[]): Promise<any> {
+  push(...args: any[]): Promise<any> {
     const { spanName, options } = prepareInstrumentation('push');
 
-    return await instrument(spanName, () => this.git.push(...args), options);
+    return instrument(
+      spanName,
+      async () => await this.git.push(...args),
+      options,
+    );
   }
-  async pull(args: string[]): Promise<any> {
+  pull(args: string[]): Promise<any> {
     const { spanName, options } = prepareInstrumentation('pull');
 
-    return await instrument(spanName, () => this.git.pull(args), options);
+    return instrument(spanName, async () => await this.git.pull(args), options);
   }
-  async fetch(args: string[]): Promise<any> {
+  fetch(args: string[]): Promise<any> {
     const { spanName, options } = prepareInstrumentation('fetch');
 
-    return await instrument(spanName, () => this.git.fetch(args), options);
+    return instrument(
+      spanName,
+      async () => await this.git.fetch(args),
+      options,
+    );
   }
-  async clone(repo: string, dir: string, options: string[]): Promise<void> {
+  clone(repo: string, dir: string, options: string[]): Promise<string> {
     const { spanName, options: spanOptions } = prepareInstrumentation('clone');
 
-    await instrument(
+    return instrument(
       spanName,
-      () => this.git.clone(repo, dir, options),
+      async () => await this.git.clone(repo, dir, options),
       spanOptions,
     );
   }
@@ -196,21 +225,29 @@ export class InstrumentedSimpleGit {
 
     return instrument(
       spanName,
-      () => this.git.commit(message, files, options),
+      async () => await this.git.commit(message, files, options),
       spanOptions,
     );
   }
-  status(args?: string[]): Response<StatusResult> {
+  status(args?: string[]): Promise<StatusResult> {
     const { spanName, options } = prepareInstrumentation('status');
 
-    return instrument(spanName, () => this.git.status(args), options);
+    return instrument(
+      spanName,
+      async () => await this.git.status(args),
+      options,
+    );
   }
-  async log<T = DefaultLogFields>(
+  log<T = DefaultLogFields>(
     options?: TaskOptions | LogOptions<T>,
   ): Promise<LogResult<T>> {
     const { spanName, options: spanOptions } = prepareInstrumentation('log');
 
-    return await instrument(spanName, () => this.git.log(options), spanOptions);
+    return instrument(
+      spanName,
+      async () => await this.git.log(options),
+      spanOptions,
+    );
   }
   async revparse(optionOrOptions: string | TaskOptions): Promise<string> {
     const { spanName, options } = prepareInstrumentation('log');
@@ -227,65 +264,75 @@ export class InstrumentedSimpleGit {
       options,
     );
   }
-  async show(args: string[]): Promise<string> {
+  show(args: string[]): Promise<string> {
     const { spanName, options } = prepareInstrumentation('show');
 
-    return await instrument(spanName, () => this.git.show(args), options);
+    return instrument(spanName, async () => await this.git.show(args), options);
   }
-  async diff(args: string[]): Promise<string> {
+  diff(args: string[]): Promise<string> {
     const { spanName, options } = prepareInstrumentation('diff');
 
-    return await instrument(spanName, () => this.git.diff(args), options);
+    return instrument(spanName, async () => await this.git.diff(args), options);
   }
 
-  async diffSummary(options: TaskOptions): Promise<DiffResult> {
+  diffSummary(options: TaskOptions): Promise<DiffResult> {
     const { spanName, options: spanOptions } = prepareInstrumentation('diff');
 
-    return await instrument(
+    return instrument(
       spanName,
-      () => this.git.diffSummary(options),
+      async () => await this.git.diffSummary(options),
       spanOptions,
     );
   }
-  async getRemotes(
+  getRemotes(
     verbose?: boolean,
   ): Promise<RemoteWithRefs[] | RemoteWithoutRefs[]> {
     const { spanName, options } = prepareInstrumentation('remote');
 
-    return await instrument(
+    return instrument(
       spanName,
       async () => {
         if (verbose === true) {
-          return await instrument('other', () => this.git.getRemotes(true));
+          return await instrument(
+            'other',
+            async () => await this.git.getRemotes(true),
+          );
         } else {
-          return await instrument('other', () => this.git.getRemotes());
+          return await instrument(
+            'other',
+            async () => await this.git.getRemotes(),
+          );
         }
       },
       options,
     );
   }
-  async addRemote(name: string, repo: string): Promise<void> {
+  addRemote(name: string, repo: string): Promise<string> {
     const { spanName, options } = prepareInstrumentation('remote');
 
-    await instrument(spanName, () => this.git.addRemote(name, repo), options);
+    return instrument(
+      spanName,
+      async () => await this.git.addRemote(name, repo),
+      options,
+    );
   }
   env(env: Record<string, string>): this {
     this.git = this.git.env(env);
     return this;
   }
-  async catFile(args: string[]): Promise<string> {
+  catFile(args: string[]): Promise<string> {
     const { spanName, options } = prepareInstrumentation('remote');
 
-    return await instrument(spanName, () => this.git.catFile(args), options);
+    return instrument(spanName, () => this.git.catFile(args), options);
   }
-  async listRemote(args: string[]): Promise<string> {
+  listRemote(args: string[]): Promise<string> {
     const { spanName, options } = prepareInstrumentation('ls-remote');
 
-    return await instrument(spanName, () => this.git.listRemote(args), options);
+    return instrument(spanName, () => this.git.listRemote(args), options);
   }
-  async submoduleUpdate(args: string[]): Promise<void> {
+  submoduleUpdate(args: string[]): Promise<string> {
     const { spanName, options } = prepareInstrumentation('submodule');
 
-    await instrument(spanName, () => this.git.submoduleUpdate(args), options);
+    return instrument(spanName, () => this.git.submoduleUpdate(args), options);
   }
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
A previous refactor had incorrectly made it so we were not correctly
`await`ing any calls to the SimpleGit method calls.

This has mostly led to the Git operations continuing to work, but the
instrumentation hasn't been correctly rendering.

This also corrects incorrect return types that were previously not
returned correctly.

## Screenshots

Before (`git clone` immediately returns):

<img width="797" height="257" alt="Screenshot 2025-12-01 at 11 41 19" src="https://github.com/user-attachments/assets/bd0dc127-7907-4255-8c86-69cdeb006674" />


After (`git clone` returns correct timing)

<img width="1062" height="452" alt="Screenshot 2025-12-01 at 11 40 25" src="https://github.com/user-attachments/assets/905a236c-1a79-4c11-bf35-de4051a3041a" />



## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
