### PR TITLE
fix(instrumentation): instrument command execution

### DIFF
--- a/lib/util/exec/common.spec.ts
+++ b/lib/util/exec/common.spec.ts
@@ -1,14 +1,22 @@
 import { spawn as _spawn } from 'node:child_process';
 import type { SendHandle, Serializable } from 'node:child_process';
 import { Readable } from 'node:stream';
+import * as _instrumentation from '../../instrumentation';
 import { regEx } from '../regex';
+import {
+  addSecretForSanitizing,
+  clearGlobalSanitizedSecretsList,
+  clearRepoSanitizedSecretsList,
+} from '../sanitize';
 import { exec, rawExec } from './common';
 import type { DataListener, RawExecOptions } from './types';
 import { partial } from '~test/util';
 
+vi.mock('../../instrumentation');
 vi.mock('node:child_process');
 vi.unmock('./common');
 
+const instrument = vi.spyOn(_instrumentation, 'instrument');
 const spawn = vi.mocked(_spawn);
 
 type MessageListener = (message: Serializable, sendHandle: SendHandle) => void;
@@ -158,6 +166,10 @@ describe('util/exec/common', () => {
   const cmd = 'ls -l';
   const stdout = 'out message';
   const stderr = 'err message';
+
+  beforeEach(() => {
+    instrument.mockImplementationOnce((_name: string, fn: () => any) => fn());
+  });
 
   describe('exec', () => {
     it('command exits with code 0', async () => {
@@ -351,6 +363,62 @@ describe('util/exec/common', () => {
       ).resolves.toEqual({
         stderr,
         stdout,
+      });
+    });
+
+    describe('is instrumented', () => {
+      beforeEach(() => {
+        clearRepoSanitizedSecretsList();
+        clearGlobalSanitizedSecretsList();
+      });
+
+      it('calls instrument function', async () => {
+        const cmd = 'ls -l';
+        const stub = getSpawnStub({
+          cmd,
+          exitCode: 0,
+          exitSignal: null,
+          stdout,
+          stderr,
+        });
+        spawn.mockImplementationOnce((cmd, opts) => stub);
+
+        await rawExec(
+          cmd,
+          partial<RawExecOptions>({ encoding: 'utf8', shell: 'bin/bash' }),
+        );
+
+        expect(instrument).toHaveBeenCalledTimes(1);
+        expect(instrument).toHaveBeenCalledWith(
+          'rawExec: ls -l',
+          expect.any(Function),
+        );
+      });
+
+      it('command name and arguments are sanitized', async () => {
+        addSecretForSanitizing('ls', 'global');
+        addSecretForSanitizing('npm_nOTValidSecret', 'repo');
+
+        const cmd = 'ls -al /path/to/secret --npm-token npm_nOTValidSecret';
+        const stub = getSpawnStub({
+          cmd,
+          exitCode: 0,
+          exitSignal: null,
+          stdout,
+          stderr,
+        });
+        spawn.mockImplementationOnce((cmd, opts) => stub);
+
+        await rawExec(
+          cmd,
+          partial<RawExecOptions>({ encoding: 'utf8', shell: 'bin/bash' }),
+        );
+
+        expect(instrument).toHaveBeenCalledTimes(1);
+        expect(instrument).toHaveBeenCalledWith(
+          'rawExec: **redacted** -al /path/to/secret --npm-token **redacted**',
+          expect.any(Function),
+        );
       });
     });
   });

--- a/lib/util/exec/common.ts
+++ b/lib/util/exec/common.ts
@@ -2,7 +2,9 @@ import type { ChildProcess } from 'node:child_process';
 import { spawn } from 'node:child_process';
 import type { Readable } from 'node:stream';
 import { isNullOrUndefined } from '@sindresorhus/is';
+import { instrument } from '../../instrumentation';
 import { getEnv } from '../env';
+import { sanitize } from '../sanitize';
 import type { ExecErrorData } from './exec-error';
 import { ExecError } from './exec-error';
 import type { DataListener, ExecResult, RawExecOptions } from './types';
@@ -169,4 +171,5 @@ function kill(cp: ChildProcess, signal: NodeJS.Signals): boolean {
 export const rawExec: (
   cmd: string,
   opts: RawExecOptions,
-) => Promise<ExecResult> = exec;
+) => Promise<ExecResult> = (cmd: string, opts: RawExecOptions) =>
+  instrument(`rawExec: ${sanitize(cmd)}`, () => exec(cmd, opts));


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->


As part of ongoing work to improve OpenTelemetry instrumentation of
Renovate in #38609, we can introduce an instrumented call for each
external command execution.

This makes sure we cover the key functions used for command
execution -  `rawExec` - across the codebase, which is used
under-the-hood by `exec`.

Because commands could include sensitive arguments (such as repo or
global secrets) we need to make sure we sanitize the span name.

Note that we don't add instrumentation to `tools/utils/exec.ts` as it's
only used for i.e. building the docs site, and isn't used as part of the
core Renovate CLI.




## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/JamieTanna-Mend-testing/backstage

When using:

```javascript
module.exports = {
  secrets: {
    FAKE: "renovate/",
    FAKE_2: "yarn",
  }
}
```

<img width="1166" height="87" alt="Screenshot 2025-12-17 at 10 02 07" src="https://github.com/user-attachments/assets/96013d7f-bbbe-4d97-aaf5-66b29c59e147" />


<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
