### PR TITLE
feat(bitbucket): massage issue markdown for abandoned deps section

### DIFF
--- a/lib/modules/platform/bitbucket/index.spec.ts
+++ b/lib/modules/platform/bitbucket/index.spec.ts
@@ -1668,6 +1668,19 @@ describe('modules/platform/bitbucket/index', () => {
 
       expect(bitbucket.massageMarkdown(prBody)).toMatchSnapshot();
     });
+
+    it('updates abandoned dependencies heading and place note inside', () => {
+      const prBody =
+        '> ℹ **Note**\n>\n' +
+        'These dependencies have not received updates for an extended period and may be unmaintained:\n' +
+        '<details><summary>View abandoned dependencies (6)</summary>';
+
+      expect(bitbucket.massageMarkdown(prBody)).toEqual(
+        '## Abandoned dependencies  (6)\n' +
+          '> ℹ **Note**\n>\n' +
+          'These dependencies have not received updates for an extended period and may be unmaintained:\n',
+      );
+    });
   });
 
   describe('updatePr()', () => {

--- a/lib/modules/platform/bitbucket/index.ts
+++ b/lib/modules/platform/bitbucket/index.ts
@@ -613,9 +613,10 @@ export function massageMarkdown(input: string): string {
       'renaming the PR to start with "rebase!"',
     )
     .replace(
-      regEx(/(>[\s\S]+?)<summary>View abandoned dependencies(.*)<\/summary>/),
-      '## Abandoned dependencies $2\n$1',
+      regEx(/<summary>View abandoned dependencies(.*)<\/summary>/),
+      '## Abandoned dependencies $1',
     )
+    .replace(regEx(/(>[\s\S]+?)(## Abandoned dependencies.*)/), '$2\n$1')
     .replace(regEx(/<\/?summary>/g), '**')
     .replace(regEx(/<\/?(details|blockquote)>/g), '')
     .replace(regEx(`\n---\n\n.*?<!-- rebase-check -->.*?\n`), '')

--- a/lib/modules/platform/bitbucket/index.ts
+++ b/lib/modules/platform/bitbucket/index.ts
@@ -612,6 +612,10 @@ export function massageMarkdown(input: string): string {
       'checking the rebase/retry box above',
       'renaming the PR to start with "rebase!"',
     )
+    .replace(
+      regEx(/(>[\s\S]+?)<summary>View abandoned dependencies(.*)<\/summary>/),
+      '## Abandoned dependencies $2\n$1',
+    )
     .replace(regEx(/<\/?summary>/g), '**')
     .replace(regEx(/<\/?(details|blockquote)>/g), '')
     .replace(regEx(`\n---\n\n.*?<!-- rebase-check -->.*?\n`), '')


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Massage markdown for abandoned dependencies section within Bitbucket issues.
- Rename heading since collapsible syntax isn't supported
- Relocate NOTE within renamed section

<!-- Describe what behavior is changed by this PR. -->

## Context

| **Before** |**After** |
| - | - |
| <img width="960" height="769" alt="Screenshot 2025-12-02 at 5 08 22 PM" src="https://github.com/user-attachments/assets/7764acaa-1c04-4430-9923-781fed1adff8" /> | <img width="959" height="777" alt="Screenshot 2025-12-02 at 5 09 47 PM" src="https://github.com/user-attachments/assets/15f27935-0a0f-4ff2-bf74-13f833c492da" /> |


Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
