### PR TITLE
feat(presets): add helpers for `golang.org/x` packages

### DIFF
--- a/lib/config/presets/index.spec.ts
+++ b/lib/config/presets/index.spec.ts
@@ -580,6 +580,8 @@ describe('config/presets/index', () => {
           'replacements:all',
           'workarounds:all',
           'helpers:githubDigestChangelogs',
+          'helpers:goXPackagesChangelogLink',
+          'helpers:goXPackagesNameLink',
         ],
       });
     });

--- a/lib/config/presets/internal/config.ts
+++ b/lib/config/presets/internal/config.ts
@@ -37,6 +37,8 @@ export const presets: Record<string, Preset> = {
       'replacements:all',
       'workarounds:all',
       'helpers:githubDigestChangelogs',
+      'helpers:goXPackagesChangelogLink',
+      'helpers:goXPackagesNameLink',
     ],
   },
   semverAllMonthly: {

--- a/lib/config/presets/internal/helpers.ts
+++ b/lib/config/presets/internal/helpers.ts
@@ -32,6 +32,24 @@ export const presets: Record<string, Preset> = {
       },
     ],
   },
+  goXPackagesChangelogLink: {
+    description: 'Correctly link to the source code for golang.org/x packages',
+    matchManagers: ['gomod'],
+    // NOTE that digests are not supported with the below diff view
+    matchUpdateTypes: ['major', 'minor', 'patch'],
+    prBodyDefinitions: {
+      Change:
+        "{{#if (containsString depName 'golang.org/x/')}}[`{{{displayFrom}}}` -> `{{{displayTo}}}`](https://cs.opensource.google/{{{replace '^golang\\.org' 'go' depName}}}/+/refs/tags/{{{currentValue}}}...refs/tags/{{{newValue}}}){{else}}`{{{displayFrom}}}` -> `{{{displayTo}}}`{{/if}}",
+    },
+  },
+  goXPackagesNameLink: {
+    description: "Link to pkg.go.dev/... for golang.org/x packages' title",
+    matchManagers: ['gomod'],
+    prBodyDefinitions: {
+      Package:
+        "{{#if (containsString depName 'golang.org/x/')}}[{{{depName}}}](https://pkg.go.dev/{{{depName}}}){{else}}{{{depNameLinked}}}{{/if}}",
+    },
+  },
   pinGitHubActionDigests: {
     description: 'Pin `github-action` digests.',
     packageRules: [


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
When working with Go modules, the `golang.org/x` need to be treated
slightly differently, as they're hosted on Google's
`cs.opensource.google` infrastructure.

This adapts changes from [0] to:

- provide a linked `depName`, through to `pkg.go.dev` for the package
- provide a link through to `cs.opensource.google` for the given
  changelog

We also wire this in by default for `config:recommended` users.

[0]: https://code.forgejo.org/forgejo/renovate-config/src/commit/42f4672021ac9907141d34966f38f735be401734/go.json#L59-L73


## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: https://github.com/JamieTanna-Mend-testing/oapi-codegen-runtime-2

I.e. https://github.com/JamieTanna-Mend-testing/oapi-codegen-runtime-2/pull/5

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
