### PR TITLE
fix(types): make `result` a strong type

### DIFF
--- a/lib/constants/error-messages.ts
+++ b/lib/constants/error-messages.ts
@@ -2,6 +2,11 @@
 export const SYSTEM_INSUFFICIENT_DISK_SPACE = 'disk-space';
 export const SYSTEM_INSUFFICIENT_MEMORY = 'out-of-memory';
 
+export const SystemErrors = [
+  SYSTEM_INSUFFICIENT_DISK_SPACE,
+  SYSTEM_INSUFFICIENT_MEMORY,
+] as const;
+
 // Platform Error
 export const PLATFORM_AUTHENTICATION_ERROR = 'authentication-error';
 export const PLATFORM_BAD_CREDENTIALS = 'bad-credentials';
@@ -10,6 +15,17 @@ export const PLATFORM_INTEGRATION_UNAUTHORIZED = 'integration-unauthorized';
 export const PLATFORM_NOT_FOUND = 'platform-not-found';
 export const PLATFORM_RATE_LIMIT_EXCEEDED = 'rate-limit-exceeded';
 export const PLATFORM_UNKNOWN_ERROR = 'platform-unknown-error';
+
+/** cause repo to be considered as disabled */
+export const PlatformErrors = [
+  PLATFORM_AUTHENTICATION_ERROR,
+  PLATFORM_BAD_CREDENTIALS,
+  PLATFORM_GPG_FAILED,
+  PLATFORM_INTEGRATION_UNAUTHORIZED,
+  PLATFORM_NOT_FOUND,
+  PLATFORM_RATE_LIMIT_EXCEEDED,
+  PLATFORM_UNKNOWN_ERROR,
+] as const;
 
 // Config Error
 export const CONFIG_VALIDATION = 'config-validation';
@@ -20,6 +36,18 @@ export const CONFIG_VARIABLES_INVALID = 'config-variables-invalid';
 export const CONFIG_GIT_URL_UNAVAILABLE = 'config-git-url-unavailable';
 export const CONFIG_INHERIT_NOT_FOUND = 'config-inherit-not-found';
 export const CONFIG_INHERIT_PARSE_ERROR = 'config-inherit-parse-error';
+
+/** cause repo to be considered as disabled */
+export const ConfigErrors = [
+  CONFIG_VALIDATION,
+  CONFIG_PRESETS_INVALID,
+  CONFIG_SECRETS_EXPOSED,
+  CONFIG_SECRETS_INVALID,
+  CONFIG_VARIABLES_INVALID,
+  CONFIG_GIT_URL_UNAVAILABLE,
+  CONFIG_INHERIT_NOT_FOUND,
+  CONFIG_INHERIT_PARSE_ERROR,
+] as const;
 
 // Repository Errors - causes repo to be considered as disabled
 export const REPOSITORY_ACCESS_FORBIDDEN = 'forbidden';
@@ -40,10 +68,37 @@ export const REPOSITORY_NO_PACKAGE_FILES = 'no-package-files';
 export const REPOSITORY_RENAMED = 'renamed';
 export const REPOSITORY_UNINITIATED = 'uninitiated';
 
+/** cause repo to be considered as disabled */
+export const RepositoryErrors = [
+  REPOSITORY_ACCESS_FORBIDDEN,
+  REPOSITORY_ARCHIVED,
+  REPOSITORY_BLOCKED,
+  REPOSITORY_CANNOT_FORK,
+  REPOSITORY_DISABLED,
+  REPOSITORY_CLOSED_ONBOARDING,
+  REPOSITORY_DISABLED_BY_CONFIG,
+  REPOSITORY_NO_CONFIG,
+  REPOSITORY_EMPTY,
+  REPOSITORY_FORK_MISSING,
+  REPOSITORY_FORK_MODE_FORKED,
+  REPOSITORY_FORKED,
+  REPOSITORY_MIRRORED,
+  REPOSITORY_NOT_FOUND,
+  REPOSITORY_NO_PACKAGE_FILES,
+  REPOSITORY_RENAMED,
+  REPOSITORY_UNINITIATED,
+] as const;
+
 // Temporary Error
 export const REPOSITORY_CHANGED = 'repository-changed';
 export const TEMPORARY_ERROR = 'temporary-error';
 export const NO_VULNERABILITY_ALERTS = 'no-vulnerability-alerts';
+
+export const TemporaryErrors = [
+  REPOSITORY_CHANGED,
+  TEMPORARY_ERROR,
+  NO_VULNERABILITY_ALERTS,
+] as const;
 
 // Manager Error
 export const MANAGER_LOCKFILE_ERROR = 'lockfile-error';

--- a/lib/workers/repository/index.ts
+++ b/lib/workers/repository/index.ts
@@ -42,7 +42,7 @@ import { OnboardingState } from './onboarding/common';
 import { ensureOnboardingPr } from './onboarding/pr';
 import { extractDependencies, updateRepo } from './process';
 import type { ExtractResult } from './process/extract-update';
-import type { ProcessResult } from './result';
+import type { ProcessResult, RepositoryResult } from './result';
 import { processResult } from './result';
 
 // istanbul ignore next
@@ -60,7 +60,7 @@ export async function renovateRepository(
       localDir: string;
       errorRes?: string;
     }> => {
-      let errorRes: string | undefined;
+      let errorRes: RepositoryResult | undefined;
       let config = GlobalConfig.set(
         applySecretsAndVariablesToConfig({
           config: repoConfig,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
As a way to make it more predictable what the possible states the
`result` in a given `Repository finished` log message can be, we can
wrap these into a type.

This requires a slight refactor where these are used to make sure that
Typescript is happy with the value being returned.

## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
