### PR TITLE
fix(bitbucket-server): resize mend.io merge confidence badges

### DIFF
--- a/lib/modules/platform/bitbucket-server/index.spec.ts
+++ b/lib/modules/platform/bitbucket-server/index.spec.ts
@@ -2289,6 +2289,13 @@ Followed by some information.
 <!-- followed by some more comments -->`);
           expect(prBody).toMatchSnapshot();
         });
+
+        it('resizes mend.io merge confidence badges', () => {
+          const badgeUrl =
+            'https://developer.mend.io/api/mc/badges/age/npm/yargs/18.0.0?slim=true';
+          const prBody = bitbucket.massageMarkdown(`| ![age](${badgeUrl}) |`);
+          expect(prBody).toBe(`| ![age](${badgeUrl}){height=20} |`);
+        });
       });
 
       describe('getBranchStatus()', () => {

--- a/lib/modules/platform/bitbucket-server/index.ts
+++ b/lib/modules/platform/bitbucket-server/index.ts
@@ -1342,7 +1342,13 @@ export function massageMarkdown(input: string): string {
     .replace(regEx(/<\/?summary>/g), '**')
     .replace(regEx(/<\/?details>/g), '')
     .replace(regEx(`\n---\n\n.*?<!-- rebase-check -->.*?(\n|$)`), '')
-    .replace(regEx(/<!--.*?-->/gs), '');
+    .replace(regEx(/<!--.*?-->/gs), '')
+    .replace(
+      regEx(
+        /(!\[.+?\]\(https:\/\/developer\.mend\.io\/api\/mc\/badges\/.+?\))/g,
+      ),
+      '$1{height=20}',
+    );
 }
 
 export function maxBodyLength(): number {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Resizes mend.io badges provided via the default [prBodyDefinitions](https://docs.renovatebot.com/configuration-options/#prbodydefinitions) to look visually more appealing on Bitbucket Server.

Before:
<img width="400" src="https://github.com/user-attachments/assets/80003761-8d74-47a0-8638-f1f34e8099cb" />

After:
<img width="300" src="https://github.com/user-attachments/assets/82d831c0-193c-4094-a178-6185c637d593" />

<!-- Describe what behavior is changed by this PR. -->

## Context

- https://github.com/renovatebot/renovate/discussions/36665

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
