### PR TITLE
fix(docs): look up open issues on `main` builds for Renovate docs

### DIFF
--- a/tools/docs/github-query-items.ts
+++ b/tools/docs/github-query-items.ts
@@ -78,7 +78,20 @@ export async function getOpenGitHubItems(): Promise<RenovateOpenItems> {
   }
 
   if (process.env.CI) {
-    return result;
+    if (
+      process.env.GITHUB_REF === 'main' &&
+      process.env.GITHUB_REPOSITORY !== 'renovatebot/renovatebot.github.io' &&
+      process.env.GITHUB_REPOSITORY !== 'renovatebot/renovate'
+    ) {
+      logger.warn(
+        {
+          repository: process.env.GITHUB_REPOSITORY,
+          ref: process.env.GITHUB_REF,
+        },
+        "Skipping collection of open GitHub Issues, as we're running CI on a non-HEAD branch of Renovate or its docs site",
+      );
+      return result;
+    }
   }
 
   try {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
We're currently always skipping the detection of open bugs/features, so
even though https://github.com/renovatebot/renovatebot.github.io/pull/746 introduced authentication to GitHub, this didn't
actually lead to the lookup when running in CI.

If we're not running in Renovate's CI build (i.e. as part of the release
process) or the docs site's CI build (as part of post-release
operations) we should continue to skip the build, when running in CI.

This also makes it clearer with a WARN log line to explain why this is
being skipped.

## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
