### PR TITLE
fix(docs): add required permissions for `build:docs`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -635,6 +635,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     if: github.event.pull_request.draft != true
+    permissions:
+      contents: read
+      issues: read
+
     steps:
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

As it currently fails because we only have `contents:read` i.e.

```

ERROR: Error getting query results
       "err": {
         "cmd": "/bin/sh -c gh issue list --json \"title,number,url,labels\" --search \"type:Bug\" --limit 1000",
         "stderr": "gh: To use GitHub CLI in automation, set the GH_TOKEN environment variable.\n",
         "stdout": "",
         "options": {
           "encoding": "utf-8",
           "env": ["CI", "HOME", "PATH", "LANG"],
           "maxBuffer": 10485760,
           "timeout": 900000
         },
         "exitCode": 4,
         "name": "ExecError",
         "message": "Command failed: gh issue list --json \"title,number,url,labels\" --search \"type:Bug\" --limit 1000\ngh: To use GitHub CLI in automation, set the GH_TOKEN environment variable.\n",
         "stack": "ExecError: Command failed: gh issue list --json \"title,number,url,labels\" --search \"type:Bug\" --limit 1000\ngh: To use GitHub CLI in automation, set the GH_TOKEN environment variable.\n\n    at ChildProcess.<anonymous> (/home/runner/work/renovate/renovate/lib/util/exec/common.ts:120:11)\n    at ChildProcess.emit (node:events:520:35)\n    at ChildProcess.emit (node:domain:489:12)\n    at ChildProcess._handle.onexit (node:internal/child_process:294:12)"
       }
ERROR: Unexpected error
       "err": {
         "cmd": "/bin/sh -c gh issue list --json \"title,number,url,labels\" --search \"type:Bug\" --limit 1000",
         "stderr": "gh: To use GitHub CLI in automation, set the GH_TOKEN environment variable.\n",
         "stdout": "",
         "options": {
           "encoding": "utf-8",
           "env": ["CI", "HOME", "PATH", "LANG"],
           "maxBuffer": 10485760,
           "timeout": 900000
         },
         "exitCode": 4,
         "name": "ExecError",
         "message": "Command failed: gh issue list --json \"title,number,url,labels\" --search \"type:Bug\" --limit 1000\ngh: To use GitHub CLI in automation, set the GH_TOKEN environment variable.\n",
         "stack": "ExecError: Command failed: gh issue list --json \"title,number,url,labels\" --search \"type:Bug\" --limit 1000\ngh: To use GitHub CLI in automation, set the GH_TOKEN environment variable.\n\n    at ChildProcess.<anonymous> (/home/runner/work/renovate/renovate/lib/util/exec/common.ts:120:11)\n    at ChildProcess.emit (node:events:520:35)\n    at ChildProcess.emit (node:domain:489:12)\n    at ChildProcess._handle.onexit (node:internal/child_process:294:12)"
       }
```

Follow-up to #39801 

## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
