### PR TITLE
fix(docs): revert lookup for open issues on `main`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -635,10 +635,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     if: github.event.pull_request.draft != true
-    permissions:
-      contents: read
-      issues: read
-
     steps:
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -664,8 +664,6 @@ jobs:
       - name: Build
         run: pnpm build:docs
         env:
-          # TODO: work out why we can't use `GITHUB_TOKEN` as we're using it in the docs repo
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SKIP_GITHUB_ISSUES: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'true' || '' }}
 

--- a/tools/docs/github-query-items.ts
+++ b/tools/docs/github-query-items.ts
@@ -78,20 +78,7 @@ export async function getOpenGitHubItems(): Promise<RenovateOpenItems> {
   }
 
   if (process.env.CI) {
-    if (
-      process.env.GITHUB_REF === 'main' &&
-      process.env.GITHUB_REPOSITORY !== 'renovatebot/renovatebot.github.io' &&
-      process.env.GITHUB_REPOSITORY !== 'renovatebot/renovate'
-    ) {
-      logger.warn(
-        {
-          repository: process.env.GITHUB_REPOSITORY,
-          ref: process.env.GITHUB_REF,
-        },
-        "Skipping collection of open GitHub Issues, as we're running CI on a non-HEAD branch of Renovate or its docs site",
-      );
-      return result;
-    }
+    return result;
   }
 
   try {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
- **Revert "fix(docs): wire in `GH_TOKEN` for `gh` CLI (#39812)"**
- **Revert "fix(docs): add required permissions for `build:docs` (#39809)"**
- **Revert "fix(docs): look up open issues on `main` builds for Renovate docs (#39801)"**


As it's broken the `main` build.

## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
