### PR TITLE
feat(bun): add support for bunfig.toml registry config

### DIFF
--- a/lib/modules/manager/bun/bunfig.spec.ts
+++ b/lib/modules/manager/bun/bunfig.spec.ts
@@ -31,17 +31,14 @@ registry = "https://registry.example.com"
       });
     });
 
-    it('parses registry object with url', () => {
+    it('parses registry object with url and extracts url', () => {
       const toml = `
 [install]
 registry = { url = "https://registry.example.com", token = "abc123" }
 `;
       expect(parseBunfigToml(toml)).toEqual({
         install: {
-          registry: {
-            url: 'https://registry.example.com',
-            token: 'abc123',
-          },
+          registry: 'https://registry.example.com',
         },
       });
     });
@@ -74,10 +71,7 @@ otherorg = { url = "https://registry.other.com", token = "secret" }
           registry: 'https://registry.example.com',
           scopes: {
             myorg: 'https://registry.myorg.com',
-            otherorg: {
-              url: 'https://registry.other.com',
-              token: 'secret',
-            },
+            otherorg: 'https://registry.other.com',
           },
         },
       });
@@ -119,13 +113,11 @@ registry = "https://registry.example.com"
       );
     });
 
-    it('returns default registry object url for unscoped package', () => {
+    it('returns default registry for unscoped package with object config', () => {
+      // After schema transform, registry is always a string URL
       const config = {
         install: {
-          registry: {
-            url: 'https://registry.example.com',
-            token: 'abc',
-          },
+          registry: 'https://registry.example.com',
         },
       };
       expect(resolveRegistryUrl('lodash', config)).toBe(
@@ -147,14 +139,12 @@ registry = "https://registry.example.com"
       );
     });
 
-    it('returns scoped registry object url for scoped package', () => {
+    it('returns scoped registry for scoped package with object config', () => {
+      // After schema transform, scoped registries are always string URLs
       const config = {
         install: {
           scopes: {
-            myorg: {
-              url: 'https://registry.myorg.com',
-              token: 'secret',
-            },
+            myorg: 'https://registry.myorg.com',
           },
         },
       };

--- a/lib/modules/manager/bun/bunfig.spec.ts
+++ b/lib/modules/manager/bun/bunfig.spec.ts
@@ -1,0 +1,195 @@
+import { parseBunfigToml, resolveRegistryUrl } from './bunfig';
+
+describe('modules/manager/bun/bunfig', () => {
+  describe('parseBunfigToml', () => {
+    it('returns null for invalid TOML', () => {
+      expect(parseBunfigToml('invalid toml {')).toBeNull();
+    });
+
+    it('returns empty config for empty TOML', () => {
+      expect(parseBunfigToml('')).toEqual({});
+    });
+
+    it('parses simple string registry', () => {
+      const toml = `
+[install]
+registry = "https://registry.example.com"
+`;
+      expect(parseBunfigToml(toml)).toEqual({
+        install: {
+          registry: 'https://registry.example.com',
+        },
+      });
+    });
+
+    it('parses registry object with url', () => {
+      const toml = `
+[install]
+registry = { url = "https://registry.example.com", token = "abc123" }
+`;
+      expect(parseBunfigToml(toml)).toEqual({
+        install: {
+          registry: {
+            url: 'https://registry.example.com',
+            token: 'abc123',
+          },
+        },
+      });
+    });
+
+    it('parses scoped registries', () => {
+      const toml = `
+[install.scopes]
+myorg = "https://registry.myorg.com"
+`;
+      expect(parseBunfigToml(toml)).toEqual({
+        install: {
+          scopes: {
+            myorg: 'https://registry.myorg.com',
+          },
+        },
+      });
+    });
+
+    it('parses mixed default and scoped registries', () => {
+      const toml = `
+[install]
+registry = "https://registry.example.com"
+
+[install.scopes]
+myorg = "https://registry.myorg.com"
+otherorg = { url = "https://registry.other.com", token = "secret" }
+`;
+      expect(parseBunfigToml(toml)).toEqual({
+        install: {
+          registry: 'https://registry.example.com',
+          scopes: {
+            myorg: 'https://registry.myorg.com',
+            otherorg: {
+              url: 'https://registry.other.com',
+              token: 'secret',
+            },
+          },
+        },
+      });
+    });
+
+    it('ignores unrelated TOML sections', () => {
+      const toml = `
+[run]
+shell = "zsh"
+
+[install]
+registry = "https://registry.example.com"
+`;
+      expect(parseBunfigToml(toml)).toEqual({
+        install: {
+          registry: 'https://registry.example.com',
+        },
+      });
+    });
+  });
+
+  describe('resolveRegistryUrl', () => {
+    it('returns null when no install config', () => {
+      expect(resolveRegistryUrl('dep', {})).toBeNull();
+    });
+
+    it('returns null when no registry configured', () => {
+      expect(resolveRegistryUrl('dep', { install: {} })).toBeNull();
+    });
+
+    it('returns default registry for unscoped package', () => {
+      const config = {
+        install: {
+          registry: 'https://registry.example.com',
+        },
+      };
+      expect(resolveRegistryUrl('lodash', config)).toBe(
+        'https://registry.example.com',
+      );
+    });
+
+    it('returns default registry object url for unscoped package', () => {
+      const config = {
+        install: {
+          registry: {
+            url: 'https://registry.example.com',
+            token: 'abc',
+          },
+        },
+      };
+      expect(resolveRegistryUrl('lodash', config)).toBe(
+        'https://registry.example.com',
+      );
+    });
+
+    it('returns scoped registry for scoped package', () => {
+      const config = {
+        install: {
+          registry: 'https://registry.example.com',
+          scopes: {
+            myorg: 'https://registry.myorg.com',
+          },
+        },
+      };
+      expect(resolveRegistryUrl('@myorg/utils', config)).toBe(
+        'https://registry.myorg.com',
+      );
+    });
+
+    it('returns scoped registry object url for scoped package', () => {
+      const config = {
+        install: {
+          scopes: {
+            myorg: {
+              url: 'https://registry.myorg.com',
+              token: 'secret',
+            },
+          },
+        },
+      };
+      expect(resolveRegistryUrl('@myorg/utils', config)).toBe(
+        'https://registry.myorg.com',
+      );
+    });
+
+    it('falls back to default registry for unmatched scope', () => {
+      const config = {
+        install: {
+          registry: 'https://registry.example.com',
+          scopes: {
+            myorg: 'https://registry.myorg.com',
+          },
+        },
+      };
+      expect(resolveRegistryUrl('@other/pkg', config)).toBe(
+        'https://registry.example.com',
+      );
+    });
+
+    it('returns null for unmatched scope with no default', () => {
+      const config = {
+        install: {
+          scopes: {
+            myorg: 'https://registry.myorg.com',
+          },
+        },
+      };
+      expect(resolveRegistryUrl('@other/pkg', config)).toBeNull();
+    });
+
+    it('handles scope with @ prefix in config', () => {
+      const config = {
+        install: {
+          scopes: {
+            '@myorg': 'https://registry.myorg.com',
+          },
+        },
+      };
+      expect(resolveRegistryUrl('@myorg/utils', config)).toBe(
+        'https://registry.myorg.com',
+      );
+    });
+  });
+});

--- a/lib/modules/manager/bun/bunfig.spec.ts
+++ b/lib/modules/manager/bun/bunfig.spec.ts
@@ -10,6 +10,15 @@ describe('modules/manager/bun/bunfig', () => {
       expect(parseBunfigToml('')).toEqual({});
     });
 
+    it('returns null for valid TOML with invalid schema', () => {
+      // Valid TOML but registry is not a string or valid object
+      const toml = `
+[install]
+registry = 123
+`;
+      expect(parseBunfigToml(toml)).toBeNull();
+    });
+
     it('parses simple string registry', () => {
       const toml = `
 [install]

--- a/lib/modules/manager/bun/bunfig.spec.ts
+++ b/lib/modules/manager/bun/bunfig.spec.ts
@@ -1,5 +1,5 @@
 import { codeBlock } from 'common-tags';
-import { parseBunfigToml, resolveRegistryUrl } from './bunfig';
+import { parseBunfigToml, resolveRegistryUrl } from './bunfig.ts';
 
 describe('modules/manager/bun/bunfig', () => {
   describe('parseBunfigToml', () => {

--- a/lib/modules/manager/bun/bunfig.spec.ts
+++ b/lib/modules/manager/bun/bunfig.spec.ts
@@ -1,3 +1,4 @@
+import { codeBlock } from 'common-tags';
 import { parseBunfigToml, resolveRegistryUrl } from './bunfig';
 
 describe('modules/manager/bun/bunfig', () => {
@@ -12,18 +13,18 @@ describe('modules/manager/bun/bunfig', () => {
 
     it('returns null for valid TOML with invalid schema', () => {
       // Valid TOML but registry is not a string or valid object
-      const toml = `
-[install]
-registry = 123
-`;
+      const toml = codeBlock`
+        [install]
+        registry = 123
+      `;
       expect(parseBunfigToml(toml)).toBeNull();
     });
 
     it('parses simple string registry', () => {
-      const toml = `
-[install]
-registry = "https://registry.example.com"
-`;
+      const toml = codeBlock`
+        [install]
+        registry = "https://registry.example.com"
+      `;
       expect(parseBunfigToml(toml)).toEqual({
         install: {
           registry: 'https://registry.example.com',
@@ -32,10 +33,10 @@ registry = "https://registry.example.com"
     });
 
     it('parses registry object with url and extracts url', () => {
-      const toml = `
-[install]
-registry = { url = "https://registry.example.com", token = "abc123" }
-`;
+      const toml = codeBlock`
+        [install]
+        registry = { url = "https://registry.example.com", token = "abc123" }
+      `;
       expect(parseBunfigToml(toml)).toEqual({
         install: {
           registry: 'https://registry.example.com',
@@ -44,10 +45,10 @@ registry = { url = "https://registry.example.com", token = "abc123" }
     });
 
     it('parses scoped registries', () => {
-      const toml = `
-[install.scopes]
-myorg = "https://registry.myorg.com"
-`;
+      const toml = codeBlock`
+        [install.scopes]
+        myorg = "https://registry.myorg.com"
+      `;
       expect(parseBunfigToml(toml)).toEqual({
         install: {
           scopes: {
@@ -58,14 +59,14 @@ myorg = "https://registry.myorg.com"
     });
 
     it('parses mixed default and scoped registries', () => {
-      const toml = `
-[install]
-registry = "https://registry.example.com"
+      const toml = codeBlock`
+        [install]
+        registry = "https://registry.example.com"
 
-[install.scopes]
-myorg = "https://registry.myorg.com"
-otherorg = { url = "https://registry.other.com", token = "secret" }
-`;
+        [install.scopes]
+        myorg = "https://registry.myorg.com"
+        otherorg = { url = "https://registry.other.com", token = "secret" }
+      `;
       expect(parseBunfigToml(toml)).toEqual({
         install: {
           registry: 'https://registry.example.com',
@@ -78,13 +79,13 @@ otherorg = { url = "https://registry.other.com", token = "secret" }
     });
 
     it('ignores unrelated TOML sections', () => {
-      const toml = `
-[run]
-shell = "zsh"
+      const toml = codeBlock`
+        [run]
+        shell = "zsh"
 
-[install]
-registry = "https://registry.example.com"
-`;
+        [install]
+        registry = "https://registry.example.com"
+      `;
       expect(parseBunfigToml(toml)).toEqual({
         install: {
           registry: 'https://registry.example.com',

--- a/lib/modules/manager/bun/bunfig.ts
+++ b/lib/modules/manager/bun/bunfig.ts
@@ -1,4 +1,3 @@
-import { isString } from '@sindresorhus/is';
 import { z } from 'zod';
 import { logger } from '../../../logger';
 import { findLocalSiblingOrParent, readLocalFile } from '../../../util/fs';
@@ -7,21 +6,14 @@ import { parse as parseToml } from '../../../util/toml';
 
 /**
  * Schema for bunfig.toml registry configuration.
- * Supports both string URLs and object with url/token/username/password.
+ * Supports both string URLs and object with url.
  * Transforms to extract just the URL string.
  * See: https://bun.sh/docs/runtime/bunfig#install-registry
  */
-const BunfigRegistrySchema = z
-  .union([
-    z.string(),
-    z.object({
-      url: z.string(),
-      token: z.string().optional(),
-      username: z.string().optional(),
-      password: z.string().optional(),
-    }),
-  ])
-  .transform((val) => (isString(val) ? val : val.url));
+const BunfigRegistrySchema = z.union([
+  z.string(),
+  z.object({ url: z.string() }).transform((val) => val.url),
+]);
 
 const BunfigInstallSchema = z.object({
   registry: BunfigRegistrySchema.optional(),

--- a/lib/modules/manager/bun/bunfig.ts
+++ b/lib/modules/manager/bun/bunfig.ts
@@ -1,0 +1,112 @@
+import { z } from 'zod';
+import { logger } from '../../../logger';
+import { findLocalSiblingOrParent, readLocalFile } from '../../../util/fs';
+import { Result } from '../../../util/result';
+import { parse as parseToml } from '../../../util/toml';
+
+/**
+ * Schema for bunfig.toml registry configuration.
+ * Supports both string URLs and object with url/token/username/password.
+ * See: https://bun.sh/docs/runtime/bunfig#install-registry
+ */
+const BunfigRegistrySchema = z.union([
+  z.string(),
+  z.object({
+    url: z.string(),
+    token: z.string().optional(),
+    username: z.string().optional(),
+    password: z.string().optional(),
+  }),
+]);
+
+const BunfigInstallSchema = z.object({
+  registry: BunfigRegistrySchema.optional(),
+  scopes: z.record(z.string(), BunfigRegistrySchema).optional(),
+});
+
+const BunfigSchema = z.object({
+  install: BunfigInstallSchema.optional(),
+});
+
+export type BunfigConfig = z.infer<typeof BunfigSchema>;
+export type BunfigRegistryConfig = z.infer<typeof BunfigRegistrySchema>;
+
+/**
+ * Extracts the URL from a registry config (string or object).
+ */
+function getRegistryUrl(config: BunfigRegistryConfig): string {
+  return typeof config === 'string' ? config : config.url;
+}
+
+/**
+ * Resolves the registry URL for a given package name based on bunfig.toml config.
+ * Scoped packages (@org/pkg) are matched against scoped registries first.
+ */
+export function resolveRegistryUrl(
+  packageName: string,
+  bunfigConfig: BunfigConfig,
+): string | null {
+  const install = bunfigConfig.install;
+  if (!install) {
+    return null;
+  }
+
+  // Check scoped registries first
+  if (install.scopes) {
+    for (const scope in install.scopes) {
+      // Bun scopes in bunfig.toml don't include the @ prefix
+      const scopePrefix = scope.startsWith('@') ? scope : `@${scope}`;
+      if (packageName.startsWith(`${scopePrefix}/`)) {
+        return getRegistryUrl(install.scopes[scope]);
+      }
+    }
+  }
+
+  // Fall back to default registry
+  if (install.registry) {
+    return getRegistryUrl(install.registry);
+  }
+
+  return null;
+}
+
+/**
+ * Loads and parses bunfig.toml from the filesystem.
+ * Returns null if file not found or parsing fails.
+ */
+export async function loadBunfigToml(
+  packageFile: string,
+): Promise<BunfigConfig | null> {
+  const bunfigFileName = await findLocalSiblingOrParent(
+    packageFile,
+    'bunfig.toml',
+  );
+
+  if (!bunfigFileName) {
+    return null;
+  }
+
+  const content = await readLocalFile(bunfigFileName, 'utf8');
+  if (!content) {
+    return null;
+  }
+
+  return parseBunfigToml(content);
+}
+
+/**
+ * Parses bunfig.toml content string into a typed config object.
+ */
+export function parseBunfigToml(content: string): BunfigConfig | null {
+  try {
+    const parsed = parseToml(content);
+    return Result.parse(parsed, BunfigSchema)
+      .onError((err) => {
+        logger.debug({ err }, 'Failed to parse bunfig.toml');
+      })
+      .unwrapOrNull();
+  } catch (err) {
+    logger.debug({ err }, 'Failed to parse bunfig.toml TOML syntax');
+    return null;
+  }
+}

--- a/lib/modules/manager/bun/bunfig.ts
+++ b/lib/modules/manager/bun/bunfig.ts
@@ -20,7 +20,7 @@ const BunfigRegistrySchema = z
       password: z.string().optional(),
     }),
   ])
-  .transform((val) => (typeof val === 'string' ? val : val.url));
+  .transform((val) => (isString(val) ? val : val.url));
 
 const BunfigInstallSchema = z.object({
   registry: BunfigRegistrySchema.optional(),

--- a/lib/modules/manager/bun/bunfig.ts
+++ b/lib/modules/manager/bun/bunfig.ts
@@ -1,3 +1,4 @@
+import { isString } from '@sindresorhus/is';
 import { z } from 'zod';
 import { logger } from '../../../logger';
 import { findLocalSiblingOrParent, readLocalFile } from '../../../util/fs';

--- a/lib/modules/manager/bun/bunfig.ts
+++ b/lib/modules/manager/bun/bunfig.ts
@@ -1,6 +1,40 @@
-import { logger } from '../../../logger';
-import { findLocalSiblingOrParent, readLocalFile } from '../../../util/fs';
-import { BunfigConfig } from './schema';
+import { logger } from '../../../logger/index.ts';
+import {
+  findLocalSiblingOrParent,
+  readLocalFile,
+} from '../../../util/fs/index.ts';
+import { parse as parseToml } from '../../../util/toml.ts';
+import {
+  type BunfigConfig,
+  type BunfigRegistryConfig,
+  BunfigSchema,
+  type RawBunfigConfig,
+} from './schema.ts';
+
+function getRegistryUrl(config: BunfigRegistryConfig): string {
+  return typeof config === 'string' ? config : config.url;
+}
+
+function normalizeBunfigConfig(config: RawBunfigConfig): BunfigConfig {
+  const install = config.install;
+  if (!install) {
+    return {};
+  }
+
+  return {
+    install: {
+      registry: install.registry ? getRegistryUrl(install.registry) : undefined,
+      scopes: install.scopes
+        ? Object.fromEntries(
+            Object.entries(install.scopes).map(([scope, registryConfig]) => [
+              scope,
+              getRegistryUrl(registryConfig),
+            ]),
+          )
+        : undefined,
+    },
+  };
+}
 
 /**
  * Resolves the registry URL for a given package name based on bunfig.toml config.
@@ -62,11 +96,17 @@ export async function loadBunfigToml(
  * Parses bunfig.toml content string into a typed config object.
  */
 export function parseBunfigToml(content: string): BunfigConfig | null {
-  const res = BunfigConfig.safeParse(content);
-  if (res.success) {
-    return res.data;
-  }
+  try {
+    const parsed = parseToml(content);
+    const res = BunfigSchema.safeParse(parsed);
+    if (res.success) {
+      return normalizeBunfigConfig(res.data);
+    }
 
-  logger.debug({ err: res.error }, 'Failed to parse bunfig.toml');
-  return null;
+    logger.debug({ err: res.error }, 'Failed to parse bunfig.toml');
+    return null;
+  } catch (err) {
+    logger.debug({ err }, 'Failed to parse bunfig.toml TOML syntax');
+    return null;
+  }
 }

--- a/lib/modules/manager/bun/bunfig.ts
+++ b/lib/modules/manager/bun/bunfig.ts
@@ -1,30 +1,6 @@
-import { z } from 'zod';
 import { logger } from '../../../logger';
 import { findLocalSiblingOrParent, readLocalFile } from '../../../util/fs';
-import { Result } from '../../../util/result';
-import { parse as parseToml } from '../../../util/toml';
-
-/**
- * Schema for bunfig.toml registry configuration.
- * Supports both string URLs and object with url.
- * Transforms to extract just the URL string.
- * See: https://bun.sh/docs/runtime/bunfig#install-registry
- */
-const BunfigRegistrySchema = z.union([
-  z.string(),
-  z.object({ url: z.string() }).transform((val) => val.url),
-]);
-
-const BunfigInstallSchema = z.object({
-  registry: BunfigRegistrySchema.optional(),
-  scopes: z.record(z.string(), BunfigRegistrySchema).optional(),
-});
-
-const BunfigSchema = z.object({
-  install: BunfigInstallSchema.optional(),
-});
-
-export type BunfigConfig = z.infer<typeof BunfigSchema>;
+import { BunfigConfig } from './schema';
 
 /**
  * Resolves the registry URL for a given package name based on bunfig.toml config.
@@ -86,15 +62,11 @@ export async function loadBunfigToml(
  * Parses bunfig.toml content string into a typed config object.
  */
 export function parseBunfigToml(content: string): BunfigConfig | null {
-  try {
-    const parsed = parseToml(content);
-    return Result.parse(parsed, BunfigSchema)
-      .onError((err) => {
-        logger.debug({ err }, 'Failed to parse bunfig.toml');
-      })
-      .unwrapOrNull();
-  } catch (err) {
-    logger.debug({ err }, 'Failed to parse bunfig.toml TOML syntax');
-    return null;
+  const res = BunfigConfig.safeParse(content);
+  if (res.success) {
+    return res.data;
   }
+
+  logger.debug({ err: res.error }, 'Failed to parse bunfig.toml');
+  return null;
 }

--- a/lib/modules/manager/bun/extract.spec.ts
+++ b/lib/modules/manager/bun/extract.spec.ts
@@ -327,6 +327,26 @@ describe('modules/manager/bun/extract', () => {
       expect(packageFiles[0].deps[0].registryUrls).toBeUndefined();
     });
 
+    it('handles empty bunfig.toml file gracefully', async () => {
+      vi.mocked(fs.getSiblingFileName).mockReturnValue('package.json');
+      vi.mocked(fs.readLocalFile).mockResolvedValueOnce(
+        JSON.stringify({
+          name: 'test',
+          version: '0.0.1',
+          dependencies: { lodash: '1.0.0' },
+        }),
+      );
+      vi.mocked(fs.findLocalSiblingOrParent).mockResolvedValueOnce(
+        'bunfig.toml',
+      );
+      // bunfig.toml exists but is empty/null
+      vi.mocked(fs.readLocalFile).mockResolvedValueOnce(null);
+
+      const packageFiles = await extractAllPackageFiles({}, ['bun.lock']);
+
+      expect(packageFiles[0].deps[0].registryUrls).toBeUndefined();
+    });
+
     it('applies bunfig.toml registry to workspace packages', async () => {
       vi.mocked(fs.getSiblingFileName).mockReturnValue('package.json');
       vi.mocked(fs.readLocalFile)
@@ -379,6 +399,29 @@ describe('modules/manager/bun/extract', () => {
       expect(workspacePkg?.deps[0].registryUrls).toEqual([
         'https://registry.example.com',
       ]);
+    });
+
+    it('handles invalid bunfig.toml schema gracefully', async () => {
+      vi.mocked(fs.getSiblingFileName).mockReturnValue('package.json');
+      vi.mocked(fs.readLocalFile).mockResolvedValueOnce(
+        JSON.stringify({
+          name: 'test',
+          version: '0.0.1',
+          dependencies: { lodash: '1.0.0' },
+        }),
+      );
+      vi.mocked(fs.findLocalSiblingOrParent).mockResolvedValueOnce(
+        'bunfig.toml',
+      );
+      // Valid TOML but invalid schema (registry should be string or object with url)
+      vi.mocked(fs.readLocalFile).mockResolvedValueOnce(`
+[install]
+registry = 123
+`);
+
+      const packageFiles = await extractAllPackageFiles({}, ['bun.lock']);
+
+      expect(packageFiles[0].deps[0].registryUrls).toBeUndefined();
     });
   });
 });

--- a/lib/modules/manager/bun/extract.spec.ts
+++ b/lib/modules/manager/bun/extract.spec.ts
@@ -260,8 +260,13 @@ describe('modules/manager/bun/extract', () => {
           dependencies: { lodash: '1.0.0' },
         }),
       );
-      vi.mocked(fs.findLocalSiblingOrParent).mockResolvedValueOnce(
-        'bunfig.toml',
+      vi.mocked(fs.findLocalSiblingOrParent).mockImplementation(
+        (_packageFile, configFile): Promise<string | null> => {
+          if (configFile === 'bunfig.toml') {
+            return Promise.resolve('bunfig.toml');
+          }
+          return Promise.resolve(null);
+        },
       );
       vi.mocked(fs.readLocalFile).mockResolvedValueOnce(codeBlock`
         [install]
@@ -287,8 +292,13 @@ describe('modules/manager/bun/extract', () => {
           },
         }),
       );
-      vi.mocked(fs.findLocalSiblingOrParent).mockResolvedValueOnce(
-        'bunfig.toml',
+      vi.mocked(fs.findLocalSiblingOrParent).mockImplementation(
+        (_packageFile, configFile): Promise<string | null> => {
+          if (configFile === 'bunfig.toml') {
+            return Promise.resolve('bunfig.toml');
+          }
+          return Promise.resolve(null);
+        },
       );
       vi.mocked(fs.readLocalFile).mockResolvedValueOnce(codeBlock`
         [install]
@@ -320,7 +330,9 @@ describe('modules/manager/bun/extract', () => {
           dependencies: { lodash: '1.0.0' },
         }),
       );
-      vi.mocked(fs.findLocalSiblingOrParent).mockResolvedValueOnce(null);
+      vi.mocked(fs.findLocalSiblingOrParent).mockImplementation(() =>
+        Promise.resolve(null),
+      );
 
       const packageFiles = await extractAllPackageFiles({}, ['bun.lock']);
 
@@ -336,8 +348,13 @@ describe('modules/manager/bun/extract', () => {
           dependencies: { lodash: '1.0.0' },
         }),
       );
-      vi.mocked(fs.findLocalSiblingOrParent).mockResolvedValueOnce(
-        'bunfig.toml',
+      vi.mocked(fs.findLocalSiblingOrParent).mockImplementation(
+        (_packageFile, configFile): Promise<string | null> => {
+          if (configFile === 'bunfig.toml') {
+            return Promise.resolve('bunfig.toml');
+          }
+          return Promise.resolve(null);
+        },
       );
       // bunfig.toml exists but is empty/null
       vi.mocked(fs.readLocalFile).mockResolvedValueOnce(null);
@@ -359,8 +376,13 @@ describe('modules/manager/bun/extract', () => {
             dependencies: { lodash: '1.0.0' },
           }),
         );
-      vi.mocked(fs.findLocalSiblingOrParent).mockResolvedValueOnce(
-        'bunfig.toml',
+      vi.mocked(fs.findLocalSiblingOrParent).mockImplementation(
+        (_packageFile, configFile): Promise<string | null> => {
+          if (configFile === 'bunfig.toml') {
+            return Promise.resolve('bunfig.toml');
+          }
+          return Promise.resolve(null);
+        },
       );
       vi.mocked(fs.readLocalFile).mockResolvedValueOnce(codeBlock`
         [install]
@@ -410,8 +432,13 @@ describe('modules/manager/bun/extract', () => {
           dependencies: { lodash: '1.0.0' },
         }),
       );
-      vi.mocked(fs.findLocalSiblingOrParent).mockResolvedValueOnce(
-        'bunfig.toml',
+      vi.mocked(fs.findLocalSiblingOrParent).mockImplementation(
+        (_packageFile, configFile): Promise<string | null> => {
+          if (configFile === 'bunfig.toml') {
+            return Promise.resolve('bunfig.toml');
+          }
+          return Promise.resolve(null);
+        },
       );
       // Valid TOML but invalid schema (registry should be string or object with url)
       vi.mocked(fs.readLocalFile).mockResolvedValueOnce(codeBlock`

--- a/lib/modules/manager/bun/extract.spec.ts
+++ b/lib/modules/manager/bun/extract.spec.ts
@@ -1,3 +1,4 @@
+import { codeBlock } from 'common-tags';
 import { fs } from '~test/util.ts';
 import { extractAllPackageFiles } from './extract.ts';
 
@@ -247,5 +248,137 @@ describe('modules/manager/bun/extract', () => {
     expect(packageFiles[0].npmrc).toBe(
       'registry=https://custom.registry.com\n',
     );
+  });
+
+  describe('bunfig.toml registry support', () => {
+    it('applies default registry from bunfig.toml', async () => {
+      vi.mocked(fs.getSiblingFileName).mockReturnValue('package.json');
+      vi.mocked(fs.readLocalFile).mockResolvedValueOnce(
+        JSON.stringify({
+          name: 'test',
+          version: '0.0.1',
+          dependencies: { lodash: '1.0.0' },
+        }),
+      );
+      vi.mocked(fs.findLocalSiblingOrParent).mockResolvedValueOnce(
+        'bunfig.toml',
+      );
+      vi.mocked(fs.readLocalFile).mockResolvedValueOnce(codeBlock`
+        [install]
+        registry = "https://registry.example.com"
+      `);
+
+      const packageFiles = await extractAllPackageFiles({}, ['bun.lock']);
+
+      expect(packageFiles[0].deps[0].registryUrls).toEqual([
+        'https://registry.example.com',
+      ]);
+    });
+
+    it('applies scoped registry from bunfig.toml', async () => {
+      vi.mocked(fs.getSiblingFileName).mockReturnValue('package.json');
+      vi.mocked(fs.readLocalFile).mockResolvedValueOnce(
+        JSON.stringify({
+          name: 'test',
+          version: '0.0.1',
+          dependencies: {
+            lodash: '1.0.0',
+            '@myorg/utils': '2.0.0',
+          },
+        }),
+      );
+      vi.mocked(fs.findLocalSiblingOrParent).mockResolvedValueOnce(
+        'bunfig.toml',
+      );
+      vi.mocked(fs.readLocalFile).mockResolvedValueOnce(codeBlock`
+        [install]
+        registry = "https://registry.example.com"
+
+        [install.scopes]
+        myorg = "https://registry.myorg.com"
+      `);
+
+      const packageFiles = await extractAllPackageFiles({}, ['bun.lock']);
+
+      const lodashDep = packageFiles[0].deps.find(
+        (d) => d.depName === 'lodash',
+      );
+      const myorgDep = packageFiles[0].deps.find(
+        (d) => d.depName === '@myorg/utils',
+      );
+
+      expect(lodashDep?.registryUrls).toEqual(['https://registry.example.com']);
+      expect(myorgDep?.registryUrls).toEqual(['https://registry.myorg.com']);
+    });
+
+    it('handles missing bunfig.toml gracefully', async () => {
+      vi.mocked(fs.getSiblingFileName).mockReturnValue('package.json');
+      vi.mocked(fs.readLocalFile).mockResolvedValueOnce(
+        JSON.stringify({
+          name: 'test',
+          version: '0.0.1',
+          dependencies: { lodash: '1.0.0' },
+        }),
+      );
+      vi.mocked(fs.findLocalSiblingOrParent).mockResolvedValueOnce(null);
+
+      const packageFiles = await extractAllPackageFiles({}, ['bun.lock']);
+
+      expect(packageFiles[0].deps[0].registryUrls).toBeUndefined();
+    });
+
+    it('applies bunfig.toml registry to workspace packages', async () => {
+      vi.mocked(fs.getSiblingFileName).mockReturnValue('package.json');
+      vi.mocked(fs.readLocalFile)
+        // Root package.json with workspaces
+        .mockResolvedValueOnce(
+          JSON.stringify({
+            name: 'root',
+            version: '1.0.0',
+            workspaces: ['packages/*'],
+            dependencies: { lodash: '1.0.0' },
+          }),
+        );
+      vi.mocked(fs.findLocalSiblingOrParent).mockResolvedValueOnce(
+        'bunfig.toml',
+      );
+      vi.mocked(fs.readLocalFile).mockResolvedValueOnce(codeBlock`
+        [install]
+        registry = "https://registry.example.com"
+      `);
+      vi.mocked(fs.getParentDir).mockReturnValueOnce('');
+      // Workspace package.json
+      vi.mocked(fs.readLocalFile).mockResolvedValueOnce(
+        JSON.stringify({
+          name: 'pkg1',
+          version: '1.0.0',
+          dependencies: { axios: '2.0.0' },
+        }),
+      );
+
+      const matchedFiles = [
+        'bun.lock',
+        'package.json',
+        'packages/pkg1/package.json',
+      ];
+
+      const packageFiles = await extractAllPackageFiles({}, matchedFiles);
+
+      // Root package should have registry applied
+      const rootPkg = packageFiles.find(
+        (p) => p.packageFile === 'package.json',
+      );
+      expect(rootPkg?.deps[0].registryUrls).toEqual([
+        'https://registry.example.com',
+      ]);
+
+      // Workspace package should also have registry applied
+      const workspacePkg = packageFiles.find(
+        (p) => p.packageFile === 'packages/pkg1/package.json',
+      );
+      expect(workspacePkg?.deps[0].registryUrls).toEqual([
+        'https://registry.example.com',
+      ]);
+    });
   });
 });

--- a/lib/modules/manager/bun/extract.spec.ts
+++ b/lib/modules/manager/bun/extract.spec.ts
@@ -414,10 +414,10 @@ describe('modules/manager/bun/extract', () => {
         'bunfig.toml',
       );
       // Valid TOML but invalid schema (registry should be string or object with url)
-      vi.mocked(fs.readLocalFile).mockResolvedValueOnce(`
-[install]
-registry = 123
-`);
+      vi.mocked(fs.readLocalFile).mockResolvedValueOnce(codeBlock`
+        [install]
+        registry = 123
+      `);
 
       const packageFiles = await extractAllPackageFiles({}, ['bun.lock']);
 

--- a/lib/modules/manager/bun/extract.ts
+++ b/lib/modules/manager/bun/extract.ts
@@ -5,7 +5,6 @@ import {
   getSiblingFileName,
   readLocalFile,
 } from '../../../util/fs/index.ts';
-} from '../../../util/fs/index.ts';
 import { NpmDatasource } from '../../datasource/npm/index.ts';
 
 import { extractPackageJson } from '../npm/extract/common/package-file.ts';

--- a/lib/modules/manager/bun/extract.ts
+++ b/lib/modules/manager/bun/extract.ts
@@ -5,18 +5,45 @@ import {
   getSiblingFileName,
   readLocalFile,
 } from '../../../util/fs/index.ts';
+} from '../../../util/fs/index.ts';
+import { NpmDatasource } from '../../datasource/npm/index.ts';
 
 import { extractPackageJson } from '../npm/extract/common/package-file.ts';
 import type { NpmPackage } from '../npm/extract/types.ts';
 import { resolveNpmrc } from '../npm/npmrc.ts';
 import type { NpmManagerData } from '../npm/types.ts';
 import type { ExtractConfig, PackageFile } from '../types.ts';
+import {
+  type BunfigConfig,
+  loadBunfigToml,
+  resolveRegistryUrl,
+} from './bunfig.ts';
 import { filesMatchingWorkspaces } from './utils.ts';
 
 function matchesFileName(fileNameWithPath: string, fileName: string): boolean {
   return (
     fileNameWithPath === fileName || fileNameWithPath.endsWith(`/${fileName}`)
   );
+}
+
+/**
+ * Applies registry URLs from bunfig.toml to dependencies.
+ */
+function applyRegistryUrls(
+  packageFile: PackageFile,
+  bunfigConfig: BunfigConfig,
+): void {
+  for (const dep of packageFile.deps) {
+    if (dep.depName && dep.datasource === NpmDatasource.id) {
+      const registryUrl = resolveRegistryUrl(
+        dep.packageName ?? dep.depName,
+        bunfigConfig,
+      );
+      if (registryUrl) {
+        dep.registryUrls = [registryUrl];
+      }
+    }
+  }
 }
 
 export async function processPackageFile(
@@ -71,6 +98,15 @@ export async function extractAllPackageFiles(
     if (res) {
       packageFiles.push({ ...res, lockFiles: [lockFile] });
     }
+
+    // Load bunfig.toml for registry configuration
+    const bunfigConfig = await loadBunfigToml(packageFile);
+
+    // Apply registry URLs from bunfig.toml if present
+    if (bunfigConfig && res) {
+      applyRegistryUrls(res, bunfigConfig);
+    }
+
     // Check if package.json contains workspaces
     const workspaces = res?.managerData?.workspaces;
 
@@ -90,6 +126,10 @@ export async function extractAllPackageFiles(
       for (const workspaceFile of workspacePackageFiles) {
         const res = await processPackageFile(workspaceFile, config);
         if (res) {
+          // Apply registry URLs from root bunfig.toml to workspace packages
+          if (bunfigConfig) {
+            applyRegistryUrls(res, bunfigConfig);
+          }
           packageFiles.push({ ...res, lockFiles: [lockFile] });
         }
       }

--- a/lib/modules/manager/bun/extract.ts
+++ b/lib/modules/manager/bun/extract.ts
@@ -12,11 +12,8 @@ import type { NpmPackage } from '../npm/extract/types.ts';
 import { resolveNpmrc } from '../npm/npmrc.ts';
 import type { NpmManagerData } from '../npm/types.ts';
 import type { ExtractConfig, PackageFile } from '../types.ts';
-import {
-  type BunfigConfig,
-  loadBunfigToml,
-  resolveRegistryUrl,
-} from './bunfig.ts';
+import { loadBunfigToml, resolveRegistryUrl } from './bunfig.ts';
+import type { BunfigConfig } from './schema.ts';
 import { filesMatchingWorkspaces } from './utils.ts';
 
 function matchesFileName(fileNameWithPath: string, fileName: string): boolean {

--- a/lib/modules/manager/bun/schema.ts
+++ b/lib/modules/manager/bun/schema.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+import { Toml } from '../../../util/schema-utils';
+
+const BunfigRegistrySchema = z.union([
+  z.string(),
+  z.object({ url: z.string() }).transform((val) => val.url),
+]);
+
+const BunfigInstallSchema = z.object({
+  registry: BunfigRegistrySchema.optional(),
+  scopes: z.record(z.string(), BunfigRegistrySchema).optional(),
+});
+
+export const BunfigSchema = z.object({
+  install: BunfigInstallSchema.optional(),
+});
+
+export const BunfigConfig = Toml.pipe(BunfigSchema);
+export type BunfigConfig = z.infer<typeof BunfigSchema>;

--- a/lib/modules/manager/bun/schema.ts
+++ b/lib/modules/manager/bun/schema.ts
@@ -1,19 +1,28 @@
 import { z } from 'zod';
-import { Toml } from '../../../util/schema-utils';
 
-const BunfigRegistrySchema = z.union([
+const BunfigRegistryConfigSchema = z.union([
   z.string(),
-  z.object({ url: z.string() }).transform((val) => val.url),
+  z.object({ url: z.string() }),
 ]);
 
 const BunfigInstallSchema = z.object({
-  registry: BunfigRegistrySchema.optional(),
-  scopes: z.record(z.string(), BunfigRegistrySchema).optional(),
+  registry: BunfigRegistryConfigSchema.optional(),
+  scopes: z.record(z.string(), BunfigRegistryConfigSchema).optional(),
 });
 
 export const BunfigSchema = z.object({
   install: BunfigInstallSchema.optional(),
 });
 
-export const BunfigConfig = Toml.pipe(BunfigSchema);
-export type BunfigConfig = z.infer<typeof BunfigConfig>;
+const ResolvedBunfigInstallSchema = z.object({
+  registry: z.string().optional(),
+  scopes: z.record(z.string(), z.string()).optional(),
+});
+
+export const ResolvedBunfigSchema = z.object({
+  install: ResolvedBunfigInstallSchema.optional(),
+});
+
+export type BunfigConfig = z.infer<typeof ResolvedBunfigSchema>;
+export type BunfigRegistryConfig = z.infer<typeof BunfigRegistryConfigSchema>;
+export type RawBunfigConfig = z.infer<typeof BunfigSchema>;

--- a/lib/modules/manager/bun/schema.ts
+++ b/lib/modules/manager/bun/schema.ts
@@ -16,4 +16,4 @@ export const BunfigSchema = z.object({
 });
 
 export const BunfigConfig = Toml.pipe(BunfigSchema);
-export type BunfigConfig = z.infer<typeof BunfigSchema>;
+export type BunfigConfig = z.infer<typeof BunfigConfig>;


### PR DESCRIPTION
## Changes

This PR adds support for reading registry config from `bunfig.toml` when Renovate detects a Bun lockfile.

## Context

- [x] This closes an existing Issue, Closes: #24460

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Code and unit tests generated using GitHub Copilot in "Plan" and "Agent" mode using the model Claude Opus 4.5 (Preview). Commit messages and PR descriptions are manual.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation

- [ ] I have updated the documentation, or
- [x] No documentation update is required

Not sure if or on what page this addition should be documented.

## How I've tested my work

I have verified these changes via:

- [ ] Code inspection only
- [x] Newly added/modified unit tests
- [ ] No unit tests, but ran on a real repository
- [ ] Both unit tests + ran on a real repository

The public repository: N/A