### PR TITLE
feat(bazel): add support for rules_img module extension

### DIFF
--- a/lib/modules/manager/bazel-module/extract.ts
+++ b/lib/modules/manager/bazel-module/extract.ts
@@ -6,6 +6,7 @@ import type { PackageDependency, PackageFileContent } from '../types';
 import * as bazelrc from './bazelrc';
 import { parse } from './parser';
 import type { ResultFragment } from './parser/fragments';
+import { ImgExtensionToDockerPackageDep } from './parser/img';
 import { RuleToMavenPackageDep, fillRegistryUrls } from './parser/maven';
 import { RuleToDockerPackageDep } from './parser/oci';
 import {
@@ -25,6 +26,7 @@ export async function extractPackageFile(
     const gitRepositoryDeps = extractGitRepositoryDeps(records);
     const mavenDeps = extractMavenDeps(records);
     const dockerDeps = LooseArray(RuleToDockerPackageDep).parse(records);
+    const imgDeps = LooseArray(ImgExtensionToDockerPackageDep).parse(records);
     const rulesImgDeps = transformRulesImgCalls(records);
 
     if (gitRepositoryDeps.length) {
@@ -37,6 +39,10 @@ export async function extractPackageFile(
 
     if (dockerDeps.length) {
       pfc.deps.push(...dockerDeps);
+    }
+
+    if (imgDeps.length) {
+      pfc.deps.push(...imgDeps);
     }
 
     if (rulesImgDeps.length) {

--- a/lib/modules/manager/bazel-module/parser/extension-tags.ts
+++ b/lib/modules/manager/bazel-module/parser/extension-tags.ts
@@ -3,6 +3,7 @@ import { regEx } from '../../../../util/regex';
 import { kvParams } from './common';
 import type { Ctx } from './context';
 
+import { imgExtensionPrefix, imgExtensionTags } from './img';
 import { mavenExtensionPrefix, mavenExtensionTags } from './maven';
 import { ociExtensionPrefix, ociExtensionTags } from './oci';
 
@@ -20,10 +21,14 @@ import { ociExtensionPrefix, ociExtensionTags } from './oci';
 // by assuming the extension names start with well-known prefixes.
 
 const supportedExtensionRegex = regEx(
-  `^(${ociExtensionPrefix}|${mavenExtensionPrefix}).*$`,
+  `^(${ociExtensionPrefix}|${mavenExtensionPrefix}|${imgExtensionPrefix}).*$`,
 );
 
-const supportedExtensionTags = [...mavenExtensionTags, ...ociExtensionTags];
+const supportedExtensionTags = [
+  ...mavenExtensionTags,
+  ...ociExtensionTags,
+  ...imgExtensionTags,
+];
 
 const supportedExtensionTagsRegex = regEx(
   `^(${supportedExtensionTags.join('|')})$`,

--- a/lib/modules/manager/bazel-module/parser/img.ts
+++ b/lib/modules/manager/bazel-module/parser/img.ts
@@ -1,0 +1,52 @@
+import { z } from 'zod';
+import { DockerDatasource } from '../../../datasource/docker';
+import type { PackageDependency } from '../../types';
+import { ExtensionTagFragment, StringFragment } from './fragments';
+
+export const imgExtensionPrefix = 'images';
+
+const pullTag = 'pull';
+
+export const imgExtensionTags = ['pull'];
+
+export const ImgExtensionToDockerPackageDep = ExtensionTagFragment.extend({
+  extension: z.literal(imgExtensionPrefix),
+  tag: z.literal(pullTag),
+  children: z.object({
+    name: StringFragment.optional(),
+    repository: StringFragment,
+    registry: StringFragment.optional(),
+    tag: StringFragment.optional(),
+    digest: StringFragment.optional(),
+  }),
+}).transform(
+  ({
+    rawString,
+    children: { name, repository, registry, tag, digest },
+  }): PackageDependency => {
+    // Construct the package name from registry and repository
+    let packageName = repository.value;
+    if (registry?.value) {
+      packageName = `${registry.value}/${repository.value}`;
+    }
+
+    const result: PackageDependency = {
+      datasource: DockerDatasource.id,
+      depType: 'img_pull',
+      // If name is not specified, use repository as the identifier
+      depName: name?.value ?? repository.value,
+      packageName,
+      currentValue: tag?.value,
+      currentDigest: digest?.value,
+      // Provide a replace string so the auto replacer can replace both the tag
+      // and digest if applicable.
+      replaceString: rawString,
+    };
+
+    if (registry?.value) {
+      result.registryUrls = [`https://${registry.value}`];
+    }
+
+    return result;
+  },
+);

--- a/lib/modules/manager/bazel-module/parser/index.spec.ts
+++ b/lib/modules/manager/bazel-module/parser/index.spec.ts
@@ -373,6 +373,82 @@ describe('modules/manager/bazel-module/parser/index', () => {
       ]);
     });
 
+    it('finds images.pull with name', () => {
+      const input = codeBlock`
+        images.pull(
+          name = "ubuntu",
+          digest = "sha256:1e622c5f073b4f6bfad6632f2616c7f59ef256e96fe78bf6a595d1dc4376ac02",
+          registry = "index.docker.io",
+          repository = "library/ubuntu",
+          tag = "24.04",
+        )
+      `;
+
+      const res = parse(input);
+      expect(res).toEqual([
+        fragments.extensionTag(
+          'images',
+          'images',
+          'pull',
+          0,
+          {
+            name: fragments.string('ubuntu'),
+            digest: fragments.string(
+              'sha256:1e622c5f073b4f6bfad6632f2616c7f59ef256e96fe78bf6a595d1dc4376ac02',
+            ),
+            registry: fragments.string('index.docker.io'),
+            repository: fragments.string('library/ubuntu'),
+            tag: fragments.string('24.04'),
+          },
+          codeBlock`
+            images.pull(
+              name = "ubuntu",
+              digest = "sha256:1e622c5f073b4f6bfad6632f2616c7f59ef256e96fe78bf6a595d1dc4376ac02",
+              registry = "index.docker.io",
+              repository = "library/ubuntu",
+              tag = "24.04",
+            )
+          `,
+          true,
+        ),
+      ]);
+    });
+
+    it('finds images.pull without name', () => {
+      const input = codeBlock`
+        images.pull(
+          digest = "sha256:029d4461bd98f124e531380505ceea2072418fdf28752aa73b7b273ba3048903",
+          registry = "gcr.io",
+          repository = "distroless/base",
+        )
+      `;
+
+      const res = parse(input);
+      expect(res).toEqual([
+        fragments.extensionTag(
+          'images',
+          'images',
+          'pull',
+          0,
+          {
+            digest: fragments.string(
+              'sha256:029d4461bd98f124e531380505ceea2072418fdf28752aa73b7b273ba3048903',
+            ),
+            registry: fragments.string('gcr.io'),
+            repository: fragments.string('distroless/base'),
+          },
+          codeBlock`
+            images.pull(
+              digest = "sha256:029d4461bd98f124e531380505ceea2072418fdf28752aa73b7b273ba3048903",
+              registry = "gcr.io",
+              repository = "distroless/base",
+            )
+          `,
+          true,
+        ),
+      ]);
+    });
+
     it('finds the git_repository', () => {
       const input = codeBlock`
         git_repository(


### PR DESCRIPTION
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds support for the rules_img module extension (images.pull tag class) for pulling container images in Bazel MODULE.bazel files.

The implementation handles registry/repository splitting and optional name attributes, similar to the existing rules_oci extension support.

## Context

Please select one of the following:

- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>
