### PR TITLE
feat(replacements): add gopkg-in-yaml-to-go-yaml-in-yaml

### DIFF
--- a/lib/data/replacements.json
+++ b/lib/data/replacements.json
@@ -19,6 +19,7 @@
       "replacements:framer-motion-to-motion",
       "replacements:hapi-to-scoped",
       "replacements:google-github-action-release-please-to-googleapis",
+      "replacements:gopkg-in-yaml-to-go-yaml-in-yaml",
       "replacements:jade-to-pug",
       "replacements:joi-to-scoped",
       "replacements:joi-to-unscoped",
@@ -703,6 +704,21 @@
         "matchDatasources": ["github-tags"],
         "matchPackageNames": ["google-github-actions/release-please-action"],
         "replacementName": "googleapis/release-please-action"
+      }
+    ]
+  },
+  "gopkg-in-yaml-to-go-yaml-in-yaml": {
+    "description": "`go.yaml.in/yaml` supersedes `gopkg.in/yaml`.",
+    "packageRules": [
+      {
+        "matchDatasources": ["go"],
+        "matchPackageNames": ["gopkg.in/yaml.v2"],
+        "replacementName": "go.yaml.in/yaml/v2"
+      },
+      {
+        "matchDatasources": ["go"],
+        "matchPackageNames": ["gopkg.in/yaml.v3"],
+        "replacementName": "go.yaml.in/yaml/v3"
       }
     ]
   },


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

The `go.yaml.in/yaml/vX` Go module supersedes `gopkg.in/yaml.vX`. 

This is a widely used Go module, and therefore would be nice to have Renovate suggest the replacement.

Refs
- https://github.com/yaml/go-yaml/blob/52cbc44455daa2a9b462d2cc7db5077d68af53e3/README.md#project-status
- https://github.com/go-yaml/yaml/blob/944c86a7d29391925ed6ac33bee98a0516f1287a/README.md

Discussion: https://github.com/renovatebot/renovate/discussions/39942

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
