### PR TITLE
chore(config-validator): add `--help` command

### DIFF
--- a/lib/config-validator.ts
+++ b/lib/config-validator.ts
@@ -58,7 +58,37 @@ interface PackageJson {
   'renovate-config'?: Record<string, RenovateConfig>;
 }
 
+function usage(): void {
+  /* eslint-disable no-console */
+  console.log('Usage: renovate-config-validator [options] [config-files...]');
+  console.log('');
+  console.log(
+    'Validate your Renovate configuration (repo config, shared presets or global configuration)',
+  );
+  console.log('');
+  console.log(
+    'If no [config-files...] are given, renovate-config-validator will look at the default config file locations (https://docs.renovatebot.com/configuration-options/)',
+  );
+
+  console.log('  Examples:');
+  console.log('');
+  console.log('    $ renovate-config-validator');
+  console.log('    $ renovate-config-validator --strict');
+  console.log('    $ renovate-config-validator first_config.json');
+  console.log('    $ renovate-config-validator --strict config.js');
+  console.log(
+    '    $ env RENOVATE_CONFIG_FILE=obscure-name.json renovate-config-validator',
+  );
+  /* eslint-enable no-console */
+}
+
 (async () => {
+  const helpArgIndex = process.argv.indexOf('--help');
+  const help = helpArgIndex >= 0;
+  if (help) {
+    usage();
+    return;
+  }
   const strictArgIndex = process.argv.indexOf('--strict');
   const strict = strictArgIndex >= 0;
   if (strict) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

As noted by @wyardley in #34542, it would be useful to have basic usage
examples when using `--help`.


## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

When running:

```console
% node dist/config-validator.js --help
Usage: renovate-config-validator [options] [config-files...]

Validate your Renovate configuration (repo config, shared presets or global configuration)

If no [config-files...] are given, renovate-config-validator will look at the default config file locations (https://docs.renovatebot.com/configuration-options/)
  Examples:

    $ renovate-config-validator
    $ renovate-config-validator --strict
    $ renovate-config-validator first_config.json
    $ renovate-config-validator --strict config.js
    $ env RENOVATE_CONFIG_FILE=obscure-name.json renovate-config-validator
```

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
