### PR TITLE
fix(manager/gradle): ignore DependencySubstitution modules

### DIFF
--- a/lib/modules/manager/gradle/parser.spec.ts
+++ b/lib/modules/manager/gradle/parser.spec.ts
@@ -610,6 +610,19 @@ describe('modules/manager/gradle/parser', () => {
       });
     });
 
+    describe('dependencySubstitution constructs', () => {
+      it.each`
+        input                                                                   | output
+        ${'substitute module("foo:bar:1.2.3")'}                                 | ${null}
+        ${'substitute(module("foo:bar:1.2.3"))'}                                | ${null}
+        ${'substitute module("foo:bar:1.2.3") with module("bar:qux:4.5.6")'}    | ${{ depName: 'bar:qux', currentValue: '4.5.6' }}
+        ${'substitute(module("foo:bar:1.2.3")).using(module("bar:qux:4.5.6"))'} | ${{ depName: 'bar:qux', currentValue: '4.5.6' }}
+      `('$input', ({ input, output }) => {
+        const { deps } = parseGradle(input);
+        expect(deps).toMatchObject([output].filter(isTruthy));
+      });
+    });
+
     describe('plugins', () => {
       it.each`
         def                 | input                                      | output

--- a/lib/modules/manager/gradle/parser/dependencies.ts
+++ b/lib/modules/manager/gradle/parser/dependencies.ts
@@ -239,6 +239,19 @@ const qImplicitTestSuites = qDotOrBraceExpr(
   .handler(handleImplicitDep)
   .handler(cleanupTempVars);
 
+// substitute module("foo:bar:1.2.3") using "baz:qux:4.5.6"
+// substitute(module("foo:bar:1.2.3")).using("baz:qux:4.5.6")
+const qIgnoreSubstitutedDependencies = q.sym<Ctx>('substitute').alt(
+  q.sym<Ctx>('module').tree(),
+  q.tree({
+    type: 'wrapped-tree',
+    maxDepth: 1,
+    startsWith: '(',
+    endsWith: ')',
+    search: q.sym<Ctx>('module').tree(),
+  }),
+);
+
 export const qDependencies = q.alt(
   qDependencyStrings,
   qDependencySet,
@@ -249,4 +262,6 @@ export const qDependencies = q.alt(
   qImplicitTestSuites,
   // avoid heuristic matching of gradle feature variant capabilities
   qDotOrBraceExpr('java', q.sym<Ctx>('registerFeature').tree()),
+  // avoid matching substituted dependency modules
+  qIgnoreSubstitutedDependencies,
 );


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Avoids matching dependencies used in [DependencySubstitution](https://docs.gradle.org/current/userguide/resolution_rules.html#sec:project-to-module-substitution) constructs as introduced with Gradle 9.x. These deps are supposed to be replaced by the indicates substitutes and should remain unchanged by design.

<!-- Describe what behavior is changed by this PR. -->

## Context

https://github.com/renovatebot/renovate/discussions/39858

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
