### PR TITLE
fix(forgejo): support fallback for all `forgejo-*` host types

### DIFF
--- a/lib/util/http/auth.ts
+++ b/lib/util/http/auth.ts
@@ -2,6 +2,7 @@ import { isNonEmptyString, isString } from '@sindresorhus/is';
 import type { Options } from 'got';
 import {
   GITEA_API_USING_HOST_TYPES,
+  FORGEJO_API_USING_HOST_TYPES,
   GITHUB_API_USING_HOST_TYPES,
   GITLAB_API_USING_HOST_TYPES,
 } from '../../constants';
@@ -42,6 +43,11 @@ export function applyAuthorization<GotOptions extends AuthGotOptions>(
     ) {
       // Gitea v1.8.0 and later support `Bearer` as alternate to `token`
       // https://github.com/go-gitea/gitea/pull/5378
+      options.headers.authorization = `Bearer ${options.token}`;
+    } else if (
+      options.hostType &&
+      FORGEJO_API_USING_HOST_TYPES.includes(options.hostType)
+    ) {
       options.headers.authorization = `Bearer ${options.token}`;
     } else if (
       options.hostType &&

--- a/lib/util/http/auth.ts
+++ b/lib/util/http/auth.ts
@@ -39,15 +39,15 @@ export function applyAuthorization<GotOptions extends AuthGotOptions>(
       }
     } else if (
       options.hostType &&
+      FORGEJO_API_USING_HOST_TYPES.includes(options.hostType)
+    ) {
+      options.headers.authorization = `Bearer ${options.token}`;
+    } else if (
+      options.hostType &&
       GITEA_API_USING_HOST_TYPES.includes(options.hostType)
     ) {
       // Gitea v1.8.0 and later support `Bearer` as alternate to `token`
       // https://github.com/go-gitea/gitea/pull/5378
-      options.headers.authorization = `Bearer ${options.token}`;
-    } else if (
-      options.hostType &&
-      FORGEJO_API_USING_HOST_TYPES.includes(options.hostType)
-    ) {
       options.headers.authorization = `Bearer ${options.token}`;
     } else if (
       options.hostType &&

--- a/lib/util/http/auth.ts
+++ b/lib/util/http/auth.ts
@@ -1,8 +1,8 @@
 import { isNonEmptyString, isString } from '@sindresorhus/is';
 import type { Options } from 'got';
 import {
-  GITEA_API_USING_HOST_TYPES,
   FORGEJO_API_USING_HOST_TYPES,
+  GITEA_API_USING_HOST_TYPES,
   GITHUB_API_USING_HOST_TYPES,
   GITLAB_API_USING_HOST_TYPES,
 } from '../../constants';

--- a/lib/util/http/host-rules.ts
+++ b/lib/util/http/host-rules.ts
@@ -126,21 +126,6 @@ export function findMatchingRule<GotOptions extends HostRulesGotOptions>(
     };
   }
 
-  // Fallback to `gitea` hostType
-  if (
-    hostType &&
-    GITEA_API_USING_HOST_TYPES.includes(hostType) &&
-    hostType !== 'gitea'
-  ) {
-    res = {
-      ...hostRules.find({
-        hostType: 'gitea',
-        url,
-      }),
-      ...res,
-    };
-  }
-
   // Fallback to `forgejo` hostType
   if (
     hostType &&
@@ -150,6 +135,21 @@ export function findMatchingRule<GotOptions extends HostRulesGotOptions>(
     res = {
       ...hostRules.find({
         hostType: 'forgejo',
+        url,
+      }),
+      ...res,
+    };
+  }
+
+  // Fallback to `gitea` hostType
+  if (
+    hostType &&
+    GITEA_API_USING_HOST_TYPES.includes(hostType) &&
+    hostType !== 'gitea'
+  ) {
+    res = {
+      ...hostRules.find({
+        hostType: 'gitea',
         url,
       }),
       ...res,

--- a/lib/util/http/host-rules.ts
+++ b/lib/util/http/host-rules.ts
@@ -3,6 +3,7 @@ import { GlobalConfig } from '../../config/global';
 import {
   BITBUCKET_API_USING_HOST_TYPES,
   BITBUCKET_SERVER_API_USING_HOST_TYPES,
+  FORGEJO_API_USING_HOST_TYPES,
   GITEA_API_USING_HOST_TYPES,
   GITHUB_API_USING_HOST_TYPES,
   GITLAB_API_USING_HOST_TYPES,
@@ -134,6 +135,21 @@ export function findMatchingRule<GotOptions extends HostRulesGotOptions>(
     res = {
       ...hostRules.find({
         hostType: 'gitea',
+        url,
+      }),
+      ...res,
+    };
+  }
+
+  // Fallback to `forgejo` hostType
+  if (
+    hostType &&
+    FORGEJO_API_USING_HOST_TYPES.includes(hostType) &&
+    hostType !== 'forgejo'
+  ) {
+    res = {
+      ...hostRules.find({
+        hostType: 'forgejo',
         url,
       }),
       ...res,


### PR DESCRIPTION
## Changes

When running renovate against my self-hosted forgejo instance, I noticed that some requests to forgejo API were not properly authenticated and were failing with 403. My config file was:

```js
module.exports = {
  platform: "forgejo",
  endpoint: "https://---redacted---",
  autodiscover: true,
}
```

I was also setting the `RENOVATE_TOKEN` env var with a valid token. As a user, I am expecting this to be sufficient for any API call targeting my instance.

After some investigation, I noticed that requests with `hostType: 'forgejo'` were authenticated and successful but those with `hostType: 'forgejo-tags'` were left unauthenticated and failing.  I noticed that adding an explicit host rule with `hostType: 'forgejo-tags'` and proper authentication was indeed making the calls succeed. But as a user, I don't expect to _have to_ repeat my token for each and every host subtype.

I dug a little more in the code and found -I think- the cause of the bug: `lib/util/http/host-rules.ts` is not applying any fallback mechanism like it does for gitea. Since gitea and forgejo are still very close to one another in terms of behavior, that does not seem right. I added the fallback and my 403 errors went away.

When investigating, I found another place where a fallback was present for gitea but was missing for forgejo: `lib/util/http/auth.ts` applies bearer auth if a token is present. I figured this deserved a fix as well but that does not seem to have any impact on _my_ issue, so I am not quite sure if this change is relevant or not. Hopefully you can :)

### Disclaimer

I humbly confess I did not understand all the ins and outs of authentication in renovate. I used my intuition and common sense to hopefully fix what I believe to be a bug in renovate. But give me your honest feedback about both changes. If they should deserve separate PRs or if they are not ideal, I am happy to improve the PR.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution. (I'd rather die than do such thing :scream:)
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required, to my knowledge. Let me know if there are places that deserve an update, though!

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: none. I used a private repo.