### PR TITLE
fix(gerrit): pass credentials to api calls in initPlatform

### DIFF
--- a/lib/modules/platform/gerrit/client.spec.ts
+++ b/lib/modules/platform/gerrit/client.spec.ts
@@ -26,7 +26,12 @@ describe('modules/platform/gerrit/client', () => {
         .scope(gerritEndpointUrl)
         .get('/a/config/server/version')
         .reply(200, gerritRestResponse('3.9.1'), jsonResultHeader);
-      expect(await client.getGerritVersion()).toBe('3.9.1');
+      expect(
+        await client.getGerritVersion({
+          username: 'user',
+          password: 'pass',
+        }),
+      ).toBe('3.9.1');
     });
   });
 

--- a/lib/modules/platform/gerrit/client.ts
+++ b/lib/modules/platform/gerrit/client.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { REPOSITORY_ARCHIVED } from '../../../constants/error-messages';
 import { logger } from '../../../logger';
 import { GerritHttp } from '../../../util/http/gerrit';
+import type { HttpOptions } from '../../../util/http/types';
 import { getQueryString } from '../../../util/url';
 import type {
   GerritAccountInfo,
@@ -29,9 +30,12 @@ class GerritClient {
     this.gerritVersion = version;
   }
 
-  async getGerritVersion(): Promise<string> {
+  async getGerritVersion(
+    options: Pick<HttpOptions, 'username' | 'password'>,
+  ): Promise<string> {
     const res = await this.gerritHttp.getJson(
       'a/config/server/version',
+      options,
       z.string(),
     );
     return res.body;

--- a/lib/modules/platform/gerrit/index.ts
+++ b/lib/modules/platform/gerrit/index.ts
@@ -88,7 +88,10 @@ export async function initPlatform({
     if (env.RENOVATE_X_PLATFORM_VERSION) {
       gerritVersion = env.RENOVATE_X_PLATFORM_VERSION;
     } else {
-      gerritVersion = await client.getGerritVersion();
+      gerritVersion = await client.getGerritVersion({
+        username,
+        password,
+      });
     }
   } catch (err) {
     logger.debug(


### PR DESCRIPTION
We need to explicitly pass the gerrit credentials to the api calls in initPlaform since the host rules for the platform aren't set up until later on, so the standard http library won't find any credentials for the gerrit platform yet.

This follows the same pattern as many of the other platforms on renovate where they also explicitly pass credentials for the api calls made during their initPlatform.

This appears to have been broken recently due to the recent addition of an authenticated version api call in
https://github.com/renovatebot/renovate/pull/39223

See https://github.com/renovatebot/renovate/discussions/39969

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
