### PR TITLE
fix(replacements): `@tsconfig/node` versions

### DIFF
--- a/lib/data/replacements.json
+++ b/lib/data/replacements.json
@@ -1046,31 +1046,31 @@
         "matchDatasources": ["npm"],
         "matchPackageNames": ["@tsconfig/node10"],
         "replacementName": "@tsconfig/node12",
-        "replacementVersion": "12.0.0"
+        "replacementVersion": "12.1.0"
       },
       {
         "matchDatasources": ["npm"],
         "matchPackageNames": ["@tsconfig/node12"],
         "replacementName": "@tsconfig/node14",
-        "replacementVersion": "14.0.0"
+        "replacementVersion": "14.1.0"
       },
       {
         "matchDatasources": ["npm"],
         "matchPackageNames": ["@tsconfig/node14"],
         "replacementName": "@tsconfig/node16",
-        "replacementVersion": "16.0.0"
+        "replacementVersion": "16.1.0"
       },
       {
         "matchDatasources": ["npm"],
         "matchPackageNames": ["@tsconfig/node16", "@tsconfig/node17"],
         "replacementName": "@tsconfig/node18",
-        "replacementVersion": "18.0.0"
+        "replacementVersion": "18.2.0"
       },
       {
         "matchDatasources": ["npm"],
         "matchPackageNames": ["@tsconfig/node18", "@tsconfig/node19"],
         "replacementName": "@tsconfig/node20",
-        "replacementVersion": "20.0.0"
+        "replacementVersion": "20.1.0"
       },
       {
         "matchDatasources": ["npm"],


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Update `replacementVersion` for older `@tsconfig/nodeXX` deps.

Validated via `https://www.npmjs.com/package/@tsconfig/nodeXX?activeTab=versions`

<!-- Describe what behavior is changed by this PR. -->

## Context

See https://github.com/renovatebot/renovate/pull/36308#issuecomment-3649392295

It appears that their versioning previously started at `1.0.0` before being aligned to the node major version

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
