### PR TITLE
fix(presets): `helpers:githubDigestChangelogs` should only apply to Git digest updates

### DIFF
--- a/lib/config/presets/internal/helpers.ts
+++ b/lib/config/presets/internal/helpers.ts
@@ -27,6 +27,12 @@ export const presets: Record<string, Preset> = {
     packageRules: [
       {
         changelogUrl: '{{sourceUrl}}/compare/{{currentDigest}}..{{newDigest}}',
+        matchDatasources: [
+          'git-refs',
+          'git-tags',
+          'github-releases',
+          'github-tags',
+        ],
         matchSourceUrls: ['https://github.com/**'],
         matchUpdateTypes: ['digest'],
       },


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
Otherwise, as noted in #39650, we'll incorrectly match on i.e.

https://github.com/nginx/nginx/compare/sha256:6697f8bc5fbb0a0e38f10f90cef119892bb1b5f10d61d17949027583c0eec73f..sha256:e8d62a25409b03ae4a10beb101bb937682f8d311f747e8feee362edff24c81d9


## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
