### PR TITLE
fix(workers): re-attempt platform automerge only in case of new commits

### DIFF
--- a/lib/workers/repository/update/branch/index.spec.ts
+++ b/lib/workers/repository/update/branch/index.spec.ts
@@ -3040,6 +3040,30 @@ describe('workers/repository/update/branch/index', () => {
       );
     });
 
+    it('should not reattempt platform automerge without commitSha', async () => {
+      getUpdated.getUpdatedPackageFiles.mockResolvedValueOnce({
+        ...updatedPackageFiles,
+      });
+      npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
+        artifactErrors: [],
+        updatedArtifacts: [],
+      });
+      scm.branchExists.mockResolvedValue(true);
+      platform.getBranchPr.mockResolvedValueOnce(
+        partial<Pr>({
+          number: 123,
+          state: 'open',
+        }),
+      );
+      prWorker.getPlatformPrOptions.mockReturnValue({
+        usePlatformAutomerge: true,
+      });
+      commit.commitFilesToBranch.mockResolvedValueOnce(null);
+
+      await branchWorker.processBranch(config);
+      expect(platform.reattemptPlatformAutomerge).not.toHaveBeenCalled();
+    });
+
     it('should not reattempt platform automerge in dry run', async () => {
       getUpdated.getUpdatedPackageFiles.mockResolvedValueOnce({
         ...updatedPackageFiles,

--- a/lib/workers/repository/update/branch/index.ts
+++ b/lib/workers/repository/update/branch/index.ts
@@ -711,6 +711,7 @@ export async function processBranch(
     if (branchPr) {
       const platformPrOptions = getPlatformPrOptions(config);
       if (
+        commitSha &&
         platformPrOptions.usePlatformAutomerge &&
         platform.reattemptPlatformAutomerge
       ) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Ensures that platform automerge is only re-attempted when needed (due to rebase) instead of attempting it always for any unmerged PR.

https://github.com/renovatebot/renovate/pull/26567 introduced functionality to re-enable platform automerge when a PR is updated. This approach nowhere ensures that  `reattemptPlatformAutomerge()` is only called in case of new commits on a branch. Since `reattemptPlatformAutomerge()` works idempotent on all supported platforms, it also doesn't fail if auto-merge is already active, which may explain why this went unnoticed so far.

The issue with the current approach is that it adds unnecessary extra HTTP requests which, in the case of GitLab with 5 retries for failed attempts, slow down renovate execution.

<!-- Describe what behavior is changed by this PR. -->

## Context

- Found this while working on https://github.com/renovatebot/renovate/pull/39885
- Fixes https://github.com/renovatebot/renovate/discussions/39978
  - https://github.com/renovatebot/renovate/pull/39979 addresses the symptoms (which is still a good addition IMHO), but not the root cause

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://gitlab.com/entropy_cat/platform-automerge-test/-/merge_requests/2

<details>

<summary>Log before this change (only relevant parts)</summary>

```shell
DEBUG: Branch already exists (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
DEBUG: branch.isBehindBase(): using git to calculate (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
DEBUG: branch.isBehindBase(): false (repository=entropy_cat/platform-automerge-test, baseBranch=main, branch=renovate/yaml-2.x)
       "branchName": "renovate/yaml-2.x"
DEBUG: Branch is up-to-date (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
DEBUG: isBranchConflicted(main, renovate/yaml-2.x) (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
DEBUG: branch.isConflicted(): using git to calculate (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
DEBUG: branch.isConflicted(): false (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
DEBUG: Branch does not need rebasing (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
DEBUG: Using reuseExistingBranch: true (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
DEBUG: Setting current branch to main (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
DEBUG: latest commit (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
       "branchName": "main",
       "latestCommitDate": "2025-12-15T21:12:42Z",
       "sha": "f2a77ae51b0c2d23a52587451db1c22f24a29906"
DEBUG: manager.getUpdatedPackageFiles() reuseExistingBranch=true (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
DEBUG: npm.updateDependency(): dependencies.yaml = 2.8.2 (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
DEBUG: No package files need updating (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
DEBUG: Getting updated lock files (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
DEBUG: Writing package.json files (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
       "packageFiles": ["package.json"]
DEBUG: Writing any updated package files (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
DEBUG: No updated lock files in branch (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
DEBUG: No changes to package files, skipping post-upgrade tasks (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
DEBUG: No files to commit (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
DEBUG: Setting current branch to main (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
DEBUG: latest commit (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
       "branchName": "main",
       "latestCommitDate": "2025-12-15T21:12:42Z",
       "sha": "f2a77ae51b0c2d23a52587451db1c22f24a29906"
 INFO: Extra debugging for demo purposes PR #2 (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
       "commitSha": null
DEBUG: PR not yet in mergeable state. Retrying 1 (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
DEBUG: PR not yet in mergeable state. Retrying 2 (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
DEBUG: PR not yet in mergeable state. Retrying 3 (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
DEBUG: PR not yet in mergeable state. Retrying 4 (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
DEBUG: PR not yet in mergeable state. Retrying 5 (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
DEBUG: PR platform automerge re-attempted...prNo: 2 (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
DEBUG: Checking if we can automerge branch (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
DEBUG: mergeStatus=no automerge (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
DEBUG: Ensuring PR (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
DEBUG: There are 0 errors and 0 warnings (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
...
DEBUG: HTTP statistics (repository=entropy_cat/platform-automerge-test)
         "gitlab.com": {
           "count": 16,
           "reqAvgMs": 592,
           "reqMedianMs": 448,
           "reqMaxMs": 2690,
           "queueAvgMs": 0,
           "queueMedianMs": 0,
           "queueMaxMs": 1
         }
```

</details>

<details>

<summary>Log after this change (only relevant parts)</summary>

```shell
DEBUG: Branch already exists (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
DEBUG: branch.isBehindBase(): using git to calculate (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
DEBUG: branch.isBehindBase(): false (repository=entropy_cat/platform-automerge-test, baseBranch=main, branch=renovate/yaml-2.x)
       "branchName": "renovate/yaml-2.x"
DEBUG: Branch is up-to-date (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
DEBUG: isBranchConflicted(main, renovate/yaml-2.x) (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
DEBUG: branch.isConflicted(): using git to calculate (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
DEBUG: branch.isConflicted(): false (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
DEBUG: Branch does not need rebasing (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
DEBUG: Using reuseExistingBranch: true (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
DEBUG: Setting current branch to main (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
DEBUG: latest commit (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
       "branchName": "main",
       "latestCommitDate": "2025-12-15T21:12:42Z",
       "sha": "f2a77ae51b0c2d23a52587451db1c22f24a29906"
DEBUG: manager.getUpdatedPackageFiles() reuseExistingBranch=true (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
DEBUG: npm.updateDependency(): dependencies.yaml = 2.8.2 (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
DEBUG: No package files need updating (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
DEBUG: Getting updated lock files (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
DEBUG: Writing package.json files (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
       "packageFiles": ["package.json"]
DEBUG: Writing any updated package files (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
DEBUG: No updated lock files in branch (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
DEBUG: No changes to package files, skipping post-upgrade tasks (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
DEBUG: No files to commit (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
DEBUG: Setting current branch to main (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
DEBUG: latest commit (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
       "branchName": "main",
       "latestCommitDate": "2025-12-15T21:12:42Z",
       "sha": "f2a77ae51b0c2d23a52587451db1c22f24a29906"
DEBUG: Checking if we can automerge branch (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
DEBUG: mergeStatus=no automerge (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
DEBUG: Ensuring PR (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
DEBUG: There are 0 errors and 0 warnings (repository=entropy_cat/platform-automerge-test, branch=renovate/yaml-2.x)
...
DEBUG: HTTP statistics (repository=entropy_cat/platform-automerge-test)
         "gitlab.com": {
           "count": 10,
           "reqAvgMs": 409,
           "reqMedianMs": 379,
           "reqMaxMs": 542,
           "queueAvgMs": 0,
           "queueMedianMs": 0,
           "queueMaxMs": 1
         }
```

</details>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
