### PR TITLE
refactor: remove uses of "renovation"

### DIFF
--- a/docs/usage/docker.md
+++ b/docs/usage/docker.md
@@ -164,7 +164,7 @@ For example, to disable digest updates for Docker Compose only but leave them fo
 
 The following configuration options are applicable to Docker:
 
-### Disable all Docker Renovation
+### Disable all Docker updates
 
 Add `"docker:disable"` to your `extends` array.
 

--- a/lib/modules/manager/flux/schema.ts
+++ b/lib/modules/manager/flux/schema.ts
@@ -7,7 +7,7 @@ export const KubernetesResource = z.object({
     name: z.string(),
     // For Flux, the namespace property is optional, but matching HelmReleases to HelmRepositories would be
     // much more difficult without it (we'd have to examine the parent Kustomizations to discover the value),
-    // so we require it for renovation.
+    // so we require it for Renovate run.
     namespace: z.string().optional(),
   }),
 });

--- a/lib/modules/platform/azure/index.ts
+++ b/lib/modules/platform/azure/index.ts
@@ -219,7 +219,9 @@ export async function initRepo({
   }
   logger.debug({ repositoryDetails: repo }, 'Repository details');
   if (repo.isDisabled) {
-    logger.debug('Repository is disabled- throwing error to abort renovation');
+    logger.debug(
+      'Repository is disabled- throwing error to abort Renovate run',
+    );
     throw new Error(REPOSITORY_ARCHIVED);
   }
   /* v8 ignore next */

--- a/lib/modules/platform/forgejo/index.ts
+++ b/lib/modules/platform/forgejo/index.ts
@@ -297,26 +297,26 @@ const platform: Platform = {
 
     // Ensure appropriate repository state and permissions
     if (repo.archived) {
-      logger.debug('Repository is archived - aborting renovation');
+      logger.debug('Repository is archived - aborting Renovate run');
       throw new Error(REPOSITORY_ARCHIVED);
     }
     if (repo.mirror) {
-      logger.debug('Repository is a mirror - aborting renovation');
+      logger.debug('Repository is a mirror - aborting Renovate run');
       throw new Error(REPOSITORY_MIRRORED);
     }
     if (repo.permissions.pull === false || repo.permissions.push === false) {
       logger.debug(
-        'Repository does not permit pull or push - aborting renovation',
+        'Repository does not permit pull or push - aborting Renovate run',
       );
       throw new Error(REPOSITORY_ACCESS_FORBIDDEN);
     }
     if (repo.empty) {
-      logger.debug('Repository is empty - aborting renovation');
+      logger.debug('Repository is empty - aborting Renovate run');
       throw new Error(REPOSITORY_EMPTY);
     }
 
     if (repo.has_pull_requests === false) {
-      logger.debug('Repo has disabled pull requests - aborting renovation');
+      logger.debug('Repo has disabled pull requests - aborting Renovate run');
       throw new Error(REPOSITORY_BLOCKED);
     }
 
@@ -338,7 +338,7 @@ const platform: Platform = {
       config.mergeMethod = mergeStyle;
     } else {
       logger.debug(
-        'Repository has no allowed merge methods - aborting renovation',
+        'Repository has no allowed merge methods - aborting Renovate run',
       );
       throw new Error(REPOSITORY_BLOCKED);
     }

--- a/lib/modules/platform/forgejo/utils.ts
+++ b/lib/modules/platform/forgejo/utils.ts
@@ -186,6 +186,6 @@ export function isAllowed(style: PRMergeMethod, repo: Repo): boolean {
     case 'fast-forward-only':
       return repo.allow_fast_forward_only_merge;
   }
-  logger.debug('Repo has unknown merge style - aborting renovation');
+  logger.debug('Repo has unknown merge style - aborting Renovate run');
   throw new Error(REPOSITORY_BLOCKED);
 }

--- a/lib/modules/platform/gitea/index.ts
+++ b/lib/modules/platform/gitea/index.ts
@@ -300,26 +300,26 @@ const platform: Platform = {
 
     // Ensure appropriate repository state and permissions
     if (repo.archived) {
-      logger.debug('Repository is archived - aborting renovation');
+      logger.debug('Repository is archived - aborting Renovate run');
       throw new Error(REPOSITORY_ARCHIVED);
     }
     if (repo.mirror) {
-      logger.debug('Repository is a mirror - aborting renovation');
+      logger.debug('Repository is a mirror - aborting Renovate run');
       throw new Error(REPOSITORY_MIRRORED);
     }
     if (repo.permissions.pull === false || repo.permissions.push === false) {
       logger.debug(
-        'Repository does not permit pull or push - aborting renovation',
+        'Repository does not permit pull or push - aborting Renovate run',
       );
       throw new Error(REPOSITORY_ACCESS_FORBIDDEN);
     }
     if (repo.empty) {
-      logger.debug('Repository is empty - aborting renovation');
+      logger.debug('Repository is empty - aborting Renovate run');
       throw new Error(REPOSITORY_EMPTY);
     }
 
     if (repo.has_pull_requests === false) {
-      logger.debug('Repo has disabled pull requests - aborting renovation');
+      logger.debug('Repo has disabled pull requests - aborting Renovate run');
       throw new Error(REPOSITORY_BLOCKED);
     }
 
@@ -341,7 +341,7 @@ const platform: Platform = {
       config.mergeMethod = mergeStyle;
     } else {
       logger.debug(
-        'Repository has no allowed merge methods - aborting renovation',
+        'Repository has no allowed merge methods - aborting Renovate run',
       );
       throw new Error(REPOSITORY_BLOCKED);
     }

--- a/lib/modules/platform/gitea/utils.ts
+++ b/lib/modules/platform/gitea/utils.ts
@@ -186,6 +186,6 @@ export function isAllowed(style: PRMergeMethod, repo: Repo): boolean {
     case 'fast-forward-only':
       return repo.allow_fast_forward_only_merge;
   }
-  logger.debug('Repo has unknown merge style - aborting renovation');
+  logger.debug('Repo has unknown merge style - aborting Renovate run');
   throw new Error(REPOSITORY_BLOCKED);
 }

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -570,7 +570,7 @@ export async function initRepo({
     }
     if (repo.isArchived) {
       logger.debug(
-        'Repository is archived - throwing error to abort renovation',
+        'Repository is archived - throwing error to abort Renovate run',
       );
       throw new Error(REPOSITORY_ARCHIVED);
     }

--- a/lib/modules/platform/gitlab/index.ts
+++ b/lib/modules/platform/gitlab/index.ts
@@ -280,26 +280,26 @@ export async function initRepo({
     );
     if (res.body.archived) {
       logger.debug(
-        'Repository is archived - throwing error to abort renovation',
+        'Repository is archived - throwing error to abort Renovate run',
       );
       throw new Error(REPOSITORY_ARCHIVED);
     }
 
     if (res.body.mirror && GlobalConfig.get('includeMirrors') !== true) {
       logger.debug(
-        'Repository is a mirror - throwing error to abort renovation',
+        'Repository is a mirror - throwing error to abort Renovate run',
       );
       throw new Error(REPOSITORY_MIRRORED);
     }
     if (res.body.repository_access_level === 'disabled') {
       logger.debug(
-        'Repository portion of project is disabled - throwing error to abort renovation',
+        'Repository portion of project is disabled - throwing error to abort Renovate run',
       );
       throw new Error(REPOSITORY_DISABLED);
     }
     if (res.body.merge_requests_access_level === 'disabled') {
       logger.debug(
-        'MRs are disabled for the project - throwing error to abort renovation',
+        'MRs are disabled for the project - throwing error to abort Renovate run',
       );
       throw new Error(REPOSITORY_DISABLED);
     }

--- a/lib/workers/repository/error.ts
+++ b/lib/workers/repository/error.ts
@@ -123,7 +123,7 @@ export default async function handleError(
     return err.message;
   }
   if (err.message === REPOSITORY_CHANGED) {
-    logger.info('Repository has changed during renovation - aborting');
+    logger.info('Repository has changed during Renovate run - aborting');
     delete config.branchList;
     return err.message;
   }

--- a/lib/workers/repository/update/branch/index.ts
+++ b/lib/workers/repository/update/branch/index.ts
@@ -906,7 +906,7 @@ export async function processBranch(
     } else if (!(err instanceof ExternalHostError)) {
       logger.warn({ err }, `Error updating branch`);
     }
-    // Don't throw here - we don't want to stop the other renovations
+    // Don't throw here - we don't want to stop the other Renovate runs
     return {
       branchExists,
       prNo: branchPr?.number,
@@ -1069,7 +1069,7 @@ export async function processBranch(
       logger.debug('Passing PR error up');
       throw err;
     }
-    // Otherwise don't throw here - we don't want to stop the other renovations
+    // Otherwise don't throw here - we don't want to stop the other Renovate runs
     logger.error({ err }, `Error ensuring PR`);
   }
   if (!branchExists) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
As a follow-up to #23408  / #23405, there were a few other cases still present in
the codebase.

## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
