### PR TITLE
refactor(platforms): changes around `createdAt` field

### DIFF
--- a/lib/modules/platform/codecommit/index.ts
+++ b/lib/modules/platform/codecommit/index.ts
@@ -191,6 +191,7 @@ export async function getPrList(): Promise<CodeCommitPr[]> {
       number: Number.parseInt(prId),
       title: prInfo.title!,
       body: prInfo.description!,
+      createdAt: prInfo.creationDate?.toISOString(),
     };
     fetchedPrs.push(pr);
   }

--- a/lib/modules/platform/gerrit/index.spec.ts
+++ b/lib/modules/platform/gerrit/index.spec.ts
@@ -213,6 +213,7 @@ describe('modules/platform/gerrit/index', () => {
             commit_with_footers: 'Renovate-Branch: source',
           }),
         },
+        created: '2025-04-14 16:33:37.000000000',
       });
       clientMock.findChanges.mockResolvedValueOnce([change]);
       await expect(
@@ -227,7 +228,9 @@ describe('modules/platform/gerrit/index', () => {
 
   describe('getPr()', () => {
     it('getPr() - found', async () => {
-      const change = partial<GerritChange>({});
+      const change = partial<GerritChange>({
+        created: '2025-04-14 16:33:37.000000000',
+      });
       clientMock.getChange.mockResolvedValueOnce(change);
       await expect(gerrit.getPr(123456)).resolves.toEqual(
         mapGerritChangeToPr(change),
@@ -391,6 +394,7 @@ describe('modules/platform/gerrit/index', () => {
             commit_with_footers: 'Renovate-Branch: renovate/dependency-1.x',
           }),
         },
+        created: '2025-04-14T16:33:37.000000000',
       });
       clientMock.getBranchChange.mockResolvedValueOnce(change);
       await expect(
@@ -416,6 +420,7 @@ describe('modules/platform/gerrit/index', () => {
             commit_with_footers: 'Renovate-Branch: renovate/dependency-1.x',
           }),
         },
+        created: '2025-04-14 16:33:37.000000000',
       });
       clientMock.getBranchChange.mockResolvedValueOnce(change);
       await expect(
@@ -454,6 +459,7 @@ describe('modules/platform/gerrit/index', () => {
             commit_with_footers: 'Renovate-Branch: renovate/dependency-1.x',
           }),
         },
+        created: '2025-04-14 16:33:37.000000000',
       });
       clientMock.findChanges.mockResolvedValueOnce([change, change, change]);
       await expect(gerrit.getPrList()).resolves.toHaveLength(3);

--- a/lib/modules/platform/gerrit/utils.spec.ts
+++ b/lib/modules/platform/gerrit/utils.spec.ts
@@ -144,6 +144,7 @@ describe('modules/platform/gerrit/utils', () => {
               'Some change\n\nRenovate-Branch: renovate/dependency-1.x\nChange-Id: ...',
           }),
         },
+        created: '2025-04-14 16:33:37.000000000',
       });
       expect(utils.mapGerritChangeToPr(change)).toEqual({
         number: 123456,
@@ -156,6 +157,7 @@ describe('modules/platform/gerrit/utils', () => {
         bodyStruct: {
           hash: hashBody(''),
         },
+        createdAt: '2025-04-14T16:33:37.000000000',
       });
     });
 
@@ -172,6 +174,7 @@ describe('modules/platform/gerrit/utils', () => {
               'Some change\n\nRenovate-Broke: renovate/dependency-1.x\nChange-Id: ...',
           }),
         },
+        created: '2025-04-14 16:33:37.000000000',
       });
       expect(utils.mapGerritChangeToPr(change)).toBeNull();
     });
@@ -189,6 +192,7 @@ describe('modules/platform/gerrit/utils', () => {
               'Some change\n\nRenovate-Broke: renovate/dependency-1.x\nChange-Id: ...',
           }),
         },
+        created: '2025-04-14 16:33:37.000000000',
       });
       expect(
         utils.mapGerritChangeToPr(change, {
@@ -205,6 +209,7 @@ describe('modules/platform/gerrit/utils', () => {
         bodyStruct: {
           hash: hashBody(''),
         },
+        createdAt: '2025-04-14T16:33:37.000000000',
       });
     });
 
@@ -221,6 +226,7 @@ describe('modules/platform/gerrit/utils', () => {
               'Some change\n\nRenovate-Branch: renovate/dependency-1.x\nChange-Id: ...',
           }),
         },
+        created: '2025-04-14 16:33:37.000000000',
       });
       expect(
         utils.mapGerritChangeToPr(change, {
@@ -237,6 +243,7 @@ describe('modules/platform/gerrit/utils', () => {
         bodyStruct: {
           hash: hashBody('PR Body'),
         },
+        createdAt: '2025-04-14T16:33:37.000000000',
       });
     });
   });

--- a/lib/modules/platform/gerrit/utils.ts
+++ b/lib/modules/platform/gerrit/utils.ts
@@ -96,7 +96,7 @@ export function mapGerritChangeToPr(
     sourceBranch,
     targetBranch: change.branch,
     title: change.subject,
-    createdAt: change.created?.replace(' ', 'T'),
+    createdAt: change.created.replace(' ', 'T'),
     labels: change.hashtags,
     reviewers:
       change.reviewers?.REVIEWER?.map((reviewer) => reviewer.username!) ?? [],


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- Return `createdAt` value in `code-commit` platform
- remove optional chaning around `createdAt` in `gerrit`
<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
