### PR TITLE
fix(manager/mise): expand file patterns to match mise's config search

### DIFF
--- a/docs/usage/node.md
+++ b/docs/usage/node.md
@@ -21,7 +21,7 @@ Renovate can manage the Node.js version in the following files:
 - The [`.nvmrc`](https://github.com/creationix/nvm#nvmrc) file for the [Node Version Manager](https://github.com/creationix/nvm)
 - The [`.node-version`](https://github.com/nodenv/nodenv#choosing-the-node-version) file for the [nodenv](https://github.com/nodenv/nodenv) environment manager
 - The [`.tool-versions`](https://asdf-vm.com/manage/configuration.html#tool-versions) file for the [asdf](https://github.com/asdf-vm/asdf) version manager
-- The [`.mise.toml`](https://mise.jdx.dev/configuration.html#mise-toml) file for the [mise](https://github.com/jdx/mise) version manager
+- The mise [configuration files](https://mise.jdx.dev/configuration.html#mise-toml) (e.g., `mise.toml`, `.mise.toml`, `.config/mise.toml`) for the [mise](https://github.com/jdx/mise) version manager
 - The [`node_js`](https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#Specifying-Node.js-versions) field in [`.travis.yml`](https://docs.travis-ci.com/user/customizing-the-build/)
 
 ## Configuring which version of npm Renovate uses

--- a/lib/modules/manager/mise/index.spec.ts
+++ b/lib/modules/manager/mise/index.spec.ts
@@ -2,7 +2,7 @@ import { matchRegexOrGlobList } from '../../../util/string-match';
 import { defaultConfig } from '.';
 
 describe('modules/manager/mise/index', () => {
-  describe('file names match managerFilePatterns', () => {
+  describe('managerFilePatterns', () => {
     it.each`
       path                                     | expected
       ${'mise.toml'}                           | ${true}

--- a/lib/modules/manager/mise/index.spec.ts
+++ b/lib/modules/manager/mise/index.spec.ts
@@ -1,0 +1,50 @@
+import { matchRegexOrGlobList } from '../../../util/string-match';
+import { defaultConfig } from '.';
+
+describe('modules/manager/mise/index', () => {
+  describe('file names match managerFilePatterns', () => {
+    it.each`
+      path                                     | expected
+      ${'mise.toml'}                           | ${true}
+      ${'.mise.toml'}                          | ${true}
+      ${'mise.local.toml'}                     | ${true}
+      ${'.mise.local.toml'}                    | ${true}
+      ${'mise.production.toml'}                | ${true}
+      ${'.mise.dev.toml'}                      | ${true}
+      ${'mise/config.toml'}                    | ${true}
+      ${'.mise/config.toml'}                   | ${true}
+      ${'mise/config.local.toml'}              | ${true}
+      ${'.mise/config.production.toml'}        | ${true}
+      ${'.config/mise.toml'}                   | ${true}
+      ${'.config/mise.local.toml'}             | ${true}
+      ${'.config/mise.staging.toml'}           | ${true}
+      ${'.config/mise/config.toml'}            | ${true}
+      ${'.config/mise/config.local.toml'}      | ${true}
+      ${'.config/mise/config.production.toml'} | ${true}
+      ${'.config/mise/mise.toml'}              | ${true}
+      ${'.config/mise/mise.local.toml'}        | ${true}
+      ${'.config/mise/mise.dev.toml'}          | ${true}
+      ${'.rtx.toml'}                           | ${true}
+      ${'.rtx.local.toml'}                     | ${true}
+      ${'.rtx.production.toml'}                | ${true}
+      ${'subdir/mise.toml'}                    | ${true}
+      ${'subdir/.mise.toml'}                   | ${true}
+      ${'subdir/.config/mise.toml'}            | ${true}
+      ${'subdir/.config/mise/config.toml'}     | ${true}
+      ${'deep/nested/path/mise.toml'}          | ${true}
+      ${'deep/nested/.config/mise/mise.toml'}  | ${true}
+      ${'foo.toml'}                            | ${false}
+      ${'mise.json'}                           | ${false}
+      ${'mise.yaml'}                           | ${false}
+      ${'mise-config.toml'}                    | ${false}
+      ${'rtx.toml'}                            | ${false}
+      ${'.config/other.toml'}                  | ${false}
+      ${'mise.toml.backup'}                    | ${false}
+      ${'.mise.toml.bak'}                      | ${false}
+    `('matchRegexOrGlobList("$path") === $expected', ({ path, expected }) => {
+      expect(
+        matchRegexOrGlobList(path, defaultConfig.managerFilePatterns),
+      ).toBe(expected);
+    });
+  });
+});

--- a/lib/modules/manager/mise/index.ts
+++ b/lib/modules/manager/mise/index.ts
@@ -21,8 +21,12 @@ export const url = 'https://mise.jdx.dev';
 
 export const defaultConfig = {
   managerFilePatterns: [
-    '/(^|/)\\.?mise\\.toml$/',
-    '/(^|/)\\.?mise/config\\.toml$/',
+    '/(^|/)\\.?mise(\\.[^.]+)?\\.toml$/',
+    '/(^|/)\\.?mise/config(\\.[^.]+)?\\.toml$/',
+    '/(^|/)\\.config/mise(\\.[^.]+)?\\.toml$/',
+    '/(^|/)\\.config/mise/config(\\.[^.]+)?\\.toml$/',
+    '/(^|/)\\.config/mise/mise(\\.[^.]+)?\\.toml$/',
+    '/(^|/)\\.rtx(\\.[^.]+)?\\.toml$/',
   ],
 };
 

--- a/lib/modules/manager/mise/index.ts
+++ b/lib/modules/manager/mise/index.ts
@@ -21,23 +21,12 @@ export const url = 'https://mise.jdx.dev';
 
 export const defaultConfig = {
   managerFilePatterns: [
-    '**/mise.toml',
-    '**/mise.*.toml',
-    '**/.mise.toml',
-    '**/.mise.*.toml',
-    '**/mise/config.toml',
-    '**/mise/config.*.toml',
-    '**/.mise/config.toml',
-    '**/.mise/config.*.toml',
-    '**/.config/mise.toml',
-    '**/.config/mise.*.toml',
-    '**/.config/mise/config.toml',
-    '**/.config/mise/config.*.toml',
-    '**/.config/mise/mise.toml',
-    '**/.config/mise/mise.*.toml',
+    '**/{,.}mise{,.*}.toml',
+    '**/{,.}mise/config{,.*}.toml',
+    '**/.config/mise{,,*}.toml',
+    '**/.config/mise/{mise,config}{,.*}.toml',
     '**/.config/mise/conf.d/*.toml',
-    '**/.rtx.toml',
-    '**/.rtx.*.toml',
+    '**/.rtx{,.*}.toml',
   ],
 };
 

--- a/lib/modules/manager/mise/index.ts
+++ b/lib/modules/manager/mise/index.ts
@@ -21,12 +21,23 @@ export const url = 'https://mise.jdx.dev';
 
 export const defaultConfig = {
   managerFilePatterns: [
-    '/(^|/)\\.?mise(\\.[^.]+)?\\.toml$/',
-    '/(^|/)\\.?mise/config(\\.[^.]+)?\\.toml$/',
-    '/(^|/)\\.config/mise(\\.[^.]+)?\\.toml$/',
-    '/(^|/)\\.config/mise/config(\\.[^.]+)?\\.toml$/',
-    '/(^|/)\\.config/mise/mise(\\.[^.]+)?\\.toml$/',
-    '/(^|/)\\.rtx(\\.[^.]+)?\\.toml$/',
+    '**/mise.toml',
+    '**/mise.*.toml',
+    '**/.mise.toml',
+    '**/.mise.*.toml',
+    '**/mise/config.toml',
+    '**/mise/config.*.toml',
+    '**/.mise/config.toml',
+    '**/.mise/config.*.toml',
+    '**/.config/mise.toml',
+    '**/.config/mise.*.toml',
+    '**/.config/mise/config.toml',
+    '**/.config/mise/config.*.toml',
+    '**/.config/mise/mise.toml',
+    '**/.config/mise/mise.*.toml',
+    '**/.config/mise/conf.d/*.toml',
+    '**/.rtx.toml',
+    '**/.rtx.*.toml',
   ],
 };
 

--- a/lib/modules/manager/mise/index.ts
+++ b/lib/modules/manager/mise/index.ts
@@ -23,7 +23,7 @@ export const defaultConfig = {
   managerFilePatterns: [
     '**/{,.}mise{,.*}.toml',
     '**/{,.}mise/config{,.*}.toml',
-    '**/.config/mise{,,*}.toml',
+    '**/.config/mise{,.*}.toml',
     '**/.config/mise/{mise,config}{,.*}.toml',
     '**/.config/mise/conf.d/*.toml',
     '**/.rtx{,.*}.toml',

--- a/lib/modules/manager/mise/readme.md
+++ b/lib/modules/manager/mise/readme.md
@@ -1,4 +1,15 @@
-Renovate can update the [mise](https://mise.jdx.dev/configuration.html#mise-toml) `mise.toml` file.
+Renovate can update [mise](https://mise.jdx.dev/configuration.html#mise-toml) configuration files.
+
+### Supported configuration files
+
+Renovate supports all standard mise configuration file patterns:
+
+- `mise.toml`, `.mise.toml`
+- `mise/config.toml`, `.mise/config.toml`
+- `.config/mise.toml`, `.config/mise/config.toml`, `.config/mise/mise.toml`
+- `.rtx.toml` (legacy)
+- Environment-specific variants (e.g., `mise.production.toml`, `.mise.dev.toml`)
+- Local variants (e.g., `mise.local.toml`, `.mise.local.toml`)
 
 ### Renovate only updates primary versions
 

--- a/lib/modules/manager/mise/readme.md
+++ b/lib/modules/manager/mise/readme.md
@@ -1,4 +1,4 @@
-Renovate can update [mise](https://mise.jdx.dev/configuration.html#mise-toml) configuration files.
+Renovate can update [mise configuration files](https://mise.jdx.dev/configuration.html#mise-toml).
 
 ### Supported configuration files
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
Updates mise manager file patterns to align with the official mise configuration file search patterns. The patterns now include:
- Additional config locations (.config/mise/, .config/mise.toml)
- Legacy rtx.toml files
- Environment-specific configs (e.g., mise.production.toml)
- Local configs (e.g., mise.local.toml)

This ensures Renovate detects all mise configuration files that mise itself recognizes.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

I've used AI-generated tests, but reviews them manually

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
