### PR TITLE
feat: allow to define custom presets in self-hosted config

### DIFF
--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -549,6 +549,32 @@ The above configuration approach will mean the values are redacted in logs like 
          "customEnvVariables": {"SECRET_TOKEN": "{{ secrets.SECRET_TOKEN }}"},
 ```
 
+## customPresets
+
+For example, in your `config.js`:
+
+```js
+module.exports = {
+  customPresets: {
+    myPreset: {
+      description: 'My custom preset',
+      labels: ['custom-label'],
+    },
+    'group:my-group': {
+      groupName: 'My Group',
+    },
+  },
+};
+```
+
+Then in a repository's `renovate.json`:
+
+```json
+{
+  "extends": ["custom:myPreset", "custom:group:my-group"]
+}
+```
+
 ## deleteAdditionalConfigFile
 
 If set to `true` Renovate tries to delete the additional self-hosted config file after reading it.

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -386,6 +386,17 @@ const options: RenovateOptions[] = [
     },
   },
   {
+    name: 'customPresets',
+    description:
+      'Define presets here which can be extended by repositories. Note: they must be referenced with a `custom:` prefix.',
+    type: 'object',
+    globalOnly: true,
+    default: {},
+    mergeable: true,
+    cli: false,
+    env: false,
+  },
+  {
     name: 'minimumGroupSize',
     description:
       'The minimum number of updates which must be in a group for branches to be created.',

--- a/lib/config/presets/index.spec.ts
+++ b/lib/config/presets/index.spec.ts
@@ -517,6 +517,51 @@ describe('config/presets/index', () => {
         PLATFORM_RATE_LIMIT_EXCEEDED,
       );
     });
+
+    it('resolves custom presets defined in config', async () => {
+      config.customPresets = {
+        myPreset: {
+          description: 'My custom preset',
+          labels: ['custom-label'],
+        },
+      };
+      config.extends = ['custom:myPreset'];
+
+      const res = await presets.resolveConfigPresets(config);
+
+      expect(res.labels).toEqual(['custom-label']);
+      expect(res.description).toEqual(['My custom preset']);
+    });
+
+    it('resolves custom presets with params', async () => {
+      config.customPresets = {
+        group: {
+          groupName: '{{arg0}}',
+        },
+      };
+      config.extends = ['custom:group(my-group)'];
+
+      const res = await presets.resolveConfigPresets(config);
+
+      expect(res.groupName).toEqual('my-group');
+    });
+
+    it('resolves nested custom presets', async () => {
+      config.customPresets = {
+        base: {
+          addLabels: ['base-label'],
+        },
+        derived: {
+          extends: ['custom:base'],
+          addLabels: ['derived-label'],
+        },
+      };
+      config.extends = ['custom:derived'];
+
+      const res = await presets.resolveConfigPresets(config);
+
+      expect(res.addLabels).toEqual(['base-label', 'derived-label']);
+    });
   });
 
   describe('replaceArgs', () => {

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -172,6 +172,7 @@ export interface GlobalOnlyConfigLegacy {
   baseDir?: string;
   cacheDir?: string;
   containerbaseDir?: string;
+  customPresets?: Record<string, RenovateConfig>;
   detectHostRulesFromEnv?: boolean;
   dockerCliOptions?: string;
   endpoint?: string;

--- a/lib/config/validation.spec.ts
+++ b/lib/config/validation.spec.ts
@@ -1,6 +1,6 @@
 import { getConfigFileNames } from './app-strings';
 import { GlobalConfig } from './global';
-import type { RenovateConfig } from './types';
+import type { AllConfig, RenovateConfig } from './types';
 import * as configValidation from './validation';
 import { partial } from '~test/util';
 
@@ -1959,6 +1959,43 @@ describe('config/validation', () => {
             ),
           },
         ]);
+      });
+
+      it('customPresets', async () => {
+        const config = {
+          customPresets: {
+            myPreset: {
+              description: ['My custom preset'],
+              labels: ['custom-label'],
+            },
+          },
+        };
+        const { warnings, errors } = await configValidation.validateConfig(
+          'global',
+          config,
+        );
+        expect(errors).toHaveLength(0);
+        expect(warnings).toHaveLength(0);
+      });
+
+      it('customPresets validates each preset config', async () => {
+        const config = {
+          customPresets: {
+            badPreset: {
+              // match* selectors are only valid in packageRules
+              matchPackageNames: ['foo'],
+            },
+          },
+        } as AllConfig;
+        const { warnings, errors } = await configValidation.validateConfig(
+          'global',
+          config,
+        );
+        expect(errors).toHaveLength(0);
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0].message).toContain(
+          'matchPackageNames should be inside a `packageRule` only',
+        );
       });
 
       it('gitUrl', async () => {

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -954,6 +954,28 @@ async function validateGlobalConfig(
           )) {
             warnings.push(warning);
           }
+        } else if (key === 'customPresets') {
+          for (const [presetName, presetConfig] of Object.entries(val)) {
+            if (!isPlainObject(presetConfig)) {
+              warnings.push({
+                topic: 'Configuration Error',
+                message: `Invalid \`${currentPath}.${presetName}\` configuration: value must be a JSON object.`,
+              });
+              continue;
+            }
+
+            const subValidation = await validateConfig(
+              'repo',
+              presetConfig as unknown as AllConfig,
+              true,
+              `${currentPath}.${presetName}`,
+            );
+            for (const warning of subValidation.warnings.concat(
+              subValidation.errors,
+            )) {
+              warnings.push(warning);
+            }
+          }
         } else if (key === 'force') {
           const subValidation = await validateConfig('global', val);
           for (const warning of subValidation.warnings.concat(

--- a/lib/workers/global/config/parse/index.ts
+++ b/lib/workers/global/config/parse/index.ts
@@ -4,7 +4,7 @@ import { setPrivateKeys } from '../../../../config/decrypt';
 import * as defaultsParser from '../../../../config/defaults';
 import { resolveConfigPresets } from '../../../../config/presets';
 import { applySecretsAndVariablesToConfig } from '../../../../config/secrets';
-import type { AllConfig } from '../../../../config/types';
+import type { AllConfig, RenovateConfig } from '../../../../config/types';
 import { mergeChildConfig } from '../../../../config/utils';
 import { CONFIG_PRESETS_INVALID } from '../../../../constants/error-messages';
 import { logger, setContext } from '../../../../logger';
@@ -24,10 +24,11 @@ import { hostRulesFromEnv } from './host-rules-from-env';
 export async function resolveGlobalExtends(
   globalExtends: string[],
   ignorePresets?: string[],
+  customPresets?: Record<string, RenovateConfig>,
 ): Promise<AllConfig> {
   try {
     // Make a "fake" config to pass to resolveConfigPresets and resolve globalPresets
-    const config = { extends: globalExtends, ignorePresets };
+    const config = { extends: globalExtends, ignorePresets, customPresets };
     const resolvedConfig = await resolveConfigPresets(config);
     return resolvedConfig;
   } catch (err) {
@@ -69,6 +70,7 @@ export async function parseConfigs(
     resolvedGlobalExtends = await resolveGlobalExtends(
       config.globalExtends,
       config.ignorePresets,
+      config.customPresets,
     );
     config = mergeChildConfig(resolvedGlobalExtends, config);
     delete config.globalExtends;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

Moved to discussion: https://github.com/renovatebot/renovate/discussions/40119

## Changes

<!-- Describe what behavior is changed by this PR. -->

This PR adds support for defining custom presets in the global Renovate config for self-hosted users.

Those presets should be defined in a `customPresets` object in the global config, and can then be referenced in repository configs using the `custom:` prefix.

This feature allows for self-hosted users to define readily reusable presets without Renovate needing to fetch them from a remote source, and therefore reducing the number of external requests made by Renovate.

Besides, changes to presets defined this way can be more easily tested as they will be loaded from the local global config file instead of having to merge the preset changes so that Renovate can later fetch them from the remote source.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

I used Claude Sonnet 4.5 to help me write the initial implementation and tests for this feature, and then I manually refined the generated code.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/felipecrs/renovate-test-custom-presets/pulls

```js
// config.js

customPresets: {
  groupAll: {
    packageRules: [
      {
        description: "Group all dependencies into a single PR",
        matchPackageNames: ["*"],
        groupName: "dependencies",
      },
    ];
  }
}
```

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
