### PR TITLE
chore(cli): show default values in the `--help` output

### DIFF
--- a/lib/workers/global/config/parse/cli.spec.ts
+++ b/lib/workers/global/config/parse/cli.spec.ts
@@ -28,20 +28,23 @@ describe('workers/global/config/parse/cli', () => {
   });
 
   describe('.getConfig(argv)', () => {
-    it('returns empty argv', () => {
-      expect(cli.getConfig(argv)).toEqual({});
+    it('returns object with options that have defaults', () => {
+      expect(cli.getConfig(argv)).toMatchObject({
+        allowedCommands: [],
+        rebaseWhen: 'auto',
+      });
     });
 
     it('supports boolean no value', () => {
       argv.push('--config-migration');
-      expect(cli.getConfig(argv)).toEqual({ configMigration: true });
+      expect(cli.getConfig(argv)).toMatchObject({ configMigration: true });
       argv = argv.slice(0, -1);
     });
 
     it('supports boolean space true', () => {
       argv.push('--config-migration');
       argv.push('true');
-      expect(cli.getConfig(argv)).toEqual({ configMigration: true });
+      expect(cli.getConfig(argv)).toMatchObject({ configMigration: true });
     });
 
     it('throws exception for invalid boolean value', () => {
@@ -57,45 +60,47 @@ describe('workers/global/config/parse/cli', () => {
     it('supports boolean space false', () => {
       argv.push('--config-migration');
       argv.push('false');
-      expect(cli.getConfig(argv)).toEqual({ configMigration: false });
+      expect(cli.getConfig(argv)).toMatchObject({ configMigration: false });
     });
 
     it('supports boolean equals true', () => {
       argv.push('--config-migration=true');
-      expect(cli.getConfig(argv)).toEqual({ configMigration: true });
+      expect(cli.getConfig(argv)).toMatchObject({ configMigration: true });
     });
 
     it('supports boolean equals false', () => {
       argv.push('--config-migration=false');
-      expect(cli.getConfig(argv)).toEqual({ configMigration: false });
+      expect(cli.getConfig(argv)).toMatchObject({ configMigration: false });
     });
 
     it('supports list single', () => {
       argv.push('--labels=a');
-      expect(cli.getConfig(argv)).toEqual({ labels: ['a'] });
+      expect(cli.getConfig(argv)).toMatchObject({ labels: ['a'] });
     });
 
     it('supports list multiple', () => {
       argv.push('--labels=a,b,c');
-      expect(cli.getConfig(argv)).toEqual({ labels: ['a', 'b', 'c'] });
+      expect(cli.getConfig(argv)).toMatchObject({ labels: ['a', 'b', 'c'] });
     });
 
     it('supports string', () => {
       argv.push('--token=a');
-      expect(cli.getConfig(argv)).toEqual({ token: 'a' });
+      expect(cli.getConfig(argv)).toMatchObject({ token: 'a' });
     });
 
     it('supports repositories', () => {
       argv.push('foo');
       argv.push('bar');
-      expect(cli.getConfig(argv)).toEqual({ repositories: ['foo', 'bar'] });
+      expect(cli.getConfig(argv)).toMatchObject({
+        repositories: ['foo', 'bar'],
+      });
     });
 
     it('parses json lists correctly', () => {
       argv.push(
         `--host-rules=[{"matchHost":"docker.io","hostType":"${DockerDatasource.id}","username":"user","password":"password"}]`,
       );
-      expect(cli.getConfig(argv)).toEqual({
+      expect(cli.getConfig(argv)).toMatchObject({
         hostRules: [
           {
             matchHost: 'docker.io',
@@ -109,14 +114,14 @@ describe('workers/global/config/parse/cli', () => {
 
     it('parses [] correctly as empty list of hostRules', () => {
       argv.push(`--host-rules=[]`);
-      expect(cli.getConfig(argv)).toEqual({
+      expect(cli.getConfig(argv)).toMatchObject({
         hostRules: [],
       });
     });
 
     it('parses an empty string correctly as empty list of hostRules', () => {
       argv.push(`--host-rules=`);
-      expect(cli.getConfig(argv)).toEqual({
+      expect(cli.getConfig(argv)).toMatchObject({
         hostRules: [],
       });
     });
@@ -143,21 +148,21 @@ describe('workers/global/config/parse/cli', () => {
 
     it('parses json object correctly when empty', () => {
       argv.push(`--onboarding-config=`);
-      expect(cli.getConfig(argv)).toEqual({
+      expect(cli.getConfig(argv)).toMatchObject({
         onboardingConfig: {},
       });
     });
 
     it('parses json {} object correctly', () => {
       argv.push(`--onboarding-config={}`);
-      expect(cli.getConfig(argv)).toEqual({
+      expect(cli.getConfig(argv)).toMatchObject({
         onboardingConfig: {},
       });
     });
 
     it('parses json object correctly', () => {
       argv.push(`--onboarding-config={"extends": ["config:recommended"]}`);
-      expect(cli.getConfig(argv)).toEqual({
+      expect(cli.getConfig(argv)).toMatchObject({
         onboardingConfig: {
           extends: ['config:recommended'],
         },
@@ -173,37 +178,37 @@ describe('workers/global/config/parse/cli', () => {
 
     it('dryRun boolean true', () => {
       argv.push('--dry-run=true');
-      expect(cli.getConfig(argv)).toEqual({ dryRun: 'full' });
+      expect(cli.getConfig(argv)).toMatchObject({ dryRun: 'full' });
     });
 
     it('dryRun no value', () => {
       argv.push('--dry-run');
-      expect(cli.getConfig(argv)).toEqual({ dryRun: 'full' });
+      expect(cli.getConfig(argv)).toMatchObject({ dryRun: 'full' });
     });
 
     it('dryRun boolean false', () => {
       argv.push('--dry-run=false');
-      expect(cli.getConfig(argv)).toEqual({ dryRun: null });
+      expect(cli.getConfig(argv)).toMatchObject({ dryRun: null });
     });
 
     it('dryRun  null', () => {
       argv.push('--dry-run=null');
-      expect(cli.getConfig(argv)).toEqual({ dryRun: null });
+      expect(cli.getConfig(argv)).toMatchObject({ dryRun: null });
     });
 
     it('requireConfig boolean true', () => {
       argv.push('--require-config=true');
-      expect(cli.getConfig(argv)).toEqual({ requireConfig: 'required' });
+      expect(cli.getConfig(argv)).toMatchObject({ requireConfig: 'required' });
     });
 
     it('requireConfig no value', () => {
       argv.push('--require-config');
-      expect(cli.getConfig(argv)).toEqual({ requireConfig: 'required' });
+      expect(cli.getConfig(argv)).toMatchObject({ requireConfig: 'required' });
     });
 
     it('requireConfig boolean false', () => {
       argv.push('--require-config=false');
-      expect(cli.getConfig(argv)).toEqual({ requireConfig: 'optional' });
+      expect(cli.getConfig(argv)).toMatchObject({ requireConfig: 'optional' });
     });
   });
 });

--- a/lib/workers/global/config/parse/cli.ts
+++ b/lib/workers/global/config/parse/cli.ts
@@ -58,6 +58,7 @@ export function getConfig(input: string[]): AllConfig {
         optionString,
         option.description,
         coersions[option.type],
+        option.default,
       );
     }
   });


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes



As a way to make the CLI's options more discoverable, we can wire in the
`default` value if found.

As we now have the defaults returned, the config object cannot be
checked for deep equality, but instead we need to check for specific
properties.



## Context

Please select one of the below:

- [x] This closes an existing Issue: Closes #40144
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
