### PR TITLE
fix: set git env vars for corepack use and pnpm post update

### DIFF
--- a/lib/modules/manager/npm/artifacts.ts
+++ b/lib/modules/manager/npm/artifacts.ts
@@ -7,6 +7,7 @@ import {
   readLocalFile,
   writeLocalFile,
 } from '../../../util/fs';
+import { getGitEnvironmentVariables } from '../../../util/git/auth';
 import { regEx } from '../../../util/regex';
 import type { UpdateArtifact, UpdateArtifactsResult } from '../types';
 import { PNPM_CACHE_DIR, PNPM_STORE_DIR } from './constants';
@@ -78,6 +79,9 @@ export async function updateArtifacts({
       npm_config_store_dir: pnpmConfigStoreDir,
       pnpm_config_cache_dir: pnpmConfigCacheDir,
       pnpm_config_store_dir: pnpmConfigStoreDir,
+      // corepack use installs the dependencies, so we need to pass
+      // the git environment variables to it to resolve git-hosted private packages
+      ...getGitEnvironmentVariables(),
     },
     toolConstraints: [
       nodeConstraints,

--- a/lib/modules/manager/npm/post-update/pnpm.ts
+++ b/lib/modules/manager/npm/post-update/pnpm.ts
@@ -17,6 +17,7 @@ import {
   localPathExists,
   readLocalFile,
 } from '../../../../util/fs';
+import { getGitEnvironmentVariables } from '../../../../util/git/auth';
 import { uniqueStrings } from '../../../../util/string';
 import { parseSingleYaml } from '../../../../util/yaml';
 import type { PostUpdateConfig, Upgrade } from '../../types';
@@ -70,6 +71,8 @@ export async function generateLockFile(
       // pnpm stops reading npm_config_* env vars since v11
       pnpm_config_cache_dir: pnpmConfigCacheDir,
       pnpm_config_store_dir: pnpmConfigStoreDir,
+      // allows pnpm to resolve git-hosted private packages
+      ...getGitEnvironmentVariables(),
     };
     const execOptions: ExecOptions = {
       cwdFile: lockFileName,

--- a/lib/modules/manager/npm/post-update/pnpm.ts
+++ b/lib/modules/manager/npm/post-update/pnpm.ts
@@ -17,6 +17,7 @@ import {
   localPathExists,
   readLocalFile,
 } from '../../../../util/fs/index.ts';
+import { getGitEnvironmentVariables } from '../../../../util/git/auth.ts';
 import { uniqueStrings } from '../../../../util/string.ts';
 import { parseSingleYaml } from '../../../../util/yaml.ts';
 import type { PostUpdateConfig, Upgrade } from '../../types.ts';
@@ -72,6 +73,8 @@ export async function generateLockFile(
       // pnpm stops reading npm_config_* env vars since v11
       pnpm_config_cache_dir: pnpmConfigCacheDir,
       pnpm_config_store_dir: pnpmConfigStoreDir,
+      // allows pnpm to resolve git-hosted private packages
+      ...getGitEnvironmentVariables(),
     };
 
     const { nodeMaxMemory } = getToolSettingsOptions(config.toolSettings);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Added git authentication environment variables to extraEnv for JS package manager installations and pnpm lockfile updates.
- https://github.com/renovatebot/renovate/discussions/39026

pnpm tries to resolve a Git URL using the `git ls-remote` command, with `ssh` as a fallback.  
That’s why we need to expose GitHub authentication environment variables during pnpm actions to resolve private GitHub packages over HTTPS.
https://github.com/pnpm/pnpm/blob/9eddabb32b1d484cc0e0d9ae4c0b1ea9a2eb247a/resolving/git-resolver/src/parseBareSpecifier.ts#L67

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [x] Yes — other (please describe): To understand the code

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
