### PR TITLE
fix(cache): use `bitbucket-server` as platform cache key

### DIFF
--- a/lib/modules/platform/bitbucket-server/pr-cache.spec.ts
+++ b/lib/modules/platform/bitbucket-server/pr-cache.spec.ts
@@ -94,7 +94,7 @@ describe('modules/platform/bitbucket-server/pr-cache', () => {
     ]);
     expect(cache).toEqual({
       platform: {
-        bitbucketServer: {
+        'bitbucket-server': {
           pullRequestsCache: {
             author: 'some-author',
             items: {
@@ -138,7 +138,7 @@ describe('modules/platform/bitbucket-server/pr-cache', () => {
     ]);
     expect(cache).toEqual({
       platform: {
-        bitbucketServer: {
+        'bitbucket-server': {
           pullRequestsCache: {
             items: {
               '1': prInfo(pr1),
@@ -153,7 +153,7 @@ describe('modules/platform/bitbucket-server/pr-cache', () => {
 
   it('resets cache for not matching authors', async () => {
     cache.platform = {
-      bitbucketServer: {
+      'bitbucket-server': {
         pullRequestsCache: {
           items: {
             '1': prInfo(pr1),
@@ -186,7 +186,7 @@ describe('modules/platform/bitbucket-server/pr-cache', () => {
     ]);
     expect(cache).toEqual({
       platform: {
-        bitbucketServer: {
+        'bitbucket-server': {
           pullRequestsCache: {
             author: 'some-author',
             items: {
@@ -201,7 +201,7 @@ describe('modules/platform/bitbucket-server/pr-cache', () => {
 
   it('syncs cache', async () => {
     cache.platform = {
-      bitbucketServer: {
+      'bitbucket-server': {
         pullRequestsCache: {
           items: {
             '1': prInfo(pr1),
@@ -232,7 +232,7 @@ describe('modules/platform/bitbucket-server/pr-cache', () => {
     ]);
     expect(cache).toEqual({
       platform: {
-        bitbucketServer: {
+        'bitbucket-server': {
           pullRequestsCache: {
             items: {
               '1': prInfo(pr1),

--- a/lib/modules/platform/bitbucket-server/pr-cache.ts
+++ b/lib/modules/platform/bitbucket-server/pr-cache.ts
@@ -11,11 +11,7 @@ import { prInfo } from './utils';
 
 /* v8 ignore next */
 function migrateBitbucketServerCache(platform: unknown): void {
-  if (!isPlainObject(platform)) {
-    return;
-  }
-
-  if (!isPlainObject(platform.bitbucketServer)) {
+  if (!isPlainObject(platform?.bitbucketServer)) {
     return;
   }
 

--- a/lib/modules/platform/bitbucket-server/pr-cache.ts
+++ b/lib/modules/platform/bitbucket-server/pr-cache.ts
@@ -1,26 +1,27 @@
-import { isNullOrUndefined, isString } from '@sindresorhus/is';
+import { isNullOrUndefined, isPlainObject, isString } from '@sindresorhus/is';
 import { dequal } from 'dequal';
 import { DateTime } from 'luxon';
 import { logger } from '../../../logger';
 import * as memCache from '../../../util/cache/memory';
 import { getCache } from '../../../util/cache/repository';
-import type { RepoCacheData } from '../../../util/cache/repository/types';
 import type { BitbucketServerHttp } from '../../../util/http/bitbucket-server';
 import { getQueryString } from '../../../util/url';
 import type { BbsPr, BbsPrCacheData, BbsRestPr } from './types';
 import { prInfo } from './utils';
 
 /* v8 ignore next */
-function migrateBitbucketServerCache(
-  platform: RepoCacheData['platform'],
-): void {
-  const legacy = platform as Record<string, unknown> | undefined;
-  if (legacy?.bitbucketServer) {
-    platform!['bitbucket-server'] = legacy.bitbucketServer as NonNullable<
-      RepoCacheData['platform']
-    >['bitbucket-server'];
-    delete legacy.bitbucketServer;
+function migrateBitbucketServerCache(platform: unknown): void {
+  if (!isPlainObject(platform)) {
+    return;
   }
+
+  const bitbucketServer = platform.bitbucketServer;
+  if (!isPlainObject(bitbucketServer)) {
+    return;
+  }
+
+  delete platform.bitbucketServer;
+  platform['bitbucket-server'] = bitbucketServer;
 }
 
 export class BbsPrCache {

--- a/lib/modules/platform/bitbucket-server/pr-cache.ts
+++ b/lib/modules/platform/bitbucket-server/pr-cache.ts
@@ -11,7 +11,11 @@ import { prInfo } from './utils';
 
 /* v8 ignore next */
 function migrateBitbucketServerCache(platform: unknown): void {
-  if (!isPlainObject(platform?.bitbucketServer)) {
+  if (!isPlainObject(platform)) {
+    return;
+  }
+
+  if (!isPlainObject(platform.bitbucketServer)) {
     return;
   }
 

--- a/lib/modules/platform/bitbucket-server/pr-cache.ts
+++ b/lib/modules/platform/bitbucket-server/pr-cache.ts
@@ -15,13 +15,12 @@ function migrateBitbucketServerCache(platform: unknown): void {
     return;
   }
 
-  const bitbucketServer = platform.bitbucketServer;
-  if (!isPlainObject(bitbucketServer)) {
+  if (!isPlainObject(platform.bitbucketServer)) {
     return;
   }
 
+  platform['bitbucket-server'] = platform.bitbucketServer;
   delete platform.bitbucketServer;
-  platform['bitbucket-server'] = bitbucketServer;
 }
 
 export class BbsPrCache {

--- a/lib/util/cache/repository/types.ts
+++ b/lib/util/cache/repository/types.ts
@@ -156,7 +156,7 @@ export interface RepoCacheData {
     gitlab?: {
       pullRequestsCache?: unknown;
     };
-    bitbucketServer?: {
+    'bitbucket-server'?: {
       pullRequestsCache?: unknown;
     };
   };


### PR DESCRIPTION
## Changes

Change the Bitbucket Server platform cache key from `bitbucketServer` (camelCase) to `bitbucket-server` (kebab-case) to match the platform ID in `PLATFORM_HOST_TYPES`.

Adds migration logic to automatically convert existing caches using the old key to the new format, ensuring a non-breaking upgrade path.

## Context

- [x] This closes an existing Issue, Closes: #39895

## AI assistance disclosure

- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).

Claude Code was used to implement the fix, write tests, and create this PR.

## Documentation (please check one with an [x])

- [x] No documentation update is required

## How I've tested my work (please select one)

- [x] Newly added/modified unit tests
