### PR TITLE
fix(auto-replace): prevent digest corruption when using replacementNameTemplate

### DIFF
--- a/lib/workers/repository/update/branch/auto-replace.ts
+++ b/lib/workers/repository/update/branch/auto-replace.ts
@@ -291,7 +291,11 @@ export async function doAutoReplace(
       } else if (
         currentDigestShort &&
         newDigest &&
-        currentDigestShort !== newDigest
+        currentDigestShort !== newDigest &&
+        // Only use short digest replacement when there's no full currentDigest
+        // that already matches newDigest (otherwise we'd incorrectly replace
+        // part of an already-correct digest)
+        !(currentDigest && currentDigest === newDigest)
       ) {
         if (!newString.includes(currentDigestShort)) {
           logger.debug(


### PR DESCRIPTION
## Changes

When using `replacementNameTemplate` with Docker images that have pre-pinned digests, the auto-replace logic was incorrectly entering the `currentDigestShort` replacement branch even when the digest didn't need to be changed.

Since `currentDigest === newDigest`, the first digest replacement block was skipped. But the `else if` checked only `currentDigestShort !== newDigest`, which was true (e.g., `"5fa2edb" !== "sha256:5fa2edb..."`), causing it to replace the short string with the full digest, corrupting the result to `sha256:sha256:...` format.

The fix adds a guard condition to skip the `currentDigestShort` replacement when the full `currentDigest` already matches `newDigest`.

## Context

- [x] This closes an existing Issue, Closes: #40169

## AI assistance disclosure

- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).

Used Claude Code to investigate the bug, identify the root cause, implement the fix, and write the regression test.

## Documentation (please check one with an [x])

- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/renovate-testing/renovate-dockerfile-replacement-reproduction