### PR TITLE
chore(build): exclude nested `node_modules` from tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,7 @@
   },
   "include": ["**/*.mts", "**/*.ts", "**/*.js", "**/*.mjs", "**/*.cjs"],
   "exclude": [
-    "node_modules",
+    "**/node_modules",
     "./.cache",
     "./dist",
     "./.pnpm-store/",


### PR DESCRIPTION
## Changes

Fix ESLint hanging during local development by excluding nested `node_modules` directories from tsconfig.

Changed `"node_modules"` to `"**/node_modules"` in tsconfig.json exclude, preventing the TypeScript project service from scanning `test/e2e/node_modules` (26k files, 300MB).

## Context

- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).

## Documentation (please check one with an [x])

- [x] No documentation update is required

## How I've tested my work (please select one)

- [x] Code inspection only