### PR TITLE
chore(tools): Add `check` script

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -94,6 +94,16 @@ And some options:
 - `--verbose=false` to avoid the test list
 - `--coverage=false` to avoid collecting coverage, faster for the part you need the test to pass
 
+### Quick Local CI Check
+
+For a local check that mirrors CI:
+
+```bash
+pnpm check
+```
+
+This runs all checks in parallel: auto-fixes, lint, type-check, and only the test shards affected by your changes.
+
 ## Do not force push to your pull request branch
 
 Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again.

--- a/docs/development/local-development.md
+++ b/docs/development/local-development.md
@@ -148,6 +148,14 @@ We test all PRs using the same tests, run on GitHub Actions.
 
 Refactor PRs should ideally not change or remove tests (adding tests is OK).
 
+### Quick Local CI
+
+For fast iteration during development, use `pnpm check`, which runs all checks in parallel and only tests the shards affected by your changes:
+
+```bash
+pnpm check
+```
+
 ### Vitest
 
 Run the Vitest unit tests with the `pnpm vitest` command.

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "vitest": "GIT_ALLOW_PROTOCOL=file LOG_LEVEL=fatal vitest run --logHeapUsage",
     "lint": "run-s ls-lint type-check oxlint eslint prettier markdown-lint git-check doc-fence-check",
     "lint-fix": "run-s oxlint-fix eslint-fix prettier-fix markdown-lint-fix",
+    "check": "tsx tools/check/index.ts",
     "ls-lint": "ls-lint",
     "markdown-lint": "markdownlint-cli2",
     "markdown-lint-fix": "markdownlint-cli2 --fix",

--- a/tools/check/coverage.ts
+++ b/tools/check/coverage.ts
@@ -1,0 +1,144 @@
+import fs from 'fs-extra';
+import upath from 'upath';
+import { z } from 'zod';
+import type { CoverageInfo } from './types.js';
+
+const StatementLocation = z.object({
+  start: z.object({ line: z.number() }),
+  end: z.object({ line: z.number() }),
+});
+
+const CoverageEntry = z.object({
+  statementMap: z.record(z.string(), StatementLocation),
+  s: z.record(z.string(), z.number()),
+});
+
+const CoverageJson = z.record(z.string(), CoverageEntry);
+
+type CoverageData = z.infer<typeof CoverageJson>;
+
+function groupConsecutiveNumbers(numbers: number[]): string[] {
+  if (numbers.length === 0) {
+    return [];
+  }
+
+  const sorted = [...numbers].sort((a, b) => a - b);
+  const ranges: string[] = [];
+  let start = sorted[0];
+  let end = sorted[0];
+
+  for (let i = 1; i < sorted.length; i++) {
+    if (sorted[i] === end + 1) {
+      end = sorted[i];
+    } else {
+      ranges.push(start === end ? `${start}` : `${start}-${end}`);
+      start = sorted[i];
+      end = sorted[i];
+    }
+  }
+
+  ranges.push(start === end ? `${start}` : `${start}-${end}`);
+  return ranges;
+}
+
+function loadCoverageFile(coverageDir: string): CoverageData | null {
+  const coverageFile = upath.resolve(coverageDir, 'coverage-final.json');
+  if (!fs.existsSync(coverageFile)) {
+    return null;
+  }
+
+  try {
+    const rawJson: unknown = JSON.parse(fs.readFileSync(coverageFile, 'utf8'));
+    const parseResult = CoverageJson.safeParse(rawJson);
+    return parseResult.success ? parseResult.data : null;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeCoveragePaths(
+  data: CoverageData,
+): Map<string, CoverageData[string]> {
+  const normalized = new Map<string, CoverageData[string]>();
+  for (const [key, value] of Object.entries(data)) {
+    normalized.set(upath.normalize(key), value);
+  }
+  return normalized;
+}
+
+function isSourceFile(path: string): boolean {
+  return path.endsWith('.ts') && !path.endsWith('.spec.ts');
+}
+
+function extractFileCoverage(
+  file: string,
+  coverage: Map<string, CoverageData[string]>,
+): CoverageInfo | null {
+  const absPath = upath.resolve(process.cwd(), file);
+  const entry = coverage.get(absPath);
+  if (!entry) {
+    return null;
+  }
+
+  const { statementMap, s: statementCoverage } = entry;
+  const totalStatements = Object.keys(statementMap).length;
+  if (totalStatements === 0) {
+    return null;
+  }
+
+  const coveredStatements = Object.values(statementCoverage).filter(
+    (count) => count > 0,
+  ).length;
+  const percentage = (coveredStatements / totalStatements) * 100;
+
+  if (percentage >= 100) {
+    return null;
+  }
+
+  const uncoveredLineSet = new Set<number>();
+  for (const [stmtId, count] of Object.entries(statementCoverage)) {
+    if (count !== 0) {
+      continue;
+    }
+
+    const stmt = statementMap[stmtId];
+    if (!stmt) {
+      continue;
+    }
+
+    for (let line = stmt.start.line; line <= stmt.end.line; line++) {
+      uncoveredLineSet.add(line);
+    }
+  }
+
+  return {
+    file,
+    percentage,
+    uncoveredLines: groupConsecutiveNumbers(Array.from(uncoveredLineSet)),
+  };
+}
+
+export function parseCoverageJson(
+  coverageDir: string,
+  changedFiles: string[],
+): CoverageInfo[] {
+  const data = loadCoverageFile(coverageDir);
+  if (!data) {
+    return [];
+  }
+
+  const normalized = normalizeCoveragePaths(data);
+  const results: CoverageInfo[] = [];
+
+  for (const file of changedFiles) {
+    if (!isSourceFile(file)) {
+      continue;
+    }
+    const info = extractFileCoverage(file, normalized);
+    if (info) {
+      results.push(info);
+    }
+  }
+
+  return results;
+}

--- a/tools/check/execution.ts
+++ b/tools/check/execution.ts
@@ -1,0 +1,61 @@
+import { execa } from 'execa';
+import { formatCompletedLine, isTTY } from './tui.js';
+import type {
+  CheckResult,
+  ExecutionProgress,
+  ParallelCheck,
+  ProcessManager,
+} from './types.js';
+
+export async function runCommand(
+  cmd: string,
+  args: string[],
+  processManager: ProcessManager,
+  env?: Record<string, string>,
+): Promise<{ success: boolean; output: string }> {
+  const subprocess = execa(cmd, args, {
+    env,
+    signal: processManager.abortController.signal,
+    all: true,
+    reject: false,
+  });
+  processManager.subprocesses.add(subprocess);
+
+  const result = await subprocess;
+  processManager.subprocesses.delete(subprocess);
+  return { success: result.exitCode === 0, output: result.all ?? '' };
+}
+
+export async function runChecksParallel(
+  checks: ParallelCheck[],
+  resultOffset: number,
+  progress: ExecutionProgress,
+  processManager: ProcessManager,
+): Promise<void> {
+  await Promise.all(
+    checks.map(async (check, idx) => {
+      progress.startedIndices.add(resultOffset + idx);
+      const start = Date.now();
+      const { success, output } = await runCommand(
+        check.cmd,
+        check.args,
+        processManager,
+      );
+      const duration = (Date.now() - start) / 1000;
+
+      const result: CheckResult = {
+        name: check.name,
+        success,
+        duration,
+        output,
+      };
+      progress.results[resultOffset + idx] = { result };
+
+      if (!isTTY) {
+        console.log(
+          formatCompletedLine(result.name, result.success, result.duration),
+        );
+      }
+    }),
+  );
+}

--- a/tools/check/git.ts
+++ b/tools/check/git.ts
@@ -1,0 +1,50 @@
+import { execa } from 'execa';
+
+async function getGitFiles(args: string[]): Promise<string[]> {
+  try {
+    const result = await execa('git', args);
+    return result.stdout
+      .trim()
+      .split('\n')
+      .filter((f) => f);
+  } catch {
+    return [];
+  }
+}
+
+async function getMergeBase(base: string): Promise<string> {
+  try {
+    const result = await execa('git', ['merge-base', base, 'HEAD']);
+    return result.stdout.trim();
+  } catch {
+    return base;
+  }
+}
+
+export async function getChangedFiles(base: string): Promise<string[]> {
+  const files = new Set<string>();
+
+  // Find where we branched from (merge-base), not current base HEAD
+  const mergeBase = await getMergeBase(base);
+
+  // Committed changes since branching from base
+  for (const f of await getGitFiles(['diff', '--name-only', mergeBase])) {
+    files.add(f);
+  }
+
+  // Uncommitted changes (staged + unstaged)
+  for (const f of await getGitFiles(['diff', '--name-only', 'HEAD'])) {
+    files.add(f);
+  }
+
+  // Untracked files (new files not yet added to git)
+  for (const f of await getGitFiles([
+    'ls-files',
+    '--others',
+    '--exclude-standard',
+  ])) {
+    files.add(f);
+  }
+
+  return Array.from(files);
+}

--- a/tools/check/index.ts
+++ b/tools/check/index.ts
@@ -1,0 +1,257 @@
+/**
+ * Fast local CI check script
+ *
+ * Usage: pnpm check [options]
+ *
+ * Options:
+ *   --no-fix          Skip auto-fix (eslint-fix, prettier-fix)
+ *   --no-test         Skip tests
+ *   --full            Run full vitest instead of only affected shards
+ *   --base <branch>   Compare against different base branch (default: main)
+ */
+
+import { parseArgs } from 'node:util';
+import {
+  TOTAL_SHARDS,
+  getMatchingShards,
+  getTestPatternsForShards,
+} from '../test-shards.js';
+import { parseCoverageJson } from './coverage.js';
+import { runChecksParallel, runCommand } from './execution.js';
+import { getChangedFiles } from './git.js';
+import {
+  ANSI,
+  formatCompletedLine,
+  formatDuration,
+  formatWaitingLine,
+  isTTY,
+  printCoverageReport,
+  printFailedOutputs,
+  renderFinalState,
+  renderProgress,
+  startRenderLoop,
+  stopRenderLoop,
+} from './tui.js';
+import type {
+  CheckResult,
+  CheckResultWithCoverage,
+  CliArgs,
+  ExecutionProgress,
+  ParallelCheck,
+  ProcessManager,
+} from './types.js';
+
+// Module-level state for signal handler (set by main, checked by handler)
+let currentProgress: ExecutionProgress | null = null;
+let currentProcessManager: ProcessManager | null = null;
+
+function handleSigint(): void {
+  if (currentProcessManager) {
+    currentProcessManager.abortController.abort();
+
+    for (const proc of currentProcessManager.subprocesses) {
+      proc.kill('SIGTERM');
+    }
+    currentProcessManager.subprocesses.clear();
+
+    stopRenderLoop(currentProcessManager);
+  }
+
+  if (currentProgress) {
+    renderFinalState(currentProgress, true);
+  }
+
+  if (isTTY) {
+    process.stdout.write(ANSI.SHOW_CURSOR);
+  }
+  process.exit(130);
+}
+
+// Register signal handler at module load (like original)
+process.on('SIGINT', handleSigint);
+
+function pnpmScript(name: string): ParallelCheck {
+  return { name, cmd: 'pnpm', args: [name] };
+}
+
+const FIX_CHECKS = ['oxlint-fix', 'eslint-fix', 'prettier-fix'].map(pnpmScript);
+const FIXABLE_CHECKS = ['oxlint', 'eslint', 'prettier'].map(pnpmScript);
+const OTHER_CHECKS = [
+  'ls-lint',
+  'git-check',
+  'markdown-lint',
+  'doc-fence-check',
+  'lint-documentation',
+  'lint-other',
+  'test-schema',
+  'type-check',
+].map(pnpmScript);
+
+function parseCliArgs(): CliArgs {
+  const { values } = parseArgs({
+    options: {
+      'no-fix': { type: 'boolean', default: false },
+      'no-test': { type: 'boolean', default: false },
+      full: { type: 'boolean', default: false },
+      base: { type: 'string', default: 'main' },
+    },
+  });
+
+  return {
+    noFix: values['no-fix'] ?? false,
+    noTest: values['no-test'] ?? false,
+    full: values.full ?? false,
+    base: values.base ?? 'main',
+  };
+}
+
+function buildTestChecks(
+  args: CliArgs,
+  changedFiles: string[],
+): ParallelCheck[] {
+  if (args.noTest) {
+    return [];
+  }
+
+  if (args.full) {
+    return [{ name: 'test (all)', cmd: 'pnpm', args: ['vitest'] }];
+  }
+
+  const shardsToRun = getMatchingShards(changedFiles);
+  if (shardsToRun.length === 0) {
+    return [];
+  }
+
+  const patterns = getTestPatternsForShards(shardsToRun);
+  const n = shardsToRun.length;
+
+  if (n === TOTAL_SHARDS) {
+    return [{ name: 'test (all)', cmd: 'pnpm', args: ['vitest'] }];
+  }
+
+  const name = `test (${n} ${n === 1 ? 'shard' : 'shards'})`;
+  return [{ name, cmd: 'pnpm', args: ['vitest', ...patterns] }];
+}
+
+async function main(): Promise<void> {
+  const startTime = Date.now();
+  const args = parseCliArgs();
+  const changedFiles = await getChangedFiles(args.base);
+
+  const testChecks = buildTestChecks(args, changedFiles);
+
+  // Fix checks run sequentially first (eslint-fix, prettier-fix)
+  // When skipped, we run the non-fix variants (eslint, prettier) in parallel
+  const fixChecks: ParallelCheck[] = args.noFix ? [] : [...FIX_CHECKS];
+  const lintChecks: ParallelCheck[] = [
+    ...(args.noFix ? FIXABLE_CHECKS : []),
+    ...OTHER_CHECKS,
+  ];
+
+  const allChecks = [...fixChecks, ...lintChecks, ...testChecks];
+
+  const processManager: ProcessManager = {
+    subprocesses: new Set(),
+    abortController: new AbortController(),
+    renderInterval: null,
+  };
+
+  const progress: ExecutionProgress = {
+    startTime,
+    checks: allChecks,
+    results: allChecks.map(() => null),
+    startedIndices: new Set(),
+    spinnerFrame: 0,
+    displayLines: allChecks.length + 2,
+  };
+
+  // Set module-level state for signal handler
+  currentProgress = progress;
+  currentProcessManager = processManager;
+
+  console.log('Checks:');
+
+  if (isTTY) {
+    process.stdout.write(ANSI.HIDE_CURSOR);
+    for (const check of allChecks) {
+      console.log(formatWaitingLine(check.name));
+    }
+    console.log('');
+    console.log('Total: 0s');
+  }
+
+  startRenderLoop(progress, processManager);
+
+  // Fix checks run sequentially
+  for (let i = 0; i < fixChecks.length; i++) {
+    const check = fixChecks[i];
+    progress.startedIndices.add(i);
+
+    const checkStart = Date.now();
+    const { success, output } = await runCommand(
+      check.cmd,
+      check.args,
+      processManager,
+    );
+    const duration = (Date.now() - checkStart) / 1000;
+    const result: CheckResult = { name: check.name, success, duration, output };
+    progress.results[i] = { result };
+
+    if (!isTTY) {
+      console.log(formatCompletedLine(check.name, success, duration));
+    }
+  }
+
+  // Run all lint checks in parallel
+  await runChecksParallel(
+    lintChecks,
+    fixChecks.length,
+    progress,
+    processManager,
+  );
+
+  // Run tests (single vitest process)
+  if (testChecks.length > 0) {
+    await runChecksParallel(
+      testChecks,
+      fixChecks.length + lintChecks.length,
+      progress,
+      processManager,
+    );
+  }
+
+  stopRenderLoop(processManager);
+  renderProgress(progress);
+
+  const allResults = progress.results.filter(
+    (r): r is CheckResultWithCoverage => r !== null,
+  );
+  const hasFailure = allResults.some((r) => !r.result.success);
+
+  // Parse coverage for changed files with gaps
+  const coverage =
+    testChecks.length > 0 ? parseCoverageJson('./coverage', changedFiles) : [];
+
+  printCoverageReport(coverage);
+  printFailedOutputs(progress.results);
+
+  if (isTTY) {
+    process.stdout.write(ANSI.SHOW_CURSOR);
+  } else {
+    const totalDuration = (Date.now() - startTime) / 1000;
+    console.log('');
+    console.log(`Total: ${formatDuration(totalDuration)}`);
+  }
+
+  if (hasFailure) {
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  if (isTTY) {
+    process.stdout.write(ANSI.SHOW_CURSOR);
+  }
+  console.error(err);
+  process.exit(1);
+});

--- a/tools/check/test-filter.ts
+++ b/tools/check/test-filter.ts
@@ -1,0 +1,41 @@
+const TEST_OUTPUT_MARKERS = [
+  '❯',
+  'FAIL',
+  '×',
+  'Test Files',
+  'Tests',
+  'Start at',
+  'Duration',
+  '⎯',
+  'Error',
+  'expected',
+  'Received',
+  'Expected',
+];
+
+function isRelevantTestLine(line: string): boolean {
+  return TEST_OUTPUT_MARKERS.some((marker) => line.includes(marker));
+}
+
+export function filterTestOutput(output: string): string {
+  const lines = output.split('\n');
+  const filtered: string[] = [];
+  let capturing = false;
+
+  for (const line of lines) {
+    if (line.includes('✓') && !line.includes('failed')) {
+      capturing = false;
+      continue;
+    }
+
+    if (isRelevantTestLine(line)) {
+      capturing = true;
+    }
+
+    if (capturing || line.trim() === '') {
+      filtered.push(line);
+    }
+  }
+
+  return filtered.join('\n').trim();
+}

--- a/tools/check/tui.ts
+++ b/tools/check/tui.ts
@@ -1,0 +1,200 @@
+import { styleText } from 'node:util';
+import { filterTestOutput } from './test-filter.js';
+import type {
+  CheckResultWithCoverage,
+  CoverageInfo,
+  ExecutionProgress,
+  ProcessManager,
+} from './types.js';
+
+export const TUI = {
+  NAME_WIDTH: 36,
+  LINE_WIDTH: 50,
+  SPINNER_MS: 80,
+} as const;
+
+export const ANSI = {
+  moveUp: (n: number): string => `\x1b[${n}A`,
+  HIDE_CURSOR: '\x1b[?25l',
+  SHOW_CURSOR: '\x1b[?25h',
+} as const;
+
+const ICONS = {
+  WAITING: '⏳',
+  SPINNER: ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'] as const,
+} as const;
+
+export const isTTY = process.stdout.isTTY ?? false;
+
+export function formatCompletedLine(
+  name: string,
+  success: boolean,
+  duration: number,
+): string {
+  const nameCol = `${name} `.padEnd(TUI.NAME_WIDTH, '.');
+  const status = success ? styleText('green', '✓') : styleText('red', '✗');
+  const secs = String(Math.round(duration)).padStart(3);
+  // Visible: "  " + name(36) + " " + icon + " " + secs(3) + "s" = 45
+  return `  ${nameCol} ${status} ${secs}s` + ' '.repeat(TUI.LINE_WIDTH - 45);
+}
+
+export function formatWaitingLine(name: string): string {
+  const nameCol = `${name} `.padEnd(TUI.NAME_WIDTH, '.');
+  // Visible: "  " + name(36) + " " + icon = 40
+  return `  ${nameCol} ${ICONS.WAITING}` + ' '.repeat(TUI.LINE_WIDTH - 40);
+}
+
+function formatRunningLine(name: string, spinner: string): string {
+  const nameCol = `${name} `.padEnd(TUI.NAME_WIDTH, '.');
+  // Visible: "  " + name(36) + " " + spinner = 40
+  return `  ${nameCol} ${spinner}` + ' '.repeat(TUI.LINE_WIDTH - 40);
+}
+
+function formatInterruptedLine(name: string): string {
+  const nameCol = `${name} `.padEnd(TUI.NAME_WIDTH, '.');
+  // Visible: "  " + name(36) + " " + "-" = 40
+  return `  ${nameCol} -` + ' '.repeat(TUI.LINE_WIDTH - 40);
+}
+
+export function formatDuration(seconds: number): string {
+  return `${Math.round(seconds)}s`;
+}
+
+export function renderProgress(progress: ExecutionProgress): void {
+  if (!isTTY) {
+    return;
+  }
+
+  const spinner = ICONS.SPINNER[progress.spinnerFrame];
+  const elapsed = Math.round((Date.now() - progress.startTime) / 1000);
+
+  const lines: string[] = [];
+  for (let i = 0; i < progress.checks.length; i++) {
+    const entry = progress.results[i];
+    if (entry) {
+      lines.push(
+        formatCompletedLine(
+          entry.result.name,
+          entry.result.success,
+          entry.result.duration,
+        ),
+      );
+    } else if (progress.startedIndices.has(i)) {
+      lines.push(formatRunningLine(progress.checks[i].name, spinner));
+    } else {
+      lines.push(formatWaitingLine(progress.checks[i].name));
+    }
+  }
+  lines.push(' '.repeat(TUI.LINE_WIDTH));
+  lines.push(`Total: ${elapsed}s`.padEnd(TUI.LINE_WIDTH));
+
+  const frame =
+    ANSI.moveUp(progress.displayLines) + '\r' + lines.join('\n') + '\n';
+  process.stdout.write(frame);
+}
+
+export function renderFinalState(
+  progress: ExecutionProgress,
+  interrupted: boolean,
+): void {
+  if (!isTTY) {
+    return;
+  }
+
+  const lines: string[] = [];
+  for (let i = 0; i < progress.checks.length; i++) {
+    const entry = progress.results[i];
+    if (entry) {
+      lines.push(
+        formatCompletedLine(
+          entry.result.name,
+          entry.result.success,
+          entry.result.duration,
+        ),
+      );
+    } else {
+      lines.push(formatInterruptedLine(progress.checks[i].name));
+    }
+  }
+
+  while (lines.length < progress.displayLines) {
+    lines.push(' '.repeat(TUI.LINE_WIDTH));
+  }
+
+  const frame =
+    ANSI.moveUp(progress.displayLines) + '\r' + lines.join('\n') + '\n';
+  process.stdout.write(frame);
+
+  if (interrupted) {
+    printFailedOutputs(progress.results);
+    const totalDuration = (Date.now() - progress.startTime) / 1000;
+    console.log('');
+    console.log(`Total: ${formatDuration(totalDuration)} (interrupted)`);
+  }
+}
+
+export function startRenderLoop(
+  progress: ExecutionProgress,
+  processManager: ProcessManager,
+): void {
+  if (!isTTY) {
+    return;
+  }
+  processManager.renderInterval = setInterval(() => {
+    progress.spinnerFrame = (progress.spinnerFrame + 1) % ICONS.SPINNER.length;
+    renderProgress(progress);
+  }, TUI.SPINNER_MS);
+}
+
+export function stopRenderLoop(processManager: ProcessManager): void {
+  if (processManager.renderInterval) {
+    clearInterval(processManager.renderInterval);
+    processManager.renderInterval = null;
+  }
+}
+
+export function printFailedOutputs(
+  results: (CheckResultWithCoverage | null)[],
+): void {
+  for (const entry of results) {
+    if (!entry || entry.result.success || !entry.result.output.trim()) {
+      continue;
+    }
+    let filteredOutput = entry.result.output;
+    if (entry.result.name.startsWith('test')) {
+      const filtered = filterTestOutput(entry.result.output);
+      if (filtered) {
+        filteredOutput = filtered;
+      }
+    }
+    console.log('');
+    console.log(`--- ${entry.result.name} output ---`);
+    console.log(filteredOutput);
+    console.log(`--- end ${entry.result.name} ---`);
+  }
+}
+
+export function printCoverageReport(coverage: CoverageInfo[]): void {
+  if (coverage.length === 0) {
+    return;
+  }
+
+  console.log('Coverage:');
+
+  const minDots = 3;
+  const longestPath = Math.max(...coverage.map((c) => c.file.length));
+  const coverageWidth = Math.max(TUI.NAME_WIDTH, longestPath + 1 + minDots);
+
+  for (const info of coverage) {
+    const pct = Math.round(info.percentage);
+    const hasGaps = info.uncoveredLines.length > 0;
+    const status = hasGaps ? '✗' : '✓';
+    const nameCol = `${info.file} `.padEnd(coverageWidth, '.');
+    console.log(`  ${nameCol} ${status}  ${pct}%`);
+
+    if (hasGaps) {
+      const lineRefs = info.uncoveredLines.map((l) => `L${l}`).join(', ');
+      console.log(`    ${lineRefs}`);
+    }
+  }
+}

--- a/tools/check/types.ts
+++ b/tools/check/types.ts
@@ -1,0 +1,47 @@
+import type { ExecaChildProcess } from 'execa';
+
+export interface CliArgs {
+  noFix: boolean;
+  noTest: boolean;
+  full: boolean;
+  base: string;
+}
+
+export interface ParallelCheck {
+  name: string;
+  cmd: string;
+  args: string[];
+}
+
+export interface CheckResult {
+  name: string;
+  success: boolean;
+  duration: number;
+  output: string;
+}
+
+export interface CoverageInfo {
+  file: string;
+  percentage: number;
+  uncoveredLines: string[];
+}
+
+export interface CheckResultWithCoverage {
+  result: CheckResult;
+  coverage?: CoverageInfo[];
+}
+
+export interface ProcessManager {
+  subprocesses: Set<ExecaChildProcess>;
+  abortController: AbortController;
+  renderInterval: ReturnType<typeof setInterval> | null;
+}
+
+export interface ExecutionProgress {
+  startTime: number;
+  checks: readonly ParallelCheck[];
+  results: (CheckResultWithCoverage | null)[];
+  startedIndices: Set<number>;
+  spinnerFrame: number;
+  displayLines: number;
+}

--- a/tools/publish-release.ts
+++ b/tools/publish-release.ts
@@ -22,7 +22,10 @@ const program = new Command('pnpm release:prepare')
 void (async () => {
   await program.parseAsync();
   const opts = program.opts();
-  logger.info(`Publishing v${opts.version}...`);
+  if (!opts.version) {
+    throw new Error('--version is required');
+  }
+  logger.info(`Publishing v${opts.version.toString()}...`);
   const meta = await bake('push', opts);
 
   if (meta?.['push-slim']?.['containerimage.digest']) {

--- a/tools/test-shards.ts
+++ b/tools/test-shards.ts
@@ -1,21 +1,32 @@
 import crypto from 'node:crypto';
+import { globSync } from 'glob';
 import { minimatch } from 'minimatch';
 import { testShards } from './test/shards';
 import type { RunsOn, ShardGroup } from './test/types';
 
+const TOTAL_SHARDS = Object.keys(testShards).length;
+
+function toMatchPattern(path: string): string {
+  return path.endsWith('.spec.ts')
+    ? path.replace(/\.spec\.ts$/, '{.ts,.spec.ts}')
+    : `${path}/**/*`;
+}
+
 /**
  * Given the file list affected by commit, return the list
- * of shards that  test these changes.
+ * of shards that test these changes.
+ *
+ * Exported for reuse in local-ci tooling.
  */
-function getMatchingShards(files: string[]): string[] {
+export function getMatchingShards(files: string[]): string[] {
   const matchingShards = new Set<string>();
   for (const file of files) {
+    // Only lib/ files can match test shards
+    if (!file.startsWith('lib/')) {
+      continue;
+    }
     for (const [key, { matchPaths }] of Object.entries(testShards)) {
-      const patterns = matchPaths.map((path) =>
-        path.endsWith('.spec.ts')
-          ? path.replace(/\.spec\.ts$/, '{.ts,.spec.ts}')
-          : `${path}/**/*`,
-      );
+      const patterns = matchPaths.map(toMatchPattern);
 
       if (patterns.some((pattern) => minimatch(file, pattern))) {
         matchingShards.add(key);
@@ -25,6 +36,37 @@ function getMatchingShards(files: string[]): string[] {
   }
 
   return Object.keys(testShards).filter((shard) => matchingShards.has(shard));
+}
+
+export { TOTAL_SHARDS };
+
+/**
+ * Convert shard names to vitest-compatible test file patterns.
+ *
+ * Vitest CLI filters are substring/regex matches, not globs.
+ * This expands glob patterns (like [a-c]*) into actual paths.
+ */
+export function getTestPatternsForShards(shardNames: string[]): string[] {
+  const patterns: string[] = [];
+  for (const name of shardNames) {
+    const shard = testShards[name];
+    for (const path of shard.matchPaths) {
+      // Specific .spec.ts files pass through directly
+      if (path.endsWith('.spec.ts')) {
+        patterns.push(path);
+        continue;
+      }
+
+      const isGlobPattern = path.includes('[') || path.includes('*');
+      if (isGlobPattern) {
+        const expanded = globSync(path, { nodir: false });
+        patterns.push(...expanded);
+      } else {
+        patterns.push(path);
+      }
+    }
+  }
+  return patterns;
 }
 
 /**
@@ -54,90 +96,100 @@ function scheduleItems<T>(items: T[], availableInstances: number): T[][] {
   return result;
 }
 
-let shardKeys = Object.keys(testShards);
+/**
+ * Main function for CI shard scheduling.
+ * Only runs when SCHEDULE_TEST_SHARDS=true is set.
+ */
+function main(): void {
+  let shardKeys = Object.keys(testShards);
 
-if (process.env.FILTER_SHARDS === 'true' && process.env.CHANGED_FILES) {
-  try {
-    const changedFiles: string[] = JSON.parse(process.env.CHANGED_FILES);
-    const matchingShards = getMatchingShards(changedFiles);
-    if (matchingShards.length === 0) {
-      console.log(`test-matrix-empty=true`);
-      process.exit(0);
+  if (process.env.FILTER_SHARDS === 'true' && process.env.CHANGED_FILES) {
+    try {
+      const changedFiles: string[] = JSON.parse(process.env.CHANGED_FILES);
+      const matchingShards = getMatchingShards(changedFiles);
+      if (matchingShards.length === 0) {
+        console.log(`test-matrix-empty=true`);
+        process.exit(0);
+      }
+      shardKeys = shardKeys.filter((key) => matchingShards.includes(key));
+    } catch (err) {
+      console.error(err);
+      process.exit(1);
     }
-    shardKeys = shardKeys.filter((key) => matchingShards.includes(key));
-  } catch (err) {
-    console.error(err);
-    process.exit(1);
   }
-}
 
-/**
- * Not all runners are created equal.
- * Minutes cost proportion is 1:2:10 for Ubuntu:Windows:MacOS.
- *
- * Although it's free in our case,
- * we can't run as many Windows and MacOS runners as we want.
- *
- * Because of this, we partition shards into groups, given that:
- * - There are 16 shards in total
- * - We can't run more than 10 Windows runners
- * - We can't run more than 5 MacOS runners
- */
-const shardGrouping: Record<string, string[][]> = {
-  'ubuntu-latest': scheduleItems(shardKeys, 16),
-};
+  /**
+   * Not all runners are created equal.
+   * Minutes cost proportion is 1:2:10 for Ubuntu:Windows:MacOS.
+   *
+   * Although it's free in our case,
+   * we can't run as many Windows and MacOS runners as we want.
+   *
+   * Because of this, we partition shards into groups, given that:
+   * - There are 16 shards in total
+   * - We can't run more than 10 Windows runners
+   * - We can't run more than 5 MacOS runners
+   */
+  const shardGrouping: Record<string, string[][]> = {
+    'ubuntu-latest': scheduleItems(shardKeys, 16),
+  };
 
-if (process.env.ALL_PLATFORMS === 'true') {
-  // shardGrouping['windows-latest'] = scheduleItems(shardKeys, 8);
-  shardGrouping['macos-latest'] = scheduleItems(shardKeys, 4);
-}
-
-const shardGroups: ShardGroup[] = [];
-for (const [os, groups] of Object.entries(shardGrouping)) {
-  const coverage = os === 'ubuntu-latest';
-
-  const total = groups.length;
-  for (let idx = 0; idx < groups.length; idx += 1) {
-    const number = idx + 1;
-    const platform = os.replace(/-latest$/, '');
-    const name =
-      platform === 'ubuntu'
-        ? `test (${number}/${total})`
-        : `test-${platform} (${number}/${total})`;
-
-    const shards = groups[idx];
-    const cacheKey = crypto
-      .createHash('md5')
-      .update(shards.join(':'))
-      .digest('hex');
-
-    const runnerTimeoutMinutes =
-      {
-        ubuntu: 10,
-        windows: 20,
-        macos: 20,
-      }[platform] ?? 20;
-
-    const testTimeoutMilliseconds =
-      {
-        windows: 240000,
-      }[platform] ?? 120000;
-
-    shardGroups.push({
-      os: os as RunsOn,
-      coverage,
-      name,
-      shards: shards.join(' '),
-      'cache-key': cacheKey,
-      'runner-timeout-minutes': runnerTimeoutMinutes,
-      'test-timeout-milliseconds': testTimeoutMilliseconds,
-      'upload-artifact-name': `coverage-${shards.sort().join('_')}`,
-    });
+  if (process.env.ALL_PLATFORMS === 'true') {
+    // shardGrouping['windows-latest'] = scheduleItems(shardKeys, 8);
+    shardGrouping['macos-latest'] = scheduleItems(shardKeys, 4);
   }
+
+  const shardGroups: ShardGroup[] = [];
+  for (const [os, groups] of Object.entries(shardGrouping)) {
+    const coverage = os === 'ubuntu-latest';
+
+    const total = groups.length;
+    for (let idx = 0; idx < groups.length; idx += 1) {
+      const number = idx + 1;
+      const platform = os.replace(/-latest$/, '');
+      const name =
+        platform === 'ubuntu'
+          ? `test (${number}/${total})`
+          : `test-${platform} (${number}/${total})`;
+
+      const shards = groups[idx];
+      const cacheKey = crypto
+        .createHash('md5')
+        .update(shards.join(':'))
+        .digest('hex');
+
+      const runnerTimeoutMinutes =
+        {
+          ubuntu: 10,
+          windows: 20,
+          macos: 20,
+        }[platform] ?? 20;
+
+      const testTimeoutMilliseconds =
+        {
+          windows: 240000,
+        }[platform] ?? 120000;
+
+      shardGroups.push({
+        os: os as RunsOn,
+        coverage,
+        name,
+        shards: shards.join(' '),
+        'cache-key': cacheKey,
+        'runner-timeout-minutes': runnerTimeoutMinutes,
+        'test-timeout-milliseconds': testTimeoutMilliseconds,
+        'upload-artifact-name': `coverage-${shards.sort().join('_')}`,
+      });
+    }
+  }
+
+  /**
+   * Output will be consumed by `setup` CI job.
+   */
+  console.log(`test-shard-matrix=${JSON.stringify(shardGroups)}`);
 }
 
-/**
- * Output will be consumed by `setup` CI job.
- */
-
-console.log(`test-shard-matrix=${JSON.stringify(shardGroups)}`);
+// Only run main when invoked as a script (not when imported)
+if (process.env.SCHEDULE_TEST_SHARDS === 'true') {
+  main();
+}


### PR DESCRIPTION
## Changes

Add `pnpm check` - a fast local CI script.

**Features:**
- Runs eslint-fix and prettier-fix first, then all other checks in parallel
- Only runs test shards affected by changed files (via `git diff` against base)
- Live terminal updates with spinners and progress timer
- Shows coverage gaps for changed files (only for full test runs, to avoid false positives)
- Graceful SIGINT handling with partial results

**Options:**
- `--no-fix` - Skip auto-fix (eslint-fix, prettier-fix)
- `--no-test` - Skip tests
- `--full` - Run full vitest instead of only affected shards
- `--base <branch>` - Compare against different base (default: main)

```
❯ pnpm check
Checks:
  eslint-fix ......................... ✓   2s
  prettier-fix ....................... ✓   2s
  ls-lint ............................ ✓   1s
  git-check .......................... ✓   1s
  markdown-lint ...................... ✓   3s
  doc-fence-check .................... ✓   5s
  lint-documentation ................. ✓   7s
  lint-other ......................... ✓   2s
  test-schema ........................ ✓   6s
  type-check ......................... ✓  20s

Total: 24s
```

## Context

- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).

## Documentation (please check one with an [x])

- [x] I have updated the documentation

## How I've tested my work (please select one)

- [x] Code inspection only