### PR TITLE
refactor(tools): reduce noise in generate-imports script

### DIFF
--- a/tools/generate-imports.mjs
+++ b/tools/generate-imports.mjs
@@ -4,16 +4,13 @@ import { minimatch } from 'minimatch';
 import upath from 'upath';
 import { hashFile, hashFromArray } from './utils/hash.mjs';
 
-console.log('generating imports');
 const newFiles = new Set();
 
 if (!fs.existsSync('lib')) {
-  console.log('> missing sources');
   process.exit(0);
 }
 
 if (!fs.existsSync('data')) {
-  console.log('> missing data folder');
   process.exit(0);
 }
 
@@ -126,7 +123,6 @@ async function generateData() {
     const rawFileContent = await fs.readFile(file, 'utf8');
     const value = JSON.stringify(rawFileContent);
 
-    console.log(`> ${key}`);
     contentMapAssignments.push(`data.set('${key}', ${value});`);
   }
 
@@ -161,7 +157,6 @@ export type ManagerName = typeof AllManagersListLiteral[number];
 }
 
 async function generateHash() {
-  console.log('generating hashes');
   try {
     const hashMap = `export const hashMap = new Map<string, string>();`;
     /** @type {Record<string, string>[]} */
@@ -201,7 +196,7 @@ async function generateHash() {
       [hashMap, hashStrings.join('\n')].join('\n\n'),
     );
   } catch (err) {
-    console.log('ERROR:', err.message);
+    console.error(err);
     process.exit(1);
   }
 }
@@ -220,8 +215,8 @@ await (async () => {
           await fs.remove(file);
         }),
     );
-  } catch (e) {
-    console.log(e.toString());
+  } catch (err) {
+    console.error(err);
     process.exit(1);
   }
 })();


### PR DESCRIPTION
## Changes

Remove verbose console.log statements from `generate-imports.mjs` to reduce noise during build process. Use `console.error` for actual error messages.

## Context

- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).

## Documentation (please check one with an [x])

- [x] No documentation update is required

## How I've tested my work (please select one)

- [x] Code inspection only