### PR TITLE
refactor(platform/local): use shared `rawExec` for commands

### DIFF
--- a/lib/modules/platform/local/scm.spec.ts
+++ b/lib/modules/platform/local/scm.spec.ts
@@ -1,11 +1,13 @@
-import { execSync as _execSync } from 'node:child_process';
+import { rawExec as _rawExec } from '../../../util/exec/common';
+import type { ExecResult } from '../../../util/exec/types';
 import { LocalFs } from './scm';
+import { partial } from '~test/util';
 
 vi.mock('glob', () => ({
   glob: vi.fn().mockImplementation(() => Promise.resolve(['file1', 'file2'])),
 }));
-vi.mock('node:child_process');
-const execSync = vi.mocked(_execSync);
+vi.mock('../../../util/exec/common');
+const execSync = vi.mocked(_rawExec);
 
 describe('modules/platform/local/scm', () => {
   let localFs: LocalFs;
@@ -50,7 +52,13 @@ describe('modules/platform/local/scm', () => {
 
   describe('getFileList', () => {
     it('should return file list using git', async () => {
-      execSync.mockReturnValueOnce('file1\nfile2');
+      execSync.mockReturnValueOnce(
+        Promise.resolve(
+          partial<ExecResult>({
+            stdout: 'file1\nfile2',
+          }),
+        ),
+      );
       expect(await localFs.getFileList()).toHaveLength(2);
 
       expect(execSync).toHaveBeenCalledExactlyOnceWith('git ls-files', {

--- a/lib/modules/platform/local/scm.ts
+++ b/lib/modules/platform/local/scm.ts
@@ -1,6 +1,6 @@
-import { execSync } from 'node:child_process';
 import { glob } from 'glob';
 import { logger } from '../../../logger';
+import { rawExec } from '../../../util/exec/common';
 import type { CommitFilesConfig, LongCommitSha } from '../../../util/git/types';
 import type { PlatformScm } from '../types';
 
@@ -34,7 +34,9 @@ export class LocalFs implements PlatformScm {
     try {
       // fetch file list using git
       const maxBuffer = 10 * 1024 * 1024; // 10 MiB in bytes
-      const stdout = execSync('git ls-files', { encoding: 'utf-8', maxBuffer });
+      const stdout = (
+        await rawExec('git ls-files', { encoding: 'utf-8', maxBuffer })
+      ).stdout;
       logger.debug('Got file list using git');
       fileList = stdout.split('\n');
     } catch {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
Otherwise we miss out on instrumentation, and it makes it more difficult
to centrally change configuration.

## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

Tested with this repo:

```sh
npm run compile:ts
node dist/renovate.js --platform local
```

And saw no impact to running against the repo to extract files

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
