### PR TITLE
feat(github-actions): Support digests for non-semver refs

### DIFF
--- a/lib/modules/manager/github-actions/__fixtures__/workflow_4.yml
+++ b/lib/modules/manager/github-actions/__fixtures__/workflow_4.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/checkout@1e204e9a9253d643386038d443f96446fa156a97 #v2.1.0
       - uses: actions/checkout@1e204e9a9253d643386038d443f96446fa156a97 #v2.1.0
       - uses: actions/checkout@1e204e # v2.1.0
+      - uses: actions/checkout@1e204e # some-ref-name
       - uses: actions/checkout@01aecc#v2.1.0
       - uses: actions/checkout@689fcce700ae7ffc576f2b029b51b2ffb66d3abd # comment containing 2.1.0
       - uses: actions/checkout@689fcce700ae7ffc576f2b029b51b2ffb66d3abd # v2.1.0 additional comment

--- a/lib/modules/manager/github-actions/__snapshots__/extract.spec.ts.snap
+++ b/lib/modules/manager/github-actions/__snapshots__/extract.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`modules/manager/github-actions/extract > extractPackageFile() > extracts multiple action tag lines from yaml configuration file 1`] = `
 [
   {
-    "autoReplaceStringTemplate": "{{depName}}/shellcheck@{{#if newDigest}}{{newDigest}}{{#if newValue}} # ref={{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}",
+    "autoReplaceStringTemplate": "{{depName}}/shellcheck@{{#if newDigest}}{{newDigest}}{{#if newValue}} # {{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}",
     "commitMessageTopic": "{{{depName}}} action",
     "currentValue": "master",
     "datasource": "github-digest",
@@ -119,7 +119,7 @@ exports[`modules/manager/github-actions/extract > extractPackageFile() > extract
 exports[`modules/manager/github-actions/extract > extractPackageFile() > extracts multiple docker image lines from yaml configuration file 1`] = `
 [
   {
-    "autoReplaceStringTemplate": "{{depName}}/shellcheck@{{#if newDigest}}{{newDigest}}{{#if newValue}} # ref={{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}",
+    "autoReplaceStringTemplate": "{{depName}}/shellcheck@{{#if newDigest}}{{newDigest}}{{#if newValue}} # {{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}",
     "commitMessageTopic": "{{{depName}}} action",
     "currentValue": "master",
     "datasource": "github-digest",
@@ -139,7 +139,7 @@ exports[`modules/manager/github-actions/extract > extractPackageFile() > extract
     "replaceString": "replicated/dockerfilelint",
   },
   {
-    "autoReplaceStringTemplate": "{{depName}}/cli@{{#if newDigest}}{{newDigest}}{{#if newValue}} # ref={{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}",
+    "autoReplaceStringTemplate": "{{depName}}/cli@{{#if newDigest}}{{newDigest}}{{#if newValue}} # {{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}",
     "commitMessageTopic": "{{{depName}}} action",
     "currentValue": "master",
     "datasource": "github-digest",

--- a/lib/modules/manager/github-actions/__snapshots__/extract.spec.ts.snap
+++ b/lib/modules/manager/github-actions/__snapshots__/extract.spec.ts.snap
@@ -3,14 +3,14 @@
 exports[`modules/manager/github-actions/extract > extractPackageFile() > extracts multiple action tag lines from yaml configuration file 1`] = `
 [
   {
-    "autoReplaceStringTemplate": "{{depName}}/shellcheck@{{#if newDigest}}{{newDigest}}{{#if newValue}} # {{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}",
+    "autoReplaceStringTemplate": "{{depName}}/shellcheck@{{#if newDigest}}{{newDigest}}{{#if newValue}} # ref={{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}",
     "commitMessageTopic": "{{{depName}}} action",
     "currentValue": "master",
-    "datasource": "github-tags",
+    "datasource": "github-digest",
     "depName": "actions/bin",
     "depType": "action",
     "replaceString": "actions/bin/shellcheck@master",
-    "versioning": "docker",
+    "versioning": "exact",
   },
   {
     "autoReplaceStringTemplate": "{{depName}}@{{#if newDigest}}{{newDigest}}{{#if newValue}} # {{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}",
@@ -119,14 +119,14 @@ exports[`modules/manager/github-actions/extract > extractPackageFile() > extract
 exports[`modules/manager/github-actions/extract > extractPackageFile() > extracts multiple docker image lines from yaml configuration file 1`] = `
 [
   {
-    "autoReplaceStringTemplate": "{{depName}}/shellcheck@{{#if newDigest}}{{newDigest}}{{#if newValue}} # {{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}",
+    "autoReplaceStringTemplate": "{{depName}}/shellcheck@{{#if newDigest}}{{newDigest}}{{#if newValue}} # ref={{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}",
     "commitMessageTopic": "{{{depName}}} action",
     "currentValue": "master",
-    "datasource": "github-tags",
+    "datasource": "github-digest",
     "depName": "actions/bin",
     "depType": "action",
     "replaceString": "actions/bin/shellcheck@master",
-    "versioning": "docker",
+    "versioning": "exact",
   },
   {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
@@ -139,14 +139,14 @@ exports[`modules/manager/github-actions/extract > extractPackageFile() > extract
     "replaceString": "replicated/dockerfilelint",
   },
   {
-    "autoReplaceStringTemplate": "{{depName}}/cli@{{#if newDigest}}{{newDigest}}{{#if newValue}} # {{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}",
+    "autoReplaceStringTemplate": "{{depName}}/cli@{{#if newDigest}}{{newDigest}}{{#if newValue}} # ref={{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}",
     "commitMessageTopic": "{{{depName}}} action",
     "currentValue": "master",
-    "datasource": "github-tags",
+    "datasource": "github-digest",
     "depName": "actions/docker",
     "depType": "action",
     "replaceString": "actions/docker/cli@master",
-    "versioning": "docker",
+    "versioning": "exact",
   },
   {
     "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",

--- a/lib/modules/manager/github-actions/extract.spec.ts
+++ b/lib/modules/manager/github-actions/extract.spec.ts
@@ -433,6 +433,11 @@ describe('modules/manager/github-actions/extract', () => {
           replaceString: 'actions/checkout@1e204e # v2.1.0',
         },
         {
+          currentDigestShort: '1e204e',
+          currentValue: 'some-ref-name',
+          replaceString: 'actions/checkout@1e204e # some-ref-name',
+        },
+        {
           currentValue: '01aecc#v2.1.0',
           replaceString: 'actions/checkout@01aecc#v2.1.0',
         },

--- a/lib/modules/manager/github-actions/extract.spec.ts
+++ b/lib/modules/manager/github-actions/extract.spec.ts
@@ -70,7 +70,10 @@ describe('modules/manager/github-actions/extract', () => {
       expect(res?.deps).toMatchSnapshot();
       expect(
         res?.deps.filter((d) => d.datasource === 'github-tags'),
-      ).toHaveLength(8);
+      ).toHaveLength(7);
+      expect(
+        res?.deps.filter((d) => d.datasource === 'github-digest'),
+      ).toHaveLength(1);
     });
 
     it('use github.com as registry when no settings provided', () => {
@@ -471,6 +474,47 @@ describe('modules/manager/github-actions/extract', () => {
         },
       ]);
       expect(res!.deps[14]).not.toHaveProperty('skipReason');
+    });
+
+    it('extracts non-semver ref automatically', () => {
+      const res = extractPackageFile(
+        `
+        jobs:
+          build:
+            steps:
+              - uses: taiki-e/install-action@cargo-llvm-cov
+        `,
+        'workflow.yml',
+      );
+      expect(res?.deps[0]).toMatchObject({
+        depName: 'taiki-e/install-action',
+        currentValue: 'cargo-llvm-cov',
+        versioning: 'exact',
+        autoReplaceStringTemplate:
+          '{{depName}}@{{#if newDigest}}{{newDigest}}{{#if newValue}} # ref={{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}',
+      });
+    });
+
+    it('extracts pinned non-semver ref with digest', () => {
+      const res = extractPackageFile(
+        `
+        jobs:
+          build:
+            steps:
+              - uses: taiki-e/install-action@4b1248585248751e3b12fd020cf7ac91540ca09c # ref=cargo-llvm-cov
+        `,
+        'workflow.yml',
+      );
+      expect(res?.deps[0]).toMatchObject({
+        depName: 'taiki-e/install-action',
+        currentValue: 'cargo-llvm-cov',
+        currentDigest: '4b1248585248751e3b12fd020cf7ac91540ca09c',
+        versioning: 'exact',
+        replaceString:
+          'taiki-e/install-action@4b1248585248751e3b12fd020cf7ac91540ca09c # ref=cargo-llvm-cov',
+        autoReplaceStringTemplate:
+          '{{depName}}@{{#if newDigest}}{{newDigest}}{{#if newValue}} # ref={{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}',
+      });
     });
 
     it('extracts actions with fqdn', () => {

--- a/lib/modules/manager/github-actions/extract.spec.ts
+++ b/lib/modules/manager/github-actions/extract.spec.ts
@@ -489,9 +489,10 @@ describe('modules/manager/github-actions/extract', () => {
       expect(res?.deps[0]).toMatchObject({
         depName: 'taiki-e/install-action',
         currentValue: 'cargo-llvm-cov',
+        datasource: 'github-digest',
         versioning: 'exact',
         autoReplaceStringTemplate:
-          '{{depName}}@{{#if newDigest}}{{newDigest}}{{#if newValue}} # ref={{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}',
+          '{{depName}}@{{#if newDigest}}{{newDigest}}{{#if newValue}} # {{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}',
       });
     });
 
@@ -501,7 +502,7 @@ describe('modules/manager/github-actions/extract', () => {
         jobs:
           build:
             steps:
-              - uses: taiki-e/install-action@4b1248585248751e3b12fd020cf7ac91540ca09c # ref=cargo-llvm-cov
+              - uses: taiki-e/install-action@4b1248585248751e3b12fd020cf7ac91540ca09c # cargo-llvm-cov
         `,
         'workflow.yml',
       );
@@ -509,11 +510,12 @@ describe('modules/manager/github-actions/extract', () => {
         depName: 'taiki-e/install-action',
         currentValue: 'cargo-llvm-cov',
         currentDigest: '4b1248585248751e3b12fd020cf7ac91540ca09c',
+        datasource: 'github-digest',
         versioning: 'exact',
         replaceString:
-          'taiki-e/install-action@4b1248585248751e3b12fd020cf7ac91540ca09c # ref=cargo-llvm-cov',
+          'taiki-e/install-action@4b1248585248751e3b12fd020cf7ac91540ca09c # cargo-llvm-cov',
         autoReplaceStringTemplate:
-          '{{depName}}@{{#if newDigest}}{{newDigest}}{{#if newValue}} # ref={{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}',
+          '{{depName}}@{{#if newDigest}}{{newDigest}}{{#if newValue}} # {{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}',
       });
     });
 

--- a/lib/modules/manager/github-actions/index.ts
+++ b/lib/modules/manager/github-actions/index.ts
@@ -1,5 +1,6 @@
 import type { Category } from '../../../constants/index.ts';
 import { GiteaTagsDatasource } from '../../datasource/gitea-tags/index.ts';
+import { GithubDigestDatasource } from '../../datasource/github-digest/index.ts';
 import { GithubRunnersDatasource } from '../../datasource/github-runners/index.ts';
 import { GithubTagsDatasource } from '../../datasource/github-tags/index.ts';
 
@@ -18,6 +19,7 @@ export const defaultConfig = {
 
 export const supportedDatasources = [
   GiteaTagsDatasource.id,
-  GithubTagsDatasource.id,
+  GithubDigestDatasource.id,
   GithubRunnersDatasource.id,
+  GithubTagsDatasource.id,
 ];

--- a/lib/modules/manager/github-actions/parse.spec.ts
+++ b/lib/modules/manager/github-actions/parse.spec.ts
@@ -245,6 +245,24 @@ describe('modules/manager/github-actions/parse', () => {
         pinnedVersion: 'node/v20',
       });
     });
+
+    it('parses ref=<value> for non-semver refs', () => {
+      const result = parseComment('ref=cargo-llvm-cov');
+      expect(result).toEqual({
+        index: 0,
+        matchedString: 'ref=cargo-llvm-cov',
+        pinnedVersion: 'cargo-llvm-cov',
+      });
+    });
+
+    it('parses ref=<value> with leading whitespace', () => {
+      const result = parseComment(' ref=nextest');
+      expect(result).toEqual({
+        index: 0,
+        matchedString: ' ref=nextest',
+        pinnedVersion: 'nextest',
+      });
+    });
   });
 
   describe('parseQuote', () => {

--- a/lib/modules/manager/github-actions/parse.spec.ts
+++ b/lib/modules/manager/github-actions/parse.spec.ts
@@ -246,22 +246,26 @@ describe('modules/manager/github-actions/parse', () => {
       });
     });
 
-    it('parses ref=<value> for non-semver refs', () => {
-      const result = parseComment('ref=cargo-llvm-cov');
+    it('parses bare non-semver ref', () => {
+      const result = parseComment(' cargo-llvm-cov');
       expect(result).toEqual({
         index: 0,
-        matchedString: 'ref=cargo-llvm-cov',
-        pinnedVersion: 'cargo-llvm-cov',
+        matchedString: ' cargo-llvm-cov',
+        ref: 'cargo-llvm-cov',
       });
     });
 
-    it('parses ref=<value> with leading whitespace', () => {
-      const result = parseComment(' ref=nextest');
+    it('parses bare branch name', () => {
+      const result = parseComment(' main');
       expect(result).toEqual({
         index: 0,
-        matchedString: ' ref=nextest',
-        pinnedVersion: 'nextest',
+        matchedString: ' main',
+        ref: 'main',
       });
+    });
+
+    it('ignores multi-word comments', () => {
+      expect(parseComment('do not update')).toEqual({});
     });
   });
 

--- a/lib/modules/manager/github-actions/parse.ts
+++ b/lib/modules/manager/github-actions/parse.ts
@@ -194,21 +194,19 @@ export function parseActionReference(uses: string): ActionReference | null {
 
 export interface CommentData {
   pinnedVersion?: string;
+  ref?: string;
   ratchetExclude?: boolean;
   matchedString?: string;
   index?: number;
 }
 
-// Matches version strings with optional prefixes, e.g.:
-// - "@v1.2.3", "v1.2.3", "1.2.3"
-// - "renovate: pin @v1.2.3", "tag=v1.2.3"
-// - "ratchet:owner/repo@v1.2.3"
-// - "stable/v1.2.3", "stable-v1.2.3"
-const pinnedVersionRe = regEx(
+const pinTokenRe = regEx(
   /^\s*(?:(?:renovate\s*:\s*)?(?:pin\s+|tag\s*=\s*)?|(?:ratchet:[\w-]+\/[.\w-]+))?@?(?<version>([\w-]*[-/])?v?\d+(?:\.\d+(?:\.\d+)?)?)/,
 );
 
-const refEqualsRe = regEx(/^\s*ref=(?<version>[^\s]+)/);
+export const versionLikeRe = regEx(/^v?\d+/);
+
+const bareTokenRe = regEx(/^\s*(?<token>\S+)\s*$/);
 
 export function parseComment(commentBody: string): CommentData {
   const trimmed = commentBody.trim();
@@ -217,7 +215,7 @@ export function parseComment(commentBody: string): CommentData {
   }
 
   // We use commentBody (with leading spaces) to get the correct index relative to the comment start
-  const match = pinnedVersionRe.exec(commentBody);
+  const match = pinTokenRe.exec(commentBody);
   if (match?.groups?.version) {
     return {
       pinnedVersion: match.groups.version,
@@ -226,12 +224,20 @@ export function parseComment(commentBody: string): CommentData {
     };
   }
 
-  const refMatch = refEqualsRe.exec(commentBody);
-  if (refMatch?.groups?.version) {
+  const bareMatch = bareTokenRe.exec(commentBody);
+  if (bareMatch?.groups?.token) {
+    const token = bareMatch.groups.token;
+    if (versionLikeRe.test(token)) {
+      return {
+        pinnedVersion: token,
+        matchedString: bareMatch[0],
+        index: bareMatch.index,
+      };
+    }
     return {
-      pinnedVersion: refMatch.groups.version,
-      matchedString: refMatch[0],
-      index: refMatch.index,
+      ref: token,
+      matchedString: bareMatch[0],
+      index: bareMatch.index,
     };
   }
 

--- a/lib/modules/manager/github-actions/parse.ts
+++ b/lib/modules/manager/github-actions/parse.ts
@@ -208,6 +208,8 @@ const pinnedVersionRe = regEx(
   /^\s*(?:(?:renovate\s*:\s*)?(?:pin\s+|tag\s*=\s*)?|(?:ratchet:[\w-]+\/[.\w-]+))?@?(?<version>([\w-]*[-/])?v?\d+(?:\.\d+(?:\.\d+)?)?)/,
 );
 
+const refEqualsRe = regEx(/^\s*ref=(?<version>[^\s]+)/);
+
 export function parseComment(commentBody: string): CommentData {
   const trimmed = commentBody.trim();
   if (trimmed === 'ratchet:exclude') {
@@ -221,6 +223,15 @@ export function parseComment(commentBody: string): CommentData {
       pinnedVersion: match.groups.version,
       matchedString: match[0],
       index: match.index,
+    };
+  }
+
+  const refMatch = refEqualsRe.exec(commentBody);
+  if (refMatch?.groups?.version) {
+    return {
+      pinnedVersion: refMatch.groups.version,
+      matchedString: refMatch[0],
+      index: refMatch.index,
     };
   }
 
@@ -290,7 +301,7 @@ export function parseUsesLine(line: string): ParsedUsesLine | null {
   );
 
   const { value, quote } = parseQuote(rawValuePart);
-  // commentPart always starts with '#' since we found ' #' and sliced after the space
+  // commentPart always starts with '#' (see commentIndex search above)
   const cleanCommentBody = commentPart.slice(1);
 
   return {

--- a/lib/modules/manager/github-actions/parse.ts
+++ b/lib/modules/manager/github-actions/parse.ts
@@ -226,16 +226,8 @@ export function parseComment(commentBody: string): CommentData {
 
   const bareMatch = bareTokenRe.exec(commentBody);
   if (bareMatch?.groups?.token) {
-    const token = bareMatch.groups.token;
-    if (versionLikeRe.test(token)) {
-      return {
-        pinnedVersion: token,
-        matchedString: bareMatch[0],
-        index: bareMatch.index,
-      };
-    }
     return {
-      ref: token,
+      ref: bareMatch.groups.token,
       matchedString: bareMatch[0],
       index: bareMatch.index,
     };

--- a/lib/modules/manager/github-actions/readme.md
+++ b/lib/modules/manager/github-actions/readme.md
@@ -53,10 +53,10 @@ Since these refs have no version ordering, only digest pinning updates are suppo
 - `taiki-e/install-action@cargo-llvm-cov` → `github-digest` datasource (digest pinning only)
 - `actions/checkout@main` → `github-digest` datasource (digest pinning only)
 
-When pinning, Renovate uses a `# ref=<value>` comment to preserve the original ref:
+When pinning, Renovate adds a comment to preserve the original ref:
 
 ```yaml
-- uses: taiki-e/install-action@d8c10dae823f48238abff23fee4146b448aed2f1 # ref=cargo-llvm-cov
+- uses: taiki-e/install-action@d8c10dae823f48238abff23fee4146b448aed2f1 # cargo-llvm-cov
 ```
 
 Non-semver ref support is currently limited to GitHub-hosted actions.

--- a/lib/modules/manager/github-actions/readme.md
+++ b/lib/modules/manager/github-actions/readme.md
@@ -39,6 +39,29 @@ If you want to automatically pin action digests add the `helpers:pinGitHubAction
 }
 ```
 
+### Non-semver refs (branches and feature tags)
+
+Renovate supports GitHub Actions that reference non-semver refs like branch names (`main`, `master`) or feature-oriented tags (`cargo-llvm-cov`).
+
+When the action reference doesn't look like a version number (i.e., doesn't match `/^v?\d+/`), Renovate routes to the `github-digest` datasource which fetches both tags and branches.
+Since these refs have no version ordering, only digest pinning updates are supported.
+
+**Routing logic:**
+
+- `actions/checkout@v4.2.0` → `github-tags` datasource (version updates)
+- `actions/checkout@v4` → `github-tags` datasource (version updates)
+- `taiki-e/install-action@cargo-llvm-cov` → `github-digest` datasource (digest pinning only)
+- `actions/checkout@main` → `github-digest` datasource (digest pinning only)
+
+When pinning, Renovate uses a `# ref=<value>` comment to preserve the original ref:
+
+```yaml
+- uses: taiki-e/install-action@d8c10dae823f48238abff23fee4146b448aed2f1 # ref=cargo-llvm-cov
+```
+
+Non-semver ref support is currently limited to GitHub-hosted actions.
+Gitea and Forgejo support the same ref types, but Renovate does not yet handle them for these platforms.
+
 ### Non-support of Variables
 
 Renovate ignores any GitHub runners which are configured in variables.


### PR DESCRIPTION
## Changes

Add support for GitHub Actions with non-semver refs like `taiki-e/install-action@cargo-llvm-cov` (feature tags) and `actions/checkout@main` (branches).

New `github-digest` datasource fetches tags and branches via GraphQL, prioritizing tags when names conflict. Version-like refs (`v1`, `v1.0.0`) continue using `github-tags`; non-version refs route to `github-digest` with `exact` versioning.

Pinned format uses `# ref=<value>` comment:
```yaml
- uses: taiki-e/install-action@d8c10da... # ref=cargo-llvm-cov
```

Example PRs:
- https://github.com/renovate-testing/github-actions-refs-test/pull/9
- https://github.com/renovate-testing/github-actions-refs-test/pull/10
- https://github.com/renovate-testing/github-actions-refs-test/pull/11

## Context

- Closes: #40095
- Closes: #28016

## AI assistance disclosure

- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).

## Documentation (please check one with an [x])

- [x] No documentation update is required

## How I've tested my work (please select one)

- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/renovate-testing/github-actions-refs-test