### PR TITLE
feat: Add `github-digest` datasource

### DIFF
--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -445,6 +445,7 @@ Other valid cache namespaces are as follows:
 - `datasource-git`
 - `datasource-gitea-releases`
 - `datasource-gitea-tags`
+- `datasource-github-digest`
 - `datasource-github-release-attachments`
 - `datasource-gitlab-packages`
 - `datasource-gitlab-releases`

--- a/lib/modules/datasource/api.ts
+++ b/lib/modules/datasource/api.ts
@@ -34,6 +34,7 @@ import { GitRefsDatasource } from './git-refs/index.ts';
 import { GitTagsDatasource } from './git-tags/index.ts';
 import { GiteaReleasesDatasource } from './gitea-releases/index.ts';
 import { GiteaTagsDatasource } from './gitea-tags/index.ts';
+import { GithubDigestDatasource } from './github-digest/index.ts';
 import { GithubReleaseAttachmentsDatasource } from './github-release-attachments/index.ts';
 import { GithubReleasesDatasource } from './github-releases/index.ts';
 import { GithubRunnersDatasource } from './github-runners/index.ts';
@@ -117,6 +118,7 @@ api.set(GitRefsDatasource.id, new GitRefsDatasource());
 api.set(GitTagsDatasource.id, new GitTagsDatasource());
 api.set(GiteaReleasesDatasource.id, new GiteaReleasesDatasource());
 api.set(GiteaTagsDatasource.id, new GiteaTagsDatasource());
+api.set(GithubDigestDatasource.id, new GithubDigestDatasource());
 api.set(
   GithubReleaseAttachmentsDatasource.id,
   new GithubReleaseAttachmentsDatasource(),

--- a/lib/modules/datasource/github-digest/index.spec.ts
+++ b/lib/modules/datasource/github-digest/index.spec.ts
@@ -1,0 +1,210 @@
+import * as githubGraphql from '../../../util/github/graphql/index.ts';
+import * as hostRules from '../../../util/host-rules.ts';
+import { asTimestamp } from '../../../util/timestamp.ts';
+import { getPkgReleases } from '../index.ts';
+import { GithubDigestDatasource } from './index.ts';
+
+describe('modules/datasource/github-digest/index', () => {
+  const github = new GithubDigestDatasource();
+
+  beforeEach(() => {
+    vi.spyOn(hostRules, 'hosts').mockReturnValue([]);
+    vi.spyOn(hostRules, 'find').mockReturnValue({
+      token: 'some-token',
+    });
+  });
+
+  describe('getReleases', () => {
+    const packageName = 'some/repo';
+
+    it('returns tags and branches merged', async () => {
+      vi.spyOn(githubGraphql, 'queryTags').mockResolvedValueOnce([
+        {
+          version: 'v1.0.0',
+          gitRef: 'v1.0.0',
+          releaseTimestamp: asTimestamp('2021-01-01')!,
+          hash: 'tag-hash-1',
+        },
+      ]);
+      vi.spyOn(githubGraphql, 'queryBranches').mockResolvedValueOnce([
+        {
+          version: 'main',
+          gitRef: 'main',
+          releaseTimestamp: asTimestamp('2022-01-01')!,
+          hash: 'branch-hash-1',
+        },
+        {
+          version: 'develop',
+          gitRef: 'develop',
+          releaseTimestamp: asTimestamp('2022-02-01')!,
+          hash: 'branch-hash-2',
+        },
+      ]);
+
+      const res = await getPkgReleases({ datasource: github.id, packageName });
+
+      expect(res).toEqual({
+        registryUrl: 'https://github.com',
+        releases: [
+          {
+            version: 'v1.0.0',
+            gitRef: 'v1.0.0',
+            releaseTimestamp: '2021-01-01T00:00:00.000Z',
+            newDigest: 'tag-hash-1',
+          },
+          {
+            version: 'main',
+            gitRef: 'main',
+            releaseTimestamp: '2022-01-01T00:00:00.000Z',
+            newDigest: 'branch-hash-1',
+          },
+          {
+            version: 'develop',
+            gitRef: 'develop',
+            releaseTimestamp: '2022-02-01T00:00:00.000Z',
+            newDigest: 'branch-hash-2',
+          },
+        ],
+        sourceUrl: 'https://github.com/some/repo',
+      });
+    });
+
+    it('prioritizes tags over branches with same name', async () => {
+      vi.spyOn(githubGraphql, 'queryTags').mockResolvedValueOnce([
+        {
+          version: 'v4',
+          gitRef: 'v4',
+          releaseTimestamp: asTimestamp('2021-01-01')!,
+          hash: 'tag-v4-hash',
+        },
+      ]);
+      vi.spyOn(githubGraphql, 'queryBranches').mockResolvedValueOnce([
+        {
+          version: 'v4',
+          gitRef: 'v4',
+          releaseTimestamp: asTimestamp('2022-01-01')!,
+          hash: 'branch-v4-hash',
+        },
+        {
+          version: 'main',
+          gitRef: 'main',
+          releaseTimestamp: asTimestamp('2022-02-01')!,
+          hash: 'main-hash',
+        },
+      ]);
+
+      const res = await getPkgReleases({ datasource: github.id, packageName });
+
+      expect(res).toEqual({
+        registryUrl: 'https://github.com',
+        releases: [
+          {
+            version: 'v4',
+            gitRef: 'v4',
+            releaseTimestamp: '2021-01-01T00:00:00.000Z',
+            newDigest: 'tag-v4-hash',
+          },
+          {
+            version: 'main',
+            gitRef: 'main',
+            releaseTimestamp: '2022-02-01T00:00:00.000Z',
+            newDigest: 'main-hash',
+          },
+        ],
+        sourceUrl: 'https://github.com/some/repo',
+      });
+    });
+
+    it('returns only branches when no tags', async () => {
+      vi.spyOn(githubGraphql, 'queryTags').mockResolvedValueOnce([]);
+      vi.spyOn(githubGraphql, 'queryBranches').mockResolvedValueOnce([
+        {
+          version: 'v4',
+          gitRef: 'v4',
+          releaseTimestamp: asTimestamp('2022-01-01')!,
+          hash: 'branch-hash',
+        },
+      ]);
+
+      const res = await getPkgReleases({ datasource: github.id, packageName });
+
+      expect(res).toEqual({
+        registryUrl: 'https://github.com',
+        releases: [
+          {
+            version: 'v4',
+            gitRef: 'v4',
+            releaseTimestamp: '2022-01-01T00:00:00.000Z',
+            newDigest: 'branch-hash',
+          },
+        ],
+        sourceUrl: 'https://github.com/some/repo',
+      });
+    });
+  });
+
+  describe('getDigest', () => {
+    const packageName = 'some/repo';
+
+    it('returns tag digest when tag exists', async () => {
+      vi.spyOn(githubGraphql, 'queryTags').mockResolvedValueOnce([
+        {
+          version: 'v1.0.0',
+          gitRef: 'v1.0.0',
+          releaseTimestamp: asTimestamp('2021-01-01')!,
+          hash: 'tag-hash',
+        },
+      ]);
+
+      const res = await github.getDigest({ packageName }, 'v1.0.0');
+
+      expect(res).toBe('tag-hash');
+    });
+
+    it('returns branch digest when tag not found', async () => {
+      vi.spyOn(githubGraphql, 'queryTags').mockResolvedValueOnce([]);
+      vi.spyOn(githubGraphql, 'queryBranches').mockResolvedValueOnce([
+        {
+          version: 'v4',
+          gitRef: 'v4',
+          releaseTimestamp: asTimestamp('2022-01-01')!,
+          hash: 'branch-hash',
+        },
+      ]);
+
+      const res = await github.getDigest({ packageName }, 'v4');
+
+      expect(res).toBe('branch-hash');
+    });
+
+    it('prefers tag over branch with same name', async () => {
+      vi.spyOn(githubGraphql, 'queryTags').mockResolvedValueOnce([
+        {
+          version: 'v4',
+          gitRef: 'v4',
+          releaseTimestamp: asTimestamp('2021-01-01')!,
+          hash: 'tag-hash',
+        },
+      ]);
+
+      const res = await github.getDigest({ packageName }, 'v4');
+
+      expect(res).toBe('tag-hash');
+    });
+
+    it('returns null when not found in tags or branches', async () => {
+      vi.spyOn(githubGraphql, 'queryTags').mockResolvedValueOnce([]);
+      vi.spyOn(githubGraphql, 'queryBranches').mockResolvedValueOnce([]);
+
+      const res = await github.getDigest({ packageName }, 'nonexistent');
+
+      expect(res).toBeNull();
+    });
+
+    it('returns null when newValue is undefined', async () => {
+      const res = await github.getDigest({ packageName }, undefined);
+
+      expect(res).toBeNull();
+    });
+  });
+});

--- a/lib/modules/datasource/github-digest/index.spec.ts
+++ b/lib/modules/datasource/github-digest/index.spec.ts
@@ -141,6 +141,28 @@ describe('modules/datasource/github-digest/index', () => {
         sourceUrl: 'https://github.com/some/repo',
       });
     });
+
+    it('throws when tags query fails', async () => {
+      vi.spyOn(githubGraphql, 'queryTags').mockRejectedValueOnce(
+        new Error('Tags query failed'),
+      );
+      vi.spyOn(githubGraphql, 'queryBranches').mockResolvedValueOnce([]);
+
+      await expect(github.getReleases({ packageName })).rejects.toThrow(
+        'Tags query failed',
+      );
+    });
+
+    it('throws when branches query fails', async () => {
+      vi.spyOn(githubGraphql, 'queryTags').mockResolvedValueOnce([]);
+      vi.spyOn(githubGraphql, 'queryBranches').mockRejectedValueOnce(
+        new Error('Branches query failed'),
+      );
+
+      await expect(github.getReleases({ packageName })).rejects.toThrow(
+        'Branches query failed',
+      );
+    });
   });
 
   describe('getDigest', () => {

--- a/lib/modules/datasource/github-digest/index.ts
+++ b/lib/modules/datasource/github-digest/index.ts
@@ -1,0 +1,137 @@
+import type { PackageCacheNamespace } from '../../../util/cache/package/types.ts';
+import { withCache } from '../../../util/cache/package/with-cache.ts';
+import {
+  queryBranches,
+  queryTags,
+} from '../../../util/github/graphql/index.ts';
+import { getSourceUrl } from '../../../util/github/url.ts';
+import { GithubHttp } from '../../../util/http/github.ts';
+import * as exactVersioning from '../../versioning/exact/index.ts';
+import { Datasource } from '../datasource.ts';
+import type {
+  DigestConfig,
+  GetReleasesConfig,
+  Release,
+  ReleaseResult,
+} from '../types.ts';
+
+export class GithubDigestDatasource extends Datasource {
+  static readonly id = 'github-digest';
+
+  private static readonly cacheNamespace: PackageCacheNamespace = `datasource-${GithubDigestDatasource.id}`;
+
+  override readonly defaultRegistryUrls = ['https://github.com'];
+
+  override readonly registryStrategy = 'hunt';
+
+  override readonly releaseTimestampSupport = true;
+  override readonly releaseTimestampNote =
+    'The release timestamp is determined from the commit date.';
+  override readonly sourceUrlSupport = 'package';
+  override readonly sourceUrlNote =
+    'The source URL is determined by using the `packageName` and `registryUrl`.';
+
+  override readonly defaultVersioning = exactVersioning.id;
+
+  override http: GithubHttp;
+
+  constructor() {
+    super(GithubDigestDatasource.id);
+    this.http = new GithubHttp(GithubDigestDatasource.id);
+  }
+
+  private static getCacheKey(
+    registryUrl: string | undefined,
+    packageName: string,
+    suffix: string,
+  ): string {
+    return `${registryUrl}:${packageName}:${suffix}`;
+  }
+
+  override getReleases(config: GetReleasesConfig): Promise<ReleaseResult> {
+    const { registryUrl, packageName: repo } = config;
+    const sourceUrl = getSourceUrl(repo, registryUrl);
+
+    return withCache(
+      {
+        namespace: GithubDigestDatasource.cacheNamespace,
+        key: GithubDigestDatasource.getCacheKey(registryUrl, repo, 'releases'),
+      },
+      async () => {
+        const [tagsResult, branchesResult] = await Promise.all([
+          queryTags(config, this.http),
+          queryBranches(config, this.http),
+        ]);
+
+        // Tags take priority over branches when names conflict
+        const releases: Release[] = tagsResult.map(
+          ({ version, releaseTimestamp, gitRef, hash }) => ({
+            version,
+            releaseTimestamp,
+            gitRef,
+            newDigest: hash,
+          }),
+        );
+        const tagVersions = new Set(tagsResult.map((t) => t.version));
+        for (const {
+          version,
+          releaseTimestamp,
+          gitRef,
+          hash,
+        } of branchesResult) {
+          if (!tagVersions.has(version)) {
+            releases.push({
+              version,
+              releaseTimestamp,
+              gitRef,
+              newDigest: hash,
+            });
+          }
+        }
+
+        return {
+          sourceUrl,
+          releases,
+        };
+      },
+    );
+  }
+
+  override async getDigest(
+    { packageName: repo, registryUrl }: DigestConfig,
+    newValue?: string,
+  ): Promise<string | null> {
+    if (!newValue) {
+      return null;
+    }
+
+    return await withCache(
+      {
+        namespace: GithubDigestDatasource.cacheNamespace,
+        key: GithubDigestDatasource.getCacheKey(
+          registryUrl,
+          repo,
+          `digest:${newValue}`,
+        ),
+      },
+      async () => {
+        const config = { packageName: repo, registryUrl };
+
+        // Tags take priority over branches
+        const tags = await queryTags(config, this.http);
+        const tagItem = tags.find(({ version }) => version === newValue);
+        if (tagItem?.hash) {
+          return tagItem.hash;
+        }
+
+        const branches = await queryBranches(config, this.http);
+        const branchItem = branches.find(({ version }) => version === newValue);
+        if (branchItem?.hash) {
+          return branchItem.hash;
+        }
+
+        return null;
+      },
+    );
+  }
+}

--- a/lib/modules/datasource/github-digest/readme.md
+++ b/lib/modules/datasource/github-digest/readme.md
@@ -1,0 +1,3 @@
+This datasource fetches both tags and branches from GitHub repositories, prioritizing tags over branches when names conflict.
+
+It's designed for GitHub Actions that reference non-semver refs like branch names (`main`, `master`) or commit SHAs. It uses exact versioning, meaning no version ordering is performed - only digest pinning updates are supported.

--- a/lib/util/cache/package/namespaces.ts
+++ b/lib/util/cache/package/namespaces.ts
@@ -59,6 +59,7 @@ export const packageCacheNamespaces = [
   'datasource-forgejo-tags',
   'datasource-gitea-releases',
   'datasource-gitea-tags',
+  'datasource-github-digest',
   'datasource-github-release-attachments',
   'datasource-gitlab-packages',
   'datasource-gitlab-releases',


### PR DESCRIPTION
## Changes

Add `github-digest` datasource that fetches both tags and branches from GitHub repositories via GraphQL, prioritizing tags when names conflict.

Designed for GitHub Actions that reference non-semver refs like `v4` (could be tag or branch) or branch names like `main`. Uses exact versioning - no version ordering, only digest pinning updates.

This datasource is not yet used by any manager. Follow-up PR will wire it into `github-actions` manager.

## Context

- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

Part of work for #40095 and #28016.

## AI assistance disclosure

- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).

## Documentation (please check one with an [x])

- [x] No documentation update is required

## How I've tested my work (please select one)

- [x] Newly added/modified unit tests