### PR TITLE
fix(util/exec): don't use `shell` by default

### DIFF
--- a/docs/usage/security-and-permissions.md
+++ b/docs/usage/security-and-permissions.md
@@ -101,6 +101,9 @@ This may pose a significant security risk if the repository's integrity is compr
 
 Because such insider attack is an inherent and unavoidable risk, the Renovate project will not issue CVEs for such attacks or weaknesses other than in exceptional circumstances.
 
+Note that when Renovate runs `postUpgradeTasks`, the script executes inside a shell, which means that they can call out to other commands or access shell variables, if the allowlist via `allowedCommands` does not restrict it.
+As it is difficult to craft a regular expression that may deny usage of special characters to shells, it is likely that this will not be possible to avoid at this time.
+
 ###### Execution of code (outsider attack)
 
 Separately, there are also opportunities for malicious external code to execute, as part of Renovate's update process.

--- a/lib/util/exec/common.spec.ts
+++ b/lib/util/exec/common.spec.ts
@@ -207,6 +207,7 @@ describe('util/exec/common', () => {
 
       expect(execa).toHaveBeenCalledWith(
         cmd,
+        [],
         expect.objectContaining({ shell: '/bin/zsh' }),
       );
     });
@@ -226,6 +227,7 @@ describe('util/exec/common', () => {
 
       expect(execa).toHaveBeenCalledWith(
         cmd,
+        [],
         expect.objectContaining({ shell: true }),
       );
     });
@@ -248,6 +250,7 @@ describe('util/exec/common', () => {
 
       expect(execa).toHaveBeenCalledWith(
         cmd,
+        [],
         expect.objectContaining({ shell: true }),
       );
     });

--- a/lib/util/exec/common.spec.ts
+++ b/lib/util/exec/common.spec.ts
@@ -189,6 +189,69 @@ describe('util/exec/common', () => {
       });
     });
 
+    it('can specify a shell', async () => {
+      const cmd = 'ls -l';
+      const stub = getSpawnStub({
+        cmd,
+        exitCode: 0,
+        exitSignal: null,
+        stdout,
+        stderr,
+      });
+      execa.mockImplementationOnce((cmd, opts) => stub);
+
+      await exec(
+        cmd,
+        partial<RawExecOptions>({ encoding: 'utf8', shell: '/bin/zsh' }),
+      );
+
+      expect(execa).toHaveBeenCalledWith(
+        cmd,
+        expect.objectContaining({ shell: '/bin/zsh' }),
+      );
+    });
+
+    it('defaults to shell=true', async () => {
+      const cmd = 'ls -l';
+      const stub = getSpawnStub({
+        cmd,
+        exitCode: 0,
+        exitSignal: null,
+        stdout,
+        stderr,
+      });
+      execa.mockImplementationOnce((cmd, opts) => stub);
+
+      await exec(cmd, partial<RawExecOptions>({}));
+
+      expect(execa).toHaveBeenCalledWith(
+        cmd,
+        expect.objectContaining({ shell: true }),
+      );
+    });
+
+    it('cannot specify shell=false', async () => {
+      const cmd = 'ls -l';
+      const stub = getSpawnStub({
+        cmd,
+        exitCode: 0,
+        exitSignal: null,
+        stdout,
+        stderr,
+      });
+      execa.mockImplementationOnce((cmd, opts) => stub);
+
+      await exec(
+        cmd,
+        partial<RawExecOptions>({ encoding: 'utf8', shell: false }),
+      );
+
+      expect(execa).toHaveBeenCalledWith(
+        cmd,
+        expect.objectContaining({ shell: true }),
+      );
+    });
+
     it('should invoke the output listeners', async () => {
       const cmd = 'ls -l';
       const stub = getSpawnStub({

--- a/lib/util/exec/common.spec.ts
+++ b/lib/util/exec/common.spec.ts
@@ -235,7 +235,30 @@ describe('util/exec/common', () => {
       );
     });
 
-    it('defaults to shell=true', async () => {
+    it('can specify a command with spaces, with no shell', async () => {
+      const cmd = 'ls "Application Support"';
+      const stub = getSpawnStub({
+        cmd,
+        exitCode: 0,
+        exitSignal: null,
+        stdout,
+        stderr,
+      });
+      execa.mockImplementationOnce((cmd, opts) => stub);
+
+      await exec(
+        cmd,
+        partial<RawExecOptions>({ encoding: 'utf8', shell: false }),
+      );
+
+      expect(execa).toHaveBeenCalledWith(
+        'ls',
+        ['Application Support'],
+        expect.objectContaining({ shell: false }),
+      );
+    });
+
+    it('defaults to shell=false', async () => {
       const cmd = 'ls -l';
       const stub = getSpawnStub({
         cmd,
@@ -249,13 +272,96 @@ describe('util/exec/common', () => {
       await exec(cmd, partial<RawExecOptions>({}));
 
       expect(execa).toHaveBeenCalledWith(
+        'ls',
+        ['-l'],
+        expect.objectContaining({ shell: false }),
+      );
+    });
+
+    it('the command is provided as a string with no arguments when shell is a string', async () => {
+      const cmd = 'ls -l';
+      const stub = getSpawnStub({
+        cmd,
+        exitCode: 0,
+        exitSignal: null,
+        stdout,
+        stderr,
+      });
+      execa.mockImplementationOnce((cmd, opts) => stub);
+
+      await exec(cmd, partial<RawExecOptions>({ shell: '/bin/fish' }));
+
+      expect(execa).toHaveBeenCalledWith(
+        'ls -l',
+        [],
+        expect.objectContaining({}),
+      );
+    });
+
+    it('the command is provided as a string with no arguments when shell=true', async () => {
+      const cmd = 'ls -l';
+      const stub = getSpawnStub({
+        cmd,
+        exitCode: 0,
+        exitSignal: null,
+        stdout,
+        stderr,
+      });
+      execa.mockImplementationOnce((cmd, opts) => stub);
+
+      await exec(cmd, partial<RawExecOptions>({ shell: true }));
+
+      expect(execa).toHaveBeenCalledWith(
+        'ls -l',
+        [],
+        expect.objectContaining({}),
+      );
+    });
+
+    it('the command is split into the command and arguments when shell=false', async () => {
+      const cmd = 'ls -l';
+      const stub = getSpawnStub({
+        cmd,
+        exitCode: 0,
+        exitSignal: null,
+        stdout,
+        stderr,
+      });
+      execa.mockImplementationOnce((cmd, opts) => stub);
+
+      await exec(cmd, partial<RawExecOptions>({}));
+
+      expect(execa).toHaveBeenCalledWith(
+        'ls',
+        ['-l'],
+        expect.objectContaining({ shell: false }),
+      );
+    });
+
+    it('can specify shell=true', async () => {
+      const cmd = 'ls -l';
+      const stub = getSpawnStub({
+        cmd,
+        exitCode: 0,
+        exitSignal: null,
+        stdout,
+        stderr,
+      });
+      execa.mockImplementationOnce((cmd, opts) => stub);
+
+      await exec(
+        cmd,
+        partial<RawExecOptions>({ encoding: 'utf8', shell: true }),
+      );
+
+      expect(execa).toHaveBeenCalledWith(
         cmd,
         [],
         expect.objectContaining({ shell: true }),
       );
     });
 
-    it('cannot specify shell=false', async () => {
+    it('can specify shell=false', async () => {
       const cmd = 'ls -l';
       const stub = getSpawnStub({
         cmd,
@@ -272,9 +378,9 @@ describe('util/exec/common', () => {
       );
 
       expect(execa).toHaveBeenCalledWith(
-        cmd,
-        [],
-        expect.objectContaining({ shell: true }),
+        'ls',
+        ['-l'],
+        expect.objectContaining({ shell: false }),
       );
     });
 

--- a/lib/util/exec/common.spec.ts
+++ b/lib/util/exec/common.spec.ts
@@ -212,6 +212,29 @@ describe('util/exec/common', () => {
       );
     });
 
+    it('can specify a command with spaces, with a shell', async () => {
+      const cmd = 'ls "Application Support"';
+      const stub = getSpawnStub({
+        cmd,
+        exitCode: 0,
+        exitSignal: null,
+        stdout,
+        stderr,
+      });
+      execa.mockImplementationOnce((cmd, opts) => stub);
+
+      await exec(
+        cmd,
+        partial<RawExecOptions>({ encoding: 'utf8', shell: '/bin/zsh' }),
+      );
+
+      expect(execa).toHaveBeenCalledWith(
+        cmd,
+        [],
+        expect.objectContaining({ shell: '/bin/zsh' }),
+      );
+    });
+
     it('defaults to shell=true', async () => {
       const cmd = 'ls -l';
       const stub = getSpawnStub({

--- a/lib/util/exec/common.ts
+++ b/lib/util/exec/common.ts
@@ -2,6 +2,7 @@ import type { ChildProcess } from 'node:child_process';
 import type { Readable } from 'node:stream';
 import { isNullOrUndefined } from '@sindresorhus/is';
 import { execa } from 'execa';
+import { split } from 'shlex';
 import { instrument } from '../../instrumentation';
 import { getEnv } from '../env';
 import { sanitize } from '../sanitize';
@@ -79,16 +80,32 @@ function registerDataListeners(
   }
 }
 
-export function exec(cmd: string, opts: RawExecOptions): Promise<ExecResult> {
+export function exec(
+  theCmd: string,
+  opts: RawExecOptions,
+): Promise<ExecResult> {
   return new Promise((resolve, reject) => {
-    const args: string[] = [];
+    let cmd = theCmd;
+    let args: string[] = [];
     const maxBuffer = opts.maxBuffer ?? 10 * 1024 * 1024; // Set default max buffer size to 10MB
+
+    // don't use shell by default, as it leads to potential security issues
+    const shell = opts.shell ?? false;
+    // if we're not in shell mode, we need to provide the command and arguments
+    if (shell === false) {
+      const parts = split(cmd);
+      if (parts) {
+        cmd = parts[0];
+        args = parts.slice(1);
+      }
+    }
+
     const cp = execa(cmd, args, {
       ...opts,
       // force detached on non WIN platforms
       // https://github.com/nodejs/node/issues/21825#issuecomment-611328888
       detached: process.platform !== 'win32',
-      shell: typeof opts.shell === 'string' ? opts.shell : true, // force shell
+      shell,
     });
 
     // handle streams

--- a/lib/util/exec/common.ts
+++ b/lib/util/exec/common.ts
@@ -81,8 +81,9 @@ function registerDataListeners(
 
 export function exec(cmd: string, opts: RawExecOptions): Promise<ExecResult> {
   return new Promise((resolve, reject) => {
+    const args: string[] = [];
     const maxBuffer = opts.maxBuffer ?? 10 * 1024 * 1024; // Set default max buffer size to 10MB
-    const cp = execa(cmd, {
+    const cp = execa(cmd, args, {
       ...opts,
       // force detached on non WIN platforms
       // https://github.com/nodejs/node/issues/21825#issuecomment-611328888

--- a/lib/util/exec/common.ts
+++ b/lib/util/exec/common.ts
@@ -111,19 +111,25 @@ export function exec(cmd: string, opts: RawExecOptions): Promise<ExecResult> {
       if (signal) {
         kill(cp, signal);
         reject(
-          new ExecError(`Command failed: ${cmd}\nInterrupted by ${signal}`, {
-            ...rejectInfo(),
-            signal,
-          }),
+          new ExecError(
+            `Command failed: ${cp.spawnargs.join(' ')}\nInterrupted by ${signal}`,
+            {
+              ...rejectInfo(),
+              signal,
+            },
+          ),
         );
         return;
       }
       if (code !== 0) {
         reject(
-          new ExecError(`Command failed: ${cmd}\n${stringify(stderr)}`, {
-            ...rejectInfo(),
-            exitCode: code,
-          }),
+          new ExecError(
+            `Command failed: ${cp.spawnargs.join(' ')}\n${stringify(stderr)}`,
+            {
+              ...rejectInfo(),
+              exitCode: code,
+            },
+          ),
         );
         return;
       }

--- a/lib/util/exec/types.ts
+++ b/lib/util/exec/types.ts
@@ -55,4 +55,5 @@ export interface ExecOptions {
   // Following are pass-through to child process
   maxBuffer?: number | undefined;
   timeout?: number | undefined;
+  shell?: boolean | string | undefined;
 }

--- a/lib/workers/repository/update/branch/execute-post-upgrade-commands.spec.ts
+++ b/lib/workers/repository/update/branch/execute-post-upgrade-commands.spec.ts
@@ -630,10 +630,13 @@ describe('workers/repository/update/branch/execute-post-upgrade-commands', () =>
         config,
       );
 
-      expect(exec.exec).toHaveBeenCalledExactlyOnceWith('some-command', {
-        cwd: localDir,
-        extraEnv: gitEnvVars,
-      });
+      expect(exec.exec).toHaveBeenCalledExactlyOnceWith(
+        'some-command',
+        expect.objectContaining({
+          cwd: localDir,
+          extraEnv: gitEnvVars,
+        }),
+      );
       expect(res.artifactErrors).toHaveLength(0);
     });
 
@@ -675,9 +678,12 @@ describe('workers/repository/update/branch/execute-post-upgrade-commands', () =>
 
       await postUpgradeCommands.postUpgradeCommandsExecutor(commands, config);
 
-      expect(exec.exec).toHaveBeenCalledExactlyOnceWith('some-command', {
-        cwd: 'projects/npm/jest-29.5.0',
-      });
+      expect(exec.exec).toHaveBeenCalledExactlyOnceWith(
+        'some-command',
+        expect.objectContaining({
+          cwd: 'projects/npm/jest-29.5.0',
+        }),
+      );
     });
 
     it('uses localDir when workingDirTemplate is not provided', async () => {
@@ -714,9 +720,12 @@ describe('workers/repository/update/branch/execute-post-upgrade-commands', () =>
 
       await postUpgradeCommands.postUpgradeCommandsExecutor(commands, config);
 
-      expect(exec.exec).toHaveBeenCalledExactlyOnceWith('some-command', {
-        cwd: '/default/dir',
-      });
+      expect(exec.exec).toHaveBeenCalledExactlyOnceWith(
+        'some-command',
+        expect.objectContaining({
+          cwd: '/default/dir',
+        }),
+      );
     });
   });
 });

--- a/lib/workers/repository/update/branch/execute-post-upgrade-commands.ts
+++ b/lib/workers/repository/update/branch/execute-post-upgrade-commands.ts
@@ -129,6 +129,10 @@ export async function postUpgradeCommandsExecutor(
             logger.trace({ cmd: compiledCmd }, 'Executing post-upgrade task');
 
             const execOpts: ExecOptions = {
+              // WARNING to self-hosted administrators: always run post-upgrade commands with `shell` mode on, which has the risk of arbitrary environment variable access or additional command execution
+              // It is very likely this will be susceptible to these risks, even if you allowlist (via `allowedCommands`), as there may be special characters included in the given commands that can be leveraged here
+              shell: true,
+
               cwd: isNonEmptyString(workingDir)
                 ? workingDir
                 : GlobalConfig.get('localDir'),

--- a/lib/workers/repository/update/branch/index.spec.ts
+++ b/lib/workers/repository/update/branch/index.spec.ts
@@ -2199,10 +2199,13 @@ describe('workers/repository/update/branch/index', () => {
         result: 'done',
         commitSha: null,
       });
-      expect(exec.exec).toHaveBeenCalledExactlyOnceWith('echo semver', {
-        cwd: '/localDir',
-        extraEnv: {},
-      });
+      expect(exec.exec).toHaveBeenCalledExactlyOnceWith(
+        'echo semver',
+        expect.objectContaining({
+          cwd: '/localDir',
+          extraEnv: {},
+        }),
+      );
     });
 
     it('executes post-upgrade tasks with multiple dependecy in one branch', async () => {
@@ -2327,14 +2330,22 @@ describe('workers/repository/update/branch/index', () => {
         result: 'done',
         commitSha: null,
       });
-      expect(exec.exec).toHaveBeenNthCalledWith(1, 'echo some-dep-name-1', {
-        cwd: '/localDir',
-        extraEnv: {},
-      });
-      expect(exec.exec).toHaveBeenNthCalledWith(2, 'echo some-dep-name-2', {
-        cwd: '/localDir',
-        extraEnv: {},
-      });
+      expect(exec.exec).toHaveBeenNthCalledWith(
+        1,
+        'echo some-dep-name-1',
+        expect.objectContaining({
+          cwd: '/localDir',
+          extraEnv: {},
+        }),
+      );
+      expect(exec.exec).toHaveBeenNthCalledWith(
+        2,
+        'echo some-dep-name-2',
+        expect.objectContaining({
+          cwd: '/localDir',
+          extraEnv: {},
+        }),
+      );
       expect(exec.exec).toHaveBeenCalledTimes(2);
       const calledWithConfig = commit.commitFilesToBranch.mock.calls[0][0];
       const updatedArtifacts = calledWithConfig.updatedArtifacts;
@@ -2476,10 +2487,14 @@ describe('workers/repository/update/branch/index', () => {
         result: 'done',
         commitSha: null,
       });
-      expect(exec.exec).toHaveBeenNthCalledWith(1, 'echo hardcoded-string', {
-        cwd: '/localDir',
-        extraEnv: {},
-      });
+      expect(exec.exec).toHaveBeenNthCalledWith(
+        1,
+        'echo hardcoded-string',
+        expect.objectContaining({
+          cwd: '/localDir',
+          extraEnv: {},
+        }),
+      );
       expect(exec.exec).toHaveBeenCalledTimes(1);
       expect(
         findFileContent(
@@ -2681,10 +2696,14 @@ describe('workers/repository/update/branch/index', () => {
           result: 'done',
           commitSha: null,
         });
-        expect(exec.exec).toHaveBeenNthCalledWith(1, 'echo hardcoded-string', {
-          cwd: '/localDir',
-          extraEnv: {},
-        });
+        expect(exec.exec).toHaveBeenNthCalledWith(
+          1,
+          'echo hardcoded-string',
+          expect.objectContaining({
+            cwd: '/localDir',
+            extraEnv: {},
+          }),
+        );
         expect(exec.exec).toHaveBeenCalledTimes(1);
         expect(
           findFileContent(


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

This resolves https://github.com/renovatebot/renovate/security/advisories/GHSA-pfq2-hh62-7m96 by hardening execution of external commands to no longer run inside a shell.

## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
