### PR TITLE
feat(self-hosted): allow choice of `shell: true` for `postUpgradeTasks`

### DIFF
--- a/docs/usage/security-and-permissions.md
+++ b/docs/usage/security-and-permissions.md
@@ -103,6 +103,7 @@ Because such insider attack is an inherent and unavoidable risk, the Renovate pr
 
 Note that when Renovate runs `postUpgradeTasks`, the script executes inside a shell, which means that they can call out to other commands or access shell variables, if the allowlist via `allowedCommands` does not restrict it.
 As it is difficult to craft a regular expression that may deny usage of special characters to shells, it is likely that this will not be possible to avoid at this time.
+This can be disabled using [`allowShellExecutorForPostUpgradeCommands=false`](./self-hosted-configuration.md#allowshellexecutorforpostupgradecommands).
 
 ###### Execution of code (outsider attack)
 

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -29,6 +29,8 @@ Please also see [Self-Hosted Experimental Options](./self-hosted-experimental.md
 
 ## allowScripts
 
+## allowShellExecutorForPostUpgradeCommands
+
 ## allowedCommands
 
 A list of regular expressions that decide which commands in `postUpgradeTasks` are allowed to run.

--- a/lib/config/global.ts
+++ b/lib/config/global.ts
@@ -6,6 +6,7 @@ export class GlobalConfig {
     'allowCustomCrateRegistries',
     'allowPlugins',
     'allowScripts',
+    'allowShellExecutorForPostUpgradeCommands',
     'allowedCommands',
     'allowedEnv',
     'allowedHeaders',

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -974,6 +974,14 @@ const options: RenovateOptions[] = [
     default: false,
   },
   {
+    name: 'allowShellExecutorForPostUpgradeCommands',
+    description:
+      'Whether to run commands for `postUpgradeTasks` inside a shell. This has security implications, as it means that they can call out to other commands or access shell variables. It is difficult to craft an `allowedCommands` regex to restrict this.',
+    globalOnly: true,
+    type: 'boolean',
+    default: true,
+  },
+  {
     name: 'allowCustomCrateRegistries',
     description: 'Set this to `true` to allow custom crate registries.',
     globalOnly: true,

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -209,6 +209,7 @@ export interface RepoGlobalConfig {
   allowCustomCrateRegistries?: boolean;
   allowPlugins?: boolean;
   allowScripts?: boolean;
+  allowShellExecutorForPostUpgradeCommands?: boolean;
   allowedEnv?: string[];
   allowedHeaders?: string[];
   binarySource?: BinarySource;

--- a/lib/workers/repository/update/branch/execute-post-upgrade-commands.ts
+++ b/lib/workers/repository/update/branch/execute-post-upgrade-commands.ts
@@ -131,7 +131,10 @@ export async function postUpgradeCommandsExecutor(
             const execOpts: ExecOptions = {
               // WARNING to self-hosted administrators: always run post-upgrade commands with `shell` mode on, which has the risk of arbitrary environment variable access or additional command execution
               // It is very likely this will be susceptible to these risks, even if you allowlist (via `allowedCommands`), as there may be special characters included in the given commands that can be leveraged here
-              shell: true,
+              shell: GlobalConfig.get(
+                'allowShellExecutorForPostUpgradeCommands',
+                true,
+              ),
 
               cwd: isNonEmptyString(workingDir)
                 ? workingDir


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
As part of hardening the configuration around executing
`postUpgradeTasks` with `shell: true`, we can give self-hosted
administrators the opportunity to configure this.

This continues to be on-by-default to be non-breaking, but in the next
major version can be flipped to the safer option.

## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
