### PR TITLE
fix(util/exec): allow running with `shell: true` for Containerbase installs

### DIFF
--- a/lib/util/exec/containerbase.ts
+++ b/lib/util/exec/containerbase.ts
@@ -375,6 +375,8 @@ export async function generateInstallCommands(
       const installCommand = `install-tool ${toolName} ${quote(toolVersion)}`;
       installCommands.push(installCommand);
       if (allToolConfig[toolName].hash) {
+        // WARNING this requires `shell: true` when executing
+        // TODO #40232 to rework this
         installCommands.push(`hash -d ${toolName} 2>/dev/null || true`);
       }
     }

--- a/lib/util/exec/index.spec.ts
+++ b/lib/util/exec/index.spec.ts
@@ -251,6 +251,7 @@ describe('util/exec/index', () => {
             env: containerbaseEnv,
             timeout: 900000,
             maxBuffer: 10485760,
+            shell: true,
             stdin: 'pipe',
             stdout: 'pipe',
             stderr: 'pipe',
@@ -280,6 +281,7 @@ describe('util/exec/index', () => {
             env: containerbaseEnvFiltered,
             timeout: 900000,
             maxBuffer: 10485760,
+            shell: true,
             stdin: 'pipe',
             stdout: 'pipe',
             stderr: 'pipe',
@@ -317,6 +319,7 @@ describe('util/exec/index', () => {
             env: containerbaseEnvFiltered,
             timeout: 900000,
             maxBuffer: 10485760,
+            shell: true,
             stdin: 'pipe',
             stdout: 'pipe',
             stderr: 'pipe',
@@ -339,6 +342,7 @@ describe('util/exec/index', () => {
             env: { ...containerbaseEnv, SELECTED_ENV_VAR: 'Default value' },
             timeout: 900000,
             maxBuffer: 10485760,
+            shell: true,
             stdin: 'pipe',
             stdout: 'pipe',
             stderr: 'pipe',
@@ -371,6 +375,7 @@ describe('util/exec/index', () => {
             env: { ...containerbaseEnv, SELECTED_ENV_VAR: 'Default value' },
             timeout: 900000,
             maxBuffer: 10485760,
+            shell: true,
             stdin: 'pipe',
             stdout: 'pipe',
             stderr: 'pipe',
@@ -399,6 +404,7 @@ describe('util/exec/index', () => {
             env: containerbaseEnv,
             timeout: 900000,
             maxBuffer: 10485760,
+            shell: true,
             stdin: 'pipe',
             stdout: 'pipe',
             stderr: 'pipe',
@@ -427,6 +433,7 @@ describe('util/exec/index', () => {
             env: containerbaseEnv,
             timeout: 900000,
             maxBuffer: 10485760,
+            shell: true,
             stdin: 'pipe',
             stdout: 'pipe',
             stderr: 'pipe',
@@ -458,6 +465,7 @@ describe('util/exec/index', () => {
             env: containerbaseEnv,
             timeout: 900000,
             maxBuffer: 10485760,
+            shell: true,
             stdin: 'pipe',
             stdout: 'pipe',
             stderr: 'pipe',
@@ -489,6 +497,7 @@ describe('util/exec/index', () => {
             env: containerbaseEnv,
             timeout: 900000,
             maxBuffer: 10485760,
+            shell: true,
             stdin: 'pipe',
             stdout: 'pipe',
             stderr: 'pipe',
@@ -523,6 +532,7 @@ describe('util/exec/index', () => {
             env: containerbaseEnv,
             timeout: 900000,
             maxBuffer: 10485760,
+            shell: true,
             stdin: 'pipe',
             stdout: 'pipe',
             stderr: 'pipe',
@@ -551,6 +561,7 @@ describe('util/exec/index', () => {
             env: containerbaseEnv,
             timeout: 900000,
             maxBuffer: 10485760,
+            shell: true,
             stdin: 'pipe',
             stdout: 'pipe',
             stderr: 'pipe',
@@ -575,6 +586,7 @@ describe('util/exec/index', () => {
             env: containerbaseEnv,
             timeout: 20 * 60 * 1000,
             maxBuffer: 10485760,
+            shell: true,
             stdin: 'pipe',
             stdout: 'pipe',
             stderr: 'pipe',
@@ -621,6 +633,7 @@ describe('util/exec/index', () => {
             env: containerbaseEnv,
             timeout: 900000,
             maxBuffer: 1024,
+            shell: true,
             stdin: 'pipe',
             stdout: 'pipe',
             stderr: 'pipe',
@@ -646,6 +659,7 @@ describe('util/exec/index', () => {
             },
             timeout: 900000,
             maxBuffer: 10485760,
+            shell: true,
             stdin: 'pipe',
             stdout: 'pipe',
             stderr: 'pipe',
@@ -676,6 +690,7 @@ describe('util/exec/index', () => {
             },
             timeout: 900000,
             maxBuffer: 10485760,
+            shell: true,
             stdin: 'pipe',
             stdout: 'pipe',
             stderr: 'pipe',
@@ -712,6 +727,7 @@ describe('util/exec/index', () => {
             },
             timeout: 900000,
             maxBuffer: 10485760,
+            shell: true,
             stdin: 'pipe',
             stdout: 'pipe',
             stderr: 'pipe',
@@ -748,6 +764,7 @@ describe('util/exec/index', () => {
             },
             timeout: 900000,
             maxBuffer: 10485760,
+            shell: true,
             stdin: 'pipe',
             stdout: 'pipe',
             stderr: 'pipe',
@@ -913,6 +930,27 @@ describe('util/exec/index', () => {
     process.env.CONTAINERBASE = 'true';
     const promise = exec('foobar', { toolConstraints: [{ toolName: 'npm' }] });
     await expect(promise).rejects.toThrow('No tool releases found.');
+  });
+
+  // TODO #40232 to remove this
+  it('Sets shell=true when using binarySource=install', async () => {
+    process.env = processEnv;
+    cpExec.mockImplementation(() => {
+      return Promise.resolve({ stdout: '', stderr: '' });
+    });
+
+    GlobalConfig.set({ ...globalConfig, binarySource: 'install' });
+    process.env.CONTAINERBASE = 'true';
+    await exec('foobar', {
+      toolConstraints: [{ toolName: 'npm', constraint: '2.5.0' }],
+    });
+
+    expect(cpExec).toHaveBeenCalledWith(
+      'install-tool npm 2.5.0',
+      expect.objectContaining({
+        shell: true,
+      }),
+    );
   });
 
   it('Supports binarySource=install preCommands', async () => {

--- a/lib/util/exec/index.ts
+++ b/lib/util/exec/index.ts
@@ -60,6 +60,8 @@ function getRawExecOptions(opts: ExecOptions): RawExecOptions {
     stdin: 'pipe',
     stdout: opts.ignoreStdout ? 'ignore' : 'pipe',
     stderr: 'pipe',
+    // only set shell if it has a value
+    ...(opts.shell === undefined ? {} : { shell: opts.shell }),
   };
 }
 
@@ -86,6 +88,10 @@ async function prepareRawExec(
     logger.debug(`Setting CONTAINERBASE_CACHE_DIR to ${containerbaseDir!}`);
     opts.env ??= {};
     opts.env.CONTAINERBASE_CACHE_DIR = containerbaseDir;
+
+    // WARNING this is required to allow executing `hash`, which is a shell built-in. We should be very careful that commands executed here are controlled only by Renovate's code, and that arguments are quoted
+    // TODO #40232 to replace this
+    opts.shell = true;
   }
 
   let rawOptions = getRawExecOptions(opts);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

After recent changes to remove `shell: true`, it's clear from #40231
that this breaks Containerbase's installing of tools, as we use the
`hash` shell built-in.

This requires we make sure that the `shell` option is passed around.

We will temporarily re-enable this, and then follow up in #40232 to
remove this requirement.



## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #40231
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
