### PR TITLE
fix(util/exec): remove `hash` for Containerbase installs

### DIFF
--- a/lib/modules/manager/npm/post-update/npm.spec.ts
+++ b/lib/modules/manager/npm/post-update/npm.spec.ts
@@ -432,8 +432,6 @@ describe('modules/manager/npm/post-update/npm', () => {
           '&& ' +
           'install-tool npm 6.0.0 ' +
           '&& ' +
-          'hash -d npm 2>/dev/null || true ' +
-          '&& ' +
           'npm install --package-lock-only --no-audit' +
           '"',
       },
@@ -460,7 +458,6 @@ describe('modules/manager/npm/post-update/npm', () => {
     expect(execSnapshots).toMatchObject([
       { cmd: 'install-tool node 16.16.0' },
       { cmd: 'install-tool npm 6.0.0' },
-      { cmd: 'hash -d npm 2>/dev/null || true' },
       {
         cmd: 'npm install --package-lock-only --no-audit --ignore-scripts',
       },

--- a/lib/util/exec/containerbase.spec.ts
+++ b/lib/util/exec/containerbase.spec.ts
@@ -258,14 +258,5 @@ describe('util/exec/containerbase', () => {
         'install-tool composer 2.1.0',
       ]);
     });
-
-    it('hashes npm', async () => {
-      const toolConstraints: ToolConstraint[] = [{ toolName: 'npm' }];
-      const res = await generateInstallCommands(toolConstraints);
-      expect(res).toEqual([
-        'install-tool npm 2.1.0',
-        'hash -d npm 2>/dev/null || true',
-      ]);
-    });
   });
 });

--- a/lib/util/exec/containerbase.ts
+++ b/lib/util/exec/containerbase.ts
@@ -150,7 +150,6 @@ const allToolConfig: Record<string, ToolConfig> = {
   npm: {
     datasource: 'npm',
     packageName: 'npm',
-    hash: true,
     versioning: npmVersioningId,
   },
   pdm: {
@@ -374,9 +373,6 @@ export async function generateInstallCommands(
       const { toolName } = toolConstraint;
       const installCommand = `install-tool ${toolName} ${quote(toolVersion)}`;
       installCommands.push(installCommand);
-      if (allToolConfig[toolName].hash) {
-        installCommands.push(`hash -d ${toolName} 2>/dev/null || true`);
-      }
     }
   }
   return installCommands;

--- a/lib/util/exec/types.ts
+++ b/lib/util/exec/types.ts
@@ -9,7 +9,6 @@ export interface ToolConfig {
   datasource: string;
   extractVersion?: string;
   packageName: string;
-  hash?: boolean;
   versioning: string;
 }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
After recent changes to remove `shell: true`, it's clear from #40231
that this breaks Containerbase's installing of tools, as we use the
`hash` shell built-in.

As we no longer need the `hash` call, we can remove it.

An alternative to #40233.


## Context

Please select one of the below:

- [x] This closes an existing Issue: Closes #40231, #40232.
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
