### PR TITLE
feat(manager/mise): add github backend support

### DIFF
--- a/lib/modules/manager/mise/backends.spec.ts
+++ b/lib/modules/manager/mise/backends.spec.ts
@@ -3,6 +3,7 @@ import {
   createCargoToolConfig,
   createDotnetToolConfig,
   createGemToolConfig,
+  createGithubToolConfig,
   createGoToolConfig,
   createNpmToolConfig,
   createPipxToolConfig,
@@ -305,6 +306,90 @@ describe('modules/manager/mise/backends', () => {
         datasource: 'github-releases',
         currentValue: '1.10.17',
         extractVersion: '^v?(?<version>\\d+\\.\\d+\\.)',
+      });
+    });
+  });
+
+  describe('createGithubToolConfig()', () => {
+    it('should set extractVersion if version does not have leading v', () => {
+      expect(createGithubToolConfig('cli/cli', '2.64.0', {})).toStrictEqual({
+        packageName: 'cli/cli',
+        datasource: 'github-releases',
+        currentValue: '2.64.0',
+        extractVersion: '^v?(?<version>.+)',
+      });
+    });
+
+    it('should not set extractVersion if version has leading v', () => {
+      expect(
+        createGithubToolConfig('junegunn/fzf', 'v0.56.3', {}),
+      ).toStrictEqual({
+        packageName: 'junegunn/fzf',
+        datasource: 'github-releases',
+        currentValue: 'v0.56.3',
+      });
+    });
+
+    it('should support tag_regex option without v prefix in version', () => {
+      expect(
+        createGithubToolConfig('owner/repo', '1.0.0', {
+          tag_regex: '^\\d+\\.\\d+\\.',
+        }),
+      ).toStrictEqual({
+        packageName: 'owner/repo',
+        datasource: 'github-releases',
+        currentValue: '1.0.0',
+        extractVersion: '^v?(?<version>\\d+\\.\\d+\\.)',
+      });
+    });
+
+    it('should support tag_regex option with v prefix in version', () => {
+      expect(
+        createGithubToolConfig('owner/repo', 'v1.0.0', {
+          tag_regex: '^\\d+\\.\\d+\\.',
+        }),
+      ).toStrictEqual({
+        packageName: 'owner/repo',
+        datasource: 'github-releases',
+        currentValue: 'v1.0.0',
+        extractVersion: '^(?<version>\\d+\\.\\d+\\.)',
+      });
+    });
+
+    it('should trim leading ^ from tag_regex', () => {
+      expect(
+        createGithubToolConfig('owner/repo', '1.0.0', {
+          tag_regex: '^\\d+\\.\\d+\\.',
+        }),
+      ).toStrictEqual({
+        packageName: 'owner/repo',
+        datasource: 'github-releases',
+        currentValue: '1.0.0',
+        extractVersion: '^v?(?<version>\\d+\\.\\d+\\.)',
+      });
+    });
+
+    it('should handle tag_regex with v? prefix when version lacks v', () => {
+      expect(
+        createGithubToolConfig('owner/repo', '1.0.0', {
+          tag_regex: '^v?\\d+\\.\\d+\\.',
+        }),
+      ).toStrictEqual({
+        packageName: 'owner/repo',
+        datasource: 'github-releases',
+        currentValue: '1.0.0',
+        extractVersion: '^v?(?<version>\\d+\\.\\d+\\.)',
+      });
+    });
+
+    it('should handle empty options object', () => {
+      expect(
+        createGithubToolConfig('BurntSushi/ripgrep', '14.1.1', {}),
+      ).toStrictEqual({
+        packageName: 'BurntSushi/ripgrep',
+        datasource: 'github-releases',
+        currentValue: '14.1.1',
+        extractVersion: '^v?(?<version>.+)',
       });
     });
   });

--- a/lib/modules/manager/mise/backends.ts
+++ b/lib/modules/manager/mise/backends.ts
@@ -237,3 +237,41 @@ export function createUbiToolConfig(
     ...(isString(extractVersion) ? { extractVersion } : {}),
   };
 }
+
+/**
+ * Create a tooling config for github backend
+ */
+export function createGithubToolConfig(
+  name: string,
+  version: string,
+  toolOptions: MiseToolOptions,
+): BackendToolingConfig {
+  let extractVersion: string | undefined = undefined;
+
+  const hasVPrefix = version.startsWith('v');
+  const setsTagRegex = !hasVPrefix || isString(toolOptions.tag_regex);
+
+  if (setsTagRegex) {
+    // By default, use a regex that matches any tag
+    let tagRegex = '.+';
+    // Filter versions by tag_regex if it is specified
+    if (isString(toolOptions.tag_regex)) {
+      // Remove the leading '^' if it exists to avoid duplication
+      tagRegex = toolOptions.tag_regex.replace(/^\^/, '');
+      if (!hasVPrefix) {
+        // Remove the leading 'v?' if it exists to avoid duplication
+        tagRegex = tagRegex.replace(/^v\??/, '');
+      }
+    }
+
+    // Trim the 'v' prefix if the current version does not have it
+    extractVersion = `^${hasVPrefix ? '' : 'v?'}(?<version>${tagRegex})`;
+  }
+
+  return {
+    packageName: name,
+    datasource: GithubReleasesDatasource.id,
+    currentValue: version,
+    ...(isString(extractVersion) ? { extractVersion } : {}),
+  };
+}

--- a/lib/modules/manager/mise/extract.spec.ts
+++ b/lib/modules/manager/mise/extract.spec.ts
@@ -662,6 +662,56 @@ describe('modules/manager/mise/extract', () => {
       });
     });
 
+    it('extracts github backend tools', () => {
+      const content = codeBlock`
+      [tools]
+      "github:cli/cli" = "2.64.0"
+      "github:junegunn/fzf" = "v0.56.3"
+      "github:BurntSushi/ripgrep" = { version = "14.1.1" }
+      "github:owner/repo[tag_regex=^\\\\d+\\\\.]" = "1.0.0"
+      'github:owner/repo' = { tag_regex = '^\\d+\\.\\d+\\.', version = "2.0.0" }
+    `;
+      const result = extractPackageFile(content, miseFilename);
+      expect(result).toMatchObject({
+        deps: [
+          {
+            depName: 'github:cli/cli',
+            currentValue: '2.64.0',
+            packageName: 'cli/cli',
+            datasource: 'github-releases',
+            extractVersion: '^v?(?<version>.+)',
+          },
+          {
+            depName: 'github:junegunn/fzf',
+            currentValue: 'v0.56.3',
+            packageName: 'junegunn/fzf',
+            datasource: 'github-releases',
+          },
+          {
+            depName: 'github:BurntSushi/ripgrep',
+            currentValue: '14.1.1',
+            packageName: 'BurntSushi/ripgrep',
+            datasource: 'github-releases',
+            extractVersion: '^v?(?<version>.+)',
+          },
+          {
+            depName: 'github:owner/repo',
+            currentValue: '1.0.0',
+            packageName: 'owner/repo',
+            datasource: 'github-releases',
+            extractVersion: '^v?(?<version>\\d+\\.)',
+          },
+          {
+            depName: 'github:owner/repo',
+            currentValue: '2.0.0',
+            packageName: 'owner/repo',
+            datasource: 'github-releases',
+            extractVersion: '^v?(?<version>\\d+\\.\\d+\\.)',
+          },
+        ],
+      });
+    });
+
     it('provides skipReason for lines with unsupported tooling', () => {
       const content = codeBlock`
       [tools]

--- a/lib/modules/manager/mise/extract.ts
+++ b/lib/modules/manager/mise/extract.ts
@@ -16,6 +16,7 @@ import {
   createCargoToolConfig,
   createDotnetToolConfig,
   createGemToolConfig,
+  createGithubToolConfig,
   createGoToolConfig,
   createNpmToolConfig,
   createPipxToolConfig,
@@ -144,6 +145,8 @@ function getToolConfig(
       return createSpmToolConfig(toolName);
     case 'ubi':
       return createUbiToolConfig(toolName, version, toolOptions);
+    case 'github':
+      return createGithubToolConfig(toolName, version, toolOptions);
     default:
       // Unsupported backend
       return null;

--- a/lib/modules/manager/mise/index.ts
+++ b/lib/modules/manager/mise/index.ts
@@ -40,6 +40,7 @@ const backendDatasources = {
   cargo: [CrateDatasource.id, GitTagsDatasource.id, GitRefsDatasource.id],
   dotnet: [NugetDatasource.id],
   gem: [RubygemsDatasource.id],
+  github: [GithubReleasesDatasource.id],
   go: [GoDatasource.id],
   npm: [NpmDatasource.id],
   pipx: [PypiDatasource.id, GithubTagsDatasource.id, GitRefsDatasource.id],

--- a/lib/modules/manager/mise/readme.md
+++ b/lib/modules/manager/mise/readme.md
@@ -51,6 +51,7 @@ Renovate's `mise` manager supports the following [backends](https://mise.jdx.dev
 - [`asdf`](https://mise.jdx.dev/dev-tools/backends/asdf.html)
 - [`aqua`](https://mise.jdx.dev/dev-tools/backends/aqua.html)
 - [`cargo`](https://mise.jdx.dev/dev-tools/backends/cargo.html)
+- [`github`](https://mise.jdx.dev/dev-tools/backends/github.html)
 - [`go`](https://mise.jdx.dev/dev-tools/backends/go.html)
 - [`npm`](https://mise.jdx.dev/dev-tools/backends/npm.html)
 - [`pipx`](https://mise.jdx.dev/dev-tools/backends/pipx.html)


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Add support for bumps for mise tools defined using the github plugin.

Essentially should be the same as using the following rule: https://github.com/lewtec/renovate-config/blob/c1c6e66188c6cc69c3b27a446e0cb9573e0d01a4/base.json#L31

Solves the following discussion: https://github.com/renovatebot/renovate/discussions/39517
<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

I used Claude Code to essentially ask it to make an implementation plan, it found which code to change, it changed it, I found some rough edges, asked it to fix passing the appropriate external context, like the GitHub plugin doc in Mise to follow the standard, I also asked it to find out the guidelines to write the commit, reviewed everything, tested with a repo I know it would benefit from this and here we are.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/lucasew/mise-ci/

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
