### PR TITLE
fix(nix): extract correct dep when inputs are duplicated

### DIFF
--- a/lib/modules/manager/nix/extract.spec.ts
+++ b/lib/modules/manager/nix/extract.spec.ts
@@ -1450,4 +1450,20 @@ describe('modules/manager/nix/extract', () => {
       ],
     });
   });
+
+  it('returns null when node is missing', async () => {
+    const flakeLock = codeBlock`{
+      "nodes": {
+        "root": {
+          "inputs": {
+            "unknown-flake": "unknown-flake"
+          }
+        }
+      },
+      "root": "root",
+      "version": 7
+    }`;
+    fs.readLocalFile.mockResolvedValueOnce(flakeLock);
+    expect(await extractPackageFile('', 'flake.nix')).toBeNull();
+  });
 });

--- a/lib/modules/manager/nix/extract.spec.ts
+++ b/lib/modules/manager/nix/extract.spec.ts
@@ -1441,7 +1441,7 @@ describe('modules/manager/nix/extract', () => {
       deps: [
         {
           currentValue: 'nixos-unstable',
-          depName: 'nixpkgs_2',
+          depName: 'nixpkgs',
           datasource: GitRefsDatasource.id,
           packageName: 'https://github.com/NixOS/nixpkgs',
           versioning: nixpkgsVersioning,

--- a/lib/modules/manager/nix/extract.spec.ts
+++ b/lib/modules/manager/nix/extract.spec.ts
@@ -1466,4 +1466,20 @@ describe('modules/manager/nix/extract', () => {
     fs.readLocalFile.mockResolvedValueOnce(flakeLock);
     expect(await extractPackageFile('', 'flake.nix')).toBeNull();
   });
+
+  it('returns null when no valid nodes in root', async () => {
+    const flakeLock = codeBlock`{
+      "nodes": {
+        "root": {
+          "inputs": {
+            "nixpkgs": "nixpkgs"
+          }
+        }
+      },
+      "root": "root",
+      "version": 7
+    }`;
+    fs.readLocalFile.mockResolvedValueOnce(flakeLock);
+    expect(await extractPackageFile('', 'flake.nix')).toBeNull();
+  });
 });

--- a/lib/modules/manager/nix/extract.spec.ts
+++ b/lib/modules/manager/nix/extract.spec.ts
@@ -1467,12 +1467,28 @@ describe('modules/manager/nix/extract', () => {
     expect(await extractPackageFile('', 'flake.nix')).toBeNull();
   });
 
-  it('returns null when no valid nodes in root', async () => {
+  it('returns null when root input is not a string', async () => {
     const flakeLock = codeBlock`{
       "nodes": {
+        "nixpkgs": {
+          "locked": {
+            "lastModified": 1757068644,
+            "narHash": "sha256-NOrUtIhTkIIumj1E/Rsv1J37Yi3xGStISEo8tZm3KW4=",
+            "owner": "NixOS",
+            "repo": "nixpkgs",
+            "rev": "8eb28adfa3dc4de28e792e3bf49fcf9007ca8ac9",
+            "type": "github"
+          },
+          "original": {
+            "owner": "NixOS",
+            "ref": "nixos-unstable",
+            "repo": "nixpkgs",
+            "type": "github"
+          }
+        },
         "root": {
           "inputs": {
-            "nixpkgs": "nixpkgs"
+            "nixpkgs": ["nixpkgs"]
           }
         }
       },

--- a/lib/modules/manager/nix/extract.ts
+++ b/lib/modules/manager/nix/extract.ts
@@ -43,9 +43,25 @@ export async function extractPackageFile(
   }
 
   const flakeLock = flakeLockParsed.data;
-  const rootInputs = flakeLock.nodes.root.inputs;
+  const rootInputs = flakeLock.nodes[flakeLock.root].inputs;
+
+  if (!rootInputs) {
+    logger.debug(
+      { flakeLockFile },
+      `root node in flake.lock does not contain inputs, skipping`,
+    );
+    return null;
+  }
 
   for (const [depName, nodeName] of Object.entries(rootInputs)) {
+    if (typeof nodeName !== 'string') {
+      logger.debug(
+        { flakeLockFile, nodeName },
+        `input node name is not a string, skipping`,
+      );
+      continue;
+    }
+
     if (!Object.hasOwn(flakeLock.nodes, nodeName)) {
       logger.debug(
         { flakeLockFile, nodeName },

--- a/lib/modules/manager/nix/extract.ts
+++ b/lib/modules/manager/nix/extract.ts
@@ -43,9 +43,9 @@ export async function extractPackageFile(
   }
 
   const flakeLock = flakeLockParsed.data;
-  const rootInputs = flakeLock.nodes.root.inputs;
+  const rootInputs = Object.values(flakeLock.nodes.root.inputs ?? []).flat();
 
-  if (!rootInputs) {
+  if (rootInputs.length === 0) {
     logger.debug(
       { flakeLockFile, error: flakeLockParsed.error },
       `flake.lock is missing "root" node`,
@@ -60,7 +60,7 @@ export async function extractPackageFile(
     }
 
     // skip all locked and transitivie nodes as they cannot be updated by regular means
-    if (!(depName in rootInputs)) {
+    if (!rootInputs.includes(depName)) {
       continue;
     }
 

--- a/lib/modules/manager/nix/extract.ts
+++ b/lib/modules/manager/nix/extract.ts
@@ -46,7 +46,7 @@ export async function extractPackageFile(
   const rootInputs = flakeLock.nodes.root.inputs;
 
   for (const [depName, nodeName] of Object.entries(rootInputs)) {
-    if (Object.hasOwn(flakeLock.nodes, nodeName) === false) {
+    if (!Object.hasOwn(flakeLock.nodes, nodeName)) {
       logger.debug(
         { flakeLockFile, nodeName },
         `input node not found in flake.lock, skipping`,

--- a/lib/modules/manager/nix/schema.ts
+++ b/lib/modules/manager/nix/schema.ts
@@ -35,9 +35,17 @@ const NixInput = z.object({
   original: OriginalInput.optional(),
 });
 
+const RootInput = z.object({
+  inputs: z.record(z.string(), z.string()),
+});
+
 export const NixFlakeLock = Json.pipe(
   z.object({
-    nodes: z.record(z.string(), NixInput),
+    nodes: z
+      .object({
+        root: RootInput,
+      })
+      .catchall(NixInput),
     version: z.literal(7),
   }),
 );

--- a/lib/modules/manager/nix/schema.ts
+++ b/lib/modules/manager/nix/schema.ts
@@ -35,17 +35,10 @@ const NixInput = z.object({
   original: OriginalInput.optional(),
 });
 
-const RootInput = z.object({
-  inputs: z.record(z.string(), z.string()),
-});
-
 export const NixFlakeLock = Json.pipe(
   z.object({
-    nodes: z
-      .object({
-        root: RootInput,
-      })
-      .catchall(NixInput),
+    nodes: z.record(z.string(), NixInput),
+    root: z.string(),
     version: z.literal(7),
   }),
 );


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Currently, renovate assumes that the *name* of a root input corresponds to a node name. This is incorrect, as it is actually the root input's *value* that maps an input to a node. If there are multiple dependencies that share the same name (for example, transitive dependencies nixpkgs, nixpkgs_2, nixpkgs_3...), renovate will extract information from the node `nixpkgs` even if the root input `nixpkgs` is actually pointing to `nixpkgs_2`.

While a relatively simple issue, some refactoring was needed as the dependency name must still be the root input's name, as that's what `nix flake update` expects during `updateArtifacts()`.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!--- The public repository: <URL> -->

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
