### PR TITLE
fix(util/exec): allow ignoring failures per-command

### DIFF
--- a/lib/util/exec/common.spec.ts
+++ b/lib/util/exec/common.spec.ts
@@ -11,7 +11,7 @@ import {
 import { exec, rawExec } from './common';
 import { ExecError } from './exec-error';
 import type { DataListener, RawExecOptions } from './types';
-import { partial } from '~test/util';
+import { logger, partial } from '~test/util';
 
 vi.mock('../../instrumentation');
 vi.mock('node:child_process');
@@ -190,6 +190,33 @@ describe('util/exec/common', () => {
       });
     });
 
+    it('throws if an error occurs, when using CommandWithOptions', async () => {
+      const cmd = 'ls -l';
+      const stub = getSpawnStub({
+        cmd,
+        exitCode: 1,
+        exitSignal: null,
+        stdout,
+        stderr,
+      });
+      execa.mockImplementationOnce((cmd, opts) => stub);
+
+      await expect(
+        exec(
+          { command: ['ls', '-l'] },
+          partial<RawExecOptions>({ timeout: 5 }),
+        ),
+      ).rejects.toThrow(
+        new ExecError(`Command failed: ls -l\nerr message`, {
+          cmd: 'ls -l',
+          exitCode: 1,
+          stdout,
+          stderr,
+          options: { timeout: 5 },
+        }),
+      );
+    });
+
     it('throws if an error occurs', async () => {
       const cmd = 'ls -l';
       const stub = getSpawnStub({
@@ -211,6 +238,61 @@ describe('util/exec/common', () => {
           stderr,
           options: { timeout: 5 },
         }),
+      );
+    });
+
+    it('throws if an error occurs, and we specify ignoreFailure=false', async () => {
+      const cmd = 'ls -l';
+      const stub = getSpawnStub({
+        cmd,
+        exitCode: 1,
+        exitSignal: null,
+        stdout,
+        stderr,
+      });
+      execa.mockImplementationOnce((cmd, opts) => stub);
+
+      await expect(
+        exec(
+          { command: ['ls', '-l'], ignoreFailure: false },
+          partial<RawExecOptions>({ timeout: 5 }),
+        ),
+      ).rejects.toThrow(
+        new ExecError(`Command failed: ls -l\nerr message`, {
+          cmd: 'ls -l',
+          exitCode: 1,
+          stdout,
+          stderr,
+          options: { timeout: 5 },
+        }),
+      );
+    });
+
+    it('does not throw if an error occurs, but we specify ignoreFailure=true', async () => {
+      const cmd = 'ls -l';
+      const stub = getSpawnStub({
+        cmd,
+        exitCode: 1,
+        exitSignal: null,
+        stdout,
+        stderr,
+      });
+      execa.mockImplementationOnce((cmd, opts) => stub);
+
+      await expect(
+        exec(
+          { command: ['ls', '-l'], ignoreFailure: true },
+          partial<RawExecOptions>({ timeout: 5 }),
+        ),
+      ).resolves.toEqual({
+        stderr,
+        stdout,
+        exitCode: 1,
+      });
+
+      expect(logger.logger.once.debug).toHaveBeenCalledWith(
+        { command: 'ls -l', stdout, stderr, exitCode: 1 },
+        'Ignoring failure to execute comamnd `ls -l`, as ignoreFailure=true is set',
       );
     });
 

--- a/lib/util/exec/common.ts
+++ b/lib/util/exec/common.ts
@@ -2,14 +2,20 @@ import type { ChildProcess } from 'node:child_process';
 import type { Readable } from 'node:stream';
 import { isNullOrUndefined } from '@sindresorhus/is';
 import { execa } from 'execa';
-import { split } from 'shlex';
+import { join, split } from 'shlex';
 import { instrument } from '../../instrumentation';
+import { logger } from '../../logger';
 import { getEnv } from '../env';
 import { sanitize } from '../sanitize';
 import type { ExecErrorData } from './exec-error';
 import { ExecError } from './exec-error';
-import type { DataListener, ExecResult, RawExecOptions } from './types';
-
+import type {
+  CommandWithOptions,
+  DataListener,
+  ExecResult,
+  RawExecOptions,
+} from './types';
+import { asRawCommand, isCommandWithOptions } from './utils';
 // https://man7.org/linux/man-pages/man7/signal.7.html#NAME
 // Non TERM/CORE signals
 // The following is step 3. in https://github.com/renovatebot/renovate/issues/16197#issuecomment-1171423890
@@ -81,11 +87,20 @@ function registerDataListeners(
 }
 
 export function exec(
-  theCmd: string,
+  commandArgument: string | CommandWithOptions,
   opts: RawExecOptions,
 ): Promise<ExecResult> {
+  let theCmd = commandArgument;
+  let ignoreFailure = false;
+  if (isCommandWithOptions(commandArgument)) {
+    theCmd = join(commandArgument.command);
+    if (commandArgument.ignoreFailure !== undefined) {
+      ignoreFailure = commandArgument.ignoreFailure;
+    }
+  }
+
   return new Promise((resolve, reject) => {
-    let cmd = theCmd;
+    let cmd = asRawCommand(theCmd);
     let args: string[] = [];
     const maxBuffer = opts.maxBuffer ?? 10 * 1024 * 1024; // Set default max buffer size to 10MB
 
@@ -139,15 +154,34 @@ export function exec(
         return;
       }
       if (code !== 0) {
-        reject(
-          new ExecError(
-            `Command failed: ${cp.spawnargs.join(' ')}\n${stringify(stderr)}`,
-            {
-              ...rejectInfo(),
-              exitCode: code,
-            },
-          ),
+        if (ignoreFailure === undefined || ignoreFailure === false) {
+          reject(
+            new ExecError(
+              `Command failed: ${cp.spawnargs.join(' ')}\n${stringify(stderr)}`,
+              {
+                ...rejectInfo(),
+                exitCode: code,
+              },
+            ),
+          );
+          return;
+        }
+
+        logger.once.debug(
+          {
+            command: cp.spawnargs.join(' '),
+            stdout: stringify(stdout),
+            stderr: stringify(stderr),
+            exitCode: code,
+          },
+          `Ignoring failure to execute comamnd \`${cp.spawnargs.join(' ')}\`, as ignoreFailure=true is set`,
         );
+
+        resolve({
+          stderr: stringify(stderr),
+          stdout: stringify(stdout),
+          exitCode: code,
+        });
         return;
       }
       resolve({
@@ -193,7 +227,10 @@ function kill(cp: ChildProcess, signal: NodeJS.Signals): boolean {
 }
 
 export const rawExec: (
-  cmd: string,
+  cmd: string | CommandWithOptions,
   opts: RawExecOptions,
-) => Promise<ExecResult> = (cmd: string, opts: RawExecOptions) =>
-  instrument(`rawExec: ${sanitize(cmd)}`, () => exec(cmd, opts));
+) => Promise<ExecResult> = (
+  cmd: string | CommandWithOptions,
+  opts: RawExecOptions,
+) =>
+  instrument(`rawExec: ${sanitize(asRawCommand(cmd))}`, () => exec(cmd, opts));

--- a/lib/util/exec/docker/index.spec.ts
+++ b/lib/util/exec/docker/index.spec.ts
@@ -237,6 +237,64 @@ describe('util/exec/docker/index', () => {
       expect(res).toBe(command(image));
     });
 
+    it('adds `|| true` if ignoreFailure is set on a pre-command', async () => {
+      mockExecAll();
+      const res = await generateDockerCommand(
+        ['ls'],
+        [
+          'foo',
+          {
+            command: ['bar'],
+            ignoreFailure: true,
+          },
+          {
+            command: ['bleh'],
+          },
+          'baz',
+        ],
+        dockerOptions,
+      );
+      expect(res).toBe(
+        `docker run --rm ` +
+          `--name=renovate_${image} ` +
+          `--label=renovate_child ` +
+          `--user=some-user ` +
+          `-e FOO -e BAR ` +
+          `-w "/tmp/foobar" ` +
+          `ghcr.io/containerbase/sidecar ` +
+          `bash -l -c "foo && bar || true && bleh && baz && ls"`,
+      );
+    });
+
+    it('adds `|| true` if ignoreFailure is set on a command', async () => {
+      mockExecAll();
+      const res = await generateDockerCommand(
+        [
+          'foo',
+          {
+            command: ['bar'],
+            ignoreFailure: true,
+          },
+          {
+            command: ['bleh'],
+          },
+          'baz',
+        ],
+        ['pre'],
+        dockerOptions,
+      );
+      expect(res).toBe(
+        `docker run --rm ` +
+          `--name=renovate_${image} ` +
+          `--label=renovate_child ` +
+          `--user=some-user ` +
+          `-e FOO -e BAR ` +
+          `-w "/tmp/foobar" ` +
+          `ghcr.io/containerbase/sidecar ` +
+          `bash -l -c "pre && foo && bar || true && bleh && baz"`,
+      );
+    });
+
     it('handles volumes', async () => {
       mockExecAll();
       const volumes: VolumeOption[] = [

--- a/lib/util/exec/index.spec.ts
+++ b/lib/util/exec/index.spec.ts
@@ -5,7 +5,14 @@ import { TEMPORARY_ERROR } from '../../constants/error-messages';
 import { setCustomEnv } from '../env';
 import * as dockerModule from './docker';
 import { getHermitEnvs } from './hermit';
-import type { ExecOptions, RawExecOptions, VolumeOption } from './types';
+import type {
+  CommandWithOptions,
+  ExecOptions,
+  ExecResult,
+  RawExecOptions,
+  VolumeOption,
+} from './types';
+import { asRawCommand } from './utils';
 import { exec } from '.';
 import { exec as cpExec, envMock } from '~test/exec-util';
 
@@ -914,7 +921,7 @@ describe('util/exec/index', () => {
     const actualCmd: string[] = [];
     const actualOpts: RawExecOptions[] = [];
     cpExec.mockImplementation((execCmd, execOpts) => {
-      actualCmd.push(execCmd);
+      actualCmd.push(asRawCommand(execCmd));
       actualOpts.push(execOpts);
 
       return Promise.resolve({ stdout: '', stderr: '' });
@@ -936,7 +943,7 @@ describe('util/exec/index', () => {
 
     const actualCmd: string[] = [];
     cpExec.mockImplementation((execCmd) => {
-      actualCmd.push(execCmd);
+      actualCmd.push(asRawCommand(execCmd));
       return Promise.resolve({ stdout: '', stderr: '' });
     });
 
@@ -973,6 +980,97 @@ describe('util/exec/index', () => {
     ]);
   });
 
+  it('throws when an error is thrown', async () => {
+    process.env = processEnv;
+    cpExec.mockImplementation(() => {
+      throw new Error('some error occurred');
+    });
+    GlobalConfig.set({ ...globalConfig, binarySource: 'install' });
+    const promise = exec('foobar');
+    await expect(promise).rejects.toThrow('some error occurred');
+  });
+
+  it('rejects and throws if an error is thrown, even if we specify ignoreFailure=true', async () => {
+    process.env = processEnv;
+    cpExec.mockImplementation(() => {
+      throw new Error('some error occurred');
+    });
+    GlobalConfig.set({ ...globalConfig });
+    const promise = exec([
+      {
+        command: ['foobar'],
+        ignoreFailure: true,
+      },
+    ]);
+    await expect(promise).rejects.toThrow('some error occurred');
+  });
+
+  it('does not reject and throw if rawExec returns an exit code, and we specify ignoreFailure=true', async () => {
+    process.env = processEnv;
+    const stdout = 'out';
+    const stderr = 'err';
+    cpExec.mockImplementation(
+      (): Promise<ExecResult> =>
+        // NOTE that this only makes sense as a return value when `ignoreFailure=true` is set
+        Promise.resolve({
+          stdout,
+          stderr,
+          exitCode: 10,
+        }),
+    );
+    GlobalConfig.set({ ...globalConfig });
+    const promise = exec([
+      {
+        command: ['foobar'],
+        // NOTE that the implementation would only work if `ignoreFailure: true`
+        ignoreFailure: true,
+      },
+    ]);
+    await expect(promise).resolves.toEqual({
+      stdout,
+      stderr,
+      exitCode: 10,
+    });
+  });
+
+  it('exec takes an array with both `string`s and `CommandWithOptions` as an argument', async () => {
+    const command: CommandWithOptions = {
+      command: ['exit 1'],
+      ignoreFailure: true,
+    };
+
+    cpExec.mockImplementationOnce((execCmd, execOpts) => {
+      return Promise.resolve({ stdout: '', stderr: '' });
+    });
+
+    cpExec.mockImplementationOnce((execCmd, execOpts) => {
+      return Promise.resolve({ stdout: 'out', stderr: 'err', exitCode: 5 });
+    });
+
+    await expect(exec(['ls', command])).resolves.toEqual({
+      stdout: 'out',
+      stderr: 'err',
+      exitCode: 5,
+    });
+  });
+
+  it('exec takes CommandWithOptions as an argument', async () => {
+    const command: CommandWithOptions = {
+      command: ['exit 1'],
+      ignoreFailure: true,
+    };
+
+    cpExec.mockImplementation((execCmd, execOpts) => {
+      return Promise.resolve({ stdout: 'out', stderr: 'err', exitCode: 5 });
+    });
+
+    await expect(exec([command])).resolves.toEqual({
+      stdout: 'out',
+      stderr: 'err',
+      exitCode: 5,
+    });
+  });
+
   it('Supports binarySource=install', async () => {
     process.env = processEnv;
     cpExec.mockImplementation(() => {
@@ -988,7 +1086,7 @@ describe('util/exec/index', () => {
     process.env = processEnv;
     const actualCmd: string[] = [];
     cpExec.mockImplementation((execCmd) => {
-      actualCmd.push(execCmd);
+      actualCmd.push(asRawCommand(execCmd));
       return Promise.resolve({ stdout: '', stderr: '' });
     });
 

--- a/lib/util/exec/index.ts
+++ b/lib/util/exec/index.ts
@@ -13,6 +13,7 @@ import {
 } from './docker';
 import { getHermitEnvs, isHermit } from './hermit';
 import type {
+  CommandWithOptions,
   DockerOptions,
   ExecOptions,
   ExecResult,
@@ -20,7 +21,7 @@ import type {
   Opt,
   RawExecOptions,
 } from './types';
-import { getChildEnv } from './utils';
+import { asRawCommands, getChildEnv } from './utils';
 
 function dockerEnvVars(extraEnv: ExtraEnv, childEnv: ExtraEnv): string[] {
   const extraEnvKeys = Object.keys(extraEnv);
@@ -69,12 +70,16 @@ function isDocker(docker: Opt<DockerOptions>): docker is DockerOptions {
 }
 
 interface RawExecArguments {
-  rawCommands: string[];
+  rawCommands: (string | CommandWithOptions)[];
   rawOptions: RawExecOptions;
 }
 
 async function prepareRawExec(
-  cmd: string | string[],
+  cmd:
+    | string
+    | string[]
+    | CommandWithOptions[]
+    | (string | CommandWithOptions)[],
   opts: ExecOptions,
 ): Promise<RawExecArguments> {
   const { docker } = opts;
@@ -108,7 +113,7 @@ async function prepareRawExec(
     const cwd = getCwd(opts);
     const dockerOptions: DockerOptions = { ...docker, cwd, envVars };
     const dockerCommand = await generateDockerCommand(
-      rawCommands,
+      asRawCommands(rawCommands),
       [
         ...(await generateInstallCommands(opts.toolConstraints)),
         ...preCommands,
@@ -152,7 +157,11 @@ async function prepareRawExec(
 }
 
 export async function exec(
-  cmd: string | string[],
+  cmd:
+    | string
+    | string[]
+    | CommandWithOptions[]
+    | (string | CommandWithOptions)[],
   opts: ExecOptions = {},
 ): Promise<ExecResult> {
   const { docker } = opts;

--- a/lib/util/exec/types.ts
+++ b/lib/util/exec/types.ts
@@ -38,6 +38,13 @@ export interface RawExecOptions extends ExecaOptions {
 export interface ExecResult {
   stdout: string;
   stderr: string;
+  /**
+   * The process' exit code in the case of a failure.
+   *
+   * This is only set if using `ignoreFailure` when executing a command
+   *
+   */
+  exitCode?: number;
 }
 
 export type ExtraEnv<T = unknown> = Record<string, T>;
@@ -55,4 +62,14 @@ export interface ExecOptions {
   maxBuffer?: number | undefined;
   timeout?: number | undefined;
   shell?: boolean | string | undefined;
+}
+
+/**
+ * configuration that can be configured on a per-command basis, that doesn't make sense to be on the `RawExecOptions`
+ */
+export interface CommandWithOptions {
+  command: string[];
+
+  /** do not throw errors when a command fails, but do log that an error occurred */
+  ignoreFailure?: boolean;
 }

--- a/lib/util/exec/utils.spec.ts
+++ b/lib/util/exec/utils.spec.ts
@@ -1,0 +1,159 @@
+import type { CommandWithOptions } from './types';
+import { asRawCommands, isCommandWithOptions } from './utils';
+
+describe('util/exec/utils', () => {
+  describe('isCommandWithOptions', () => {
+    describe('when command is an array of 1 command', () => {
+      it('is a CommandWithOptions', () => {
+        const valid: CommandWithOptions = {
+          command: ['ls'],
+        };
+
+        expect(isCommandWithOptions(valid)).toBeTrue();
+      });
+    });
+
+    describe('when command is an array of many command', () => {
+      it('is a CommandWithOptions', () => {
+        const valid: CommandWithOptions = {
+          command: ['go', 'mod', 'tidy'],
+        };
+
+        expect(isCommandWithOptions(valid)).toBeTrue();
+      });
+    });
+
+    describe('when command is an empty array', () => {
+      it('is not a CommandWithOptions', () => {
+        const valid: CommandWithOptions = {
+          command: [],
+        };
+
+        expect(isCommandWithOptions(valid)).toBeFalse();
+      });
+    });
+
+    describe('when command is a string', () => {
+      it('is not a CommandWithOptions', () => {
+        const invalid = {
+          command: 'ls -al',
+        };
+
+        expect(isCommandWithOptions(invalid)).toBeFalse();
+      });
+    });
+
+    describe('when command is a mixed array of strings booleans', () => {
+      it('is not a CommandWithOptions', () => {
+        const invalid = {
+          command: ['ls', true, '-l', false],
+        };
+
+        expect(isCommandWithOptions(invalid)).toBeFalse();
+      });
+    });
+
+    describe('when command is an array of booleans', () => {
+      it('is not a CommandWithOptions', () => {
+        const invalid = {
+          command: [true, false],
+        };
+
+        expect(isCommandWithOptions(invalid)).toBeFalse();
+      });
+    });
+
+    describe('when command is valid, and no ignoreFailure is present', () => {
+      it('is a CommandWithOptions', () => {
+        const valid: CommandWithOptions = {
+          command: ['go'],
+        };
+
+        expect(isCommandWithOptions(valid)).toBeTrue();
+      });
+    });
+
+    describe('when command is valid, and ignoreFailure is not a boolean', () => {
+      it('is not a CommandWithOptions', () => {
+        const invalid = {
+          command: ['go'],
+          ignoreFailure: 'hello',
+        };
+
+        expect(isCommandWithOptions(invalid)).toBeFalse();
+      });
+    });
+
+    describe('when command is valid, and ignoreFailure=false', () => {
+      it('is a CommandWithOptions', () => {
+        const valid: CommandWithOptions = {
+          command: ['go'],
+          ignoreFailure: false,
+        };
+
+        expect(isCommandWithOptions(valid)).toBeTrue();
+      });
+    });
+
+    describe('when command is valid, and ignoreFailure=true', () => {
+      it('is a CommandWithOptions', () => {
+        const valid: CommandWithOptions = {
+          command: ['go'],
+          ignoreFailure: true,
+        };
+
+        expect(isCommandWithOptions(valid)).toBeTrue();
+      });
+    });
+  });
+
+  describe('asRawCommands', () => {
+    describe('with a string', () => {
+      it('returns array of strings', () => {
+        const res = asRawCommands('go mod tidy');
+
+        expect(res).toBeArrayOfSize(1);
+        expect(res).toEqual(['go mod tidy']);
+      });
+    });
+
+    describe('with an array of strings', () => {
+      it('returns array of strings', () => {
+        const res = asRawCommands(['go mod tidy']);
+
+        expect(res).toBeArrayOfSize(1);
+        expect(res).toEqual(['go mod tidy']);
+      });
+    });
+
+    describe('with many commands', () => {
+      it('returns an array of many strings', () => {
+        const res = asRawCommands([
+          'go mod tidy',
+          'make tidy',
+          'make generate',
+        ]);
+
+        expect(res).toBeArrayOfSize(3);
+        expect(res).toEqual(['go mod tidy', 'make tidy', 'make generate']);
+      });
+    });
+
+    describe('with `CommandWithOptions`', () => {
+      it('returns commands from the `CommandWithOptions`', () => {
+        const res = asRawCommands([
+          {
+            command: ['ls'],
+            ignoreFailure: true,
+          },
+          {
+            command: ['go', 'mod', 'tidy'],
+          },
+        ]);
+
+        expect(res).toBeArrayOfSize(2);
+        expect(res).toEqual(['ls', 'go mod tidy']);
+      });
+    });
+  });
+});

--- a/lib/util/exec/utils.ts
+++ b/lib/util/exec/utils.ts
@@ -1,7 +1,8 @@
-import { isString } from '@sindresorhus/is';
+import { isBoolean, isString } from '@sindresorhus/is';
+import { join } from 'shlex';
 import { getCustomEnv, getUserEnv } from '../env';
 import { getChildProcessEnv } from './env';
-import type { ExecOptions } from './types';
+import type { CommandWithOptions, ExecOptions } from './types';
 
 export function getChildEnv({
   extraEnv,
@@ -34,4 +35,45 @@ export function getChildEnv({
   }
 
   return result;
+}
+
+export function isCommandWithOptions(cmd: unknown): cmd is CommandWithOptions {
+  if (!(typeof cmd === 'object' && cmd !== null && 'command' in cmd)) {
+    return false;
+  }
+
+  if (!Array.isArray(cmd.command)) {
+    return false;
+  }
+
+  if (!cmd.command.length) {
+    return false;
+  }
+
+  if (cmd.command.some((v) => !isString(v))) {
+    return false;
+  }
+
+  if ('ignoreFailure' in cmd && !isBoolean(cmd.ignoreFailure)) {
+    return false;
+  }
+
+  return true;
+}
+
+export function asRawCommand(cmd: string | CommandWithOptions): string {
+  if (isCommandWithOptions(cmd)) {
+    return join(cmd.command);
+  }
+
+  return cmd;
+}
+
+export function asRawCommands(
+  cmds: string | (string | CommandWithOptions)[],
+): string[] {
+  if (isString(cmds)) {
+    return [cmds];
+  }
+  return cmds.map((cmd) => asRawCommand(cmd));
 }

--- a/test/exec-util.ts
+++ b/test/exec-util.ts
@@ -2,7 +2,10 @@ import is from '@sindresorhus/is';
 import traverse from 'neotraverse/legacy';
 import upath from 'upath';
 import { rawExec as _exec } from '../lib/util/exec/common';
-import type { RawExecOptions } from '../lib/util/exec/types';
+import type {
+  CommandWithOptions,
+  RawExecOptions,
+} from '../lib/util/exec/types';
 import { regEx } from '../lib/util/regex';
 
 export type ExecResult = { stdout: string; stderr: string } | Error;
@@ -16,7 +19,10 @@ export interface ExecSnapshot {
 
 export type ExecSnapshots = ExecSnapshot[];
 
-function execSnapshot(cmd: string, options?: RawExecOptions): ExecSnapshot {
+function execSnapshot(
+  cmd: string | CommandWithOptions,
+  options?: RawExecOptions,
+): ExecSnapshot {
   const snapshot = {
     cmd,
     options,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->



As part of future changes which will fix issues with Composer + Yarn 1
introduced by https://github.com/renovatebot/renovate/pull/40228, we need to find
a way to ignore command failure, on a per-command basis.

To do this, we can provide a refactor to introduce a new type,
`CommandWithOptions` which has the ability to specify whether to
`ignoreFailure`.

To make this less of a refactor than would otherwise require, we can
pass around a `(string | CommandWithOptions)[]`
(or a `string[]` or a `CommandWithOptions[]`) to be used, and use
helpers `asRawCommand` and `asRawCommands` to extract the underlying
command where necessary.

In the case a command's failure is being ignored, return the error code
in the `ExecResult`.

We also need to make sure that when executing in Docker, we still
provide the `|| true`s, otherwise we'll start to see commands failing
unexpectedly.



This can be seen in use in:

- #40291 
- https://github.com/renovatebot/renovate/pull/40292

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

Prerequisite for #40284 

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
