### PR TITLE
fix(composer): don't rely on shell semantics for ignoring command failures

### DIFF
--- a/lib/modules/manager/composer/artifacts.spec.ts
+++ b/lib/modules/manager/composer/artifacts.spec.ts
@@ -1080,7 +1080,10 @@ describe('modules/manager/composer/artifacts', () => {
         options: { cwd: '/tmp/github/some/repo' },
       },
       {
-        cmd: 'git stash pop || true',
+        cmd: {
+          command: ['git', 'stash', 'pop'],
+          ignoreFailure: true,
+        },
       },
       {
         cmd: 'composer update --with-dependencies --ignore-platform-reqs --no-ansi --no-interaction --no-scripts --no-autoloader --no-plugins',
@@ -1126,7 +1129,10 @@ describe('modules/manager/composer/artifacts', () => {
         options: { cwd: '/tmp/github/some/repo' },
       },
       {
-        cmd: 'git stash pop || true',
+        cmd: {
+          command: ['git', 'stash', 'pop'],
+          ignoreFailure: true,
+        },
       },
       {
         cmd: 'composer update --with-dependencies --ignore-platform-reqs --no-ansi --no-interaction --no-scripts --no-autoloader --no-plugins',

--- a/lib/modules/manager/composer/artifacts.ts
+++ b/lib/modules/manager/composer/artifacts.ts
@@ -11,7 +11,11 @@ import {
   takePersonalAccessTokenIfPossible,
 } from '../../../util/check-token';
 import { exec } from '../../../util/exec';
-import type { ExecOptions, ToolConstraint } from '../../../util/exec/types';
+import type {
+  CommandWithOptions,
+  ExecOptions,
+  ToolConstraint,
+} from '../../../util/exec/types';
 import {
   deleteLocalFile,
   ensureCacheDir,
@@ -160,7 +164,7 @@ export async function updateArtifacts({
       docker: {},
     };
 
-    const commands: string[] = [];
+    const commands: (string | CommandWithOptions)[] = [];
 
     // Determine whether install is required before update
     if (requireComposerDependencyInstallation(lockfile)) {
@@ -170,7 +174,7 @@ export async function updateArtifacts({
       logger.trace({ preCmd, preArgs }, 'composer pre-update command');
       commands.push('git stash -- composer.json');
       commands.push(`${preCmd} ${preArgs}`);
-      commands.push('git stash pop || true');
+      commands.push({ command: ['git', 'stash', 'pop'], ignoreFailure: true });
     }
 
     if (config.isLockFileMaintenance) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes


As reported in #40284, since https://github.com/renovatebot/renovate/pull/40228
we've seen Composer failing to update.

We can take advantage of the new `ignoreFailure` option to replace the
usage of shell semantics.

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #40284 
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/JamieTanna-Mend-testing/renovate-repro-symfony-flex

Without this (42.71.4):

```
DEBUG: Executing command (repository=JamieTanna-Mend-testing/renovate-repro-symfony-flex, branch=renovate/lock-file-maintenance)
       "command": "composer install --ignore-platform-req='ext-*' --ignore-platform-req='lib-*' --no-ansi --no-interaction --no-scripts --no-autoloader --no-plugins"
DEBUG: exec completed (repository=JamieTanna-Mend-testing/renovate-repro-symfony-flex, branch=renovate/lock-file-maintenance)
       "durationMs": 2322,
       "stdout": "",
       "stderr": "No composer.lock file present. Updating dependencies to latest instead of installing from lock file. See https://getcomposer.org/install for more information.\nLoading composer repositories with package information\nUpdating dependencies\nLock file operations: 1 install, 0 updates, 0 removals\n  - Locking symfony/flex (v2.10.0)\nWriting lock file\nInstalling dependencies from lock file (including require-dev)\nPackage operations: 0 installs, 1 update, 0 rem
ovals\n  - Upgrading symfony/flex (v2.9.0 => v2.10.0): Extracting archive\nThe \"symfony/flex\" plugin was not loaded as plugins are disabled.\n1 package you are using is looking for funding.\nUse the `composer fund` command to find out more!\n"
DEBUG: Executing command (repository=JamieTanna-Mend-testing/renovate-repro-symfony-flex, branch=renovate/lock-file-maintenance)
       "command": "git stash pop || true"
DEBUG: rawExec err (repository=JamieTanna-Mend-testing/renovate-repro-symfony-flex, branch=renovate/lock-file-maintenance)
       "err": {
         "cmd": "git stash pop || true",
         "stderr": "Too many revisions specified: '||' 'true'\n",
         "stdout": "",
         "options": {
           "cwd": "/var/folders/yd/2y3vx75x75l1x2nrt4n0pdm00000gn/T/renovate/repos/github/JamieTanna-Mend-testing/renovate-repro-symfony-flex",
           "env": [
             "COMPOSER_CACHE_DIR",
             "COMPOSER_AUTH",
             "HOME",
             "PATH",
             "LANG",
             "CONTAINERBASE_CACHE_DIR"
           ],
           "maxBuffer": 10485760,
           "timeout": 900000,
           "stdin": "pipe",
           "stdout": "pipe",
           "stderr": "pipe"
         },
         "exitCode": 1,
         "name": "ExecError",
         "message": "Command failed: git stash pop || true\nToo many revisions specified: '||' 'true'\n",
         "stack": "ExecError: Command failed: git stash pop || true\nToo many revisions specified: '||' 'true'\n\n    at ChildProcess.<anonymous> (/Users/jamietanna/.npm/_npx/59c0475bfd22776c/node_modules/renovate/lib/util/exec/common.ts:143:11)\n    at ChildProcess.emit (node:events:520:35)\n    at ChildProcess.emit (node:domain:489:12)\n    at Process.ChildProcess._handle.onexit (node:internal/child_process:293:12)"
       },
       "durationMs": 28
DEBUG: Failed to generate composer.lock (repository=JamieTanna-Mend-testing/renovate-repro-symfony-flex, branch=renovate/lock-file-maintenance)
       "err": {
         "cmd": "git stash pop || true",
         "stderr": "Too many revisions specified: '||' 'true'\n",
         "stdout": "",
         "options": {
           "cwd": "/var/folders/yd/2y3vx75x75l1x2nrt4n0pdm00000gn/T/renovate/repos/github/JamieTanna-Mend-testing/renovate-repro-symfony-flex",
           "env": [
             "COMPOSER_CACHE_DIR",
             "COMPOSER_AUTH",
             "HOME",
             "PATH",
             "LANG",
             "CONTAINERBASE_CACHE_DIR"
           ],
           "maxBuffer": 10485760,
           "timeout": 900000,
           "stdin": "pipe",
           "stdout": "pipe",
           "stderr": "pipe"
         },
         "exitCode": 1,
         "name": "ExecError",
         "message": "Command failed: git stash pop || true\nToo many revisions specified: '||' 'true'\n",
         "stack": "ExecError: Command failed: git stash pop || true\nToo many revisions specified: '||' 'true'\n\n    at ChildProcess.<anonymous> (/Users/jamietanna/.npm/_npx/59c0475bfd22776c/node_modules/renovate/lib/util/exec/common.ts:143:11)\n    at ChildProcess.emit (node:events:520:35)\n    at ChildProcess.emit (node:domain:489:12)\n    at Process.ChildProcess._handle.onexit (node:internal/child_process:293:12)"
       }
DEBUG: No package files need updating (repository=JamieTanna-Mend-testing/renovate-repro-symfony-flex, branch=renovate/lock-file-maintenance)
...
DEBUG: Updating status check state to failed (repository=JamieTanna-Mend-testing/renovate-repro-symfony-flex, branch=renovate/lock-file-maintenance)
DEBUG: Setting branch status (repository=JamieTanna-Mend-testing/renovate-repro-symfony-flex, branch=renovate/lock-file-maintenance)
       "context": "renovate/artifacts",
       "state": "red"
...
 INFO: PR updated (repository=JamieTanna-Mend-testing/renovate-repro-symfony-flex, branch=renovate/lock-file-maintenance)
       "pr": 3,
       "prTitle": "Lock file maintenance"
DEBUG: setPrCache() (repository=JamieTanna-Mend-testing/renovate-repro-symfony-flex, branch=renovate/lock-file-maintenance)
 WARN: artifactErrors (repository=JamieTanna-Mend-testing/renovate-repro-symfony-flex, branch=renovate/lock-file-maintenance)
       "artifactErrors": [
         {
           "lockFile": "composer.lock",
           "stderr": "Command failed: git stash pop || true\nToo many revisions specified: '||' 'true'\n"
         }
       ]
DEBUG: Getting comments for #3 (repository=JamieTanna-Mend-testing/renovate-repro-symfony-flex, branch=renovate/lock-file-maintenance)
```

With this:

```
DEBUG: Executing command (repository=JamieTanna-Mend-testing/renovate-repro-symfony-flex, branch=renovate/lock-file-maintenance)
       "command": "git stash -- composer.json"
DEBUG: exec completed (repository=JamieTanna-Mend-testing/renovate-repro-symfony-flex, branch=renovate/lock-file-maintenance)
       "durationMs": 10,
       "stdout": "No local changes to save\n",
       "stderr": ""
DEBUG: Executing command (repository=JamieTanna-Mend-testing/renovate-repro-symfony-flex, branch=renovate/lock-file-maintenance)
       "command": "composer install --ignore-platform-req='ext-*' --ignore-platform-req='lib-*' --no-ansi --no-interaction --no-scripts --no-autoloader --no-plugins"
DEBUG: exec completed (repository=JamieTanna-Mend-testing/renovate-repro-symfony-flex, branch=renovate/lock-file-maintenance)
       "durationMs": 1318,
       "stdout": "",
       "stderr": "No composer.lock file present. Updating dependencies to latest instead of installing from lock file. See https://getcomposer.org/install for more information.\nLoading composer repositories with package information\nUpdating dependencies\nLock file operations: 1 install, 0 updates, 0 removals\n  - Locking symfony/flex (v2.10.0)\nWriting lock file\nInstalling dependencies from lock file (including require-dev)\nNothing to install, update or remove\n1 package
 you are using is looking for funding.\nUse the `composer fund` command to find out more!\n"
DEBUG: Executing command (repository=JamieTanna-Mend-testing/renovate-repro-symfony-flex, branch=renovate/lock-file-maintenance)
       "command": {"command": "git stash pop", "ignoreFailure": true}
DEBUG: exec completed (repository=JamieTanna-Mend-testing/renovate-repro-symfony-flex, branch=renovate/lock-file-maintenance)
       "durationMs": 15,
       "stdout": "",
       "stderr": "No stash entries found.\n"
DEBUG: Executing command (repository=JamieTanna-Mend-testing/renovate-repro-symfony-flex, branch=renovate/lock-file-maintenance)
       "command": "composer update --ignore-platform-req='ext-*' --ignore-platform-req='lib-*' --no-ansi --no-interaction --no-scripts --no-autoloader --no-plugins"
DEBUG: exec completed (repository=JamieTanna-Mend-testing/renovate-repro-symfony-flex, branch=renovate/lock-file-maintenance)
       "durationMs": 1236,
       "stdout": "",
       "stderr": "Loading composer repositories with package information\nUpdating dependencies\nNothing to modify in lock file\nWriting lock file\nInstalling dependencies from lock file (including require-dev)\nNothing to install, update or remove\n1 package you are using is looking for funding.\nUse the `composer fund` command to find out more!\nNo security vulnerability advisories found.\n"
DEBUG: Returning updated composer.lock (repository=JamieTanna-Mend-testing/renovate-repro-symfony-flex, branch=renovate/lock-file-maintenance)
DEBUG: Committing vendor files in vendor (repository=JamieTanna-Mend-testing/renovate-repro-symfony-flex, branch=renovate/lock-file-maintenance)
DEBUG: No package files need updating (repository=JamieTanna-Mend-testing/renovate-repro-symfony-flex, branch=renovate/lock-file-maintenance)
```



<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
