### PR TITLE
fix(yarn): don't rely on shell semantics for ignoring command failures

### DIFF
--- a/lib/modules/manager/npm/post-update/yarn.spec.ts
+++ b/lib/modules/manager/npm/post-update/yarn.spec.ts
@@ -741,7 +741,15 @@ describe('modules/manager/npm/post-update/yarn', () => {
     const options = { cwd: 'some-dir' };
     expect(execSnapshots).toMatchObject([
       {
-        cmd: `sed -i 's/ steps,/ steps.slice(0,1),/' some-dir/.yarn/cli.js || true`,
+        cmd: {
+          command: [
+            'sed',
+            '-i',
+            `s/ steps,/ steps.slice(0,1),/`,
+            'some-dir/.yarn/cli.js',
+          ],
+          ignoreFailure: true,
+        },
         options,
       },
       {
@@ -788,7 +796,8 @@ describe('modules/manager/npm/post-update/yarn', () => {
           ` && ` +
           `install-tool yarn-slim 1.22.18` +
           ` && ` +
-          `sed -i 's/ steps,/ steps.slice(0,1),/' some-dir/.yarn/cli.js || true` +
+          // NOTE that this has a `|| true` appended inside the `exec(...)` function
+          `sed -i 's/ steps,/ steps.slice(0,1),/' some-dir/.yarn/cli.js` +
           ` && ` +
           `yarn install --ignore-engines --ignore-platform --network-timeout 100000 --ignore-scripts` +
           `"`,


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes


As reported in #40259, since https://github.com/renovatebot/renovate/pull/40228
we've seen Yarn 1 failing to update.

We can take advantage of the new `ignoreFailure` option to replace the
usage of shell semantics.

## Context

#40259

Please select one of the following:

- [x] This closes an existing Issue, Closes: #40294
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
