### PR TITLE
feat(platform/bitbucket): calculate effectiveBaseBranch during pr update

### DIFF
--- a/lib/config/global.ts
+++ b/lib/config/global.ts
@@ -13,6 +13,7 @@ export class GlobalConfig {
     'allowedUnsafeExecutions',
     'autodiscoverRepoOrder',
     'autodiscoverRepoSort',
+    'bbUseDevelopmentBranch',
     'binarySource',
     'cacheDir',
     'cacheHardTtlMinutes',

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -212,6 +212,7 @@ export interface RepoGlobalConfig {
   allowShellExecutorForPostUpgradeCommands?: boolean;
   allowedEnv?: string[];
   allowedHeaders?: string[];
+  bbUseDevelopmentBranch?: boolean;
   binarySource?: BinarySource;
   cacheDir?: string;
   cacheHardTtlMinutes?: number;

--- a/lib/modules/platform/bitbucket/index.spec.ts
+++ b/lib/modules/platform/bitbucket/index.spec.ts
@@ -1,3 +1,4 @@
+import { GlobalConfig } from '../../../config/global';
 import * as memCache from '../../../util/cache/memory';
 import { setBaseUrl } from '../../../util/http/bitbucket';
 import type { PlatformResult, RepoParams } from '../types';
@@ -22,6 +23,7 @@ const pr = {
 
 describe('modules/platform/bitbucket/index', () => {
   beforeEach(() => {
+    GlobalConfig.reset();
     git.branchExists.mockReturnValue(true);
     git.isBranchBehindBase.mockResolvedValue(false);
     hostRules.clear();
@@ -262,6 +264,8 @@ describe('modules/platform/bitbucket/index', () => {
 
   describe('bbUseDevelopmentBranch', () => {
     it('not enabled: defaults to using main branch', async () => {
+      GlobalConfig.set({ bbUseDevelopmentBranch: false });
+
       httpMock
         .scope(baseUrl)
         .get('/2.0/repositories/some/repo')
@@ -273,13 +277,14 @@ describe('modules/platform/bitbucket/index', () => {
 
       const res = await bitbucket.initRepo({
         repository: 'some/repo',
-        bbUseDevelopmentBranch: false,
       });
 
       expect(res.defaultBranch).toBe('master');
     });
 
     it('enabled: uses development branch when development branch exists', async () => {
+      GlobalConfig.set({ bbUseDevelopmentBranch: true });
+
       httpMock
         .scope(baseUrl)
         .get('/2.0/repositories/some/repo')
@@ -295,13 +300,14 @@ describe('modules/platform/bitbucket/index', () => {
 
       const res = await bitbucket.initRepo({
         repository: 'some/repo',
-        bbUseDevelopmentBranch: true,
       });
 
       expect(res.defaultBranch).toBe('develop');
     });
 
     it('enabled: falls back to mainbranch if development branch does not exist', async () => {
+      GlobalConfig.set({ bbUseDevelopmentBranch: true });
+
       httpMock
         .scope(baseUrl)
         .get('/2.0/repositories/some/repo')
@@ -317,7 +323,6 @@ describe('modules/platform/bitbucket/index', () => {
 
       const res = await bitbucket.initRepo({
         repository: 'some/repo',
-        bbUseDevelopmentBranch: true,
       });
 
       expect(res.defaultBranch).toBe('master');

--- a/lib/modules/platform/bitbucket/index.ts
+++ b/lib/modules/platform/bitbucket/index.ts
@@ -194,7 +194,6 @@ export async function initRepo({
   repository,
   cloneSubmodules,
   cloneSubmodulesFilter,
-  bbUseDevelopmentBranch,
 }: RepoParams): Promise<RepoResult> {
   logger.debug(`initRepo("${repository}")`);
   const opts = hostRules.find({
@@ -207,6 +206,10 @@ export async function initRepo({
   } as Config;
   let info: RepoInfo;
   let mainBranch: string;
+  const bbUseDevelopmentBranch = GlobalConfig.get(
+    'bbUseDevelopmentBranch',
+    false,
+  );
   try {
     const { body: repoInfo } = await bitbucketHttp.getJson(
       `/2.0/repositories/${repository}`,

--- a/lib/modules/platform/types.ts
+++ b/lib/modules/platform/types.ts
@@ -47,7 +47,6 @@ export interface RepoParams {
   renovateUsername?: string;
   cloneSubmodules?: boolean;
   cloneSubmodulesFilter?: string[];
-  bbUseDevelopmentBranch?: boolean;
 }
 
 export interface PrDebugData {

--- a/lib/workers/repository/update/pr/index.ts
+++ b/lib/workers/repository/update/pr/index.ts
@@ -173,7 +173,10 @@ export async function ensurePr(
 
   // for Bitbucket
   let effectiveBaseBranch = config.baseBranch;
-  if (GlobalConfig.get('bbUseDevelopmentBranch') && config.defaultBranch) {
+  if (
+    GlobalConfig.get('bbUseDevelopmentBranch', false) &&
+    config.defaultBranch
+  ) {
     effectiveBaseBranch = config.defaultBranch;
   }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

For Bitbucket Cloud users who are using the global config [bbUseDevelopmentBranch](https://docs.renovatebot.com/self-hosted-configuration/#bbusedevelopmentbranch), use config.defaultBranch as the effective base branch

<!-- Describe what behavior is changed by this PR. -->

## Context

We had ~100 open PRs that were flagged as `abandoned`.  After some triage, I believe the cause to be that for these repositories we had changed the `main branch` configuration from `master` -> `main`, which left these open PRs targeting the previous base branch orphaned.



Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
