### PR TITLE
feat: prune branches if target and main branches are different

### DIFF
--- a/lib/workers/repository/finalize/prune.spec.ts
+++ b/lib/workers/repository/finalize/prune.spec.ts
@@ -222,7 +222,7 @@ describe('workers/repository/finalize/prune', () => {
       expect(platform.updatePr).toHaveBeenCalledTimes(0);
     });
 
-    it('autoclosed PR when target branch differs from base branch', async () => {
+    it('autocloses PR when target branch differs from base branch', async () => {
       config.branchList = ['renovate/a', 'renovate/b'];
       config.baseBranch = 'main';
       git.getBranchList.mockReturnValueOnce(

--- a/lib/workers/repository/finalize/prune.ts
+++ b/lib/workers/repository/finalize/prune.ts
@@ -96,7 +96,6 @@ async function cleanUpBranches(
             { branchName, prNo: pr.number, prTitle: pr.title },
             'Autoclosing PR',
           );
-
           let newPrTitle = pr.title;
 
           // Clean up any abandoned references

--- a/lib/workers/repository/finalize/prune.ts
+++ b/lib/workers/repository/finalize/prune.ts
@@ -79,8 +79,13 @@ async function cleanUpBranches(
             `DRY-RUN: Would autoclose PR`,
           );
         } else {
-          if (!isTargetAndBaseBranchesSame) {
-            logger.debug(
+          if (isTargetAndBaseBranchesSame) {
+            logger.info(
+              { branchName, prNo: pr.number, prTitle: pr.title },
+              'Autoclosing PR',
+            );
+          } else {
+            logger.info(
               {
                 prNo: pr.number,
                 prTitle: pr.title,
@@ -91,10 +96,6 @@ async function cleanUpBranches(
             );
           }
 
-          logger.info(
-            { branchName, prNo: pr.number, prTitle: pr.title },
-            'Autoclosing PR',
-          );
           let newPrTitle = pr.title;
 
           // Clean up any abandoned references

--- a/lib/workers/repository/finalize/prune.ts
+++ b/lib/workers/repository/finalize/prune.ts
@@ -101,7 +101,7 @@ async function cleanUpBranches(
 
           // Clean up any abandoned references
           if (pr.title.endsWith(abandonedPrSuffix)) {
-            newPrTitle = newPrTitle.replaceAll(abandonedPrSuffix, '');
+            newPrTitle = newPrTitle.replaceAll(abandonedPrSuffix, '').trim();
 
             await ensureCommentRemoval({
               type: 'by-topic',

--- a/lib/workers/repository/finalize/prune.ts
+++ b/lib/workers/repository/finalize/prune.ts
@@ -43,7 +43,6 @@ async function cleanUpBranches(
         state: 'open',
         targetBranch: baseBranch,
       });
-
       const branchIsModified = await scm.isBranchModified(
         branchName,
         baseBranch,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Compare the pr target branch and main branch during the cleanup/pruning process.

If branches are different, assume orphaned and clean up. 

Tested against 4-5 internal Bitbucket Cloud repositories in our organization which experiences this when we switched the repo `main branch` configuration from `master` to `main`

<!-- Describe what behavior is changed by this PR. -->

## Context

When pruning/cleaning up branches, if would previously consider a branch modified, even when the pr target branch and main branch where different.

Now, that is used when considering if a branch has been modified, or is orphaned.

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
