### PR TITLE
refactor(manager/gradle): rewrite reorderFiles() for performance

### DIFF
--- a/lib/modules/manager/gradle/parser/version-catalogs.ts
+++ b/lib/modules/manager/gradle/parser/version-catalogs.ts
@@ -12,6 +12,8 @@ import {
 } from './common';
 import { handleLibraryDep, handlePlugin } from './handlers';
 
+const qAlias = qStringValue.handler((ctx) => storeInTokenMap(ctx, 'alias'));
+
 const qVersionCatalogVersion = q
   .op<Ctx>('.')
   .alt(
@@ -34,8 +36,7 @@ const qVersionCatalogVersion = q
 
 // library("foo.bar", "foo", "bar")
 const qVersionCatalogDependencies = q
-  .sym<Ctx>('library', storeVarToken)
-  .handler((ctx) => storeInTokenMap(ctx, 'methodName'))
+  .sym<Ctx>('library')
   .tree({
     type: 'wrapped-tree',
     maxDepth: 1,
@@ -43,8 +44,7 @@ const qVersionCatalogDependencies = q
     endsWith: ')',
     search: q
       .begin<Ctx>()
-      .join(qStringValue)
-      .handler((ctx) => storeInTokenMap(ctx, 'alias'))
+      .join(qAlias)
       .op(',')
       .join(qGroupId)
       .op(',')
@@ -66,10 +66,9 @@ const qVersionCatalogPlugins = q
     endsWith: ')',
     search: q
       .begin<Ctx>()
-      .join(qStringValue)
-      .handler((ctx) => storeInTokenMap(ctx, 'alias'))
+      .join(qAlias)
       .op(',')
-      .alt(qStringValue)
+      .alt(qValueMatcher)
       .handler((ctx) => storeInTokenMap(ctx, 'pluginName'))
       .end(),
   })
@@ -85,11 +84,7 @@ const qVersionCatalogAliasDependencies = q
     maxDepth: 1,
     startsWith: '(',
     endsWith: ')',
-    search: q
-      .begin<Ctx>()
-      .join(qStringValue)
-      .handler((ctx) => storeInTokenMap(ctx, 'alias'))
-      .end(),
+    search: q.begin<Ctx>().join(qAlias).end(),
   })
   .op('.')
   .sym('to')


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

* `version-catalogs.ts`
  * Remove `.handler((ctx) => storeInTokenMap(ctx, 'methodName'))` as it is not needed/used anywhere
  * Change `pluginName` matching to `qValueMatcher`, since this value can be interpolated. Also aligns with `plugins.ts`
  * Extract `qAlias` 

* `utils.ts`:
  * Improve time complexity of `reorderFiles()` from O(n² log n) to O(n log n) by pre-computing paths and doing file ranking only once. In practice, this means a ~100-200x speedup for ordering 1000 files. The underlying logic is unchanged, only the execution order was optimized.

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

This PR is a preparation to improve version catalog handling around cases like https://github.com/renovatebot/renovate/discussions/40147.
It should help to keep follow-up changesets smaller.

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
