### PR TITLE
chore(util/exec): allow specifying `shell` on `CommandWithOptions`

### DIFF
--- a/lib/util/exec/common.spec.ts
+++ b/lib/util/exec/common.spec.ts
@@ -319,6 +319,52 @@ describe('util/exec/common', () => {
       );
     });
 
+    it('can specify a specific shell with CommandWithOptions', async () => {
+      const cmd = 'ls -l';
+      const stub = getSpawnStub({
+        cmd,
+        exitCode: 0,
+        exitSignal: null,
+        stdout,
+        stderr,
+      });
+      execa.mockImplementationOnce((cmd, opts) => stub);
+
+      await exec(
+        { command: ['ls', '-l'], shell: '/bin/zsh' },
+        partial<RawExecOptions>({ encoding: 'utf8' }),
+      );
+
+      expect(execa).toHaveBeenCalledWith(
+        cmd,
+        [],
+        expect.objectContaining({ shell: '/bin/zsh' }),
+      );
+    });
+
+    it('can specify shell=true with CommandWithOptions', async () => {
+      const cmd = 'ls -l';
+      const stub = getSpawnStub({
+        cmd,
+        exitCode: 0,
+        exitSignal: null,
+        stdout,
+        stderr,
+      });
+      execa.mockImplementationOnce((cmd, opts) => stub);
+
+      await exec(
+        { command: ['ls', '-l'], shell: true },
+        partial<RawExecOptions>({ encoding: 'utf8' }),
+      );
+
+      expect(execa).toHaveBeenCalledWith(
+        cmd,
+        [],
+        expect.objectContaining({ shell: true }),
+      );
+    });
+
     it('can specify a command with spaces, with a shell', async () => {
       const cmd = 'ls "Application Support"';
       const stub = getSpawnStub({

--- a/lib/util/exec/common.ts
+++ b/lib/util/exec/common.ts
@@ -105,7 +105,14 @@ export function exec(
     const maxBuffer = opts.maxBuffer ?? 10 * 1024 * 1024; // Set default max buffer size to 10MB
 
     // don't use shell by default, as it leads to potential security issues
-    const shell = opts.shell ?? false;
+    let shell = opts.shell ?? false;
+    if (
+      isCommandWithOptions(commandArgument) &&
+      commandArgument.shell !== undefined
+    ) {
+      shell = commandArgument.shell;
+    }
+
     // if we're not in shell mode, we need to provide the command and arguments
     if (shell === false) {
       const parts = split(cmd);

--- a/lib/util/exec/types.ts
+++ b/lib/util/exec/types.ts
@@ -72,4 +72,11 @@ export interface CommandWithOptions {
 
   /** do not throw errors when a command fails, but do log that an error occurred */
   ignoreFailure?: boolean;
+
+  /**
+   * Execute the `command` within a shell
+   *
+   * WARNING this can result in security issues if this includes user-controlled commands
+   * **/
+  shell?: boolean | string;
 }

--- a/lib/util/exec/utils.spec.ts
+++ b/lib/util/exec/utils.spec.ts
@@ -105,6 +105,83 @@ describe('util/exec/utils', () => {
         expect(isCommandWithOptions(valid)).toBeTrue();
       });
     });
+
+    describe('when command is valid, and no shell is present', () => {
+      it('is a CommandWithOptions', () => {
+        const valid: CommandWithOptions = {
+          command: ['go'],
+        };
+
+        expect(isCommandWithOptions(valid)).toBeTrue();
+      });
+    });
+
+    describe('when command is valid, and shell is not a string or a boolean', () => {
+      it('is not a CommandWithOptions', () => {
+        const invalid = {
+          command: ['go'],
+          shell: 1234.0,
+        };
+
+        expect(isCommandWithOptions(invalid)).toBeFalse();
+      });
+    });
+
+    describe('when command is valid, and shell is an empty string', () => {
+      it('is not a CommandWithOptions', () => {
+        const invalid = {
+          command: ['go'],
+          shell: '',
+        };
+
+        expect(isCommandWithOptions(invalid)).toBeFalse();
+      });
+    });
+
+    describe('when command is valid, and shell is a string with only whitespace', () => {
+      it('is not a CommandWithOptions', () => {
+        const invalid = {
+          command: ['go'],
+          shell: ' \t\r\n',
+        };
+
+        expect(isCommandWithOptions(invalid)).toBeFalse();
+      });
+    });
+
+    describe('when command is valid, and shell is a non-empty string', () => {
+      it('is not a CommandWithOptions', () => {
+        const valid: CommandWithOptions = {
+          command: ['go'],
+          // NOTE that this isn't a likely case, but proves that this works
+          shell: 'a',
+        };
+
+        expect(isCommandWithOptions(valid)).toBeTrue();
+      });
+    });
+
+    describe('when command is valid, and shell=false', () => {
+      it('is a CommandWithOptions', () => {
+        const valid: CommandWithOptions = {
+          command: ['go'],
+          shell: false,
+        };
+
+        expect(isCommandWithOptions(valid)).toBeTrue();
+      });
+    });
+
+    describe('when command is valid, and shell=true', () => {
+      it('is a CommandWithOptions', () => {
+        const valid: CommandWithOptions = {
+          command: ['go'],
+          shell: true,
+        };
+
+        expect(isCommandWithOptions(valid)).toBeTrue();
+      });
+    });
   });
 
   describe('asRawCommands', () => {

--- a/lib/util/exec/utils.ts
+++ b/lib/util/exec/utils.ts
@@ -1,4 +1,8 @@
-import { isBoolean, isString } from '@sindresorhus/is';
+import {
+  isBoolean,
+  isNonEmptyStringAndNotWhitespace,
+  isString,
+} from '@sindresorhus/is';
 import { join } from 'shlex';
 import { getCustomEnv, getUserEnv } from '../env';
 import { getChildProcessEnv } from './env';
@@ -55,6 +59,13 @@ export function isCommandWithOptions(cmd: unknown): cmd is CommandWithOptions {
   }
 
   if ('ignoreFailure' in cmd && !isBoolean(cmd.ignoreFailure)) {
+    return false;
+  }
+
+  if (
+    'shell' in cmd &&
+    !(isBoolean(cmd.shell) || isNonEmptyStringAndNotWhitespace(cmd.shell))
+  ) {
     return false;
   }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
As part of future changes, we need to be able to specify on a
per-command level whether a `shell` should be used.

Before we do this, we should make it possible to provide the `shell`
specifier.

Pre-req for https://github.com/renovatebot/renovate/issues/40302


## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
