### PR TITLE
fix(flux): use shell semantics for file redirection

### DIFF
--- a/lib/modules/manager/flux/artifacts.spec.ts
+++ b/lib/modules/manager/flux/artifacts.spec.ts
@@ -44,6 +44,9 @@ describe('modules/manager/flux/artifacts', () => {
     expect(snapshots).toMatchObject([
       {
         cmd: 'flux install --export --components source-controller,kustomize-controller,helm-controller,notification-controller > clusters/my-cluster/flux-system/gotk-components.yaml',
+        options: {
+          shell: true,
+        },
       },
     ]);
   });

--- a/lib/modules/manager/flux/artifacts.ts
+++ b/lib/modules/manager/flux/artifacts.ts
@@ -25,6 +25,7 @@ export async function updateArtifacts({
     }
     const cmd = `flux install ${args.join(' ')} > ${quote(packageFileName)}`;
     const execOptions: ExecOptions = {
+      shell: true,
       docker: {},
       toolConstraints: [
         {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

As reported in #40275, since f430552de4a07caadcdc6c413b2a506b539f10ee
we've seen Flux failing to update.

We can take advantage of the new `shell` option to handle this safe
shell semantics usage for file redirection.


## Context

Depends on https://github.com/renovatebot/renovate/pull/40323

Please select one of the following:

- [x] This closes an existing Issue, Closes: #40302
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/agriessbosch/renovate-repro-40302

Before (7c467de395c11cdef5cdcb352cf09ed36aa78dc8):

```
DEBUG: Executing command (repository=agriessbosch/renovate-repro-40302, branch=renovate/fluxcd-flux2-2.x)
       "command": "install-tool flux v2.7.5"
DEBUG: exec completed (repository=agriessbosch/renovate-repro-40302, branch=renovate/fluxcd-flux2-2.x)
       "durationMs": 2526,
       "stdout": "[10:21:01.879] DEBUG (69): discovered distro\n    distro: {\n      \"name\": \"Ubuntu\",\n      \"versionCode\": \"noble\",\n      \"versionId\": \"24.04\"\n    }\n[10:21:01.880] DEBUG (69): prepare commands\n[10:21:01.88
2] DEBUG (69): Try resolving version for flux@2.7.5 ...\n[10:21:01.882] INFO (69): Installing tool flux@2.7.5...\n[10:21:01.897] DEBUG (69): setting path mode\n    path: \"/opt/containerbase/data/types.nedb\"\n    mode: 436\n    s: 420\n[1
0:21:01.897] DEBUG (69): setting path mode\n    path: \"/opt/containerbase/data/state.nedb\"\n    mode: 436\n    s: 420\n[10:21:01.898] DEBUG (69): setting path mode\n    path: \"/opt/containerbase/data/versions.nedb\"\n    mode: 436\n
s: 420\n[10:21:01.898] DEBUG (69): setting path mode\n    path: \"/opt/containerbase/data/links.nedb\"\n    mode: 436\n    s: 420\n[10:21:01.901] DEBUG (69): ipc server started\n[10:21:01.901] DEBUG (69): validate tool\n    tool: \"flux\"\
n[10:21:01.901] DEBUG (69): install tool\n    tool: \"flux\"\n[10:21:01.901] DEBUG (69): downloading file\n    url: \"https://github.com/fluxcd/flux2/releases/download/v2.7.5/flux_2.7.5_checksums.txt\"\n[10:21:02.051] DEBUG (69): downloadi
ng file\n    url: \"https://github.com/fluxcd/flux2/releases/download/v2.7.5/flux_2.7.5_linux_arm64.tar.gz\"\n    expectedChecksum: \"89d3ebb47ee5f7a0def33217e8dcb885e0bec41d01d0e23fc84e9aba0416c24e\"\n    checksumType: \"sha256\"\n[10:21:
04.027] DEBUG (69): creating dir\n    path: \"/opt/containerbase/tools/flux\"\n[10:21:04.029] DEBUG (69): setting path mode\n    path: \"/opt/containerbase/tools/flux\"\n    mode: 509\n    s: 493\n[10:21:04.029] DEBUG (69): creating dir\n
   path: \"/opt/containerbase/tools/flux/2.7.5\"\n[10:21:04.167] DEBUG (69): link tool\n    tool: \"flux\"\n[10:21:04.169] DEBUG (69): setting path mode\n    path: \"/opt/containerbase/bin/flux\"\n    mode: 509\n    s: 420\n[10:21:04.169]
DEBUG (69): post-install tool\n    tool: \"flux\"\n[10:21:04.169] DEBUG (69): linked tools\n    tool: \"flux\"\n    version: \"2.7.5\"\n    links: [\n      \"flux\"\n    ]\n[10:21:04.170] DEBUG (69): test tool\n    tool: \"flux\"\nflux ver
sion 2.7.5\n[10:21:04.288] DEBUG (69): cleaning apt caches\n[10:21:04.296] INFO (69): Install tool flux succeeded in 2.4s.\n",
       "stderr": ""
DEBUG: Executing command (repository=agriessbosch/renovate-repro-40302, branch=renovate/fluxcd-flux2-2.x)
       "command": "flux install --export --components source-controller,kustomize-controller,helm-controller,notification-controller > cluster/flux-system/gotk-components.yaml"
DEBUG: rawExec err (repository=agriessbosch/renovate-repro-40302, branch=renovate/fluxcd-flux2-2.x)
       "err": {
         "cmd": "flux install --export --components source-controller,kustomize-controller,helm-controller,notification-controller > cluster/flux-system/gotk-components.yaml",
         "stderr": "✗ unknown command \">\" for \"flux install\"\n",
         "stdout": "",
         "options": {
           "cwd": "/tmp/renovate/repos/github/agriessbosch/renovate-repro-40302",
           "env": ["HOME", "PATH", "LC_ALL", "LANG", "CONTAINERBASE_CACHE_DIR"],
           "maxBuffer": 10485760,
           "timeout": 900000,
           "stdin": "pipe",
           "stdout": "pipe",
           "stderr": "pipe"
         },
         "exitCode": 1,
         "name": "ExecError",
         "message": "Command failed: flux install --export --components source-controller,kustomize-controller,helm-controller,notification-controller > cluster/flux-system/gotk-components.yaml\n✗ unknown command \">\" for \"flux install\"
\n",
         "stack": "ExecError: Command failed: flux install --export --components source-controller,kustomize-controller,helm-controller,notification-controller > cluster/flux-system/gotk-components.yaml\n✗ unknown command \">\" for \"flux
install\"\n\n    at ChildProcess.<anonymous> (/app/lib/util/exec/common.ts:159:13)\n    at ChildProcess.emit (node:events:520:35)\n    at ChildProcess.emit (node:domain:489:12)\n    at Process.ChildProcess._handle.onexit (node:internal/chi
ld_process:294:12)"
       },
       "durationMs": 112
DEBUG: Error generating new Flux system manifests (repository=agriessbosch/renovate-repro-40302, branch=renovate/fluxcd-flux2-2.x)
       "err": {
         "cmd": "flux install --export --components source-controller,kustomize-controller,helm-controller,notification-controller > cluster/flux-system/gotk-components.yaml",
         "stderr": "✗ unknown command \">\" for \"flux install\"\n",
         "stdout": "",
         "options": {
           "cwd": "/tmp/renovate/repos/github/agriessbosch/renovate-repro-40302",
           "env": ["HOME", "PATH", "LC_ALL", "LANG", "CONTAINERBASE_CACHE_DIR"],
           "maxBuffer": 10485760,
           "timeout": 900000,
           "stdin": "pipe",
           "stdout": "pipe",
           "stderr": "pipe"
         },
         "exitCode": 1,
         "name": "ExecError",
         "message": "Command failed: flux install --export --components source-controller,kustomize-controller,helm-controller,notification-controller > cluster/flux-system/gotk-components.yaml\n✗ unknown command \">\" for \"flux install\"
\n",
         "stack": "ExecError: Command failed: flux install --export --components source-controller,kustomize-controller,helm-controller,notification-controller > cluster/flux-system/gotk-components.yaml\n✗ unknown command \">\" for \"flux
install\"\n\n    at ChildProcess.<anonymous> (/app/lib/util/exec/common.ts:159:13)\n    at ChildProcess.emit (node:events:520:35)\n    at ChildProcess.emit (node:domain:489:12)\n    at Process.ChildProcess._handle.onexit (node:internal/chi
ld_process:294:12)"
       }
DEBUG: Updated 1 package files (repository=agriessbosch/renovate-repro-40302, branch=renovate/fluxcd-flux2-2.x)
```

After:

```
DEBUG: Using containerbase dynamic installs (repository=agriessbosch/renovate-repro-40302, branch=renovate/fluxcd-flux2-2.x)
DEBUG: Executing command (repository=agriessbosch/renovate-repro-40302, branch=renovate/fluxcd-flux2-2.x)
       "command": "install-tool flux v2.7.5"
DEBUG: exec completed (repository=agriessbosch/renovate-repro-40302, branch=renovate/fluxcd-flux2-2.x)
       "durationMs": 4273,
       "stdout": "[10:23:03.969] DEBUG (65): discovered distro\n    distro: {\n      \"name\": \"Ubuntu\",\n      \"versionCode\": \"noble\",\n      \"versionId\": \"24.04\"\n    }\n[10:23:03.969] DEBUG (65): prepare commands\n[10:23:03.97
2] DEBUG (65): Try resolving version for flux@2.7.5 ...\n[10:23:03.972] INFO (65): Installing tool flux@2.7.5...\n[10:23:03.987] DEBUG (65): setting path mode\n    path: \"/opt/containerbase/data/links.nedb\"\n    mode: 436\n    s: 420\n[1
0:23:03.987] DEBUG (65): setting path mode\n    path: \"/opt/containerbase/data/types.nedb\"\n    mode: 436\n    s: 420\n[10:23:03.987] DEBUG (65): setting path mode\n    path: \"/opt/containerbase/data/versions.nedb\"\n    mode: 436\n
s: 420\n[10:23:03.987] DEBUG (65): setting path mode\n    path: \"/opt/containerbase/data/state.nedb\"\n    mode: 436\n    s: 420\n[10:23:03.990] DEBUG (65): ipc server started\n[10:23:03.990] DEBUG (65): validate tool\n    tool: \"flux\"\
n[10:23:03.991] DEBUG (65): install tool\n    tool: \"flux\"\n[10:23:03.991] DEBUG (65): downloading file\n    url: \"https://github.com/fluxcd/flux2/releases/download/v2.7.5/flux_2.7.5_checksums.txt\"\n[10:23:05.129] DEBUG (65): downloadi
ng file\n    url: \"https://github.com/fluxcd/flux2/releases/download/v2.7.5/flux_2.7.5_linux_arm64.tar.gz\"\n    expectedChecksum: \"89d3ebb47ee5f7a0def33217e8dcb885e0bec41d01d0e23fc84e9aba0416c24e\"\n    checksumType: \"sha256\"\nflux ve
rsion 2.7.5\n[10:23:07.268] DEBUG (65): creating dir\n    path: \"/opt/containerbase/tools/flux\"\n[10:23:07.269] DEBUG (65): setting path mode\n    path: \"/opt/containerbase/tools/flux\"\n    mode: 509\n    s: 493\n[10:23:07.270] DEBUG (
65): creating dir\n    path: \"/opt/containerbase/tools/flux/2.7.5\"\n[10:23:07.405] DEBUG (65): link tool\n    tool: \"flux\"\n[10:23:07.407] DEBUG (65): setting path mode\n    path: \"/opt/containerbase/bin/flux\"\n    mode: 509\n    s:
420\n[10:23:07.407] DEBUG (65): post-install tool\n    tool: \"flux\"\n[10:23:07.407] DEBUG (65): linked tools\n    tool: \"flux\"\n    version: \"2.7.5\"\n    links: [\n      \"flux\"\n    ]\n[10:23:07.407] DEBUG (65): test tool\n    tool
: \"flux\"\n[10:23:07.523] DEBUG (65): cleaning apt caches\n[10:23:07.531] INFO (65): Install tool flux succeeded in 3.5s.\n",
       "stderr": ""
DEBUG: Executing command (repository=agriessbosch/renovate-repro-40302, branch=renovate/fluxcd-flux2-2.x)
       "command": "flux install --export --components source-controller,kustomize-controller,helm-controller,notification-controller > cluster/flux-system/gotk-components.yaml"
DEBUG: exec completed (repository=agriessbosch/renovate-repro-40302, branch=renovate/fluxcd-flux2-2.x)
       "durationMs": 224,
       "stdout": "",
       "stderr": ""
DEBUG: Updated 1 package files (repository=agriessbosch/renovate-repro-40302, branch=renovate/fluxcd-flux2-2.x)
DEBUG: Updated 1 lock files (repository=agriessbosch/renovate-repro-40302, branch=renovate/fluxcd-flux2-2.x)
       "updatedArtifacts": ["cluster/flux-system/gotk-components.yaml"]
DEBUG: 1 file(s) to commit (repository=agriessbosch/renovate-repro-40302, branch=renovate/fluxcd-flux2-2.x)
DEBUG: Preparing files for committing to branch renovate/fluxcd-flux2-2.x (repository=agriessbosch/renovate-repro-40302, branch=renovate/fluxcd-flux2-2.x)
```


<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
