### PR TITLE
feat(bitbucket): increase max body length

### DIFF
--- a/lib/modules/platform/bitbucket/index.ts
+++ b/lib/modules/platform/bitbucket/index.ts
@@ -664,7 +664,7 @@ function massageCollapsibleSectionsIntoLists(body: string): string {
 }
 
 export function maxBodyLength(): number {
-  return 1000000;
+  return 250000;
 }
 
 export async function ensureIssue({

--- a/lib/modules/platform/bitbucket/index.ts
+++ b/lib/modules/platform/bitbucket/index.ts
@@ -664,7 +664,7 @@ function massageCollapsibleSectionsIntoLists(body: string): string {
 }
 
 export function maxBodyLength(): number {
-  return 50000;
+  return 1000000;
 }
 
 export async function ensureIssue({

--- a/lib/modules/platform/forgejo/index.ts
+++ b/lib/modules/platform/forgejo/index.ts
@@ -1091,7 +1091,7 @@ const platform: Platform = {
 };
 
 export function maxBodyLength(): number {
-  return 250000;
+  return 1000000;
 }
 
 /* eslint-disable @typescript-eslint/unbound-method */

--- a/lib/modules/platform/forgejo/index.ts
+++ b/lib/modules/platform/forgejo/index.ts
@@ -1091,7 +1091,7 @@ const platform: Platform = {
 };
 
 export function maxBodyLength(): number {
-  return 1000000;
+  return 250000;
 }
 
 /* eslint-disable @typescript-eslint/unbound-method */


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Increase Bitbucket Cloud max body length to 250K.

Tested against a real repo with PR body
<img width="222" height="19" alt="Screenshot 2026-01-09 at 12 25 32 AM" src="https://github.com/user-attachments/assets/e0017ff5-80af-4862-a04c-7ead7d08730c" />

Couldn't find official documentation on the limit - could possible be higher than 250K

<!-- Describe what behavior is changed by this PR. -->

## Context

Prevent issues from being truncated (particularly release notes)

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
