### PR TITLE
feat: add gopkg.in/yaml.v2 to go.yaml.in/yaml/v2 replacement config

### DIFF
--- a/lib/data/replacements.json
+++ b/lib/data/replacements.json
@@ -52,6 +52,7 @@
       "replacements:vso-task-lib-to-azure-pipelines-task-lib",
       "replacements:vsts-task-lib-to-azure-pipelines-task-lib",
       "replacements:xmldom-to-scoped",
+      "replacements:yaml-gopkg-to-go-yaml",
       "replacements:zap"
     ],
     "ignoreDeps": []
@@ -1141,6 +1142,16 @@
         "matchPackageNames": ["xmldom", "xmldom-alpha"],
         "replacementName": "@xmldom/xmldom",
         "replacementVersion": "0.7.5"
+      }
+    ]
+  },
+  "yaml-gopkg-to-go-yaml": {
+    "description": "The `gopkg.in/yaml.v2` package is no longer maintained. Use `go.yaml.in/yaml/v2` instead.",
+    "packageRules": [
+      {
+        "matchDatasources": ["go"],
+        "matchPackageNames": ["gopkg.in/yaml.v2"],
+        "replacementName": "go.yaml.in/yaml/v2"
       }
     ]
   },


### PR DESCRIPTION
## Changes

Add replacement rule to migrate from the unmaintained gopkg.in/yaml.v2 package to the actively maintained fork go.yaml.in/yaml/v2.

* `gopkg.in/yaml.v2` - https://github.com/go-yaml/yaml/tree/v2.4.0 - is archived since 01 Apr 2025
* `go.yaml.in/yaml/v2` - https://github.com/yaml/go-yaml/tree/v2 - is the current maintained fork

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [x] Yes — other (please describe): this PR is fully generated by AI, given its trivial nature

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>
