### PR TITLE
refactor: replace chalk with node util for styling in logger

### DIFF
--- a/lib/logger/pretty-stdout.spec.ts
+++ b/lib/logger/pretty-stdout.spec.ts
@@ -1,13 +1,6 @@
-import chalk from 'chalk';
+import * as util from 'node:util';
 import * as prettyStdout from './pretty-stdout';
 import type { BunyanRecord } from './types';
-
-vi.mock('chalk', () => ({
-  default: ['bgRed', 'blue', 'gray', 'green', 'magenta', 'red'].reduce(
-    (r, c) => Object.defineProperty(r, c, { value: (s: string) => s }),
-    {},
-  ),
-}));
 
 describe('logger/pretty-stdout', () => {
   describe('getMeta(rec)', () => {
@@ -32,7 +25,7 @@ describe('logger/pretty-stdout', () => {
         repository: 'a/b',
       };
       expect(prettyStdout.getMeta(rec as any)).toEqual(
-        chalk.gray(' (repository=a/b)'),
+        util.styleText('gray', ' (repository=a/b)'),
       );
     });
 
@@ -44,7 +37,7 @@ describe('logger/pretty-stdout', () => {
         module: 'test',
       };
       expect(prettyStdout.getMeta(rec as any)).toEqual(
-        chalk.gray(' (repository=a/b, branch=c) [test]'),
+        util.styleText('gray', ' (repository=a/b, branch=c) [test]'),
       );
     });
   });

--- a/lib/logger/pretty-stdout.ts
+++ b/lib/logger/pretty-stdout.ts
@@ -3,7 +3,6 @@
 
 import { Stream } from 'node:stream';
 import * as util from 'node:util';
-import chalk from 'chalk';
 import stringify from 'json-stringify-pretty-compact';
 import { regEx } from '../util/regex';
 import type { BunyanRecord } from './types';
@@ -29,12 +28,12 @@ const metaFields = [
 ];
 
 const levels: Record<number, string> = {
-  10: chalk.gray('TRACE'),
-  20: chalk.blue('DEBUG'),
-  30: chalk.green(' INFO'),
-  40: chalk.magenta(' WARN'),
-  50: chalk.red('ERROR'),
-  60: chalk.bgRed('FATAL'),
+  10: util.styleText('gray', 'TRACE'),
+  20: util.styleText('blue', 'DEBUG'),
+  30: util.styleText('green', ' INFO'),
+  40: util.styleText('magenta', ' WARN'),
+  50: util.styleText('red', 'ERROR'),
+  60: util.styleText('bgRed', 'FATAL'),
 };
 
 export function indent(str: string, leading = false): string {
@@ -55,7 +54,7 @@ export function getMeta(rec: BunyanRecord): string {
     .map((field) => `${field}=${String(rec[field])}`)
     .join(', ');
   res = ` (${metaStr})${res}`;
-  return chalk.gray(res);
+  return util.styleText('gray', res);
 }
 
 export function getDetails(rec: BunyanRecord): string {

--- a/package.json
+++ b/package.json
@@ -190,7 +190,6 @@
     "azure-devops-node-api": "15.1.2",
     "bunyan": "1.8.15",
     "cacache": "20.0.3",
-    "chalk": "5.6.2",
     "changelog-filename-regex": "2.0.1",
     "clean-git-ref": "2.0.1",
     "commander": "14.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,9 +141,6 @@ importers:
       cacache:
         specifier: 20.0.3
         version: 20.0.3
-      chalk:
-        specifier: 5.6.2
-        version: 5.6.2
       changelog-filename-regex:
         specifier: 2.0.1
         version: 2.0.1


### PR DESCRIPTION
## Changes

replace chalk with node builtin util for styling in logger

## Context

Please select one of the following:

- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.

## Documentation

- [x] No documentation update is required

## How I've tested my work

I have verified these changes via:

- [x] Code inspection only

## Why?
`chalk` was only used for `lib/logger/pretty-stdout`, so keeping it pulls an extra transitive dependency (plus its transitive dependencies) into the runtime just for ANSI styling; moving to the node built-in utility shrinks the dependency tree, speeds up installs, and removes a potential supply-chain surface area.

## Availability / Compatibility
[`util.styleText`](https://nodejs.org/docs/latest/api/util.html#utilstyletextformat-text-options) was added in v21.7.0, v20.12.0 which means the supported engines (`^22.13` and `^24.11`) all satisfy the requirement, so there should be no compatibility issues.