### PR TITLE
refactor(presets): return merged presets from `resolveConfigPresets`

### DIFF
--- a/lib/config/presets/index.spec.ts
+++ b/lib/config/presets/index.spec.ts
@@ -82,7 +82,7 @@ describe('config/presets/index', () => {
       // @ts-expect-error -- invalid config
       config.foo = 1;
       config.extends = [];
-      const res = await presets.resolveConfigPresets(config);
+      const { config: res } = await presets.resolveConfigPresets(config);
       expect(config).toMatchObject(res);
       expect(res).toEqual({ foo: 1 });
     });
@@ -92,7 +92,8 @@ describe('config/presets/index', () => {
       local.getPreset.mockResolvedValueOnce({ extends: ['local>some/repo:c'] });
       local.getPreset.mockResolvedValueOnce({ extends: ['local>some/repo:c'] });
       local.getPreset.mockResolvedValueOnce({ foo: 1 });
-      expect(await presets.resolveConfigPresets(config)).toEqual({
+      const { config: res } = await presets.resolveConfigPresets(config);
+      expect(res).toEqual({
         foo: 1,
       });
       expect(local.getPreset).toHaveBeenCalledTimes(3);
@@ -233,7 +234,7 @@ describe('config/presets/index', () => {
       config.foo = 1;
       config.ignoreDeps = [];
       config.extends = [':pinVersions'];
-      const res = await presets.resolveConfigPresets(config);
+      const { config: res } = await presets.resolveConfigPresets(config);
       expect(res).toEqual({
         foo: 1,
         ignoreDeps: [],
@@ -267,7 +268,7 @@ describe('config/presets/index', () => {
           groupName: 'eslint',
         },
       ];
-      const res = await presets.resolveConfigPresets(config);
+      const { config: res } = await presets.resolveConfigPresets(config);
       expect(res).toEqual({
         packageRules: [
           {
@@ -291,7 +292,7 @@ describe('config/presets/index', () => {
 
     it('resolves eslint', async () => {
       config.extends = ['packages:eslint'];
-      const res = await presets.resolveConfigPresets(config);
+      const { config: res } = await presets.resolveConfigPresets(config);
       expect(res).toMatchSnapshot();
       // @ts-expect-error -- partial config
       expect(res.matchPackageNames).toHaveLength(10);
@@ -299,7 +300,7 @@ describe('config/presets/index', () => {
 
     it('resolves linters', async () => {
       config.extends = ['packages:linters'];
-      const res = await presets.resolveConfigPresets(config);
+      const { config: res } = await presets.resolveConfigPresets(config);
       expect(res).toMatchSnapshot();
       // @ts-expect-error -- partial config
       expect(res.matchPackageNames).toHaveLength(20);
@@ -307,7 +308,7 @@ describe('config/presets/index', () => {
 
     it('resolves nested groups', async () => {
       config.extends = [':automergeLinters'];
-      const res = await presets.resolveConfigPresets(config);
+      const { config: res } = await presets.resolveConfigPresets(config);
       expect(res).toMatchSnapshot();
       const rule = res.packageRules![0];
       expect(rule.automerge).toBeTrue();
@@ -316,7 +317,7 @@ describe('config/presets/index', () => {
 
     it('migrates automerge in presets', async () => {
       config.extends = ['ikatyang:library'];
-      const res = await presets.resolveConfigPresets(config);
+      const { config: res } = await presets.resolveConfigPresets(config);
       expect(res).toMatchSnapshot();
       expect(res.automerge).toBeUndefined();
       expect(res.minor!.automerge).toBeTrue();
@@ -324,7 +325,7 @@ describe('config/presets/index', () => {
 
     it('ignores presets', async () => {
       config.extends = ['config:recommended'];
-      const res = await presets.resolveConfigPresets(config, {}, [
+      const { config: res } = await presets.resolveConfigPresets(config, {}, [
         'config:recommended',
       ]);
       expect(config).toMatchObject(res);
@@ -337,11 +338,60 @@ describe('config/presets/index', () => {
         labels: ['self-hosted resolved'],
       });
 
-      const res = await presets.resolveConfigPresets(config);
+      const { config: res } = await presets.resolveConfigPresets(config);
 
       expect(res.labels).toEqual(['self-hosted resolved']);
       expect(local.getPreset.mock.calls).toHaveLength(1);
       expect(res).toMatchSnapshot();
+    });
+
+    it('returns the presets which have been merged into the resulting config', async () => {
+      config.extends = ['local>username/preset-repo'];
+      local.getPreset.mockResolvedValueOnce({
+        extends: ['security:openssf-scorecard'],
+        labels: ['self-hosted resolved'],
+      });
+
+      const {
+        visitedPresets: { merged },
+      } = await presets.resolveConfigPresets(config);
+
+      expect(merged).toEqual([
+        'local>username/preset-repo',
+        'security:openssf-scorecard',
+      ]);
+    });
+
+    it('de-duplicates the presets which have been meregd into the resulting config', async () => {
+      config.extends = [
+        'security:openssf-scorecard',
+        'local>username/preset-repo',
+        'security:openssf-scorecard',
+      ];
+
+      local.getPreset.mockResolvedValueOnce({
+        labels: ['self-hosted resolved'],
+        extends: ['security:openssf-scorecard'],
+        packageRules: [
+          {
+            extends: ['packages:eslint'],
+            groupName: 'eslint',
+          },
+        ],
+      });
+
+      const {
+        visitedPresets: { merged },
+      } = await presets.resolveConfigPresets(config);
+
+      expect(merged).toEqual(
+        // NOTE that we're not expecting to have a strict or stable ordering
+        expect.arrayContaining([
+          'local>username/preset-repo',
+          'security:openssf-scorecard',
+          'packages:eslint',
+        ]),
+      );
     });
 
     it('resolves self-hosted preset with templating', async () => {
@@ -353,7 +403,7 @@ describe('config/presets/index', () => {
           : Promise.reject(new Error('Failed to resolve self-hosted preset')),
       );
 
-      const res = await presets.resolveConfigPresets(config);
+      const { config: res } = await presets.resolveConfigPresets(config);
 
       expect(res.labels).toEqual(['self-hosted with template resolved']);
       expect(local.getPreset).toHaveBeenCalledExactlyOnceWith({
@@ -374,7 +424,7 @@ describe('config/presets/index', () => {
         })
         .mockResolvedValueOnce({ labels: ['self-hosted resolved'] });
 
-      const res = await presets.resolveConfigPresets(config);
+      const { config: res } = await presets.resolveConfigPresets(config);
 
       expect(res).toEqual({
         platform: 'gitlab',
@@ -402,7 +452,7 @@ describe('config/presets/index', () => {
       });
 
       expect(await presets.resolveConfigPresets(config)).toBeDefined();
-      const res = await presets.resolveConfigPresets(config);
+      const { config: res } = await presets.resolveConfigPresets(config);
       expect(res).toEqual({
         packageRules: [
           {
@@ -441,7 +491,7 @@ describe('config/presets/index', () => {
       });
 
       expect(await presets.resolveConfigPresets(config)).toBeDefined();
-      const res = await presets.resolveConfigPresets(config);
+      const { config: res } = await presets.resolveConfigPresets(config);
       expect(res).toEqual({
         packageRules: [
           {
@@ -482,7 +532,7 @@ describe('config/presets/index', () => {
       });
 
       expect(await presets.resolveConfigPresets(config)).toBeDefined();
-      const res = await presets.resolveConfigPresets(config);
+      const { config: res } = await presets.resolveConfigPresets(config);
       expect(res).toEqual({
         packageRules: [
           {

--- a/lib/config/presets/index.ts
+++ b/lib/config/presets/index.ts
@@ -179,12 +179,25 @@ export async function getPreset(
   return massage.massageConfig(migratedConfig);
 }
 
+export interface ResolveConfigPresetsResult {
+  config: AllConfig;
+  /** when resolving the given configuration, which internal/shared presets were discovered */
+  visitedPresets: {
+    /** which internal/shared presets were merged into the final config */
+    merged: string[];
+  };
+}
+
 export async function resolveConfigPresets(
   inputConfig: AllConfig,
   baseConfig?: RenovateConfig,
   _ignorePresets?: string[],
   existingPresets: string[] = [],
-): Promise<AllConfig> {
+): Promise<ResolveConfigPresetsResult> {
+  const allVisitedPresets = {
+    merged: new Set<string>(),
+  };
+
   let ignorePresets = clone(_ignorePresets);
   if (!ignorePresets || ignorePresets.length === 0) {
     ignorePresets = inputConfig.ignorePresets ?? [];
@@ -209,16 +222,22 @@ export async function resolveConfigPresets(
           inputConfig,
           existingPresets,
         );
-        const presetConfig = await resolveConfigPresets(
-          fetchedPreset,
-          baseConfig ?? inputConfig,
-          ignorePresets,
-          existingPresets.concat([preset]),
-        );
+        const { config: presetConfig, visitedPresets } =
+          await resolveConfigPresets(
+            fetchedPreset,
+            baseConfig ?? inputConfig,
+            ignorePresets,
+            existingPresets.concat([preset]),
+          );
         if (inputConfig?.ignoreDeps?.length === 0) {
           delete presetConfig.description;
         }
         config = mergeChildConfig(config, presetConfig);
+        allVisitedPresets.merged.add(preset);
+        // then also make sure we've noted any nested presets we've merged
+        for (const mergedPreset of visitedPresets.merged) {
+          allVisitedPresets.merged.add(mergedPreset);
+        }
       }
     }
   }
@@ -238,14 +257,18 @@ export async function resolveConfigPresets(
       config[key] = [] as never; // type can't be narrowed
       for (const element of val) {
         if (isObject(element)) {
-          (config[key] as RenovateConfig[]).push(
+          const { config: presetConfig, visitedPresets: visited } =
             await resolveConfigPresets(
               element as RenovateConfig,
               baseConfig,
               ignorePresets,
               existingPresets,
-            ),
-          );
+            );
+          (config[key] as RenovateConfig[]).push(presetConfig);
+
+          for (const mergedPreset of visited.merged) {
+            allVisitedPresets.merged.add(mergedPreset);
+          }
         } else {
           (config[key] as unknown[]).push(element);
         }
@@ -253,17 +276,32 @@ export async function resolveConfigPresets(
     } else if (isObject(val) && !ignoredKeys.includes(key)) {
       // Resolve nested objects
       logger.trace(`Resolving object "${key}"`);
-      config[key] = (await resolveConfigPresets(
-        val as RenovateConfig,
-        baseConfig,
-        ignorePresets,
-        existingPresets,
-      )) as never; // type can't be narrowed
+      const { config: presetConfig, visitedPresets: visited } =
+        await resolveConfigPresets(
+          val as RenovateConfig,
+          baseConfig,
+          ignorePresets,
+          existingPresets,
+        );
+      config[key] = presetConfig as never; // type can't be narrowed
+
+      for (const mergedPreset of visited.merged) {
+        allVisitedPresets.merged.add(mergedPreset);
+      }
     }
   }
   logger.trace({ config: inputConfig }, 'Input config');
-  logger.trace({ config }, 'Resolved config');
-  return config;
+  logger.trace(
+    { config, visitedPresets: allVisitedPresets },
+    'Resolved config',
+  );
+
+  return {
+    config,
+    visitedPresets: {
+      merged: Array.from(allVisitedPresets.merged),
+    },
+  };
 }
 
 async function fetchPreset(

--- a/lib/config/presets/internal/index.spec.ts
+++ b/lib/config/presets/internal/index.spec.ts
@@ -32,7 +32,7 @@ describe('config/presets/internal/index', () => {
       if (presetName !== 'description' && !ignoredPresets.includes(preset)) {
         it(`${preset} validates`, async () => {
           try {
-            const config = await resolveConfigPresets(
+            const { config } = await resolveConfigPresets(
               massageConfig(presetConfig),
             );
             const configType = groupName === 'global' ? 'global' : 'repo';

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -401,13 +401,12 @@ export async function validateConfig(
             if (key === 'packageRules') {
               for (const [subIndex, packageRule] of val.entries()) {
                 if (isObject(packageRule)) {
+                  const { config: resolved } = await resolveConfigPresets(
+                    packageRule as RenovateConfig,
+                    config,
+                  );
                   const resolvedRule = migrateConfig({
-                    packageRules: [
-                      await resolveConfigPresets(
-                        packageRule as RenovateConfig,
-                        config,
-                      ),
-                    ],
+                    packageRules: [resolved],
                   }).migratedConfig.packageRules![0];
                   warnings.push(
                     ...matchBaseBranchesValidator.check({

--- a/lib/workers/global/config/parse/index.ts
+++ b/lib/workers/global/config/parse/index.ts
@@ -28,7 +28,7 @@ export async function resolveGlobalExtends(
   try {
     // Make a "fake" config to pass to resolveConfigPresets and resolve globalPresets
     const config = { extends: globalExtends, ignorePresets };
-    const resolvedConfig = await resolveConfigPresets(config);
+    const { config: resolvedConfig } = await resolveConfigPresets(config);
     return resolvedConfig;
   } catch (err) {
     logger.error({ err }, 'Error resolving config preset');

--- a/lib/workers/repository/init/inherited.spec.ts
+++ b/lib/workers/repository/init/inherited.spec.ts
@@ -182,9 +182,14 @@ describe('workers/repository/init/inherited', () => {
       '{"onboarding":false,"labels":["test"],"extends":[":automergeAll"]}',
     );
     presets.resolveConfigPresets.mockResolvedValue({
-      onboarding: false,
-      labels: ['test'],
-      automerge: true,
+      config: {
+        onboarding: false,
+        labels: ['test'],
+        automerge: true,
+      },
+      visitedPresets: {
+        merged: [],
+      },
     });
     const res = await mergeInheritedConfig(config);
     expect(res.labels).toEqual(['test']);
@@ -215,9 +220,14 @@ describe('workers/repository/init/inherited', () => {
         errors: [],
       });
     presets.resolveConfigPresets.mockResolvedValue({
-      onboarding: false,
-      labels: ['test'],
-      automerge: true,
+      config: {
+        onboarding: false,
+        labels: ['test'],
+        automerge: true,
+      },
+      visitedPresets: {
+        merged: [],
+      },
     });
     const res = await mergeInheritedConfig(config);
     expect(res).not.toContainKey('binarySource');
@@ -254,8 +264,13 @@ describe('workers/repository/init/inherited', () => {
         ],
       });
     presets.resolveConfigPresets.mockResolvedValue({
-      labels: ['test'],
-      automerge: true,
+      config: {
+        labels: ['test'],
+        automerge: true,
+      },
+      visitedPresets: {
+        merged: [],
+      },
     });
     await expect(mergeInheritedConfig(config)).rejects.toThrow(
       CONFIG_VALIDATION,
@@ -283,9 +298,14 @@ describe('workers/repository/init/inherited', () => {
       errors: [],
     });
     presets.resolveConfigPresets.mockResolvedValue({
-      labels: ['test'],
-      automerge: true,
-      binarySource: 'docker', // global config option: should not be here
+      config: {
+        labels: ['test'],
+        automerge: true,
+        binarySource: 'docker', // global config option: should not be here
+      },
+      visitedPresets: {
+        merged: [],
+      },
     });
     const res = await mergeInheritedConfig(config);
     expect(res.labels).toEqual(['test']);

--- a/lib/workers/repository/init/inherited.ts
+++ b/lib/workers/repository/init/inherited.ts
@@ -131,7 +131,7 @@ export async function mergeInheritedConfig(
   }
 
   logger.debug('Resolving presets found in inherited config');
-  const resolvedConfig = await resolveConfigPresets(
+  const { config: resolvedConfig } = await resolveConfigPresets(
     filteredConfig,
     config,
     config.ignorePresets,

--- a/lib/workers/repository/init/merge.ts
+++ b/lib/workers/repository/init/merge.ts
@@ -246,14 +246,12 @@ export async function mergeRenovateConfig(
     npmApi.setNpmrc(decryptedConfig.npmrc);
   }
   // Decrypt after resolving in case the preset contains npm authentication instead
-  let resolvedConfig = await decryptConfig(
-    await presets.resolveConfigPresets(
-      decryptedConfig,
-      config,
-      config.ignorePresets,
-    ),
-    repository,
+  const { config: configToDecrypt } = await presets.resolveConfigPresets(
+    decryptedConfig,
+    config,
+    config.ignorePresets,
   );
+  let resolvedConfig = await decryptConfig(configToDecrypt, repository);
   logger.trace({ config: resolvedConfig }, 'resolved config');
   const migrationResult = migrateConfig(resolvedConfig);
   if (migrationResult.isMigrated) {
@@ -300,7 +298,10 @@ export async function mergeRenovateConfig(
     delete resolvedConfig.hostRules;
   }
   returnConfig = mergeChildConfig(returnConfig, resolvedConfig);
-  returnConfig = await presets.resolveConfigPresets(returnConfig, config);
+  ({ config: returnConfig } = await presets.resolveConfigPresets(
+    returnConfig,
+    config,
+  ));
   returnConfig.renovateJsonPresent = true;
   // istanbul ignore if
   if (returnConfig.ignorePaths?.length) {

--- a/lib/workers/repository/process/index.ts
+++ b/lib/workers/repository/process/index.ts
@@ -75,7 +75,10 @@ export async function getBaseBranchConfig(
       throw error;
     }
 
-    baseBranchConfig = await resolveConfigPresets(baseBranchConfig, config);
+    ({ config: baseBranchConfig } = await resolveConfigPresets(
+      baseBranchConfig,
+      config,
+    ));
     baseBranchConfig = mergeChildConfig(config, baseBranchConfig);
 
     // istanbul ignore if


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

As part of future changes in #39314 for
https://github.com/renovatebot/renovate/issues/15827, we want to log the
shallow configuration (the full resolved configuration, but without any
internal Renovate configuration presets), where we'll want to note which
presets have not been merged in.

Before that, we can start with an initial refactor to indicate which
have been merged, and return them.

## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
