### PR TITLE
refactor(presets): add an `isInternal` helper method

### DIFF
--- a/lib/config/presets/internal/index.spec.ts
+++ b/lib/config/presets/internal/index.spec.ts
@@ -64,4 +64,38 @@ describe('config/presets/internal/index', () => {
   it('returns undefined for unknown preset', () => {
     expect(internal.getPreset({ repo: 'some/repo' })).toBeUndefined();
   });
+
+  describe('isInternal', () => {
+    it('returns false for a local> preset', () => {
+      expect(internal.isInternal('local>renovatebot/.github')).toBeFalse();
+    });
+
+    it('returns false for a github> preset', () => {
+      expect(internal.isInternal('github>renovatebot/.github')).toBeFalse();
+    });
+
+    it('returns false for an un-migrated preset', () => {
+      expect(internal.isInternal('config:base')).toBeFalse();
+    });
+
+    it('returns false for an empty string', () => {
+      expect(internal.isInternal('')).toBeFalse();
+    });
+
+    it('returns true for `config:recommended`', () => {
+      expect(internal.isInternal('config:recommended')).toBeTrue();
+    });
+
+    it('returns true for a parameterised preset', () => {
+      expect(internal.isInternal(':assignee(renovate-tests)')).toBeTrue();
+    });
+
+    it('returns true for a parameterised remote preset', () => {
+      expect(
+        internal.isInternal(
+          'local>example/renovate-config-presets:assignee(renovate-tests)',
+        ),
+      ).toBeFalse();
+    });
+  });
 });

--- a/lib/config/presets/internal/index.ts
+++ b/lib/config/presets/internal/index.ts
@@ -63,3 +63,21 @@ function computeInternalPresets(): string[] {
 }
 
 export const internalPresetNames = new Set(computeInternalPresets());
+
+export function isInternal(preset: string): boolean {
+  if (internalPresetNames.has(preset)) {
+    return true;
+  }
+
+  // a parameterised preset is one that  that is parameterised will receive the argument `(...)`.
+  // As we can't look up on the preset's values itself (as it could be in any property), we can look at the preset name itself, and see if it includes the start of an opening parenthesis
+  const withoutParameterParts = preset.split('(');
+  if (
+    withoutParameterParts?.length &&
+    internalPresetNames.has(withoutParameterParts[0])
+  ) {
+    return true;
+  }
+
+  return false;
+}


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
As a follow-up to #40419, we can
introduce a helper method that handles any parameterised presets.


## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
