### PR TITLE
fix(git-submodules): infer the `sourceUrl` from the `packageName`

### DIFF
--- a/lib/modules/manager/git-submodules/extract.spec.ts
+++ b/lib/modules/manager/git-submodules/extract.spec.ts
@@ -69,6 +69,23 @@ describe('modules/manager/git-submodules/extract', () => {
       );
     });
 
+    describe('submodule sourceUrl is determined from packageName', () => {
+      it('when using SSH clone URL', async () => {
+        const res = await extractPackageFile('', '.gitmodules.3', {});
+        expect(res?.deps).toHaveLength(1);
+        expect(res?.deps[0].sourceUrl).toBe(
+          'https://github.com/PowerShell/PowerShell-Docs',
+        );
+      });
+      it('when using a relative path', async () => {
+        const res = await extractPackageFile('', '.gitmodules.4', {});
+        expect(res?.deps).toHaveLength(1);
+        expect(res?.deps[0].sourceUrl).toBe(
+          'https://github.com/PowerShell/PowerShell-Docs',
+        );
+      });
+    });
+
     it('fallback to current branch if special value is detected', async () => {
       gitMock.branch.mockResolvedValueOnce({
         all: ['staging', 'main'],
@@ -101,6 +118,7 @@ describe('modules/manager/git-submodules/extract', () => {
             currentValue: 'staging',
             depName: 'PowerShell-Docs',
             packageName: 'https://github.com/PowerShell/PowerShell-Docs',
+            sourceUrl: 'https://github.com/PowerShell/PowerShell-Docs',
           },
         ],
       });
@@ -116,6 +134,7 @@ describe('modules/manager/git-submodules/extract', () => {
             currentValue: 'v0.0.1',
             depName: 'deps/renovate1',
             packageName: 'https://github.com/renovatebot/renovate.git',
+            sourceUrl: 'https://github.com/renovatebot/renovate.git',
             versioning: 'semver',
           },
           {
@@ -123,12 +142,14 @@ describe('modules/manager/git-submodules/extract', () => {
             currentValue: '0.0.1',
             depName: 'deps/renovate2',
             packageName: 'https://github.com/renovatebot/renovate.git',
+            sourceUrl: 'https://github.com/renovatebot/renovate.git',
             versioning: 'semver',
           },
           {
             currentDigest: '4b825dc642cb6eb9a060e54bf8d69288fbee4904',
             currentValue: 'not-a-semver',
             packageName: 'https://github.com/renovatebot/renovate.git',
+            sourceUrl: 'https://github.com/renovatebot/renovate.git',
             depName: 'deps/renovate3',
           },
         ],

--- a/lib/modules/manager/git-submodules/extract.ts
+++ b/lib/modules/manager/git-submodules/extract.ts
@@ -114,6 +114,7 @@ export default async function extractPackageFile(
       deps.push({
         depName: path,
         packageName: httpSubModuleUrl,
+        sourceUrl: httpSubModuleUrl,
         currentValue: branch ?? undefined,
         currentDigest,
         ...(semVerVersioning.api.isVersion(branch)


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
As noted in #30231, it would be useful to present a changelog URL for
Git submodule PRs, which is possible with
`helpers:githubDigestChangelogs`.

However, because the `sourceUrl` is not set, this doesn't get applied.

Given the `packageName` is the HTTP URL for the Git submodule, we can
use this for our `sourceUrl`.


## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

Discussion: #30231

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/JamieTanna-Mend-testing/git-submodule-changelog/pull/2

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
