### PR TITLE
chore: ensure that `pnpm` also enforces `minimumReleaseAge`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,7 @@ env:
     patches/
     tools/
     package.json
+    pnpm-workspace.yaml
     pnpm-lock.yaml
 
 jobs:
@@ -745,7 +746,11 @@ jobs:
         run: pnpm test-e2e:pack
 
       - name: Install dependencies
-        run: pnpm test-e2e:install
+        run: |
+          # as `--ignore-workspace` doesn't seem to apply to `minimumReleaseAge`, forcibly delete our workspace
+          rm pnpm-workspace.yaml
+
+          pnpm test-e2e:install
 
       - name: E2E Test
         run: pnpm test-e2e:run

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,17 @@
 packages: []
 
 strictPeerDependencies: true
+
+# in line with https://github.com/renovatebot/.github/blob/main/default.json,
+# all non-Renovate or non-Containerbase packages should only be installed after
+# 7 days
+minimumReleaseAge: 10080
+minimumReleaseAgeExclude:
+  - '@renovatebot/detect-tools'
+  - '@renovatebot/osv-offline'
+  - '@renovatebot/pep440'
+  - '@renovatebot/pgp'
+  - '@renovatebot/ruby-semver'
+  - '@containerbase/eslint-plugin'
+  - '@containerbase/istanbul-reports-html'
+  - '@containerbase/semantic-release-pnpm'


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
On top of our Renovate configuration[0] not allowing Renovate to prepare
updates until npm packages have been available for 7 days, we can
provide "defence in depth" by also wiring in pnpm's configuration.

This takes the rules from [0] and applies them to explicitly allowlist
our packages, as well as set the limit to 7 days.

[0]: https://github.com/renovatebot/.github/blob/095f454e8b1141edb1045dd389bee4c59c51613e/default.json

## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
