### PR TITLE
fix(util/exec): correctly pass commands around when using `binarySource=docker`

### DIFF
--- a/lib/modules/manager/npm/post-update/yarn.spec.ts
+++ b/lib/modules/manager/npm/post-update/yarn.spec.ts
@@ -796,8 +796,7 @@ describe('modules/manager/npm/post-update/yarn', () => {
           ` && ` +
           `install-tool yarn-slim 1.22.18` +
           ` && ` +
-          // NOTE that this has a `|| true` appended inside the `exec(...)` function
-          `sed -i 's/ steps,/ steps.slice(0,1),/' some-dir/.yarn/cli.js` +
+          `sed -i 's/ steps,/ steps.slice(0,1),/' some-dir/.yarn/cli.js || true` +
           ` && ` +
           `yarn install --ignore-engines --ignore-platform --network-timeout 100000 --ignore-scripts` +
           `"`,

--- a/lib/util/exec/index.ts
+++ b/lib/util/exec/index.ts
@@ -21,7 +21,7 @@ import type {
   Opt,
   RawExecOptions,
 } from './types';
-import { asRawCommands, getChildEnv } from './utils';
+import { getChildEnv } from './utils';
 
 function dockerEnvVars(extraEnv: ExtraEnv, childEnv: ExtraEnv): string[] {
   const extraEnvKeys = Object.keys(extraEnv);
@@ -113,7 +113,7 @@ async function prepareRawExec(
     const cwd = getCwd(opts);
     const dockerOptions: DockerOptions = { ...docker, cwd, envVars };
     const dockerCommand = await generateDockerCommand(
-      asRawCommands(rawCommands),
+      rawCommands,
       [
         ...(await generateInstallCommands(opts.toolConstraints)),
         ...preCommands,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->


As noted in #40513, when running Composer's `lockFileMaintenance`
against a repository with `symfony/flex`[0], we hit a case[1] where
Composer needs to be installed first, which then results in a failure
when running in `binarySource=docker`, which strips any options from
`CommandWithOptions`.

This is because we were stripping the options and was inadvertently left
in as it fixed Typescript type checking, but subtly broke
implementation.

This also corrects a test that was a sign that this wasn't quite working
for Yarn, but we'd expected that it was mocked, not actually broken.

[0]: https://github.com/renovatebot/renovate/blob/795a121b5486138fd65e344ac7feaf370278d791/lib/modules/manager/composer/utils.ts#L15
[1]: https://github.com/renovatebot/renovate/blob/795a121b5486138fd65e344ac7feaf370278d791/lib/modules/manager/composer/artifacts.ts#L170




## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/JamieTanna-Mend-testing/zealous-stan/pull/1

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
