### PR TITLE
feat(presets): add `oxlint` to linters packages

### DIFF
--- a/lib/config/presets/__snapshots__/index.spec.ts.snap
+++ b/lib/config/presets/__snapshots__/index.spec.ts.snap
@@ -13,6 +13,7 @@ exports[`config/presets/index > getPreset > gets linters 1`] = `
     "packages:tslint",
   ],
   "matchPackageNames": [
+    "oxlint",
     "prettier",
     "remark-lint",
     "standard",
@@ -182,6 +183,7 @@ exports[`config/presets/index > resolveConfigPresets > resolves linters 1`] = `
     "stylelint**",
     "codelyzer",
     "/\\btslint\\b/",
+    "oxlint",
     "prettier",
     "remark-lint",
     "standard",
@@ -218,6 +220,7 @@ exports[`config/presets/index > resolveConfigPresets > resolves nested groups 1`
         "stylelint**",
         "codelyzer",
         "/\\btslint\\b/",
+        "oxlint",
         "prettier",
         "remark-lint",
         "standard",

--- a/lib/config/presets/index.spec.ts
+++ b/lib/config/presets/index.spec.ts
@@ -303,7 +303,7 @@ describe('config/presets/index', () => {
       const { config: res } = await presets.resolveConfigPresets(config);
       expect(res).toMatchSnapshot();
       // @ts-expect-error -- partial config
-      expect(res.matchPackageNames).toHaveLength(20);
+      expect(res.matchPackageNames).toHaveLength(21);
     });
 
     it('resolves nested groups', async () => {
@@ -312,7 +312,7 @@ describe('config/presets/index', () => {
       expect(res).toMatchSnapshot();
       const rule = res.packageRules![0];
       expect(rule.automerge).toBeTrue();
-      expect(rule.matchPackageNames).toHaveLength(20);
+      expect(rule.matchPackageNames).toHaveLength(21);
     });
 
     it('migrates automerge in presets', async () => {
@@ -692,7 +692,7 @@ describe('config/presets/index', () => {
       const res = await presets.getPreset('packages:linters', {});
       expect(res).toMatchSnapshot();
       // @ts-expect-error -- partial config
-      expect(res.matchPackageNames).toHaveLength(3);
+      expect(res.matchPackageNames).toHaveLength(4);
       expect(res.extends).toHaveLength(5);
     });
 

--- a/lib/config/presets/internal/packages.ts
+++ b/lib/config/presets/internal/packages.ts
@@ -105,7 +105,7 @@ export const presets: Record<string, Preset> = {
       'packages:stylelint',
       'packages:tslint',
     ],
-    matchPackageNames: ['prettier', 'remark-lint', 'standard'],
+    matchPackageNames: ['oxlint', 'prettier', 'remark-lint', 'standard'],
   },
   mapbox: {
     description: 'All Mapbox-related packages.',


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
this ensures that oxlint is added to the linters group:
- https://github.com/renovatebot/renovate/pull/40516
- https://github.com/renovatebot/renovate/pull/40515
- https://github.com/renovatebot/renovate/pull/40277#issuecomment-3747089989
<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
