### PR TITLE
fix(renovate-config-validator): refactor to use Commander

### DIFF
--- a/package.json
+++ b/package.json
@@ -275,6 +275,7 @@
     "re2": "1.23.0"
   },
   "devDependencies": {
+    "@commander-js/extra-typings": "14.0.0",
     "@containerbase/eslint-plugin": "1.1.27",
     "@containerbase/istanbul-reports-html": "1.1.24",
     "@containerbase/semantic-release-pnpm": "1.3.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -370,6 +370,9 @@ importers:
         specifier: 3.25.76
         version: 3.25.76
     devDependencies:
+      '@commander-js/extra-typings':
+        specifier: 14.0.0
+        version: 14.0.0(commander@14.0.2)
       '@containerbase/eslint-plugin':
         specifier: 1.1.27
         version: 1.1.27(eslint-plugin-import@2.32.0)(eslint-plugin-promise@7.2.1(eslint@9.39.2))(eslint@9.39.2)
@@ -957,6 +960,11 @@ packages:
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
+
+  '@commander-js/extra-typings@14.0.0':
+    resolution: {integrity: sha512-hIn0ncNaJRLkZrxBIp5AsW/eXEHNKYQBh0aPdoUqNgD+Io3NIykQqpKFyKcuasZhicGaEZJX/JBSIkZ4e5x8Dg==}
+    peerDependencies:
+      commander: ~14.0.0
 
   '@containerbase/eslint-plugin@1.1.27':
     resolution: {integrity: sha512-sz9CR/viM+7/e8fiFBEPdt2x76MUfMl4WP5s1fVG1y4LUBdf9OHdNGr6rrwV4r1GCYulsUhX/ScnSDK53ssl/Q==}
@@ -7723,6 +7731,10 @@ snapshots:
 
   '@colors/colors@1.5.0':
     optional: true
+
+  '@commander-js/extra-typings@14.0.0(commander@14.0.2)':
+    dependencies:
+      commander: 14.0.2
 
   '@containerbase/eslint-plugin@1.1.27(eslint-plugin-import@2.32.0)(eslint-plugin-promise@7.2.1(eslint@9.39.2))(eslint@9.39.2)':
     dependencies:


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
As part of recent proposed changes with `renovate-config-validator`,
we've found that before new changes are made, we should align
`renovate-config-validator` with `renovate` in using Commander for a
lightweight framework for command-line applications.

As a replacement for #39953, we can introduce a more targeted help
message, providing more examples about usage.

We also introduce `@commander-js/extra-typings` to make sure that we
have better types for the `action` function.

We also need to make sure we call `parseAsync`, as we're using an
`async` function.

## Context

Discussed in https://github.com/renovatebot/renovate/pull/39953 and in relation to https://github.com/renovatebot/renovate/issues/40521.

Marked as a `fix` to release it immediately

## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->

### Help

```console
% npm run compile:ts && env LOG_LEVEL=debug node ./dist/config-validator.js --help
Usage: renovate-config-validator [options] [config-files...]

Validate your Renovate configuration (repo config, shared presets or global configuration) files
If no [config-files...] are given, renovate-config-validator will look at the default config file locations (https://docs.renovatebot.com/configuration-options/)

Options:
  -v, --version  output the version number
  --strict       Fail command if any configuration warnings, errors, or a migration is needed
  -h, --help     display help for command

Examples:

  $ renovate-config-validator
  $ renovate-config-validator --strict
  $ renovate-config-validator first_config.json
  $ renovate-config-validator --strict config.js

  $ env RENOVATE_CONFIG_FILE=obscure-name.json renovate-config-validator
```

(Now returns an error code)

### Validation (`renovate.json`)

```console
% npm run compile:ts && env LOG_LEVEL=debug node ./dist/config-validator.js  renovate.json
 INFO: Validating renovate.json
 INFO: Config validated successfully
```

### Validation (no arguments)

```console
% npm run compile:ts && env LOG_LEVEL=debug node ./dist/config-validator.js
 INFO: Validating renovate.json
DEBUG: No config file found on disk - skipping
 INFO: Config validated successfully
```

### Validation (`env RENOVATE_CONFIG_FILE`)

```console
% npm run compile:ts && env LOG_LEVEL=debug RENOVATE_CONFIG_FILE=obscure-name.js node ./dist/config-validator.js  --strict
 INFO: Validating renovate.json
DEBUG: Checking for config file in obscure-name.js
 WARN: Config validation errors found
       "configType": "obscure-name.js",
       "errors": [
         {
           "topic": "Configuration Error",
           "message": "Invalid configuration option: invalid"
         }
       ]
 INFO: Validating obscure-name.js
ERROR: Found errors in configuration
       "file": "obscure-name.js",
       "errors": [
         {
           "topic": "Configuration Error",
           "message": "Invalid configuration option: invalid"
         }
       ]
```

### Validation (`--strict`, `config.js`)

```console
% npm run compile:ts && env LOG_LEVEL=debug node ./dist/config-validator.js  --strict
 INFO: Validating renovate.json
DEBUG: Checking for config file in config.js
 WARN: Config validation errors found
       "configType": "config.js",
       "errors": [
         {
           "topic": "Configuration Error",
           "message": "Invalid configuration option: invalid"
         }
       ]
 INFO: Validating config.js
ERROR: Found errors in configuration
       "file": "config.js",
       "errors": [
         {
           "topic": "Configuration Error",
           "message": "Invalid configuration option: invalid"
         }
       ]
1 % npm run compile:ts && env LOG_LEVEL=debug node ./dist/config-validator.js  --strict config.js
 INFO: Validating config.js
ERROR: Found errors in configuration
       "file": "config.js",
       "errors": [
         {
           "topic": "Configuration Error",
           "message": "Invalid configuration option: invalid"
         }
       ]
1 %
```

