### PR TITLE
feat(renovate-config-validator): detect global environment options

### DIFF
--- a/docs/usage/config-validation.md
+++ b/docs/usage/config-validation.md
@@ -56,6 +56,32 @@ $ npx --yes --package renovate -- renovate-config-validator first_config.json
  INFO: Config validated successfully
 ```
 
+### Providing global configuration
+
+If `renovate-config-validator` detects a `config.js`, or any [global self-hosed environment variables](./self-hosted-configuration.md), they will be set as global configuration.
+
+For instance, if you had a `config.js`:
+
+```javascript
+module.exports = {
+  // to mirror the Mend-hosted Renovate
+  globalExtends: ['global:safeEnv'],
+};
+```
+
+And a `renovate.json`:
+
+```json
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "env": {
+    "GONOSUMDB": "off"
+  }
+}
+```
+
+The `renovate-config-validator` would allow this to pass.
+
 ## Validate your config automatically
 
 You can create a [pre-commit](https://pre-commit.com) hook to validate your configuration automatically.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes


A long-standing issue with `renovate-config-validator` has been that
setting global configuration options such as `RENOVATE_ALLOWED_ENV` or
`RENOVATE_ALLOWED_COMMANDS` has no effect.

To make it possible to validate alongside the `config.js` (or other
self-hosted global configuration) as well as setting environment
variables while performing validation, we can ensure that we partially
initialise the `GlobalConfig`.

We can also make sure that this is documented as part of this change.

Functionality such as authenticating to the platform to retrieve remote
presets will be done at a future point.



## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #40521, #38973
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: 

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
If there's a config.js in the directory:

```console
% env LOG_LEVEL=debug node ~/workspaces/renovate/dist/config-validator.js
INFO: Validating renovate.json
...
DEBUG: Combined config
       "config": {
         "allowedEnv": ["GO*", "GRADLE_OPTS", "RUSTC_BOOTSTRAP"],
         "description": [
           "Hopefully safe environment variables to allow users to configure."
         ],
         "hostRules": []
       }
...
 INFO: Validating config.js
...
 INFO: Config validated successfully
```

(where there's a config.js that allows it)

And when specifying the env:

```console
% env RENOVATE_GLOBAL_EXTENDS='["global:safeEnv"]' LOG_LEVEL=debug node ~/workspaces/renovate/dist/config-validator.js
...
 INFO: Config validated successfully
```

Or:

```console
% env RENOVATE_ALLOWED_ENV='["GO*"]' LOG_LEVEL=debug node ~/workspaces/renovate/dist/config-validator.js
...
 INFO: Config validated successfully
```

If you specify a filename it'll get parsed as a global config, so this will fail:

```console
# WITHOUT:
% env RENOVATE_ALLOWED_ENV='["GO*"]' LOG_LEVEL=debug node ~/workspaces/renovate/dist/config-validator.js renovate.json
INFO: Validating renovate.json as global config
...
ERROR: Found errors in configuration
       "file": "renovate.json",
       "errors": [
         {
           "topic": "Configuration Error",
           "message": "Env variable name `GONOSUMDB` is not allowed by this bot's `allowedEnv`"
         }
       ]
```

But with `--no-global`:

```
% env RENOVATE_ALLOWED_ENV='["GO*"]' LOG_LEVEL=debug node ~/workspaces/renovate/dist/config-validator.js renovate.json --no-global
 INFO: Validating renovate.json as repo config
...
INFO: Config validated successfully
```
