### PR TITLE
chore(types): make `generateDocs`' `version` argument typed

### DIFF
--- a/tools/docs/index.ts
+++ b/tools/docs/index.ts
@@ -17,7 +17,7 @@ import { generateVersioning } from './versioning';
 export async function generateDocs(
   root = 'tmp',
   pack = true,
-  version = undefined,
+  version: string | undefined = undefined,
 ): Promise<void> {
   try {
     const dist = `${root}/docs`;

--- a/tools/prepare-release.ts
+++ b/tools/prepare-release.ts
@@ -30,9 +30,9 @@ const program = new Command('pnpm release:prepare')
 void (async () => {
   await program.parseAsync();
   const opts = program.opts();
-  logger.info(`Preparing v${opts.version} ...`);
+  logger.info(`Preparing v${opts.version?.toString()} ...`);
   build();
-  await generateDocs(undefined, undefined, opts.version);
+  await generateDocs(undefined, undefined, opts.version?.toString());
   await bake('build', opts);
 })();
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
As part of future changes to introduce further typings for Commander
(#40546), we need to provide stronger types as the `version` will now be
typed.

We can erase the `SemVer` type, and pass around a `string`, instead as
it's not necessary to keep.

## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
