### PR TITLE
fix(git): correctly merge existing `GIT_CONFIG_` variables if set

### DIFF
--- a/lib/util/git/auth.spec.ts
+++ b/lib/util/git/auth.spec.ts
@@ -3,10 +3,13 @@ import {
   getGitAuthenticatedEnvironmentVariables,
   getGitEnvironmentVariables,
 } from './auth.ts';
+import { logger } from '~test/util.ts';
 
 describe('util/git/auth', () => {
   afterEach(() => {
     delete process.env.GIT_CONFIG_COUNT;
+    delete process.env.GIT_CONFIG_KEY_0;
+    delete process.env.GIT_CONFIG_VALUE_0;
   });
 
   describe('getGitAuthenticatedEnvironmentVariables()', () => {
@@ -122,9 +125,11 @@ describe('util/git/auth', () => {
         ),
       ).toStrictEqual({
         GIT_CONFIG_COUNT: '4',
+        GIT_CONFIG_KEY_0: '',
         GIT_CONFIG_KEY_1: 'url.https://ssh:token1234@github.com/.insteadOf',
         GIT_CONFIG_KEY_2: 'url.https://git:token1234@github.com/.insteadOf',
         GIT_CONFIG_KEY_3: 'url.https://token1234@github.com/.insteadOf',
+        GIT_CONFIG_VALUE_0: '',
         GIT_CONFIG_VALUE_1: 'ssh://git@github.com/',
         GIT_CONFIG_VALUE_2: 'git@github.com:',
         GIT_CONFIG_VALUE_3: 'https://github.com/',
@@ -145,9 +150,11 @@ describe('util/git/auth', () => {
         ),
       ).toStrictEqual({
         GIT_CONFIG_COUNT: '4',
+        GIT_CONFIG_KEY_0: '',
         GIT_CONFIG_KEY_1: 'url.https://ssh:token1234@github.com/.insteadOf',
         GIT_CONFIG_KEY_2: 'url.https://git:token1234@github.com/.insteadOf',
         GIT_CONFIG_KEY_3: 'url.https://token1234@github.com/.insteadOf',
+        GIT_CONFIG_VALUE_0: '',
         GIT_CONFIG_VALUE_1: 'ssh://git@github.com/',
         GIT_CONFIG_VALUE_2: 'git@github.com:',
         GIT_CONFIG_VALUE_3: 'https://github.com/',
@@ -156,6 +163,8 @@ describe('util/git/auth', () => {
 
     it('returns url with token and already existing GIT_CONFIG_COUNT from environment', () => {
       process.env.GIT_CONFIG_COUNT = '1';
+      process.env.GIT_CONFIG_KEY_0 = 'key';
+      process.env.GIT_CONFIG_VALUE_0 = 'value';
       expect(
         getGitAuthenticatedEnvironmentVariables('https://github.com/', {
           token: 'token1234',
@@ -164,9 +173,11 @@ describe('util/git/auth', () => {
         }),
       ).toStrictEqual({
         GIT_CONFIG_COUNT: '4',
+        GIT_CONFIG_KEY_0: 'key',
         GIT_CONFIG_KEY_1: 'url.https://ssh:token1234@github.com/.insteadOf',
         GIT_CONFIG_KEY_2: 'url.https://git:token1234@github.com/.insteadOf',
         GIT_CONFIG_KEY_3: 'url.https://token1234@github.com/.insteadOf',
+        GIT_CONFIG_VALUE_0: 'value',
         GIT_CONFIG_VALUE_1: 'ssh://git@github.com/',
         GIT_CONFIG_VALUE_2: 'git@github.com:',
         GIT_CONFIG_VALUE_3: 'https://github.com/',
@@ -369,6 +380,118 @@ describe('util/git/auth', () => {
         GIT_CONFIG_VALUE_0: 'ssh://git@git.mycompany.com:7999/',
         GIT_CONFIG_VALUE_1: 'ssh://git@git.mycompany.com:7999/',
         GIT_CONFIG_VALUE_2: 'https://git.mycompany.com/scm/',
+      });
+    });
+
+    describe('when GIT_CONFIG_COUNT=1, but no values exist', () => {
+      beforeEach(() => {
+        process.env.GIT_CONFIG_COUNT = '1';
+      });
+      it('defaults them to an empty string', () => {
+        expect(
+          getGitAuthenticatedEnvironmentVariables('https://github.com/', {
+            token: 'token1234',
+            hostType: 'github',
+            matchHost: 'github.com',
+          }),
+        ).toStrictEqual({
+          GIT_CONFIG_COUNT: '4',
+          GIT_CONFIG_KEY_0: '',
+          GIT_CONFIG_KEY_1: 'url.https://ssh:token1234@github.com/.insteadOf',
+          GIT_CONFIG_KEY_2: 'url.https://git:token1234@github.com/.insteadOf',
+          GIT_CONFIG_KEY_3: 'url.https://token1234@github.com/.insteadOf',
+          GIT_CONFIG_VALUE_0: '',
+          GIT_CONFIG_VALUE_1: 'ssh://git@github.com/',
+          GIT_CONFIG_VALUE_2: 'git@github.com:',
+          GIT_CONFIG_VALUE_3: 'https://github.com/',
+        });
+      });
+
+      it('logs a warning', () => {
+        getGitAuthenticatedEnvironmentVariables('https://github.com/', {
+          token: 'token1234',
+          hostType: 'github',
+          matchHost: 'github.com',
+        });
+
+        expect(logger.logger.once.warn).toHaveBeenCalledWith(
+          'GIT_CONFIG_COUNT=1, but there was no value for GIT_CONFIG_KEY_0. Setting it to the empty string, which may break git',
+        );
+        expect(logger.logger.once.warn).toHaveBeenCalledWith(
+          'GIT_CONFIG_COUNT=1, but there was no value for GIT_CONFIG_VALUE_0. Setting it to the empty string, which may break git',
+        );
+      });
+    });
+
+    describe('when GIT_CONFIG_COUNT=2, with values', () => {
+      afterEach(() => {
+        delete process.env.GIT_CONFIG_COUNT;
+        delete process.env.GIT_CONFIG_KEY_0;
+        delete process.env.GIT_CONFIG_VALUE_0;
+        delete process.env.GIT_CONFIG_KEY_1;
+        delete process.env.GIT_CONFIG_VALUE_1;
+      });
+
+      it('handles existing values and merges them', () => {
+        process.env.GIT_CONFIG_COUNT = '2';
+        process.env.GIT_CONFIG_KEY_0 = 'url.https://foo.insteadOf';
+        process.env.GIT_CONFIG_KEY_1 = 'url.https://bar.insteadOf';
+        process.env.GIT_CONFIG_VALUE_0 = 'ssh://foo/';
+        process.env.GIT_CONFIG_VALUE_1 = 'ssh://bar/';
+
+        expect(
+          getGitAuthenticatedEnvironmentVariables('https://github.com/', {
+            token: 'token1234',
+            hostType: 'github',
+            matchHost: 'github.com',
+          }),
+        ).toStrictEqual({
+          GIT_CONFIG_COUNT: '5',
+          GIT_CONFIG_KEY_0: 'url.https://foo.insteadOf',
+          GIT_CONFIG_KEY_1: 'url.https://bar.insteadOf',
+          GIT_CONFIG_KEY_2: 'url.https://ssh:token1234@github.com/.insteadOf',
+          GIT_CONFIG_KEY_3: 'url.https://git:token1234@github.com/.insteadOf',
+          GIT_CONFIG_KEY_4: 'url.https://token1234@github.com/.insteadOf',
+          GIT_CONFIG_VALUE_0: 'ssh://foo/',
+          GIT_CONFIG_VALUE_1: 'ssh://bar/',
+          GIT_CONFIG_VALUE_2: 'ssh://git@github.com/',
+          GIT_CONFIG_VALUE_3: 'git@github.com:',
+          GIT_CONFIG_VALUE_4: 'https://github.com/',
+        });
+      });
+
+      it(`doesn't override provided environment variable with value from environment`, () => {
+        process.env.GIT_CONFIG_COUNT = '2';
+        process.env.GIT_CONFIG_KEY_0 = 'url.https://foo.insteadOf';
+        process.env.GIT_CONFIG_KEY_1 = 'url.https://bar.insteadOf';
+        process.env.GIT_CONFIG_VALUE_0 = 'ssh://foo/';
+        process.env.GIT_CONFIG_VALUE_1 = 'ssh://bar/';
+
+        expect(
+          getGitAuthenticatedEnvironmentVariables(
+            'https://github.com/',
+            {
+              token: 'token1234',
+              hostType: 'github',
+              matchHost: 'github.com',
+            },
+            {
+              GIT_CONFIG_KEY_0: 'to-be-overridden',
+            },
+          ),
+        ).toStrictEqual({
+          GIT_CONFIG_COUNT: '5',
+          GIT_CONFIG_KEY_0: 'to-be-overridden',
+          GIT_CONFIG_KEY_1: 'url.https://bar.insteadOf',
+          GIT_CONFIG_KEY_2: 'url.https://ssh:token1234@github.com/.insteadOf',
+          GIT_CONFIG_KEY_3: 'url.https://git:token1234@github.com/.insteadOf',
+          GIT_CONFIG_KEY_4: 'url.https://token1234@github.com/.insteadOf',
+          GIT_CONFIG_VALUE_0: 'ssh://foo/',
+          GIT_CONFIG_VALUE_1: 'ssh://bar/',
+          GIT_CONFIG_VALUE_2: 'ssh://git@github.com/',
+          GIT_CONFIG_VALUE_3: 'git@github.com:',
+          GIT_CONFIG_VALUE_4: 'https://github.com/',
+        });
       });
     });
   });

--- a/lib/util/git/auth.spec.ts
+++ b/lib/util/git/auth.spec.ts
@@ -1,9 +1,9 @@
+import { logger } from '~test/util.ts';
 import { add, clear } from '../host-rules.ts';
 import {
   getGitAuthenticatedEnvironmentVariables,
   getGitEnvironmentVariables,
 } from './auth.ts';
-import { logger } from '~test/util.ts';
 
 describe('util/git/auth', () => {
   afterEach(() => {
@@ -121,15 +121,19 @@ describe('util/git/auth', () => {
             hostType: 'github',
             matchHost: 'github.com',
           },
-          { GIT_CONFIG_COUNT: '1' },
+          {
+            GIT_CONFIG_COUNT: '1',
+            GIT_CONFIG_KEY_0: 'existing-key',
+            GIT_CONFIG_VALUE_0: 'existing-value',
+          },
         ),
       ).toStrictEqual({
         GIT_CONFIG_COUNT: '4',
-        GIT_CONFIG_KEY_0: '',
+        GIT_CONFIG_KEY_0: 'existing-key',
         GIT_CONFIG_KEY_1: 'url.https://ssh:token1234@github.com/.insteadOf',
         GIT_CONFIG_KEY_2: 'url.https://git:token1234@github.com/.insteadOf',
         GIT_CONFIG_KEY_3: 'url.https://token1234@github.com/.insteadOf',
-        GIT_CONFIG_VALUE_0: '',
+        GIT_CONFIG_VALUE_0: 'existing-value',
         GIT_CONFIG_VALUE_1: 'ssh://git@github.com/',
         GIT_CONFIG_VALUE_2: 'git@github.com:',
         GIT_CONFIG_VALUE_3: 'https://github.com/',
@@ -146,15 +150,19 @@ describe('util/git/auth', () => {
             hostType: 'github',
             matchHost: 'github.com',
           },
-          { GIT_CONFIG_COUNT: '1' },
+          {
+            GIT_CONFIG_COUNT: '1',
+            GIT_CONFIG_KEY_0: 'existing-key',
+            GIT_CONFIG_VALUE_0: 'existing-value',
+          },
         ),
       ).toStrictEqual({
         GIT_CONFIG_COUNT: '4',
-        GIT_CONFIG_KEY_0: '',
+        GIT_CONFIG_KEY_0: 'existing-key',
         GIT_CONFIG_KEY_1: 'url.https://ssh:token1234@github.com/.insteadOf',
         GIT_CONFIG_KEY_2: 'url.https://git:token1234@github.com/.insteadOf',
         GIT_CONFIG_KEY_3: 'url.https://token1234@github.com/.insteadOf',
-        GIT_CONFIG_VALUE_0: '',
+        GIT_CONFIG_VALUE_0: 'existing-value',
         GIT_CONFIG_VALUE_1: 'ssh://git@github.com/',
         GIT_CONFIG_VALUE_2: 'git@github.com:',
         GIT_CONFIG_VALUE_3: 'https://github.com/',

--- a/lib/util/git/auth.spec.ts
+++ b/lib/util/git/auth.spec.ts
@@ -415,10 +415,10 @@ describe('util/git/auth', () => {
         });
 
         expect(logger.logger.once.warn).toHaveBeenCalledWith(
-          'GIT_CONFIG_COUNT=1, but there was no value for GIT_CONFIG_KEY_0. Setting it to the empty string, which may break git',
+          'GIT_CONFIG_COUNT=1, but there was no value for GIT_CONFIG_KEY_0. Setting it to the empty string, which may break Git',
         );
         expect(logger.logger.once.warn).toHaveBeenCalledWith(
-          'GIT_CONFIG_COUNT=1, but there was no value for GIT_CONFIG_VALUE_0. Setting it to the empty string, which may break git',
+          'GIT_CONFIG_COUNT=1, but there was no value for GIT_CONFIG_VALUE_0. Setting it to the empty string, which may break Git',
         );
       });
     });

--- a/lib/util/git/auth.ts
+++ b/lib/util/git/auth.ts
@@ -71,11 +71,34 @@ export function getGitAuthenticatedEnvironmentVariables(
   }
 
   // create a shallow copy of the environmentVariables as base so we don't modify the input parameter object
-  // add the two new config key and value to the returnEnvironmentVariables object
-  // increase the CONFIG_COUNT by one for each rule and add it to the object
   const newEnvironmentVariables = {
     ...environmentVariables,
   };
+  // make sure we copy over any existing variables
+  if (gitConfigCount > 0) {
+    for (let i = 0; i < gitConfigCount; i++) {
+      let envKey = `GIT_CONFIG_KEY_${i}`;
+      newEnvironmentVariables[envKey] ??= env[envKey];
+      if (newEnvironmentVariables[envKey] === undefined) {
+        logger.once.warn(
+          `GIT_CONFIG_COUNT=${gitConfigCount}, but there was no value for ${envKey}. Setting it to the empty string, which may break git`,
+        );
+        newEnvironmentVariables[envKey] = '';
+      }
+
+      envKey = `GIT_CONFIG_VALUE_${i}`;
+      newEnvironmentVariables[envKey] ??= env[envKey];
+      if (newEnvironmentVariables[envKey] === undefined) {
+        logger.once.warn(
+          `GIT_CONFIG_COUNT=${gitConfigCount}, but there was no value for ${envKey}. Setting it to the empty string, which may break git`,
+        );
+        newEnvironmentVariables[envKey] = '';
+      }
+    }
+  }
+
+  // add the two new config key and value to the returnEnvironmentVariables object
+  // increase the CONFIG_COUNT by one for each rule and add it to the object
   for (const rule of authenticationRules) {
     newEnvironmentVariables[`GIT_CONFIG_KEY_${gitConfigCount}`] =
       `url.${rule.url}.insteadOf`;

--- a/lib/util/git/auth.ts
+++ b/lib/util/git/auth.ts
@@ -52,7 +52,7 @@ export function getGitAuthenticatedEnvironmentVariables(
       gitConfigCount = 0;
     }
 
-    if (gitConfigCount > 0) {
+    if (gitConfigCount > 0 && !environmentVariables?.GIT_CONFIG_COUNT) {
       for (let i = 0; i < gitConfigCount; i++) {
         let envKey = `GIT_CONFIG_KEY_${i}`;
         if (env[envKey] === undefined) {

--- a/lib/util/git/auth.ts
+++ b/lib/util/git/auth.ts
@@ -51,6 +51,26 @@ export function getGitAuthenticatedEnvironmentVariables(
       );
       gitConfigCount = 0;
     }
+
+    if (gitConfigCount > 0) {
+      for (let i = 0; i < gitConfigCount; i++) {
+        let envKey = `GIT_CONFIG_KEY_${i}`;
+        if (env[envKey] === undefined) {
+          logger.once.warn(
+            `GIT_CONFIG_COUNT=${gitConfigCount}, but there was no value for ${envKey}. Setting it to the empty string, which may break Git`,
+          );
+          env[envKey] = '';
+        }
+
+        envKey = `GIT_CONFIG_VALUE_${i}`;
+        if (env[envKey] === undefined) {
+          logger.once.warn(
+            `GIT_CONFIG_COUNT=${gitConfigCount}, but there was no value for ${envKey}. Setting it to the empty string, which may break Git`,
+          );
+          env[envKey] = '';
+        }
+      }
+    }
   }
   let authenticationRules: AuthenticationRule[];
   if (token) {
@@ -79,21 +99,9 @@ export function getGitAuthenticatedEnvironmentVariables(
     for (let i = 0; i < gitConfigCount; i++) {
       let envKey = `GIT_CONFIG_KEY_${i}`;
       newEnvironmentVariables[envKey] ??= env[envKey];
-      if (newEnvironmentVariables[envKey] === undefined) {
-        logger.once.warn(
-          `GIT_CONFIG_COUNT=${gitConfigCount}, but there was no value for ${envKey}. Setting it to the empty string, which may break git`,
-        );
-        newEnvironmentVariables[envKey] = '';
-      }
 
       envKey = `GIT_CONFIG_VALUE_${i}`;
       newEnvironmentVariables[envKey] ??= env[envKey];
-      if (newEnvironmentVariables[envKey] === undefined) {
-        logger.once.warn(
-          `GIT_CONFIG_COUNT=${gitConfigCount}, but there was no value for ${envKey}. Setting it to the empty string, which may break git`,
-        );
-        newEnvironmentVariables[envKey] = '';
-      }
     }
   }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->



As noted in #40580, we have cases where the `GIT_CONFIG` environment
variables may be set by a user, and Renovate doesn't correctly merge
them into the resulting variables, although it does use the existing
`GIT_CONFIG_COUNT` as its starting point for new variables.

To correctly handle this, we should make sure that if there are existing
variables set, we copy them over.

If the `GIT_CONFIG_COUNT` is set, but some value(s) are missing, we
should make sure to log a warning and default them to the empty string.

It's likely this may break Git, but be a more reasonable error than the
current behaviour.



## Context

Please select one of the below:

- [x] This closes an existing Issue: Closes #40580
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/JamieTanna-Mend-testing/issue-40575

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
