### PR TITLE
feat(pnpm): add support for configDependencies

### DIFF
--- a/lib/modules/manager/npm/extract/pnpm.spec.ts
+++ b/lib/modules/manager/npm/extract/pnpm.spec.ts
@@ -390,6 +390,46 @@ describe('modules/manager/npm/extract/pnpm', () => {
       });
     });
 
+    it('parses configDependencies in pnpm-workspace.yaml file', async () => {
+      expect(
+        await extractPnpmWorkspaceFile(
+          {
+            packages: ['*'],
+            configDependencies: {
+              '@pnpm/plugin-better-defaults':
+                '0.2.1+sha512-3Fmur80S7+vmOKMmTdKS6JofiuvpUaBIdKEpgDyr9571FHo5Z4O2nrRUaSflxvwEakeYxIaFZ5MBaqAUnYHaeg==',
+              '@myorg/pnpm-config': {
+                integrity:
+                  '0.0.9+sha512-M2/VDjgxKrrY6lAo9rcCC1GE40uJBRHKFqvtdQTAdAPasr2MG0qfN/HeLByjd1bYiKWK2MWv0gDfUGGbs+DXDQ==',
+                tarball:
+                  'https://npm.pkg.github.com/download/@myorg/pnpm-config/0.0.9/0e6f2aea83935148ec1adfd3fd8c2afefd324516',
+              },
+            },
+          },
+          'pnpm-workspace.yaml',
+        ),
+      ).toMatchObject({
+        deps: [
+          {
+            currentValue:
+              '0.2.1+sha512-3Fmur80S7+vmOKMmTdKS6JofiuvpUaBIdKEpgDyr9571FHo5Z4O2nrRUaSflxvwEakeYxIaFZ5MBaqAUnYHaeg==',
+            datasource: 'npm',
+            depName: '@pnpm/plugin-better-defaults',
+            depType: 'pnpm.configDependencies',
+            prettyDepType: 'pnpm.configDependencies',
+          },
+          {
+            currentValue:
+              '0.0.9+sha512-M2/VDjgxKrrY6lAo9rcCC1GE40uJBRHKFqvtdQTAdAPasr2MG0qfN/HeLByjd1bYiKWK2MWv0gDfUGGbs+DXDQ==',
+            datasource: 'npm',
+            depName: '@myorg/pnpm-config',
+            depType: 'pnpm.configDependencies',
+            prettyDepType: 'pnpm.configDependencies',
+          },
+        ],
+      });
+    });
+
     it('finds relevant lockfile', async () => {
       const lockfileContent = codeBlock`
         lockfileVersion: '9.0'

--- a/lib/modules/manager/npm/extract/pnpm.ts
+++ b/lib/modules/manager/npm/extract/pnpm.ts
@@ -7,7 +7,6 @@ import {
 } from '@sindresorhus/is';
 import { findPackages } from 'find-packages';
 import upath from 'upath';
-import type { z } from 'zod';
 import { GlobalConfig } from '../../../../config/global';
 import { logger } from '../../../../logger';
 import {
@@ -17,13 +16,21 @@ import {
   readLocalFile,
 } from '../../../../util/fs';
 import { parseSingleYaml } from '../../../../util/yaml';
-import type { PackageFile, PackageFileContent } from '../../types';
+import { NpmDatasource } from '../../../datasource/npm';
+import type {
+  PackageDependency,
+  PackageFile,
+  PackageFileContent,
+} from '../../types';
 import type { PnpmDependency, PnpmLockFile } from '../post-update/types';
-import type { PnpmCatalogs } from '../schema';
-import { PnpmWorkspaceFile } from '../schema';
+import { PnpmWorkspaceFile as PnpmWorkspaceFileSchema } from '../schema';
+import type { PnpmCatalogs, PnpmWorkspaceFile } from '../schema';
 import type { NpmManagerData } from '../types';
 import { extractCatalogDeps } from './common/catalogs';
+import { extractDependency } from './common/dependency';
 import type { Catalog, LockFile } from './types';
+
+export const PNPM_CONFIG_DEPENDENCY = 'pnpm.configDependencies';
 
 function isPnpmLockfile(obj: any): obj is PnpmLockFile {
   return isPlainObject(obj) && 'lockfileVersion' in obj;
@@ -38,6 +45,7 @@ export async function extractPnpmFilters(
       (await readLocalFile(fileName, 'utf8'))!,
     );
     if (
+      !contents.packages ||
       !Array.isArray(contents.packages) ||
       !contents.packages.every((item) => isString(item))
     ) {
@@ -263,7 +271,7 @@ export function tryParsePnpmWorkspaceYaml(content: string):
   | { success: false; data?: never } {
   try {
     const data = parseSingleYaml(content, {
-      customSchema: PnpmWorkspaceFile,
+      customSchema: PnpmWorkspaceFileSchema,
     });
     return { success: true, data };
   } catch {
@@ -271,17 +279,48 @@ export function tryParsePnpmWorkspaceYaml(content: string):
   }
 }
 
-type PnpmCatalogs = z.TypeOf<typeof PnpmCatalogs>;
+function extractConfigDeps(
+  configDeps: Record<string, any>,
+): PackageDependency<NpmManagerData>[] {
+  const deps: PackageDependency<NpmManagerData>[] = [];
+  for (const [key, val] of Object.entries(configDeps)) {
+    const depType = PNPM_CONFIG_DEPENDENCY;
+    const depName = key;
+    let currentValue: string;
+
+    if (isString(val)) {
+      currentValue = val;
+    } else if (isPlainObject(val) && isString(val.integrity)) {
+      currentValue = val.integrity;
+    } else {
+      continue;
+    }
+
+    const dep: PackageDependency<NpmManagerData> = {
+      depType,
+      depName,
+      ...extractDependency(depType, depName, currentValue),
+      datasource: NpmDatasource.id,
+      prettyDepType: depType,
+    };
+    deps.push(dep);
+  }
+  return deps;
+}
 
 export async function extractPnpmWorkspaceFile(
-  catalogs: PnpmCatalogs,
+  workspaceFile: PnpmWorkspaceFile,
   packageFile: string,
 ): Promise<PackageFileContent<NpmManagerData> | null> {
   logger.trace(`pnpm.extractPnpmWorkspaceFile(${packageFile})`);
 
-  const pnpmCatalogs = pnpmCatalogsToArray(catalogs);
+  const pnpmCatalogs = pnpmCatalogsToArray(workspaceFile);
 
   const deps = extractCatalogDeps(pnpmCatalogs);
+
+  if (isNonEmptyObject(workspaceFile.configDependencies)) {
+    deps.push(...extractConfigDeps(workspaceFile.configDependencies));
+  }
 
   let pnpmShrinkwrap;
   const filePath = getSiblingFileName(packageFile, 'pnpm-lock.yaml');

--- a/lib/modules/manager/npm/extract/types.ts
+++ b/lib/modules/manager/npm/extract/types.ts
@@ -46,9 +46,10 @@ export interface LockFile {
 }
 
 export interface PnpmWorkspaceFile {
-  packages: string[];
+  packages?: string[];
   catalog?: Record<string, string>;
   catalogs?: Record<string, Record<string, string>>;
+  configDependencies?: Record<string, any>;
 }
 
 /**

--- a/lib/modules/manager/npm/readme.md
+++ b/lib/modules/manager/npm/readme.md
@@ -11,6 +11,7 @@ The following `depTypes` are currently supported by the npm manager :
 - `resolutions`
 - `pnpm.overrides`
 - `pnpm.catalog` or `pnpm.catalog.<name>`. [Matches any default and named pnpm catalogs](https://pnpm.io/catalogs#defining-catalogs).
+- `pnpm.configDependencies`. Supports updating `configDependencies` in `pnpm-workspace.yaml`.
 - `yarn.catalog` or `yarn.catalogs.<name>`. [Matches any default and named yarn catalogs](https://yarnpkg.com/features/catalogs).
 
 ### npm problems and workarounds

--- a/lib/modules/manager/npm/schema.ts
+++ b/lib/modules/manager/npm/schema.ts
@@ -5,6 +5,12 @@ export const PnpmCatalogs = z.object({
   catalog: z.optional(z.record(z.string())),
   catalogs: z.optional(z.record(z.record(z.string()))),
 });
+export type PnpmCatalogs = z.infer<typeof PnpmCatalogs>;
+
+export const PnpmConfigDependencies = z.object({
+  configDependencies: z.optional(z.record(z.any())),
+});
+export type PnpmConfigDependencies = z.infer<typeof PnpmConfigDependencies>;
 
 export const YarnCatalogs = z.object({
   catalog: z.optional(z.record(z.string())),
@@ -30,9 +36,10 @@ export type YarnConfig = z.infer<typeof YarnConfig>;
 
 export const PnpmWorkspaceFile = z
   .object({
-    packages: z.array(z.string()),
+    packages: z.array(z.string()).optional(),
   })
-  .and(PnpmCatalogs);
+  .and(PnpmCatalogs)
+  .and(PnpmConfigDependencies);
 export type PnpmWorkspaceFile = z.infer<typeof PnpmWorkspaceFile>;
 
 export const PackageManager = z

--- a/lib/modules/manager/npm/update/dependency/index.ts
+++ b/lib/modules/manager/npm/update/dependency/index.ts
@@ -12,7 +12,10 @@ import type {
 } from '../../extract/types';
 import type { NpmDepType, NpmManagerData } from '../../types';
 import { getNewGitValue, getNewNpmAliasValue } from './common';
-import { updatePnpmCatalogDependency } from './pnpm';
+import {
+  updatePnpmCatalogDependency,
+  updatePnpmConfigDependency,
+} from './pnpm';
 import { updateYarnrcCatalogDependency } from './yarn';
 
 function renameObjKey(
@@ -120,6 +123,9 @@ export function updateDependency({
 }: UpdateDependencyConfig): string | null {
   if (upgrade.depType?.startsWith('pnpm.catalog')) {
     return updatePnpmCatalogDependency({ fileContent, upgrade });
+  }
+  if (upgrade.depType === 'pnpm.configDependencies') {
+    return updatePnpmConfigDependency({ fileContent, upgrade });
   }
   if (upgrade.depType?.startsWith('yarn.catalog')) {
     return updateYarnrcCatalogDependency({ fileContent, upgrade });

--- a/lib/modules/manager/npm/update/dependency/pnpm.spec.ts
+++ b/lib/modules/manager/npm/update/dependency/pnpm.spec.ts
@@ -571,4 +571,49 @@ describe('modules/manager/npm/update/dependency/pnpm', () => {
     });
     expect(testContent).toBeNull();
   });
+
+  it('handles pnpm configDependencies (scalar)', () => {
+    const upgrade = {
+      depType: 'pnpm.configDependencies',
+      depName: '@pnpm/plugin-better-defaults',
+      newValue: '0.2.2',
+    };
+    const pnpmWorkspaceYaml = codeBlock`
+      configDependencies:
+        '@pnpm/plugin-better-defaults': 0.2.1+sha512-abc
+    `;
+    const testContent = npmUpdater.updateDependency({
+      fileContent: pnpmWorkspaceYaml,
+      upgrade,
+    });
+    expect(testContent).toEqual(codeBlock`
+      configDependencies:
+        '@pnpm/plugin-better-defaults': 0.2.2
+    `);
+  });
+
+  it('handles pnpm configDependencies (object)', () => {
+    const upgrade = {
+      depType: 'pnpm.configDependencies',
+      depName: '@myorg/pnpm-config-myorg',
+      currentValue: '0.0.9',
+      newValue: '0.1.0',
+    };
+    const pnpmWorkspaceYaml = codeBlock`
+      configDependencies:
+        '@myorg/pnpm-config-myorg':
+          integrity: 0.0.9+sha512-M2/VDjgxKrrY6lAo9rcCC1GE40uJBRHKFqvtdQTAdAPasr2MG0qfN/HeLByjd1bYiKWK2MWv0gDfUGGbs+DXDQ==
+          tarball: https://npm.pkg.github.com/download/@myorg/pnpm-config-myorg/0.0.9/0e6f2aea83935148ec1adfd3fd8c2afefd324516
+    `;
+    const testContent = npmUpdater.updateDependency({
+      fileContent: pnpmWorkspaceYaml,
+      upgrade,
+    });
+    expect(testContent).toEqual(codeBlock`
+      configDependencies:
+        '@myorg/pnpm-config-myorg':
+          integrity: 0.1.0
+          tarball: https://npm.pkg.github.com/download/@myorg/pnpm-config-myorg/0.1.0/0e6f2aea83935148ec1adfd3fd8c2afefd324516
+    `);
+  });
 });

--- a/lib/modules/manager/npm/update/dependency/pnpm.ts
+++ b/lib/modules/manager/npm/update/dependency/pnpm.ts
@@ -3,7 +3,7 @@ import type { Document } from 'yaml';
 import { CST, isCollection, isPair, isScalar, parseDocument } from 'yaml';
 import { logger } from '../../../../../logger';
 import type { UpdateDependencyConfig } from '../../../types';
-import { PnpmCatalogs } from '../../schema';
+import { PnpmCatalogs, PnpmConfigDependencies } from '../../schema';
 import { getNewGitValue, getNewNpmAliasValue } from './common';
 
 export function updatePnpmCatalogDependency({
@@ -84,6 +84,98 @@ export function updatePnpmCatalogDependency({
 
   /* v8 ignore next 3 -- this should not happen in practice, but we must satisfy the types */
   if (!modifiedDocument.contents?.srcToken) {
+    return null;
+  }
+
+  return CST.stringify(modifiedDocument.contents.srcToken);
+}
+
+export function updatePnpmConfigDependency({
+  fileContent,
+  upgrade,
+}: UpdateDependencyConfig): string | null {
+  const { depType, depName } = upgrade;
+
+  let { newValue } = upgrade;
+
+  newValue = getNewGitValue(upgrade) ?? newValue;
+  newValue = getNewNpmAliasValue(newValue, upgrade) ?? newValue;
+
+  logger.trace(
+    `npm.updatePnpmConfigDependency(): ${depType}.${depName} = ${newValue}`,
+  );
+
+  let document;
+  let parsedContents;
+
+  try {
+    document = parseDocument(fileContent, { keepSourceTokens: true });
+    parsedContents = PnpmConfigDependencies.parse(document.toJS());
+  } catch (err) {
+    logger.debug({ err }, 'Could not parse pnpm-workspace YAML file.');
+    return null;
+  }
+
+  const oldVersion = parsedContents.configDependencies?.[depName!];
+
+  if (oldVersion === newValue) {
+    logger.trace('Version is already updated');
+    return fileContent;
+  }
+
+  const configDeps = document.get('configDependencies', true);
+  if (!isCollection(configDeps)) {
+    return null;
+  }
+
+  const oldNode = configDeps.get(depName!, true);
+
+  if (!oldNode) {
+    return null;
+  }
+
+  let modifiedDocument: Document | null = null;
+  if (isScalar(oldNode)) {
+    const path = ['configDependencies', depName!];
+    modifiedDocument = changeDependencyIn(document, path, {
+      newValue,
+      newName: upgrade.newName,
+    });
+  } else if (isCollection(oldNode)) {
+    // If it's an object, we try to update the 'integrity' field if it exists
+    const integrityPath = ['configDependencies', depName!, 'integrity'];
+    const oldIntegrityNode = (oldNode as any).get('integrity', true);
+    if (isScalar(oldIntegrityNode)) {
+      modifiedDocument = changeDependencyIn(document, integrityPath, {
+        newValue,
+      });
+    }
+
+    // Also try to update 'tarball' if it exists and contains the version
+    const tarballPath = ['configDependencies', depName!, 'tarball'];
+    const oldTarballNode = (oldNode as any).get('tarball', true);
+    if (
+      isScalar(oldTarballNode) &&
+      isString(oldTarballNode.value) &&
+      isString(upgrade.currentValue)
+    ) {
+      const newTarball = oldTarballNode.value.replace(
+        upgrade.currentValue,
+        newValue!,
+      );
+      if (newTarball !== oldTarballNode.value) {
+        modifiedDocument = changeDependencyIn(
+          modifiedDocument ?? document,
+          tarballPath,
+          {
+            newValue: newTarball,
+          },
+        );
+      }
+    }
+  }
+
+  if (!modifiedDocument?.contents?.srcToken) {
     return null;
   }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
This pull request adds support for handling `configDependencies` in `pnpm-workspace.yaml` files. It enables extracting, parsing, and updating these dependencies, both when they are simple strings and when they are objects with fields like `integrity` and `tarball`. The changes include schema updates, extraction logic, update logic, and thorough test coverage.

**Support for pnpm configDependencies:**

* Updated the `PnpmWorkspaceFile` schema and related types to support an optional `configDependencies` field, allowing for both string and object values. [[1]](diffhunk://#diff-61df431943b682d4195504495fa9c1f6099f64f0dca9ea83b11c3eb24c667770R8-R13) [[2]](diffhunk://#diff-61df431943b682d4195504495fa9c1f6099f64f0dca9ea83b11c3eb24c667770L33-R42) [[3]](diffhunk://#diff-8fbb8475659d8759e8046b8afa04e8d6600f59164ed1ddad4a5ed618dabe0537L49-R52)
* Added extraction logic in `extractPnpmWorkspaceFile` to parse and return dependencies listed under `configDependencies`, using the new `extractConfigDeps` helper. [[1]](diffhunk://#diff-db7739ddf296a529e3fed0809f62518c749c393125ba00073d05ef0308e8a676L20-R34) [[2]](diffhunk://#diff-db7739ddf296a529e3fed0809f62518c749c393125ba00073d05ef0308e8a676L266-R324)
* Added a new constant `PNPM_CONFIG_DEPENDENCY` to standardize the dependency type for config dependencies.

**Dependency update logic:**

* Implemented `updatePnpmConfigDependency` to update `configDependencies` in `pnpm-workspace.yaml`, handling both scalar and object forms (updating `integrity` and `tarball` fields as needed). Integrated this logic into the main dependency updater. [[1]](diffhunk://#diff-42d2040e76ee358eb59dd40de0f5d69e3d711ffe463d6f7ccce78b4ff6cf4e32L6-R6) [[2]](diffhunk://#diff-42d2040e76ee358eb59dd40de0f5d69e3d711ffe463d6f7ccce78b4ff6cf4e32R93-R184) [[3]](diffhunk://#diff-1affcca6f5abc376ea334a0b475cdb74fca049869d6627ca8c4c3605ba601c59L15-R18) [[4]](diffhunk://#diff-1affcca6f5abc376ea334a0b475cdb74fca049869d6627ca8c4c3605ba601c59R127-R129)

**Minor improvements and refactoring:**

* Improved type imports and code clarity in extraction and update modules.

These changes ensure that `pnpm-workspace.yaml` files with `configDependencies` are now fully supported for extraction and automated updates.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
