### PR TITLE
feat(pnpm): add support for configDependencies

### DIFF
--- a/lib/modules/datasource/npm/get.ts
+++ b/lib/modules/datasource/npm/get.ts
@@ -140,6 +140,12 @@ export async function getDependency(
         devDependencies: res.versions?.[version].devDependencies,
         attestation: isString(res.versions?.[version].dist?.attestations?.url),
       };
+      if (res.versions?.[version].dist?.integrity) {
+        release.newDigest = res.versions[version].dist.integrity;
+      }
+      if (res.versions?.[version].dist?.tarball) {
+        release.downloadUrl = res.versions[version].dist.tarball;
+      }
       const releaseTimestamp = asTimestamp(res.time?.[version]);
       if (releaseTimestamp) {
         release.releaseTimestamp = releaseTimestamp;

--- a/lib/modules/datasource/npm/get.ts
+++ b/lib/modules/datasource/npm/get.ts
@@ -112,7 +112,7 @@ export async function getDependency(
     res.homepage ??= latestVersion?.homepage;
 
     const { sourceUrl, sourceDirectory } = PackageSource.parse(res.repository);
-
+    console.log('DEBUG: versions count', Object.keys(res.versions).length);
     // Simplify response before caching and returning
     const dep: ReleaseResult = {
       homepage: res.homepage,
@@ -181,6 +181,10 @@ export async function getDependency(
       dep.isPrivate = true;
     }
 
+    console.log(
+      'DEBUG: dep.releases[0]',
+      JSON.stringify(dep.releases[0], null, 2),
+    );
     logger.trace({ dep }, 'dep');
     return dep;
   } catch (err) {

--- a/lib/modules/datasource/npm/types.ts
+++ b/lib/modules/datasource/npm/types.ts
@@ -12,6 +12,8 @@ export interface NpmAttestations {
 
 export interface NpmDistribution {
   attestations?: NpmAttestations;
+  integrity?: string;
+  tarball?: string;
 }
 
 export interface NpmResponseVersion {

--- a/lib/modules/manager/npm/extract/index.ts
+++ b/lib/modules/manager/npm/extract/index.ts
@@ -244,7 +244,11 @@ export async function extractAllPackageFiles(
       // pnpm workspace files are their own package file, defined via managerFilePatterns.
       // We duck-type the content here, to allow users to rename the file itself.
       const parsedPnpmWorkspaceYaml = tryParsePnpmWorkspaceYaml(content);
-      if (parsedPnpmWorkspaceYaml.success) {
+      if (
+        parsedPnpmWorkspaceYaml.success &&
+        !packageFile.endsWith('json') &&
+        !packageFile.endsWith('.yarnrc.yml')
+      ) {
         logger.trace(
           { packageFile },
           `Extracting file as a pnpm workspace YAML file`,

--- a/lib/modules/manager/npm/extract/pnpm.spec.ts
+++ b/lib/modules/manager/npm/extract/pnpm.spec.ts
@@ -390,6 +390,45 @@ describe('modules/manager/npm/extract/pnpm', () => {
       });
     });
 
+    it('parses configDependencies in pnpm-workspace.yaml file', async () => {
+      expect(
+        await extractPnpmWorkspaceFile(
+          {
+            configDependencies: {
+              '@pnpm/plugin-better-defaults':
+                '0.2.1+sha512-3Fmur80S7+vmOKMmTdKS6JofiuvpUaBIdKEpgDyr9571FHo5Z4O2nrRUaSflxvwEakeYxIaFZ5MBaqAUnYHaeg==',
+              '@myorg/pnpm-config': {
+                integrity:
+                  '0.0.9+sha512-M2/VDjgxKrrY6lAo9rcCC1GE40uJBRHKFqvtdQTAdAPasr2MG0qfN/HeLByjd1bYiKWK2MWv0gDfUGGbs+DXDQ==',
+                tarball:
+                  'https://npm.pkg.github.com/download/@myorg/pnpm-config/0.0.9/0e6f2aea83935148ec1adfd3fd8c2afefd324516',
+              },
+            },
+          },
+          'pnpm-workspace.yaml',
+        ),
+      ).toMatchObject({
+        deps: [
+          {
+            currentValue:
+              '0.2.1+sha512-3Fmur80S7+vmOKMmTdKS6JofiuvpUaBIdKEpgDyr9571FHo5Z4O2nrRUaSflxvwEakeYxIaFZ5MBaqAUnYHaeg==',
+            datasource: 'npm',
+            depName: '@pnpm/plugin-better-defaults',
+            depType: 'pnpm.configDependencies',
+            prettyDepType: 'pnpm.configDependencies',
+          },
+          {
+            currentValue:
+              '0.0.9+sha512-M2/VDjgxKrrY6lAo9rcCC1GE40uJBRHKFqvtdQTAdAPasr2MG0qfN/HeLByjd1bYiKWK2MWv0gDfUGGbs+DXDQ==',
+            datasource: 'npm',
+            depName: '@myorg/pnpm-config',
+            depType: 'pnpm.configDependencies',
+            prettyDepType: 'pnpm.configDependencies',
+          },
+        ],
+      });
+    });
+
     it('finds relevant lockfile', async () => {
       const lockfileContent = codeBlock`
         lockfileVersion: '9.0'

--- a/lib/modules/manager/npm/extract/types.ts
+++ b/lib/modules/manager/npm/extract/types.ts
@@ -46,9 +46,10 @@ export interface LockFile {
 }
 
 export interface PnpmWorkspaceFile {
-  packages: string[];
+  packages?: string[];
   catalog?: Record<string, string>;
   catalogs?: Record<string, Record<string, string>>;
+  configDependencies?: Record<string, any>;
 }
 
 /**

--- a/lib/modules/manager/npm/readme.md
+++ b/lib/modules/manager/npm/readme.md
@@ -11,6 +11,7 @@ The following `depTypes` are currently supported by the npm manager :
 - `resolutions`
 - `pnpm.overrides`
 - `pnpm.catalog` or `pnpm.catalog.<name>`. [Matches any default and named pnpm catalogs](https://pnpm.io/catalogs#defining-catalogs).
+- `pnpm.configDependencies`. Supports updating [configDependencies](https://pnpm.io/config-dependencies)`.
 - `yarn.catalog` or `yarn.catalogs.<name>`. [Matches any default and named yarn catalogs](https://yarnpkg.com/features/catalogs).
 
 ### npm problems and workarounds

--- a/lib/modules/manager/npm/schema.ts
+++ b/lib/modules/manager/npm/schema.ts
@@ -6,6 +6,20 @@ export const PnpmCatalogs = z.object({
   catalogs: z.optional(z.record(z.record(z.string()))),
 });
 
+export const PnpmConfigDependencies = z.object({
+  configDependencies: z.optional(
+    z.record(
+      z.union([
+        z.string(),
+        z.object({
+          integrity: z.string(),
+          tarball: z.string(),
+        }),
+      ]),
+    ),
+  ),
+});
+
 export const YarnCatalogs = z.object({
   catalog: z.optional(z.record(z.string())),
   catalogs: z.optional(z.record(z.record(z.string()))).catch(undefined),
@@ -30,9 +44,10 @@ export type YarnConfig = z.infer<typeof YarnConfig>;
 
 export const PnpmWorkspaceFile = z
   .object({
-    packages: z.array(z.string()),
+    packages: z.array(z.string()).optional(),
   })
-  .and(PnpmCatalogs);
+  .and(PnpmCatalogs)
+  .and(PnpmConfigDependencies);
 export type PnpmWorkspaceFile = z.infer<typeof PnpmWorkspaceFile>;
 
 export const PackageManager = z

--- a/lib/modules/manager/npm/update/dependency/index.ts
+++ b/lib/modules/manager/npm/update/dependency/index.ts
@@ -12,7 +12,10 @@ import type {
 } from '../../extract/types';
 import type { NpmDepType, NpmManagerData } from '../../types';
 import { getNewGitValue, getNewNpmAliasValue } from './common';
-import { updatePnpmCatalogDependency } from './pnpm';
+import {
+  updatePnpmCatalogDependency,
+  updatePnpmConfigDependency,
+} from './pnpm';
 import { updateYarnrcCatalogDependency } from './yarn';
 
 function renameObjKey(
@@ -120,6 +123,9 @@ export function updateDependency({
 }: UpdateDependencyConfig): string | null {
   if (upgrade.depType?.startsWith('pnpm.catalog')) {
     return updatePnpmCatalogDependency({ fileContent, upgrade });
+  }
+  if (upgrade.depType === 'pnpm.configDependencies') {
+    return updatePnpmConfigDependency({ fileContent, upgrade });
   }
   if (upgrade.depType?.startsWith('yarn.catalog')) {
     return updateYarnrcCatalogDependency({ fileContent, upgrade });

--- a/lib/modules/manager/npm/update/dependency/pnpm.spec.ts
+++ b/lib/modules/manager/npm/update/dependency/pnpm.spec.ts
@@ -571,4 +571,104 @@ describe('modules/manager/npm/update/dependency/pnpm', () => {
     });
     expect(testContent).toBeNull();
   });
+
+  it('handles pnpm configDependencies (scalar)', () => {
+    const upgrade = {
+      depType: 'pnpm.configDependencies',
+      depName: '@pnpm/plugin-better-defaults',
+      newValue: '0.2.2',
+    };
+    const pnpmWorkspaceYaml = codeBlock`
+      configDependencies:
+        '@pnpm/plugin-better-defaults': 0.2.1+sha512-abc
+    `;
+    const testContent = npmUpdater.updateDependency({
+      fileContent: pnpmWorkspaceYaml,
+      upgrade,
+    });
+    expect(testContent).toEqual(codeBlock`
+      configDependencies:
+        '@pnpm/plugin-better-defaults': 0.2.2
+    `);
+  });
+
+  it('handles pnpm configDependencies (scalar) with newDigest', () => {
+    const upgrade = {
+      depType: 'pnpm.configDependencies',
+      depName: '@pnpm/plugin-better-defaults',
+      newValue: '0.2.2',
+      newDigest: 'sha512-def',
+    };
+    const pnpmWorkspaceYaml = codeBlock`
+      configDependencies:
+        '@pnpm/plugin-better-defaults': 0.2.1+sha512-abc
+    `;
+    const testContent = npmUpdater.updateDependency({
+      fileContent: pnpmWorkspaceYaml,
+      upgrade,
+    });
+    expect(testContent).toEqual(codeBlock`
+      configDependencies:
+        '@pnpm/plugin-better-defaults': 0.2.2+sha512-def
+    `);
+  });
+
+  it('handles pnpm configDependencies (object)', () => {
+    const upgrade = {
+      depType: 'pnpm.configDependencies',
+      depName: '@myorg/pnpm-config-myorg',
+      currentValue:
+        '0.0.9+sha512-M2/VDjgxKrrY6lAo9rcCC1GE40uJBRHKFqvtdQTAdAPasr2MG0qfN/HeLByjd1bYiKWK2MWv0gDfUGGbs+DXDQ==',
+      currentVersion: '0.0.9',
+      newValue: '0.1.0',
+      newVersion: '0.1.0',
+    };
+    const pnpmWorkspaceYaml = codeBlock`
+      configDependencies:
+        '@myorg/pnpm-config-myorg':
+          integrity: 0.0.9+sha512-M2/VDjgxKrrY6lAo9rcCC1GE40uJBRHKFqvtdQTAdAPasr2MG0qfN/HeLByjd1bYiKWK2MWv0gDfUGGbs+DXDQ==
+          tarball: https://npm.pkg.github.com/download/@myorg/pnpm-config-myorg/0.0.9/0e6f2aea83935148ec1adfd3fd8c2afefd324516
+    `;
+    const testContent = npmUpdater.updateDependency({
+      fileContent: pnpmWorkspaceYaml,
+      upgrade,
+    });
+    expect(testContent).toEqual(codeBlock`
+      configDependencies:
+        '@myorg/pnpm-config-myorg':
+          integrity: 0.1.0
+          tarball: https://npm.pkg.github.com/download/@myorg/pnpm-config-myorg/0.1.0/0e6f2aea83935148ec1adfd3fd8c2afefd324516
+    `);
+  });
+
+  it('handles pnpm configDependencies (object) with newDigest and downloadUrl', () => {
+    const upgrade = {
+      depType: 'pnpm.configDependencies',
+      depName: '@myorg/pnpm-config-myorg',
+      currentValue:
+        '0.0.9+sha512-M2/VDjgxKrrY6lAo9rcCC1GE40uJBRHKFqvtdQTAdAPasr2MG0qfN/HeLByjd1bYiKWK2MWv0gDfUGGbs+DXDQ==',
+      currentVersion: '0.0.9',
+      newValue: '0.1.0',
+      newVersion: '0.1.0',
+      newDigest: 'sha512-def',
+      downloadUrl:
+        'https://npm.pkg.github.com/download/@myorg/pnpm-config-myorg/0.1.0/new-hash',
+    };
+    const pnpmWorkspaceYaml = codeBlock`
+      configDependencies:
+        '@myorg/pnpm-config-myorg':
+          integrity: 0.0.9+sha512-M2/VDjgxKrrY6lAo9rcCC1GE40uJBRHKFqvtdQTAdAPasr2MG0qfN/HeLByjd1bYiKWK2MWv0gDfUGGbs+DXDQ==
+          tarball: https://npm.pkg.github.com/download/@myorg/pnpm-config-myorg/0.0.9/0e6f2aea83935148ec1adfd3fd8c2afefd324516
+    `;
+    const testContent = npmUpdater.updateDependency({
+      fileContent: pnpmWorkspaceYaml,
+      upgrade,
+    });
+    expect(testContent).toEqual(codeBlock`
+      configDependencies:
+        '@myorg/pnpm-config-myorg':
+          integrity: 0.1.0+sha512-def
+          tarball: https://npm.pkg.github.com/download/@myorg/pnpm-config-myorg/0.1.0/new-hash
+    `);
+  });
 });

--- a/lib/modules/manager/npm/update/dependency/pnpm.ts
+++ b/lib/modules/manager/npm/update/dependency/pnpm.ts
@@ -3,7 +3,7 @@ import type { Document } from 'yaml';
 import { CST, isCollection, isPair, isScalar, parseDocument } from 'yaml';
 import { logger } from '../../../../../logger';
 import type { UpdateDependencyConfig } from '../../../types';
-import { PnpmCatalogs } from '../../schema';
+import { PnpmCatalogs, PnpmConfigDependencies } from '../../schema';
 import { getNewGitValue, getNewNpmAliasValue } from './common';
 
 export function updatePnpmCatalogDependency({
@@ -84,6 +84,105 @@ export function updatePnpmCatalogDependency({
 
   /* v8 ignore next 3 -- this should not happen in practice, but we must satisfy the types */
   if (!modifiedDocument.contents?.srcToken) {
+    return null;
+  }
+
+  return CST.stringify(modifiedDocument.contents.srcToken);
+}
+
+export function updatePnpmConfigDependency({
+  fileContent,
+  upgrade,
+}: UpdateDependencyConfig): string | null {
+  const { depType, depName } = upgrade;
+
+  let { newValue } = upgrade;
+
+  newValue = getNewGitValue(upgrade) ?? newValue;
+  newValue = getNewNpmAliasValue(newValue, upgrade) ?? newValue;
+
+  if (upgrade.newDigest) {
+    newValue = `${newValue}+${upgrade.newDigest}`;
+  }
+
+  logger.trace(
+    `npm.updatePnpmConfigDependency(): ${depType}.${depName} = ${newValue}`,
+  );
+
+  let document;
+  let parsedContents;
+
+  try {
+    document = parseDocument(fileContent, { keepSourceTokens: true });
+    parsedContents = PnpmConfigDependencies.parse(document.toJS());
+  } catch (err) {
+    logger.debug({ err }, 'Could not parse pnpm-workspace YAML file.');
+    return null;
+  }
+
+  const oldVersion = parsedContents.configDependencies?.[depName!];
+
+  if (oldVersion === newValue) {
+    logger.trace('Version is already updated');
+    return fileContent;
+  }
+
+  const configDeps = document.get('configDependencies', true);
+  if (!isCollection(configDeps)) {
+    return null;
+  }
+
+  const oldNode = configDeps.get(depName!, true);
+
+  if (!oldNode) {
+    return null;
+  }
+
+  let modifiedDocument: Document | null = null;
+  if (isScalar(oldNode)) {
+    const path = ['configDependencies', depName!];
+    modifiedDocument = changeDependencyIn(document, path, {
+      newValue,
+      newName: upgrade.newName,
+    });
+  } else if (isCollection(oldNode)) {
+    // If it's an object, we try to update the 'integrity' field if it exists
+    const integrityPath = ['configDependencies', depName!, 'integrity'];
+    const oldIntegrityNode = (oldNode as any).get('integrity', true);
+    if (isScalar(oldIntegrityNode)) {
+      modifiedDocument = changeDependencyIn(document, integrityPath, {
+        newValue,
+      });
+    }
+
+    // Also try to update 'tarball' if it exists
+    const tarballPath = ['configDependencies', depName!, 'tarball'];
+    const oldTarballNode = (oldNode as any).get('tarball', true);
+    if (isScalar(oldTarballNode)) {
+      const newTarball =
+        upgrade.downloadUrl ??
+        (isString(oldTarballNode.value) &&
+        isString(upgrade.currentVersion) &&
+        isString(upgrade.newVersion)
+          ? oldTarballNode.value.replace(
+              upgrade.currentVersion,
+              upgrade.newVersion,
+            )
+          : null);
+
+      if (newTarball && newTarball !== oldTarballNode.value) {
+        modifiedDocument = changeDependencyIn(
+          modifiedDocument ?? document,
+          tarballPath,
+          {
+            newValue: newTarball,
+          },
+        );
+      }
+    }
+  }
+
+  if (!modifiedDocument?.contents?.srcToken) {
     return null;
   }
 

--- a/lib/modules/manager/types.ts
+++ b/lib/modules/manager/types.ts
@@ -205,6 +205,7 @@ export interface Upgrade<T = Record<string, any>> extends PackageDependency<T> {
   newVersion?: string;
   updateType?: UpdateType;
   version?: string;
+  downloadUrl?: string;
   isLockFileMaintenance?: boolean;
   isRemediation?: boolean;
   isVulnerabilityAlert?: boolean;

--- a/lib/workers/repository/process/lookup/index.spec.ts
+++ b/lib/workers/repository/process/lookup/index.spec.ts
@@ -153,6 +153,7 @@ describe('workers/repository/process/lookup/index', () => {
           newMajor: 1,
           newMinor: 4,
           newPatch: 1,
+          downloadUrl: expect.any(String),
           newValue: '1.4.1',
           newVersion: '1.4.1',
           newVersionAgeInDays: expect.any(Number),
@@ -211,6 +212,7 @@ describe('workers/repository/process/lookup/index', () => {
           newMajor: 0,
           newMinor: 9,
           newPatch: 7,
+          downloadUrl: expect.any(String),
           newValue: '^0.9.0',
           newVersion: '0.9.7',
           newVersionAgeInDays: expect.any(Number),
@@ -224,6 +226,7 @@ describe('workers/repository/process/lookup/index', () => {
           newMajor: 1,
           newMinor: 4,
           newPatch: 1,
+          downloadUrl: expect.any(String),
           newValue: '^1.0.0',
           newVersion: '1.4.1',
           newVersionAgeInDays: expect.any(Number),
@@ -255,6 +258,7 @@ describe('workers/repository/process/lookup/index', () => {
           newMajor: 0,
           newMinor: 4,
           newPatch: 4,
+          downloadUrl: expect.any(String),
           newValue: '^0.4.0',
           newVersion: '0.4.4',
           newVersionAgeInDays: expect.any(Number),
@@ -268,6 +272,7 @@ describe('workers/repository/process/lookup/index', () => {
           newMajor: 0,
           newMinor: 9,
           newPatch: 7,
+          downloadUrl: expect.any(String),
           newValue: '^0.9.0',
           newVersion: '0.9.7',
           newVersionAgeInDays: expect.any(Number),
@@ -281,6 +286,7 @@ describe('workers/repository/process/lookup/index', () => {
           newMajor: 1,
           newMinor: 4,
           newPatch: 1,
+          downloadUrl: expect.any(String),
           newValue: '^1.0.0',
           newVersion: '1.4.1',
           newVersionAgeInDays: expect.any(Number),
@@ -309,6 +315,7 @@ describe('workers/repository/process/lookup/index', () => {
           newMajor: 0,
           newMinor: 9,
           newPatch: 7,
+          downloadUrl: expect.any(String),
           newValue: '0.9.7',
           newVersion: '0.9.7',
           newVersionAgeInDays: expect.any(Number),
@@ -321,6 +328,7 @@ describe('workers/repository/process/lookup/index', () => {
           newMajor: 1,
           newMinor: 4,
           newPatch: 1,
+          downloadUrl: expect.any(String),
           newValue: '1.4.1',
           newVersion: '1.4.1',
           newVersionAgeInDays: expect.any(Number),
@@ -350,6 +358,7 @@ describe('workers/repository/process/lookup/index', () => {
           newMajor: 0,
           newMinor: 4,
           newPatch: 4,
+          downloadUrl: expect.any(String),
           newValue: '0.4.4',
           newVersion: '0.4.4',
           newVersionAgeInDays: expect.any(Number),
@@ -362,6 +371,7 @@ describe('workers/repository/process/lookup/index', () => {
           newMajor: 0,
           newMinor: 9,
           newPatch: 7,
+          downloadUrl: expect.any(String),
           newValue: '0.9.7',
           newVersion: '0.9.7',
           newVersionAgeInDays: expect.any(Number),
@@ -374,6 +384,7 @@ describe('workers/repository/process/lookup/index', () => {
           newMajor: 1,
           newMinor: 4,
           newPatch: 1,
+          downloadUrl: expect.any(String),
           newValue: '1.4.1',
           newVersion: '1.4.1',
           newVersionAgeInDays: expect.any(Number),
@@ -403,6 +414,7 @@ describe('workers/repository/process/lookup/index', () => {
           newMajor: 1,
           newMinor: 4,
           newPatch: 1,
+          downloadUrl: expect.any(String),
           newValue: '1.4.1',
           newVersion: '1.4.1',
           newVersionAgeInDays: expect.any(Number),
@@ -439,6 +451,7 @@ describe('workers/repository/process/lookup/index', () => {
           newMajor: 0,
           newMinor: 9,
           newPatch: 7,
+          downloadUrl: expect.any(String),
           newValue: '^0.9.0',
           newVersion: '0.9.7',
           newVersionAgeInDays: expect.any(Number),
@@ -452,6 +465,7 @@ describe('workers/repository/process/lookup/index', () => {
           newMajor: 1,
           newMinor: 4,
           newPatch: 1,
+          downloadUrl: expect.any(String),
           newValue: '^1.0.0',
           newVersion: '1.4.1',
           newVersionAgeInDays: expect.any(Number),
@@ -479,6 +493,7 @@ describe('workers/repository/process/lookup/index', () => {
           newMajor: 0,
           newMinor: 9,
           newPatch: 7,
+          downloadUrl: expect.any(String),
           newValue: '0.9.7',
           newVersion: '0.9.7',
           newVersionAgeInDays: expect.any(Number),
@@ -506,6 +521,7 @@ describe('workers/repository/process/lookup/index', () => {
           newMajor: 0,
           newMinor: 9,
           newPatch: 7,
+          downloadUrl: expect.any(String),
           newValue: '0.9.7',
           newVersion: '0.9.7',
           newVersionAgeInDays: expect.any(Number),
@@ -533,6 +549,7 @@ describe('workers/repository/process/lookup/index', () => {
           newMajor: 0,
           newMinor: 9,
           newPatch: 7,
+          downloadUrl: expect.any(String),
           newValue: '0.9.7',
           newVersion: '0.9.7',
           newVersionAgeInDays: expect.any(Number),
@@ -561,6 +578,7 @@ describe('workers/repository/process/lookup/index', () => {
           newMajor: 0,
           newMinor: 9,
           newPatch: 7,
+          downloadUrl: expect.any(String),
           newValue: '0.9.7',
           newVersion: '0.9.7',
           newVersionAgeInDays: expect.any(Number),
@@ -589,6 +607,7 @@ describe('workers/repository/process/lookup/index', () => {
           newMajor: 0,
           newMinor: 9,
           newPatch: 4,
+          downloadUrl: expect.any(String),
           newValue: '0.9.4',
           newVersion: '0.9.4',
           newVersionAgeInDays: expect.any(Number),
@@ -628,6 +647,7 @@ describe('workers/repository/process/lookup/index', () => {
           newMajor: 0,
           newMinor: 9,
           newPatch: 7,
+          downloadUrl: expect.any(String),
           newValue: '0.9.7',
           newVersion: '0.9.7',
           newVersionAgeInDays: expect.any(Number),
@@ -640,6 +660,7 @@ describe('workers/repository/process/lookup/index', () => {
           newMajor: 1,
           newMinor: 4,
           newPatch: 1,
+          downloadUrl: expect.any(String),
           newValue: '1.4.1',
           newVersion: '1.4.1',
           newVersionAgeInDays: expect.any(Number),
@@ -673,6 +694,7 @@ describe('workers/repository/process/lookup/index', () => {
           newMajor: 0,
           newMinor: 9,
           newPatch: 7,
+          downloadUrl: expect.any(String),
           newValue: '0.9.7',
           newVersion: '0.9.7',
           newVersionAgeInDays: expect.any(Number),
@@ -685,6 +707,7 @@ describe('workers/repository/process/lookup/index', () => {
           newMajor: 1,
           newMinor: 4,
           newPatch: 1,
+          downloadUrl: expect.any(String),
           newValue: '1.4.1',
           newVersion: '1.4.1',
           newVersionAgeInDays: expect.any(Number),
@@ -713,6 +736,7 @@ describe('workers/repository/process/lookup/index', () => {
           newMajor: 0,
           newMinor: 9,
           newPatch: 7,
+          downloadUrl: expect.any(String),
           newValue: '0.9.7',
           newVersion: '0.9.7',
           newVersionAgeInDays: expect.any(Number),
@@ -725,6 +749,7 @@ describe('workers/repository/process/lookup/index', () => {
           newMajor: 1,
           newMinor: 4,
           newPatch: 1,
+          downloadUrl: expect.any(String),
           newValue: '1.4.1',
           newVersion: '1.4.1',
           newVersionAgeInDays: expect.any(Number),
@@ -753,6 +778,7 @@ describe('workers/repository/process/lookup/index', () => {
           newMajor: 0,
           newMinor: 8,
           newPatch: 12,
+          downloadUrl: expect.any(String),
           newValue: '0.8.12',
           newVersion: '0.8.12',
           newVersionAgeInDays: expect.any(Number),
@@ -765,6 +791,7 @@ describe('workers/repository/process/lookup/index', () => {
           newMajor: 0,
           newMinor: 9,
           newPatch: 7,
+          downloadUrl: expect.any(String),
           newValue: '0.9.7',
           newVersion: '0.9.7',
           newVersionAgeInDays: expect.any(Number),
@@ -777,6 +804,7 @@ describe('workers/repository/process/lookup/index', () => {
           newMajor: 1,
           newMinor: 4,
           newPatch: 1,
+          downloadUrl: expect.any(String),
           newValue: '1.4.1',
           newVersion: '1.4.1',
           newVersionAgeInDays: expect.any(Number),
@@ -813,6 +841,7 @@ describe('workers/repository/process/lookup/index', () => {
           newMajor: 1,
           newMinor: 4,
           newPatch: 1,
+          downloadUrl: expect.any(String),
           newValue: '^1.0.0',
           newVersion: '1.4.1',
           newVersionAgeInDays: expect.any(Number),
@@ -841,6 +870,7 @@ describe('workers/repository/process/lookup/index', () => {
           newMajor: 1,
           newMinor: 4,
           newPatch: 1,
+          downloadUrl: expect.any(String),
           newValue: '1.4.1',
           newVersion: '1.4.1',
           newVersionAgeInDays: expect.any(Number),
@@ -868,6 +898,7 @@ describe('workers/repository/process/lookup/index', () => {
           newMajor: 1,
           newMinor: 0,
           newPatch: 1,
+          downloadUrl: expect.any(String),
           newValue: '1.0.1',
           newVersion: '1.0.1',
           newVersionAgeInDays: expect.any(Number),
@@ -896,6 +927,7 @@ describe('workers/repository/process/lookup/index', () => {
           newMajor: 1,
           newMinor: 4,
           newPatch: 1,
+          downloadUrl: expect.any(String),
           newValue: '1.4.1',
           newVersion: '1.4.1',
           newVersionAgeInDays: expect.any(Number),
@@ -924,6 +956,7 @@ describe('workers/repository/process/lookup/index', () => {
           newMajor: 1,
           newMinor: 1,
           newPatch: 0,
+          downloadUrl: expect.any(String),
           newValue: '1.1.0',
           newVersion: '1.1.0',
           newVersionAgeInDays: expect.any(Number),
@@ -952,6 +985,7 @@ describe('workers/repository/process/lookup/index', () => {
           newMajor: 1,
           newMinor: 1,
           newPatch: 0,
+          downloadUrl: expect.any(String),
           newValue: '1.1.0',
           newVersion: '1.1.0',
           newVersionAgeInDays: expect.any(Number),
@@ -980,6 +1014,7 @@ describe('workers/repository/process/lookup/index', () => {
           newMajor: 1,
           newMinor: 1,
           newPatch: 0,
+          downloadUrl: expect.any(String),
           newValue: '1.1.0',
           newVersion: '1.1.0',
           newVersionAgeInDays: expect.any(Number),
@@ -1009,6 +1044,7 @@ describe('workers/repository/process/lookup/index', () => {
           newMajor: 1,
           newMinor: 4,
           newPatch: 1,
+          downloadUrl: expect.any(String),
           newValue: '1.4.1',
           newVersion: '1.4.1',
           newVersionAgeInDays: expect.any(Number),
@@ -1037,6 +1073,7 @@ describe('workers/repository/process/lookup/index', () => {
           newMajor: 1,
           newMinor: 0,
           newPatch: 1,
+          downloadUrl: expect.any(String),
           newValue: '1.0.1',
           newVersion: '1.0.1',
           newVersionAgeInDays: expect.any(Number),
@@ -1087,6 +1124,7 @@ describe('workers/repository/process/lookup/index', () => {
           newMajor: 0,
           newMinor: 9,
           newPatch: 7,
+          downloadUrl: expect.any(String),
           newValue: '~0.9.0',
           newVersion: '0.9.7',
           newVersionAgeInDays: expect.any(Number),
@@ -1095,6 +1133,7 @@ describe('workers/repository/process/lookup/index', () => {
         },
         {
           bucket: 'major',
+          downloadUrl: expect.any(String),
           isBreaking: true,
           isRange: true,
           newMajor: 1,
@@ -1241,6 +1280,7 @@ describe('workers/repository/process/lookup/index', () => {
         },
         {
           bucket: 'major',
+          downloadUrl: expect.any(String),
           isBreaking: true,
           isRange: true,
           newMajor: 1,
@@ -1276,6 +1316,7 @@ describe('workers/repository/process/lookup/index', () => {
         },
         {
           bucket: 'non-major',
+          downloadUrl: expect.any(String),
           isBreaking: false,
           isRange: true,
           newMajor: 1,
@@ -1308,6 +1349,7 @@ describe('workers/repository/process/lookup/index', () => {
           isBreaking: false,
           isLockfileUpdate: true,
           isRange: true,
+          downloadUrl: expect.any(String),
           newMajor: 1,
           newMinor: 4,
           newPatch: 1,
@@ -1338,6 +1380,7 @@ describe('workers/repository/process/lookup/index', () => {
           isBreaking: false,
           isLockfileUpdate: true,
           isRange: true,
+          downloadUrl: expect.any(String),
           newMajor: 1,
           newMinor: 4,
           newPatch: 1,
@@ -1365,6 +1408,7 @@ describe('workers/repository/process/lookup/index', () => {
       expect(updates).toEqual([
         {
           bucket: 'non-major',
+          downloadUrl: expect.any(String),
           isBreaking: false,
           isLockfileUpdate: true,
           isRange: true,
@@ -1394,6 +1438,7 @@ describe('workers/repository/process/lookup/index', () => {
       expect(updates).toEqual([
         {
           bucket: 'non-major',
+          downloadUrl: expect.any(String),
           isBreaking: false,
           isLockfileUpdate: true,
           isRange: true,
@@ -1452,6 +1497,7 @@ describe('workers/repository/process/lookup/index', () => {
       expect(updates).toEqual([
         {
           bucket: 'non-major',
+          downloadUrl: expect.any(String),
           isBreaking: false,
           isRange: true,
           newMajor: 1,
@@ -1480,6 +1526,7 @@ describe('workers/repository/process/lookup/index', () => {
       expect(updates).toEqual([
         {
           bucket: 'non-major',
+          downloadUrl: expect.any(String),
           isBreaking: false,
           isRange: true,
           newMajor: 1,
@@ -1511,6 +1558,8 @@ describe('workers/repository/process/lookup/index', () => {
       expect(updates).toEqual([
         {
           bucket: 'major',
+          downloadUrl: expect.any(String),
+          newDigest: expect.any(String),
           isBreaking: true,
           isRange: true,
           newMajor: 3,
@@ -1542,6 +1591,8 @@ describe('workers/repository/process/lookup/index', () => {
       expect(updates).toEqual([
         {
           bucket: 'major',
+          downloadUrl: expect.any(String),
+          newDigest: expect.any(String),
           isBreaking: true,
           isRange: true,
           newMajor: 3,
@@ -1651,6 +1702,7 @@ describe('workers/repository/process/lookup/index', () => {
         },
         {
           bucket: 'non-major',
+          downloadUrl: expect.any(String),
           isBreaking: false,
           isRange: true,
           newMajor: 1,
@@ -1686,6 +1738,7 @@ describe('workers/repository/process/lookup/index', () => {
         },
         {
           bucket: 'non-major',
+          downloadUrl: expect.any(String),
           isBreaking: false,
           isRange: true,
           newMajor: 1,
@@ -1714,6 +1767,7 @@ describe('workers/repository/process/lookup/index', () => {
       expect(updates).toEqual([
         {
           bucket: 'non-major',
+          downloadUrl: expect.any(String),
           isBreaking: false,
           isRange: true,
           newMajor: 1,
@@ -1742,6 +1796,7 @@ describe('workers/repository/process/lookup/index', () => {
       expect(updates).toEqual([
         {
           bucket: 'major',
+          downloadUrl: expect.any(String),
           isBreaking: true,
           isRange: true,
           newMajor: 1,
@@ -1770,6 +1825,7 @@ describe('workers/repository/process/lookup/index', () => {
       expect(updates).toEqual([
         {
           bucket: 'non-major',
+          downloadUrl: expect.any(String),
           isBreaking: false,
           isRange: true,
           newMajor: 1,
@@ -1798,6 +1854,7 @@ describe('workers/repository/process/lookup/index', () => {
       expect(updates).toEqual([
         {
           bucket: 'non-major',
+          downloadUrl: expect.any(String),
           isBreaking: false,
           isRange: true,
           newMajor: 1,
@@ -1826,6 +1883,7 @@ describe('workers/repository/process/lookup/index', () => {
       expect(updates).toEqual([
         {
           bucket: 'major',
+          downloadUrl: expect.any(String),
           isBreaking: true,
           isRange: true,
           newMajor: 1,
@@ -1854,6 +1912,7 @@ describe('workers/repository/process/lookup/index', () => {
       expect(updates).toEqual([
         {
           bucket: 'non-major',
+          downloadUrl: expect.any(String),
           isBreaking: false,
           isRange: true,
           newMajor: 1,
@@ -1882,6 +1941,7 @@ describe('workers/repository/process/lookup/index', () => {
       expect(updates).toEqual([
         {
           bucket: 'non-major',
+          downloadUrl: expect.any(String),
           isBreaking: true,
           isRange: true,
           newMajor: 0,
@@ -1895,6 +1955,7 @@ describe('workers/repository/process/lookup/index', () => {
         },
         {
           bucket: 'major',
+          downloadUrl: expect.any(String),
           isBreaking: true,
           isRange: true,
           newMajor: 1,
@@ -1923,6 +1984,7 @@ describe('workers/repository/process/lookup/index', () => {
       expect(updates).toEqual([
         {
           bucket: 'non-major',
+          downloadUrl: expect.any(String),
           isBreaking: true,
           isRange: true,
           newMajor: 0,
@@ -1936,6 +1998,7 @@ describe('workers/repository/process/lookup/index', () => {
         },
         {
           bucket: 'major',
+          downloadUrl: expect.any(String),
           isBreaking: true,
           isRange: true,
           newMajor: 1,
@@ -1964,6 +2027,7 @@ describe('workers/repository/process/lookup/index', () => {
       expect(updates).toEqual([
         {
           bucket: 'non-major',
+          downloadUrl: expect.any(String),
           isBreaking: true,
           isRange: true,
           newMajor: 0,
@@ -1977,6 +2041,7 @@ describe('workers/repository/process/lookup/index', () => {
         },
         {
           bucket: 'major',
+          downloadUrl: expect.any(String),
           isBreaking: true,
           isRange: true,
           newMajor: 1,
@@ -2008,6 +2073,8 @@ describe('workers/repository/process/lookup/index', () => {
       expect(updates).toEqual([
         {
           bucket: 'major',
+          downloadUrl: expect.any(String),
+          newDigest: expect.any(String),
           isBreaking: true,
           isRange: true,
           newMajor: 3,
@@ -2039,6 +2106,8 @@ describe('workers/repository/process/lookup/index', () => {
       expect(updates).toEqual([
         {
           bucket: 'major',
+          downloadUrl: expect.any(String),
+          newDigest: expect.any(String),
           isBreaking: true,
           isRange: true,
           newMajor: 3,
@@ -2070,8 +2139,10 @@ describe('workers/repository/process/lookup/index', () => {
       expect(updates).toEqual([
         {
           bucket: 'major',
+          downloadUrl: expect.any(String),
           isBreaking: true,
           isRange: true,
+          newDigest: expect.any(String),
           newMajor: 3,
           newMinor: 8,
           newPatch: 1,
@@ -2101,6 +2172,8 @@ describe('workers/repository/process/lookup/index', () => {
       expect(updates).toEqual([
         {
           bucket: 'major',
+          downloadUrl: expect.any(String),
+          newDigest: expect.any(String),
           isBreaking: true,
           isRange: true,
           newMajor: 3,
@@ -2129,6 +2202,7 @@ describe('workers/repository/process/lookup/index', () => {
       expect(updates).toEqual([
         {
           bucket: 'non-major',
+          downloadUrl: expect.any(String),
           isBreaking: false,
           isRange: true,
           newMajor: 1,
@@ -2171,6 +2245,7 @@ describe('workers/repository/process/lookup/index', () => {
       expect(updates).toEqual([
         {
           bucket: 'non-major',
+          downloadUrl: expect.any(String),
           isBreaking: true,
           isRange: true,
           newMajor: 0,
@@ -2184,6 +2259,7 @@ describe('workers/repository/process/lookup/index', () => {
         },
         {
           bucket: 'major',
+          downloadUrl: expect.any(String),
           isBreaking: true,
           isRange: true,
           newMajor: 1,
@@ -2212,6 +2288,7 @@ describe('workers/repository/process/lookup/index', () => {
       expect(updates).toEqual([
         {
           bucket: 'non-major',
+          downloadUrl: expect.any(String),
           isBreaking: true,
           isRange: true,
           newMajor: 0,
@@ -2225,6 +2302,7 @@ describe('workers/repository/process/lookup/index', () => {
         },
         {
           bucket: 'major',
+          downloadUrl: expect.any(String),
           isBreaking: true,
           isRange: true,
           newMajor: 1,
@@ -2253,6 +2331,7 @@ describe('workers/repository/process/lookup/index', () => {
       expect(updates).toEqual([
         {
           bucket: 'major',
+          downloadUrl: expect.any(String),
           isBreaking: true,
           isRange: true,
           newMajor: 1,
@@ -2281,6 +2360,7 @@ describe('workers/repository/process/lookup/index', () => {
       expect(updates).toEqual([
         {
           bucket: 'non-major',
+          downloadUrl: expect.any(String),
           isBreaking: false,
           isRange: true,
           newMajor: 1,
@@ -2309,6 +2389,7 @@ describe('workers/repository/process/lookup/index', () => {
       expect(updates).toEqual([
         {
           bucket: 'non-major',
+          downloadUrl: expect.any(String),
           isBreaking: false,
           isRange: true,
           newMajor: 1,
@@ -2338,6 +2419,7 @@ describe('workers/repository/process/lookup/index', () => {
       expect(updates).toEqual([
         {
           bucket: 'major',
+          downloadUrl: expect.any(String),
           isBreaking: true,
           isRange: true,
           newMajor: 2,
@@ -2366,6 +2448,7 @@ describe('workers/repository/process/lookup/index', () => {
       expect(updates).toEqual([
         {
           bucket: 'non-major',
+          downloadUrl: expect.any(String),
           isBreaking: false,
           isRange: true,
           newMajor: 1,
@@ -2394,6 +2477,7 @@ describe('workers/repository/process/lookup/index', () => {
       expect(updates).toEqual([
         {
           bucket: 'major',
+          downloadUrl: expect.any(String),
           isBreaking: true,
           isRange: true,
           newMajor: 1,
@@ -2422,6 +2506,7 @@ describe('workers/repository/process/lookup/index', () => {
       expect(updates).toEqual([
         {
           bucket: 'major',
+          downloadUrl: expect.any(String),
           isBreaking: true,
           isRange: true,
           newMajor: 1,
@@ -2450,6 +2535,7 @@ describe('workers/repository/process/lookup/index', () => {
       expect(updates).toEqual([
         {
           bucket: 'non-major',
+          downloadUrl: expect.any(String),
           isBreaking: true,
           isRange: true,
           newMajor: 0,
@@ -2463,6 +2549,7 @@ describe('workers/repository/process/lookup/index', () => {
         },
         {
           bucket: 'major',
+          downloadUrl: expect.any(String),
           isBreaking: true,
           isRange: true,
           newMajor: 1,
@@ -2491,6 +2578,7 @@ describe('workers/repository/process/lookup/index', () => {
       expect(updates).toEqual([
         {
           bucket: 'non-major',
+          downloadUrl: expect.any(String),
           isBreaking: true,
           isRange: true,
           newMajor: 0,
@@ -2504,6 +2592,7 @@ describe('workers/repository/process/lookup/index', () => {
         },
         {
           bucket: 'major',
+          downloadUrl: expect.any(String),
           isBreaking: true,
           isRange: true,
           newMajor: 1,
@@ -2547,6 +2636,7 @@ describe('workers/repository/process/lookup/index', () => {
         {
           bucket: 'major',
           isBreaking: true,
+          downloadUrl: expect.any(String),
           newMajor: 2,
           newMinor: 0,
           newPatch: 3,
@@ -2745,6 +2835,8 @@ describe('workers/repository/process/lookup/index', () => {
         {
           bucket: 'non-major',
           isBreaking: true,
+          downloadUrl: expect.any(String),
+          newDigest: expect.any(String),
           newMajor: 2,
           newMinor: 5,
           newPatch: 17,
@@ -2774,6 +2866,8 @@ describe('workers/repository/process/lookup/index', () => {
         {
           bucket: 'non-major',
           isBreaking: true,
+          downloadUrl: expect.any(String),
+          newDigest: expect.any(String),
           newMajor: 3,
           newMinor: 1,
           newPatch: 0,
@@ -2803,6 +2897,8 @@ describe('workers/repository/process/lookup/index', () => {
         {
           bucket: 'non-major',
           isBreaking: true,
+          downloadUrl: expect.any(String),
+          newDigest: expect.any(String),
           newMajor: 3,
           newMinor: 0,
           newPatch: 1,
@@ -2833,6 +2929,7 @@ describe('workers/repository/process/lookup/index', () => {
         {
           bucket: 'non-major',
           isBreaking: true,
+          downloadUrl: expect.any(String),
           newMajor: 0,
           newMinor: 0,
           newPatch: 35,
@@ -2879,6 +2976,8 @@ describe('workers/repository/process/lookup/index', () => {
       expect(updates).toEqual([
         {
           bucket: 'non-major',
+          downloadUrl: expect.any(String),
+          newDigest: expect.any(String),
           isBreaking: true,
           newMajor: 3,
           newMinor: 0,
@@ -2937,6 +3036,8 @@ describe('workers/repository/process/lookup/index', () => {
         {
           bucket: 'non-major',
           isBreaking: true,
+          downloadUrl: expect.any(String),
+          newDigest: expect.any(String),
           newMajor: 3,
           newMinor: 0,
           newPatch: 1,
@@ -3132,6 +3233,7 @@ describe('workers/repository/process/lookup/index', () => {
       expect(updates).toEqual([
         {
           bucket: 'non-major',
+          downloadUrl: expect.any(String),
           isBreaking: true,
           isRange: true,
           newMajor: 0,
@@ -3188,6 +3290,7 @@ describe('workers/repository/process/lookup/index', () => {
       expect(updates).toEqual([
         {
           bucket: 'non-major',
+          downloadUrl: expect.any(String),
           isBreaking: false,
           newMajor: 1,
           newMinor: 15,
@@ -3200,6 +3303,8 @@ describe('workers/repository/process/lookup/index', () => {
         },
         {
           bucket: 'major',
+          downloadUrl: expect.any(String),
+          newDigest: expect.any(String),
           isBreaking: true,
           newMajor: 3,
           newMinor: 8,
@@ -3230,6 +3335,7 @@ describe('workers/repository/process/lookup/index', () => {
       expect(updates).toEqual([
         {
           bucket: 'non-major',
+          downloadUrl: expect.any(String),
           isBreaking: false,
           newMajor: 1,
           newMinor: 15,
@@ -3243,6 +3349,8 @@ describe('workers/repository/process/lookup/index', () => {
         {
           bucket: 'v2',
           isBreaking: true,
+          downloadUrl: expect.any(String),
+          newDigest: expect.any(String),
           newMajor: 2,
           newMinor: 7,
           newPatch: 0,
@@ -3255,7 +3363,8 @@ describe('workers/repository/process/lookup/index', () => {
         {
           bucket: 'v3',
           isBreaking: true,
-
+          downloadUrl: expect.any(String),
+          newDigest: expect.any(String),
           newMajor: 3,
           newMinor: 8,
           newPatch: 1,
@@ -3317,6 +3426,7 @@ describe('workers/repository/process/lookup/index', () => {
           isBreaking: false,
           isBump: true,
           isRange: true,
+          downloadUrl: expect.any(String),
           newMajor: 1,
           newMinor: 4,
           newPatch: 1,
@@ -3347,6 +3457,7 @@ describe('workers/repository/process/lookup/index', () => {
           isBreaking: false,
           isBump: true,
           isRange: true,
+          downloadUrl: expect.any(String),
           newMajor: 1,
           newMinor: 0,
           newPatch: 1,
@@ -3360,6 +3471,7 @@ describe('workers/repository/process/lookup/index', () => {
           bucket: 'minor',
           isBreaking: false,
           isRange: true,
+          downloadUrl: expect.any(String),
           newMajor: 1,
           newMinor: 4,
           newPatch: 1,
@@ -3390,6 +3502,7 @@ describe('workers/repository/process/lookup/index', () => {
           isBreaking: false,
           isBump: true,
           isRange: true,
+          downloadUrl: expect.any(String),
           newMajor: 1,
           newMinor: 0,
           newPatch: 1,
@@ -3403,6 +3516,7 @@ describe('workers/repository/process/lookup/index', () => {
           bucket: 'minor',
           isBreaking: false,
           isRange: true,
+          downloadUrl: expect.any(String),
           newMajor: 1,
           newMinor: 4,
           newPatch: 1,
@@ -3429,6 +3543,7 @@ describe('workers/repository/process/lookup/index', () => {
       expect(updates).toEqual([
         {
           bucket: 'non-major',
+          downloadUrl: expect.any(String),
           isBreaking: false,
           isBump: true,
           isRange: true,
@@ -3459,6 +3574,7 @@ describe('workers/repository/process/lookup/index', () => {
       expect(updates).toEqual([
         {
           bucket: 'latest',
+          downloadUrl: expect.any(String),
           isBreaking: true,
           isBump: true,
           isRange: true,
@@ -3532,6 +3648,7 @@ describe('workers/repository/process/lookup/index', () => {
         {
           bucket: 'non-major',
           isBreaking: false,
+          downloadUrl: expect.any(String),
           newMajor: 1,
           newMinor: 4,
           newPatch: 1,
@@ -3640,6 +3757,7 @@ describe('workers/repository/process/lookup/index', () => {
           newMajor: 1,
           newMinor: 4,
           newPatch: 1,
+          downloadUrl: expect.any(String),
           newValue: '~=1.4',
           newVersion: '1.4.1',
           newVersionAgeInDays: expect.any(Number),
@@ -4530,6 +4648,7 @@ describe('workers/repository/process/lookup/index', () => {
             newMajor: 1,
             newMinor: 3,
             newPatch: 0,
+            downloadUrl: expect.any(String),
             newValue: '1.3.0',
             newVersion: '1.3.0',
             newVersionAgeInDays: expect.any(Number),
@@ -5349,6 +5468,8 @@ describe('workers/repository/process/lookup/index', () => {
           {
             bucket: 'non-major',
             isBreaking: false,
+            downloadUrl: expect.any(String),
+            newDigest: expect.any(String),
             mergeConfidenceLevel: 'high',
             newMajor: 3,
             newMinor: 8,
@@ -5379,6 +5500,8 @@ describe('workers/repository/process/lookup/index', () => {
         expect(updates).toEqual([
           {
             bucket: 'non-major',
+            downloadUrl: expect.any(String),
+            newDigest: expect.any(String),
             isBreaking: false,
             newMajor: 3,
             newMinor: 8,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
This pull request adds support for updating `pnpm.configDependencies` in `pnpm-workspace.yaml` files, enhancing the npm manager's ability to detect, extract, and update these dependencies. It also improves type definitions and extraction logic for npm and pnpm, and introduces comprehensive tests to ensure correctness. Additionally, the npm datasource now captures integrity and tarball information for more accurate updates.

**Support for pnpm configDependencies:**

- Added extraction and update logic for `configDependencies` in `pnpm-workspace.yaml`, allowing detection and automated updates of these dependencies, including handling both scalar and object forms. [[1]](diffhunk://#diff-db7739ddf296a529e3fed0809f62518c749c393125ba00073d05ef0308e8a676L20-R35) [[2]](diffhunk://#diff-db7739ddf296a529e3fed0809f62518c749c393125ba00073d05ef0308e8a676R284-R327) [[3]](diffhunk://#diff-42d2040e76ee358eb59dd40de0f5d69e3d711ffe463d6f7ccce78b4ff6cf4e32R93-R191) [[4]](diffhunk://#diff-1affcca6f5abc376ea334a0b475cdb74fca049869d6627ca8c4c3605ba601c59L15-R18) [[5]](diffhunk://#diff-1affcca6f5abc376ea334a0b475cdb74fca049869d6627ca8c4c3605ba601c59R127-R129) [[6]](diffhunk://#diff-6864f3077a30385330839317abe41dc62c8df34392a18e4a5d9cd2c665bf822aR574-R673) [[7]](diffhunk://#diff-61df431943b682d4195504495fa9c1f6099f64f0dca9ea83b11c3eb24c667770R9-R22) [[8]](diffhunk://#diff-61df431943b682d4195504495fa9c1f6099f64f0dca9ea83b11c3eb24c667770L33-R50) [[9]](diffhunk://#diff-8fbb8475659d8759e8046b8afa04e8d6600f59164ed1ddad4a5ed618dabe0537L49-R52) [[10]](diffhunk://#diff-ee1575d301c41429aa68fc0c8f40189ee835fbce5369ec04147752fcb8ad22e8R14)

- Implemented `updatePnpmConfigDependency` to update both the `integrity` and `tarball` fields when present, using new values and digests as appropriate. [[1]](diffhunk://#diff-42d2040e76ee358eb59dd40de0f5d69e3d711ffe463d6f7ccce78b4ff6cf4e32R93-R191) [[2]](diffhunk://#diff-cdc805c23949d447275b3100bb0a5ca0783ebc4bfd32b58eee99c769825e2f04R208)

**Type and schema improvements:**

- Extended type definitions and schemas for npm and pnpm to include `integrity`, `tarball`, and `configDependencies` fields, improving type safety and extraction accuracy. [[1]](diffhunk://#diff-f79cc7bd33bea5e0a82c3155e49516d1cdf656d4537b297cf8f8eead26ff9146R15-R16) [[2]](diffhunk://#diff-8fbb8475659d8759e8046b8afa04e8d6600f59164ed1ddad4a5ed618dabe0537L49-R52) [[3]](diffhunk://#diff-61df431943b682d4195504495fa9c1f6099f64f0dca9ea83b11c3eb24c667770R9-R22) [[4]](diffhunk://#diff-61df431943b682d4195504495fa9c1f6099f64f0dca9ea83b11c3eb24c667770L33-R50)

**Extraction and parsing enhancements:**

- Improved `extractAllPackageFiles` to more accurately identify pnpm workspace YAML files, avoiding false positives for non-YAML files.
- Enhanced `extractPnpmFilters` to handle missing or invalid `packages` arrays gracefully.

**Datasource improvements:**

- The npm datasource now extracts and provides `integrity` and `tarball` fields for releases, enabling more precise dependency updates. [[1]](diffhunk://#diff-55a949ed33c3266366ca069810e4559e4a157fcb6bf3cd6bb839aff60e321627R143-R148) [[2]](diffhunk://#diff-f79cc7bd33bea5e0a82c3155e49516d1cdf656d4537b297cf8f8eead26ff9146R15-R16)
<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
