### PR TITLE
fix(onboardingAutoCloseAge): correctly handle partial days elapsed

### DIFF
--- a/lib/util/date.spec.ts
+++ b/lib/util/date.spec.ts
@@ -18,14 +18,28 @@ describe('util/date', () => {
   });
 
   describe('getElapsedDays', () => {
-    it('returns elapsed days', () => {
-      const t = t0.minus({ days: 42 });
-      expect(getElapsedDays(t.toISO()!)).toBe(42);
+    describe('by default', () => {
+      it('returns elapsed days', () => {
+        const t = t0.minus({ days: 42 });
+        expect(getElapsedDays(t.toISO()!)).toBe(42);
+      });
+
+      it("returns floor'd version of floating point when partial days", () => {
+        const t = t0.minus({ days: 42, hours: 12 });
+        expect(getElapsedDays(t.toISO()!)).toBe(42);
+      });
     });
 
-    it('rounds down', () => {
-      const t = t0.minus({ days: 42, hours: 12 });
-      expect(getElapsedDays(t.toISO()!)).toBe(42);
+    describe('when floor=false', () => {
+      it('returns floating point when partial days', () => {
+        const t = t0.minus({ days: 42, hours: 12 });
+        expect(getElapsedDays(t.toISO()!, false)).toBe(42.5);
+      });
+
+      it('returns all decimal places', () => {
+        const t = t0.minus({ days: 42, hours: 2 });
+        expect(getElapsedDays(t.toISO()!, false)).toBe(42.083333333333336);
+      });
     });
   });
 

--- a/lib/util/date.ts
+++ b/lib/util/date.ts
@@ -2,12 +2,15 @@ import { DateTime } from 'luxon';
 
 const ONE_MINUTE_MS = 60 * 1000;
 
-export function getElapsedDays(timestamp: string): number {
+export function getElapsedDays(timestamp: string, floor = true): number {
   const currentVersionTimestampDate = DateTime.fromISO(timestamp);
   const now = DateTime.now();
   const diffInDays = now.diff(currentVersionTimestampDate, 'days').as('days');
-  const ageInDays = Math.floor(diffInDays);
-  return ageInDays;
+  if (floor) {
+    return Math.floor(diffInDays);
+  }
+
+  return diffInDays;
 }
 
 export function getElapsedMinutes(date: Date): number {

--- a/lib/workers/repository/onboarding/branch/check.ts
+++ b/lib/workers/repository/onboarding/branch/check.ts
@@ -159,7 +159,10 @@ export async function isOnboarded(config: RenovateConfig): Promise<boolean> {
   }
   logger.debug('Repo is not onboarded and no merged PRs exist');
   if (!config.suppressNotifications!.includes('onboardingClose')) {
-    const ageOfOnboardingPr = getElapsedDays(closedOnboardingPr.createdAt!);
+    const ageOfOnboardingPr = getElapsedDays(
+      closedOnboardingPr.createdAt!,
+      false,
+    );
     const onboardingAutoCloseAge = GlobalConfig.get('onboardingAutoCloseAge');
     if (onboardingAutoCloseAge) {
       logger.debug(
@@ -168,7 +171,7 @@ export async function isOnboarded(config: RenovateConfig): Promise<boolean> {
           createdAt: closedOnboardingPr.createdAt!,
           ageOfOnboardingPr,
         },
-        `Determining that the closed onboarding PR was created at \`${closedOnboardingPr.createdAt!}\` was created ${ageOfOnboardingPr} days ago`,
+        `Determining that the closed onboarding PR was created at \`${closedOnboardingPr.createdAt!}\` was created ${ageOfOnboardingPr.toFixed(2)} days ago`,
       );
     }
     // if we have onboardingAutoCloseAge, and it hasn't yet passed onboardingAutoCloseAge, add a comment

--- a/lib/workers/repository/onboarding/pr/index.spec.ts
+++ b/lib/workers/repository/onboarding/pr/index.spec.ts
@@ -1,4 +1,5 @@
 import type { RequestError, Response } from 'got';
+import { DateTime } from 'luxon';
 import { getConfig } from '../../../../config/defaults';
 import { GlobalConfig } from '../../../../config/global';
 import { logger } from '../../../../logger';
@@ -227,23 +228,100 @@ describe('workers/repository/onboarding/pr/index', () => {
       expect(platform.updatePr).toHaveBeenCalledTimes(0);
     });
 
-    it('ensures comment,when onboarding pr is older than onboardingAutoCloseAge', async () => {
-      config.baseBranch = 'some-branch';
-      GlobalConfig.set({ onboardingAutoCloseAge: 1 });
-      platform.getBranchPr.mockResolvedValueOnce(
-        partial<Pr>({
-          title: 'Configure Renovate',
-          bodyStruct,
-          createdAt: '2020-02-29T01:40:21Z',
+    describe('when onboardingAutoCloseAge is set', () => {
+      beforeAll(() => {
+        vi.useFakeTimers();
+      });
+
+      it('does not comment, when onboarding pr is exactly at onboardingAutoCloseAge', async () => {
+        const now = DateTime.now();
+        vi.setSystemTime(now.toMillis());
+        // at exactly 1 day ago, which means that an `onboardingAutoCloseAge=1` SHOULD NOT trigger, as it's > 1
+        const createdAt = now.minus({ hour: 24 });
+
+        config.baseBranch = 'some-branch';
+        GlobalConfig.set({ onboardingAutoCloseAge: 1 });
+        platform.getBranchPr.mockResolvedValueOnce(
+          partial<Pr>({
+            title: 'Configure Renovate',
+            bodyStruct,
+            createdAt: createdAt.toISO(),
+            number: 1,
+          }),
+        );
+        await ensureOnboardingPr(config, {}, branches);
+        expect(platform.ensureComment).toHaveBeenCalledTimes(0);
+        expect(platform.createPr).toHaveBeenCalledTimes(0);
+      });
+
+      it('ensures comment, when onboarding pr is partially over onboardingAutoCloseAge', async () => {
+        const now = DateTime.now();
+        vi.setSystemTime(now.toMillis());
+        // we're currently 1 day and 1 second ahead of the creation time, which is 1.x days since the PR was created, which means that an `onboardingAutoCloseAge=1` should trigger, as it's > 1
+        const createdAt = now.minus({ hour: 24, seconds: 1 });
+
+        config.baseBranch = 'some-branch';
+        GlobalConfig.set({ onboardingAutoCloseAge: 1 });
+        platform.getBranchPr.mockResolvedValueOnce(
+          partial<Pr>({
+            title: 'Configure Renovate',
+            bodyStruct,
+            createdAt: createdAt.toISO(),
+            number: 1,
+          }),
+        );
+        await ensureOnboardingPr(config, {}, branches);
+        expect(platform.ensureComment).toHaveBeenCalledTimes(1);
+        expect(platform.updatePr).toHaveBeenCalledWith({
           number: 1,
-        }),
-      );
-      await ensureOnboardingPr(config, {}, branches);
-      expect(platform.ensureComment).toHaveBeenCalledTimes(1);
-      expect(platform.updatePr).toHaveBeenCalledWith({
-        number: 1,
-        state: 'closed',
-        prTitle: 'Configure Renovate',
+          state: 'closed',
+          prTitle: 'Configure Renovate',
+        });
+      });
+
+      it('ensures comment, when onboarding pr is 1 day older than onboardingAutoCloseAge', async () => {
+        const now = DateTime.now();
+        vi.setSystemTime(now.toMillis());
+        // we're currently 25 hours ahead of the creation time, which is 1.x days since the PR was created, which means that an `onboardingAutoCloseAge=1` should trigger, as it's > 1
+        const createdAt = now.minus({ hour: 48 });
+
+        config.baseBranch = 'some-branch';
+        GlobalConfig.set({ onboardingAutoCloseAge: 1 });
+        platform.getBranchPr.mockResolvedValueOnce(
+          partial<Pr>({
+            title: 'Configure Renovate',
+            bodyStruct,
+            createdAt: createdAt.toISO(),
+            number: 1,
+          }),
+        );
+        await ensureOnboardingPr(config, {}, branches);
+        expect(platform.ensureComment).toHaveBeenCalledTimes(1);
+        expect(platform.updatePr).toHaveBeenCalledWith({
+          number: 1,
+          state: 'closed',
+          prTitle: 'Configure Renovate',
+        });
+      });
+
+      it('ensures comment,when onboarding pr is significantly older than onboardingAutoCloseAge', async () => {
+        config.baseBranch = 'some-branch';
+        GlobalConfig.set({ onboardingAutoCloseAge: 1 });
+        platform.getBranchPr.mockResolvedValueOnce(
+          partial<Pr>({
+            title: 'Configure Renovate',
+            bodyStruct,
+            createdAt: '2020-02-29T01:40:21Z',
+            number: 1,
+          }),
+        );
+        await ensureOnboardingPr(config, {}, branches);
+        expect(platform.ensureComment).toHaveBeenCalledTimes(1);
+        expect(platform.updatePr).toHaveBeenCalledWith({
+          number: 1,
+          state: 'closed',
+          prTitle: 'Configure Renovate',
+        });
       });
     });
 

--- a/lib/workers/repository/onboarding/pr/index.ts
+++ b/lib/workers/repository/onboarding/pr/index.ts
@@ -52,7 +52,7 @@ export async function ensureOnboardingPr(
   );
   if (existingPr) {
     // check if the existing pr crosses the onboarding autoclose age
-    const ageOfOnboardingPr = getElapsedDays(existingPr.createdAt!);
+    const ageOfOnboardingPr = getElapsedDays(existingPr.createdAt!, false);
     const onboardingAutoCloseAge = GlobalConfig.get('onboardingAutoCloseAge')!;
     if (onboardingAutoCloseAge) {
       logger.debug(
@@ -61,7 +61,7 @@ export async function ensureOnboardingPr(
           createdAt: existingPr.createdAt!,
           ageOfOnboardingPr,
         },
-        `Determining that the onboarding PR created at \`${existingPr.createdAt!}\` was created ${ageOfOnboardingPr} days ago`,
+        `Determining that the onboarding PR created at \`${existingPr.createdAt!}\` was created ${ageOfOnboardingPr.toFixed(2)} days ago`,
       );
     }
     if (


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->


As noted in #40604, we're seeing cases where we need to wait
`onboardingAutoCloseAge+1` days until the onboarding PR will be
auto-closed.

To fix this, we can refactor `getElapsedDays` to optionally return a
floating point number, which we can then perform more careful
calculations against.

As we're now being a little more careful with timings being used for our
date comparisons, we need to make sure that Vitest fakes our timer
during these tests.

Instead of long floating-point numbers, we should use a 2 decimal
place value for log messages, as they're more readable to humans.




## Context

Please select one of the below:

- [x] This closes an existing Issue: Closes #40604
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
