### PR TITLE
fix(pnpm): use exact versions in `minimumReleaseAgeExclude`

### DIFF
--- a/lib/modules/manager/npm/artifacts.ts
+++ b/lib/modules/manager/npm/artifacts.ts
@@ -179,7 +179,7 @@ async function updatePnpmWorkspace(
 
   for (const upgrade of upgrades) {
     let excludeNode = doc.get('minimumReleaseAgeExclude') as YAMLSeq | null;
-    const newVersion = upgrade.newValue ?? upgrade.newVersion;
+    const newVersion = upgrade.newVersion ?? upgrade.newValue;
 
     /* v8 ignore if -- should not happen, adding for type narrowing*/
     if (excludeNode && !isSeq(excludeNode)) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
As noted in #40610, when `newVersion` contains a caret (or other
npm-specific versioning constraints) a generated
`minimumReleaseAgeExclude` directive will result in

    ERR_PNPM_INVALID_MINIMUM_RELEASE_AGE_EXCLUDE  Invalid value in
    minimumReleaseAgeExclude: Invalid versions union. Found: "...". Use
    exact versions only.

To handle this better, we can make sure we use `newVersion` over
`newValue`, as it'll provide the raw version number.

We also need to update an unrelated to test to make sure it's using
`newVersion`.


## Context

Please select one of the below:

- [x] This closes an existing Issue: Closes #40610
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/JamieTanna-Mend-testing/pnpm-40610-renovate-test-4/pull/2

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
