### PR TITLE
fix(onboardingAutoCloseAge): close PRs when onboarding cache is up-to-date

### DIFF
--- a/lib/workers/repository/onboarding/pr/index.ts
+++ b/lib/workers/repository/onboarding/pr/index.ts
@@ -3,6 +3,7 @@ import { GlobalConfig } from '../../../../config/global';
 import type { RenovateConfig } from '../../../../config/types';
 import { logger } from '../../../../logger';
 import type { PackageFile } from '../../../../modules/manager/types';
+import type { Pr } from '../../../../modules/platform';
 import { platform } from '../../../../modules/platform';
 import { ensureComment } from '../../../../modules/platform/comment';
 import { hashBody } from '../../../../modules/platform/pr-body';
@@ -31,6 +32,53 @@ import { getBaseBranchDesc } from './base-branch';
 import { getConfigDesc } from './config-description';
 import { getExpectedPrList } from './pr-list';
 
+/**
+ * Given an existing PR, if onboardingAutoCloseAge has passed, close the PR.
+ *
+ * Returns true if the PR was closed.
+ */
+async function ensureOnboardingAutoCloseAge(existingPr: Pr): Promise<boolean> {
+  // check if the existing pr crosses the onboarding autoclose age
+  const ageOfOnboardingPr = getElapsedDays(existingPr.createdAt!, false);
+  const onboardingAutoCloseAge = GlobalConfig.get('onboardingAutoCloseAge')!;
+  if (onboardingAutoCloseAge) {
+    logger.debug(
+      {
+        onboardingAutoCloseAge,
+        createdAt: existingPr.createdAt!,
+        ageOfOnboardingPr,
+      },
+      `Determining that the onboarding PR created at \`${existingPr.createdAt!}\` was created ${ageOfOnboardingPr.toFixed(2)} days ago`,
+    );
+  }
+  if (
+    isNumber(onboardingAutoCloseAge) &&
+    ageOfOnboardingPr > onboardingAutoCloseAge
+  ) {
+    // close the pr
+    await platform.updatePr({
+      number: existingPr.number,
+      state: 'closed',
+      prTitle: existingPr.title,
+    });
+    // ensure comment
+    await ensureComment({
+      number: existingPr.number,
+      topic: `Renovate is disabled`,
+      content: `Renovate is disabled because the onboarding PR has been unmerged for more than ${onboardingAutoCloseAge} days. To enable Renovate, you can either (a) change this PR's title to get a new onboarding PR, and merge the new onboarding PR, or (b) create a Renovate config file, and commit that file to your base branch.`,
+    });
+    logger.debug(
+      {
+        ageOfOnboardingPr,
+        onboardingAutoCloseAge,
+      },
+      `Renovate is being disabled for this repository as the onboarding PR has been unmerged for more than ${onboardingAutoCloseAge} days`,
+    );
+    return true;
+  }
+  return false;
+}
+
 export async function ensureOnboardingPr(
   config: RenovateConfig,
   packageFiles: Record<string, PackageFile[]> | null,
@@ -38,7 +86,6 @@ export async function ensureOnboardingPr(
 ): Promise<void> {
   if (
     config.repoIsOnboarded === true ||
-    OnboardingState.onboardingCacheValid ||
     (config.onboardingRebaseCheckbox && !OnboardingState.prUpdateRequested)
   ) {
     return;
@@ -51,44 +98,11 @@ export async function ensureOnboardingPr(
     config.defaultBranch,
   );
   if (existingPr) {
-    // check if the existing pr crosses the onboarding autoclose age
-    const ageOfOnboardingPr = getElapsedDays(existingPr.createdAt!, false);
-    const onboardingAutoCloseAge = GlobalConfig.get('onboardingAutoCloseAge')!;
-    if (onboardingAutoCloseAge) {
-      logger.debug(
-        {
-          onboardingAutoCloseAge,
-          createdAt: existingPr.createdAt!,
-          ageOfOnboardingPr,
-        },
-        `Determining that the onboarding PR created at \`${existingPr.createdAt!}\` was created ${ageOfOnboardingPr.toFixed(2)} days ago`,
-      );
-    }
-    if (
-      isNumber(onboardingAutoCloseAge) &&
-      ageOfOnboardingPr > onboardingAutoCloseAge
-    ) {
-      // close the pr
-      await platform.updatePr({
-        number: existingPr.number,
-        state: 'closed',
-        prTitle: existingPr.title,
-      });
-      // ensure comment
-      await ensureComment({
-        number: existingPr.number,
-        topic: `Renovate is disabled`,
-        content: `Renovate is disabled because the onboarding PR has been unmerged for more than ${onboardingAutoCloseAge} days. To enable Renovate, you can either (a) change this PR's title to get a new onboarding PR, and merge the new onboarding PR, or (b) create a Renovate config file, and commit that file to your base branch.`,
-      });
-      logger.debug(
-        {
-          ageOfOnboardingPr,
-          onboardingAutoCloseAge,
-        },
-        `Renovate is being disabled for this repository as the onboarding PR has been unmerged for more than ${onboardingAutoCloseAge} days`,
-      );
+    const wasClosed = await ensureOnboardingAutoCloseAge(existingPr);
+    if (wasClosed) {
       return;
     }
+
     // skip pr-update if branch is conflicted
     if (
       await isOnboardingBranchConflicted(
@@ -112,6 +126,11 @@ export async function ensureOnboardingPr(
       return;
     }
   }
+
+  if (OnboardingState.onboardingCacheValid) {
+    return;
+  }
+
   const onboardingConfigHashComment =
     await getOnboardingConfigHashComment(config);
   const rebaseCheckBox = getRebaseCheckbox(config.onboardingRebaseCheckbox);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

As noted in #40627, when using a Repository Cache, the
onboardingAutoCloseAge does not trigger if the repository already has
its onboarding state already cached.

This is most prevalent in the Mend Developer Platform, where we heavily
cache our users' repositories, but leads to the fact that turning on
`onboardingAutoCloseAge` will take no effect.

To make this work, we can refactor how we handle `ensureOnboardingPr`,
to make sure that we still perform auto-closing even if the cache is
up-to-date.

Although not at the "rule of there", we can reduce code duplication for
`ensureOnboardingAutoCloseAge` by extracting a function.


## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes #40627
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation
## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
