### PR TITLE
fix(onboardingAutoCloseAge): mark repositories as "closed-onboarding" after close

### DIFF
--- a/lib/workers/repository/onboarding/pr/index.spec.ts
+++ b/lib/workers/repository/onboarding/pr/index.spec.ts
@@ -2,6 +2,7 @@ import type { RequestError, Response } from 'got';
 import { DateTime } from 'luxon';
 import { getConfig } from '../../../../config/defaults';
 import { GlobalConfig } from '../../../../config/global';
+import { REPOSITORY_CLOSED_ONBOARDING } from '../../../../constants/error-messages';
 import { logger } from '../../../../logger';
 import type { PackageFile } from '../../../../modules/manager/types';
 import type { Pr } from '../../../../modules/platform';
@@ -258,7 +259,9 @@ describe('workers/repository/onboarding/pr/index', () => {
             number: 1,
           }),
         );
-        await ensureOnboardingPr(config, {}, branches);
+        await expect(ensureOnboardingPr(config, {}, branches)).rejects.toThrow(
+          REPOSITORY_CLOSED_ONBOARDING,
+        );
         expect(platform.ensureComment).toHaveBeenCalledTimes(1);
         expect(platform.updatePr).toHaveBeenCalledWith({
           number: 1,
@@ -304,7 +307,9 @@ describe('workers/repository/onboarding/pr/index', () => {
             number: 1,
           }),
         );
-        await ensureOnboardingPr(config, {}, branches);
+        await expect(ensureOnboardingPr(config, {}, branches)).rejects.toThrow(
+          REPOSITORY_CLOSED_ONBOARDING,
+        );
         expect(platform.ensureComment).toHaveBeenCalledTimes(1);
         expect(platform.updatePr).toHaveBeenCalledWith({
           number: 1,
@@ -329,7 +334,9 @@ describe('workers/repository/onboarding/pr/index', () => {
             number: 1,
           }),
         );
-        await ensureOnboardingPr(config, {}, branches);
+        await expect(ensureOnboardingPr(config, {}, branches)).rejects.toThrow(
+          REPOSITORY_CLOSED_ONBOARDING,
+        );
         expect(platform.ensureComment).toHaveBeenCalledTimes(1);
         expect(platform.updatePr).toHaveBeenCalledWith({
           number: 1,
@@ -349,7 +356,9 @@ describe('workers/repository/onboarding/pr/index', () => {
             number: 1,
           }),
         );
-        await ensureOnboardingPr(config, {}, branches);
+        await expect(ensureOnboardingPr(config, {}, branches)).rejects.toThrow(
+          REPOSITORY_CLOSED_ONBOARDING,
+        );
         expect(platform.ensureComment).toHaveBeenCalledTimes(1);
         expect(platform.updatePr).toHaveBeenCalledWith({
           number: 1,

--- a/lib/workers/repository/onboarding/pr/index.ts
+++ b/lib/workers/repository/onboarding/pr/index.ts
@@ -1,6 +1,7 @@
 import { isNumber, isString } from '@sindresorhus/is';
 import { GlobalConfig } from '../../../../config/global';
 import type { RenovateConfig } from '../../../../config/types';
+import { REPOSITORY_CLOSED_ONBOARDING } from '../../../../constants/error-messages';
 import { logger } from '../../../../logger';
 import type { PackageFile } from '../../../../modules/manager/types';
 import type { Pr } from '../../../../modules/platform';
@@ -100,7 +101,7 @@ export async function ensureOnboardingPr(
   if (existingPr) {
     const wasClosed = await ensureOnboardingAutoCloseAge(existingPr);
     if (wasClosed) {
-      return;
+      throw new Error(REPOSITORY_CLOSED_ONBOARDING);
     }
 
     // skip pr-update if branch is conflicted


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
As noted in #40631, when autoclosing an onboarding PR due to age, we're
not marking the repository status as `closed-onboarding`, which means
the repository cache (and current status fo the repo) is not
appropriately updated, and a repository needs to be scanned again to
update accordingly.

We should throw this error when we've performed the auto-close, so
Renovate can then mark the status correctly.


## Context

Please select one of the below:

- [x] This closes an existing Issue: Closes #40631
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
