### PR TITLE
fix(config): ensure that config options are immutable

### DIFF
--- a/lib/config/defaults.ts
+++ b/lib/config/defaults.ts
@@ -1,3 +1,4 @@
+import { clone } from '../util/clone';
 import { getOptions } from './options';
 import type { AllConfig, RenovateOptions } from './types';
 
@@ -16,7 +17,7 @@ const defaultValueFactories = {
 export function getDefault(option: RenovateOptions): any {
   return option.default === undefined
     ? defaultValueFactories[option.type]()
-    : option.default;
+    : clone(option.default);
 }
 
 export function getConfig(): AllConfig {

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -1,3 +1,4 @@
+import { isArray, isObject } from '@sindresorhus/is';
 import { AllManagersListLiteral } from '../../manager-list.generated';
 import { getManagers } from '../../modules/manager';
 import { getCustomManagers } from '../../modules/manager/custom';
@@ -6,7 +7,7 @@ import { getVersioningList } from '../../modules/versioning';
 import { supportedDatasources } from '../presets/internal/merge-confidence';
 import { type RenovateOptions, UpdateTypesOptions } from '../types';
 
-const options: RenovateOptions[] = [
+const options: Readonly<RenovateOptions>[] = [
   {
     name: 'mode',
     description: 'Mode of operation.',
@@ -3335,7 +3336,7 @@ const options: RenovateOptions[] = [
   },
 ];
 
-export function getOptions(): RenovateOptions[] {
+export function getOptions(): Readonly<RenovateOptions>[] {
   return options;
 }
 
@@ -3344,7 +3345,7 @@ function loadManagerOptions(): void {
   for (const [name, config] of allManagers.entries()) {
     // v8 ignore else -- TODO: add test #40625
     if (config.defaultConfig) {
-      const managerConfig: RenovateOptions = {
+      const managerConfig: Readonly<RenovateOptions> = {
         name,
         description: `Configuration object for the ${name} manager`,
         stage: 'package',
@@ -3359,4 +3360,27 @@ function loadManagerOptions(): void {
   }
 }
 
+function freeze(value: unknown): void {
+  if (isArray(value)) {
+    for (const v of value) {
+      freeze(v);
+    }
+
+    Object.freeze(value);
+  } else if (isObject(value)) {
+    for (const v of Object.values(value)) {
+      freeze(v);
+    }
+
+    Object.freeze(value);
+  }
+}
+
+function freezeConfigOptions(): void {
+  for (const option of options) {
+    freeze(option);
+  }
+}
+
 loadManagerOptions();
+freezeConfigOptions();

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -260,7 +260,7 @@ export async function validateConfig(
         !optionParents[key].includes(parentName as AllowedParents)
       ) {
         // TODO: types (#22198)
-        const options = optionParents[key]?.sort().join(', ');
+        const options = optionParents[key]?.toSorted().join(', ');
         const message = `"${key}" can't be used in "${parentName}". Allowed objects: ${options}.`;
         warnings.push({
           topic: `${parentPath ? `${parentPath}.` : ''}${key}`,

--- a/tools/docs/schema.ts
+++ b/tools/docs/schema.ts
@@ -191,16 +191,19 @@ export async function generateSchema(
     type: 'object',
     properties: {},
   };
-  const configurationOptions = getOptions();
+  let configurationOptions = getOptions();
 
   if (!isGlobal) {
-    configurationOptions.map((v) => {
+    configurationOptions = configurationOptions.map((v) => {
       // TODO #38728 remove any global-only options in the repository configuration schema
       if (v.globalOnly) {
         // NOTE that the JSON Schema version we're using does not have support for deprecating, so we need to use the `description` field
-        v.description =
-          "Deprecated: This configuration option is only intended to be used with 'global' configuration when self-hosting, not used in a repository configuration file. Renovate likely won't use the configuration, and these fields will be removed from the repository configuration documentation in Renovate v43 (https://github.com/renovatebot/renovate/issues/38728)\n\n" +
-          v.description;
+        return {
+          ...v,
+          description:
+            "Deprecated: This configuration option is only intended to be used with 'global' configuration when self-hosting, not used in a repository configuration file. Renovate likely won't use the configuration, and these fields will be removed from the repository configuration documentation in Renovate v43 (https://github.com/renovatebot/renovate/issues/38728)\n\n" +
+            v.description,
+        };
       }
 
       return v;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Noticed while making changes in the JSON Schema generation, but we're
currently returning a mutable reference to all of our options, which
means that it might be possible to (accidentally) change configuration
options that then affects all of the running Renovate process.

To handle this, we can make sure to `Object.freeze` the options, as well
as making sure our types clarify this is read-only.

This isn't something that should be user-facing, but makes sure that
we're keeping these immutable.

We also need to make sure any modifications now return a new config
option.






## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
