### PR TITLE
fix(json-schema): add a separate schema for Inherit Config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ renovate-v0.0.0-semantic-release.tgz
 junit.xml
 /test-results
 renovate-schema.json
+renovate-inherited-schema.json
 renovate-global-schema.json
 **/gradle-wrapper/__fixtures__/**/.gradle
 .clinic/

--- a/docs/development/major-release.md
+++ b/docs/development/major-release.md
@@ -85,5 +85,5 @@ git push
   - [i.e.](https://gitlab.com/renovate-bot/renovate-runner/-/merge_requests/3334)
 - Add a copy of the JSON Schemas to Schema Store
   - Go to the last tagged release (of the last major version) and download `docs.tgz`
-  - Copy the `renovate-schema.json` and `renovate-global-schema.json`
+  - Copy the `renovate-schema.json`, `renovate-inherited-schema.json` and `renovate-global-schema.json`
   - See [schemastore#5294](https://github.com/SchemaStore/schemastore/pull/5294) as an example of what configuration may be needed to have the PR build pass

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "clean-cache": "node tools/clean-cache.mjs",
     "compile:ts": "tsc -p tsconfig.app.json",
     "config-validator": "tsx lib/config-validator.ts",
-    "create-json-schema": "tsx tools/generate-schema.ts && prettier --write --cache 'renovate-schema.json' renovate-global-schema.json",
+    "create-json-schema": "tsx tools/generate-schema.ts && prettier --write --cache 'renovate-schema.json' renovate-inherited-schema.json renovate-global-schema.json",
     "debug": "tsx --inspect-brk lib/renovate.ts",
     "doc-fix": "run-s markdown-lint-fix prettier-fix",
     "doc-fix-everything": "run-s doc-fix doc-fence-check lint-documentation",

--- a/tools/docs/index.ts
+++ b/tools/docs/index.ts
@@ -74,6 +74,11 @@ export async function generateDocs(
     logger.info('* json-schema');
     await generateSchema(dist, { version });
     await generateSchema(dist, {
+      filename: 'renovate-inherited-schema.json',
+      version,
+      isInherit: true,
+    });
+    await generateSchema(dist, {
       filename: 'renovate-global-schema.json',
       version,
       isGlobal: true,

--- a/tools/generate-schema.ts
+++ b/tools/generate-schema.ts
@@ -17,6 +17,10 @@ process.on('unhandledRejection', (err) => {
     logger.info('Generating json-schema');
     await generateSchema(dist);
     await generateSchema(dist, {
+      filename: 'renovate-inherited-schema.json',
+      isInherit: true,
+    });
+    await generateSchema(dist, {
       filename: 'renovate-global-schema.json',
       isGlobal: true,
     });

--- a/tools/validate-schema.ts
+++ b/tools/validate-schema.ts
@@ -43,6 +43,7 @@ async function validateSchemas(): Promise<void> {
   const fileGlobsToValidate = [
     'renovate-schema.json',
     'renovate-global-schema.json',
+    'renovate-inherited-schema.json',
     'tools/schemas/*.json',
   ];
   const expandedFiles: string[] = (


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
In shared preset repositories, some users will use a mix of Inherit
Config and Repo Config options with the existing JSON Schema.

As part of Renovate 43, we're removing the ability for any global
options to be usable in Repo Config, which would also mean that it's now
either a case of "ignoring warnings in my editor" and "using Global
Config JSON Schema", which isn't a great option.

We can instead create a third JSON Schema, one which is focussed on
shared presets that can include Inherit Config options.

This makes it clear that the repo config's JSON Schema should not be
used for anything Inherit Config.

## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

Alternative to https://github.com/renovatebot/renovate/pull/40681

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
