### PR TITLE
fix(self-hosted)!: don't allow any unsafe commands by default

### DIFF
--- a/docs/usage/security-and-permissions.md
+++ b/docs/usage/security-and-permissions.md
@@ -94,7 +94,7 @@ In certain scenarios, code from the monitored repository is executed as part of 
 This is particularly true during, for example:
 
 - `postUpgradeTasks`, where scripts specified by the repository are run
-- when a wrapper within the repository is called, like `gradlew`
+- when a wrapper within the repository is called, like `gradlew` (if setting [`allowedUnsafeExecutions=["gradleWrapper"]`](./self-hosted-configuration.md#allowedunsafeexecutions).
 
 These scripts can contain arbitrary code.
 This may pose a significant security risk if the repository's integrity is compromised, or if the repository maintainers have malicious intentions.

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -3136,7 +3136,7 @@ const options: Readonly<RenovateOptions>[] = [
         which run automatically, and are not explicitly added in \`postUpgradeTasks\``,
     type: 'array',
     subType: 'string',
-    default: ['gradleWrapper'],
+    default: [],
     allowedValues: ['goGenerate', 'gradleWrapper'],
     stage: 'repository',
     globalOnly: true,

--- a/lib/modules/manager/gradle-wrapper/artifacts.spec.ts
+++ b/lib/modules/manager/gradle-wrapper/artifacts.spec.ts
@@ -28,6 +28,9 @@ const adminConfig: RepoGlobalConfig = {
   localDir: upath.join('/tmp/github/some/repo'),
   cacheDir: upath.join('/tmp/cache'),
   containerbaseDir: upath.join('/tmp/cache/containerbase'),
+
+  // although not enabled by default, let's assume it is
+  allowedUnsafeExecutions: ['gradleWrapper'],
 };
 
 const config: UpdateArtifactsConfig = {

--- a/lib/modules/manager/gradle/artifacts.spec.ts
+++ b/lib/modules/manager/gradle/artifacts.spec.ts
@@ -25,6 +25,9 @@ const adminConfig: RepoGlobalConfig = {
   cacheDir: upath.join('/tmp/cache'),
   containerbaseDir: upath.join('/tmp/cache/containerbase'),
   dockerSidecarImage: 'ghcr.io/containerbase/sidecar',
+
+  // although not enabled by default, let's assume it is
+  allowedUnsafeExecutions: ['gradleWrapper'],
 };
 
 const osPlatformSpy = vi.spyOn(os, 'platform');
@@ -84,7 +87,7 @@ describe('modules/manager/gradle/artifacts', () => {
   });
 
   describe('isGradleExecutionAllowed', () => {
-    it('returns true when allowedUnsafeExecutions is empty (as it is a default option)', () => {
+    it('returns false when allowedUnsafeExecutions is empty (as it not enabled by default option)', () => {
       GlobalConfig.set({
         ...adminConfig,
         allowedUnsafeExecutions: undefined,
@@ -92,7 +95,7 @@ describe('modules/manager/gradle/artifacts', () => {
 
       const res = isGradleExecutionAllowed('gradlew');
 
-      expect(res).toBeTrue();
+      expect(res).toBeFalse();
     });
 
     it('returns true when allowedUnsafeExecutions includes `gradleWrapper`', () => {

--- a/lib/modules/manager/gradle/artifacts.ts
+++ b/lib/modules/manager/gradle/artifacts.ts
@@ -29,9 +29,7 @@ import {
 import { isGradleBuildFile } from './utils.ts';
 
 export function isGradleExecutionAllowed(command: string): boolean {
-  const allowlist = GlobalConfig.get('allowedUnsafeExecutions', [
-    'gradleWrapper',
-  ]);
+  const allowlist = GlobalConfig.get('allowedUnsafeExecutions', []);
 
   if (!allowlist.includes('gradleWrapper')) {
     logger.once.warn(


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

As a safety measure for self-hosted administrators, we can make sure
that we set `allowedUnsafeExecutions` to not allow any commands by
default.

This closes off a significant risk of executing Gradle Wrapper
commands, which use the repository's copy of the wrapper, and any
Gradle buildscript, when executing, which can lead to significant remote
code execution, even before you take into account malicious dependencies.


## Context

Please select one of the below:

- [x] This closes an existing Issue: Closes #39459
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
