### PR TITLE
feat(mise): add support for github backend

### DIFF
--- a/lib/modules/manager/mise/backends.spec.ts
+++ b/lib/modules/manager/mise/backends.spec.ts
@@ -133,7 +133,7 @@ describe('modules/manager/mise/backends', () => {
         packageName: 'some/repo',
         datasource: 'github-releases',
         currentValue: '1.0.0',
-        extractVersion: '^release-(?<version>.+)',
+        extractVersion: '^release\\-(?<version>.+)',
       });
     });
 
@@ -146,7 +146,7 @@ describe('modules/manager/mise/backends', () => {
         packageName: 'some/repo',
         datasource: 'github-releases',
         currentValue: 'v1.0.0',
-        extractVersion: '^version-(?<version>.+)',
+        extractVersion: '^version\\-(?<version>.+)',
       });
     });
 

--- a/lib/modules/manager/mise/backends.spec.ts
+++ b/lib/modules/manager/mise/backends.spec.ts
@@ -117,15 +117,6 @@ describe('modules/manager/mise/backends', () => {
       });
     });
 
-    it('should set extractVersion if the version does not have leading v', () => {
-      expect(createGithubToolConfig('cli/cli', '2.64.0', {})).toStrictEqual({
-        packageName: 'cli/cli',
-        datasource: 'github-releases',
-        currentValue: '2.64.0',
-        extractVersion: '^v?(?<version>.+)',
-      });
-    });
-
     it('should not set extractVersion if the version has leading v', () => {
       expect(createGithubToolConfig('cli/cli', 'v2.64.0', {})).toStrictEqual({
         packageName: 'cli/cli',

--- a/lib/modules/manager/mise/backends.spec.ts
+++ b/lib/modules/manager/mise/backends.spec.ts
@@ -113,7 +113,6 @@ describe('modules/manager/mise/backends', () => {
         packageName: 'BurntSushi/ripgrep',
         datasource: 'github-releases',
         currentValue: '14.1.1',
-        extractVersion: '^v?(?<version>.+)',
       });
     });
 
@@ -158,7 +157,6 @@ describe('modules/manager/mise/backends', () => {
         packageName: 'some/repo',
         datasource: 'github-releases',
         currentValue: '1.0.0',
-        extractVersion: '^(?<version>.+)',
       });
     });
 

--- a/lib/modules/manager/mise/backends.spec.ts
+++ b/lib/modules/manager/mise/backends.spec.ts
@@ -3,6 +3,7 @@ import {
   createCargoToolConfig,
   createDotnetToolConfig,
   createGemToolConfig,
+  createGithubToolConfig,
   createGoToolConfig,
   createNpmToolConfig,
   createPipxToolConfig,
@@ -100,6 +101,109 @@ describe('modules/manager/mise/backends', () => {
       expect(createGemToolConfig('rubocop')).toStrictEqual({
         packageName: 'rubocop',
         datasource: 'rubygems',
+      });
+    });
+  });
+
+  describe('createGithubToolConfig()', () => {
+    it('should create a tooling config with empty options', () => {
+      expect(
+        createGithubToolConfig('BurntSushi/ripgrep', '14.1.1', {}),
+      ).toStrictEqual({
+        packageName: 'BurntSushi/ripgrep',
+        datasource: 'github-releases',
+        currentValue: '14.1.1',
+        extractVersion: '^v?(?<version>.+)',
+      });
+    });
+
+    it('should set extractVersion if the version does not have leading v', () => {
+      expect(createGithubToolConfig('cli/cli', '2.64.0', {})).toStrictEqual({
+        packageName: 'cli/cli',
+        datasource: 'github-releases',
+        currentValue: '2.64.0',
+        extractVersion: '^v?(?<version>.+)',
+      });
+    });
+
+    it('should not set extractVersion if the version has leading v', () => {
+      expect(createGithubToolConfig('cli/cli', 'v2.64.0', {})).toStrictEqual({
+        packageName: 'cli/cli',
+        datasource: 'github-releases',
+        currentValue: 'v2.64.0',
+      });
+    });
+
+    it('should set extractVersion with custom version_prefix', () => {
+      expect(
+        createGithubToolConfig('some/repo', '1.0.0', {
+          version_prefix: 'release-',
+        }),
+      ).toStrictEqual({
+        packageName: 'some/repo',
+        datasource: 'github-releases',
+        currentValue: '1.0.0',
+        extractVersion: '^release-(?<version>.+)',
+      });
+    });
+
+    it('should set extractVersion with version_prefix even if version has leading v', () => {
+      expect(
+        createGithubToolConfig('some/repo', 'v1.0.0', {
+          version_prefix: 'version-',
+        }),
+      ).toStrictEqual({
+        packageName: 'some/repo',
+        datasource: 'github-releases',
+        currentValue: 'v1.0.0',
+        extractVersion: '^version-(?<version>.+)',
+      });
+    });
+
+    it('should handle empty version_prefix with version not having v', () => {
+      expect(
+        createGithubToolConfig('some/repo', '1.0.0', { version_prefix: '' }),
+      ).toStrictEqual({
+        packageName: 'some/repo',
+        datasource: 'github-releases',
+        currentValue: '1.0.0',
+        extractVersion: '^(?<version>.+)',
+      });
+    });
+
+    it('should handle empty version_prefix with version having v', () => {
+      expect(
+        createGithubToolConfig('some/repo', 'v1.0.0', { version_prefix: '' }),
+      ).toStrictEqual({
+        packageName: 'some/repo',
+        datasource: 'github-releases',
+        currentValue: 'v1.0.0',
+      });
+    });
+
+    it('should escape special regex characters in version_prefix', () => {
+      expect(
+        createGithubToolConfig('some/repo', '1.0.0', {
+          version_prefix: 'v1.0+',
+        }),
+      ).toStrictEqual({
+        packageName: 'some/repo',
+        datasource: 'github-releases',
+        currentValue: '1.0.0',
+        extractVersion: '^v1\\.0\\+(?<version>.+)',
+      });
+    });
+
+    it('should escape brackets and parentheses in version_prefix', () => {
+      expect(
+        createGithubToolConfig('some/repo', '1.0.0', {
+          version_prefix: 'prefix[test](v)',
+        }),
+      ).toStrictEqual({
+        packageName: 'some/repo',
+        datasource: 'github-releases',
+        currentValue: '1.0.0',
+        extractVersion: '^prefix\\[test\\]\\(v\\)(?<version>.+)',
       });
     });
   });

--- a/lib/modules/manager/mise/backends.ts
+++ b/lib/modules/manager/mise/backends.ts
@@ -4,7 +4,7 @@ import {
   isUndefined,
   isUrlString,
 } from '@sindresorhus/is';
-import { regEx } from '../../../util/regex.ts';
+import { escapeRegExp, regEx } from '../../../util/regex.ts';
 import { CrateDatasource } from '../../datasource/crate/index.ts';
 import { GitRefsDatasource } from '../../datasource/git-refs/index.ts';
 import { GitTagsDatasource } from '../../datasource/git-tags/index.ts';
@@ -128,16 +128,14 @@ export function createGithubToolConfig(
   const prefix = toolOptions.version_prefix;
 
   if (isNonEmptyString(prefix)) {
-    // Custom prefix - escape special regex chars
-    const escapedPrefix = prefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    extractVersion = `^${escapedPrefix}(?<version>.+)`;
+    extractVersion = `^${escapeRegExp(prefix)}(?<version>.+)`;
   }
 
   return {
     packageName: name,
     datasource: GithubReleasesDatasource.id,
     currentValue: version,
-    ...(isString(extractVersion) ? { extractVersion } : {}),
+    ...(extractVersion && { extractVersion }),
   };
 }
 

--- a/lib/modules/manager/mise/backends.ts
+++ b/lib/modules/manager/mise/backends.ts
@@ -111,6 +111,43 @@ export function createGemToolConfig(name: string): BackendToolingConfig {
 }
 
 /**
+ * Create a tooling config for github backend
+ * @link https://mise.jdx.dev/dev-tools/backends/github.html
+ */
+export function createGithubToolConfig(
+  name: string,
+  version: string,
+  toolOptions: MiseToolOptions,
+): BackendToolingConfig {
+  let extractVersion: string | undefined = undefined;
+  const hasVPrefix = version.startsWith('v');
+
+  if (isString(toolOptions.version_prefix)) {
+    const prefix = toolOptions.version_prefix;
+    if (prefix === '') {
+      // Empty prefix - no extractVersion needed if version has 'v'
+      if (!hasVPrefix) {
+        extractVersion = '^(?<version>.+)';
+      }
+    } else {
+      // Custom prefix - escape special regex chars
+      const escapedPrefix = prefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      extractVersion = `^${escapedPrefix}(?<version>.+)`;
+    }
+  } else if (!hasVPrefix) {
+    // Default: strip 'v' prefix if current version doesn't have it
+    extractVersion = '^v?(?<version>.+)';
+  }
+
+  return {
+    packageName: name,
+    datasource: GithubReleasesDatasource.id,
+    currentValue: version,
+    ...(isString(extractVersion) ? { extractVersion } : {}),
+  };
+}
+
+/**
  * Create a tooling config for go backend
  * @link https://mise.jdx.dev/dev-tools/backends/go.html
  */

--- a/lib/modules/manager/mise/backends.ts
+++ b/lib/modules/manager/mise/backends.ts
@@ -1,4 +1,10 @@
-import { isString, isUndefined, isUrlString } from '@sindresorhus/is';
+import {
+  isEmptyString,
+  isNonEmptyString,
+  isString,
+  isUndefined,
+  isUrlString,
+} from '@sindresorhus/is';
 import { regEx } from '../../../util/regex.ts';
 import { CrateDatasource } from '../../datasource/crate/index.ts';
 import { GitRefsDatasource } from '../../datasource/git-refs/index.ts';
@@ -121,19 +127,15 @@ export function createGithubToolConfig(
 ): BackendToolingConfig {
   let extractVersion: string | undefined = undefined;
   const hasVPrefix = version.startsWith('v');
+  const prefix = toolOptions.version_prefix;
 
-  if (isString(toolOptions.version_prefix)) {
-    const prefix = toolOptions.version_prefix;
-    if (prefix === '') {
-      // Empty prefix - no extractVersion needed if version has 'v'
-      if (!hasVPrefix) {
-        extractVersion = '^(?<version>.+)';
-      }
-    } else {
-      // Custom prefix - escape special regex chars
-      const escapedPrefix = prefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-      extractVersion = `^${escapedPrefix}(?<version>.+)`;
-    }
+  if (isNonEmptyString(prefix)) {
+    // Custom prefix - escape special regex chars
+    const escapedPrefix = prefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    extractVersion = `^${escapedPrefix}(?<version>.+)`;
+  } else if (isEmptyString(prefix) && !hasVPrefix) {
+    // Empty prefix - no extractVersion needed if version starts with 'v'
+    extractVersion = '^(?<version>.+)';
   } else if (!hasVPrefix) {
     // Default: strip 'v' prefix if current version doesn't have it
     extractVersion = '^v?(?<version>.+)';

--- a/lib/modules/manager/mise/backends.ts
+++ b/lib/modules/manager/mise/backends.ts
@@ -1,5 +1,4 @@
 import {
-  isEmptyString,
   isNonEmptyString,
   isString,
   isUndefined,
@@ -126,19 +125,12 @@ export function createGithubToolConfig(
   toolOptions: MiseToolOptions,
 ): BackendToolingConfig {
   let extractVersion: string | undefined = undefined;
-  const hasVPrefix = version.startsWith('v');
   const prefix = toolOptions.version_prefix;
 
   if (isNonEmptyString(prefix)) {
     // Custom prefix - escape special regex chars
     const escapedPrefix = prefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     extractVersion = `^${escapedPrefix}(?<version>.+)`;
-  } else if (isEmptyString(prefix) && !hasVPrefix) {
-    // Empty prefix - no extractVersion needed if version starts with 'v'
-    extractVersion = '^(?<version>.+)';
-  } else if (!hasVPrefix) {
-    // Default: strip 'v' prefix if current version doesn't have it
-    extractVersion = '^v?(?<version>.+)';
   }
 
   return {

--- a/lib/modules/manager/mise/extract.spec.ts
+++ b/lib/modules/manager/mise/extract.spec.ts
@@ -712,7 +712,7 @@ describe('modules/manager/mise/extract', () => {
             currentValue: '1.0.0',
             packageName: 'some/repo',
             datasource: 'github-releases',
-            extractVersion: '^release-(?<version>.+)',
+            extractVersion: '^release\\-(?<version>.+)',
           },
           {
             depName: 'github:other/repo',

--- a/lib/modules/manager/mise/extract.spec.ts
+++ b/lib/modules/manager/mise/extract.spec.ts
@@ -684,6 +684,48 @@ describe('modules/manager/mise/extract', () => {
       });
     });
 
+    it('extracts github backend tools', () => {
+      const content = codeBlock`
+      [tools]
+      "github:BurntSushi/ripgrep" = "14.1.1"
+      "github:cli/cli" = "v2.64.0"
+      "github:some/repo" = { version_prefix = "release-", version = "1.0.0" }
+      "github:other/repo[version_prefix=v]" = "2.0.0"
+    `;
+      const result = extractPackageFile(content, miseFilename);
+      expect(result).toMatchObject({
+        deps: [
+          {
+            depName: 'github:BurntSushi/ripgrep',
+            currentValue: '14.1.1',
+            packageName: 'BurntSushi/ripgrep',
+            datasource: 'github-releases',
+            extractVersion: '^v?(?<version>.+)',
+          },
+          {
+            depName: 'github:cli/cli',
+            currentValue: 'v2.64.0',
+            packageName: 'cli/cli',
+            datasource: 'github-releases',
+          },
+          {
+            depName: 'github:some/repo',
+            currentValue: '1.0.0',
+            packageName: 'some/repo',
+            datasource: 'github-releases',
+            extractVersion: '^release-(?<version>.+)',
+          },
+          {
+            depName: 'github:other/repo',
+            currentValue: '2.0.0',
+            packageName: 'other/repo',
+            datasource: 'github-releases',
+            extractVersion: '^v(?<version>.+)',
+          },
+        ],
+      });
+    });
+
     it('provides skipReason for lines with unsupported tooling', () => {
       const content = codeBlock`
       [tools]

--- a/lib/modules/manager/mise/extract.spec.ts
+++ b/lib/modules/manager/mise/extract.spec.ts
@@ -700,7 +700,6 @@ describe('modules/manager/mise/extract', () => {
             currentValue: '14.1.1',
             packageName: 'BurntSushi/ripgrep',
             datasource: 'github-releases',
-            extractVersion: '^v?(?<version>.+)',
           },
           {
             depName: 'github:cli/cli',

--- a/lib/modules/manager/mise/extract.ts
+++ b/lib/modules/manager/mise/extract.ts
@@ -16,6 +16,7 @@ import {
   createCargoToolConfig,
   createDotnetToolConfig,
   createGemToolConfig,
+  createGithubToolConfig,
   createGoToolConfig,
   createNpmToolConfig,
   createPipxToolConfig,
@@ -134,6 +135,8 @@ function getToolConfig(
       return createDotnetToolConfig(toolName);
     case 'gem':
       return createGemToolConfig(toolName);
+    case 'github':
+      return createGithubToolConfig(toolName, version, toolOptions);
     case 'go':
       return createGoToolConfig(toolName);
     case 'npm':

--- a/lib/modules/manager/mise/index.ts
+++ b/lib/modules/manager/mise/index.ts
@@ -44,6 +44,7 @@ const backendDatasources = {
   cargo: [CrateDatasource.id, GitTagsDatasource.id, GitRefsDatasource.id],
   dotnet: [NugetDatasource.id],
   gem: [RubygemsDatasource.id],
+  github: [GithubReleasesDatasource.id],
   go: [GoDatasource.id],
   npm: [NpmDatasource.id],
   pipx: [PypiDatasource.id, GithubTagsDatasource.id, GitRefsDatasource.id],

--- a/lib/modules/manager/mise/readme.md
+++ b/lib/modules/manager/mise/readme.md
@@ -62,6 +62,8 @@ Renovate's `mise` manager supports the following [backends](https://mise.jdx.dev
 - [`asdf`](https://mise.jdx.dev/dev-tools/backends/asdf.html)
 - [`aqua`](https://mise.jdx.dev/dev-tools/backends/aqua.html)
 - [`cargo`](https://mise.jdx.dev/dev-tools/backends/cargo.html)
+- [`gem`](https://mise.jdx.dev/dev-tools/backends/gem.html)
+- [`github`](https://mise.jdx.dev/dev-tools/backends/github.html)
 - [`go`](https://mise.jdx.dev/dev-tools/backends/go.html)
 - [`npm`](https://mise.jdx.dev/dev-tools/backends/npm.html)
 - [`pipx`](https://mise.jdx.dev/dev-tools/backends/pipx.html)
@@ -98,6 +100,10 @@ Renovate's `mise` manager does not support the following tool syntax:
 
 - Some of `ubi` backend tools with [`tag_regex`](https://mise.jdx.dev/dev-tools/backends/ubi.html#ubi-uses-weird-versions) option.
   The `tag_regex` option is used as `extractVersion`, but the regex engines are not the same between mise and Renovate.
+  If the version is not updated or updated incorrectly, override `extractVersion` manually in the Renovate config.
+
+- Some of `github` backend tools with [`version_prefix`](https://mise.jdx.dev/dev-tools/backends/github.html) option.
+  The `version_prefix` option is converted to `extractVersion` by escaping special regex characters.
   If the version is not updated or updated incorrectly, override `extractVersion` manually in the Renovate config.
 
 ### Supported default registry tool short names

--- a/lib/modules/manager/mise/schema.ts
+++ b/lib/modules/manager/mise/schema.ts
@@ -4,6 +4,8 @@ import { Toml } from '../../../util/schema-utils/index.ts';
 const MiseToolOptions = z.object({
   // ubi backend only
   tag_regex: z.string().optional(),
+  // github backend only
+  version_prefix: z.string().optional(),
 });
 export type MiseToolOptions = z.infer<typeof MiseToolOptions>;
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This pull request adds support for the [mise `github` backend](https://mise.jdx.dev/dev-tools/backends/github.html). This is similar to the `ubi` backend except the version constraints allowed for it seem to be more limited.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [X] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [X] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

I used Claude Code to help with this PR. In particular, it helped significantly with the tests and making sure everything outside of the core logic was updated appropriately.

## Documentation (please check one with an [x])

- [X] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [X] Both unit tests + ran on a real repository

The public repository:

I tested it against our internal GitHub Enterprise Server instance.

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
