### PR TITLE
refactor: Extract decorator logic into standalone functions

### DIFF
--- a/lib/instrumentation/decorator.spec.ts
+++ b/lib/instrumentation/decorator.spec.ts
@@ -5,52 +5,31 @@ afterAll(disableInstrumentations);
 
 describe('instrumentation/decorator', () => {
   describe('instrument', () => {
-    const spy = vi.fn(() => Promise.resolve());
+    it('should decorate class method', async () => {
+      const spy = vi.fn(() => Promise.resolve(42));
 
-    it('should instrument async function', async () => {
       class MyClass {
         @instrument({ name: 'getNumber' })
         public async getNumber(): Promise<number> {
-          await spy();
-          return Math.random();
+          return await spy();
         }
       }
+
       const myClass = new MyClass();
       const result = await myClass.getNumber();
 
-      expect(result).toBeDefined();
-      expect(result).toBeNumber();
-
+      expect(result).toBe(42);
       expect(spy).toHaveBeenCalledTimes(1);
-    });
-
-    it('should instrument multiple async function calls', async () => {
-      class MyClass {
-        @instrument({ name: 'getNumber' })
-        public async getNumber(): Promise<number> {
-          await spy();
-          return Math.random();
-        }
-      }
-      const myClass = new MyClass();
-      await myClass.getNumber();
-      await myClass.getNumber();
-      const result = await myClass.getNumber();
-
-      expect(result).toBeDefined();
-      expect(result).toBeNumber();
-
-      expect(spy).toHaveBeenCalledTimes(3);
     });
   });
 
   describe('instrumentStandalone', () => {
-    const spy = vi.fn(() => Promise.resolve('ok'));
+    it('should wrap standalone function', async () => {
+      const spy = vi.fn(() => Promise.resolve('ok'));
 
-    it('should instrument a standalone async function', async () => {
       const fn = instrumentStandalone(
         { name: 'standaloneTest' },
-        async function testFn(arg: string) {
+        async (arg: string) => {
           await spy();
           return `hello ${arg}`;
         },
@@ -58,20 +37,6 @@ describe('instrumentation/decorator', () => {
 
       const result = await fn('world');
       expect(result).toBe('hello world');
-      expect(spy).toHaveBeenCalledTimes(1);
-    });
-
-    it('should pass all arguments to the wrapped function', async () => {
-      const fn = instrumentStandalone(
-        { name: 'multiArgTest' },
-        async function testFn(a: number, b: number) {
-          await spy();
-          return a + b;
-        },
-      );
-
-      const result = await fn(2, 3);
-      expect(result).toBe(5);
       expect(spy).toHaveBeenCalledTimes(1);
     });
   });

--- a/lib/instrumentation/instrumented.spec.ts
+++ b/lib/instrumentation/instrumented.spec.ts
@@ -1,0 +1,51 @@
+import { disableInstrumentations } from './index.ts';
+import { instrumented } from './instrumented.ts';
+
+afterAll(disableInstrumentations);
+
+describe('instrumentation/instrumented', () => {
+  it('instruments async function', async () => {
+    const spy = vi.fn(() => Promise.resolve(42));
+
+    const result = await instrumented({ name: 'test-span' }, spy);
+
+    expect(result).toBe(42);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('instruments multiple calls', async () => {
+    const spy = vi.fn(() => Promise.resolve('ok'));
+
+    await instrumented({ name: 'test-span' }, spy);
+    await instrumented({ name: 'test-span' }, spy);
+    const result = await instrumented({ name: 'test-span' }, spy);
+
+    expect(result).toBe('ok');
+    expect(spy).toHaveBeenCalledTimes(3);
+  });
+
+  it('propagates errors', async () => {
+    const spy = vi.fn(() => Promise.reject(new Error('test error')));
+
+    await expect(instrumented({ name: 'test-span' }, spy)).rejects.toThrow(
+      'test error',
+    );
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('accepts options', async () => {
+    const spy = vi.fn(() => Promise.resolve('result'));
+
+    const result = await instrumented(
+      {
+        name: 'test-span',
+        attributes: { 'custom.attr': 'value' },
+        ignoreParentSpan: true,
+      },
+      spy,
+    );
+
+    expect(result).toBe('result');
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/lib/instrumentation/instrumented.ts
+++ b/lib/instrumentation/instrumented.ts
@@ -1,0 +1,45 @@
+import type { SpanKind } from '@opentelemetry/api';
+import { instrument } from './index.ts';
+import type { RenovateSpanAttributes } from './types.ts';
+
+interface InstrumentedOptions {
+  /**
+   * The name of the span.
+   */
+  name: string;
+
+  /**
+   * Attributes to add to the span.
+   */
+  attributes?: RenovateSpanAttributes;
+
+  /**
+   * When true, creates a root span instead of a child of the current span.
+   * @default false
+   */
+  ignoreParentSpan?: boolean;
+
+  /**
+   * Type of span. Default: SpanKind.INTERNAL
+   */
+  kind?: SpanKind;
+}
+
+/**
+ * Wraps an async function in an OpenTelemetry span.
+ *
+ * @param options - Instrumentation options
+ * @param fn - The async function to instrument
+ * @returns The result of the function
+ */
+export function instrumented<T>(
+  options: InstrumentedOptions,
+  fn: () => T | Promise<T>,
+): T | Promise<T> {
+  const { name, attributes, ignoreParentSpan, kind } = options;
+  return instrument(name, fn, {
+    attributes,
+    root: ignoreParentSpan,
+    kind,
+  });
+}

--- a/lib/util/cache/package/cached.spec.ts
+++ b/lib/util/cache/package/cached.spec.ts
@@ -1,0 +1,424 @@
+import { GlobalConfig } from '../../../config/global.ts';
+import * as memCache from '../memory/index.ts';
+import { cached } from './cached.ts';
+import * as file from './file.ts';
+import * as packageCache from './index.ts';
+
+vi.mock('./file.ts');
+
+describe('util/cache/package/cached', () => {
+  const setCache = file.set;
+  const getValue = vi.fn();
+  let count = 1;
+
+  beforeEach(async () => {
+    vi.useRealTimers();
+    GlobalConfig.reset();
+    memCache.init();
+    await packageCache.init({ cacheDir: 'some-dir' });
+    count = 1;
+    getValue.mockImplementation(() => {
+      const res = String(100 * count + 10 * count + count);
+      count += 1;
+      return Promise.resolve(res);
+    });
+  });
+
+  it('caches string result', async () => {
+    const fn = () => getValue();
+
+    expect(
+      await cached({ namespace: '_test-namespace', key: 'some-key' }, fn),
+    ).toBe('111');
+    expect(
+      await cached({ namespace: '_test-namespace', key: 'some-key' }, fn),
+    ).toBe('111');
+    expect(
+      await cached({ namespace: '_test-namespace', key: 'some-key' }, fn),
+    ).toBe('111');
+
+    expect(getValue).toHaveBeenCalledTimes(1);
+    expect(setCache).toHaveBeenCalledExactlyOnceWith(
+      '_test-namespace',
+      'cache-decorator:some-key',
+      { cachedAt: expect.any(String), value: '111' },
+      30,
+    );
+  });
+
+  it('disables cache if cacheable is false', async () => {
+    const fn = () => getValue();
+
+    expect(
+      await cached(
+        { namespace: '_test-namespace', key: 'key', cacheable: false },
+        fn,
+      ),
+    ).toBe('111');
+    expect(
+      await cached(
+        { namespace: '_test-namespace', key: 'key', cacheable: false },
+        fn,
+      ),
+    ).toBe('222');
+    expect(
+      await cached(
+        { namespace: '_test-namespace', key: 'key', cacheable: false },
+        fn,
+      ),
+    ).toBe('333');
+
+    expect(getValue).toHaveBeenCalledTimes(3);
+    expect(setCache).not.toHaveBeenCalled();
+  });
+
+  it('forces cache if cachePrivatePackages=true', async () => {
+    GlobalConfig.set({ cachePrivatePackages: true });
+    const fn = () => getValue();
+
+    expect(
+      await cached(
+        { namespace: '_test-namespace', key: 'key', cacheable: false },
+        fn,
+      ),
+    ).toBe('111');
+    expect(
+      await cached(
+        { namespace: '_test-namespace', key: 'key', cacheable: false },
+        fn,
+      ),
+    ).toBe('111');
+    expect(
+      await cached(
+        { namespace: '_test-namespace', key: 'key', cacheable: false },
+        fn,
+      ),
+    ).toBe('111');
+
+    expect(getValue).toHaveBeenCalledTimes(1);
+    expect(setCache).toHaveBeenCalledExactlyOnceWith(
+      '_test-namespace',
+      'cache-decorator:key',
+      { cachedAt: expect.any(String), value: '111' },
+      30,
+    );
+  });
+
+  it('caches null values', async () => {
+    const fn = async (): Promise<string | null> => {
+      await getValue();
+      return null;
+    };
+
+    expect(
+      await cached({ namespace: '_test-namespace', key: 'key' }, fn),
+    ).toBeNull();
+    expect(
+      await cached({ namespace: '_test-namespace', key: 'key' }, fn),
+    ).toBeNull();
+    expect(
+      await cached({ namespace: '_test-namespace', key: 'key' }, fn),
+    ).toBeNull();
+
+    expect(getValue).toHaveBeenCalledTimes(1);
+    expect(setCache).toHaveBeenCalledExactlyOnceWith(
+      '_test-namespace',
+      'cache-decorator:key',
+      { cachedAt: expect.any(String), value: null },
+      30,
+    );
+  });
+
+  it('does not cache undefined', async () => {
+    const fn = async (): Promise<string | undefined> => {
+      await getValue();
+      return undefined;
+    };
+
+    expect(
+      await cached({ namespace: '_test-namespace', key: 'key' }, fn),
+    ).toBeUndefined();
+    expect(
+      await cached({ namespace: '_test-namespace', key: 'key' }, fn),
+    ).toBeUndefined();
+    expect(
+      await cached({ namespace: '_test-namespace', key: 'key' }, fn),
+    ).toBeUndefined();
+
+    expect(getValue).toHaveBeenCalledTimes(3);
+    expect(setCache).not.toHaveBeenCalled();
+  });
+
+  it('uses custom ttlMinutes', async () => {
+    const fn = () => getValue();
+
+    expect(
+      await cached(
+        { namespace: '_test-namespace', key: 'key', ttlMinutes: 60 },
+        fn,
+      ),
+    ).toBe('111');
+
+    expect(setCache).toHaveBeenCalledExactlyOnceWith(
+      '_test-namespace',
+      'cache-decorator:key',
+      { cachedAt: expect.any(String), value: '111' },
+      60,
+    );
+  });
+
+  describe('fallback with hard TTL', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      GlobalConfig.set({ cacheHardTtlMinutes: 2 });
+    });
+
+    it('updates cached result after soft TTL expires', async () => {
+      const fn = () => getValue();
+
+      expect(
+        await cached(
+          {
+            namespace: '_test-namespace',
+            key: 'key',
+            ttlMinutes: 1,
+            fallback: true,
+          },
+          fn,
+        ),
+      ).toBe('111');
+      expect(getValue).toHaveBeenCalledTimes(1);
+
+      vi.advanceTimersByTime(60 * 1000 - 1);
+      expect(
+        await cached(
+          {
+            namespace: '_test-namespace',
+            key: 'key',
+            ttlMinutes: 1,
+            fallback: true,
+          },
+          fn,
+        ),
+      ).toBe('111');
+      expect(getValue).toHaveBeenCalledTimes(1);
+      expect(setCache).toHaveBeenLastCalledWith(
+        '_test-namespace',
+        'cache-decorator:key',
+        { cachedAt: expect.any(String), value: '111' },
+        2,
+      );
+
+      vi.advanceTimersByTime(1);
+      expect(
+        await cached(
+          {
+            namespace: '_test-namespace',
+            key: 'key',
+            ttlMinutes: 1,
+            fallback: true,
+          },
+          fn,
+        ),
+      ).toBe('222');
+      expect(getValue).toHaveBeenCalledTimes(2);
+      expect(setCache).toHaveBeenLastCalledWith(
+        '_test-namespace',
+        'cache-decorator:key',
+        { cachedAt: expect.any(String), value: '222' },
+        2,
+      );
+    });
+
+    it('overrides soft ttl and updates result', async () => {
+      GlobalConfig.set({
+        cacheTtlOverride: { '_test-namespace': 2 },
+        cacheHardTtlMinutes: 3,
+      });
+      const fn = () => getValue();
+
+      expect(
+        await cached(
+          {
+            namespace: '_test-namespace',
+            key: 'key',
+            ttlMinutes: 1,
+            fallback: true,
+          },
+          fn,
+        ),
+      ).toBe('111');
+      expect(getValue).toHaveBeenCalledTimes(1);
+      expect(setCache).toHaveBeenLastCalledWith(
+        '_test-namespace',
+        'cache-decorator:key',
+        { cachedAt: expect.any(String), value: '111' },
+        3,
+      );
+
+      vi.advanceTimersByTime(120 * 1000 - 1);
+      expect(
+        await cached(
+          {
+            namespace: '_test-namespace',
+            key: 'key',
+            ttlMinutes: 1,
+            fallback: true,
+          },
+          fn,
+        ),
+      ).toBe('111');
+      expect(getValue).toHaveBeenCalledTimes(1);
+      expect(setCache).toHaveBeenCalledTimes(1);
+
+      vi.advanceTimersByTime(1);
+      expect(
+        await cached(
+          {
+            namespace: '_test-namespace',
+            key: 'key',
+            ttlMinutes: 1,
+            fallback: true,
+          },
+          fn,
+        ),
+      ).toBe('222');
+      expect(getValue).toHaveBeenCalledTimes(2);
+      expect(setCache).toHaveBeenLastCalledWith(
+        '_test-namespace',
+        'cache-decorator:key',
+        { cachedAt: expect.any(String), value: '222' },
+        3,
+      );
+    });
+
+    it('returns stale result on error', async () => {
+      const fn = () => getValue();
+
+      expect(
+        await cached(
+          {
+            namespace: '_test-namespace',
+            key: 'key',
+            ttlMinutes: 1,
+            fallback: true,
+          },
+          fn,
+        ),
+      ).toBe('111');
+      expect(getValue).toHaveBeenCalledTimes(1);
+      expect(setCache).toHaveBeenLastCalledWith(
+        '_test-namespace',
+        'cache-decorator:key',
+        { cachedAt: expect.any(String), value: '111' },
+        2,
+      );
+
+      vi.advanceTimersByTime(60 * 1000);
+      getValue.mockRejectedValueOnce(new Error('test'));
+      expect(
+        await cached(
+          {
+            namespace: '_test-namespace',
+            key: 'key',
+            ttlMinutes: 1,
+            fallback: true,
+          },
+          fn,
+        ),
+      ).toBe('111');
+      expect(getValue).toHaveBeenCalledTimes(2);
+      expect(setCache).toHaveBeenCalledTimes(1);
+    });
+
+    it('drops stale value after hard TTL expires', async () => {
+      const fn = () => getValue();
+
+      expect(
+        await cached(
+          {
+            namespace: '_test-namespace',
+            key: 'key',
+            ttlMinutes: 1,
+            fallback: true,
+          },
+          fn,
+        ),
+      ).toBe('111');
+      expect(getValue).toHaveBeenCalledTimes(1);
+      expect(setCache).toHaveBeenLastCalledWith(
+        '_test-namespace',
+        'cache-decorator:key',
+        { cachedAt: expect.any(String), value: '111' },
+        2,
+      );
+
+      vi.advanceTimersByTime(2 * 60 * 1000 - 1);
+      getValue.mockRejectedValueOnce(new Error('test'));
+      expect(
+        await cached(
+          {
+            namespace: '_test-namespace',
+            key: 'key',
+            ttlMinutes: 1,
+            fallback: true,
+          },
+          fn,
+        ),
+      ).toBe('111');
+
+      vi.advanceTimersByTime(1);
+      getValue.mockRejectedValueOnce(new Error('test'));
+      await expect(
+        cached(
+          {
+            namespace: '_test-namespace',
+            key: 'key',
+            ttlMinutes: 1,
+            fallback: true,
+          },
+          fn,
+        ),
+      ).rejects.toThrow('test');
+    });
+
+    it('does not use fallback when fallback=false', async () => {
+      const fn = () => getValue();
+
+      expect(
+        await cached(
+          {
+            namespace: '_test-namespace',
+            key: 'key',
+            ttlMinutes: 1,
+            fallback: false,
+          },
+          fn,
+        ),
+      ).toBe('111');
+      expect(getValue).toHaveBeenCalledTimes(1);
+      // Without fallback, hard TTL equals soft TTL
+      expect(setCache).toHaveBeenLastCalledWith(
+        '_test-namespace',
+        'cache-decorator:key',
+        { cachedAt: expect.any(String), value: '111' },
+        1,
+      );
+
+      vi.advanceTimersByTime(60 * 1000);
+      getValue.mockRejectedValueOnce(new Error('test'));
+      // Error should propagate since fallback is disabled
+      await expect(
+        cached(
+          {
+            namespace: '_test-namespace',
+            key: 'key',
+            ttlMinutes: 1,
+            fallback: false,
+          },
+          fn,
+        ),
+      ).rejects.toThrow('test');
+    });
+  });
+});

--- a/lib/util/cache/package/cached.ts
+++ b/lib/util/cache/package/cached.ts
@@ -1,0 +1,144 @@
+import { isUndefined } from '@sindresorhus/is';
+import { DateTime } from 'luxon';
+import { GlobalConfig } from '../../../config/global.ts';
+import { logger } from '../../../logger/index.ts';
+import { acquireLock } from '../../mutex.ts';
+import * as packageCache from './index.ts';
+import { resolveTtlValues } from './ttl.ts';
+import type { DecoratorCachedRecord, PackageCacheNamespace } from './types.ts';
+
+interface CachedOptions {
+  /**
+   * The cache namespace.
+   */
+  namespace: PackageCacheNamespace;
+
+  /**
+   * The cache key.
+   */
+  key: string;
+
+  /**
+   * The TTL (or expiry) of the key in minutes.
+   * @default 30
+   */
+  ttlMinutes?: number;
+
+  /**
+   * Whether caching is enabled for this call.
+   * When false, the function is called directly without caching.
+   * @default true
+   */
+  cacheable?: boolean;
+
+  /**
+   * Enable extended hard TTL for graceful degradation.
+   * When true and upstream errors occur, stale cached data is returned.
+   * @default false
+   */
+  fallback?: boolean;
+}
+
+/**
+ * Caches the result of an async function.
+ *
+ * @param options - Cache options
+ * @param fn - The async function to cache
+ * @returns The cached or fresh result
+ */
+export async function cached<T>(
+  options: CachedOptions,
+  fn: () => T | Promise<T>,
+): Promise<T> {
+  const {
+    namespace,
+    key,
+    ttlMinutes = 30,
+    cacheable = true,
+    fallback = false,
+  } = options;
+
+  const cachePrivatePackages = GlobalConfig.get('cachePrivatePackages', false);
+  const isCacheable = cachePrivatePackages || cacheable;
+  if (!isCacheable) {
+    return fn();
+  }
+
+  // istanbul ignore if
+  if (!namespace || !key) {
+    return fn();
+  }
+
+  const cacheKey = `cache-decorator:${key}`;
+
+  // prevent concurrent processing and cache writes
+  const releaseLock = await acquireLock(cacheKey, namespace);
+
+  try {
+    const cachedRecord = await packageCache.get<DecoratorCachedRecord>(
+      namespace,
+      cacheKey,
+    );
+
+    const { softTtlMinutes, hardTtlMinutes: resolvedHardTtl } =
+      resolveTtlValues(namespace, ttlMinutes);
+
+    // The separation between "soft" and "hard" TTL allows us to treat
+    // data as obsolete according to the "soft" TTL while physically storing it
+    // according to the "hard" TTL.
+    //
+    // This helps us return obsolete data in case of upstream server errors,
+    // which is more useful than throwing exceptions ourselves.
+    //
+    // The `fallback` option controls whether this extended TTL behavior is used.
+    // When false, the "soft" just equals the "hard" ttl.
+    const hardTtlMinutes = fallback ? resolvedHardTtl : softTtlMinutes;
+
+    let fallbackValue: unknown;
+    if (cachedRecord) {
+      const now = DateTime.local();
+      const cachedAt = DateTime.fromISO(cachedRecord.cachedAt);
+
+      const softDeadline = cachedAt.plus({ minutes: softTtlMinutes });
+      if (now < softDeadline) {
+        return cachedRecord.value as T;
+      }
+
+      const hardDeadline = cachedAt.plus({ minutes: hardTtlMinutes });
+      if (now < hardDeadline) {
+        fallbackValue = cachedRecord.value;
+      }
+    }
+
+    let newValue: T;
+    try {
+      newValue = await fn();
+    } catch (err) {
+      if (!isUndefined(fallbackValue)) {
+        logger.debug(
+          { err },
+          'Package cache: callback error, returning stale data',
+        );
+        return fallbackValue as T;
+      }
+      throw err;
+    }
+
+    if (!isUndefined(newValue)) {
+      const newRecord: DecoratorCachedRecord = {
+        cachedAt: DateTime.local().toISO(),
+        value: newValue,
+      };
+      await packageCache.setWithRawTtl(
+        namespace,
+        cacheKey,
+        newRecord,
+        hardTtlMinutes,
+      );
+    }
+
+    return newValue;
+  } finally {
+    releaseLock();
+  }
+}

--- a/lib/util/cache/package/cached.ts
+++ b/lib/util/cache/package/cached.ts
@@ -64,7 +64,7 @@ export async function cached<T>(
     return fn();
   }
 
-  // istanbul ignore if
+  // istanbul ignore if -- TODO: add test #40625
   if (!namespace || !key) {
     return fn();
   }

--- a/lib/util/cache/package/decorator.spec.ts
+++ b/lib/util/cache/package/decorator.spec.ts
@@ -24,118 +24,6 @@ describe('util/cache/package/decorator', () => {
     });
   });
 
-  it('should cache string', async () => {
-    class Class {
-      @cache({ namespace: '_test-namespace', key: 'some-key' })
-      public fn(): Promise<string> {
-        return getValue();
-      }
-    }
-    const obj = new Class();
-
-    expect(await obj.fn()).toBe('111');
-    expect(await obj.fn()).toBe('111');
-    expect(await obj.fn()).toBe('111');
-
-    expect(getValue).toHaveBeenCalledTimes(1);
-    expect(setCache).toHaveBeenCalledExactlyOnceWith(
-      '_test-namespace',
-      'cache-decorator:some-key',
-      { cachedAt: expect.any(String), value: '111' },
-      30,
-    );
-  });
-
-  it('disables cache if cacheability check is false', async () => {
-    class Class {
-      @cache({
-        namespace: '_test-namespace',
-        key: 'key',
-        cacheable: () => false,
-      })
-      public fn(): Promise<string | null> {
-        return getValue();
-      }
-    }
-    const obj = new Class();
-
-    expect(await obj.fn()).toBe('111');
-    expect(await obj.fn()).toBe('222');
-    expect(await obj.fn()).toBe('333');
-
-    expect(getValue).toHaveBeenCalledTimes(3);
-    expect(setCache).not.toHaveBeenCalled();
-  });
-
-  it('forces cache if cachePrivatePackages=true', async () => {
-    GlobalConfig.set({ cachePrivatePackages: true });
-
-    class Class {
-      @cache({
-        namespace: '_test-namespace',
-        key: 'key',
-        cacheable: () => false,
-      })
-      public fn(): Promise<string | null> {
-        return getValue();
-      }
-    }
-    const obj = new Class();
-
-    expect(await obj.fn()).toBe('111');
-    expect(await obj.fn()).toBe('111');
-    expect(await obj.fn()).toBe('111');
-
-    expect(getValue).toHaveBeenCalledTimes(1);
-    expect(setCache).toHaveBeenCalledExactlyOnceWith(
-      '_test-namespace',
-      'cache-decorator:key',
-      { cachedAt: expect.any(String), value: '111' },
-      30,
-    );
-  });
-
-  it('caches null values', async () => {
-    class Class {
-      @cache({ namespace: '_test-namespace', key: 'key' })
-      public async fn(val: string | null): Promise<string | null> {
-        await getValue();
-        return val;
-      }
-    }
-    const obj = new Class();
-
-    expect(await obj.fn(null)).toBeNull();
-    expect(await obj.fn(null)).toBeNull();
-    expect(await obj.fn(null)).toBeNull();
-
-    expect(getValue).toHaveBeenCalledTimes(1);
-    expect(setCache).toHaveBeenCalledExactlyOnceWith(
-      '_test-namespace',
-      'cache-decorator:key',
-      { cachedAt: expect.any(String), value: null },
-      30,
-    );
-  });
-
-  it('does not cache undefined', async () => {
-    class Class {
-      @cache({ namespace: '_test-namespace', key: 'key' })
-      public async fn(): Promise<string | undefined> {
-        await getValue();
-        return undefined;
-      }
-    }
-    const obj = new Class();
-
-    expect(await obj.fn()).toBeUndefined();
-    expect(await obj.fn()).toBeUndefined();
-    expect(await obj.fn()).toBeUndefined();
-
-    expect(getValue).toHaveBeenCalledTimes(3);
-    expect(setCache).not.toHaveBeenCalled();
-  });
-
   it('computes cache namespace and key from arguments', async () => {
     interface Arg {
       foo: 'namespace';
@@ -188,34 +76,28 @@ describe('util/cache/package/decorator', () => {
     );
   });
 
-  describe('Fallbacks with hard TTL', () => {
-    class Class {
-      @cache({
-        namespace: '_test-namespace',
-        key: 'key',
-        ttlMinutes: 1,
-      })
-
-      // Hard TTL is enabled only for `getReleases` and `getDigest` methods
-      public getReleases(): Promise<string> {
-        return getValue();
-      }
-    }
-
+  describe('methodName determines fallback', () => {
     beforeEach(() => {
       vi.useFakeTimers();
       GlobalConfig.set({ cacheHardTtlMinutes: 2 });
     });
 
-    it('updates cached result', async () => {
+    it('enables fallback for getReleases method', async () => {
+      class Class {
+        @cache({
+          namespace: '_test-namespace',
+          key: 'key',
+          ttlMinutes: 1,
+        })
+        public getReleases(): Promise<string> {
+          return getValue();
+        }
+      }
       const obj = new Class();
 
       expect(await obj.getReleases()).toBe('111');
       expect(getValue).toHaveBeenCalledTimes(1);
-
-      vi.advanceTimersByTime(60 * 1000 - 1);
-      expect(await obj.getReleases()).toBe('111');
-      expect(getValue).toHaveBeenCalledTimes(1);
+      // Hard TTL of 2 minutes used (fallback enabled)
       expect(setCache).toHaveBeenLastCalledWith(
         '_test-namespace',
         'cache-decorator:key',
@@ -223,87 +105,40 @@ describe('util/cache/package/decorator', () => {
         2,
       );
 
-      vi.advanceTimersByTime(1);
-      expect(await obj.getReleases()).toBe('222');
-      expect(getValue).toHaveBeenCalledTimes(2);
-      expect(setCache).toHaveBeenLastCalledWith(
-        '_test-namespace',
-        'cache-decorator:key',
-        { cachedAt: expect.any(String), value: '222' },
-        2,
-      );
-    });
-
-    it('overrides soft ttl and updates result', async () => {
-      GlobalConfig.set({
-        cacheTtlOverride: { '_test-namespace': 2 },
-        cacheHardTtlMinutes: 3,
-      });
-      const obj = new Class();
-
-      expect(await obj.getReleases()).toBe('111');
-      expect(getValue).toHaveBeenCalledTimes(1);
-      expect(setCache).toHaveBeenLastCalledWith(
-        '_test-namespace',
-        'cache-decorator:key',
-        { cachedAt: expect.any(String), value: '111' },
-        3,
-      );
-
-      vi.advanceTimersByTime(120 * 1000 - 1); // namespace default ttl is 1min
-      expect(await obj.getReleases()).toBe('111');
-      expect(getValue).toHaveBeenCalledTimes(1);
-      expect(setCache).toHaveBeenCalledTimes(1);
-
-      vi.advanceTimersByTime(1);
-      expect(await obj.getReleases()).toBe('222');
-      expect(getValue).toHaveBeenCalledTimes(2);
-      expect(setCache).toHaveBeenLastCalledWith(
-        '_test-namespace',
-        'cache-decorator:key',
-        { cachedAt: expect.any(String), value: '222' },
-        3,
-      );
-    });
-
-    it('returns obsolete result on error', async () => {
-      const obj = new Class();
-
-      expect(await obj.getReleases()).toBe('111');
-      expect(getValue).toHaveBeenCalledTimes(1);
-      expect(setCache).toHaveBeenLastCalledWith(
-        '_test-namespace',
-        'cache-decorator:key',
-        { cachedAt: expect.any(String), value: '111' },
-        2,
-      );
-
+      // After soft TTL (1 min), error returns stale data
       vi.advanceTimersByTime(60 * 1000);
       getValue.mockRejectedValueOnce(new Error('test'));
       expect(await obj.getReleases()).toBe('111');
       expect(getValue).toHaveBeenCalledTimes(2);
-      expect(setCache).toHaveBeenCalledTimes(1);
     });
 
-    it('drops obsolete value after hard TTL is out', async () => {
+    it('disables fallback for other method names', async () => {
+      class Class {
+        @cache({
+          namespace: '_test-namespace',
+          key: 'key',
+          ttlMinutes: 1,
+        })
+        public otherMethod(): Promise<string> {
+          return getValue();
+        }
+      }
       const obj = new Class();
 
-      expect(await obj.getReleases()).toBe('111');
+      expect(await obj.otherMethod()).toBe('111');
       expect(getValue).toHaveBeenCalledTimes(1);
+      // Soft TTL of 1 minute used (fallback disabled)
       expect(setCache).toHaveBeenLastCalledWith(
         '_test-namespace',
         'cache-decorator:key',
         { cachedAt: expect.any(String), value: '111' },
-        2,
+        1,
       );
 
-      vi.advanceTimersByTime(2 * 60 * 1000 - 1);
+      // After soft TTL, error propagates (no fallback)
+      vi.advanceTimersByTime(60 * 1000);
       getValue.mockRejectedValueOnce(new Error('test'));
-      expect(await obj.getReleases()).toBe('111');
-
-      vi.advanceTimersByTime(1);
-      getValue.mockRejectedValueOnce(new Error('test'));
-      await expect(obj.getReleases()).rejects.toThrow('test');
+      await expect(obj.otherMethod()).rejects.toThrow('test');
     });
   });
 });


### PR DESCRIPTION
## Changes

Extract core logic from `@cache` and `@instrument` decorators into standalone functions:

- **`cached(options, fn)`** - All caching logic (mutex, TTL, soft/hard TTL fallback)
- **`instrumented(options, fn)`** - OpenTelemetry span wrapping

Decorators become thin wrappers that:
- Resolve dynamic namespace/key from method arguments
- Map `methodName` to `fallback` flag (`getReleases`/`getDigest` → `true`)
- Delegate to standalone functions

This enables using the caching and instrumentation logic without decorators (for ESM compatibility or functional patterns).

## Context

- Ref: #9890

## AI assistance disclosure

- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).

## Documentation (please check one with an [x])

- [x] No documentation update is required

## How I've tested my work (please select one)

- [x] Newly added/modified unit tests, or