### PR TITLE
refactor: Remove constructor parameter properties

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -216,6 +216,9 @@ jobs:
       - name: Lint with oxlint
         run: pnpm oxlint -f github
 
+      - name: Lint with biome
+        run: pnpm biome-ci
+
       - name: Restore eslint cache
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": false,
+      "style": {
+        "noParameterProperties": "error"
+      }
+    }
+  },
+  "files": {
+    "includes": [
+      "**",
+      "!**/node_modules",
+      "!**/dist",
+      "!**/coverage",
+      "!**/__fixtures__/**",
+      "!**/__mocks__/**",
+      "!**/*.d.ts",
+      "!config.js",
+      "!patches",
+      "!tools/mkdocs/**"
+    ]
+  }
+}

--- a/lib/logger/index.spec.ts
+++ b/lib/logger/index.spec.ts
@@ -393,7 +393,10 @@ describe('logger/index', () => {
     add({ password: 'secret"password' });
 
     class SomeClass {
-      constructor(public field: string) {}
+      public field: string;
+      constructor(field: string) {
+        this.field = field;
+      }
     }
 
     const prBody = 'test';
@@ -444,7 +447,10 @@ describe('logger/index', () => {
     add({ password: 'secret"password' });
 
     class SomeClass {
-      constructor(public field: string) {}
+      public field: string;
+      constructor(field: string) {
+        this.field = field;
+      }
     }
 
     const childLogger = (logger as RenovateLogger).childLogger();

--- a/lib/logger/renovate-logger.ts
+++ b/lib/logger/renovate-logger.ts
@@ -19,12 +19,18 @@ type LoggerFunction = (p1: string | Record<string, any>, p2?: string) => void;
 export class RenovateLogger implements Logger {
   readonly logger: Logger = { once: { reset: onceReset } } as any;
   readonly once = this.logger.once;
+  private readonly bunyanLogger: bunyan;
+  private context: string;
+  private meta: Record<string, unknown>;
 
   constructor(
-    private readonly bunyanLogger: bunyan,
-    private context: string,
-    private meta: Record<string, unknown>,
+    bunyanLogger: bunyan,
+    context: string,
+    meta: Record<string, unknown>,
   ) {
+    this.bunyanLogger = bunyanLogger;
+    this.context = context;
+    this.meta = meta;
     for (const level of loggerLevels) {
       this.logger[level] = this.logFactory(level) as never;
       this.logger.once[level] = this.logOnceFn(level);

--- a/lib/modules/datasource/datasource.ts
+++ b/lib/modules/datasource/datasource.ts
@@ -13,7 +13,10 @@ import type {
 } from './types.ts';
 
 export abstract class Datasource implements DatasourceApi {
-  protected constructor(public readonly id: string) {
+  public readonly id: string;
+
+  protected constructor(id: string) {
+    this.id = id;
     this.http = new Http(id);
   }
 

--- a/lib/modules/datasource/docker/dockerhub-cache.ts
+++ b/lib/modules/datasource/docker/dockerhub-cache.ts
@@ -13,11 +13,13 @@ const cacheNamespace = 'datasource-docker-hub-cache';
 export class DockerHubCache {
   private isChanged = false;
   private reconciledIds = new Set<number>();
+  private dockerRepository: string;
+  private cache: DockerHubCacheData;
 
-  private constructor(
-    private dockerRepository: string,
-    private cache: DockerHubCacheData,
-  ) {}
+  private constructor(dockerRepository: string, cache: DockerHubCacheData) {
+    this.dockerRepository = dockerRepository;
+    this.cache = cache;
+  }
 
   static async init(dockerRepository: string): Promise<DockerHubCache> {
     let repoCache = await packageCache.get<DockerHubCacheData>(

--- a/lib/modules/datasource/github-release-attachments/test/index.ts
+++ b/lib/modules/datasource/github-release-attachments/test/index.ts
@@ -3,10 +3,13 @@ import { partial } from '../../../../../test/util.ts';
 import type { GithubRestRelease } from '../../../../util/github/types.ts';
 
 export class GitHubReleaseAttachmentMocker {
-  constructor(
-    private readonly githubApiHost: string,
-    private readonly packageName: string,
-  ) {}
+  private readonly githubApiHost: string;
+  private readonly packageName: string;
+
+  constructor(githubApiHost: string, packageName: string) {
+    this.githubApiHost = githubApiHost;
+    this.packageName = packageName;
+  }
 
   release(version: string): GithubRestRelease {
     return this.withAssets(version, {});

--- a/lib/modules/datasource/index.spec.ts
+++ b/lib/modules/datasource/index.spec.ts
@@ -39,9 +39,11 @@ const defaultRegistriesMock: RegistriesMock = {
 class DummyDatasource extends Datasource {
   override defaultVersioning = 'python';
   override defaultRegistryUrls = ['https://reg1.com'];
+  private registriesMock: RegistriesMock;
 
-  constructor(private registriesMock: RegistriesMock = defaultRegistriesMock) {
+  constructor(registriesMock: RegistriesMock = defaultRegistriesMock) {
     super(datasource);
+    this.registriesMock = registriesMock;
   }
 
   override getReleases({
@@ -59,9 +61,11 @@ class DummyDatasource2 extends Datasource {
   override defaultRegistryUrls = function () {
     return ['https://reg1.com'];
   };
+  private registriesMock: RegistriesMock;
 
-  constructor(private registriesMock: RegistriesMock = defaultRegistriesMock) {
+  constructor(registriesMock: RegistriesMock = defaultRegistriesMock) {
     super(datasource);
+    this.registriesMock = registriesMock;
   }
 
   override getReleases({
@@ -80,9 +84,11 @@ class DummyDatasource3 extends Datasource {
   override defaultRegistryUrls = function () {
     return ['https://reg1.com'];
   };
+  private registriesMock: RegistriesMock;
 
-  constructor(private registriesMock: RegistriesMock = defaultRegistriesMock) {
+  constructor(registriesMock: RegistriesMock = defaultRegistriesMock) {
     super(datasource);
+    this.registriesMock = registriesMock;
   }
 
   override getReleases({
@@ -102,9 +108,11 @@ class DummyDatasource4 extends DummyDatasource3 {
 
 class DummyDatasource5 extends Datasource {
   override registryStrategy = undefined as never;
+  private registriesMock: RegistriesMock;
 
-  constructor(private registriesMock: RegistriesMock = defaultRegistriesMock) {
+  constructor(registriesMock: RegistriesMock = defaultRegistriesMock) {
     super(datasource);
+    this.registriesMock = registriesMock;
   }
 
   override getReleases({

--- a/lib/modules/datasource/rubygems/metadata-cache.ts
+++ b/lib/modules/datasource/rubygems/metadata-cache.ts
@@ -36,7 +36,11 @@ type CacheLoadError = CacheNotFoundError | CacheStaleError;
 type CacheError = CacheNotFoundError | CacheStaleError | CacheInvalidError;
 
 export class MetadataCache {
-  constructor(private readonly http: Http) {}
+  private readonly http: Http;
+
+  constructor(http: Http) {
+    this.http = http;
+  }
 
   async getRelease(
     registryUrl: string,

--- a/lib/modules/datasource/rubygems/versions-endpoint-cache.ts
+++ b/lib/modules/datasource/rubygems/versions-endpoint-cache.ts
@@ -135,7 +135,11 @@ export type VersionsResult = Result<
 >;
 
 export class VersionsEndpointCache {
-  constructor(private readonly http: Http) {}
+  private readonly http: Http;
+
+  constructor(http: Http) {
+    this.http = http;
+  }
 
   private cacheRequests = new Map<string, Promise<VersionsEndpointResult>>();
 

--- a/lib/modules/manager/bazel-module/bazelrc.ts
+++ b/lib/modules/manager/bazel-module/bazelrc.ts
@@ -12,17 +12,23 @@ const spaceRegex = regEx(`\\s+`);
 
 export class ImportEntry {
   readonly entryType = 'import';
-  constructor(
-    readonly path: string,
-    readonly isTry: boolean,
-  ) {}
+  readonly path: string;
+  readonly isTry: boolean;
+
+  constructor(path: string, isTry: boolean) {
+    this.path = path;
+    this.isTry = isTry;
+  }
 }
 
 export class BazelOption {
-  constructor(
-    readonly name: string,
-    readonly value?: string,
-  ) {}
+  readonly name: string;
+  readonly value?: string;
+
+  constructor(name: string, value?: string) {
+    this.name = name;
+    this.value = value;
+  }
 
   static parse(input: string): BazelOption[] {
     const options: BazelOption[] = [];
@@ -58,11 +64,15 @@ export class BazelOption {
 
 export class CommandEntry {
   readonly entryType = 'command';
-  constructor(
-    readonly command: string,
-    readonly options: BazelOption[],
-    readonly config?: string,
-  ) {}
+  readonly command: string;
+  readonly options: BazelOption[];
+  readonly config?: string;
+
+  constructor(command: string, options: BazelOption[], config?: string) {
+    this.command = command;
+    this.options = options;
+    this.config = config;
+  }
 
   getOption(name: string): BazelOption | undefined {
     return this.options.find((bo) => bo.name === name);

--- a/lib/modules/platform/bitbucket-server/pr-cache.ts
+++ b/lib/modules/platform/bitbucket-server/pr-cache.ts
@@ -26,13 +26,21 @@ function migrateBitbucketServerCache(platform: unknown): void {
 export class BbsPrCache {
   private cache: BbsPrCacheData;
   private items: BbsPr[] = [];
+  private projectKey: string;
+  private repo: string;
+  private readonly ignorePrAuthor: boolean;
+  private author: string | null;
 
   private constructor(
-    private projectKey: string,
-    private repo: string,
-    private readonly ignorePrAuthor: boolean,
-    private author: string | null,
+    projectKey: string,
+    repo: string,
+    ignorePrAuthor: boolean,
+    author: string | null,
   ) {
+    this.projectKey = projectKey;
+    this.repo = repo;
+    this.ignorePrAuthor = ignorePrAuthor;
+    this.author = author;
     const repoCache = getCache();
     repoCache.platform ??= {};
     migrateBitbucketServerCache(repoCache.platform);

--- a/lib/modules/platform/bitbucket/pr-cache.ts
+++ b/lib/modules/platform/bitbucket/pr-cache.ts
@@ -13,11 +13,12 @@ import { prFieldsFilter, prInfo, prStates } from './utils.ts';
 export class BitbucketPrCache {
   private items: Pr[] = [];
   private cache: BitbucketPrCacheData;
+  private repo: string;
+  private author: string | null;
 
-  private constructor(
-    private repo: string,
-    private author: string | null,
-  ) {
+  private constructor(repo: string, author: string | null) {
+    this.repo = repo;
+    this.author = author;
     const repoCache = getCache();
     repoCache.platform ??= {};
     repoCache.platform.bitbucket ??= {};

--- a/lib/modules/platform/forgejo/pr-cache.ts
+++ b/lib/modules/platform/forgejo/pr-cache.ts
@@ -19,12 +19,18 @@ import { API_PATH, toRenovatePR } from './utils.ts';
 export class ForgejoPrCache {
   private cache: ForgejoPrCacheData;
   private items: Pr[] = [];
+  private repo: string;
+  private readonly ignorePrAuthor: boolean;
+  private author: string | null;
 
   private constructor(
-    private repo: string,
-    private readonly ignorePrAuthor: boolean,
-    private author: string | null,
+    repo: string,
+    ignorePrAuthor: boolean,
+    author: string | null,
   ) {
+    this.repo = repo;
+    this.ignorePrAuthor = ignorePrAuthor;
+    this.author = author;
     const repoCache = getCache();
     repoCache.platform ??= {};
     repoCache.platform.forgejo ??= {};

--- a/lib/modules/platform/gitea/pr-cache.ts
+++ b/lib/modules/platform/gitea/pr-cache.ts
@@ -19,12 +19,18 @@ import { API_PATH, toRenovatePR } from './utils.ts';
 export class GiteaPrCache {
   private cache: GiteaPrCacheData;
   private items: Pr[] = [];
+  private repo: string;
+  private readonly ignorePrAuthor: boolean;
+  private author: string | null;
 
   private constructor(
-    private repo: string,
-    private readonly ignorePrAuthor: boolean,
-    private author: string | null,
+    repo: string,
+    ignorePrAuthor: boolean,
+    author: string | null,
   ) {
+    this.repo = repo;
+    this.ignorePrAuthor = ignorePrAuthor;
+    this.author = author;
     const repoCache = getCache();
     repoCache.platform ??= {};
     repoCache.platform.gitea ??= {};

--- a/lib/modules/platform/github/api-cache.ts
+++ b/lib/modules/platform/github/api-cache.ts
@@ -4,7 +4,11 @@ import { logger } from '../../../logger/index.ts';
 import type { ApiPageCache, ApiPageItem } from './types.ts';
 
 export class ApiCache<T extends ApiPageItem> {
-  constructor(private cache: ApiPageCache<T>) {}
+  private cache: ApiPageCache<T>;
+
+  constructor(cache: ApiPageCache<T>) {
+    this.cache = cache;
+  }
 
   getItems(): T[] {
     const items = Object.values(this.cache.items);

--- a/lib/modules/platform/gitlab/pr-cache.ts
+++ b/lib/modules/platform/gitlab/pr-cache.ts
@@ -15,12 +15,16 @@ import { prInfo } from './utils.ts';
 export class GitlabPrCache {
   private items: GitlabPr[] = [];
   private cache: GitlabPrCacheData;
+  private repo: string;
+  private ignorePrAuthor: boolean;
 
   private constructor(
-    private repo: string,
+    repo: string,
     author: string | null,
-    private ignorePrAuthor: boolean,
+    ignorePrAuthor: boolean,
   ) {
+    this.repo = repo;
+    this.ignorePrAuthor = ignorePrAuthor;
     const repoCache = getCache();
     repoCache.platform ??= {};
     repoCache.platform.gitlab ??= {};

--- a/lib/util/cache/package/sqlite.ts
+++ b/lib/util/cache/package/sqlite.ts
@@ -51,7 +51,10 @@ export class SqlitePackageCache {
     return res;
   }
 
-  private constructor(private client: Database) {
+  private client: Database;
+
+  private constructor(client: Database) {
+    this.client = client;
     client.pragma('journal_mode = WAL');
     client.pragma("encoding = 'UTF-8'");
 

--- a/lib/util/cache/repository/impl/base.ts
+++ b/lib/util/cache/repository/impl/base.ts
@@ -14,11 +14,13 @@ export abstract class RepoCacheBase implements RepoCache {
   protected platform = GlobalConfig.get('platform')!;
   private oldHash: string | null = null;
   private data: RepoCacheData = {};
+  protected readonly repository: string;
+  protected readonly fingerprint: string;
 
-  protected constructor(
-    protected readonly repository: string,
-    protected readonly fingerprint: string,
-  ) {}
+  protected constructor(repository: string, fingerprint: string) {
+    this.repository = repository;
+    this.fingerprint = fingerprint;
+  }
 
   protected abstract read(): Promise<string | null>;
 

--- a/lib/util/git/instrument.ts
+++ b/lib/util/git/instrument.ts
@@ -91,7 +91,11 @@ export function instrumentGit(git: SimpleGit): InstrumentedSimpleGit {
  * @see SimpleGit
  */
 export class InstrumentedSimpleGit {
-  constructor(private git: SimpleGit) {}
+  private git: SimpleGit;
+
+  constructor(git: SimpleGit) {
+    this.git = git;
+  }
 
   version(): Response<VersionResult> {
     return this.git.version();

--- a/lib/util/github/graphql/cache-strategies/abstract-cache-strategy.ts
+++ b/lib/util/github/graphql/cache-strategies/abstract-cache-strategy.ts
@@ -51,11 +51,19 @@ export abstract class AbstractGithubGraphqlCacheStrategy<
     cacheRecord: GithubGraphqlCacheRecord<GithubItem>,
   ): Promise<void>;
 
+  protected readonly cacheNs: PackageCacheNamespace;
+  protected readonly cacheKey: string;
+  protected readonly skipStabilization: boolean;
+
   constructor(
-    protected readonly cacheNs: PackageCacheNamespace,
-    protected readonly cacheKey: string,
-    protected readonly skipStabilization = false,
-  ) {}
+    cacheNs: PackageCacheNamespace,
+    cacheKey: string,
+    skipStabilization = false,
+  ) {
+    this.cacheNs = cacheNs;
+    this.cacheKey = cacheKey;
+    this.skipStabilization = skipStabilization;
+  }
 
   /**
    * Load data previously persisted by this strategy

--- a/lib/util/github/graphql/datasource-fetcher.ts
+++ b/lib/util/github/graphql/datasource-fetcher.ts
@@ -72,15 +72,19 @@ export class GithubGraphqlDatasourceFetcher<
   private cursor: string | null = null;
 
   private isPersistent: boolean | undefined;
+  private http: GithubHttp;
+  private datasourceAdapter: GithubGraphqlDatasourceAdapter<
+    GraphqlItem,
+    ResultItem
+  >;
 
   constructor(
     packageConfig: GithubPackageConfig,
-    private http: GithubHttp,
-    private datasourceAdapter: GithubGraphqlDatasourceAdapter<
-      GraphqlItem,
-      ResultItem
-    >,
+    http: GithubHttp,
+    datasourceAdapter: GithubGraphqlDatasourceAdapter<GraphqlItem, ResultItem>,
   ) {
+    this.http = http;
+    this.datasourceAdapter = datasourceAdapter;
     const { packageName, registryUrl } = packageConfig;
     [this.repoOwner, this.repoName] = packageName.split('/');
     this.baseUrl = getApiBaseUrl(registryUrl).replace(/\/v3\/$/, '/'); // Replace for GHE

--- a/lib/util/http/cache/repository-http-cache-provider.ts
+++ b/lib/util/http/cache/repository-http-cache-provider.ts
@@ -6,8 +6,11 @@ import { AbstractHttpCacheProvider } from './abstract-http-cache-provider.ts';
 import type { HttpCache } from './schema.ts';
 
 export class RepositoryHttpCacheProvider extends AbstractHttpCacheProvider {
-  constructor(private aggressive = false) {
+  private aggressive: boolean;
+
+  constructor(aggressive = false) {
     super();
+    this.aggressive = aggressive;
   }
 
   override load(method: string, url: string): Promise<unknown> {

--- a/lib/util/http/http.ts
+++ b/lib/util/http/http.ts
@@ -82,10 +82,10 @@ export abstract class HttpBase<
     return undefined;
   }
 
-  constructor(
-    protected hostType: string,
-    options: HttpOptions = {},
-  ) {
+  protected hostType: string;
+
+  constructor(hostType: string, options: HttpOptions = {}) {
+    this.hostType = hostType;
     const retryLimit = getEnv().NODE_ENV === 'test' ? 0 : 2;
     this.options = merge<InternalGotOptions>(
       options,

--- a/lib/util/lazy.ts
+++ b/lib/util/lazy.ts
@@ -10,8 +10,11 @@ interface ErrorResult {
 
 export class Lazy<T> {
   private _result?: ValueResult<T> | ErrorResult;
+  private readonly executor: () => T;
 
-  constructor(private readonly executor: () => T) {}
+  constructor(executor: () => T) {
+    this.executor = executor;
+  }
 
   hasValue(): boolean {
     return !!this._result;

--- a/lib/util/result.ts
+++ b/lib/util/result.ts
@@ -98,7 +98,11 @@ function fromNullable<
  * - `.unwrap()` is the point of consumption
  */
 export class Result<T extends Val, E extends Val = Error> {
-  private constructor(private readonly res: Res<T, E>) {}
+  private readonly res: Res<T, E>;
+
+  private constructor(res: Res<T, E>) {
+    this.res = res;
+  }
 
   static ok<T extends Val>(val: T): Result<T, never> {
     return new Result({ ok: true, val });
@@ -626,7 +630,11 @@ export class Result<T extends Val, E extends Val = Error> {
 export class AsyncResult<T extends Val, E extends Val>
   implements PromiseLike<Result<T, E>>
 {
-  private constructor(private asyncResult: Promise<Result<T, E>>) {}
+  private asyncResult: Promise<Result<T, E>>;
+
+  private constructor(asyncResult: Promise<Result<T, E>>) {
+    this.asyncResult = asyncResult;
+  }
 
   then<TResult1 = Result<T, E>>(
     onfulfilled?:

--- a/lib/util/template/index.ts
+++ b/lib/util/template/index.ts
@@ -255,7 +255,11 @@ const allowedTemplateFields = new Set([
 ]);
 
 class CompileInputProxyHandler implements ProxyHandler<CompileInput> {
-  constructor(private warnVariables: Set<string>) {}
+  private warnVariables: Set<string>;
+
+  constructor(warnVariables: Set<string>) {
+    this.warnVariables = warnVariables;
+  }
 
   get(target: CompileInput, prop: keyof CompileInput): unknown {
     if (prop === 'env') {

--- a/lib/workers/repository/config-migration/branch/commit-message.ts
+++ b/lib/workers/repository/config-migration/branch/commit-message.ts
@@ -4,10 +4,13 @@ import { CommitMessageFactory } from '../../model/commit-message-factory.ts';
 import type { CommitMessage } from '../../model/commit-message.ts';
 
 export class ConfigMigrationCommitMessageFactory {
-  constructor(
-    private readonly config: RenovateConfig,
-    private readonly configFile: string,
-  ) {}
+  private readonly config: RenovateConfig;
+  private readonly configFile: string;
+
+  constructor(config: RenovateConfig, configFile: string) {
+    this.config = config;
+    this.configFile = configFile;
+  }
 
   private create(commitMessageTopic: string): CommitMessage {
     const { commitMessage } = this.config;

--- a/lib/workers/repository/update/pr/changelog/source.ts
+++ b/lib/workers/repository/update/pr/changelog/source.ts
@@ -26,10 +26,18 @@ import type {
 
 export abstract class ChangeLogSource {
   private readonly cacheNamespace: PackageCacheNamespace;
+  private readonly platform: ChangeLogPlatform;
+  private readonly datasource:
+    | 'bitbucket-tags'
+    | 'bitbucket-server-tags'
+    | 'forgejo-tags'
+    | 'gitea-tags'
+    | 'github-tags'
+    | 'gitlab-tags';
 
   constructor(
-    private readonly platform: ChangeLogPlatform,
-    private readonly datasource:
+    platform: ChangeLogPlatform,
+    datasource:
       | 'bitbucket-tags'
       | 'bitbucket-server-tags'
       | 'forgejo-tags'
@@ -37,6 +45,8 @@ export abstract class ChangeLogSource {
       | 'github-tags'
       | 'gitlab-tags',
   ) {
+    this.platform = platform;
+    this.datasource = datasource;
     this.cacheNamespace = `changelog-${platform}-release`;
   }
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "lint-other": "vitest run --coverage false test/other/**.spec.ts",
     "oxlint": "oxlint --import-plugin",
     "oxlint-fix": "oxlint --import-plugin --fix",
+    "biome": "biome lint .",
+    "biome-ci": "biome lint --reporter=github .",
+    "biome-fix": "biome lint --write .",
     "eslint": "NODE_OPTIONS=--max-old-space-size=8192 eslint . --cache --cache-location .cache/eslint",
     "eslint-fix": "NODE_OPTIONS=--max-old-space-size=8192 eslint --cache --cache-location .cache/eslint --fix .",
     "eslint-ci": "NODE_OPTIONS=--max-old-space-size=8192 eslint . --cache --cache-strategy content --cache-location .cache/eslint --format gha",
@@ -32,8 +35,8 @@
     "git-check": "node tools/check-git-version.mjs",
     "jest": "GIT_ALLOW_PROTOCOL=file LOG_LEVEL=fatal vitest run --logHeapUsage",
     "vitest": "GIT_ALLOW_PROTOCOL=file LOG_LEVEL=fatal vitest run --logHeapUsage",
-    "lint": "run-s ls-lint type-check oxlint eslint prettier markdown-lint git-check doc-fence-check",
-    "lint-fix": "run-s oxlint-fix eslint-fix prettier-fix markdown-lint-fix",
+    "lint": "run-s ls-lint type-check oxlint biome eslint prettier markdown-lint git-check doc-fence-check",
+    "lint-fix": "run-s oxlint-fix biome-fix eslint-fix prettier-fix markdown-lint-fix",
     "check": "tsx tools/check/index.ts",
     "ls-lint": "ls-lint",
     "markdown-lint": "markdownlint-cli2",
@@ -275,6 +278,7 @@
     "re2": "1.23.0"
   },
   "devDependencies": {
+    "@biomejs/biome": "2.3.13",
     "@commander-js/extra-typings": "14.0.0",
     "@containerbase/eslint-plugin": "1.1.29",
     "@containerbase/istanbul-reports-html": "1.1.27",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -367,6 +367,9 @@ importers:
         specifier: 3.25.76
         version: 3.25.76
     devDependencies:
+      '@biomejs/biome':
+        specifier: 2.3.13
+        version: 2.3.13
       '@commander-js/extra-typings':
         specifier: 14.0.0
         version: 14.0.0(commander@14.0.2)
@@ -970,6 +973,59 @@ packages:
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
+
+  '@biomejs/biome@2.3.13':
+    resolution: {integrity: sha512-Fw7UsV0UAtWIBIm0M7g5CRerpu1eKyKAXIazzxhbXYUyMkwNrkX/KLkGI7b+uVDQ5cLUMfOC9vR60q9IDYDstA==}
+    engines: {node: '>=14.21.3'}
+    hasBin: true
+
+  '@biomejs/cli-darwin-arm64@2.3.13':
+    resolution: {integrity: sha512-0OCwP0/BoKzyJHnFdaTk/i7hIP9JHH9oJJq6hrSCPmJPo8JWcJhprK4gQlhFzrwdTBAW4Bjt/RmCf3ZZe59gwQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@biomejs/cli-darwin-x64@2.3.13':
+    resolution: {integrity: sha512-AGr8OoemT/ejynbIu56qeil2+F2WLkIjn2d8jGK1JkchxnMUhYOfnqc9sVzcRxpG9Ycvw4weQ5sprRvtb7Yhcw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@biomejs/cli-linux-arm64-musl@2.3.13':
+    resolution: {integrity: sha512-TUdDCSY+Eo/EHjhJz7P2GnWwfqet+lFxBZzGHldrvULr59AgahamLs/N85SC4+bdF86EhqDuuw9rYLvLFWWlXA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@biomejs/cli-linux-arm64@2.3.13':
+    resolution: {integrity: sha512-xvOiFkrDNu607MPMBUQ6huHmBG1PZLOrqhtK6pXJW3GjfVqJg0Z/qpTdhXfcqWdSZHcT+Nct2fOgewZvytESkw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@biomejs/cli-linux-x64-musl@2.3.13':
+    resolution: {integrity: sha512-0bdwFVSbbM//Sds6OjtnmQGp4eUjOTt6kHvR/1P0ieR9GcTUAlPNvPC3DiavTqq302W34Ae2T6u5VVNGuQtGlQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+
+  '@biomejs/cli-linux-x64@2.3.13':
+    resolution: {integrity: sha512-s+YsZlgiXNq8XkgHs6xdvKDFOj/bwTEevqEY6rC2I3cBHbxXYU1LOZstH3Ffw9hE5tE1sqT7U23C00MzkXztMw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+
+  '@biomejs/cli-win32-arm64@2.3.13':
+    resolution: {integrity: sha512-QweDxY89fq0VvrxME+wS/BXKmqMrOTZlN9SqQ79kQSIc3FrEwvW/PvUegQF6XIVaekncDykB5dzPqjbwSKs9DA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@biomejs/cli-win32-x64@2.3.13':
+    resolution: {integrity: sha512-trDw2ogdM2lyav9WFQsdsfdVy1dvZALymRpgmWsvSez0BJzBjulhOT/t+wyKeh3pZWvwP3VMs1SoOKwO3wecMQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [win32]
 
   '@breejs/later@4.2.0':
     resolution: {integrity: sha512-EVMD0SgJtOuFeg0lAVbCwa+qeTKILb87jqvLyUtQswGD9+ce2nB52Y5zbTF1Hc0MDFfbydcMcxb47jSdhikVHA==}
@@ -7907,6 +7963,41 @@ snapshots:
   '@baszalmstra/rattler@0.2.1': {}
 
   '@bcoe/v8-coverage@1.0.2': {}
+
+  '@biomejs/biome@2.3.13':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 2.3.13
+      '@biomejs/cli-darwin-x64': 2.3.13
+      '@biomejs/cli-linux-arm64': 2.3.13
+      '@biomejs/cli-linux-arm64-musl': 2.3.13
+      '@biomejs/cli-linux-x64': 2.3.13
+      '@biomejs/cli-linux-x64-musl': 2.3.13
+      '@biomejs/cli-win32-arm64': 2.3.13
+      '@biomejs/cli-win32-x64': 2.3.13
+
+  '@biomejs/cli-darwin-arm64@2.3.13':
+    optional: true
+
+  '@biomejs/cli-darwin-x64@2.3.13':
+    optional: true
+
+  '@biomejs/cli-linux-arm64-musl@2.3.13':
+    optional: true
+
+  '@biomejs/cli-linux-arm64@2.3.13':
+    optional: true
+
+  '@biomejs/cli-linux-x64-musl@2.3.13':
+    optional: true
+
+  '@biomejs/cli-linux-x64@2.3.13':
+    optional: true
+
+  '@biomejs/cli-win32-arm64@2.3.13':
+    optional: true
+
+  '@biomejs/cli-win32-x64@2.3.13':
+    optional: true
 
   '@breejs/later@4.2.0': {}
 

--- a/tools/check/index.ts
+++ b/tools/check/index.ts
@@ -74,8 +74,15 @@ function pnpmScript(name: string): ParallelCheck {
   return { name, cmd: 'pnpm', args: [name] };
 }
 
-const FIX_CHECKS = ['oxlint-fix', 'eslint-fix', 'prettier-fix'].map(pnpmScript);
-const FIXABLE_CHECKS = ['oxlint', 'eslint', 'prettier'].map(pnpmScript);
+const FIX_CHECKS = [
+  'oxlint-fix',
+  'biome-fix',
+  'eslint-fix',
+  'prettier-fix',
+].map(pnpmScript);
+const FIXABLE_CHECKS = ['oxlint', 'biome', 'eslint', 'prettier'].map(
+  pnpmScript,
+);
 const OTHER_CHECKS = [
   'ls-lint',
   'git-check',


### PR DESCRIPTION
## Changes

Add Biome linting with `noParameterProperties` rule to disallow TypeScript constructor parameter properties, and convert all existing usages to explicit class properties.

**Why**: Constructor parameter properties require TypeScript code transformation (not just type stripping), which blocks native ESM execution via `node --experimental-strip-types`.

**What**:
- Add `@biomejs/biome` with `noParameterProperties` rule
- Integrate biome into `pnpm lint`, `pnpm lint-fix`, `pnpm check`, and CI
- Convert 27 files with constructor parameter properties to explicit class properties

## Context

- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).

## Documentation (please check one with an [x])

- [x] No documentation update is required

## How I've tested my work (please select one)

- [x] Code inspection only, or

Ran `pnpm check --no-test` which passes all linting checks.