### PR TITLE
fix(datasource/docker): treat empty string as no architecture

### DIFF
--- a/lib/modules/datasource/docker/index.spec.ts
+++ b/lib/modules/datasource/docker/index.spec.ts
@@ -989,6 +989,72 @@ describe('modules/datasource/docker/index', () => {
       );
     });
 
+    it('treats empty string architecture as no architecture', async () => {
+      const currentDigest =
+        'sha256:81c09f6d42c2db8121bcd759565ea244cedc759f36a0f090ec7da9de4f7f8fe4';
+
+      httpMock
+        .scope(authUrl)
+        .get(
+          '/token?service=registry.docker.io&scope=repository:library/some-dep:pull',
+        )
+        .times(4)
+        .reply(200, { token: 'some-token' });
+      httpMock
+        .scope(baseUrl)
+        .get('/')
+        .times(3)
+        .reply(401, '', {
+          'www-authenticate':
+            'Bearer realm="https://auth.docker.io/token",service="registry.docker.io",scope="repository:library/some-dep:pull"',
+        })
+        .head('/library/some-dep/manifests/' + currentDigest)
+        .reply(200, '', {
+          'content-type':
+            'application/vnd.docker.distribution.manifest.v2+json',
+        })
+        .get('/library/some-dep/manifests/' + currentDigest)
+        .reply(200, {
+          schemaVersion: 2,
+          mediaType: 'application/vnd.docker.distribution.manifest.v2+json',
+          config: {
+            digest: 'some-config-digest',
+            mediaType: 'application/vnd.docker.container.image.v1+json',
+          },
+        })
+        .get('/library/some-dep/blobs/some-config-digest')
+        .reply(200, {
+          architecture: '', // Empty string architecture
+        });
+      httpMock
+        .scope(baseUrl)
+        .get('/')
+        .reply(401, '', {
+          'www-authenticate':
+            'Bearer realm="https://auth.docker.io/token",service="registry.docker.io",scope="repository:library/some-dep:pull"',
+        })
+        .head('/library/some-dep/manifests/some-new-value')
+        .reply(200, undefined, {
+          'docker-content-digest': 'sha256:some-digest-from-head-request',
+        });
+
+      const res = await getDigest(
+        {
+          datasource: 'docker',
+          packageName: 'some-dep',
+          currentDigest,
+        },
+        'some-new-value',
+      );
+
+      // Should log empty string same as null
+      expect(logger.logger.debug).toHaveBeenCalledWith(
+        `Current digest ${currentDigest} relates to architecture `,
+      );
+      // Should use the digest from HEAD request (no architecture-specific logic)
+      expect(res).toBe('sha256:some-digest-from-head-request');
+    });
+
     it('supports architecture-specific digest in OCI manifests with media type', async () => {
       const currentDigest =
         'sha256:0101010101010101010101010101010101010101010101010101010101010101';

--- a/lib/modules/datasource/docker/index.ts
+++ b/lib/modules/datasource/docker/index.ts
@@ -1,4 +1,4 @@
-import { isNonEmptyString, isString } from '@sindresorhus/is';
+import { isNonEmptyString } from '@sindresorhus/is';
 import { GlobalConfig } from '../../../config/global.ts';
 import { PAGE_NOT_FOUND_ERROR } from '../../../constants/error-messages.ts';
 import { logger } from '../../../logger/index.ts';
@@ -893,7 +893,7 @@ export class DockerDatasource extends Datasource {
       }
 
       if (
-        isString(architecture) ||
+        isNonEmptyString(architecture) ||
         (manifestResponse &&
           !hasKey('docker-content-digest', manifestResponse.headers))
       ) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Changed the condition for detecting architecture specific docker images, instead of `isString`, `isNonEmptyString` should be used, because certain docker images or OCI artifacts can have it as en empty string (`architecture === ''` ). In such cases, the meaning is that the image is not supposed to be runnable on a host system.

Copying the full problem description from https://github.com/renovatebot/renovate/discussions/40473:

### The problem

Beginning on this line: https://github.com/renovatebot/renovate/blob/main/lib/modules/datasource/docker/index.ts#L869 when Renovate tries to determine the image architecture, the following code can fail in a subtle way when trying to update OCI artifacts (not OCI images!) which may or may not have their `architecture` set to an empty string.

There are two situations that are covered in `getDigest()`:

1. `architecture` is a string and is one of the [GOARCH values](https://go.dev/doc/install/source#environment), so it then goes to find the arch-specific manifest
2. `architecture` is `null | undefined`, so not present in the manifest, so Renovate makes a simple `HEAD` request to pull the manifest for `newTag` and done

but the problem arises when `architecture` is an empty string (`architecture === ''`). In that case the execution follows to this block:

```
        if (!digest) {
          logger.debug(
            { registryHost, dockerRepository, newTag },
            'Extraction digest from manifest response body is deprecated',
          );
          digest = extractDigestFromResponseBody(manifestResponse!);
        }
```

and fails on parsing an empty manifest body:

```
TypeError: Cannot read properties of null (reading 'body')
    at extractDigestFromResponseBody (/home/renovate/renovate/lib/modules/datasource/docker/common.ts:334:48)
    at DockerDatasource.getDigest (/home/renovate/renovate/lib/modules/datasource/docker/index.ts:1008:49)
    at processTicksAndRejections (node:internal/process/task_queues:105:5)
    at /home/renovate/renovate/lib/util/cache/package/decorator.ts:145:19
    at lookupUpdates (/home/renovate/renovate/lib/workers/repository/process/lookup/index.ts:702:33)
    at /home/renovate/renovate/lib/workers/repository/process/fetch.ts:80:12
    at LookupStats.wrap (/home/renovate/renovate/lib/util/stats.ts:38:20)
    at /home/renovate/renovate/lib/workers/repository/process/fetch.ts:132:23
    at file:///home/renovate/renovate/node_modules/.pnpm/p-map@6.0.0/node_modules/p-map/index.js:139:20
```

### Examples

Taking the Tekton catalog as an example, we can see that some artifacts have `architecture` set:

```
$ skopeo inspect docker://ghcr.io/tektoncd/github.com/tektoncd/pipeline/cmd/git-init:v0.37.0 | jq ".Architecture"
"amd64"
```

while others do not:

```
$ skopeo inspect docker://ghcr.io/tektoncd/catalog/upstream/tasks/git-clone:0.10 | jq ".Architecture"
""
```

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [X] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

Neither applies, this is related to a discussion I opened: https://github.com/renovatebot/renovate/discussions/40473 where the problem is described in detail, but haven't received any comments.

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [X] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

I used Cursor (claude-4.5-sonnet) to generate the unit test, which I have checked manually. The code change itself was done by me.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [X] Both unit tests + ran on a real repository

The public repository: https://github.com/staticf0x/mintmaker-test/pull/182/changes

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
