### PR TITLE
fix(config/validation): show `deprecationMsg` as a warning if present

### DIFF
--- a/lib/config/validation.spec.ts
+++ b/lib/config/validation.spec.ts
@@ -1,3 +1,4 @@
+import type { HostRule } from '../types/index.ts';
 import { getConfigFileNames } from './app-strings.ts';
 import { GlobalConfig } from './global.ts';
 import type { RenovateConfig } from './types.ts';
@@ -20,6 +21,28 @@ describe('config/validation', () => {
         expect(warnings).toMatchSnapshot();
       },
     );
+
+    // NOTE that this should always refer to a deprecated option, but at some point, we may have removed them all, so we'll need to think about how to handle that, at that point
+    it('returns the deprecationMsg for `dnsCache` as a warning', async () => {
+      const config: RenovateConfig = {
+        hostRules: [
+          {
+            dnsCache: true,
+          } as HostRule,
+        ],
+      };
+      const { errors, warnings } = await configValidation.validateConfig(
+        'repo',
+        config,
+      );
+      expect(errors).toHaveLength(0);
+      expect(warnings).toMatchObject([
+        {
+          topic: 'Deprecation Warning',
+          message: `The 'dnsCache' option is deprecated: This option is deprecated and will be removed in a future release.`,
+        },
+      ]);
+    });
 
     it('allow enabled field in vulnerabilityAlerts', async () => {
       const config = {

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -102,7 +102,20 @@ function getDeprecationMessage(option: string): string | undefined {
     commitMessage: `Direct editing of commitMessage is now deprecated. Please edit commitMessage's subcomponents instead.`,
     prTitle: `Direct editing of prTitle is now deprecated. Please edit commitMessage subcomponents instead as they will be passed through to prTitle.`,
   };
-  return deprecatedOptions[option];
+  if (deprecatedOptions[option]) {
+    return deprecatedOptions[option];
+  }
+
+  const found = options.find((o) => o.name === option);
+  if (!found) {
+    return undefined;
+  }
+
+  if (!found.deprecationMsg) {
+    return undefined;
+  }
+
+  return `The '${option}' option is deprecated: ${found.deprecationMsg}`;
 }
 
 function isInhertConfigOption(key: string): boolean {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
Although we specify the `deprecationMsg`, we don't always display this
to the user through `renovate-config-validator` or through regular repo
config validation.

The `deprecationMsg` has previously been made visible in the
documentation site, but that isn't as actionable as it appearing during
validation.

We can surface this by extending the `getDeprecationMessage`, using the
existing custom messages if using an option with deprecation, and
otherwise using the `deprecationMsg` on the option itself.

The only option we have available for testing the deprecation - right
now - is the `dnsCache` option under `hostRules`.


## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
