### PR TITLE
feat(config)!: deprecate `binarySource=docker`

### DIFF
--- a/docs/usage/getting-started/running.md
+++ b/docs/usage/getting-started/running.md
@@ -57,6 +57,10 @@ We recommend this default image for most users.
 Renovate supports a persistent cache for downloaded tools, so that it only needs to unpack the tools on later runs.
 Use the [`containerbaseDir` config option](../self-hosted-configuration.md#containerbasedir) to control where Renovate stores its containerbase cache.
 
+<!-- prettier-ignore -->
+!!! warning
+    The usage of `binarySource=docker` is deprecated, and [will be removed in the future](https://github.com/renovatebot/renovate/issues/40747).
+
 If you want, you can map the Docker socket into the container so that Renovate can dynamically invoke "sidecar" images when needed.
 You'll need to set `binarySource=docker` for this to work.
 Read the [`binarySource` config option docs](../self-hosted-configuration.md#binarysource) for more information.

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -274,21 +274,25 @@ If the "development branch" is configured but the branch itself does not exist (
 
 Renovate often needs to use third-party tools in its PRs, like `npm` to update `package-lock.json` or `go` to update `go.sum`.
 
-Renovate supports four possible ways to access those tools:
+Renovate supports three possible ways to access those tools:
 
 - `global`: Uses pre-installed tools, e.g. `npm` installed via `npm install -g npm`.
 - `install` (default): Downloads and installs tools at runtime if running in a [Containerbase](https://github.com/containerbase/base) environment, otherwise falls back to `global`
-- `docker`: Runs tools inside Docker "sidecar" containers using `docker run`.
 - `hermit`: Uses the [Hermit](https://github.com/cashapp/hermit) tool installation approach.
 
-Starting in v36, Renovate's default Docker image (previously referred to as the "slim" image) uses `binarySource=install` while the "full" Docker image uses `binarySource=global`.
 If you are running Renovate in an environment where runtime download and install of tools is not possible then you should use the "full" image.
 
 If you are building your own Renovate image, e.g. by installing Renovate using `npm`, then you will need to ensure that all necessary tools are installed globally before running Renovate so that `binarySource=global` will work.
 
-The `binarySource=docker` approach should not be necessary in most cases now and `binarySource=install` is recommended instead.
-If you have a use case where you cannot use `binarySource=install` but can use `binarySource=docker` then please share it in a GitHub Discussion so that the maintainers can understand it.
+<!-- prettier-ignore -->
+!!! warning
+    The usage of `binarySource=docker` is deprecated, and [will be removed in the future](https://github.com/renovatebot/renovate/issues/40747).
+
+We also have a deprecated `docker` mode.
+
 For this to work, `docker` needs to be installed and the Docker socket available to Renovate.
+
+If you are using this mode, and cannot migrate to `binarySource=install`, [please provide feedback in this Discussion](https://github.com/renovatebot/renovate/discussions/40742).
 
 ## cacheDir
 

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -601,6 +601,8 @@ const options: Readonly<RenovateOptions>[] = [
     type: 'string',
     globalOnly: true,
     default: 'renovate_',
+    deprecationMsg:
+      'The usage of `binarySource=docker` is deprecated, and will be removed in the future',
   },
   {
     name: 'dockerCliOptions',
@@ -608,6 +610,8 @@ const options: Readonly<RenovateOptions>[] = [
       'Pass CLI flags to `docker run` command when `binarySource=docker`.',
     type: 'string',
     globalOnly: true,
+    deprecationMsg:
+      'The usage of `binarySource=docker` is deprecated, and will be removed in the future',
   },
   {
     name: 'dockerSidecarImage',
@@ -616,6 +620,8 @@ const options: Readonly<RenovateOptions>[] = [
     type: 'string',
     default: 'ghcr.io/containerbase/sidecar:13.26.7',
     globalOnly: true,
+    deprecationMsg:
+      'The usage of `binarySource=docker` is deprecated, and will be removed in the future',
   },
   {
     name: 'dockerUser',
@@ -623,6 +629,8 @@ const options: Readonly<RenovateOptions>[] = [
       'Set the `UID` and `GID` for Docker-based binaries if you use `binarySource=docker`.',
     globalOnly: true,
     type: 'string',
+    deprecationMsg:
+      'The usage of `binarySource=docker` is deprecated, and will be removed in the future',
   },
   {
     name: 'composerIgnorePlatformReqs',

--- a/lib/config/validation.spec.ts
+++ b/lib/config/validation.spec.ts
@@ -1818,6 +1818,24 @@ describe('config/validation', () => {
   });
 
   describe('validate globalOptions()', () => {
+    // TODO #40742 #40747
+    it('binarySource=docker is deprecated', async () => {
+      const config: GlobalConfig = {
+        binarySource: 'docker',
+      };
+      const { warnings } = await configValidation.validateConfig(
+        'global',
+        config,
+      );
+      expect(warnings).toEqual([
+        {
+          topic: 'Deprecation Warning',
+          message:
+            'Usage of `binarySource=docker` is deprecated, and will be removed in the future. Please migrate to `binarySource=install`. Feedback on the usage of `binarySource=docker` is welcome at https://github.com/renovatebot/renovate/discussions/40742',
+        },
+      ]);
+    });
+
     it('binarySource', async () => {
       const config = {
         binarySource: 'invalid' as never,

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -826,6 +826,15 @@ async function validateGlobalConfig(
       message: getDeprecationMessage(key)!,
     });
   }
+
+  if (key === 'binarySource' && val === 'docker') {
+    warnings.push({
+      topic: 'Deprecation Warning',
+      message:
+        'Usage of `binarySource=docker` is deprecated, and will be removed in the future. Please migrate to `binarySource=install`. Feedback on the usage of `binarySource=docker` is welcome at https://github.com/renovatebot/renovate/discussions/40742',
+    });
+  }
+
   if (val !== null) {
     // v8 ignore else -- TODO: add test #40625
     if (type === 'string') {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
As noted in #40747, we have now explicitly deprecated
`binarySource=docker`.

This has been not recommended since 2023-07, and now we're noting that
it shouldn't be used any more.

We can make sure to mark any Docker-related self-hosted configuration as
deprecated, and add a custom deprecation warning (and URL for feedback)
to usages of `binarySource=docker`, so config validation flags these
deprecated usages.

> [!NOTE]
> Config validation is blocked by https://github.com/renovatebot/renovate/pull/40753

## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
