### PR TITLE
fix!: prevent grouping of replacement updates

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -1918,6 +1918,10 @@ For example, to group all non-major devDependencies updates together into a sing
 }
 ```
 
+<!-- prettier-ignore -->
+!!! note
+    Replacement updates will never be grouped.
+
 ## groupSlug
 
 By default, Renovate will "slugify" the groupName to determine the branch name.
@@ -3721,6 +3725,10 @@ Use the `replacementName` config option to set the name of a replacement package
 Can be used in combination with `replacementVersion`.
 
 You can suggest a new community package rule by editing [the `replacements.json` file on the Renovate repository](https://github.com/renovatebot/renovate/blob/main/lib/data/replacements.json) and opening a pull request.
+
+<!-- prettier-ignore -->
+!!! note
+    Replacement updates will never be grouped.
 
 ### replacementNameTemplate
 

--- a/lib/workers/repository/updates/branch-name.spec.ts
+++ b/lib/workers/repository/updates/branch-name.spec.ts
@@ -16,6 +16,22 @@ describe('workers/repository/updates/branch-name', () => {
       expect(upgrade.branchName).toBe('some-variable-name-grouptopic');
     });
 
+    it('ignores grouping of replacement update', () => {
+      const upgrade = partial<BranchUpgradeConfig>({
+        group: {
+          branchName: '{{groupSlug}}-{{branchTopic}}',
+          branchTopic: 'grouptopic',
+        },
+        updateType: 'replacement',
+        depName: 'axios',
+        depNameSanitized: 'axios',
+        branchTopic: '{{depNameSanitized}}-replacement', // default for replacements
+        branchName: '{{branchPrefix}}{{additionalBranchPrefix}}{{branchTopic}}', // default
+      });
+      generateBranchName(upgrade);
+      expect(upgrade.branchName).toBe('axios-replacement');
+    });
+
     it('uses groupName if no slug defined, ignores sharedVariableName', () => {
       const upgrade = partial<BranchUpgradeConfig>({
         groupName: 'some group name',

--- a/lib/workers/repository/updates/branch-name.ts
+++ b/lib/workers/repository/updates/branch-name.ts
@@ -63,7 +63,8 @@ export function generateBranchName(update: BranchUpgradeConfig): void {
     );
     update.groupName = update.sharedVariableName;
   }
-  if (update.groupName) {
+
+  if (update.groupName && update.updateType !== 'replacement') {
     update.groupName = template.compile(update.groupName, update);
     logger.trace('Using group branchName template');
     // TODO: types (#22198)

--- a/lib/workers/repository/updates/branch-name.ts
+++ b/lib/workers/repository/updates/branch-name.ts
@@ -64,36 +64,43 @@ export function generateBranchName(update: BranchUpgradeConfig): void {
     update.groupName = update.sharedVariableName;
   }
 
-  if (update.groupName && update.updateType !== 'replacement') {
-    update.groupName = template.compile(update.groupName, update);
-    logger.trace('Using group branchName template');
-    // TODO: types (#22198)
-    logger.trace(
-      `Dependency ${update.depName!} is part of group ${update.groupName}`,
-    );
-    if (update.groupSlug) {
-      update.groupSlug = template.compile(update.groupSlug, update);
-    } else {
-      update.groupSlug = update.groupName;
-    }
-    update.groupSlug = slugify(update.groupSlug, {
-      lower: true,
-    });
-    if (update.updateType === 'major' && update.separateMajorMinor) {
-      if (update.separateMultipleMajor) {
-        update.groupSlug = `major-${newMajor}-${update.groupSlug}`;
+  if (update.groupName) {
+    if (update.updateType !== 'replacement') {
+      update.groupName = template.compile(update.groupName, update);
+      logger.trace('Using group branchName template');
+      // TODO: types (#22198)
+      logger.trace(
+        `Dependency ${update.depName!} is part of group ${update.groupName}`,
+      );
+      if (update.groupSlug) {
+        update.groupSlug = template.compile(update.groupSlug, update);
       } else {
-        update.groupSlug = `major-${update.groupSlug}`;
+        update.groupSlug = update.groupName;
       }
+      update.groupSlug = slugify(update.groupSlug, {
+        lower: true,
+      });
+      if (update.updateType === 'major' && update.separateMajorMinor) {
+        if (update.separateMultipleMajor) {
+          update.groupSlug = `major-${newMajor}-${update.groupSlug}`;
+        } else {
+          update.groupSlug = `major-${update.groupSlug}`;
+        }
+      }
+      if (update.updateType === 'minor' && update.separateMultipleMinor) {
+        update.groupSlug = `minor-${newMajor}.${newMinor}-${update.groupSlug}`;
+      }
+      if (update.updateType === 'patch' && update.separateMinorPatch) {
+        update.groupSlug = `patch-${update.groupSlug}`;
+      }
+      update.branchTopic = update.group!.branchTopic ?? update.branchTopic;
+      update.branchName = update.group!.branchName ?? update.branchName;
+    } else {
+      logger.debug(
+        { depName: update.depName },
+        'Ignoring grouped branch name for replacement update',
+      );
     }
-    if (update.updateType === 'minor' && update.separateMultipleMinor) {
-      update.groupSlug = `minor-${newMajor}.${newMinor}-${update.groupSlug}`;
-    }
-    if (update.updateType === 'patch' && update.separateMinorPatch) {
-      update.groupSlug = `patch-${update.groupSlug}`;
-    }
-    update.branchTopic = update.group!.branchTopic ?? update.branchTopic;
-    update.branchName = update.group!.branchName ?? update.branchName;
   }
 
   if (update.hashedBranchLength) {

--- a/lib/workers/repository/updates/branch-name.ts
+++ b/lib/workers/repository/updates/branch-name.ts
@@ -65,7 +65,12 @@ export function generateBranchName(update: BranchUpgradeConfig): void {
   }
 
   if (update.groupName) {
-    if (update.updateType !== 'replacement') {
+    if (update.updateType === 'replacement') {
+      logger.debug(
+        { depName: update.depName },
+        'Ignoring grouped branch name for replacement update',
+      );
+    } else {
       update.groupName = template.compile(update.groupName, update);
       logger.trace('Using group branchName template');
       // TODO: types (#22198)
@@ -95,11 +100,6 @@ export function generateBranchName(update: BranchUpgradeConfig): void {
       }
       update.branchTopic = update.group!.branchTopic ?? update.branchTopic;
       update.branchName = update.group!.branchName ?? update.branchName;
-    } else {
-      logger.debug(
-        { depName: update.depName },
-        'Ignoring grouped branch name for replacement update',
-      );
     }
   }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- For replacement updates ignore the `group` settings
<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #39273
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/Rahul-renovate-testing/distinct-replacements/pulls

For Before, check this PR: https://github.com/Rahul-renovate-testing/distinct-replacements/pull/1
For After, check this PR: https://github.com/Rahul-renovate-testing/distinct-replacements/pull/2 (this was only created after excluding replacement PRs from grouping)

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
