### PR TITLE
feat(sidecar): use `renovatebot/base-image` instead of `containerbase/sidecar`

### DIFF
--- a/docs/usage/key-concepts/minimum-release-age.md
+++ b/docs/usage/key-concepts/minimum-release-age.md
@@ -371,7 +371,7 @@ Will then output:
     {
       "manager": "regex",
       "datasource": "docker",
-      "depName": "ghcr.io/containerbase/sidecar",
+      "depName": "ghcr.io/renovatebot/base-image",
       "packageFile": "lib/config/options/index.ts",
       "registryUrls": ["https://ghcr.io"]
     }

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -701,7 +701,7 @@ Setting a different limit is useful for registries that ignore the `n` parameter
 
 ## dockerSidecarImage
 
-By default Renovate pulls the sidecar Docker containers from `ghcr.io/containerbase/sidecar`.
+By default Renovate pulls the sidecar Docker containers from `ghcr.io/renovatebot/base-image`.
 You can use the `dockerSidecarImage` option to override this default.
 
 Say you want to pull a custom image from `ghcr.io/your_company/sidecar`.
@@ -713,7 +713,7 @@ You would put this in your configuration file:
 }
 ```
 
-Now when Renovate pulls a new `sidecar` image, the final image is `ghcr.io/your_company/sidecar` instead of `ghcr.io/containerbase/sidecar`.
+Now when Renovate pulls a new `sidecar` image, the final image is `ghcr.io/your_company/sidecar` instead of `ghcr.io/renovatebot/base-image`.
 
 ## dockerUser
 

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -677,7 +677,7 @@ You can skip the host part, and use only the datasource and credentials.
 
 Adds a custom prefix to the default Renovate sidecar Docker containers name and label.
 
-For example, if you set `dockerChildPrefix=myprefix_` then the final container created from the `containerbase/sidecar` is:
+For example, if you set `dockerChildPrefix=myprefix_` then the final container created from the `ghcr.io/renovatebot/base-image` is:
 
 - called `myprefix_sidecar` instead of `renovate_sidecar`
 - labeled `myprefix_child` instead of `renovate_child`

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -613,7 +613,7 @@ const options: Readonly<RenovateOptions>[] = [
     description:
       'Change this value to override the default Renovate sidecar image.',
     type: 'string',
-    default: 'ghcr.io/containerbase/sidecar:13.26.7',
+    default: 'ghcr.io/renovatebot/base-image:12.31.1',
     globalOnly: true,
   },
   {

--- a/lib/modules/manager/bundler/artifacts.spec.ts
+++ b/lib/modules/manager/bundler/artifacts.spec.ts
@@ -32,7 +32,7 @@ const adminConfig: RepoGlobalConfig = {
   localDir: upath.join('/tmp/github/some/repo'),
   cacheDir: upath.join('/tmp/cache'),
   containerbaseDir: upath.join('/tmp/cache/containerbase'),
-  dockerSidecarImage: 'ghcr.io/containerbase/sidecar',
+  dockerSidecarImage: 'ghcr.io/renovatebot/base-image',
 };
 
 const config: UpdateArtifactsConfig = {};
@@ -278,7 +278,7 @@ describe('modules/manager/bundler/artifacts', () => {
           }),
         ).toEqual([updatedGemfileLock]);
         expect(execSnapshots).toMatchObject([
-          { cmd: 'docker pull ghcr.io/containerbase/sidecar' },
+          { cmd: 'docker pull ghcr.io/renovatebot/base-image' },
           { cmd: 'docker ps --filter name=renovate_sidecar -aq' },
           {
             cmd:
@@ -288,7 +288,7 @@ describe('modules/manager/bundler/artifacts', () => {
               '-e GEM_HOME ' +
               '-e CONTAINERBASE_CACHE_DIR ' +
               '-w "/tmp/github/some/repo" ' +
-              'ghcr.io/containerbase/sidecar' +
+              'ghcr.io/renovatebot/base-image' +
               ' bash -l -c "' +
               'install-tool ruby 1.2.0' +
               ' && ' +
@@ -337,7 +337,7 @@ describe('modules/manager/bundler/artifacts', () => {
           }),
         ).toEqual([updatedGemfileLock]);
         expect(execSnapshots).toMatchObject([
-          { cmd: 'docker pull ghcr.io/containerbase/sidecar' },
+          { cmd: 'docker pull ghcr.io/renovatebot/base-image' },
           { cmd: 'docker ps --filter name=renovate_sidecar -aq' },
           {
             cmd:
@@ -347,7 +347,7 @@ describe('modules/manager/bundler/artifacts', () => {
               '-e GEM_HOME ' +
               '-e CONTAINERBASE_CACHE_DIR ' +
               '-w "/tmp/github/some/repo" ' +
-              'ghcr.io/containerbase/sidecar' +
+              'ghcr.io/renovatebot/base-image' +
               ' bash -l -c "' +
               'install-tool ruby 1.2.5' +
               ' && ' +
@@ -398,7 +398,7 @@ describe('modules/manager/bundler/artifacts', () => {
           }),
         ).toEqual([updatedGemfileLock]);
         expect(execSnapshots).toMatchObject([
-          { cmd: 'docker pull ghcr.io/containerbase/sidecar' },
+          { cmd: 'docker pull ghcr.io/renovatebot/base-image' },
           { cmd: 'docker ps --filter name=renovate_sidecar -aq' },
           {
             cmd:
@@ -408,7 +408,7 @@ describe('modules/manager/bundler/artifacts', () => {
               '-e GEM_HOME ' +
               '-e CONTAINERBASE_CACHE_DIR ' +
               '-w "/tmp/github/some/repo" ' +
-              'ghcr.io/containerbase/sidecar' +
+              'ghcr.io/renovatebot/base-image' +
               ' bash -l -c "' +
               'install-tool ruby 1.3.0' +
               ' && ' +
@@ -458,7 +458,7 @@ describe('modules/manager/bundler/artifacts', () => {
           }),
         ).toEqual([updatedGemfileLock]);
         expect(execSnapshots).toMatchObject([
-          { cmd: 'docker pull ghcr.io/containerbase/sidecar' },
+          { cmd: 'docker pull ghcr.io/renovatebot/base-image' },
           { cmd: 'docker ps --filter name=renovate_sidecar -aq' },
           {
             cmd:
@@ -469,7 +469,7 @@ describe('modules/manager/bundler/artifacts', () => {
               '-e GEM_HOME ' +
               '-e CONTAINERBASE_CACHE_DIR ' +
               '-w "/tmp/github/some/repo" ' +
-              'ghcr.io/containerbase/sidecar' +
+              'ghcr.io/renovatebot/base-image' +
               ' bash -l -c "' +
               'install-tool ruby 1.2.0' +
               ' && ' +

--- a/lib/modules/manager/cargo/artifacts.spec.ts
+++ b/lib/modules/manager/cargo/artifacts.spec.ts
@@ -25,7 +25,7 @@ const adminConfig: RepoGlobalConfig = {
   localDir: upath.join('/tmp/github/some/repo'),
   cacheDir: upath.join('/tmp/cache'),
   containerbaseDir: upath.join('/tmp/cache/containerbase'),
-  dockerSidecarImage: 'ghcr.io/containerbase/sidecar',
+  dockerSidecarImage: 'ghcr.io/renovatebot/base-image',
 };
 
 describe('modules/manager/cargo/artifacts', () => {
@@ -452,7 +452,7 @@ describe('modules/manager/cargo/artifacts', () => {
       },
     ]);
     expect(execSnapshots).toMatchObject([
-      { cmd: 'docker pull ghcr.io/containerbase/sidecar' },
+      { cmd: 'docker pull ghcr.io/renovatebot/base-image' },
       {},
       {
         cmd:
@@ -461,7 +461,7 @@ describe('modules/manager/cargo/artifacts', () => {
           '-v "/tmp/cache":"/tmp/cache" ' +
           '-e CONTAINERBASE_CACHE_DIR ' +
           '-w "/tmp/github/some/repo" ' +
-          'ghcr.io/containerbase/sidecar ' +
+          'ghcr.io/renovatebot/base-image ' +
           'bash -l -c "' +
           'install-tool rust 1.65.0' +
           ' && ' +
@@ -518,7 +518,7 @@ describe('modules/manager/cargo/artifacts', () => {
       },
     ]);
     expect(execSnapshots).toMatchObject([
-      { cmd: 'docker pull ghcr.io/containerbase/sidecar' },
+      { cmd: 'docker pull ghcr.io/renovatebot/base-image' },
       {},
       {
         cmd:
@@ -540,7 +540,7 @@ describe('modules/manager/cargo/artifacts', () => {
           '-e GIT_CONFIG_VALUE_5 ' +
           '-e CONTAINERBASE_CACHE_DIR ' +
           '-w "/tmp/github/some/repo" ' +
-          'ghcr.io/containerbase/sidecar ' +
+          'ghcr.io/renovatebot/base-image ' +
           'bash -l -c "' +
           'install-tool rust 1.65.0' +
           ' && ' +

--- a/lib/modules/manager/cocoapods/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/modules/manager/cocoapods/__snapshots__/artifacts.spec.ts.snap
@@ -61,11 +61,11 @@ exports[`modules/manager/cocoapods/artifacts > returns pod exec error 1`] = `
 exports[`modules/manager/cocoapods/artifacts > returns updated Podfile 1`] = `
 [
   {
-    "cmd": "docker pull ghcr.io/containerbase/sidecar",
+    "cmd": "docker pull ghcr.io/renovatebot/base-image",
     "options": {},
   },
   {
-    "cmd": "docker run --rm --name=renovate_sidecar --label=renovate_child -v "/tmp/github/some/repo":"/tmp/github/some/repo" -v "/tmp/cache":"/tmp/cache" -e CONTAINERBASE_CACHE_DIR -w "/tmp/github/some/repo" ghcr.io/containerbase/sidecar bash -l -c "install-tool ruby 3.1.0 && install-tool cocoapods 3.1.0 && gem install cocoapods-acknowledgements && pod install"",
+    "cmd": "docker run --rm --name=renovate_sidecar --label=renovate_child -v "/tmp/github/some/repo":"/tmp/github/some/repo" -v "/tmp/cache":"/tmp/cache" -e CONTAINERBASE_CACHE_DIR -w "/tmp/github/some/repo" ghcr.io/renovatebot/base-image bash -l -c "install-tool ruby 3.1.0 && install-tool cocoapods 3.1.0 && gem install cocoapods-acknowledgements && pod install"",
     "options": {
       "cwd": "/tmp/github/some/repo",
       "env": {
@@ -91,11 +91,11 @@ exports[`modules/manager/cocoapods/artifacts > returns updated Podfile 1`] = `
 exports[`modules/manager/cocoapods/artifacts > returns updated Podfile and Pods files 1`] = `
 [
   {
-    "cmd": "docker pull ghcr.io/containerbase/sidecar",
+    "cmd": "docker pull ghcr.io/renovatebot/base-image",
     "options": {},
   },
   {
-    "cmd": "docker run --rm --name=renovate_sidecar --label=renovate_child -v "/tmp/github/some/repo":"/tmp/github/some/repo" -v "/tmp/cache":"/tmp/cache" -e CONTAINERBASE_CACHE_DIR -w "/tmp/github/some/repo" ghcr.io/containerbase/sidecar bash -l -c "install-tool ruby 3.1.0 && install-tool cocoapods 3.1.0 && pod install"",
+    "cmd": "docker run --rm --name=renovate_sidecar --label=renovate_child -v "/tmp/github/some/repo":"/tmp/github/some/repo" -v "/tmp/cache":"/tmp/cache" -e CONTAINERBASE_CACHE_DIR -w "/tmp/github/some/repo" ghcr.io/renovatebot/base-image bash -l -c "install-tool ruby 3.1.0 && install-tool cocoapods 3.1.0 && pod install"",
     "options": {
       "cwd": "/tmp/github/some/repo",
       "env": {

--- a/lib/modules/manager/cocoapods/artifacts.spec.ts
+++ b/lib/modules/manager/cocoapods/artifacts.spec.ts
@@ -25,7 +25,7 @@ const adminConfig: RepoGlobalConfig = {
   localDir: upath.join('/tmp/github/some/repo'),
   cacheDir: upath.join('/tmp/cache'),
   containerbaseDir: upath.join('/tmp/cache/containerbase'),
-  dockerSidecarImage: 'ghcr.io/containerbase/sidecar',
+  dockerSidecarImage: 'ghcr.io/renovatebot/base-image',
 };
 
 describe('modules/manager/cocoapods/artifacts', () => {
@@ -251,7 +251,7 @@ describe('modules/manager/cocoapods/artifacts', () => {
       config,
     });
     expect(execSnapshots).toMatchObject([
-      { cmd: 'docker pull ghcr.io/containerbase/sidecar' },
+      { cmd: 'docker pull ghcr.io/renovatebot/base-image' },
       {
         cmd:
           'docker run --rm --name=renovate_sidecar --label=renovate_child ' +
@@ -259,7 +259,7 @@ describe('modules/manager/cocoapods/artifacts', () => {
           '-v "/tmp/cache":"/tmp/cache" ' +
           '-e CONTAINERBASE_CACHE_DIR ' +
           '-w "/tmp/github/some/repo" ' +
-          'ghcr.io/containerbase/sidecar' +
+          'ghcr.io/renovatebot/base-image' +
           ' bash -l -c "' +
           'install-tool ruby 3.1.0' +
           ' && ' +

--- a/lib/modules/manager/composer/artifacts.spec.ts
+++ b/lib/modules/manager/composer/artifacts.spec.ts
@@ -33,7 +33,7 @@ const adminConfig: RepoGlobalConfig = {
   localDir: upath.join('/tmp/github/some/repo'),
   cacheDir: upath.join('/tmp/renovate/cache'),
   containerbaseDir: upath.join('/tmp/renovate/cache/containerbase'),
-  dockerSidecarImage: 'ghcr.io/containerbase/sidecar',
+  dockerSidecarImage: 'ghcr.io/renovatebot/base-image',
 };
 
 const repoStatus = partial<StatusResult>({
@@ -787,7 +787,7 @@ describe('modules/manager/composer/artifacts', () => {
     ]);
     expect(execSnapshots).toMatchObject([
       {
-        cmd: 'docker pull ghcr.io/containerbase/sidecar',
+        cmd: 'docker pull ghcr.io/renovatebot/base-image',
         options: {},
       },
       {
@@ -802,7 +802,7 @@ describe('modules/manager/composer/artifacts', () => {
           '-e COMPOSER_CACHE_DIR ' +
           '-e CONTAINERBASE_CACHE_DIR ' +
           '-w "/tmp/github/some/repo" ' +
-          'ghcr.io/containerbase/sidecar' +
+          'ghcr.io/renovatebot/base-image' +
           ' bash -l -c "' +
           'install-tool php 7.3' +
           ' && ' +

--- a/lib/modules/manager/conan/artifacts.spec.ts
+++ b/lib/modules/manager/conan/artifacts.spec.ts
@@ -18,7 +18,7 @@ const adminConfig: RepoGlobalConfig = {
   localDir: upath.join('/tmp/github/some/repo'),
   cacheDir: upath.join('/tmp/cache'),
   containerbaseDir: upath.join('/tmp/cache/containerbase'),
-  dockerSidecarImage: 'ghcr.io/containerbase/sidecar',
+  dockerSidecarImage: 'ghcr.io/renovatebot/base-image',
 };
 
 describe('modules/manager/conan/artifacts', () => {

--- a/lib/modules/manager/gomod/artifacts.spec.ts
+++ b/lib/modules/manager/gomod/artifacts.spec.ts
@@ -61,7 +61,7 @@ const adminConfig: RepoGlobalConfig = {
   localDir: upath.join('/tmp/github/some/repo'),
   cacheDir: upath.join('/tmp/renovate/cache'),
   containerbaseDir: upath.join('/tmp/renovate/cache/containerbase'),
-  dockerSidecarImage: 'ghcr.io/containerbase/sidecar',
+  dockerSidecarImage: 'ghcr.io/renovatebot/base-image',
 };
 
 const config: UpdateArtifactsConfig = {
@@ -820,7 +820,7 @@ describe('modules/manager/gomod/artifacts', () => {
       },
     ]);
     expect(execSnapshots).toMatchObject([
-      { cmd: 'docker pull ghcr.io/containerbase/sidecar' },
+      { cmd: 'docker pull ghcr.io/renovatebot/base-image' },
       { cmd: 'docker ps --filter name=renovate_sidecar -aq' },
       {
         cmd:
@@ -836,7 +836,7 @@ describe('modules/manager/gomod/artifacts', () => {
           '-e CGO_ENABLED ' +
           '-e CONTAINERBASE_CACHE_DIR ' +
           '-w "/tmp/github/some/repo" ' +
-          'ghcr.io/containerbase/sidecar' +
+          'ghcr.io/renovatebot/base-image' +
           ' bash -l -c "' +
           'install-tool golang 1.23.3' +
           ' && ' +
@@ -975,7 +975,7 @@ describe('modules/manager/gomod/artifacts', () => {
       },
     ]);
     expect(execSnapshots).toMatchObject([
-      { cmd: 'docker pull ghcr.io/containerbase/sidecar' },
+      { cmd: 'docker pull ghcr.io/renovatebot/base-image' },
       { cmd: 'docker ps --filter name=renovate_sidecar -aq' },
       {
         cmd:
@@ -1004,7 +1004,7 @@ describe('modules/manager/gomod/artifacts', () => {
           '-e GIT_CONFIG_VALUE_5 ' +
           '-e CONTAINERBASE_CACHE_DIR ' +
           '-w "/tmp/github/some/repo" ' +
-          'ghcr.io/containerbase/sidecar' +
+          'ghcr.io/renovatebot/base-image' +
           ' bash -l -c "' +
           'install-tool golang 1.23.3' +
           ' && ' +
@@ -1085,7 +1085,7 @@ describe('modules/manager/gomod/artifacts', () => {
       },
     ]);
     expect(execSnapshots).toMatchObject([
-      { cmd: 'docker pull ghcr.io/containerbase/sidecar' },
+      { cmd: 'docker pull ghcr.io/renovatebot/base-image' },
       {},
       {
         options: {
@@ -1505,7 +1505,7 @@ describe('modules/manager/gomod/artifacts', () => {
       { file: { contents: 'New go.sum 2', path: 'go.mod', type: 'addition' } },
     ]);
     expect(execSnapshots).toMatchObject([
-      { cmd: 'docker pull ghcr.io/containerbase/sidecar' },
+      { cmd: 'docker pull ghcr.io/renovatebot/base-image' },
       {},
       {
         cmd:
@@ -1521,7 +1521,7 @@ describe('modules/manager/gomod/artifacts', () => {
           '-e CGO_ENABLED ' +
           '-e CONTAINERBASE_CACHE_DIR ' +
           '-w "/tmp/github/some/repo" ' +
-          'ghcr.io/containerbase/sidecar' +
+          'ghcr.io/renovatebot/base-image' +
           ' bash -l -c "' +
           'install-tool golang 1.23.3' +
           ' && ' +
@@ -1570,7 +1570,7 @@ describe('modules/manager/gomod/artifacts', () => {
       { file: { contents: 'New go.sum 2', path: 'go.mod', type: 'addition' } },
     ]);
     expect(execSnapshots).toMatchObject([
-      { cmd: 'docker pull ghcr.io/containerbase/sidecar' },
+      { cmd: 'docker pull ghcr.io/renovatebot/base-image' },
       {},
       {
         cmd:
@@ -1586,7 +1586,7 @@ describe('modules/manager/gomod/artifacts', () => {
           '-e CGO_ENABLED ' +
           '-e CONTAINERBASE_CACHE_DIR ' +
           '-w "/tmp/github/some/repo" ' +
-          'ghcr.io/containerbase/sidecar' +
+          'ghcr.io/renovatebot/base-image' +
           ' bash -l -c "' +
           'install-tool golang 1.23.3' +
           ' && ' +
@@ -1635,7 +1635,7 @@ describe('modules/manager/gomod/artifacts', () => {
       { file: { contents: 'New go.sum 2', path: 'go.mod', type: 'addition' } },
     ]);
     expect(execSnapshots).toMatchObject([
-      { cmd: 'docker pull ghcr.io/containerbase/sidecar' },
+      { cmd: 'docker pull ghcr.io/renovatebot/base-image' },
       {},
       {
         cmd:
@@ -1651,7 +1651,7 @@ describe('modules/manager/gomod/artifacts', () => {
           '-e CGO_ENABLED ' +
           '-e CONTAINERBASE_CACHE_DIR ' +
           '-w "/tmp/github/some/repo" ' +
-          'ghcr.io/containerbase/sidecar' +
+          'ghcr.io/renovatebot/base-image' +
           ' bash -l -c "' +
           'install-tool golang 1.23.3' +
           ' && ' +
@@ -1700,7 +1700,7 @@ describe('modules/manager/gomod/artifacts', () => {
       { file: { contents: 'New go.sum 2', path: 'go.mod', type: 'addition' } },
     ]);
     expect(execSnapshots).toMatchObject([
-      { cmd: 'docker pull ghcr.io/containerbase/sidecar' },
+      { cmd: 'docker pull ghcr.io/renovatebot/base-image' },
       {},
       {
         cmd:
@@ -1716,7 +1716,7 @@ describe('modules/manager/gomod/artifacts', () => {
           '-e CGO_ENABLED ' +
           '-e CONTAINERBASE_CACHE_DIR ' +
           '-w "/tmp/github/some/repo" ' +
-          'ghcr.io/containerbase/sidecar' +
+          'ghcr.io/renovatebot/base-image' +
           ' bash -l -c "' +
           'install-tool golang 1.23.3' +
           ' && ' +
@@ -2367,7 +2367,7 @@ describe('modules/manager/gomod/artifacts', () => {
     ]);
     const expectedResult = [
       {
-        cmd: 'docker pull ghcr.io/containerbase/sidecar',
+        cmd: 'docker pull ghcr.io/renovatebot/base-image',
       },
       {},
       {
@@ -2384,7 +2384,7 @@ describe('modules/manager/gomod/artifacts', () => {
           '-e CGO_ENABLED ' +
           '-e CONTAINERBASE_CACHE_DIR ' +
           '-w "/tmp/github/some/repo" ' +
-          'ghcr.io/containerbase/sidecar' +
+          'ghcr.io/renovatebot/base-image' +
           ' bash -l -c "' +
           'install-tool golang 1.23.3' +
           ' && ' +
@@ -2565,7 +2565,7 @@ describe('modules/manager/gomod/artifacts', () => {
     ]);
     const expectedResult = [
       {
-        cmd: 'docker pull ghcr.io/containerbase/sidecar',
+        cmd: 'docker pull ghcr.io/renovatebot/base-image',
       },
       {},
       {
@@ -2582,7 +2582,7 @@ describe('modules/manager/gomod/artifacts', () => {
           '-e CGO_ENABLED ' +
           '-e CONTAINERBASE_CACHE_DIR ' +
           '-w "/tmp/github/some/repo" ' +
-          'ghcr.io/containerbase/sidecar' +
+          'ghcr.io/renovatebot/base-image' +
           ' bash -l -c "' +
           'install-tool golang 1.23.3' +
           ' && ' +

--- a/lib/modules/manager/gradle-wrapper/artifacts.spec.ts
+++ b/lib/modules/manager/gradle-wrapper/artifacts.spec.ts
@@ -209,7 +209,7 @@ describe('modules/manager/gradle-wrapper/artifacts', () => {
       GlobalConfig.set({
         ...adminConfig,
         binarySource: 'docker',
-        dockerSidecarImage: 'ghcr.io/containerbase/sidecar',
+        dockerSidecarImage: 'ghcr.io/renovatebot/base-image',
       });
 
       const result = await updateArtifacts({
@@ -229,7 +229,7 @@ describe('modules/manager/gradle-wrapper/artifacts', () => {
         },
       ]);
       expect(execSnapshots).toMatchObject([
-        { cmd: 'docker pull ghcr.io/containerbase/sidecar' },
+        { cmd: 'docker pull ghcr.io/renovatebot/base-image' },
         { cmd: 'docker ps --filter name=renovate_sidecar -aq' },
         {
           cmd:
@@ -239,7 +239,7 @@ describe('modules/manager/gradle-wrapper/artifacts', () => {
             '-e GRADLE_OPTS ' +
             '-e CONTAINERBASE_CACHE_DIR ' +
             '-w "/tmp/github/some/repo" ' +
-            'ghcr.io/containerbase/sidecar' +
+            'ghcr.io/renovatebot/base-image' +
             ' bash -l -c "' +
             'install-tool java 11.0.1' +
             ' && ' +

--- a/lib/modules/manager/gradle/artifacts.spec.ts
+++ b/lib/modules/manager/gradle/artifacts.spec.ts
@@ -24,7 +24,7 @@ const adminConfig: RepoGlobalConfig = {
   localDir: upath.join('/tmp/github/some/repo'),
   cacheDir: upath.join('/tmp/cache'),
   containerbaseDir: upath.join('/tmp/cache/containerbase'),
-  dockerSidecarImage: 'ghcr.io/containerbase/sidecar',
+  dockerSidecarImage: 'ghcr.io/renovatebot/base-image',
 };
 
 const osPlatformSpy = vi.spyOn(os, 'platform');
@@ -401,7 +401,7 @@ describe('modules/manager/gradle/artifacts', () => {
         },
       ]);
       expect(execSnapshots).toMatchObject([
-        { cmd: 'docker pull ghcr.io/containerbase/sidecar' },
+        { cmd: 'docker pull ghcr.io/renovatebot/base-image' },
         { cmd: 'docker ps --filter name=renovate_sidecar -aq' },
         {
           cmd:
@@ -411,7 +411,7 @@ describe('modules/manager/gradle/artifacts', () => {
             '-e GRADLE_OPTS ' +
             '-e CONTAINERBASE_CACHE_DIR ' +
             '-w "/tmp/github/some/repo" ' +
-            'ghcr.io/containerbase/sidecar' +
+            'ghcr.io/renovatebot/base-image' +
             ' bash -l -c "' +
             'install-tool java 16.0.1' +
             ' && ' +
@@ -428,7 +428,7 @@ describe('modules/manager/gradle/artifacts', () => {
             '-e GRADLE_OPTS ' +
             '-e CONTAINERBASE_CACHE_DIR ' +
             '-w "/tmp/github/some/repo" ' +
-            'ghcr.io/containerbase/sidecar' +
+            'ghcr.io/renovatebot/base-image' +
             ' bash -l -c "' +
             'install-tool java 16.0.1' +
             ' && ' +

--- a/lib/modules/manager/helmfile/artifacts.spec.ts
+++ b/lib/modules/manager/helmfile/artifacts.spec.ts
@@ -24,7 +24,7 @@ const adminConfig: RepoGlobalConfig = {
   localDir: upath.join('/tmp/github/some/repo'), // `join` fixes Windows CI
   cacheDir: upath.join('/tmp/renovate/cache'),
   containerbaseDir: upath.join('/tmp/renovate/cache/containerbase'),
-  dockerSidecarImage: 'ghcr.io/containerbase/sidecar',
+  dockerSidecarImage: 'ghcr.io/renovatebot/base-image',
 };
 
 const config: UpdateArtifactsConfig = {};
@@ -311,7 +311,7 @@ describe('modules/manager/helmfile/artifacts', () => {
     {
       binarySource: 'docker' as const,
       expectedCommands: [
-        { cmd: 'docker pull ghcr.io/containerbase/sidecar' },
+        { cmd: 'docker pull ghcr.io/renovatebot/base-image' },
         { cmd: 'docker ps --filter name=renovate_sidecar -aq' },
         {
           cmd:
@@ -324,7 +324,7 @@ describe('modules/manager/helmfile/artifacts', () => {
             '-e HELM_REPOSITORY_CACHE ' +
             '-e CONTAINERBASE_CACHE_DIR ' +
             '-w "/tmp/github/some/repo" ' +
-            'ghcr.io/containerbase/sidecar ' +
+            'ghcr.io/renovatebot/base-image ' +
             'bash -l -c "' +
             'install-tool helm v3.7.2' +
             ' && ' +

--- a/lib/modules/manager/helmv3/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/modules/manager/helmv3/__snapshots__/artifacts.spec.ts.snap
@@ -494,7 +494,7 @@ exports[`modules/manager/helmv3/artifacts > returns updated Chart.lock for lockf
 exports[`modules/manager/helmv3/artifacts > returns updated Chart.lock with docker 1`] = `
 [
   {
-    "cmd": "docker pull ghcr.io/containerbase/sidecar",
+    "cmd": "docker pull ghcr.io/renovatebot/base-image",
     "options": {},
   },
   {
@@ -502,7 +502,7 @@ exports[`modules/manager/helmv3/artifacts > returns updated Chart.lock with dock
     "options": {},
   },
   {
-    "cmd": "docker run --rm --name=renovate_sidecar --label=renovate_child -v "/tmp/github/some/repo":"/tmp/github/some/repo" -v "/tmp/renovate/cache":"/tmp/renovate/cache" -e HELM_EXPERIMENTAL_OCI -e HELM_REGISTRY_CONFIG -e HELM_REPOSITORY_CONFIG -e HELM_REPOSITORY_CACHE -e CONTAINERBASE_CACHE_DIR -w "/tmp/github/some/repo" ghcr.io/containerbase/sidecar bash -l -c "install-tool helm v3.7.2 && helm repo add repo-test https://gitlab.com/api/v4/projects/xxxxxxx/packages/helm/stable --force-update && helm dependency update ''"",
+    "cmd": "docker run --rm --name=renovate_sidecar --label=renovate_child -v "/tmp/github/some/repo":"/tmp/github/some/repo" -v "/tmp/renovate/cache":"/tmp/renovate/cache" -e HELM_EXPERIMENTAL_OCI -e HELM_REGISTRY_CONFIG -e HELM_REPOSITORY_CONFIG -e HELM_REPOSITORY_CACHE -e CONTAINERBASE_CACHE_DIR -w "/tmp/github/some/repo" ghcr.io/renovatebot/base-image bash -l -c "install-tool helm v3.7.2 && helm repo add repo-test https://gitlab.com/api/v4/projects/xxxxxxx/packages/helm/stable --force-update && helm dependency update ''"",
     "options": {
       "cwd": "/tmp/github/some/repo",
       "env": {
@@ -633,7 +633,7 @@ exports[`modules/manager/helmv3/artifacts > sets repositories from registryAlias
 exports[`modules/manager/helmv3/artifacts > sets repositories from registryAliases with docker 1`] = `
 [
   {
-    "cmd": "docker pull ghcr.io/containerbase/sidecar",
+    "cmd": "docker pull ghcr.io/renovatebot/base-image",
     "options": {},
   },
   {
@@ -641,7 +641,7 @@ exports[`modules/manager/helmv3/artifacts > sets repositories from registryAlias
     "options": {},
   },
   {
-    "cmd": "docker run --rm --name=renovate_sidecar --label=renovate_child -v "/tmp/github/some/repo":"/tmp/github/some/repo" -v "/tmp/renovate/cache":"/tmp/renovate/cache" -e HELM_EXPERIMENTAL_OCI -e HELM_REGISTRY_CONFIG -e HELM_REPOSITORY_CONFIG -e HELM_REPOSITORY_CACHE -e CONTAINERBASE_CACHE_DIR -w "/tmp/github/some/repo" ghcr.io/containerbase/sidecar bash -l -c "install-tool helm v3.7.2 && helm repo add stable http://the_stable_url --force-update && helm repo add repo1 https://the_repo1_url --force-update && helm repo add repo-test https://gitlab.com/api/v4/projects/xxxxxxx/packages/helm/stable --force-update && helm dependency update ''"",
+    "cmd": "docker run --rm --name=renovate_sidecar --label=renovate_child -v "/tmp/github/some/repo":"/tmp/github/some/repo" -v "/tmp/renovate/cache":"/tmp/renovate/cache" -e HELM_EXPERIMENTAL_OCI -e HELM_REGISTRY_CONFIG -e HELM_REPOSITORY_CONFIG -e HELM_REPOSITORY_CACHE -e CONTAINERBASE_CACHE_DIR -w "/tmp/github/some/repo" ghcr.io/renovatebot/base-image bash -l -c "install-tool helm v3.7.2 && helm repo add stable http://the_stable_url --force-update && helm repo add repo1 https://the_repo1_url --force-update && helm repo add repo-test https://gitlab.com/api/v4/projects/xxxxxxx/packages/helm/stable --force-update && helm dependency update ''"",
     "options": {
       "cwd": "/tmp/github/some/repo",
       "env": {

--- a/lib/modules/manager/helmv3/artifacts.spec.ts
+++ b/lib/modules/manager/helmv3/artifacts.spec.ts
@@ -214,7 +214,7 @@ describe('modules/manager/helmv3/artifacts', () => {
     GlobalConfig.set({
       ...adminConfig,
       binarySource: 'docker',
-      dockerSidecarImage: 'ghcr.io/containerbase/sidecar',
+      dockerSidecarImage: 'ghcr.io/renovatebot/base-image',
     });
     fs.getSiblingFileName.mockReturnValueOnce('Chart.lock');
     fs.readLocalFile.mockResolvedValueOnce(ociLockFile1 as never);
@@ -654,7 +654,7 @@ describe('modules/manager/helmv3/artifacts', () => {
     GlobalConfig.set({
       ...adminConfig,
       binarySource: 'docker',
-      dockerSidecarImage: 'ghcr.io/containerbase/sidecar',
+      dockerSidecarImage: 'ghcr.io/renovatebot/base-image',
     });
     fs.getSiblingFileName.mockReturnValueOnce('Chart.lock');
     fs.readLocalFile.mockResolvedValueOnce(ociLockFile1 as never);

--- a/lib/modules/manager/kustomize/artifacts.spec.ts
+++ b/lib/modules/manager/kustomize/artifacts.spec.ts
@@ -506,7 +506,7 @@ describe('modules/manager/kustomize/artifacts', () => {
     GlobalConfig.set({
       ...adminConfig,
       binarySource: 'docker',
-      dockerSidecarImage: 'ghcr.io/containerbase/sidecar',
+      dockerSidecarImage: 'ghcr.io/renovatebot/base-image',
     });
     const execSnapshots = mockExecAll();
 
@@ -549,7 +549,7 @@ describe('modules/manager/kustomize/artifacts', () => {
     ]);
     expect(fs.deleteLocalFile).not.toHaveBeenCalled();
     expect(execSnapshots).toMatchObject([
-      { cmd: 'docker pull ghcr.io/containerbase/sidecar' },
+      { cmd: 'docker pull ghcr.io/renovatebot/base-image' },
       { cmd: 'docker ps --filter name=renovate_sidecar -aq' },
       {
         cmd:
@@ -561,7 +561,7 @@ describe('modules/manager/kustomize/artifacts', () => {
           '-e HELM_REPOSITORY_CACHE ' +
           '-e CONTAINERBASE_CACHE_DIR ' +
           '-w "/tmp/github/some/repo" ' +
-          'ghcr.io/containerbase/sidecar ' +
+          'ghcr.io/renovatebot/base-image ' +
           'bash -l -c "' +
           'install-tool helm 3.17.0' +
           ' && ' +

--- a/lib/modules/manager/maven-wrapper/artifacts.spec.ts
+++ b/lib/modules/manager/maven-wrapper/artifacts.spec.ts
@@ -181,7 +181,7 @@ describe('modules/manager/maven-wrapper/artifacts', () => {
     GlobalConfig.set({
       localDir: './',
       binarySource: 'docker',
-      dockerSidecarImage: 'ghcr.io/containerbase/sidecar',
+      dockerSidecarImage: 'ghcr.io/renovatebot/base-image',
     });
     const execSnapshots = mockExecAll({ stdout: '', stderr: '' });
     const result = await updateArtifacts({
@@ -201,7 +201,7 @@ describe('modules/manager/maven-wrapper/artifacts', () => {
     ]);
     expect(execSnapshots).toMatchObject([
       {
-        cmd: 'docker pull ghcr.io/containerbase/sidecar',
+        cmd: 'docker pull ghcr.io/renovatebot/base-image',
         options: {},
       },
       { cmd: 'docker ps --filter name=renovate_sidecar -aq' },
@@ -211,7 +211,7 @@ describe('modules/manager/maven-wrapper/artifacts', () => {
           '-v "./":"./" ' +
           '-e CONTAINERBASE_CACHE_DIR ' +
           '-w "../.." ' +
-          'ghcr.io/containerbase/sidecar' +
+          'ghcr.io/renovatebot/base-image' +
           ' bash -l -c "' +
           'install-tool java 17.0.0 ' +
           '&& ' +

--- a/lib/modules/manager/mix/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/modules/manager/mix/__snapshots__/artifacts.spec.ts.snap
@@ -19,7 +19,7 @@ exports[`modules/manager/mix/artifacts > authenticates to private repositories i
     "options": {},
   },
   {
-    "cmd": "docker run --rm --name=renovate_sidecar --label=renovate_child -v "/tmp/github/some/repo":"/tmp/github/some/repo" -v "/tmp/cache":"/tmp/cache" -e CONTAINERBASE_CACHE_DIR -w "/tmp/github/some/repo" ghcr.io/containerbase/sidecar bash -l -c "install-tool erlang 25.0.0.0 && install-tool elixir v1.13.4 && mix hex.organization auth renovate_test --key valid_test_token && mix deps.update private_package other_package"",
+    "cmd": "docker run --rm --name=renovate_sidecar --label=renovate_child -v "/tmp/github/some/repo":"/tmp/github/some/repo" -v "/tmp/cache":"/tmp/cache" -e CONTAINERBASE_CACHE_DIR -w "/tmp/github/some/repo" ghcr.io/renovatebot/base-image bash -l -c "install-tool erlang 25.0.0.0 && install-tool elixir v1.13.4 && mix hex.organization auth renovate_test --key valid_test_token && mix deps.update private_package other_package"",
     "options": {
       "cwd": "/tmp/github/some/repo",
       "env": {
@@ -70,7 +70,7 @@ exports[`modules/manager/mix/artifacts > returns null if unchanged 1`] = `
 exports[`modules/manager/mix/artifacts > returns updated mix.lock 1`] = `
 [
   {
-    "cmd": "docker pull ghcr.io/containerbase/sidecar",
+    "cmd": "docker pull ghcr.io/renovatebot/base-image",
     "options": {},
   },
   {
@@ -78,7 +78,7 @@ exports[`modules/manager/mix/artifacts > returns updated mix.lock 1`] = `
     "options": {},
   },
   {
-    "cmd": "docker run --rm --name=renovate_sidecar --label=renovate_child -v "/tmp/github/some/repo":"/tmp/github/some/repo" -v "/tmp/cache":"/tmp/cache" -e CONTAINERBASE_CACHE_DIR -w "/tmp/github/some/repo" ghcr.io/containerbase/sidecar bash -l -c "install-tool erlang 25.0.0.0 && install-tool elixir v1.13.4 && mix deps.update plug"",
+    "cmd": "docker run --rm --name=renovate_sidecar --label=renovate_child -v "/tmp/github/some/repo":"/tmp/github/some/repo" -v "/tmp/cache":"/tmp/cache" -e CONTAINERBASE_CACHE_DIR -w "/tmp/github/some/repo" ghcr.io/renovatebot/base-image bash -l -c "install-tool erlang 25.0.0.0 && install-tool elixir v1.13.4 && mix deps.update plug"",
     "options": {
       "cwd": "/tmp/github/some/repo",
       "env": {

--- a/lib/modules/manager/mix/artifacts.spec.ts
+++ b/lib/modules/manager/mix/artifacts.spec.ts
@@ -143,7 +143,7 @@ describe('modules/manager/mix/artifacts', () => {
     GlobalConfig.set({
       ...adminConfig,
       binarySource: 'docker',
-      dockerSidecarImage: 'ghcr.io/containerbase/sidecar',
+      dockerSidecarImage: 'ghcr.io/renovatebot/base-image',
     });
     fs.readLocalFile.mockResolvedValueOnce('Old mix.lock');
     fs.getSiblingFileName.mockReturnValueOnce('mix.lock');
@@ -217,7 +217,7 @@ describe('modules/manager/mix/artifacts', () => {
     GlobalConfig.set({
       ...adminConfig,
       binarySource: 'docker',
-      dockerSidecarImage: 'ghcr.io/containerbase/sidecar',
+      dockerSidecarImage: 'ghcr.io/renovatebot/base-image',
     });
     fs.readLocalFile.mockResolvedValueOnce('Old mix.lock');
     fs.getSiblingFileName.mockReturnValueOnce('mix.lock');

--- a/lib/modules/manager/nix/artifacts.spec.ts
+++ b/lib/modules/manager/nix/artifacts.spec.ts
@@ -22,7 +22,7 @@ const adminConfig: RepoGlobalConfig = {
 const dockerAdminConfig = {
   ...adminConfig,
   binarySource: 'docker',
-  dockerSidecarImage: 'ghcr.io/containerbase/sidecar',
+  dockerSidecarImage: 'ghcr.io/renovatebot/base-image',
 } satisfies RepoGlobalConfig;
 
 process.env.CONTAINERBASE = 'true';
@@ -200,7 +200,7 @@ describe('modules/manager/nix/artifacts', () => {
       },
     ]);
     expect(execSnapshots).toMatchObject([
-      { cmd: 'docker pull ghcr.io/containerbase/sidecar' },
+      { cmd: 'docker pull ghcr.io/renovatebot/base-image' },
       { cmd: 'docker ps --filter name=renovate_sidecar -aq' },
       {
         cmd:
@@ -209,7 +209,7 @@ describe('modules/manager/nix/artifacts', () => {
           '-v "/tmp/renovate/cache":"/tmp/renovate/cache" ' +
           '-e CONTAINERBASE_CACHE_DIR ' +
           '-w "/tmp/github/some/repo" ' +
-          'ghcr.io/containerbase/sidecar ' +
+          'ghcr.io/renovatebot/base-image ' +
           'bash -l -c "' +
           'install-tool nix 2.10.0 ' +
           '&& ' +
@@ -330,7 +330,7 @@ describe('modules/manager/nix/artifacts', () => {
       },
     ]);
     expect(execSnapshots).toMatchObject([
-      { cmd: 'docker pull ghcr.io/containerbase/sidecar' },
+      { cmd: 'docker pull ghcr.io/renovatebot/base-image' },
       { cmd: 'docker ps --filter name=renovate_sidecar -aq' },
       {
         cmd:
@@ -339,7 +339,7 @@ describe('modules/manager/nix/artifacts', () => {
           '-v "/tmp/renovate/cache":"/tmp/renovate/cache" ' +
           '-e CONTAINERBASE_CACHE_DIR ' +
           '-w "/tmp/github/some/repo" ' +
-          'ghcr.io/containerbase/sidecar ' +
+          'ghcr.io/renovatebot/base-image ' +
           'bash -l -c "' +
           'install-tool nix 2.10.0 ' +
           '&& ' +

--- a/lib/modules/manager/npm/artifacts.spec.ts
+++ b/lib/modules/manager/npm/artifacts.spec.ts
@@ -22,7 +22,7 @@ const adminConfig: RepoGlobalConfig = {
 const dockerAdminConfig = {
   ...adminConfig,
   binarySource: 'docker',
-  dockerSidecarImage: 'ghcr.io/containerbase/sidecar',
+  dockerSidecarImage: 'ghcr.io/renovatebot/base-image',
 } satisfies RepoGlobalConfig;
 
 process.env.CONTAINERBASE = 'true';
@@ -155,7 +155,7 @@ describe('modules/manager/npm/artifacts', () => {
     ]);
 
     expect(execSnapshots).toMatchObject([
-      { cmd: 'docker pull ghcr.io/containerbase/sidecar' },
+      { cmd: 'docker pull ghcr.io/renovatebot/base-image' },
       { cmd: 'docker ps --filter name=renovate_sidecar -aq' },
       {
         cmd:
@@ -164,7 +164,7 @@ describe('modules/manager/npm/artifacts', () => {
           '-v "/tmp/renovate/cache":"/tmp/renovate/cache" ' +
           '-e CONTAINERBASE_CACHE_DIR ' +
           '-w "/tmp/github/some/repo" ' +
-          'ghcr.io/containerbase/sidecar ' +
+          'ghcr.io/renovatebot/base-image ' +
           'bash -l -c "' +
           'install-tool node 20.1.0 ' +
           '&& ' +

--- a/lib/modules/manager/npm/post-update/npm.spec.ts
+++ b/lib/modules/manager/npm/post-update/npm.spec.ts
@@ -404,7 +404,7 @@ describe('modules/manager/npm/post-update/npm', () => {
       cacheDir: '/tmp',
       binarySource: 'docker',
       allowScripts: true,
-      dockerSidecarImage: 'ghcr.io/containerbase/sidecar',
+      dockerSidecarImage: 'ghcr.io/renovatebot/base-image',
     });
     const execSnapshots = mockExecAll();
     fs.readLocalFile.mockResolvedValue('package-lock-contents');
@@ -418,7 +418,7 @@ describe('modules/manager/npm/post-update/npm', () => {
     expect(fs.readLocalFile).toHaveBeenCalledTimes(1);
     expect(res.lockFile).toBe('package-lock-contents');
     expect(execSnapshots).toMatchObject([
-      { cmd: 'docker pull ghcr.io/containerbase/sidecar' },
+      { cmd: 'docker pull ghcr.io/renovatebot/base-image' },
       { cmd: 'docker ps --filter name=renovate_sidecar -aq' },
       {
         cmd:
@@ -426,7 +426,7 @@ describe('modules/manager/npm/post-update/npm', () => {
           '-v "/tmp":"/tmp" ' +
           '-e CONTAINERBASE_CACHE_DIR ' +
           '-w "some-dir" ' +
-          'ghcr.io/containerbase/sidecar ' +
+          'ghcr.io/renovatebot/base-image ' +
           'bash -l -c "' +
           'install-tool node 16.16.0 ' +
           '&& ' +

--- a/lib/modules/manager/npm/post-update/pnpm.spec.ts
+++ b/lib/modules/manager/npm/post-update/pnpm.spec.ts
@@ -505,7 +505,7 @@ describe('modules/manager/npm/post-update/pnpm', () => {
       cacheDir: '/tmp',
       binarySource: 'docker',
       allowScripts: true,
-      dockerSidecarImage: 'ghcr.io/containerbase/sidecar',
+      dockerSidecarImage: 'ghcr.io/renovatebot/base-image',
     });
     const execSnapshots = mockExecAll();
     fs.readLocalFile.mockResolvedValue('package-lock-contents');
@@ -518,7 +518,7 @@ describe('modules/manager/npm/post-update/pnpm', () => {
     expect(fs.readLocalFile).toHaveBeenCalledTimes(1);
     expect(res.lockFile).toBe('package-lock-contents');
     expect(execSnapshots).toMatchObject([
-      { cmd: 'docker pull ghcr.io/containerbase/sidecar' },
+      { cmd: 'docker pull ghcr.io/renovatebot/base-image' },
       { cmd: 'docker ps --filter name=renovate_sidecar -aq' },
       {
         cmd:
@@ -526,7 +526,7 @@ describe('modules/manager/npm/post-update/pnpm', () => {
           '-v "/tmp":"/tmp" ' +
           '-e CONTAINERBASE_CACHE_DIR ' +
           '-w "some-dir" ' +
-          'ghcr.io/containerbase/sidecar ' +
+          'ghcr.io/renovatebot/base-image ' +
           'bash -l -c "' +
           'install-tool node 16.16.0 ' +
           '&& install-tool pnpm 6.0.0 ' +

--- a/lib/modules/manager/npm/post-update/yarn.spec.ts
+++ b/lib/modules/manager/npm/post-update/yarn.spec.ts
@@ -769,7 +769,7 @@ describe('modules/manager/npm/post-update/yarn', () => {
       localDir: '.',
       binarySource: 'docker',
       cacheDir: '/tmp/cache',
-      dockerSidecarImage: 'ghcr.io/containerbase/sidecar',
+      dockerSidecarImage: 'ghcr.io/renovatebot/base-image',
     });
     Fixtures.mock(
       {
@@ -789,10 +789,10 @@ describe('modules/manager/npm/post-update/yarn', () => {
     expect(res.lockFile).toBe(plocktest1YarnLockV1);
     const options = {};
     expect(execSnapshots).toMatchObject([
-      { cmd: 'docker pull ghcr.io/containerbase/sidecar', options },
+      { cmd: 'docker pull ghcr.io/renovatebot/base-image', options },
       {
         cmd:
-          `docker run --rm --name=renovate_sidecar --label=renovate_child -v ".":"." -v "/tmp/cache":"/tmp/cache" -e CI -e CONTAINERBASE_CACHE_DIR -w "some-dir" ghcr.io/containerbase/sidecar ` +
+          `docker run --rm --name=renovate_sidecar --label=renovate_child -v ".":"." -v "/tmp/cache":"/tmp/cache" -e CI -e CONTAINERBASE_CACHE_DIR -w "some-dir" ghcr.io/renovatebot/base-image ` +
           `bash -l -c "` +
           `install-tool node 16.16.0` +
           ` && ` +

--- a/lib/modules/manager/nuget/artifacts.spec.ts
+++ b/lib/modules/manager/nuget/artifacts.spec.ts
@@ -252,7 +252,7 @@ describe('modules/manager/nuget/artifacts', () => {
     GlobalConfig.set({
       ...adminConfig,
       binarySource: 'docker',
-      dockerSidecarImage: 'ghcr.io/containerbase/sidecar',
+      dockerSidecarImage: 'ghcr.io/renovatebot/base-image',
     });
     const execSnapshots = mockExecAll();
     fs.getSiblingFileName.mockReturnValueOnce('packages.lock.json');
@@ -282,7 +282,7 @@ describe('modules/manager/nuget/artifacts', () => {
     ]);
     expect(execSnapshots).toMatchObject([
       {
-        cmd: 'docker pull ghcr.io/containerbase/sidecar',
+        cmd: 'docker pull ghcr.io/renovatebot/base-image',
       },
       {
         cmd: 'docker ps --filter name=renovate_sidecar -aq',
@@ -296,7 +296,7 @@ describe('modules/manager/nuget/artifacts', () => {
           '-e MSBUILDDISABLENODEREUSE ' +
           '-e CONTAINERBASE_CACHE_DIR ' +
           '-w "/tmp/github/some/repo" ' +
-          'ghcr.io/containerbase/sidecar ' +
+          'ghcr.io/renovatebot/base-image ' +
           'bash -l -c "' +
           'install-tool dotnet 7.0.100' +
           ' && ' +

--- a/lib/modules/manager/pep621/artifacts.spec.ts
+++ b/lib/modules/manager/pep621/artifacts.spec.ts
@@ -62,7 +62,7 @@ describe('modules/manager/pep621/artifacts', () => {
       GlobalConfig.set({
         ...adminConfig,
         binarySource: 'docker',
-        dockerSidecarImage: 'ghcr.io/containerbase/sidecar',
+        dockerSidecarImage: 'ghcr.io/renovatebot/base-image',
       });
       fs.getSiblingFileName.mockReturnValueOnce('pdm.lock');
       fs.readLocalFile.mockResolvedValueOnce('old test content');
@@ -103,7 +103,7 @@ requires-python = "<3.9"
       ]);
       expect(execSnapshots).toMatchObject([
         {
-          cmd: 'docker pull ghcr.io/containerbase/sidecar',
+          cmd: 'docker pull ghcr.io/renovatebot/base-image',
           options: {},
         },
         {
@@ -117,7 +117,7 @@ requires-python = "<3.9"
             '-v "/tmp/cache":"/tmp/cache" ' +
             '-e CONTAINERBASE_CACHE_DIR ' +
             '-w "/tmp/github/some/repo" ' +
-            'ghcr.io/containerbase/sidecar ' +
+            'ghcr.io/renovatebot/base-image ' +
             'bash -l -c "' +
             'install-tool python 3.8.1 ' +
             '&& ' +

--- a/lib/modules/manager/pep621/processors/pdm.spec.ts
+++ b/lib/modules/manager/pep621/processors/pdm.spec.ts
@@ -57,7 +57,7 @@ describe('modules/manager/pep621/processors/pdm', () => {
       GlobalConfig.set({
         ...adminConfig,
         binarySource: 'docker',
-        dockerSidecarImage: 'ghcr.io/containerbase/sidecar',
+        dockerSidecarImage: 'ghcr.io/renovatebot/base-image',
       });
       fs.getSiblingFileName.mockReturnValueOnce('pdm.lock');
       fs.readLocalFile.mockResolvedValueOnce('test content');
@@ -84,7 +84,7 @@ describe('modules/manager/pep621/processors/pdm', () => {
       expect(result).toBeNull();
       expect(execSnapshots).toMatchObject([
         {
-          cmd: 'docker pull ghcr.io/containerbase/sidecar',
+          cmd: 'docker pull ghcr.io/renovatebot/base-image',
         },
         {
           cmd: 'docker ps --filter name=renovate_sidecar -aq',
@@ -96,7 +96,7 @@ describe('modules/manager/pep621/processors/pdm', () => {
             '-v "/tmp/cache":"/tmp/cache" ' +
             '-e CONTAINERBASE_CACHE_DIR ' +
             '-w "/tmp/github/some/repo" ' +
-            'ghcr.io/containerbase/sidecar ' +
+            'ghcr.io/renovatebot/base-image ' +
             'bash -l -c "' +
             'install-tool python 3.11.2 ' +
             '&& ' +

--- a/lib/modules/manager/pep621/processors/uv.spec.ts
+++ b/lib/modules/manager/pep621/processors/uv.spec.ts
@@ -402,7 +402,7 @@ describe('modules/manager/pep621/processors/uv', () => {
       GlobalConfig.set({
         ...adminConfig,
         binarySource: 'docker',
-        dockerSidecarImage: 'ghcr.io/containerbase/sidecar',
+        dockerSidecarImage: 'ghcr.io/renovatebot/base-image',
       });
       fs.findLocalSiblingOrParent.mockResolvedValueOnce('uv.lock');
       fs.readLocalFile.mockResolvedValueOnce('test content');
@@ -437,7 +437,7 @@ describe('modules/manager/pep621/processors/uv', () => {
       expect(result).toBeNull();
       expect(execSnapshots).toMatchObject([
         {
-          cmd: 'docker pull ghcr.io/containerbase/sidecar',
+          cmd: 'docker pull ghcr.io/renovatebot/base-image',
         },
         {
           cmd: 'docker ps --filter name=renovate_sidecar -aq',
@@ -449,7 +449,7 @@ describe('modules/manager/pep621/processors/uv', () => {
             '-v "/tmp/cache":"/tmp/cache" ' +
             '-e CONTAINERBASE_CACHE_DIR ' +
             '-w "/tmp/github/some/repo" ' +
-            'ghcr.io/containerbase/sidecar ' +
+            'ghcr.io/renovatebot/base-image ' +
             'bash -l -c "' +
             'install-tool python 3.11.1 ' +
             '&& ' +

--- a/lib/modules/manager/pip-compile/artifacts.spec.ts
+++ b/lib/modules/manager/pip-compile/artifacts.spec.ts
@@ -62,7 +62,7 @@ const adminConfig: RepoGlobalConfig = {
 const dockerAdminConfig = {
   ...adminConfig,
   binarySource: 'docker',
-  dockerSidecarImage: 'ghcr.io/containerbase/sidecar',
+  dockerSidecarImage: 'ghcr.io/renovatebot/base-image',
 } satisfies RepoGlobalConfig;
 
 process.env.CONTAINERBASE = 'true';
@@ -195,7 +195,7 @@ describe('modules/manager/pip-compile/artifacts', () => {
     ).not.toBeNull();
 
     expect(execSnapshots).toMatchObject([
-      { cmd: 'docker pull ghcr.io/containerbase/sidecar' },
+      { cmd: 'docker pull ghcr.io/renovatebot/base-image' },
       { cmd: 'docker ps --filter name=renovate_sidecar -aq' },
       {
         cmd:
@@ -208,7 +208,7 @@ describe('modules/manager/pip-compile/artifacts', () => {
           '-e PYTHON_KEYRING_BACKEND ' +
           '-e CONTAINERBASE_CACHE_DIR ' +
           '-w "/tmp/github/some/repo" ' +
-          'ghcr.io/containerbase/sidecar ' +
+          'ghcr.io/renovatebot/base-image ' +
           'bash -l -c "' +
           'install-tool python 3.10.2 ' +
           '&& ' +
@@ -531,7 +531,7 @@ describe('modules/manager/pip-compile/artifacts', () => {
     ).not.toBeNull();
 
     expect(execSnapshots).toMatchObject([
-      { cmd: 'docker pull ghcr.io/containerbase/sidecar' },
+      { cmd: 'docker pull ghcr.io/renovatebot/base-image' },
       { cmd: 'docker ps --filter name=renovate_sidecar -aq' },
       {
         cmd:
@@ -544,7 +544,7 @@ describe('modules/manager/pip-compile/artifacts', () => {
           '-e PYTHON_KEYRING_BACKEND ' +
           '-e CONTAINERBASE_CACHE_DIR ' +
           '-w "/tmp/github/some/repo" ' +
-          'ghcr.io/containerbase/sidecar ' +
+          'ghcr.io/renovatebot/base-image ' +
           'bash -l -c "' +
           'install-tool python 3.10.2 ' +
           '&& ' +

--- a/lib/modules/manager/pip_requirements/artifacts.spec.ts
+++ b/lib/modules/manager/pip_requirements/artifacts.spec.ts
@@ -191,7 +191,7 @@ describe('modules/manager/pip_requirements/artifacts', () => {
     GlobalConfig.set({
       ...adminConfig,
       binarySource: 'docker',
-      dockerSidecarImage: 'ghcr.io/containerbase/sidecar',
+      dockerSidecarImage: 'ghcr.io/renovatebot/base-image',
     });
     fs.readLocalFile.mockResolvedValueOnce('new content');
     fs.ensureCacheDir.mockResolvedValueOnce('/tmp/cache');
@@ -219,7 +219,7 @@ describe('modules/manager/pip_requirements/artifacts', () => {
     ]);
 
     expect(execSnapshots).toMatchObject([
-      { cmd: 'docker pull ghcr.io/containerbase/sidecar' },
+      { cmd: 'docker pull ghcr.io/renovatebot/base-image' },
       { cmd: 'docker ps --filter name=renovate_sidecar -aq' },
       {
         cmd:
@@ -229,7 +229,7 @@ describe('modules/manager/pip_requirements/artifacts', () => {
           '-e PIP_CACHE_DIR ' +
           '-e CONTAINERBASE_CACHE_DIR ' +
           '-w "/tmp/github/some/repo" ' +
-          'ghcr.io/containerbase/sidecar ' +
+          'ghcr.io/renovatebot/base-image ' +
           'bash -l -c "' +
           'install-tool python 3.10.2 ' +
           '&& ' +

--- a/lib/modules/manager/pipenv/artifacts.spec.ts
+++ b/lib/modules/manager/pipenv/artifacts.spec.ts
@@ -50,7 +50,7 @@ const adminConfig: RepoGlobalConfig = {
 const dockerAdminConfig = {
   ...adminConfig,
   binarySource: 'docker',
-  dockerSidecarImage: 'ghcr.io/containerbase/sidecar',
+  dockerSidecarImage: 'ghcr.io/renovatebot/base-image',
 } satisfies RepoGlobalConfig;
 
 const config: UpdateArtifactsConfig = {};
@@ -556,7 +556,7 @@ describe('modules/manager/pipenv/artifacts', () => {
     ).not.toBeNull();
 
     expect(execSnapshots).toMatchObject([
-      { cmd: 'docker pull ghcr.io/containerbase/sidecar' },
+      { cmd: 'docker pull ghcr.io/renovatebot/base-image' },
       { cmd: 'docker ps --filter name=renovate_sidecar -aq' },
       {
         cmd:
@@ -568,7 +568,7 @@ describe('modules/manager/pipenv/artifacts', () => {
           '-e WORKON_HOME ' +
           '-e CONTAINERBASE_CACHE_DIR ' +
           '-w "/tmp/github/some/repo" ' +
-          'ghcr.io/containerbase/sidecar' +
+          'ghcr.io/renovatebot/base-image' +
           ' bash -l -c "' +
           'install-tool python 3.7.6' +
           ' && ' +
@@ -859,7 +859,7 @@ describe('modules/manager/pipenv/artifacts', () => {
     ).not.toBeNull();
 
     expect(execSnapshots).toMatchObject([
-      { cmd: 'docker pull ghcr.io/containerbase/sidecar' },
+      { cmd: 'docker pull ghcr.io/renovatebot/base-image' },
       { cmd: 'docker ps --filter name=renovate_sidecar -aq' },
       {
         cmd:
@@ -871,7 +871,7 @@ describe('modules/manager/pipenv/artifacts', () => {
           '-e WORKON_HOME ' +
           '-e CONTAINERBASE_CACHE_DIR ' +
           '-w "/tmp/github/some/repo" ' +
-          'ghcr.io/containerbase/sidecar' +
+          'ghcr.io/renovatebot/base-image' +
           ' bash -l -c "' +
           'install-tool python 3.10.2' +
           ' && ' +
@@ -946,7 +946,7 @@ describe('modules/manager/pipenv/artifacts', () => {
     ).not.toBeNull();
 
     expect(execSnapshots).toMatchObject([
-      { cmd: 'docker pull ghcr.io/containerbase/sidecar' },
+      { cmd: 'docker pull ghcr.io/renovatebot/base-image' },
       { cmd: 'docker ps --filter name=renovate_sidecar -aq' },
       {
         cmd:
@@ -958,7 +958,7 @@ describe('modules/manager/pipenv/artifacts', () => {
           '-e WORKON_HOME ' +
           '-e CONTAINERBASE_CACHE_DIR ' +
           '-w "/tmp/github/some/repo" ' +
-          'ghcr.io/containerbase/sidecar' +
+          'ghcr.io/renovatebot/base-image' +
           ' bash -l -c "' +
           'install-tool python 3.10.2' +
           ' && ' +
@@ -1032,7 +1032,7 @@ describe('modules/manager/pipenv/artifacts', () => {
     ).not.toBeNull();
 
     expect(execSnapshots).toMatchObject([
-      { cmd: 'docker pull ghcr.io/containerbase/sidecar' },
+      { cmd: 'docker pull ghcr.io/renovatebot/base-image' },
       { cmd: 'docker ps --filter name=renovate_sidecar -aq' },
       {
         cmd:
@@ -1044,7 +1044,7 @@ describe('modules/manager/pipenv/artifacts', () => {
           '-e WORKON_HOME ' +
           '-e CONTAINERBASE_CACHE_DIR ' +
           '-w "/tmp/github/some/repo" ' +
-          'ghcr.io/containerbase/sidecar' +
+          'ghcr.io/renovatebot/base-image' +
           ' bash -l -c "' +
           'install-tool python 3.10.2' +
           ' && ' +

--- a/lib/modules/manager/pixi/artifacts.spec.ts
+++ b/lib/modules/manager/pixi/artifacts.spec.ts
@@ -53,7 +53,7 @@ const adminConfig: RepoGlobalConfig = {
   localDir: upath.join('/tmp/github/some/repo'),
   cacheDir: upath.join('/tmp/cache'),
   containerbaseDir: upath.join('/tmp/cache/containerbase'),
-  dockerSidecarImage: 'ghcr.io/containerbase/sidecar',
+  dockerSidecarImage: 'ghcr.io/renovatebot/base-image',
 };
 
 const config: UpdateArtifactsConfig = {};
@@ -171,7 +171,7 @@ describe('modules/manager/pixi/artifacts', () => {
         },
       ]);
       expect(execSnapshots).toMatchObject([
-        { cmd: 'docker pull ghcr.io/containerbase/sidecar' },
+        { cmd: 'docker pull ghcr.io/renovatebot/base-image' },
         { cmd: 'docker ps --filter name=renovate_sidecar -aq' },
         {
           cmd:
@@ -182,7 +182,7 @@ describe('modules/manager/pixi/artifacts', () => {
             '-e RATTLER_CACHE_DIR ' +
             '-e CONTAINERBASE_CACHE_DIR ' +
             '-w "/tmp/github/some/repo" ' +
-            'ghcr.io/containerbase/sidecar ' +
+            'ghcr.io/renovatebot/base-image ' +
             'bash -l -c "' +
             'install-tool pixi 0.41.4 ' +
             '&& ' +

--- a/lib/modules/manager/poetry/artifacts.spec.ts
+++ b/lib/modules/manager/poetry/artifacts.spec.ts
@@ -388,7 +388,7 @@ describe('modules/manager/poetry/artifacts', () => {
       GlobalConfig.set({
         ...adminConfig,
         binarySource: 'docker',
-        dockerSidecarImage: 'ghcr.io/containerbase/sidecar',
+        dockerSidecarImage: 'ghcr.io/renovatebot/base-image',
       });
       const execSnapshots = mockExecAll();
       fs.ensureCacheDir.mockResolvedValueOnce('/tmp/renovate/cache/others/pip');
@@ -427,7 +427,7 @@ describe('modules/manager/poetry/artifacts', () => {
         },
       ]);
       expect(execSnapshots).toMatchObject([
-        { cmd: 'docker pull ghcr.io/containerbase/sidecar' },
+        { cmd: 'docker pull ghcr.io/renovatebot/base-image' },
         { cmd: 'docker ps --filter name=renovate_sidecar -aq' },
         {
           cmd:
@@ -437,7 +437,7 @@ describe('modules/manager/poetry/artifacts', () => {
             '-e PIP_CACHE_DIR ' +
             '-e CONTAINERBASE_CACHE_DIR ' +
             '-w "/tmp/github/some/repo" ' +
-            'ghcr.io/containerbase/sidecar ' +
+            'ghcr.io/renovatebot/base-image ' +
             'bash -l -c "' +
             'install-tool python 3.4.2 ' +
             '&& ' +
@@ -453,7 +453,7 @@ describe('modules/manager/poetry/artifacts', () => {
       GlobalConfig.set({
         ...adminConfig,
         binarySource: 'docker',
-        dockerSidecarImage: 'ghcr.io/containerbase/sidecar',
+        dockerSidecarImage: 'ghcr.io/renovatebot/base-image',
       });
       hostRules.find.mockReturnValueOnce({
         token: 'some-token',
@@ -503,7 +503,7 @@ describe('modules/manager/poetry/artifacts', () => {
         },
       ]);
       expect(execSnapshots).toMatchObject([
-        { cmd: 'docker pull ghcr.io/containerbase/sidecar' },
+        { cmd: 'docker pull ghcr.io/renovatebot/base-image' },
         { cmd: 'docker ps --filter name=renovate_sidecar -aq' },
         {
           cmd:
@@ -526,7 +526,7 @@ describe('modules/manager/poetry/artifacts', () => {
             '-e PIP_CACHE_DIR ' +
             '-e CONTAINERBASE_CACHE_DIR ' +
             '-w "/tmp/github/some/repo" ' +
-            'ghcr.io/containerbase/sidecar ' +
+            'ghcr.io/renovatebot/base-image ' +
             'bash -l -c "' +
             'install-tool python 3.4.2 ' +
             '&& ' +
@@ -542,7 +542,7 @@ describe('modules/manager/poetry/artifacts', () => {
       GlobalConfig.set({
         ...adminConfig,
         binarySource: 'docker',
-        dockerSidecarImage: 'ghcr.io/containerbase/sidecar',
+        dockerSidecarImage: 'ghcr.io/renovatebot/base-image',
       });
       const execSnapshots = mockExecAll();
 
@@ -582,7 +582,7 @@ describe('modules/manager/poetry/artifacts', () => {
         },
       ]);
       expect(execSnapshots).toMatchObject([
-        { cmd: 'docker pull ghcr.io/containerbase/sidecar' },
+        { cmd: 'docker pull ghcr.io/renovatebot/base-image' },
         { cmd: 'docker ps --filter name=renovate_sidecar -aq' },
         {
           cmd:
@@ -592,7 +592,7 @@ describe('modules/manager/poetry/artifacts', () => {
             '-e PIP_CACHE_DIR ' +
             '-e CONTAINERBASE_CACHE_DIR ' +
             '-w "/tmp/github/some/repo" ' +
-            'ghcr.io/containerbase/sidecar ' +
+            'ghcr.io/renovatebot/base-image ' +
             'bash -l -c "' +
             'install-tool python 2.7.5 ' +
             '&& ' +

--- a/lib/modules/manager/pub/artifacts.spec.ts
+++ b/lib/modules/manager/pub/artifacts.spec.ts
@@ -204,7 +204,7 @@ describe('modules/manager/pub/artifacts', () => {
       GlobalConfig.set({
         ...adminConfig,
         binarySource: 'docker',
-        dockerSidecarImage: 'ghcr.io/containerbase/sidecar',
+        dockerSidecarImage: 'ghcr.io/renovatebot/base-image',
       });
       const execSnapshots = mockExecAll();
       fs.getSiblingFileName.mockReturnValueOnce(lockFile);
@@ -226,7 +226,7 @@ describe('modules/manager/pub/artifacts', () => {
       ]);
       expect(execSnapshots).toMatchObject([
         {
-          cmd: 'docker pull ghcr.io/containerbase/sidecar',
+          cmd: 'docker pull ghcr.io/renovatebot/base-image',
         },
         {
           cmd: 'docker ps --filter name=renovate_sidecar -aq',
@@ -238,7 +238,7 @@ describe('modules/manager/pub/artifacts', () => {
             '-v "/tmp/cache":"/tmp/cache" ' +
             '-e CONTAINERBASE_CACHE_DIR ' +
             '-w "/tmp/github/some/repo" ' +
-            'ghcr.io/containerbase/sidecar ' +
+            'ghcr.io/renovatebot/base-image ' +
             'bash -l -c "' +
             `install-tool ${params.sdk} 3.3.9` +
             ' && ' +

--- a/lib/modules/manager/vendir/artifacts.spec.ts
+++ b/lib/modules/manager/vendir/artifacts.spec.ts
@@ -23,7 +23,7 @@ const adminConfig: RepoGlobalConfig = {
   localDir: upath.join('/tmp/github/some/repo'), // `join` fixes Windows CI
   cacheDir: upath.join('/tmp/renovate/cache'),
   containerbaseDir: upath.join('/tmp/cache/containerbase'),
-  dockerSidecarImage: 'ghcr.io/containerbase/sidecar',
+  dockerSidecarImage: 'ghcr.io/renovatebot/base-image',
 };
 
 const config: UpdateArtifactsConfig = {};
@@ -488,7 +488,7 @@ describe('modules/manager/vendir/artifacts', () => {
         },
       ]);
       expect(execSnapshots).toMatchObject([
-        { cmd: 'docker pull ghcr.io/containerbase/sidecar' },
+        { cmd: 'docker pull ghcr.io/renovatebot/base-image' },
         { cmd: 'docker ps --filter name=renovate_sidecar -aq' },
         {
           cmd:
@@ -498,7 +498,7 @@ describe('modules/manager/vendir/artifacts', () => {
             '-v "/tmp/cache/containerbase":"/tmp/cache/containerbase" ' +
             '-e CONTAINERBASE_CACHE_DIR ' +
             '-w "/tmp/github/some/repo" ' +
-            'ghcr.io/containerbase/sidecar' +
+            'ghcr.io/renovatebot/base-image' +
             ' bash -l -c "' +
             'install-tool vendir 0.35.0' +
             ' && ' +

--- a/lib/util/exec/docker/index.spec.ts
+++ b/lib/util/exec/docker/index.spec.ts
@@ -219,13 +219,13 @@ describe('util/exec/docker/index', () => {
       (opts ? `${opts} ` : '') +
       `-e FOO -e BAR ` +
       `-w "/tmp/foobar" ` +
-      `ghcr.io/containerbase/sidecar ` +
+      `ghcr.io/renovatebot/base-image ` +
       `bash -l -c "foo && bar"`;
 
     beforeEach(() => {
       GlobalConfig.set({
         dockerUser: 'some-user',
-        dockerSidecarImage: 'ghcr.io/containerbase/sidecar',
+        dockerSidecarImage: 'ghcr.io/renovatebot/base-image',
       });
     });
 
@@ -263,7 +263,7 @@ describe('util/exec/docker/index', () => {
           `--user=some-user ` +
           `-e FOO -e BAR ` +
           `-w "/tmp/foobar" ` +
-          `ghcr.io/containerbase/sidecar ` +
+          `ghcr.io/renovatebot/base-image ` +
           `bash -l -c "foo && bar || true && bleh && baz && ls"`,
       );
     });
@@ -292,7 +292,7 @@ describe('util/exec/docker/index', () => {
           `--user=some-user ` +
           `-e FOO -e BAR ` +
           `-w "/tmp/foobar" ` +
-          `ghcr.io/containerbase/sidecar ` +
+          `ghcr.io/renovatebot/base-image ` +
           `bash -l -c "pre && foo && bar || true && bleh && baz"`,
       );
     });
@@ -322,7 +322,7 @@ describe('util/exec/docker/index', () => {
         cacheDir: '/tmp/cache',
         containerbaseDir: '/tmp/containerbase',
         dockerUser: 'some-user',
-        dockerSidecarImage: 'ghcr.io/containerbase/sidecar',
+        dockerSidecarImage: 'ghcr.io/renovatebot/base-image',
       });
       const volumes: VolumeOption[] = ['/tmp/foo'];
       const res = await generateDockerCommand(commands, preCommands, {
@@ -343,7 +343,7 @@ describe('util/exec/docker/index', () => {
         cacheDir: '/tmp/cache',
         containerbaseDir: '/tmp/cache/containerbase',
         dockerUser: 'some-user',
-        dockerSidecarImage: 'ghcr.io/containerbase/sidecar',
+        dockerSidecarImage: 'ghcr.io/renovatebot/base-image',
       });
       const volumes: VolumeOption[] = ['/tmp/foo'];
       const res = await generateDockerCommand(commands, preCommands, {
@@ -360,7 +360,7 @@ describe('util/exec/docker/index', () => {
       GlobalConfig.set({
         dockerUser: 'some-user',
         dockerCliOptions: '--memory=4g --cpus=".5"',
-        dockerSidecarImage: 'ghcr.io/containerbase/sidecar',
+        dockerSidecarImage: 'ghcr.io/renovatebot/base-image',
       });
       const res = await generateDockerCommand(commands, preCommands, {
         ...dockerOptions,

--- a/lib/util/exec/docker/index.spec.ts
+++ b/lib/util/exec/docker/index.spec.ts
@@ -66,7 +66,7 @@ describe('util/exec/docker/index', () => {
       ]);
       await removeDockerContainer('bar', 'foo_');
       expect(execSnapshots).toMatchObject([
-        { cmd: 'docker ps --filter name=foo_bar -aq' },
+        { cmd: 'docker ps --filter name=foo_sidecar -aq' },
         { cmd: 'docker rm -f 12345' },
       ]);
     });

--- a/lib/util/exec/docker/index.spec.ts
+++ b/lib/util/exec/docker/index.spec.ts
@@ -1,19 +1,16 @@
 import { GlobalConfig } from '../../../config/global.ts';
 import { SYSTEM_INSUFFICIENT_MEMORY } from '../../../constants/error-messages.ts';
 import { logger } from '../../../logger/index.ts';
-import * as modulesDatasource from '../../../modules/datasource/index.ts';
 import type { VolumeOption } from '../types.ts';
 import {
   generateDockerCommand,
-  getDockerTag,
   prefetchDockerImage,
   removeDanglingContainers,
   removeDockerContainer,
   resetPrefetchedImages,
-  sideCarImage,
+  sideCarName,
 } from './index.ts';
 import { mockExecAll, mockExecSequence } from '~test/exec-util.ts';
-import { partial } from '~test/util.ts';
 
 vi.mock('../../../modules/datasource/index.ts', () => ({
   getPkgReleases: vi.fn(),
@@ -43,65 +40,6 @@ describe('util/exec/docker/index', () => {
         { cmd: 'docker pull foo:2.0.0' },
         { cmd: 'docker pull bar:3.0.0' },
       ]);
-    });
-  });
-
-  describe('getDockerTag', () => {
-    it('returns "latest" for invalid constraint', async () => {
-      const res = await getDockerTag('foo', '!@#$%', 'semver');
-      expect(res).toBe('latest');
-    });
-
-    it('returns "latest" for bad release results', async () => {
-      vi.spyOn(modulesDatasource, 'getPkgReleases')
-        .mockResolvedValueOnce(undefined as never)
-        .mockResolvedValueOnce(partial<modulesDatasource.ReleaseResult>())
-        .mockResolvedValueOnce(
-          partial<modulesDatasource.ReleaseResult>({ releases: [] }),
-        );
-      expect(await getDockerTag('foo', '1.2.3', 'semver')).toBe('latest');
-      expect(await getDockerTag('foo', '1.2.3', 'semver')).toBe('latest');
-      expect(await getDockerTag('foo', '1.2.3', 'semver')).toBe('latest');
-    });
-
-    it('returns tag for good release results', async () => {
-      const releases = [
-        { version: '1.0.0' },
-        { version: '1.0.1' },
-        { version: '1.0.2' },
-        { version: '1.2.0' },
-        { version: '1.2.1' },
-        { version: '1.2.2' },
-        { version: '1.2.3' },
-        { version: '1.2.4' },
-        { version: '1.9.0' },
-        { version: '1.9.1' },
-        { version: '1.9.2' },
-        { version: '1.9.9' },
-        { version: '2.0.0' },
-        { version: '2.0.1' },
-        { version: '2.0.2' },
-        { version: '2.1.0' },
-        { version: '2.1.1' },
-        { version: '2.1.2' },
-      ];
-      vi.spyOn(modulesDatasource, 'getPkgReleases').mockResolvedValueOnce(
-        partial<modulesDatasource.ReleaseResult>({ releases }),
-      );
-      expect(await getDockerTag('foo', '^1.2.3', 'npm')).toBe('1.9.9');
-    });
-
-    it('filters out node unstable', async () => {
-      const releases = [
-        { version: '12.0.0' },
-        { version: '13.0.1' },
-        { version: '14.0.2' },
-        { version: '15.0.2' },
-      ];
-      vi.spyOn(modulesDatasource, 'getPkgReleases').mockResolvedValueOnce(
-        partial<modulesDatasource.ReleaseResult>({ releases }),
-      );
-      expect(await getDockerTag('foo', '>=12', 'node')).toBe('14.0.2');
     });
   });
 
@@ -205,7 +143,6 @@ describe('util/exec/docker/index', () => {
     const preCommands = [null as never, 'foo', undefined as never];
     const commands = ['bar'];
     const envVars = ['FOO', 'BAR'];
-    const image = sideCarImage;
     const dockerOptions = {
       cwd: '/tmp/foobar',
       envVars,
@@ -235,8 +172,9 @@ describe('util/exec/docker/index', () => {
         commands,
         preCommands,
         dockerOptions,
+        'ghcr.io/renovatebot/base-image',
       );
-      expect(res).toBe(command(image));
+      expect(res).toBe(command(sideCarName));
     });
 
     it('adds `|| true` if ignoreFailure is set on a pre-command', async () => {
@@ -255,10 +193,11 @@ describe('util/exec/docker/index', () => {
           'baz',
         ],
         dockerOptions,
+        'ghcr.io/renovatebot/base-image',
       );
       expect(res).toBe(
         `docker run --rm ` +
-          `--name=renovate_${image} ` +
+          `--name=renovate_${sideCarName} ` +
           `--label=renovate_child ` +
           `--user=some-user ` +
           `-e FOO -e BAR ` +
@@ -284,10 +223,11 @@ describe('util/exec/docker/index', () => {
         ],
         ['pre'],
         dockerOptions,
+        'ghcr.io/renovatebot/base-image',
       );
       expect(res).toBe(
         `docker run --rm ` +
-          `--name=renovate_${image} ` +
+          `--name=renovate_${sideCarName} ` +
           `--label=renovate_child ` +
           `--user=some-user ` +
           `-e FOO -e BAR ` +
@@ -304,13 +244,18 @@ describe('util/exec/docker/index', () => {
         ['/tmp/bar', `/tmp/bar`],
         ['/tmp/baz', `/home/baz`],
       ];
-      const res = await generateDockerCommand(commands, preCommands, {
-        ...dockerOptions,
-        volumes: [...volumes, ...volumes],
-      });
+      const res = await generateDockerCommand(
+        commands,
+        preCommands,
+        {
+          ...dockerOptions,
+          volumes: [...volumes, ...volumes],
+        },
+        'ghcr.io/renovatebot/base-image',
+      );
       expect(res).toBe(
         command(
-          image,
+          sideCarName,
           `-v "/tmp/foo":"/tmp/foo" -v "/tmp/bar":"/tmp/bar" -v "/tmp/baz":"/home/baz"`,
         ),
       );
@@ -325,13 +270,18 @@ describe('util/exec/docker/index', () => {
         dockerSidecarImage: 'ghcr.io/renovatebot/base-image',
       });
       const volumes: VolumeOption[] = ['/tmp/foo'];
-      const res = await generateDockerCommand(commands, preCommands, {
-        ...dockerOptions,
-        volumes: [...volumes, ...volumes],
-      });
+      const res = await generateDockerCommand(
+        commands,
+        preCommands,
+        {
+          ...dockerOptions,
+          volumes: [...volumes, ...volumes],
+        },
+        'ghcr.io/renovatebot/base-image',
+      );
       expect(res).toBe(
         command(
-          image,
+          sideCarName,
           `-v "/tmp/cache":"/tmp/cache" -v "/tmp/containerbase":"/tmp/containerbase" -v "/tmp/foo":"/tmp/foo"`,
         ),
       );
@@ -346,12 +296,20 @@ describe('util/exec/docker/index', () => {
         dockerSidecarImage: 'ghcr.io/renovatebot/base-image',
       });
       const volumes: VolumeOption[] = ['/tmp/foo'];
-      const res = await generateDockerCommand(commands, preCommands, {
-        ...dockerOptions,
-        volumes: [...volumes, ...volumes],
-      });
+      const res = await generateDockerCommand(
+        commands,
+        preCommands,
+        {
+          ...dockerOptions,
+          volumes: [...volumes, ...volumes],
+        },
+        'ghcr.io/renovatebot/base-image',
+      );
       expect(res).toBe(
-        command(image, `-v "/tmp/cache":"/tmp/cache" -v "/tmp/foo":"/tmp/foo"`),
+        command(
+          sideCarName,
+          `-v "/tmp/cache":"/tmp/cache" -v "/tmp/foo":"/tmp/foo"`,
+        ),
       );
     });
 
@@ -362,10 +320,17 @@ describe('util/exec/docker/index', () => {
         dockerCliOptions: '--memory=4g --cpus=".5"',
         dockerSidecarImage: 'ghcr.io/renovatebot/base-image',
       });
-      const res = await generateDockerCommand(commands, preCommands, {
-        ...dockerOptions,
-      });
-      expect(res).toBe(command(image, undefined, `--memory=4g --cpus=".5"`));
+      const res = await generateDockerCommand(
+        commands,
+        preCommands,
+        {
+          ...dockerOptions,
+        },
+        'ghcr.io/renovatebot/base-image',
+      );
+      expect(res).toBe(
+        command(sideCarName, undefined, `--memory=4g --cpus=".5"`),
+      );
     });
 
     // TODO: it('handles tag constraint', async () => {

--- a/lib/util/exec/index.spec.ts
+++ b/lib/util/exec/index.spec.ts
@@ -48,7 +48,7 @@ describe('util/exec/index', () => {
   const globalConfig: RepoGlobalConfig = {
     cacheDir,
     containerbaseDir,
-    dockerSidecarImage: 'ghcr.io/containerbase/sidecar',
+    dockerSidecarImage: 'ghcr.io/renovatebot/base-image',
   };
 
   beforeEach(() => {
@@ -64,7 +64,7 @@ describe('util/exec/index', () => {
   });
 
   const image = dockerModule.sideCarImage;
-  const fullImage = `ghcr.io/containerbase/sidecar`;
+  const fullImage = `ghcr.io/renovatebot/base-image`;
   const name = `renovate_${image}`;
   const inCmd = 'echo hello';
   const outCmd = ['echo hello'];
@@ -471,7 +471,7 @@ describe('util/exec/index', () => {
           },
         ],
         adminConfig: {
-          dockerSidecarImage: 'ghcr.io/containerbase/sidecar',
+          dockerSidecarImage: 'ghcr.io/renovatebot/base-image',
           binarySource: 'docker',
         },
       },

--- a/lib/util/exec/index.spec.ts
+++ b/lib/util/exec/index.spec.ts
@@ -63,9 +63,9 @@ describe('util/exec/index', () => {
     process.env = processEnvOrig;
   });
 
-  const image = dockerModule.sideCarImage;
+  const sideCarName = dockerModule.sideCarName;
   const fullImage = `ghcr.io/renovatebot/base-image`;
-  const name = `renovate_${image}`;
+  const name = `renovate_${sideCarName}`;
   const inCmd = 'echo hello';
   const outCmd = ['echo hello'];
   const volume_1 = '/path/to/volume-1';
@@ -453,9 +453,9 @@ describe('util/exec/index', () => {
         inCmd,
         inOpts: { docker },
         outCmd: [
-          `docker pull ghcr.io/containerbase/${image}`,
+          `docker pull ghcr.io/renovatebot/base-image`,
           dockerRemoveCmd,
-          `docker run --rm --name=${name} --label=renovate_child ${defaultVolumes} -e CONTAINERBASE_CACHE_DIR -w "${cwd}" ghcr.io/containerbase/${image} bash -l -c "${inCmd}"`,
+          `docker run --rm --name=${name} --label=renovate_child ${defaultVolumes} -e CONTAINERBASE_CACHE_DIR -w "${cwd}" ghcr.io/renovatebot/base-image bash -l -c "${inCmd}"`,
         ],
         outOpts: [
           dockerPullOpts,
@@ -485,8 +485,8 @@ describe('util/exec/index', () => {
         inOpts: { docker },
         outCmd: [
           dockerPullCmd,
-          `docker ps --filter name=myprefix_${image} -aq`,
-          `docker run --rm --name=myprefix_${image} --label=myprefix_child ${defaultVolumes} -e CONTAINERBASE_CACHE_DIR -w "${cwd}" ${fullImage} bash -l -c "${inCmd}"`,
+          `docker ps --filter name=myprefix_${sideCarName} -aq`,
+          `docker run --rm --name=myprefix_${sideCarName} --label=myprefix_child ${defaultVolumes} -e CONTAINERBASE_CACHE_DIR -w "${cwd}" ${fullImage} bash -l -c "${inCmd}"`,
         ],
         outOpts: [
           dockerPullOpts,
@@ -967,16 +967,16 @@ describe('util/exec/index', () => {
       `echo hello`,
       `echo hello`,
       `docker pull ${fullImage}`,
-      `docker ps --filter name=renovate_${image} -aq`,
-      `docker run --rm --name=renovate_${image} --label=renovate_child ${defaultCacheVolume} -e CONTAINERBASE_CACHE_DIR ${fullImage} bash -l -c "echo hello"`,
-      `docker ps --filter name=renovate_${image} -aq`,
-      `docker run --rm --name=renovate_${image} --label=renovate_child ${defaultCacheVolume} -e CONTAINERBASE_CACHE_DIR ${fullImage} bash -l -c "echo hello"`,
+      `docker ps --filter name=renovate_${sideCarName} -aq`,
+      `docker run --rm --name=renovate_${sideCarName} --label=renovate_child ${defaultCacheVolume} -e CONTAINERBASE_CACHE_DIR ${fullImage} bash -l -c "echo hello"`,
+      `docker ps --filter name=renovate_${sideCarName} -aq`,
+      `docker run --rm --name=renovate_${sideCarName} --label=renovate_child ${defaultCacheVolume} -e CONTAINERBASE_CACHE_DIR ${fullImage} bash -l -c "echo hello"`,
       `echo hello`,
       `echo hello`,
-      `docker ps --filter name=renovate_${image} -aq`,
-      `docker run --rm --name=renovate_${image} --label=renovate_child ${defaultCacheVolume} -e CONTAINERBASE_CACHE_DIR ${fullImage} bash -l -c "echo hello"`,
-      `docker ps --filter name=renovate_${image} -aq`,
-      `docker run --rm --name=renovate_${image} --label=renovate_child ${defaultCacheVolume} -e CONTAINERBASE_CACHE_DIR ${fullImage} bash -l -c "echo hello"`,
+      `docker ps --filter name=renovate_${sideCarName} -aq`,
+      `docker run --rm --name=renovate_${sideCarName} --label=renovate_child ${defaultCacheVolume} -e CONTAINERBASE_CACHE_DIR ${fullImage} bash -l -c "echo hello"`,
+      `docker ps --filter name=renovate_${sideCarName} -aq`,
+      `docker run --rm --name=renovate_${sideCarName} --label=renovate_child ${defaultCacheVolume} -e CONTAINERBASE_CACHE_DIR ${fullImage} bash -l -c "echo hello"`,
     ]);
   });
 

--- a/lib/util/exec/index.ts
+++ b/lib/util/exec/index.ts
@@ -9,7 +9,6 @@ import { generateInstallCommands, isDynamicInstall } from './containerbase.ts';
 import {
   generateDockerCommand,
   removeDockerContainer,
-  sideCarImage,
 } from './docker/index.ts';
 import { getHermitEnvs, isHermit } from './hermit.ts';
 import type {
@@ -81,6 +80,7 @@ async function prepareRawExec(
     | CommandWithOptions[]
     | (string | CommandWithOptions)[],
   opts: ExecOptions,
+  sideCarImage: string,
 ): Promise<RawExecArguments> {
   const { docker } = opts;
   const preCommands = opts.preCommands ?? [];
@@ -119,6 +119,7 @@ async function prepareRawExec(
         ...preCommands,
       ],
       dockerOptions,
+      sideCarImage,
     );
     rawCommands = [dockerCommand];
   } else if (isDynamicInstall(opts.toolConstraints)) {
@@ -166,8 +167,13 @@ export async function exec(
 ): Promise<ExecResult> {
   const { docker } = opts;
   const dockerChildPrefix = GlobalConfig.get('dockerChildPrefix', 'renovate_');
+  const sideCarImage = GlobalConfig.get('dockerSidecarImage')!;
 
-  const { rawCommands, rawOptions } = await prepareRawExec(cmd, opts);
+  const { rawCommands, rawOptions } = await prepareRawExec(
+    cmd,
+    opts,
+    sideCarImage,
+  );
   const useDocker = isDocker(docker);
 
   let res: ExecResult = { stdout: '', stderr: '' };

--- a/renovate.json
+++ b/renovate.json
@@ -109,7 +109,7 @@
       "customType": "regex",
       "managerFilePatterns": ["lib/config/options/index.ts"],
       "matchStrings": [
-        "default: '(?<depName>ghcr.io/containerbase/sidecar):(?<currentValue>.*)'"
+        "default: '(?<depName>ghcr.io/renovatebot/base-image):(?<currentValue>.*)'"
       ],
       "datasourceTemplate": "docker"
     }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
This is not breaking because it's same registry and  `renovatebot/base-image` extends `containerbase/sidecar` a little.
It currently only adds docker cli.

This also reduces updates, so we don't get the sidecar update first and then the base image.

Removed unused code and pass image name around.

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
