### PR TITLE
fix!: prevent grouping of lockfile maintenance updates

### DIFF
--- a/lib/config/presets/internal/config.ts
+++ b/lib/config/presets/internal/config.ts
@@ -44,7 +44,7 @@ export const presets: Record<string, Preset> = {
   },
   semverAllMonthly: {
     description:
-      'Preserve SemVer ranges and update everything together once a month.',
+      'Preserve SemVer ranges and update everything together once a month. (excluding replacements and lockfile maintenance)',
     extends: [
       ':preserveSemverRanges',
       'group:all',
@@ -53,13 +53,12 @@ export const presets: Record<string, Preset> = {
     ],
     lockFileMaintenance: {
       commitMessageAction: 'Update',
-      extends: ['group:all'],
     },
     separateMajorMinor: false,
   },
   semverAllWeekly: {
     description:
-      'Preserve SemVer ranges and update everything together once a week.',
+      'Preserve SemVer ranges and update everything together once a week (excluding replacements and lockfile maintenance).',
     extends: [
       ':preserveSemverRanges',
       'group:all',
@@ -68,7 +67,6 @@ export const presets: Record<string, Preset> = {
     ],
     lockFileMaintenance: {
       commitMessageAction: 'Update',
-      extends: ['group:all'],
     },
     separateMajorMinor: false,
   },

--- a/lib/config/presets/internal/group.ts
+++ b/lib/config/presets/internal/group.ts
@@ -10,9 +10,6 @@ const staticGroups = {
     description: 'Group all updates together.',
     groupName: 'all dependencies',
     groupSlug: 'all',
-    lockFileMaintenance: {
-      enabled: false,
-    },
     packageRules: [
       {
         groupName: 'all dependencies',

--- a/lib/workers/repository/updates/branch-name.spec.ts
+++ b/lib/workers/repository/updates/branch-name.spec.ts
@@ -32,6 +32,22 @@ describe('workers/repository/updates/branch-name', () => {
       expect(upgrade.branchName).toBe('axios-replacement');
     });
 
+    it('ignores grouping of lockfile maintenance update', () => {
+      const upgrade = partial<BranchUpgradeConfig>({
+        group: {
+          branchName: '{{groupSlug}}-{{branchTopic}}',
+          branchTopic: 'grouptopic',
+        },
+        updateType: 'lockFileMaintenance',
+        depName: 'axios',
+        depNameSanitized: 'axios',
+        branchTopic: 'lock-file-maintenance', // default for lockFileMaintenance
+        branchName: '{{branchPrefix}}{{additionalBranchPrefix}}{{branchTopic}}', // default
+      });
+      generateBranchName(upgrade);
+      expect(upgrade.branchName).toBe('lock-file-maintenance');
+    });
+
     it('uses groupName if no slug defined, ignores sharedVariableName', () => {
       const upgrade = partial<BranchUpgradeConfig>({
         groupName: 'some group name',

--- a/lib/workers/repository/updates/branch-name.ts
+++ b/lib/workers/repository/updates/branch-name.ts
@@ -67,10 +67,10 @@ export function generateBranchName(update: BranchUpgradeConfig): void {
   }
 
   if (update.groupName) {
-    if (update.updateType === 'replacement') {
+    if (['lockFileMaintenance', 'replacement'].includes(update.updateType!)) {
       logger.debug(
         { depName: update.depName },
-        'Ignoring grouped branch name for replacement update',
+        'Ignoring grouped branch name for replacement update or lockfile maintenance',
       );
     } else {
       update.groupName = template.compile(update.groupName, update);

--- a/lib/workers/repository/updates/generate.ts
+++ b/lib/workers/repository/updates/generate.ts
@@ -471,10 +471,9 @@ export function generateBranchConfig(
   // explicit set `isLockFileMaintenance` for the branch for groups
   if (config.upgrades.some((upgrade) => upgrade.isLockFileMaintenance)) {
     config.isLockFileMaintenance = true;
-    // istanbul ignore if: not worth testing
+    // istanbul ignore if: should never happen
     if (config.upgrades.some((upgrade) => !upgrade.isLockFileMaintenance)) {
-      // TODO: warn?
-      logger.debug(
+      logger.warn(
         'Grouping lockfile maintenance with other update types is not supported',
       );
     }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Ignore custom grouping for lockfile mantenance. It causes hard to detect troubles.
<!-- Describe what behavior is changed by this PR. -->

## Context

- https://github.com/renovatebot/renovate/discussions/22630#discussioncomment-6118212

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
