### PR TITLE
fix(onboardingAutoCloseAge): don't allow higher inherited value than global

### DIFF
--- a/lib/util/common.spec.ts
+++ b/lib/util/common.spec.ts
@@ -244,5 +244,54 @@ describe('util/common', () => {
       });
       expect(getInheritedOrGlobal('configFileNames')).toBeUndefined();
     });
+
+    describe('when requesting onboardingAutoCloseAge, do not allow inherit config to override global config', () => {
+      it('returns inherited value when inherited < global', () => {
+        GlobalConfig.set({
+          onboardingAutoCloseAge: 10,
+        });
+        InheritConfig.set({
+          onboardingAutoCloseAge: 5,
+        });
+        expect(getInheritedOrGlobal('onboardingAutoCloseAge')).toBe(5);
+      });
+
+      it('returns global value when inherited > global value', () => {
+        GlobalConfig.set({
+          onboardingAutoCloseAge: 5,
+        });
+        InheritConfig.set({
+          onboardingAutoCloseAge: 10,
+        });
+        expect(getInheritedOrGlobal('onboardingAutoCloseAge')).toBe(5);
+      });
+
+      it('returns inherited value when inherited == global', () => {
+        GlobalConfig.set({
+          onboardingAutoCloseAge: 5,
+        });
+        InheritConfig.set({
+          onboardingAutoCloseAge: 5,
+        });
+        expect(getInheritedOrGlobal('onboardingAutoCloseAge')).toBe(5);
+      });
+
+      it('returns inherited value when global value is not set', () => {
+        GlobalConfig.set({
+          onboardingAutoCloseAge: undefined,
+        });
+        InheritConfig.set({
+          onboardingAutoCloseAge: 10,
+        });
+        expect(getInheritedOrGlobal('onboardingAutoCloseAge')).toBe(10);
+      });
+
+      it('returns global value when inherited value is not set', () => {
+        GlobalConfig.set({
+          onboardingAutoCloseAge: 10,
+        });
+        expect(getInheritedOrGlobal('onboardingAutoCloseAge')).toBe(10);
+      });
+    });
   });
 });

--- a/lib/util/common.ts
+++ b/lib/util/common.ts
@@ -1,3 +1,4 @@
+import { isNumber } from '@sindresorhus/is';
 import JSON5 from 'json5';
 import * as JSONC from 'jsonc-parser';
 import type { JsonValue } from 'type-fest';
@@ -156,9 +157,22 @@ export function getInheritedOrGlobal<Key extends keyof GlobalInheritableConfig>(
   key: Key,
 ): GlobalInheritableConfig[Key] {
   const inheritedValue = InheritConfig.get(key);
+  const globalValue = GlobalConfig.get(key);
+
   if (inheritedValue !== NOT_PRESET) {
+    // Don't allow inherited config to make `onboardingAutoCloseAge` a lower value than our global setting
+    if (
+      key === 'onboardingAutoCloseAge' &&
+      isNumber(inheritedValue) &&
+      isNumber(globalValue)
+    ) {
+      if (globalValue < inheritedValue) {
+        return globalValue;
+      }
+    }
+
     return inheritedValue;
   }
 
-  return GlobalConfig.get(key);
+  return globalValue;
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Our intent for `onboardingAutoCloseAge` would be that the global
config would take precedence over the inherited config value.

Our implementation missed this, which means that inherited config could
then override the value, including disabling it.

To correct this, we can make sure that when using `getInheritedOrGlobal`
we only allow the inherit config option if it is lower than the global
option.

## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe): Claude Sonnet 4.5

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
