### PR TITLE
feat(replacements): Update grafana-oss replacement

### DIFF
--- a/lib/data/replacements.json
+++ b/lib/data/replacements.json
@@ -714,7 +714,13 @@
       {
         "matchDatasources": ["docker"],
         "matchPackageNames": ["/^(?:docker\\.io/)?grafana/grafana-oss$/"],
-        "matchCurrentVersion": "12.1.1",
+        "matchCurrentVersion": "12.3.2",
+        "replacementName": "grafana/grafana"
+      },
+      {
+        "matchDatasources": ["docker"],
+        "matchPackageNames": ["/^(?:docker\\.io/)?grafana/grafana-oss$/"],
+        "matchCurrentVersion": "12.3.2-ubuntu",
         "replacementName": "grafana/grafana"
       }
     ]


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Updates the grafana replacement rule to a newer version (`12.3.2` instead of `12.1.1`) pushed to the [deprecated repository](https://hub.docker.com/r/grafana/grafana-oss/tags).

This is a follow up to #39512 and #40293, updating to a more recent version, in case users of the deprecated repository have already upgraded to a newer version. I also added the `-ubuntu` variant so that may be replaced too. I checked the digests for both image versions to match, so even digest-pinned versions can be safely replaced.

To avoid creating more PRs, we could leave this PR open until a `12.4.0` release on the [main repository](https://hub.docker.com/r/grafana/grafana/tags) exists, as that [should be the first version not being released on the deprecated repository](https://grafana.com/docs/grafana/v12.3/setup-grafana/installation/docker/) and update this PR to the latest `12.3.x` version.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
