### PR TITLE
chore(docs-testing): Allow an option to be present in "main" and self-hosted docs

### DIFF
--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -607,6 +607,12 @@ export interface RenovateOptionBase {
    * Furthermore, the option should be documented in docs/usage/self-hosted-configuration.md.
    */
   globalOnly?: boolean;
+  /**
+   * If true, the option needs to appear in both docs/usage/configuration-options.md
+   * and docs/usage/self-hosted-configuration.md.
+   * This is purely a documentation validation option, no runtime implications.
+   */
+  docAlsoGlobal?: boolean;
 
   inheritConfigSupport?: boolean;
 

--- a/test/docs/documentation.spec.ts
+++ b/test/docs/documentation.spec.ts
@@ -146,7 +146,7 @@ describe('docs/documentation', () => {
 
       function getRequiredSelfHostedOptions(): string[] {
         return options
-          .filter((option) => option.globalOnly)
+          .filter((option) => option.globalOnly ?? option.docAlsoGlobal)
           .map((option) => option.name)
           .sort();
       }


### PR DESCRIPTION
The change #40090 adds a configuration option that demands slightly different docs for the self-hosted docs and the repo level docs. The current test `documentation.spec.ts` doesn't cover that case.

This change adds a new configuration-option `docAlsoGlobal` to allow one option to be present in both markdown files.

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [X] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [X] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
