### PR TITLE
feat: allow local platform to make changes

### DIFF
--- a/lib/util/fs/index.spec.ts
+++ b/lib/util/fs/index.spec.ts
@@ -136,17 +136,32 @@ describe('util/fs/index', () => {
   });
 
   describe('deleteLocalFile', () => {
-    it('throws if platform is local', async () => {
-      GlobalConfig.set({ platform: 'local' });
-      await expect(deleteLocalFile('foo/bar/file.txt')).rejects.toThrow();
-    });
-
     it('deletes file', async () => {
       const filePath = `${localDir}/foo/bar/file.txt`;
       await fs.outputFile(filePath, 'foobar');
 
       expect(await fs.pathExists(filePath)).toBeTrue();
       await deleteLocalFile('foo/bar/file.txt');
+      expect(await fs.pathExists(filePath)).toBeFalse();
+    });
+
+    it('throws if platform is local and dryRun is set', async () => {
+      GlobalConfig.set({ platform: 'local', dryRun: 'full', localDir });
+      const filePath = `${localDir}/foo/bar/file.txt`;
+      await fs.outputFile(filePath, 'foobar');
+
+      expect(await fs.pathExists(filePath)).toBeTrue();
+      await expect(deleteLocalFile('foo/bar/file.txt')).rejects.toThrow();
+    });
+
+    it('deletes file if platform is local and dryRun is null', async () => {
+      GlobalConfig.set({ platform: 'local', localDir });
+      const filePath = `${localDir}/test-delete.txt`;
+      await fs.outputFile(filePath, 'content');
+      expect(await fs.pathExists(filePath)).toBeTrue();
+
+      await deleteLocalFile('test-delete.txt');
+
       expect(await fs.pathExists(filePath)).toBeFalse();
     });
   });

--- a/lib/util/fs/index.ts
+++ b/lib/util/fs/index.ts
@@ -65,9 +65,8 @@ export async function writeLocalFile(
 }
 
 export async function deleteLocalFile(fileName: string): Promise<void> {
-  // This a failsafe and hopefully will never be triggered
-  if (GlobalConfig.get('platform') === 'local') {
-    throw new Error('Cannot delete file when platform=local');
+  if (GlobalConfig.get('platform') === 'local' && GlobalConfig.get('dryRun')) {
+    throw new Error('Cannot delete file when platform=local in dry-run mode');
   }
   const localDir = GlobalConfig.get('localDir');
   if (localDir) {

--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -560,6 +560,25 @@ describe('util/git/index', { timeout: 10000 }, () => {
     it('returns null for 404', async () => {
       expect(await git.getFile('some-path', 'some-branch')).toBeNull();
     });
+
+    it('reads from local filesystem if platform is local', async () => {
+      const tmpDir2 = await tmp.dir({ unsafeCleanup: true });
+      GlobalConfig.set({ platform: 'local', localDir: tmpDir2.path });
+      await fs.writeFile(`${tmpDir2.path}/test-file.txt`, 'local content');
+
+      const res = await git.getFile('test-file.txt');
+
+      expect(res).toBe('local content');
+    });
+
+    it('returns null for 404 if platform is local', async () => {
+      const tmpDir2 = await tmp.dir({ unsafeCleanup: true });
+      GlobalConfig.set({ platform: 'local', localDir: tmpDir2.path });
+
+      const res = await git.getFile('some-missing-path');
+
+      expect(res).toBeNull();
+    });
   });
 
   describe('getFiles(filePath)', () => {

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -28,6 +28,7 @@ import { incLimitedValue } from '../../workers/global/limits.ts';
 import { getCache } from '../cache/repository/index.ts';
 import { getEnv } from '../env.ts';
 import { getChildEnv } from '../exec/utils.ts';
+import { readLocalFile } from '../fs/index.ts';
 import { newlineRegex, regEx } from '../regex.ts';
 import { matchRegexOrGlobList } from '../string-match.ts';
 import { getGitEnvironmentVariables } from './auth.ts';
@@ -1081,6 +1082,9 @@ export async function getFile(
   filePath: string,
   branchName?: string,
 ): Promise<string | null> {
+  if (GlobalConfig.get('platform') === 'local') {
+    return readLocalFile(filePath, 'utf8');
+  }
   await syncGit();
   try {
     const content = await git.show([


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

The `local` platform is intended mostly for dry-runs and configuration testing; it does not currently allow actually making any changes to files on disk. However, the `local` platform doesn't _need_ to be tied to dry-runs, and having the ability to update packages locally could be useful in certain situations:
* supporting (semi-automated) dependency updates in repos managed by mailing list
* verifying that file changes look good while testing or onboarding without pushing a branch
* corporate environments where a team is not willing to onboard to Renovate but requires occasional dependency updates

This PR makes a small set of changes to allow filesystem operations while using the `local` platform with `dryRun` disabled. In testing, these are sufficient to support local-only dependency updates.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

This was the subject of several recent discussions: https://github.com/renovatebot/renovate/discussions/39182, https://github.com/renovatebot/renovate/discussions/37869, https://github.com/renovatebot/renovate/discussions/36764, etc.

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/glasir/renovate-test-repo/

Because this change only affects the `local` platform, it doesn't produce the usual Renovate branch or pull request. Instead, I tested by cloning the linked repo locally, then running
```
pnpm exec node ../renovate/dist/renovate.js \
  --platform local \
  --dry-run=false \
  --onboarding false
```
(this command is slightly awkward because the local platform always sets `localDir` to `$CWD`)

I then committed the changes to a new branch and pushed them here: https://github.com/glasir/renovate-test-repo/compare/chore/run-renovate-local-platform


<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
