### PR TITLE
chore: add prState to branches info extended log output

### DIFF
--- a/lib/workers/repository/finalize/index.ts
+++ b/lib/workers/repository/finalize/index.ts
@@ -36,7 +36,7 @@ export async function finalizeRepo(
     logger.debug('Repo is activated');
     config.repoIsActivated = true;
   }
-  runBranchSummary(config);
+  runBranchSummary(config, prList);
   runRenovateRepoStats(config, prList);
 }
 

--- a/lib/workers/repository/finalize/repository-statistics.ts
+++ b/lib/workers/repository/finalize/repository-statistics.ts
@@ -1,3 +1,4 @@
+import { isNumber } from '@sindresorhus/is';
 import type { RenovateConfig } from '../../../config/types.ts';
 import { addBranchStats } from '../../../instrumentation/reporting.ts';
 import { logger } from '../../../logger/index.ts';
@@ -111,7 +112,7 @@ function filterDependencyDashboardData(
       upgradesFiltered.push(filteredUpgrade);
     }
 
-    const prState = typeof prNo === 'number' ? prStateMap.get(prNo) : undefined;
+    const prState = isNumber(prNo) ? prStateMap.get(prNo) : undefined;
 
     const filteredBranch: Partial<BranchCache> & { prState?: string } = {
       branchName,

--- a/lib/workers/repository/finalize/repository-statistics.ts
+++ b/lib/workers/repository/finalize/repository-statistics.ts
@@ -111,7 +111,7 @@ function filterDependencyDashboardData(
       upgradesFiltered.push(filteredUpgrade);
     }
 
-    const prState = prNo != null ? prStateMap.get(prNo) : undefined;
+    const prState = typeof prNo === 'number' ? prStateMap.get(prNo) : undefined;
 
     const filteredBranch: Partial<BranchCache> & { prState?: string } = {
       branchName,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
Adds `prState` field to each branch object in the `branchesInformation` data logged with the "branches info extended" message. This allows external tools consuming Renovate logs to distinguish between open, closed, and merged PRs for each branch.
 
- Updated `runBranchSummary()` to accept `prList` parameter
- Created O(1) lookup map from PR number to PR state 
- Added `prState` to the filtered branch output in `filterDependencyDashboardData()` 
- `prState` is `undefined` when `prNo` is null or PR is not found in the list

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [X] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [X] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [X] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
