### PR TITLE
fix(nix): use alias to refer to node that will be updated

### DIFF
--- a/lib/modules/manager/nix/extract.ts
+++ b/lib/modules/manager/nix/extract.ts
@@ -1,4 +1,3 @@
-import { InputSerialization$ } from '@aws-sdk/client-s3';
 import { logger } from '../../../logger/index.ts';
 import { getSiblingFileName, readLocalFile } from '../../../util/fs/index.ts';
 import { regEx } from '../../../util/regex.ts';

--- a/lib/modules/manager/nix/extract.ts
+++ b/lib/modules/manager/nix/extract.ts
@@ -55,11 +55,10 @@ export async function extractPackageFile(
 
   // collect all root input aliases, these are a map of input name -> alias, the alias is the item we want to
   // update under nodes
-  const aliasVals = [];
+  const rootAliases = new Set<string>();
   for (const input in rootInputs) {
-    aliasVals.push(rootInputs[input]);
+    rootAliases.add(rootInputs[input] as string);
   }
-  const rootAliases = new Set(aliasVals);
 
   for (const [depName, flakeInput] of Object.entries(flakeLock.nodes) as [
     string,

--- a/lib/modules/manager/nix/extract.ts
+++ b/lib/modules/manager/nix/extract.ts
@@ -9,7 +9,7 @@ import type {
   PackageDependency,
   PackageFileContent,
 } from '../types.ts';
-import { NixFlakeLock } from './schema.ts';
+import { NixFlakeLock, type NixInput } from './schema.ts';
 
 // as documented upstream
 // https://github.com/NixOS/nix/blob/master/doc/manual/source/protocols/tarball-fetcher.md#gitea-and-forgejo-support
@@ -43,7 +43,7 @@ export async function extractPackageFile(
   }
 
   const flakeLock = flakeLockParsed.data;
-  const rootInputs = flakeLock.nodes.root.inputs;
+  const rootInputs = flakeLock.nodes.root?.inputs;
 
   if (!rootInputs) {
     logger.debug(
@@ -57,14 +57,14 @@ export async function extractPackageFile(
   // update under nodes
   const aliasVals = [];
   for (const input in rootInputs) {
-    if (rootInputs[input] instanceof Array) {
-      continue;
-    }
     aliasVals.push(rootInputs[input]);
   }
   const rootAliases = new Set(aliasVals);
 
-  for (const [depName, flakeInput] of Object.entries(flakeLock.nodes)) {
+  for (const [depName, flakeInput] of Object.entries(flakeLock.nodes) as [
+    string,
+    NixInput,
+  ][]) {
     // the root input is a magic string for the entrypoint and only references other flake inputs
     if (depName === 'root') {
       continue;

--- a/lib/modules/manager/nix/schema.ts
+++ b/lib/modules/manager/nix/schema.ts
@@ -29,15 +29,26 @@ const OriginalInput = z.object({
   url: z.string().optional(),
 });
 
-const NixInput = z.object({
+export const NixInput = z.object({
   inputs: z.record(z.string(), z.string().or(z.array(z.string()))).optional(),
   locked: LockedInput.optional(),
   original: OriginalInput.optional(),
 });
 
+export type NixInput = z.infer<typeof NixInput>;
+
+// https://github.com/NixOS/nix/blob/f7fc24c/src/libflake/include/nix/flake/lockfile.hh
 export const NixFlakeLock = Json.pipe(
   z.object({
-    nodes: z.record(z.string(), NixInput),
+    nodes: z.union([
+      z.record(
+        z.literal('root'),
+        z.object({
+          inputs: z.record(z.string(), z.string()),
+        }),
+      ),
+      z.record(z.string(), NixInput),
+    ]),
     version: z.literal(7),
   }),
 );

--- a/lib/modules/manager/nix/schema.ts
+++ b/lib/modules/manager/nix/schema.ts
@@ -40,15 +40,15 @@ export type NixInput = z.infer<typeof NixInput>;
 // https://github.com/NixOS/nix/blob/f7fc24c/src/libflake/include/nix/flake/lockfile.hh
 export const NixFlakeLock = Json.pipe(
   z.object({
-    nodes: z.union([
-      z.record(
-        z.literal('root'),
-        z.object({
-          inputs: z.record(z.string(), z.string()),
-        }),
-      ),
-      z.record(z.string(), NixInput),
-    ]),
+    nodes: z
+      .object({
+        root: z
+          .object({
+            inputs: z.record(z.string(), z.string()).optional(),
+          })
+          .optional(),
+      })
+      .catchall(NixInput),
     version: z.literal(7),
   }),
 );


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Extracts the aliases into a set and if a node is a member of the set, then it is a root input node, otherwise ignore it as it is a secondary input/dependency.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

Discussion: https://github.com/renovatebot/renovate/discussions/40866

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Copilot attempted to autocomplete my lines but suggestions were not accepted as they were generally wrong. It _was_ running, so disclosing that.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: https://github.com/tebriel/renovate-repro

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
