### PR TITLE
fix(types): RenovateRepository not inheriting RenovateConfig

### DIFF
--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -305,11 +305,9 @@ export type UpdateConfig<
 
 export type RenovateRepository =
   | string
-  | {
+  | (RenovateConfig & {
       repository: string;
-      secrets?: Record<string, string>;
-      variables?: Record<string, string>;
-    };
+    });
 
 export type UseBaseBranchConfigType = 'merge' | 'none';
 export type ConstraintsFilter = 'strict' | 'none';


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Under Renovate self-hosted config, you can define repositories either by name (string) or by an object that accepts a `repository` key and any Renovate config ([ref](https://docs.renovatebot.com/self-hosted-configuration/#repositories)).

However, the type for this object was wrong and was incorrectly flagging issues where it shouldn't.

This PR fixes it.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: https://github.com/felipecrs/renovate-repro-gomod-ignore-file

```js
// config.js
// ...

  repositories: [
    {
      repository: 'felipecrs/renovate-repro-gomod-ignore-file',
      enabledManagers: ['gomod'],
      postUpdateOptions: ["gomodTidy"],
      packageRules: [
        {
          description: "Disable updates for project-b/go.mod",
          matchFileNames: ["project-b/go.mod"],
          enabled: false
        }
      ],
      extends: [
        'config:recommended',
      ],
    }
  ],

// ...
```

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
