### PR TITLE
feat(platform/bitbucket): support mixed auth (workspace access token + personal api token)

### DIFF
--- a/lib/modules/platform/bitbucket/readme.md
+++ b/lib/modules/platform/bitbucket/readme.md
@@ -21,8 +21,32 @@ After you installed the hosted app, please read the [reading list](../../../read
 
 ## Authentication
 
-First, [create an API token](https://support.atlassian.com/bitbucket-cloud/docs/create-an-api-token/) for the bot account.
-Give the bot API token the following permission scopes:
+### Recommended: Workspace Access Tokens
+
+**We recommend using [Workspace Access Tokens](https://support.atlassian.com/bitbucket-cloud/docs/workspace-access-tokens/)** instead of personal access tokens.
+Workspace Access Tokens provide higher API rate limits than personal access tokens, which is important for repositories with many dependencies.
+
+Create a Workspace Access Token with the following permission scopes:
+
+| Scopes               |
+| -------------------- |
+| Account: Read        |
+| Repository: Read     |
+| Repository: Write    |
+| Pull Requests: Read  |
+| Pull Requests: Write |
+
+Let Renovate use your Workspace Access Token by doing _one_ of the following:
+
+- Set your token as an environment variable `RENOVATE_TOKEN`
+- Set your token when you run Renovate in the CLI with `--token=`
+- Set your token as a `token` in your `config.js` file
+
+### Alternative: Personal Access Tokens
+
+If you prefer to use a personal access token, [create an API token](https://support.atlassian.com/bitbucket-cloud/docs/create-an-api-token/) for the bot account with the following scopes:
+
+Note: if you're only using a Personal Access Token for Dependency Dashboard issues you can restrict this further.
 
 | Permission                                                                                                               | Scope                |
 | ------------------------------------------------------------------------------------------------------------------------ | -------------------- |
@@ -37,7 +61,7 @@ Give the bot API token the following permission scopes:
 
 The bot also needs to validate the workspace membership status of pull-request reviewers, for that, [create a new user group](https://support.atlassian.com/bitbucket-cloud/docs/organize-workspace-members-into-groups/) in the workspace with the **Create repositories** permission and add the bot user to it.
 
-Let Renovate use your API token by doing _one_ of the following:
+Let Renovate use your personal API token by doing _one_ of the following:
 
 - Set your API token as a `password` in your `config.js` file
 - Set your API token as an environment variable `RENOVATE_PASSWORD`
@@ -47,6 +71,15 @@ Remember to:
 
 - Set the `username` for the bot account, which is your Atlassian account email. You can find your email through "Personal Bitbucket settings" on the "Email aliases" page for your account
 - Set `platform=bitbucket` somewhere in your Renovate config file
+
+### Authentication Flow
+
+Renovate uses different authentication methods depending on the API endpoint:
+
+- **For `/issues` endpoints**: When both `username`+`password` and `token` are provided, Renovate will prefer username+password authentication (Basic auth) for issues-related API calls
+- **For all other endpoints**: When a `token` is available, Renovate will use Bearer token authentication
+
+This hybrid approach ensures compatibility with Bitbucket Cloud's API requirements while maximizing the benefits of higher rate limits when using Workspace Access Tokens.
 
 ## Unsupported platform features/concepts
 

--- a/lib/util/http/auth.spec.ts
+++ b/lib/util/http/auth.spec.ts
@@ -162,17 +162,15 @@ describe('util/http/auth', () => {
 
         applyAuthorization(opts);
 
-        expect(opts).toMatchInlineSnapshot(`
-        {
-          "headers": {
-            "authorization": "Basic dXNlckBvcmcuY29tOjAxMjM0NTY3ODkwMTIzNDV0ZXN0",
+        expect(opts).toMatchObject({
+          headers: {
+            authorization: 'Basic dXNlckBvcmcuY29tOjAxMjM0NTY3ODkwMTIzNDV0ZXN0',
           },
-          "hostType": "bitbucket",
-          "password": "0123456789012345test",
-          "url": "https://api.bitbucket.com/2.0/repositories/foo/bar/pullrequests",
-          "username": "user@org.com",
-        }
-      `);
+          hostType: 'bitbucket',
+          password: '0123456789012345test',
+          url: 'https://api.bitbucket.com/2.0/repositories/foo/bar/pullrequests',
+          username: 'user@org.com',
+        });
       });
 
       it(`bitbucket api token`, () => {
@@ -185,16 +183,14 @@ describe('util/http/auth', () => {
 
         applyAuthorization(opts);
 
-        expect(opts).toMatchInlineSnapshot(`
-        {
-          "headers": {
-            "authorization": "Bearer 0123456789012345test",
+        expect(opts).toMatchObject({
+          headers: {
+            authorization: 'Bearer 0123456789012345test',
           },
-          "hostType": "bitbucket",
-          "token": "0123456789012345test",
-          "url": "https://api.bitbucket.com/2.0/repositories/foo/bar/pullrequests",
-        }
-      `);
+          hostType: 'bitbucket',
+          token: '0123456789012345test',
+          url: 'https://api.bitbucket.com/2.0/repositories/foo/bar/pullrequests',
+        });
       });
 
       it(`bitbucket mutli-auth use username+password for /issues`, () => {
@@ -209,18 +205,16 @@ describe('util/http/auth', () => {
 
         applyAuthorization(opts);
 
-        expect(opts).toMatchInlineSnapshot(`
-        {
-          "headers": {
-            "authorization": "Basic dXNlckBvcmcuY29tOjAxMjM0NTY3ODkwMTIzNDV0ZXN0",
+        expect(opts).toMatchObject({
+          headers: {
+            authorization: 'Basic dXNlckBvcmcuY29tOjAxMjM0NTY3ODkwMTIzNDV0ZXN0',
           },
-          "hostType": "bitbucket",
-          "password": "0123456789012345test",
-          "token": "0123456789012345test",
-          "url": "https://api.bitbucket.com/2.0/repositories/foo/bar/issues",
-          "username": "user@org.com",
-        }
-      `);
+          hostType: 'bitbucket',
+          password: '0123456789012345test',
+          token: '0123456789012345test',
+          url: 'https://api.bitbucket.com/2.0/repositories/foo/bar/issues',
+          username: 'user@org.com',
+        });
       });
     });
 

--- a/lib/util/http/auth.spec.ts
+++ b/lib/util/http/auth.spec.ts
@@ -25,16 +25,17 @@ describe('util/http/auth', () => {
       `);
     });
 
-    it('gitea password', () => {
-      const opts: GotOptions = {
-        headers: {},
-        hostType: 'gitea',
-        password: 'XXXX',
-      };
+    describe('gitea', () => {
+      it('gitea password', () => {
+        const opts: GotOptions = {
+          headers: {},
+          hostType: 'gitea',
+          password: 'XXXX',
+        };
 
-      applyAuthorization(opts);
+        applyAuthorization(opts);
 
-      expect(opts).toMatchInlineSnapshot(`
+        expect(opts).toMatchInlineSnapshot(`
         {
           "headers": {
             "authorization": "Basic OlhYWFg=",
@@ -43,18 +44,18 @@ describe('util/http/auth', () => {
           "password": "XXXX",
         }
       `);
-    });
+      });
 
-    it('gittea token', () => {
-      const opts: GotOptions = {
-        headers: {},
-        token: 'XXXX',
-        hostType: 'gitea',
-      };
+      it('gittea token', () => {
+        const opts: GotOptions = {
+          headers: {},
+          token: 'XXXX',
+          hostType: 'gitea',
+        };
 
-      applyAuthorization(opts);
+        applyAuthorization(opts);
 
-      expect(opts).toMatchInlineSnapshot(`
+        expect(opts).toMatchInlineSnapshot(`
         {
           "headers": {
             "authorization": "Bearer XXXX",
@@ -63,35 +64,37 @@ describe('util/http/auth', () => {
           "token": "XXXX",
         }
       `);
-    });
-
-    it('github token', () => {
-      const opts: GotOptions = {
-        headers: {},
-        token: 'XXX',
-        hostType: 'github',
-      };
-
-      applyAuthorization(opts);
-
-      expect(opts).toEqual({
-        headers: {
-          authorization: 'token XXX',
-        },
-        hostType: 'github',
-        token: 'XXX',
       });
     });
 
-    it('github token for datasource using github api', () => {
-      const opts: GotOptions = {
-        headers: {},
-        token: 'ZZZZ',
-        hostType: 'github-releases',
-      };
-      applyAuthorization(opts);
+    describe('github', () => {
+      it('github token', () => {
+        const opts: GotOptions = {
+          headers: {},
+          token: 'XXX',
+          hostType: 'github',
+        };
 
-      expect(opts).toMatchInlineSnapshot(`
+        applyAuthorization(opts);
+
+        expect(opts).toEqual({
+          headers: {
+            authorization: 'token XXX',
+          },
+          hostType: 'github',
+          token: 'XXX',
+        });
+      });
+
+      it('github token for datasource using github api', () => {
+        const opts: GotOptions = {
+          headers: {},
+          token: 'ZZZZ',
+          hostType: 'github-releases',
+        };
+        applyAuthorization(opts);
+
+        expect(opts).toMatchInlineSnapshot(`
         {
           "headers": {
             "authorization": "token ZZZZ",
@@ -100,19 +103,21 @@ describe('util/http/auth', () => {
           "token": "ZZZZ",
         }
       `);
+      });
     });
 
-    it(`gitlab personal access token`, () => {
-      const opts: GotOptions = {
-        headers: {},
-        // Personal Access Token is exactly 20 characters long
-        token: '0123456789012345test',
-        hostType: 'gitlab',
-      };
+    describe('gitlab', () => {
+      it(`gitlab personal access token`, () => {
+        const opts: GotOptions = {
+          headers: {},
+          // Personal Access Token is exactly 20 characters long
+          token: '0123456789012345test',
+          hostType: 'gitlab',
+        };
 
-      applyAuthorization(opts);
+        applyAuthorization(opts);
 
-      expect(opts).toMatchInlineSnapshot(`
+        expect(opts).toMatchInlineSnapshot(`
         {
           "headers": {
             "Private-token": "0123456789012345test",
@@ -121,19 +126,19 @@ describe('util/http/auth', () => {
           "token": "0123456789012345test",
         }
       `);
-    });
+      });
 
-    it(`gitlab oauth token`, () => {
-      const opts: GotOptions = {
-        headers: {},
-        token:
-          'a40bdd925a0c0b9c4cdd19d101c0df3b2bcd063ab7ad6706f03bcffcec01test',
-        hostType: 'gitlab',
-      };
+      it(`gitlab oauth token`, () => {
+        const opts: GotOptions = {
+          headers: {},
+          token:
+            'a40bdd925a0c0b9c4cdd19d101c0df3b2bcd063ab7ad6706f03bcffcec01test',
+          hostType: 'gitlab',
+        };
 
-      applyAuthorization(opts);
+        applyAuthorization(opts);
 
-      expect(opts).toMatchInlineSnapshot(`
+        expect(opts).toMatchInlineSnapshot(`
         {
           "headers": {
             "authorization": "Bearer a40bdd925a0c0b9c4cdd19d101c0df3b2bcd063ab7ad6706f03bcffcec01test",
@@ -142,6 +147,81 @@ describe('util/http/auth', () => {
           "token": "a40bdd925a0c0b9c4cdd19d101c0df3b2bcd063ab7ad6706f03bcffcec01test",
         }
       `);
+      });
+    });
+
+    describe('bitbucket', () => {
+      it(`bitbucket username + password`, () => {
+        const opts: GotOptions = {
+          headers: {},
+          username: 'user@org.com',
+          password: '0123456789012345test',
+          hostType: 'bitbucket',
+          url: 'https://api.bitbucket.com/2.0/repositories/foo/bar/pullrequests',
+        };
+
+        applyAuthorization(opts);
+
+        expect(opts).toMatchInlineSnapshot(`
+        {
+          "headers": {
+            "authorization": "Basic dXNlckBvcmcuY29tOjAxMjM0NTY3ODkwMTIzNDV0ZXN0",
+          },
+          "hostType": "bitbucket",
+          "password": "0123456789012345test",
+          "url": "https://api.bitbucket.com/2.0/repositories/foo/bar/pullrequests",
+          "username": "user@org.com",
+        }
+      `);
+      });
+
+      it(`bitbucket api token`, () => {
+        const opts: GotOptions = {
+          headers: {},
+          token: '0123456789012345test',
+          hostType: 'bitbucket',
+          url: 'https://api.bitbucket.com/2.0/repositories/foo/bar/pullrequests',
+        };
+
+        applyAuthorization(opts);
+
+        expect(opts).toMatchInlineSnapshot(`
+        {
+          "headers": {
+            "authorization": "Bearer 0123456789012345test",
+          },
+          "hostType": "bitbucket",
+          "token": "0123456789012345test",
+          "url": "https://api.bitbucket.com/2.0/repositories/foo/bar/pullrequests",
+        }
+      `);
+      });
+
+      it(`bitbucket mutli-auth use username+password for /issues`, () => {
+        const opts: GotOptions = {
+          headers: {},
+          username: 'user@org.com',
+          password: '0123456789012345test',
+          token: '0123456789012345test',
+          hostType: 'bitbucket',
+          url: 'https://api.bitbucket.com/2.0/repositories/foo/bar/issues',
+        };
+
+        applyAuthorization(opts);
+
+        expect(opts).toMatchInlineSnapshot(`
+        {
+          "headers": {
+            "authorization": "Basic dXNlckBvcmcuY29tOjAxMjM0NTY3ODkwMTIzNDV0ZXN0",
+          },
+          "hostType": "bitbucket",
+          "password": "0123456789012345test",
+          "token": "0123456789012345test",
+          "url": "https://api.bitbucket.com/2.0/repositories/foo/bar/issues",
+          "username": "user@org.com",
+        }
+      `);
+      });
     });
 
     it(`npm basic token`, () => {

--- a/lib/util/http/auth.ts
+++ b/lib/util/http/auth.ts
@@ -73,8 +73,7 @@ export function applyAuthorization<GotOptions extends AuthGotOptions>(
       BITBUCKET_API_USING_HOST_TYPES.includes(options.hostType)
     ) {
       // Bitbucket Cloud /issues endpoint requires username+password authentication
-      // For other endpoints, prefer workspace access tokens which have higher rate-limits
-      // Match Bitbucket API pattern: /2.0/repositories/{workspace}/{repo}/issues
+      // Match Bitbucket API pattern: /repositories/{workspace}/{repo}/issues
       const url =
         typeof options.url === 'string'
           ? options.url

--- a/lib/util/http/auth.ts
+++ b/lib/util/http/auth.ts
@@ -19,10 +19,10 @@ export type AuthGotOptions = Pick<
   | 'token'
   | 'username'
   | 'password'
+  | 'url'
 >;
 
 export function applyAuthorization<GotOptions extends AuthGotOptions>(
-  url: string,
   inOptions: GotOptions,
 ): GotOptions {
   const options: GotOptions = { ...inOptions };
@@ -75,6 +75,10 @@ export function applyAuthorization<GotOptions extends AuthGotOptions>(
       // Bitbucket Cloud /issues endpoint requires username+password authentication
       // For other endpoints, prefer workspace access tokens which have higher rate-limits
       // Match Bitbucket API pattern: /2.0/repositories/{workspace}/{repo}/issues
+      const url =
+        typeof options.url === 'string'
+          ? options.url
+          : (options.url?.href ?? '');
       const isIssuesEndpoint = regEx(
         /\/repositories\/[^/]+\/[^/]+\/issues/,
       ).test(url);

--- a/lib/util/http/auth.ts
+++ b/lib/util/http/auth.ts
@@ -82,10 +82,14 @@ export function applyAuthorization<GotOptions extends AuthGotOptions>(
       const isIssuesEndpoint = regEx(
         /\/repositories\/[^/]+\/[^/]+\/issues/,
       ).test(url);
-      if (isIssuesEndpoint && options.password !== undefined) {
+      if (
+        isIssuesEndpoint &&
+        options.username !== undefined &&
+        options.password !== undefined
+      ) {
         // Use username+password for /issues endpoint
         const auth = Buffer.from(
-          `${options.username ?? ''}:${options.password}`,
+          `${options.username}:${options.password}`,
         ).toString('base64');
         options.headers.authorization = `Basic ${auth}`;
         delete options.username;

--- a/lib/util/http/auth.ts
+++ b/lib/util/http/auth.ts
@@ -18,11 +18,10 @@ export type AuthGotOptions = Pick<
   | 'token'
   | 'username'
   | 'password'
-> & {
-  href?: string;
-};
+>;
 
 export function applyAuthorization<GotOptions extends AuthGotOptions>(
+  url: string,
   inOptions: GotOptions,
 ): GotOptions {
   const options: GotOptions = { ...inOptions };
@@ -74,7 +73,8 @@ export function applyAuthorization<GotOptions extends AuthGotOptions>(
     ) {
       // Bitbucket Cloud /issues endpoint requires username+password authentication
       // For other endpoints, prefer workspace access tokens which have higher rate-limits
-      const isIssuesEndpoint = options.href?.includes('/issues');
+      // Match Bitbucket API pattern: /2.0/repositories/{workspace}/{repo}/issues
+      const isIssuesEndpoint = /\/repositories\/[^/]+\/[^/]+\/issues/.test(url);
       if (isIssuesEndpoint && options.password !== undefined) {
         // Use username+password for /issues endpoint
         const auth = Buffer.from(

--- a/lib/util/http/auth.ts
+++ b/lib/util/http/auth.ts
@@ -7,6 +7,7 @@ import {
   GITHUB_API_USING_HOST_TYPES,
   GITLAB_API_USING_HOST_TYPES,
 } from '../../constants/index.ts';
+import { regEx } from '../regex.ts';
 import type { GotOptions } from './types.ts';
 
 export type AuthGotOptions = Pick<
@@ -74,7 +75,9 @@ export function applyAuthorization<GotOptions extends AuthGotOptions>(
       // Bitbucket Cloud /issues endpoint requires username+password authentication
       // For other endpoints, prefer workspace access tokens which have higher rate-limits
       // Match Bitbucket API pattern: /2.0/repositories/{workspace}/{repo}/issues
-      const isIssuesEndpoint = /\/repositories\/[^/]+\/[^/]+\/issues/.test(url);
+      const isIssuesEndpoint = regEx(
+        /\/repositories\/[^/]+\/[^/]+\/issues/,
+      ).test(url);
       if (isIssuesEndpoint && options.password !== undefined) {
         // Use username+password for /issues endpoint
         const auth = Buffer.from(

--- a/lib/util/http/http.ts
+++ b/lib/util/http/http.ts
@@ -158,7 +158,7 @@ export abstract class HttpBase<
       logger.debug(`Host is disabled - rejecting request. HostUrl: ${url}`);
       throw new Error(HOST_DISABLED);
     }
-    options = applyAuthorization(options);
+    options = applyAuthorization(url, options);
     options.timeout ??= 60000;
 
     let cacheProvider: HttpCacheProvider | undefined;
@@ -673,7 +673,7 @@ export abstract class HttpBase<
     if (combinedOptions.enabled === false) {
       throw new Error(HOST_DISABLED);
     }
-    combinedOptions = applyAuthorization(combinedOptions);
+    combinedOptions = applyAuthorization(resolvedUrl, combinedOptions);
 
     return stream(resolvedUrl, combinedOptions);
   }

--- a/lib/util/http/http.ts
+++ b/lib/util/http/http.ts
@@ -158,7 +158,7 @@ export abstract class HttpBase<
       logger.debug(`Host is disabled - rejecting request. HostUrl: ${url}`);
       throw new Error(HOST_DISABLED);
     }
-    options = applyAuthorization(url, options);
+    options = applyAuthorization(options);
     options.timeout ??= 60000;
 
     let cacheProvider: HttpCacheProvider | undefined;
@@ -673,7 +673,7 @@ export abstract class HttpBase<
     if (combinedOptions.enabled === false) {
       throw new Error(HOST_DISABLED);
     }
-    combinedOptions = applyAuthorization(resolvedUrl, combinedOptions);
+    combinedOptions = applyAuthorization(combinedOptions);
 
     return stream(resolvedUrl, combinedOptions);
   }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Update http client auth fn to support mixed authentication for Bitbucket Cloud.

[Workspace Access Tokens](https://support.atlassian.com/bitbucket-cloud/docs/workspace-access-tokens/) have significantly higher API rate limits, however there are no permissions currently for Issues read/write, which is required for those using `Dependency Dashboard` within Bitbucket Cloud.

This update falls back to `username` + `password` auth for `/issue` operations, while all others will use `token` when present.

<!-- Describe what behavior is changed by this PR. -->

## Context

**Workspace Access Tokens**
<img width="300" height="384" alt="Screenshot 2026-02-04 at 12 32 38 PM" src="https://github.com/user-attachments/assets/fe491174-43dd-43de-83da-6d6b9ff6d4a5" />


Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
