### PR TITLE
fix(npm): guard against pnpm not being used in repo when handling npm vulnerabilities

### DIFF
--- a/lib/modules/manager/npm/artifacts.ts
+++ b/lib/modules/manager/npm/artifacts.ts
@@ -159,8 +159,9 @@ async function updatePnpmWorkspace(
 
   const pnpmShrinkwrap = upgrades
     .map((upgrade) => upgrade.managerData?.pnpmShrinkwrap)
-    .find((shrinkwrap): shrinkwrap is string =>
-      isString(shrinkwrap) && Boolean(shrinkwrap.length),
+    .find(
+      (shrinkwrap): shrinkwrap is string =>
+        isString(shrinkwrap) && Boolean(shrinkwrap.length),
     );
   if (!pnpmShrinkwrap) {
     logger.debug(

--- a/lib/modules/manager/npm/artifacts.ts
+++ b/lib/modules/manager/npm/artifacts.ts
@@ -157,8 +157,12 @@ async function updatePnpmWorkspace(
     return null;
   }
 
-  const pnpmShrinkwrap = upgrades[0].managerData?.pnpmShrinkwrap;
-  if (!isString(pnpmShrinkwrap)) {
+  const pnpmShrinkwrap = upgrades
+    .map((upgrade) => upgrade.managerData?.pnpmShrinkwrap)
+    .find((shrinkwrap): shrinkwrap is string =>
+      isString(shrinkwrap) && Boolean(shrinkwrap.length),
+    );
+  if (!pnpmShrinkwrap) {
     logger.debug(
       'No pnpm shrinkwrap found, not attempting to update pnpm-workspace.yaml',
     );


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Update the npm usage of pnpm to guard against pnpm not being used

Our repo doesn't use pnmp, but we do use npm. When enabling npm for vulnerability alerts we would get:

```
     "stack": "TypeError: The \"path\" argument must be of type string. Received undefined\n    at Object.dirname (node:path:1442:5)\n    at Object.dirname (/usr/local/renovate/node_modules/.pnpm/upath@2.0.1/node_modules/upath/build/code/upath.js:51:33)\n    at updatePnpmWorkspace (/usr/local/renovate/lib/modules/manager/npm/artifacts.ts:161:29)\n    at updateArtifacts (/usr/local/renovate/lib/modules/manager/npm/artifacts.ts:39:19)\n    at processTicksAndRejections (node:internal/process/task_queues:103:5)\n    at managerUpdateArtifacts (/usr/local/renovate/lib/workers/repository/update/branch/get-updated.ts:488:10)\n    at getUpdatedPackageFiles (/usr/local/renovate/lib/workers/repository/update/branch/get-updated.ts:334:25)\n    at processBranch (/usr/local/renovate/lib/workers/repository/update/branch/index.ts:581:19)\n    at res.attributes (/usr/local/renovate/lib/workers/repository/process/write.ts:177:21)\n    at writeUpdates (/usr/local/renovate/lib/workers/repository/process/write.ts:150:17)\n    at update (/usr/local/renovate/lib/workers/repository/process/extract-update.ts:253:11)\n    at Object.renovateRepository (/usr/local/renovate/lib/workers/repository/index.ts:142:19)\n    at attributes (/usr/local/renovate/lib/workers/global/index.ts:198:11)\n    at start (/usr/local/renovate/lib/workers/global/index.ts:183:7)\n    at /usr/local/renovate/lib/renovate.ts:19:22"
```

Because we didn't use pnpm. This PR just guards against pnmp not being used

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [x] Yes — other (please describe):

Discussed the issue with Codex to ensure I understood the relevant code. IDE auto complete via vscode/github, generated the vulnerability for the test

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
