### PR TITLE
feat(managers/npm): allow specifying `toolSettings.nodeMaxMemory`

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -4783,13 +4783,9 @@ Defaults to `jvmMaxMemory`.
 
 ### nodeMaxMemory
 
-Maximum memory in MiB for Node child processes invoked by Renovate.
-
 <!-- prettier-ignore -->
 !!! note
     This does not apply to _every_ Node process created by Renovate, only the managers noted above.
-
-If unset (as it is by default), the Node process will automagically determine the memory limit to use.
 
 ## updateInternalDeps
 

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -4781,6 +4781,16 @@ To allow repositories to use _more_ than 512m of heap during any invocations of 
 Initial heap size in MB for Java VMs. Must be less than or equal to `jvmMaxMemory`.
 Defaults to `jvmMaxMemory`.
 
+### nodeMaxMemory
+
+Maximum memory in MiB for Node child processes invoked by Renovate.
+
+<!-- prettier-ignore -->
+!!! note
+    This does not apply to _every_ Node process created by Renovate, only the managers noted above.
+
+If unset (as it is by default), the Node process will automagically determine the memory limit to use.
+
 ## updateInternalDeps
 
 Renovate defaults to skipping any internal package dependencies within monorepos.

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -3442,6 +3442,16 @@ const options: Readonly<RenovateOptions>[] = [
     cli: false,
     env: false,
   },
+  {
+    name: 'nodeMaxMemory',
+    description:
+      'Maximum memory in MiB for Node child processes invoked by Renovate. If unset, the Node process will automagically determine the memory limit to use. Repo configuration for this value will be ignored if it exceeds the global configuration for `toolSettings.nodeMaxMemory`',
+    type: 'integer',
+    parents: ['toolSettings'],
+    supportedManagers: ['npm'],
+    cli: false,
+    env: false,
+  },
 ];
 
 export function getOptions(): Readonly<RenovateOptions>[] {

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -814,4 +814,5 @@ export interface BumpVersionConfig {
 export interface ToolSettingsOptions {
   jvmMaxMemory?: number;
   jvmMemory?: number;
+  nodeMaxMemory?: number;
 }

--- a/lib/modules/manager/npm/post-update/npm.ts
+++ b/lib/modules/manager/npm/post-update/npm.ts
@@ -9,7 +9,7 @@ import {
   TEMPORARY_ERROR,
 } from '../../../../constants/error-messages.ts';
 import { logger } from '../../../../logger/index.ts';
-import { exec } from '../../../../util/exec/index.ts';
+import { exec, getToolSettingsOptions } from '../../../../util/exec/index.ts';
 import type {
   ExecOptions,
   ExtraEnv,
@@ -29,7 +29,11 @@ import { PackageLock } from '../schema.ts';
 import { composeLockFile, parseLockFile } from '../utils.ts';
 import { getNodeToolConstraint } from './node-version.ts';
 import type { GenerateLockFileResult } from './types.ts';
-import { getPackageManagerVersion, lazyLoadPackageJson } from './utils.ts';
+import {
+  getNodeOptions,
+  getPackageManagerVersion,
+  lazyLoadPackageJson,
+} from './utils.ts';
 
 async function getNpmConstraintFromPackageLock(
   lockFileDir: string,
@@ -111,6 +115,12 @@ export async function generateLockFile(
       NPM_CONFIG_CACHE: env.NPM_CONFIG_CACHE,
       npm_config_store: env.npm_config_store,
     };
+
+    const { nodeMaxMemory } = getToolSettingsOptions(config.toolSettings);
+    if (nodeMaxMemory) {
+      extraEnv.NODE_OPTIONS = getNodeOptions(nodeMaxMemory);
+    }
+
     const execOptions: ExecOptions = {
       cwdFile: lockFileName,
       extraEnv,

--- a/lib/modules/manager/npm/post-update/pnpm.ts
+++ b/lib/modules/manager/npm/post-update/pnpm.ts
@@ -4,7 +4,7 @@ import upath from 'upath';
 import { GlobalConfig } from '../../../../config/global.ts';
 import { TEMPORARY_ERROR } from '../../../../constants/error-messages.ts';
 import { logger } from '../../../../logger/index.ts';
-import { exec } from '../../../../util/exec/index.ts';
+import { exec, getToolSettingsOptions } from '../../../../util/exec/index.ts';
 import type {
   ExecOptions,
   ExtraEnv,
@@ -24,7 +24,11 @@ import { PNPM_CACHE_DIR, PNPM_STORE_DIR } from '../constants.ts';
 import type { PnpmWorkspaceFile } from '../extract/types.ts';
 import { getNodeToolConstraint } from './node-version.ts';
 import type { GenerateLockFileResult, PnpmLockFile } from './types.ts';
-import { getPackageManagerVersion, lazyLoadPackageJson } from './utils.ts';
+import {
+  getNodeOptions,
+  getPackageManagerVersion,
+  lazyLoadPackageJson,
+} from './utils.ts';
 
 function getPnpmConstraintFromUpgrades(upgrades: Upgrade[]): string | null {
   for (const upgrade of upgrades) {
@@ -69,6 +73,12 @@ export async function generateLockFile(
       pnpm_config_cache_dir: pnpmConfigCacheDir,
       pnpm_config_store_dir: pnpmConfigStoreDir,
     };
+
+    const { nodeMaxMemory } = getToolSettingsOptions(config.toolSettings);
+    if (nodeMaxMemory) {
+      extraEnv.NODE_OPTIONS = getNodeOptions(nodeMaxMemory);
+    }
+
     const execOptions: ExecOptions = {
       cwdFile: lockFileName,
       extraEnv,

--- a/lib/modules/manager/npm/post-update/utils.ts
+++ b/lib/modules/manager/npm/post-update/utils.ts
@@ -54,3 +54,7 @@ export function getPackageManagerVersion(
   }
   return null;
 }
+
+export function getNodeOptions(nodeMaxMemory: number): string {
+  return `--max-old-space-size=${nodeMaxMemory}`;
+}

--- a/lib/modules/manager/npm/post-update/yarn.spec.ts
+++ b/lib/modules/manager/npm/post-update/yarn.spec.ts
@@ -96,6 +96,95 @@ describe('modules/manager/npm/post-update/yarn', () => {
     },
   );
 
+  describe.each([
+    ['1.22.0', '^1.10.0', 2],
+    ['2.1.0', '>= 2.0.0', 1],
+    ['2.2.0', '2.2.0', 1],
+    ['3.0.0', '3.0.0', 1],
+  ])(
+    'passes NODE_OPTIONS using yarn v%s',
+    (yarnVersion, yarnCompatibility, _expectedFsCalls) => {
+      it('if nodeMaxMemory set on global config', async () => {
+        Fixtures.mock(
+          {
+            '.yarnrc': 'yarn-path ./.yarn/cli.js\n',
+            'yarn.lock': 'package-lock-contents',
+          },
+          '/some-dir',
+        );
+        GlobalConfig.set({
+          localDir: '/',
+          cacheDir: '/tmp/cache',
+          toolSettings: {
+            nodeMaxMemory: 2345,
+          },
+        });
+        const execSnapshots = mockExecAll({
+          stdout: yarnVersion,
+          stderr: '',
+        });
+        const config = {
+          constraints: {
+            yarn: yarnCompatibility,
+          },
+          postUpdateOptions: ['yarnDedupeFewer', 'yarnDedupeHighest'],
+        };
+        const res = await yarnHelper.generateLockFile(
+          'some-dir',
+          {
+            YARN_CACHE_FOLDER: '/tmp/renovate/cache/yarn',
+            YARN_GLOBAL_FOLDER: '/tmp/renovate/cache/berry',
+          },
+          config,
+        );
+        expect(res.error).toBeUndefined();
+
+        // there may be other command(s), but checking that at least 1 has it is sufficient
+        expect(execSnapshots[0].options?.env?.NODE_OPTIONS).toEqual(
+          '--max-old-space-size=2345',
+        );
+      });
+
+      it('if nodeMaxMemory set on repo config', async () => {
+        Fixtures.mock(
+          {
+            '.yarnrc': 'yarn-path ./.yarn/cli.js\n',
+            'yarn.lock': 'package-lock-contents',
+          },
+          '/some-dir',
+        );
+        GlobalConfig.set({ localDir: '/', cacheDir: '/tmp/cache' });
+        const execSnapshots = mockExecAll({
+          stdout: yarnVersion,
+          stderr: '',
+        });
+        const config = {
+          constraints: {
+            yarn: yarnCompatibility,
+          },
+          postUpdateOptions: ['yarnDedupeFewer', 'yarnDedupeHighest'],
+          toolSettings: {
+            nodeMaxMemory: 2345,
+          },
+        };
+        const res = await yarnHelper.generateLockFile(
+          'some-dir',
+          {
+            YARN_CACHE_FOLDER: '/tmp/renovate/cache/yarn',
+            YARN_GLOBAL_FOLDER: '/tmp/renovate/cache/berry',
+          },
+          config,
+        );
+        expect(res.error).toBeUndefined();
+
+        // there may be other command(s), but checking that at least 1 has it is sufficient
+        expect(execSnapshots[0].options?.env?.NODE_OPTIONS).toEqual(
+          '--max-old-space-size=2345',
+        );
+      });
+    },
+  );
+
   it('only skips build if skipInstalls is false', async () => {
     Fixtures.mock(
       {

--- a/lib/modules/manager/npm/post-update/yarn.ts
+++ b/lib/modules/manager/npm/post-update/yarn.ts
@@ -10,7 +10,7 @@ import {
 import { logger } from '../../../../logger/index.ts';
 import { ExternalHostError } from '../../../../types/errors/external-host-error.ts';
 import { getEnv } from '../../../../util/env.ts';
-import { exec } from '../../../../util/exec/index.ts';
+import { exec, getToolSettingsOptions } from '../../../../util/exec/index.ts';
 import type {
   CommandWithOptions,
   ExecOptions,
@@ -30,7 +30,11 @@ import { getYarnLock, getYarnVersionFromLock } from '../extract/yarn.ts';
 import type { NpmManagerData } from '../types.ts';
 import { getNodeToolConstraint } from './node-version.ts';
 import type { GenerateLockFileResult } from './types.ts';
-import { getPackageManagerVersion, lazyLoadPackageJson } from './utils.ts';
+import {
+  getNodeOptions,
+  getPackageManagerVersion,
+  lazyLoadPackageJson,
+} from './utils.ts';
 
 export async function checkYarnrc(
   lockFileDir: string,
@@ -195,6 +199,11 @@ export async function generateLockFile(
       } else {
         extraEnv.YARN_ENABLE_SCRIPTS = '0';
       }
+    }
+
+    const { nodeMaxMemory } = getToolSettingsOptions(config.toolSettings);
+    if (nodeMaxMemory) {
+      extraEnv.NODE_OPTIONS = getNodeOptions(nodeMaxMemory);
     }
 
     const execOptions: ExecOptions = {

--- a/lib/modules/manager/types.ts
+++ b/lib/modules/manager/types.ts
@@ -349,6 +349,7 @@ export interface PostUpdateConfig<T = Record<string, any>>
   yarnLock?: string;
   branchName: string;
   reuseExistingBranch?: boolean;
+  toolSettings?: ToolSettingsOptions;
 
   isLockFileMaintenance?: boolean;
 }

--- a/lib/util/exec/index.spec.ts
+++ b/lib/util/exec/index.spec.ts
@@ -1414,6 +1414,133 @@ describe('util/exec/index', () => {
         });
       });
     });
+
+    describe('for Node settings', () => {
+      beforeEach(() => {
+        GlobalConfig.set({
+          toolSettings: { nodeMaxMemory: 1024 },
+        });
+
+        // remove any test-specific overrides
+        delete config.toolSettings;
+      });
+
+      it('does not return a default value if no global or repo config', () => {
+        GlobalConfig.set({});
+
+        const res = getToolSettingsOptions(undefined);
+
+        expect(res).toMatchObject({
+          nodeMaxMemory: undefined,
+        });
+      });
+
+      it('does not return default values if empty global config', () => {
+        GlobalConfig.set({
+          toolSettings: {},
+        });
+
+        const res = getToolSettingsOptions(undefined);
+
+        expect(res).toMatchObject({
+          nodeMaxMemory: undefined,
+        });
+      });
+
+      describe('does not allow floating point numbers', () => {
+        it('in global config', () => {
+          GlobalConfig.set({
+            toolSettings: { nodeMaxMemory: 1024.1536 },
+          });
+
+          const res = getToolSettingsOptions(undefined);
+
+          expect(res).toMatchObject({
+            nodeMaxMemory: 1024,
+          });
+        });
+
+        it('in repo config', () => {
+          GlobalConfig.set({});
+
+          config.toolSettings = {
+            nodeMaxMemory: 1024.1536,
+          };
+
+          const res = getToolSettingsOptions(config.toolSettings);
+
+          expect(res).toMatchObject({
+            nodeMaxMemory: 1024,
+          });
+        });
+      });
+
+      describe('when using repo config to override memory limits', () => {
+        it('when below global settings, repo settings are used', () => {
+          config.toolSettings = {
+            nodeMaxMemory: 700,
+          };
+
+          const res = getToolSettingsOptions(config.toolSettings);
+
+          expect(res).toMatchObject({
+            nodeMaxMemory: 700,
+          });
+        });
+
+        it('when repo settings are the same as global settings, they are used', () => {
+          config.toolSettings = {
+            nodeMaxMemory: 1024,
+          };
+
+          const res = getToolSettingsOptions(config.toolSettings);
+
+          expect(res).toMatchObject({
+            nodeMaxMemory: 1024,
+          });
+        });
+
+        it('when repo nodeMaxMemory setting is lower than global settings, it is applied', () => {
+          config.toolSettings = {
+            nodeMaxMemory: 128,
+          };
+
+          const res = getToolSettingsOptions(config.toolSettings);
+
+          expect(res).toMatchObject({
+            nodeMaxMemory: 128,
+          });
+        });
+
+        it('when repo nodeMaxMemory setting is higher than global settings, they are ignored', () => {
+          config.toolSettings = {
+            nodeMaxMemory: 8192,
+          };
+
+          const res = getToolSettingsOptions(config.toolSettings);
+
+          expect(res).toMatchObject({
+            nodeMaxMemory: 1024,
+          });
+        });
+
+        it('when repo nodeMaxMemory setting is higher than global settings, a debug log is logged', () => {
+          config.toolSettings = {
+            nodeMaxMemory: 8192,
+          };
+
+          const res = getToolSettingsOptions(config.toolSettings);
+
+          expect(logger.logger.once.debug).toHaveBeenCalledWith(
+            'A higher nodeMaxMemory (8192) than the global configuration (1024) is not permitted for Node invocations. Using global configuration instead',
+          );
+
+          expect(res).toMatchObject({
+            nodeMaxMemory: 1024,
+          });
+        });
+      });
+    });
   });
 
   describe('gradleJvmArg()', () => {

--- a/lib/util/exec/index.ts
+++ b/lib/util/exec/index.ts
@@ -236,6 +236,7 @@ export function getToolSettingsOptions(
 
   options.jvmMaxMemory = defaults?.jvmMaxMemory ?? 512;
   options.jvmMemory = defaults?.jvmMemory ?? options.jvmMaxMemory;
+  options.nodeMaxMemory ??= defaults?.nodeMaxMemory;
 
   if (repoConfig !== undefined) {
     if (repoConfig.jvmMaxMemory) {
@@ -254,10 +255,26 @@ export function getToolSettingsOptions(
     if (repoConfig.jvmMemory) {
       options.jvmMemory = repoConfig.jvmMemory;
     }
+
+    if (repoConfig.nodeMaxMemory) {
+      if (
+        options.nodeMaxMemory &&
+        repoConfig.nodeMaxMemory > options.nodeMaxMemory
+      ) {
+        logger.once.debug(
+          `A higher nodeMaxMemory (${repoConfig.nodeMaxMemory}) than the global configuration (${options.nodeMaxMemory}) is not permitted for Node invocations. Using global configuration instead`,
+        );
+      } else {
+        options.nodeMaxMemory = repoConfig.nodeMaxMemory;
+      }
+    }
   }
 
   options.jvmMaxMemory = Math.floor(options.jvmMaxMemory);
   options.jvmMemory = Math.floor(options.jvmMemory);
+  if (options.nodeMaxMemory) {
+    options.nodeMaxMemory = Math.floor(options.nodeMaxMemory);
+  }
 
   // make sure that the starting memory can't be more than the max memory
   options.jvmMemory = Math.min(options.jvmMemory, options.jvmMaxMemory);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

As noted in #40942, we're seeing an increase in memory usage across
`pnpm` and `yarn` users in Mend-hosted apps.

To allow limiting the maximum memory that any `node` child processes
will use, we can add a new `toolSettings.nodeMaxMemory` to (hopefully)
mitigate this.

Similar to the `toolSettings.jvmMaxMemory`, the self-hosted
administrator can set a maximum, which cannot be exceeded by repo-level
configuration.



## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/renovatebot/renovate/pull/40957#issuecomment-4003706544

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
