### PR TITLE
fix(gerrit): use the `ready` push option to ensure changes are not wip

### DIFF
--- a/lib/modules/platform/gerrit/scm.spec.ts
+++ b/lib/modules/platform/gerrit/scm.spec.ts
@@ -337,7 +337,7 @@ describe('modules/platform/gerrit/scm', () => {
         files: [],
         sourceRef: 'renovate/dependency-1.x',
         targetRef: 'refs/for/main',
-        pushOptions: ['notify=NONE'],
+        pushOptions: ['notify=NONE', 'ready'],
       });
     });
 
@@ -378,7 +378,7 @@ describe('modules/platform/gerrit/scm', () => {
         files: [],
         sourceRef: 'renovate/dependency-1.x',
         targetRef: 'refs/for/main',
-        pushOptions: ['notify=NONE', 'label=Code-Review+2'],
+        pushOptions: ['notify=NONE', 'ready', 'label=Code-Review+2'],
       });
     });
 
@@ -427,7 +427,7 @@ describe('modules/platform/gerrit/scm', () => {
         files: [],
         sourceRef: 'renovate/dependency-1.x',
         targetRef: 'refs/for/main', // not new-main
-        pushOptions: ['notify=NONE'],
+        pushOptions: ['notify=NONE', 'ready'],
       });
     });
 
@@ -523,7 +523,7 @@ describe('modules/platform/gerrit/scm', () => {
         files: [],
         sourceRef: 'renovate/dependency-1.x',
         targetRef: 'refs/for/main',
-        pushOptions: ['notify=NONE', 'label=Code-Review+2'],
+        pushOptions: ['notify=NONE', 'ready', 'label=Code-Review+2'],
       });
     });
 
@@ -568,6 +568,7 @@ describe('modules/platform/gerrit/scm', () => {
         targetRef: 'refs/for/main',
         pushOptions: [
           'notify=NONE',
+          'ready',
           'label=Code-Review+2',
           'hashtag=hashtag1',
           'hashtag=hashtag2',
@@ -627,6 +628,7 @@ describe('modules/platform/gerrit/scm', () => {
         targetRef: 'refs/for/main',
         pushOptions: [
           'notify=NONE',
+          'ready',
           'label=Code-Review+2',
           'hashtag=hashtag1',
           'hashtag=hashtag2',

--- a/lib/modules/platform/gerrit/scm.ts
+++ b/lib/modules/platform/gerrit/scm.ts
@@ -146,7 +146,7 @@ export class GerritScm extends DefaultGitScm {
         hasChanges = await git.hasDiff('HEAD', 'FETCH_HEAD'); // avoid pushing empty patch sets
       }
       if (hasChanges || commit.force) {
-        const pushOptions = ['notify=NONE'];
+        const pushOptions = ['notify=NONE', 'ready'];
         if (commit.autoApprove) {
           pushOptions.push('label=Code-Review+2');
         }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

In gerrit, changes can be set to WIP by default instead of ready. This breaks renovate because it doesn't see WIP changes and just creates new ones again every run.

The solution is to always include the "ready" push option to ensure the changes are ready and not wip.

https://gerrit-review.googlesource.com/Documentation/user-upload.html

This can occur with the gerrit project configuration which set all reviews as drafts by default regardless of the user's settings:
```
[change]
	workInProgressByDefault = true
```

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: N/A

Ran against a private gerrit instance.

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
