### PR TITLE
feat(gitlab): add experimental MR pipeline status check support

### DIFF
--- a/docs/usage/self-hosted-experimental.md
+++ b/docs/usage/self-hosted-experimental.md
@@ -82,6 +82,11 @@ If set, Renovate will use this as a delay to proceed with an automerge.
 
 Default value: `250` (milliseconds).
 
+## `RENOVATE_X_GITLAB_MR_STATUS_CHECK`
+
+If set to `"true"`, Renovate will prefer posting status checks to the MR pipeline instead of the branch pipeline.
+If no MR pipeline is found, it falls back to the branch pipeline.
+
 ## `RENOVATE_X_HARD_EXIT`
 
 If set to any value, Renovate will use a "hard" `process.exit()` once all work is done, even if a sub-process is otherwise delaying Node.js from exiting.

--- a/lib/modules/platform/gitlab/index.ts
+++ b/lib/modules/platform/gitlab/index.ts
@@ -972,6 +972,16 @@ export async function setBranchStatus({
 
   try {
     for (let attempt = 1; attempt <= retryTimes + 1; attempt += 1) {
+      // Prefer MR pipeline if experimental env var is set
+      if (env.RENOVATE_X_GITLAB_MR_STATUS_CHECK === 'true') {
+        const mr = await getBranchPr(branchName);
+        if (mr?.headPipelineId) {
+          options.pipeline_id = mr.headPipelineId;
+          break;
+        }
+      }
+
+      // Fall back to branch pipeline
       const commitUrl = `projects/${config.repository}/repository/commits/${branchSha}`;
       await gitlabApi
         .getJsonSafe(commitUrl, { memCache: false }, LastPipelineId)

--- a/lib/modules/platform/gitlab/schema.ts
+++ b/lib/modules/platform/gitlab/schema.ts
@@ -35,6 +35,7 @@ export const GitLabMergeRequestSchema = z.object({
   sha: LongCommitShaSchema.nullish(),
   head_pipeline: z
     .object({
+      id: z.number(),
       status: z.string(),
       sha: LongCommitShaSchema,
     })

--- a/lib/modules/platform/gitlab/types.ts
+++ b/lib/modules/platform/gitlab/types.ts
@@ -21,6 +21,7 @@ export interface GitLabUser {
 export interface GitlabPr extends Pr {
   headPipelineStatus?: string;
   headPipelineSha?: string;
+  headPipelineId?: number;
 }
 
 export interface UpdateMergeRequest {

--- a/lib/modules/platform/gitlab/utils.ts
+++ b/lib/modules/platform/gitlab/utils.ts
@@ -37,6 +37,7 @@ export function prInfo(mr: GitLabMergeRequest): GitlabPr {
       headPipelineStatus: mr.head_pipeline?.status,
     }),
     ...(mr.head_pipeline?.sha && { headPipelineSha: mr.head_pipeline?.sha }),
+    ...(mr.head_pipeline?.id && { headPipelineId: mr.head_pipeline?.id }),
 
     ...(isNonEmptyArray(mr.reviewers) && {
       reviewers: mr.reviewers?.map(({ username }) => username),


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Add RENOVATE_X_GITLAB_MR_STATUS_CHECK env var to prefer posting status checks to MR pipelines instead of branch pipelines. When enabled, falls back to branch pipeline if no MR pipeline exists.

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: https://github.com/renovatebot/renovate/discussions/27111
  - I'm not 100% sure whether this is 100% fixed, but we're seeing very similar situations where duplicate pipelines are triggering merges even though there are failing pipelines.
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
  - I have used Roo Code with Opus 4.5 to pinpoint the root cause and iterate on a minimal fix.
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
