### PR TITLE
feat(presets): add Error Prone dependency group

### DIFF
--- a/lib/config/presets/internal/group.preset.ts
+++ b/lib/config/presets/internal/group.preset.ts
@@ -115,15 +115,6 @@ const staticGroups = {
       },
     ],
   },
-  errorProne: {
-    description: 'Group Error Prone packages.',
-    packageRules: [
-      {
-        groupName: 'Error Prone',
-        matchPackageNames: ['com.google.errorprone:**'],
-      },
-    ],
-  },
   flyway: {
     description: 'Group Java Flyway packages.',
     packageRules: [

--- a/lib/config/presets/internal/group.preset.ts
+++ b/lib/config/presets/internal/group.preset.ts
@@ -115,6 +115,15 @@ const staticGroups = {
       },
     ],
   },
+  errorProne: {
+    description: 'Group Error Prone packages.',
+    packageRules: [
+      {
+        groupName: 'Error Prone',
+        matchPackageNames: ['com.google.errorprone:**'],
+      },
+    ],
+  },
   flyway: {
     description: 'Group Java Flyway packages.',
     packageRules: [

--- a/lib/data/monorepo.json
+++ b/lib/data/monorepo.json
@@ -316,6 +316,7 @@
     "emotion": "https://github.com/emotion-js/emotion",
     "enumeratum": "https://github.com/lloydmeta/enumeratum",
     "envelop": "https://github.com/n1ru4l/envelop",
+    "error-prone": "https://github.com/google/error-prone",
     "eslint": "https://github.com/eslint/eslint",
     "eslint-config-globex": "https://github.com/GlobexDesignsInc/eslint-config-globex",
     "eslint-stylistic": "https://github.com/eslint-stylistic/eslint-stylistic",


### PR DESCRIPTION
## Changes

Adds an [Error Prone](https://errorprone.info/) monorepo for the `google/error-prone` repo.

Error Prone releases versions of all their packages at once, with a single version for all of them ([example](https://github.com/google/error-prone/releases)). A typical Java codebase using Error Prone has dependencies on `com.google.errorprone:error_prone_annotations` and `com.google.errorprone:error_prone_core` (and occasionally `com.google.errorprone:error_prone_refaster`).

## Context

Please select one of the following:

- [ ] This closes an existing Issue
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

I used AI to make the change to `group.preset.ts`.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository