### PR TITLE
fix(bitbucket-server): when adding reviewers use name instead of slug

### DIFF
--- a/lib/modules/platform/bitbucket-server/index.spec.ts
+++ b/lib/modules/platform/bitbucket-server/index.spec.ts
@@ -1025,7 +1025,7 @@ describe('modules/platform/bitbucket-server/index', () => {
             )
             .reply(200, [
               {
-                slug: 'usernamefoundbyemail',
+                name: 'usernamefoundbyemail',
                 active: true,
                 displayName: 'Not relevant',
                 emailAddress: 'test@test.com',
@@ -1054,7 +1054,7 @@ describe('modules/platform/bitbucket-server/index', () => {
         });
       });
 
-      describe('getUserSlugsByEmail', () => {
+      describe('getUsernamesByEmail', () => {
         it('throws when lookup fails', async () => {
           const scope = await initRepo();
           scope
@@ -1070,7 +1070,7 @@ describe('modules/platform/bitbucket-server/index', () => {
             .reply(500, []);
 
           await expect(
-            bitbucket.getUserSlugsByEmail('e-mail@test.com'),
+            bitbucket.getUsernamesByEmail('e-mail@test.com'),
           ).rejects.toThrow('Response code 500 (Internal Server Error)');
         });
 
@@ -1088,7 +1088,7 @@ describe('modules/platform/bitbucket-server/index', () => {
             )
             .reply(200, []);
 
-          const actual = await bitbucket.getUserSlugsByEmail('e-mail@test.com');
+          const actual = await bitbucket.getUsernamesByEmail('e-mail@test.com');
           expect(actual).toBeEmptyArray();
         });
 
@@ -1106,14 +1106,14 @@ describe('modules/platform/bitbucket-server/index', () => {
             )
             .reply(200, [
               {
-                slug: 'usernamefoundbyemail',
+                name: 'usernamefoundbyemail',
                 active: false,
                 displayName: 'Not relevant',
                 emailAddress: 'e-mail@test.com',
               },
             ]);
 
-          const actual = await bitbucket.getUserSlugsByEmail('e-mail@test.com');
+          const actual = await bitbucket.getUsernamesByEmail('e-mail@test.com');
           expect(actual).toBeEmptyArray();
         });
 
@@ -1131,20 +1131,20 @@ describe('modules/platform/bitbucket-server/index', () => {
             )
             .reply(200, [
               {
-                slug: 'usernamefoundbyemail',
+                name: 'usernamefoundbyemail',
                 active: true,
                 displayName: 'Not relevant',
                 emailAddress: 'e-mail@test.com',
               },
               {
-                slug: 'usernamefoundbyemailtoo',
+                name: 'usernamefoundbyemailtoo',
                 active: true,
                 displayName: 'Not relevant',
                 emailAddress: 'e-mail@test.com',
               },
             ]);
 
-          const actual = await bitbucket.getUserSlugsByEmail('mail@test.com');
+          const actual = await bitbucket.getUsernamesByEmail('mail@test.com');
           expect(actual).toBeEmptyArray();
         });
 
@@ -1162,23 +1162,23 @@ describe('modules/platform/bitbucket-server/index', () => {
             )
             .reply(200, [
               {
-                slug: 'usernamefoundbyemail',
+                name: 'usernamefoundbyemail',
                 active: true,
                 displayName: 'Not relevant',
                 emailAddress: 'e-mail@test.com',
               },
               {
-                slug: 'usernamefoundbyemailtoo',
+                name: 'e-mail@test.com',
                 active: true,
                 displayName: 'Not relevant',
                 emailAddress: 'e-mail@test.com',
               },
             ]);
 
-          const actual = await bitbucket.getUserSlugsByEmail('e-mail@test.com');
+          const actual = await bitbucket.getUsernamesByEmail('e-mail@test.com');
           expect(actual).toStrictEqual([
             'usernamefoundbyemail',
-            'usernamefoundbyemailtoo',
+            'e-mail@test.com',
           ]);
         });
       });
@@ -2977,19 +2977,19 @@ Followed by some information.
                   },
                   users: [
                     {
-                      slug: 'alice',
+                      name: 'alice',
                       active: true,
                       emailAddress: 'alice@alice.com',
                       displayName: 'alice',
                     },
                     {
-                      slug: 'bob',
+                      name: 'bob',
                       active: false,
                       emailAddress: 'bob@bob.com',
                       displayName: 'bob',
                     },
                     {
-                      slug: 'carol',
+                      name: 'carol',
                       active: true,
                       emailAddress: 'carol@carol.com',
                       displayName: 'carol',
@@ -3061,12 +3061,12 @@ Followed by some information.
                   name: 'my-reviewer-group',
                   users: [
                     {
-                      slug: 'user1',
+                      name: 'user1',
                       active: false,
                       displayName: 'user1',
                     },
                     {
-                      slug: 'user2',
+                      name: 'user2',
                       active: false,
                       displayName: 'user2',
                     },
@@ -3097,7 +3097,7 @@ Followed by some information.
                   },
                   users: [
                     {
-                      slug: 'jane',
+                      name: 'jane',
                       active: true,
                       emailAddress: 'jane@project.com',
                       displayName: 'jane',
@@ -3111,7 +3111,7 @@ Followed by some information.
                   },
                   users: [
                     {
-                      slug: 'zoe',
+                      name: 'zoe',
                       active: true,
                       emailAddress: 'zoe@repo.com',
                       displayName: 'zoe',
@@ -3144,7 +3144,7 @@ Followed by some information.
                   },
                   users: [
                     {
-                      slug: 'jane',
+                      name: 'jane',
                       active: true,
                       emailAddress: 'jane@project.com',
                       displayName: 'jane',
@@ -3191,19 +3191,19 @@ Followed by some information.
 
           const userArray = [
             {
-              slug: 'zoe',
+              name: 'zoe',
               active: true,
               emailAddress: 'zoe@zoe.com',
               displayName: 'zoe',
             },
             {
-              slug: 'user1',
+              name: 'user1',
               active: true,
               emailAddress: 'user1@user1.com',
               displayName: 'user1',
             },
             {
-              slug: 'user2',
+              name: 'user2',
               active: true,
               emailAddress: 'user2@user2.com',
               displayName: 'user2',
@@ -3231,25 +3231,25 @@ Followed by some information.
             '@reviewer-group/my-reviewer-group:random',
           ]);
           expect(users).toHaveLength(1);
-          expect(userArray.map((u) => u.slug)).toContain(users[0]);
+          expect(userArray.map((u) => u.name)).toContain(users[0]);
         });
         it('handles random with number correctly', async () => {
           const scope = await initRepo();
           const userArray = [
             {
-              slug: 'zoe',
+              name: 'zoe',
               active: true,
               emailAddress: 'zoe@zoe.com',
               displayName: 'zoe',
             },
             {
-              slug: 'user1',
+              name: 'user1',
               active: true,
               emailAddress: 'user1@user1.com',
               displayName: 'user1',
             },
             {
-              slug: 'user2',
+              name: 'user2',
               active: true,
               emailAddress: 'user2@user2.com',
               displayName: 'user2',
@@ -3278,7 +3278,7 @@ Followed by some information.
           ]);
           expect(users).toHaveLength(2);
           users.forEach((user) => {
-            expect(userArray.map((u) => u.slug)).toContain(user);
+            expect(userArray.map((u) => u.name)).toContain(user);
           });
         });
 
@@ -3286,19 +3286,19 @@ Followed by some information.
           const scope = await initRepo();
           const userArray = [
             {
-              slug: 'zoe',
+              name: 'zoe',
               active: true,
               emailAddress: 'zoe@zoe.com',
               displayName: 'zoe',
             },
             {
-              slug: 'user1',
+              name: 'user1',
               active: true,
               emailAddress: 'user1@user1.com',
               displayName: 'user1',
             },
             {
-              slug: 'user2',
+              name: 'user2',
               active: true,
               emailAddress: 'user2@user2.com',
               displayName: 'user2',
@@ -3327,7 +3327,7 @@ Followed by some information.
           ]);
           expect(users).toHaveLength(3);
           users.forEach((user) => {
-            expect(userArray.map((u) => u.slug)).toContain(user);
+            expect(userArray.map((u) => u.name)).toContain(user);
           });
         });
 
@@ -3348,7 +3348,7 @@ Followed by some information.
                   },
                   users: [
                     {
-                      slug: 'nope',
+                      name: 'nope',
                       active: true,
                       emailAddress: 'nope@nope.com',
                       displayName: 'nope',
@@ -3372,13 +3372,13 @@ Followed by some information.
                   },
                   users: [
                     {
-                      slug: 'alice',
+                      name: 'alice',
                       active: true,
                       emailAddress: 'alice@alice.com',
                       displayName: 'alice',
                     },
                     {
-                      slug: 'bob',
+                      name: 'bob',
                       active: true,
                       emailAddress: 'bob@bob.com',
                       displayName: 'bob',

--- a/lib/modules/platform/bitbucket-server/schema.ts
+++ b/lib/modules/platform/bitbucket-server/schema.ts
@@ -2,10 +2,10 @@ import { z } from 'zod';
 import { EmailAddress } from '../../../util/schema-utils/index.ts';
 
 export const User = z.object({
+  name: z.string(),
   displayName: z.string(),
   emailAddress: EmailAddress.catch(''),
   active: z.boolean(),
-  slug: z.string(),
 });
 
 export const Users = z.array(User);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Switches the reviewer resolution in Bitbucket Server to use usernames (required field) instead of user slugs. User slugs are URL-friendly representations of usernames that are only supposed to be used in request URLs but not in payloads.

The current approach to add reviewers fails when `name != slug`. This occurs, for instance, when email addresses are used as usernames and e.g., `some@host.org` (name) becomes `some_host.org` (slug).

<!-- Describe what behavior is changed by this PR. -->

## Context

- Fixes https://github.com/renovatebot/renovate/discussions/38960
- Relates to https://github.com/renovatebot/renovate/pull/37199

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

Tested with a local installation of BB:
- Create user with email address `some@host.org` as `username`, add to repository
- Set `"reviewers": ["some@host.org"]` in `renovate.json`
- Before this change, same error as in https://github.com/renovatebot/renovate/discussions/38960#discussioncomment-15715128
- After this change: 

```
DEBUG: Added reviewers (repository=REN/bbtest, branch=renovate/yaml-2.x)
  "reviewers": ["some@host.org"]
```

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
