### PR TITLE
fix(types): don't use `infer` from Zod

### DIFF
--- a/lib/util/http/http.ts
+++ b/lib/util/http/http.ts
@@ -2,7 +2,7 @@ import { isPlainObject, isUndefined } from '@sindresorhus/is';
 import merge from 'deepmerge';
 import type { Options, RetryObject } from 'got';
 import type { Merge, SetRequired } from 'type-fest';
-import type { infer as Infer } from 'zod';
+import type { z } from 'zod';
 import { ZodType } from 'zod';
 import { GlobalConfig } from '../../config/global.ts';
 import { HOST_DISABLED } from '../../constants/error-messages.ts';
@@ -422,17 +422,17 @@ export abstract class HttpBase<
   async getYaml<Schema extends ZodType<any, any, any>>(
     url: string,
     schema: Schema,
-  ): Promise<HttpResponse<Infer<Schema>>>;
+  ): Promise<HttpResponse<z.infer<Schema>>>;
   async getYaml<Schema extends ZodType<any, any, any>>(
     url: string,
     options: Opts,
     schema: Schema,
-  ): Promise<HttpResponse<Infer<Schema>>>;
+  ): Promise<HttpResponse<z.infer<Schema>>>;
   async getYaml<Schema extends ZodType<any, any, any>>(
     arg1: string,
     arg2?: Opts | Schema,
     arg3?: Schema,
-  ): Promise<HttpResponse<Infer<Schema>>> {
+  ): Promise<HttpResponse<z.infer<Schema>>> {
     const url = arg1;
     let schema: Schema;
     let httpOptions: Opts | undefined;
@@ -456,7 +456,7 @@ export abstract class HttpBase<
   getYamlSafe<
     ResT extends NonNullable<unknown>,
     Schema extends ZodType<ResT> = ZodType<ResT>,
-  >(url: string, schema: Schema): AsyncResult<Infer<Schema>, SafeJsonError>;
+  >(url: string, schema: Schema): AsyncResult<z.infer<Schema>, SafeJsonError>;
   getYamlSafe<
     ResT extends NonNullable<unknown>,
     Schema extends ZodType<ResT> = ZodType<ResT>,
@@ -464,7 +464,7 @@ export abstract class HttpBase<
     url: string,
     options: Opts,
     schema: Schema,
-  ): AsyncResult<Infer<Schema>, SafeJsonError>;
+  ): AsyncResult<z.infer<Schema>, SafeJsonError>;
   getYamlSafe<
     ResT extends NonNullable<unknown>,
     Schema extends ZodType<ResT> = ZodType<ResT>,
@@ -520,19 +520,19 @@ export abstract class HttpBase<
   getJson<Schema extends ZodType<any, any, any>>(
     url: string,
     schema: Schema,
-  ): Promise<HttpResponse<Infer<Schema>>>;
+  ): Promise<HttpResponse<z.infer<Schema>>>;
   getJson<Schema extends ZodType<any, any, any>>(
     url: string,
     options: JSONOpts,
     schema: Schema,
-  ): Promise<HttpResponse<Infer<Schema>>>;
+  ): Promise<HttpResponse<z.infer<Schema>>>;
   getJson<Schema extends ZodType<any, any, any>>(
     arg1: string,
     arg2?: JSONOpts | Schema,
     arg3?: Schema,
-  ): Promise<HttpResponse<Infer<Schema>>> {
-    const args = this.resolveArgs<Infer<Schema>>(arg1, arg2, arg3);
-    return this.requestJson<Infer<Schema>>('get', args);
+  ): Promise<HttpResponse<z.infer<Schema>>> {
+    const args = this.resolveArgs<z.infer<Schema>>(arg1, arg2, arg3);
+    return this.requestJson<z.infer<Schema>>('get', args);
   }
 
   /**
@@ -545,12 +545,12 @@ export abstract class HttpBase<
   getJsonSafe<ResT extends NonNullable<unknown>, Schema extends ZodType<ResT>>(
     url: string,
     schema: Schema,
-  ): AsyncResult<Infer<Schema>, SafeJsonError>;
+  ): AsyncResult<z.infer<Schema>, SafeJsonError>;
   getJsonSafe<ResT extends NonNullable<unknown>, Schema extends ZodType<ResT>>(
     url: string,
     options: JSONOpts,
     schema: Schema,
-  ): AsyncResult<Infer<Schema>, SafeJsonError>;
+  ): AsyncResult<z.infer<Schema>, SafeJsonError>;
   getJsonSafe<ResT extends NonNullable<unknown>, Schema extends ZodType<ResT>>(
     arg1: string,
     arg2?: JSONOpts | Schema,
@@ -573,12 +573,12 @@ export abstract class HttpBase<
   postJson<T, Schema extends ZodType<T> = ZodType<T>>(
     url: string,
     schema: Schema,
-  ): Promise<HttpResponse<Infer<Schema>>>;
+  ): Promise<HttpResponse<z.infer<Schema>>>;
   postJson<T, Schema extends ZodType<T> = ZodType<T>>(
     url: string,
     options: JSONOpts,
     schema: Schema,
-  ): Promise<HttpResponse<Infer<Schema>>>;
+  ): Promise<HttpResponse<z.infer<Schema>>>;
   postJson<T = unknown, Schema extends ZodType<T> = ZodType<T>>(
     arg1: string,
     arg2?: JSONOpts | Schema,
@@ -592,12 +592,12 @@ export abstract class HttpBase<
   putJson<T, Schema extends ZodType<T> = ZodType<T>>(
     url: string,
     schema: Schema,
-  ): Promise<HttpResponse<Infer<Schema>>>;
+  ): Promise<HttpResponse<z.infer<Schema>>>;
   putJson<T, Schema extends ZodType<T> = ZodType<T>>(
     url: string,
     options: JSONOpts,
     schema: Schema,
-  ): Promise<HttpResponse<Infer<Schema>>>;
+  ): Promise<HttpResponse<z.infer<Schema>>>;
   putJson<T = unknown, Schema extends ZodType<T> = ZodType<T>>(
     arg1: string,
     arg2?: JSONOpts | Schema,
@@ -611,12 +611,12 @@ export abstract class HttpBase<
   patchJson<T, Schema extends ZodType<T> = ZodType<T>>(
     url: string,
     schema: Schema,
-  ): Promise<HttpResponse<Infer<Schema>>>;
+  ): Promise<HttpResponse<z.infer<Schema>>>;
   patchJson<T, Schema extends ZodType<T> = ZodType<T>>(
     url: string,
     options: JSONOpts,
     schema: Schema,
-  ): Promise<HttpResponse<Infer<Schema>>>;
+  ): Promise<HttpResponse<z.infer<Schema>>>;
   patchJson<T = unknown, Schema extends ZodType<T> = ZodType<T>>(
     arg1: string,
     arg2?: JSONOpts | Schema,
@@ -630,12 +630,12 @@ export abstract class HttpBase<
   deleteJson<T, Schema extends ZodType<T> = ZodType<T>>(
     url: string,
     schema: Schema,
-  ): Promise<HttpResponse<Infer<Schema>>>;
+  ): Promise<HttpResponse<z.infer<Schema>>>;
   deleteJson<T, Schema extends ZodType<T> = ZodType<T>>(
     url: string,
     options: JSONOpts,
     schema: Schema,
-  ): Promise<HttpResponse<Infer<Schema>>>;
+  ): Promise<HttpResponse<z.infer<Schema>>>;
   deleteJson<T = unknown, Schema extends ZodType<T> = ZodType<T>>(
     arg1: string,
     arg2?: JSONOpts | Schema,
@@ -681,18 +681,18 @@ export abstract class HttpBase<
   async getToml<Schema extends ZodType<any, any, any>>(
     url: string,
     schema?: Schema,
-  ): Promise<HttpResponse<Infer<Schema>>>;
+  ): Promise<HttpResponse<z.infer<Schema>>>;
   async getToml<Schema extends ZodType<any, any, any>>(
     url: string,
     options: JSONOpts,
     schema: Schema,
-  ): Promise<HttpResponse<Infer<Schema>>>;
+  ): Promise<HttpResponse<z.infer<Schema>>>;
   async getToml<Schema extends ZodType<any, any, any>>(
     arg1: string,
     arg2?: JSONOpts | Schema,
     arg3?: Schema,
-  ): Promise<HttpResponse<Infer<Schema>>> {
-    const { url, schema, httpOptions } = this.resolveArgs<Infer<Schema>>(
+  ): Promise<HttpResponse<z.infer<Schema>>> {
+    const { url, schema, httpOptions } = this.resolveArgs<z.infer<Schema>>(
       arg1,
       arg2,
       arg3,
@@ -711,7 +711,7 @@ export abstract class HttpBase<
     if (schema) {
       res.body = await Toml.pipe(schema).parseAsync(res.body);
     } else {
-      res.body = (await Toml.parseAsync(res.body)) as Infer<Schema>;
+      res.body = (await Toml.parseAsync(res.body)) as z.infer<Schema>;
     }
 
     return res;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
Due to [an upstream issue with Rolldown](https://github.com/rolldown/tsdown/issues/764), the import of `Infer` gets
rewritten by Rolldown to `infer` in the `.d.ts` files, which then
results in Typescript not compiling.




## Context

As noted in https://github.com/renovatebot/renovate/issues/41038, without this we see:

```
Error: node_modules/renovate/dist/util/http/http.d.ts(44,106): error TS1003: Identifier expected.
Error: node_modules/renovate/dist/util/http/http.d.ts(44,114): error TS1109: Expression expected.
Error: node_modules/renovate/dist/util/http/http.d.ts(44,116): error TS1109: Expression expected.
Error: node_modules/renovate/dist/util/http/http.d.ts(45,48): error TS1005: '?' expected.
...
(all from that file)
```

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

(Tested with a Mend-internal repo)

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
