### PR TITLE
feat(presets/workarounds): support bellsoft/hardened-liberica-runtime-container Image

### DIFF
--- a/lib/config/presets/internal/workarounds.preset.ts
+++ b/lib/config/presets/internal/workarounds.preset.ts
@@ -222,7 +222,10 @@ export const presets: Record<string, Preset> = {
         description: 'Liberica JDK Lite version optimized for the Cloud',
         matchCurrentValue: '/^jdk-[^a][^l]{2}/',
         matchDatasources: ['docker'],
-        matchPackageNames: ['bellsoft/liberica-runtime-container'],
+        matchPackageNames: [
+          'bellsoft/hardened-liberica-runtime-container',
+          'bellsoft/liberica-runtime-container',
+        ],
         versioning:
           'regex:^jdk-(?<major>\\d+)?(\\.(?<minor>\\d+))?(\\.(?<patch>\\d+))?([\\._+](?<build>(\\d\\.?)+))?(-(?<compatibility>.*))?$',
       },
@@ -231,7 +234,10 @@ export const presets: Record<string, Preset> = {
           'Liberica JDK that can be used to create a custom runtime with a help of jlink tool',
         matchCurrentValue: '/^jdk-all/',
         matchDatasources: ['docker'],
-        matchPackageNames: ['bellsoft/liberica-runtime-container'],
+        matchPackageNames: [
+          'bellsoft/hardened-liberica-runtime-container',
+          'bellsoft/liberica-runtime-container',
+        ],
         versioning:
           'regex:^jdk-all-(?<major>\\d+)?(\\.(?<minor>\\d+))?(\\.(?<patch>\\d+))?([\\._+](?<build>(\\d\\.?)+))?(-(?<compatibility>.*))?$',
       },
@@ -240,7 +246,10 @@ export const presets: Record<string, Preset> = {
           'Liberica JRE (only the runtime without the rest of JDK tools) for running Java applications',
         matchCurrentValue: '/^jre-/',
         matchDatasources: ['docker'],
-        matchPackageNames: ['bellsoft/liberica-runtime-container'],
+        matchPackageNames: [
+          'bellsoft/hardened-liberica-runtime-container',
+          'bellsoft/liberica-runtime-container',
+        ],
         versioning:
           'regex:^jre-(?<major>\\d+)?(\\.(?<minor>\\d+))?(\\.(?<patch>\\d+))?([\\._+](?<build>(\\d\\.?)+))?(-(?<compatibility>.*))?$',
       },

--- a/lib/config/presets/internal/workarounds.preset.ts
+++ b/lib/config/presets/internal/workarounds.preset.ts
@@ -196,7 +196,10 @@ export const presets: Record<string, Preset> = {
         description:
           'Limit Java runtime versions to LTS releases. To receive all major releases add `workarounds:javaLTSVersions` to the `ignorePresets` array.',
         matchDatasources: ['docker'],
-        matchPackageNames: ['bellsoft/liberica-runtime-container'],
+        matchPackageNames: [
+          'bellsoft/hardened-liberica-runtime-container',
+          'bellsoft/liberica-runtime-container',
+        ],
       },
     ],
   },


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This adds support for the `bellsoft/hardened-liberica-runtime-container` image by adding it to the presets `workarounds:libericaJdkDockerVersioning` and `workarounds:javaLTSVersions`.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
