### PR TITLE
feat(presets/monorepos): Add additional dotnet resources

### DIFF
--- a/lib/data/monorepo.json
+++ b/lib/data/monorepo.json
@@ -283,6 +283,9 @@
     "docusaurus": "https://github.com/facebook/docusaurus",
     "dot-swashbuckle": "https://github.com/Havunen/DotSwashbuckle",
     "dotnet": [
+      "https://asp.net/",
+      "https://docs.microsoft.com/ef/core/",
+      "https://dot.net/",
       "https://github.com/dotnet/aspnetcore",
       "https://github.com/dotnet/dotnet",
       "https://github.com/dotnet/efcore",


### PR DESCRIPTION
Microsoft did probably something strange. Only after adding this 3 urls, grouping of dotnet updates worked again

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

This is the PR description from my private repo which was created with this "rule" changes:
This MR contains the following updates:

| Package | Type | Update | Change |
|---|---|---|---|
| [Microsoft.AspNetCore.Authentication.Facebook](https://asp.net/) | nuget | patch | `10.0.2` → `10.0.3` |
| [Microsoft.AspNetCore.Authentication.JwtBearer](https://asp.net/) | nuget | patch | `10.0.2` → `10.0.3` |
| [Microsoft.AspNetCore.Authentication.OpenIdConnect](https://asp.net/) | nuget | patch | `10.0.2` → `10.0.3` |
| [Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation](https://asp.net/) | nuget | patch | `10.0.2` → `10.0.3` |
| [Microsoft.AspNetCore.Mvc.Testing](https://asp.net/) | nuget | patch | `10.0.2` → `10.0.3` |
| [Microsoft.AspNetCore.TestHost](https://asp.net/) | nuget | patch | `10.0.2` → `10.0.3` |
| [Microsoft.EntityFrameworkCore](https://docs.microsoft.com/ef/core/) ([source](https://docs.microsoft.com/ef/core/)) | nuget | patch | `10.0.2` → `10.0.3` |
| [Microsoft.EntityFrameworkCore.Abstractions](https://docs.microsoft.com/ef/core/) ([source](https://docs.microsoft.com/ef/core/)) | nuget | patch | `10.0.2` → `10.0.3` |
| [Microsoft.EntityFrameworkCore.Analyzers](https://docs.microsoft.com/ef/core/) ([source](https://docs.microsoft.com/ef/core/)) | nuget | patch | `10.0.2` → `10.0.3` |
| [Microsoft.EntityFrameworkCore.Design](https://docs.microsoft.com/ef/core/) ([source](https://docs.microsoft.com/ef/core/)) | nuget | patch | `10.0.2` → `10.0.3` |
| [Microsoft.EntityFrameworkCore.InMemory](https://docs.microsoft.com/ef/core/) ([source](https://docs.microsoft.com/ef/core/)) | nuget | patch | `10.0.2` → `10.0.3` |
| [Microsoft.EntityFrameworkCore.Proxies](https://docs.microsoft.com/ef/core/) ([source](https://docs.microsoft.com/ef/core/)) | nuget | patch | `10.0.2` → `10.0.3` |
| [Microsoft.EntityFrameworkCore.Relational](https://docs.microsoft.com/ef/core/) ([source](https://docs.microsoft.com/ef/core/)) | nuget | patch | `10.0.2` → `10.0.3` |
| [Microsoft.EntityFrameworkCore.SqlServer](https://docs.microsoft.com/ef/core/) ([source](https://docs.microsoft.com/ef/core/)) | nuget | patch | `10.0.2` → `10.0.3` |
| [Microsoft.EntityFrameworkCore.SqlServer.NetTopologySuite](https://docs.microsoft.com/ef/core/) ([source](https://docs.microsoft.com/ef/core/)) | nuget | patch | `10.0.2` → `10.0.3` |
| [Microsoft.EntityFrameworkCore.Sqlite](https://docs.microsoft.com/ef/core/) ([source](https://docs.microsoft.com/ef/core/)) | nuget | patch | `10.0.2` → `10.0.3` |
| [Microsoft.EntityFrameworkCore.Tools](https://docs.microsoft.com/ef/core/) ([source](https://docs.microsoft.com/ef/core/)) | nuget | patch | `10.0.2` → `10.0.3` |
| [Microsoft.Extensions.Caching.SqlServer](https://asp.net/) | nuget | patch | `10.0.2` → `10.0.3` |
| [Microsoft.Extensions.Configuration.Abstractions](https://dot.net/) | nuget | patch | `10.0.2` → `10.0.3` |
| [Microsoft.Extensions.Configuration.Binder](https://dot.net/) | nuget | patch | `10.0.2` → `10.0.3` |
| [Microsoft.Extensions.DependencyInjection](https://dot.net/) | nuget | patch | `10.0.2` → `10.0.3` |
| [Microsoft.Extensions.DependencyModel](https://dot.net/) | nuget | patch | `10.0.2` → `10.0.3` |
| [Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore](https://asp.net/) | nuget | patch | `10.0.2` → `10.0.3` |
| [Microsoft.Extensions.Hosting.Abstractions](https://dot.net/) | nuget | patch | `10.0.2` → `10.0.3` |
| [Microsoft.Extensions.Http](https://dot.net/) | nuget | patch | `10.0.2` → `10.0.3` |
| [Microsoft.Extensions.Http.Polly](https://asp.net/) | nuget | patch | `10.0.2` → `10.0.3` |
| [Microsoft.Extensions.Http.Resilience](https://dot.net/) ([source](https://github.com/dotnet/extensions)) | nuget | minor | `10.2.0` → `10.3.0` |
| [Microsoft.Extensions.ServiceDiscovery](https://dot.net/) ([source](https://github.com/dotnet/extensions)) | nuget | minor | `10.2.0` → `10.3.0` |
| [System.DirectoryServices.Protocols](https://dot.net/) | nuget | patch | `10.0.2` → `10.0.3` |
| [dotnet-ef](https://docs.microsoft.com/ef/core/) ([source](https://docs.microsoft.com/ef/core/)) | nuget | patch | `10.0.2` → `10.0.3` |

---

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
