### PR TITLE
docs(nuget): add `supportsLockFileMaintenance` flag

### DIFF
--- a/lib/modules/manager/nuget/index.ts
+++ b/lib/modules/manager/nuget/index.ts
@@ -7,6 +7,8 @@ export { updateArtifacts } from './artifacts.ts';
 export { extractPackageFile } from './extract.ts';
 export { bumpPackageVersion } from './update.ts';
 
+export const supportsLockFileMaintenance = true;
+
 export const displayName = 'NuGet';
 export const url = 'https://learn.microsoft.com/nuget';
 export const categories: Category[] = ['dotnet'];


### PR DESCRIPTION
The NuGet manager supports lock file maintenance via `packages.lock.json` but was missing the `supportsLockFileMaintenance` flag.

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->


## Context

lockfile maintenance is supported for nuget
Please select one of the following:

Necessary for: https://github.com/renovatebot/renovate/pull/41133

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
