### PR TITLE
feat: add support for jsonc as a config file suffix

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -12,13 +12,17 @@ You can store your Renovate configuration file in one of these locations:
 
 1. `renovate.json`
 1. `renovate.json5`
+1. `renovate.jsonc`
 1. `.github/renovate.json`
 1. `.github/renovate.json5`
+1. `.github/renovate.jsonc`
 1. `.gitlab/renovate.json`
 1. `.gitlab/renovate.json5`
+1. `.gitlab/renovate.jsonc`
 1. `.renovaterc`
 1. `.renovaterc.json`
 1. `.renovaterc.json5`
+1. `.renovaterc.jsonc`
 1. `package.json` _(within a `"renovate"` section)_
 
 Or in a custom file present within the [`configFileNames`](./self-hosted-configuration.md#configfilenames).
@@ -30,8 +34,8 @@ The bot first checks all the files in the `configFileNames` array before checkin
 
 <!-- prettier-ignore -->
 !!! note
-     Renovate supports `JSONC` for `.json` files and any config files without file extension (e.g. `.renovaterc`).
-     We also recommend you prefer using `JSONC` within a `.json` file to using a `.json5` file if you want to add comments.
+     Renovate supports `JSONC` for `.json` and `.jsonc` files and any config files without file extension (e.g. `.renovaterc`).
+     We also recommend you prefer using `JSONC` within a `.json` or `.jsonc` file to using a `.json5` file if you want to add comments.
 
 When Renovate runs on a repository, it tries to find the configuration files in the order listed above.
 Renovate stops the search after it finds the first match.

--- a/docs/usage/getting-started/installing-onboarding.md
+++ b/docs/usage/getting-started/installing-onboarding.md
@@ -92,13 +92,17 @@ The "Configure Renovate" PR will include a `renovate.json` file in the root dire
 If you don't want a `renovate.json` file in your repository you can use one of the following files instead:
 
 - `renovate.json5`
+- `renovate.jsonc`
 - `.github/renovate.json`
 - `.github/renovate.json5`
+- `.github/renovate.jsonc`
 - `.gitlab/renovate.json`
 - `.gitlab/renovate.json5`
+- `.gitlab/renovate.jsonc`
 - `.renovaterc`
 - `.renovaterc.json`
 - `.renovaterc.json5`
+- `.renovaterc.jsonc`
 - `package.json` (deprecated)
 
 Or in a custom file present within the [`configFileNames`](../self-hosted-configuration.md#configfilenames).

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -13,7 +13,7 @@ The config options below _must_ be configured in the bot/admin config, so in eit
 
 <!-- prettier-ignore -->
 !!! note
-     Renovate supports `JSONC` for `.json` files and any config files without file extension (e.g. `.renovaterc`).
+     Renovate supports `JSONC` for `.json` or `.jsonc` files and any config files without file extension (e.g. `.renovaterc`).
 
 For information about how to configure Renovate with a `config.js` see the [Using `config.js` documentation](./getting-started/running.md#using-configjs).
 

--- a/lib/config/app-strings.ts
+++ b/lib/config/app-strings.ts
@@ -5,13 +5,17 @@ import { regEx } from '../util/regex.ts';
 const configFileNames = [
   'renovate.json',
   'renovate.json5',
+  'renovate.jsonc',
   '.github/renovate.json',
   '.github/renovate.json5',
+  '.github/renovate.jsonc',
   '.gitlab/renovate.json',
   '.gitlab/renovate.json5',
+  '.gitlab/renovate.jsonc',
   '.renovaterc',
   '.renovaterc.json',
   '.renovaterc.json5',
+  '.renovaterc.jsonc',
   'package.json',
 ];
 

--- a/lib/workers/global/config/parse/util.ts
+++ b/lib/workers/global/config/parse/util.ts
@@ -52,6 +52,7 @@ export async function getParsedContent(file: string): Promise<RenovateConfig> {
     case '.yaml':
     case '.yml':
       return parseSingleYaml(await readSystemFile(file, 'utf8'));
+    case '.jsonc':
     case '.json5':
     case '.json':
       return parseJson(


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Based off of [this discussion](https://github.com/renovatebot/renovate/discussions/38060), I'm adding support for config files ending in `.jsonc`, so that people who want to can specify that their config is JSONC with the suffix.

## Context

Doing this allows for JSONC files to be automatically identified by stuff like linters.

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

I used AI for my initial search of trying to find places that would need changing. 

- [ ] No — I did not use AI for this contribution.
- [X] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [X] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

I was having trouble getting 
- [X] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
