### PR TITLE
test(docs): ensure `lockFileMaintenance` table is up-to-date

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2590,6 +2590,8 @@ Renovate then commits that lock file to the update branch and creates the lock f
 
 Supported lock files:
 
+<!-- supported-lock-files-begin -->
+
 | Manager           | Lockfile                                           |
 | ----------------- | -------------------------------------------------- |
 | `bun`             | `bun.lockb`, `bun.lock`                            |
@@ -2614,6 +2616,8 @@ Supported lock files:
 | `pub`             | `pubspec.lock`                                     |
 | `terraform`       | `.terraform.lock.hcl`                              |
 | `uv`              | `uv.lock`                                          |
+
+<!-- supported-lock-files-end -->
 
 Support for new lock files may be added via feature request.
 

--- a/test/docs/documentation.spec.ts
+++ b/test/docs/documentation.spec.ts
@@ -213,10 +213,10 @@ describe('docs/documentation', () => {
         const table = getSupportedLockFilesTable('configuration-options.md');
         expect(Object.keys(table).length).toBeGreaterThan(0);
 
-        const expected = getExpectedSupportedLockFilesTableMarkdown(table);
-        const actual = getExpectedSupportedLockFilesTableMarkdown(
+        const expected = getExpectedSupportedLockFilesTableMarkdown(
           getExpectedSupportedLockFilesTable(),
         );
+        const actual = getExpectedSupportedLockFilesTableMarkdown(table);
 
         try {
           expect(

--- a/test/docs/documentation.spec.ts
+++ b/test/docs/documentation.spec.ts
@@ -203,7 +203,7 @@ describe('docs/documentation', () => {
 
         for (const key in table) {
           const val = table[key];
-          md += `| ${key} | ${val} |\n`;
+          md += `| \`${key}\` | ${val} |\n`;
         }
 
         return md;


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
As noted in #19340, it would be handy to keep this table up-to-date.

Following how we do this with `cache-namespaces`, we can add a
documentation test to make sure that the table that's found in the
Markdown is in-sync with a freshly generated version of this.

In the case that there's an error, we can provide a copy-paste output to
the console that a user can replace the table with.

Note that this removes the `uv` entry as technically it is the `pep621`
manager that updates `uv.lock`.

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #19340
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Claude Sonnet 4.5

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
