### PR TITLE
fix: use baseBranches fallback when pruning stale branches

### DIFF
--- a/lib/workers/repository/finalize/prune.spec.ts
+++ b/lib/workers/repository/finalize/prune.spec.ts
@@ -244,6 +244,48 @@ describe('workers/repository/finalize/prune', () => {
       expect(platform.updatePr).toHaveBeenCalledTimes(0);
     });
 
+    it('falls back to baseBranches when base branch cannot be extracted from branch name', async () => {
+      config.branchList = ['renovate/a', 'renovate/b'];
+      config.baseBranches = ['develop'];
+      config.defaultBranch = 'main';
+      git.getBranchList.mockReturnValueOnce(
+        config.branchList.concat(['renovate/c']),
+      );
+      scm.isBranchModified.mockResolvedValueOnce(false);
+      await cleanup.pruneStaleBranches(config, config.branchList);
+      expect(git.getBranchList).toHaveBeenCalledTimes(1);
+      expect(scm.isBranchModified).toHaveBeenCalledTimes(1);
+      expect(scm.isBranchModified).toHaveBeenCalledWith(
+        'renovate/c',
+        'develop',
+      );
+      expect(scm.deleteBranch).toHaveBeenCalledExactlyOnceWith('renovate/c');
+    });
+
+    it('extracts base branch from branch name when baseBranches is set without baseBranchPatterns', async () => {
+      config.branchList = ['renovate/develop-a'];
+      config.baseBranches = ['develop', 'staging'];
+      config.defaultBranch = 'main';
+      git.getBranchList.mockReturnValueOnce(
+        config.branchList.concat(['renovate/develop-b', 'renovate/staging-a']),
+      );
+      scm.isBranchModified.mockResolvedValueOnce(false);
+      scm.isBranchModified.mockResolvedValueOnce(false);
+      await cleanup.pruneStaleBranches(config, config.branchList);
+      expect(git.getBranchList).toHaveBeenCalledTimes(1);
+      expect(scm.isBranchModified).toHaveBeenCalledTimes(2);
+
+      expect(scm.isBranchModified).toHaveBeenCalledWith(
+        'renovate/develop-b',
+        'develop',
+      );
+
+      expect(scm.isBranchModified).toHaveBeenCalledWith(
+        'renovate/staging-a',
+        'staging',
+      );
+    });
+
     it('does not delete modified orphan branch', async () => {
       config.branchList = ['renovate/a', 'renovate/b'];
       git.getBranchList.mockReturnValueOnce(

--- a/lib/workers/repository/finalize/prune.ts
+++ b/lib/workers/repository/finalize/prune.ts
@@ -31,7 +31,9 @@ async function cleanUpBranches(
       // use default branch if no base branches are configured
       // use default branch name if no match (can happen when base branches are configured later)
       const baseBranch =
-        baseBranchRe?.exec(branchName)?.[1] ?? config.defaultBranch!;
+        baseBranchRe?.exec(branchName)?.[1] ??
+        config.baseBranches?.[0] ??
+        config.defaultBranch!;
       const pr = await platform.findPr({
         branchName,
         state: 'open',
@@ -116,11 +118,11 @@ async function cleanUpBranches(
 }
 
 /**
- * Calculates a {RegExp} to extract the base branch from a branch name if base branch patterns is configured.
+ * Calculates a {RegExp} to extract the base branch from a branch name if base branches are configured.
  * @param config Renovate configuration
  */
 function calculateBaseBranchRegex(config: RenovateConfig): RegExp | null {
-  if (!config.baseBranchPatterns?.length || !config.baseBranches?.length) {
+  if (!config.baseBranches?.length) {
     return null;
   }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

When the base branch cannot be extracted from the branch name,
fall back to baseBranches[0] before defaultBranch. This fixes
incorrect "already modified" detection when baseBranches differ
from the repository's default branch.

For example, with baseBranches: ['develop'] and defaultBranch: 'main',
a branch like 'renovate/some-dep-1.x' does not encode the base branch
in its name (Renovate only does this for multiple base branches).
The regex produces no match, so without this fallback the prune logic
compares against 'main' instead of 'develop', picking up unrelated
commits and incorrectly marking the branch as "already modified".

Also generate the base branch regex when baseBranches is configured
directly (without baseBranchPatterns), so multiple base branches
are handled correctly regardless of how they were configured.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [x] Yes — other (please describe):
Claude Code helped me debug the issue, wrote the fix and the tests. It also wrote the commit message I've used in this PR description. 
I've verified the change to `const baseBranch` works in our renovatebot setup.
The change to `calculateBaseBranchRegex` I haven't tested, but existing tests succeed and Claude added a regression test.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: no public repository unfortunately.

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
