### PR TITLE
feat(presets): Update aws-sdk-js-v3 monorepo

### DIFF
--- a/lib/data/monorepo.json
+++ b/lib/data/monorepo.json
@@ -55,7 +55,10 @@
     "aws-sdk-client-mock": "https://github.com/m-radzikowski/aws-sdk-client-mock",
     "aws-sdk-go": "https://github.com/aws/aws-sdk-go",
     "aws-sdk-go-v2": "https://github.com/aws/aws-sdk-go-v2",
-    "aws-sdk-js-v3": "https://github.com/aws/aws-sdk-js-v3",
+    "aws-sdk-js-v3": [
+      "https://github.com/smithy-lang/smithy-typescript",
+      "https://github.com/aws/aws-sdk-js-v3"
+    ],
     "aws-sdk-net": "https://github.com/aws/aws-sdk-net",
     "aws-sdk-rust": [
       "https://github.com/smithy-lang/smithy-rs",


### PR DESCRIPTION
Per the publishing section at https://github.com/smithy-lang/smithy-typescript, the AWS SDK is a customer of smithy-typescript and uses a fair amount of code there.

Note: My only real concern here is that the smithy/typescript stuff is not written specifically for aws. At least it's not documented that way. But I figured I'd submit this and live by whatever decision you make. Thanks.

## Changes

Updated the `aws-sdk-js-v3` monorepo preset so that it includes the smithy-lang/typescript packages as well. The AWS SDK uses most of these so whenever the @aws-sdk packages are updated, usually the @smithy packages are updated with them.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [X] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

There is a discussion for this though https://github.com/renovatebot/renovate/discussions/41158

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [X] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

I didn't see any docs though this is displayed here https://docs.renovatebot.com/presets-monorepo/#monorepoaws-sdk-js-v3 . Wasn't sure if that was auto-generated or not.

## How I've tested my work (please select one)

I have verified these changes via:

- [X] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: