### PR TITLE
fix(datasource/python-version): gracefully handle python.org 429 rate limiting

### DIFF
--- a/lib/modules/datasource/python-version/index.ts
+++ b/lib/modules/datasource/python-version/index.ts
@@ -1,4 +1,6 @@
+import { logger } from '../../../logger/index.ts';
 import { withCache } from '../../../util/cache/package/with-cache.ts';
+import { HttpError } from '../../../util/http/index.ts';
 import { id as versioning } from '../../versioning/python/index.ts';
 import { Datasource } from '../datasource.ts';
 import { registryUrl as eolRegistryUrl } from '../endoflife-date/common.ts';
@@ -75,7 +77,15 @@ export class PythonVersionDatasource extends Datasource {
           .filter((release) => pythonPrebuildVersions.has(release.version)),
       );
     } catch (err) {
-      this.handleGenericErrors(err);
+      if (err instanceof HttpError && err.response?.statusCode === 429) {
+        logger.debug(
+          { err },
+          'Rate limited by python.org, using prebuild releases',
+        );
+        result.releases.push(...(pythonPrebuildReleases?.releases ?? []));
+      } else {
+        this.handleGenericErrors(err);
+      }
     }
     for (const release of result.releases) {
       release.isDeprecated = pythonEolVersions.get(


### PR DESCRIPTION
## Summary

- When python.org returns HTTP 429 (rate limited), the datasource now falls back to containerbase prebuild releases instead of throwing `ExternalHostError` which aborts the entire repository
- Non-429 errors continue to be handled by `handleGenericErrors()` as before
- Prebuild releases still go through the EOL deprecation loop

## Test plan

- [ ] New test: `falls back to prebuild releases on 429` — mocks python.org returning 429, verifies releases come from prebuild data with EOL applied
- [ ] Existing 500 and error tests unchanged and passing