### PR TITLE
feat(presets): support registryUrl in tfvarsVersions preset

### DIFF
--- a/lib/config/presets/internal/custom-managers.preset.ts
+++ b/lib/config/presets/internal/custom-managers.preset.ts
@@ -135,7 +135,7 @@ export const presets: Record<string, Preset> = {
         customType: 'regex',
         managerFilePatterns: ['**/*.tfvars'],
         matchStrings: [
-          '#\\s*renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?(?: extractVersion=(?<extractVersion>.*?))?\\s.*?_version\\s*=\\s*"(?<currentValue>.*)"',
+          '#\\s*renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?(?: extractVersion=(?<extractVersion>.*?))?(?: registryUrl=(?<registryUrl>[^\\s]+?))?\\s.*?_version\\s*=\\s*"(?<currentValue>.*)"',
         ],
         versioningTemplate: '{{#if versioning}}{{{versioning}}}{{/if}}',
       },

--- a/lib/config/presets/internal/custom-managers.spec.ts
+++ b/lib/config/presets/internal/custom-managers.spec.ts
@@ -809,6 +809,40 @@ describe('config/presets/internal/custom-managers', () => {
     });
   });
 
+  describe('Update `*_version` variables in `.tfvars` files', () => {
+    const customManager = presets.tfvarsVersions.customManagers?.[0];
+
+    it(`find dependencies in file`, async () => {
+      const fileContent = codeBlock`
+        # renovate: datasource=docker depName=python registryUrl=https://index.docker.io
+        python_version = "3.14.0-alpine"
+        # renovate: datasource=npm depName=pnpm
+        pnpm_version = "10.19.0"
+      `;
+
+      const res = await extractPackageFile(
+        'regex',
+        fileContent,
+        'terraform.tfvars',
+        customManager!,
+      );
+
+      expect(res?.deps).toMatchObject([
+        {
+          currentValue: '3.14.0-alpine',
+          datasource: 'docker',
+          depName: 'python',
+          registryUrls: ['https://index.docker.io/'],
+        },
+        {
+          currentValue: '10.19.0',
+          datasource: 'npm',
+          depName: 'pnpm',
+        },
+      ]);
+    });
+  });
+
   describe('Update `tsconfig/node` version in tsconfig.json', () => {
     const customManager = presets.tsconfigNodeVersions.customManagers?.[0];
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Add `registryUrl` to the `customManagers:tfvarsVersions` preset bringing it into parity with other custom manager presets.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [X] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [X] Yes — other (please describe):

I was lazy so I asked gippity to make the code changes. But the change is trivial and I have already done this change for other managers in the past.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [X] Both unit tests + ran on a real repository

The public repository: https://github.com/alexaka1/repro-renovate-tfvars/pull/4

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
