### PR TITLE
feat(managers/bun): support Host Rules generation from an `.npmrc`

### DIFF
--- a/lib/modules/manager/bun/extract.ts
+++ b/lib/modules/manager/bun/extract.ts
@@ -8,6 +8,7 @@ import {
 
 import { extractPackageJson } from '../npm/extract/common/package-file.ts';
 import type { NpmPackage } from '../npm/extract/types.ts';
+import { resolveNpmrc } from '../npm/npmrc.ts';
 import type { NpmManagerData } from '../npm/types.ts';
 import type { ExtractConfig, PackageFile } from '../types.ts';
 import { filesMatchingWorkspaces } from './utils.ts';
@@ -20,6 +21,7 @@ function matchesFileName(fileNameWithPath: string, fileName: string): boolean {
 
 export async function processPackageFile(
   packageFile: string,
+  config: ExtractConfig,
 ): Promise<PackageFile | null> {
   const fileContent = await readLocalFile(packageFile, 'utf8');
   if (!fileContent) {
@@ -38,9 +40,13 @@ export async function processPackageFile(
     logger.debug({ packageFile }, 'No dependencies found');
     return null;
   }
+
+  const { npmrc } = await resolveNpmrc(packageFile, config);
+
   return {
     ...result,
     packageFile,
+    npmrc,
   };
 }
 export async function extractAllPackageFiles(
@@ -61,7 +67,7 @@ export async function extractAllPackageFiles(
   );
   for (const lockFile of allLockFiles) {
     const packageFile = getSiblingFileName(lockFile, 'package.json');
-    const res = await processPackageFile(packageFile);
+    const res = await processPackageFile(packageFile, config);
     if (res) {
       packageFiles.push({ ...res, lockFiles: [lockFile] });
     }
@@ -82,7 +88,7 @@ export async function extractAllPackageFiles(
     if (workspacePackageFiles.length) {
       logger.debug({ workspacePackageFiles }, 'Found bun workspace files');
       for (const workspaceFile of workspacePackageFiles) {
-        const res = await processPackageFile(workspaceFile);
+        const res = await processPackageFile(workspaceFile, config);
         if (res) {
           packageFiles.push({ ...res, lockFiles: [lockFile] });
         }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

As noted in #41215 and #40830, when using the Bun manager in a
repository that has a `.npmrc`, the `.npmrc` is not used.

This is at odds with `bun`'s tooling itself reading from this file, so
we should make it possible to parse + make the `npmrc` available for
usage.

We can add this with our new `resolveNpmrc` function.

We do not need to add in-depth test coverage as this should be handled
by `resolveNpmrc`.


## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #41215
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe): Claude Sonnet 4.5 (GitHub Copilot + `crush`)


## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/ladzaretti-testing/bun-npmrc

```
DEBUG: GET https://fake.registry.example/fakescope/@fakescope%2Fdefinitely-not-real = (code=ENOTFOUND, statusCode=-1 retryCount=2, duration=4) (repository=ladzaretti-testing/bun-npmrc)
DEBUG: Failed to look up npm package @fakescope/definitely-not-real (repository=ladzaretti-testing/bun-npmrc, packageFile=package.json, dependency=@fakescope/definitely-not-real)
```

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
