### PR TITLE
refactor(platform): programatically mark Platforms as experimental

### DIFF
--- a/lib/modules/platform/codecommit/index.ts
+++ b/lib/modules/platform/codecommit/index.ts
@@ -51,6 +51,7 @@ interface Config {
 }
 
 export const id = 'codecommit';
+export const experimental = true;
 
 const platformConfig = {
   endpoint: 'https://git-codecommit.us-east-1.amazonaws.com',

--- a/lib/modules/platform/codecommit/readme.md
+++ b/lib/modules/platform/codecommit/readme.md
@@ -8,10 +8,6 @@
     The Renovate maintainers have decided that we will not add any new features unless a company is willing to contribute feature(s) for CodeCommit **and maintain them**.
     For more details [see Discussion 39741](https://github.com/renovatebot/renovate/discussions/39741#discussioncomment-15172240).
 
-<!-- prettier-ignore -->
-!!! warning "This feature is flagged as experimental"
-    Experimental features might be changed or even removed at any time.
-
 ## Authentication
 
 ### IAM Role

--- a/lib/modules/platform/gerrit/index.ts
+++ b/lib/modules/platform/gerrit/index.ts
@@ -44,6 +44,7 @@ import {
 } from './utils.ts';
 
 export const id = 'gerrit';
+export const experimental = true;
 
 const defaults: {
   endpoint?: string;

--- a/lib/modules/platform/gerrit/readme.md
+++ b/lib/modules/platform/gerrit/readme.md
@@ -1,9 +1,5 @@
 # Gerrit
 
-<!-- prettier-ignore -->
-!!! warning "This feature is flagged as experimental"
-    Experimental features might be changed or even removed at any time.
-
 ## Supported Gerrit versions
 
 Renovate supports all Gerrit 3.x versions.

--- a/lib/modules/platform/local/index.ts
+++ b/lib/modules/platform/local/index.ts
@@ -8,6 +8,7 @@ import type {
 } from '../types.ts';
 
 export const id = 'local';
+export const experimental = true;
 
 export function initPlatform(_params: PlatformParams): Promise<PlatformResult> {
   return Promise.resolve({

--- a/lib/modules/platform/types.ts
+++ b/lib/modules/platform/types.ts
@@ -231,6 +231,12 @@ export interface FileOwnerRule {
 }
 
 export interface Platform {
+  /**
+   * Whether this is an experimental Platform.
+   *
+   * Experimental features might be changed or even removed at any time.
+   */
+  experimental?: true;
   findIssue(title: string): Promise<Issue | null>;
   getIssueList(): Promise<Issue[]>;
   getIssue?(number: number, memCache?: boolean): Promise<Issue | null>;

--- a/tools/docs/platforms.ts
+++ b/tools/docs/platforms.ts
@@ -9,7 +9,6 @@ export async function generatePlatforms(
   dist: string,
   platformIssuesMap: OpenItems,
 ): Promise<void> {
-  let platformContent = 'Supported values for `platform` are: \n\n';
   for (const [id, platform] of platforms) {
     let md = codeBlock`
       ---
@@ -41,11 +40,25 @@ export async function generatePlatforms(
     await updateFile(`${dist}/modules/platform/${id}/index.md`, md);
   }
 
-  platformContent += Array.from(platforms.keys())
-    .map((v) => `* ${getModuleLink(v, `\`${v}\``)}\n`)
-    .join('\n');
+  let platformContent = 'Supported values for `platform` are: \n\n';
+  for (const [id, platform] of platforms) {
+    if (platform.experimental) {
+      continue;
+    }
 
-  platformContent += '\n';
+    platformContent += `* ${getModuleLink(id, `\`${id}\``)}\n`;
+  }
+
+  platformContent +=
+    '\nAdditionally, the following `platform` values are experimental:\n\n';
+
+  for (const [id, platform] of platforms) {
+    if (!platform.experimental) {
+      continue;
+    }
+
+    platformContent += `* ${getModuleLink(id, `\`${id}\``)}\n`;
+  }
 
   let indexContent = await readFile(`docs/usage/modules/platform/index.md`);
   indexContent = replaceContent(indexContent, platformContent);

--- a/tools/docs/platforms.ts
+++ b/tools/docs/platforms.ts
@@ -1,5 +1,5 @@
 import { codeBlock } from 'common-tags';
-import { getPlatformList } from '../../lib/modules/platform/index.ts';
+import platforms from '../../lib/modules/platform/api.ts';
 import { readFile, updateFile } from '../utils/index.ts';
 import type { OpenItems } from './github-query-items.ts';
 import { generateFeatureAndBugMarkdown } from './github-query-items.ts';
@@ -10,22 +10,38 @@ export async function generatePlatforms(
   platformIssuesMap: OpenItems,
 ): Promise<void> {
   let platformContent = 'Supported values for `platform` are: \n\n';
-  const platforms = getPlatformList();
-  for (const platform of platforms) {
+  for (const [id, platform] of platforms) {
     let md = codeBlock`
       ---
-      edit_url: https://github.com/renovatebot/renovate/edit/main/lib/modules/platform/${platform}/readme.md
+      edit_url: https://github.com/renovatebot/renovate/edit/main/lib/modules/platform/${id}/readme.md
       ---
       `;
-
     md += '\n\n';
-    md += await readFile(`lib/modules/platform/${platform}/readme.md`);
-    md += generateFeatureAndBugMarkdown(platformIssuesMap, platform);
 
-    await updateFile(`${dist}/modules/platform/${platform}/index.md`, md);
+    const contents = await readFile(`lib/modules/platform/${id}/readme.md`);
+    const lines = contents.split('\n');
+
+    if (platform.experimental) {
+      // make sure that we don't mangle the <h1> of the page, as it is used to infer the page title by Mkdocs
+      md += lines[0]; // title of the platform
+      md += '\n\n';
+
+      md += codeBlock`<!-- prettier-ignore -->
+!!! warning "This feature is flagged as experimental"
+    Experimental features might be changed or even removed at any time.
+    `;
+      md += '\n\n';
+
+      md += lines.slice(1).join('\n');
+    }
+
+    md += contents;
+    md += generateFeatureAndBugMarkdown(platformIssuesMap, id);
+
+    await updateFile(`${dist}/modules/platform/${id}/index.md`, md);
   }
 
-  platformContent += platforms
+  platformContent += Array.from(platforms.keys())
     .map((v) => `* ${getModuleLink(v, `\`${v}\``)}\n`)
     .join('\n');
 

--- a/tools/docs/platforms.ts
+++ b/tools/docs/platforms.ts
@@ -25,10 +25,11 @@ export async function generatePlatforms(
       md += lines[0]; // title of the platform
       md += '\n\n';
 
-      md += codeBlock`<!-- prettier-ignore -->
-!!! warning "This feature is flagged as experimental"
-    Experimental features might be changed or even removed at any time.
-    `;
+      md += codeBlock`
+        <!-- prettier-ignore -->
+        !!! warning "This feature is flagged as experimental"
+            Experimental features might be changed or even removed at any time.
+      `;
       md += '\n\n';
 
       md += lines.slice(1).join('\n');


### PR DESCRIPTION


<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

As part of future changes (#39800), we'll want to be able to more
straightforwardly determine whether a given Platform is experimental.

To do this, we can add a new optional `experimental` flag to the
`Platform`.

As part of having this available, we can refactor how our docs for
Platforms are built, and replace a hand-authored experimental notice, we
can automagically insert it into the built docs.

To make sure that we don't break the rendering of the Markdown for
Mkdocs, we need to insert the experimental notice after the page
heading.

As we're now using the Platform itself, not only the ID, we need to
refactor how `tools/docs/platforms.ts` renders the pages.



## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
