### PR TITLE
fix: allow grouping of `lockFileMaintenance` updates

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -1920,7 +1920,7 @@ For example, to group all non-major devDependencies updates together into a sing
 
 <!-- prettier-ignore -->
 !!! note
-    Replacement updates and lock file maintenance will never be grouped.
+    Replacement updates will never be grouped.
 
 ## groupSlug
 
@@ -3706,7 +3706,7 @@ You can suggest a new community package rule by editing [the `replacements.json`
 
 <!-- prettier-ignore -->
 !!! note
-    Replacement updates and lock file maintenance will never be grouped.
+    Replacement updates will never be grouped.
 
 ### replacementNameTemplate
 

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -1921,6 +1921,8 @@ For example, to group all non-major devDependencies updates together into a sing
 <!-- prettier-ignore -->
 !!! note
     Replacement updates will never be grouped.
+    <br>
+    Lock file maintenance will never be grouped with other dependency updates.
 
 ## groupSlug
 
@@ -3707,6 +3709,8 @@ You can suggest a new community package rule by editing [the `replacements.json`
 <!-- prettier-ignore -->
 !!! note
     Replacement updates will never be grouped.
+    <br>
+    Lock file maintenance will never be grouped with other dependency updates.
 
 ### replacementNameTemplate
 

--- a/lib/config/presets/internal/config.preset.ts
+++ b/lib/config/presets/internal/config.preset.ts
@@ -42,7 +42,7 @@ export const presets: Record<string, Preset> = {
   },
   semverAllMonthly: {
     description:
-      'Preserve SemVer ranges and update everything together once a month. (excluding replacements and lockfile maintenance)',
+      'Preserve SemVer ranges and update everything together once a month. (excluding replacements)',
     extends: [
       ':preserveSemverRanges',
       'group:all',
@@ -56,7 +56,7 @@ export const presets: Record<string, Preset> = {
   },
   semverAllWeekly: {
     description:
-      'Preserve SemVer ranges and update everything together once a week (excluding replacements and lockfile maintenance).',
+      'Preserve SemVer ranges and update everything together once a week (excluding replacements).',
     extends: [
       ':preserveSemverRanges',
       'group:all',

--- a/lib/config/presets/internal/config.preset.ts
+++ b/lib/config/presets/internal/config.preset.ts
@@ -42,7 +42,7 @@ export const presets: Record<string, Preset> = {
   },
   semverAllMonthly: {
     description:
-      'Preserve SemVer ranges and update everything together once a month. (excluding replacements)',
+      'Preserve SemVer ranges and update everything together once a month. (excluding replacements and lockfile maintenance)',
     extends: [
       ':preserveSemverRanges',
       'group:all',
@@ -56,7 +56,7 @@ export const presets: Record<string, Preset> = {
   },
   semverAllWeekly: {
     description:
-      'Preserve SemVer ranges and update everything together once a week (excluding replacements).',
+      'Preserve SemVer ranges and update everything together once a week (excluding replacements and lockfile maintenance).',
     extends: [
       ':preserveSemverRanges',
       'group:all',

--- a/lib/workers/repository/updates/branch-name.spec.ts
+++ b/lib/workers/repository/updates/branch-name.spec.ts
@@ -60,6 +60,32 @@ describe('workers/repository/updates/branch-name', () => {
       expect(upgrade.branchName).toBe('lock-file-maintenance');
     });
 
+    it('separates lockFileMaintenance from non-lockFileMaintenance with same groupName', () => {
+      const groupConfig = {
+        branchName: '{{groupSlug}}-{{branchTopic}}',
+        branchTopic: 'grouptopic',
+      };
+      const lockFileUpdate = partial<BranchUpgradeConfig>({
+        groupName: 'all',
+        updateType: 'lockFileMaintenance',
+        depName: 'lock-file',
+        group: groupConfig,
+      });
+      const regularUpdate = partial<BranchUpgradeConfig>({
+        groupName: 'all',
+        updateType: 'minor',
+        depName: 'axios',
+        group: groupConfig,
+      });
+      generateBranchName(lockFileUpdate);
+      generateBranchName(regularUpdate);
+      expect(lockFileUpdate.branchName).toBe(
+        'lock-file-maintenance-all-grouptopic',
+      );
+      expect(regularUpdate.branchName).toBe('all-grouptopic');
+      expect(lockFileUpdate.branchName).not.toBe(regularUpdate.branchName);
+    });
+
     it('uses groupName if no slug defined, ignores sharedVariableName', () => {
       const upgrade = partial<BranchUpgradeConfig>({
         groupName: 'some group name',

--- a/lib/workers/repository/updates/branch-name.spec.ts
+++ b/lib/workers/repository/updates/branch-name.spec.ts
@@ -33,21 +33,31 @@ describe('workers/repository/updates/branch-name', () => {
       );
     });
 
-    it('ignores grouping of lockfile maintenance update', () => {
+    it('applies grouping for lockfile maintenance update', () => {
       const upgrade = partial<BranchUpgradeConfig>({
-        groupName: 'grouptopic',
+        groupName: 'my lockfiles',
         updateType: 'lockFileMaintenance',
         depName: 'axios',
-        depNameSanitized: 'axios',
-        branchTopic: 'lock-file-maintenance', // default for lockFileMaintenance
-        branchName: '{{branchPrefix}}{{additionalBranchPrefix}}{{branchTopic}}', // default
+        group: {
+          branchName: '{{groupSlug}}-{{branchTopic}}',
+          branchTopic: 'grouptopic',
+        },
+      });
+      generateBranchName(upgrade);
+      expect(upgrade.branchName).toBe(
+        'lock-file-maintenance-my-lockfiles-grouptopic',
+      );
+    });
+
+    it('uses default branch name for lockfile maintenance without groupName', () => {
+      const upgrade = partial<BranchUpgradeConfig>({
+        updateType: 'lockFileMaintenance',
+        depName: 'axios',
+        branchTopic: 'lock-file-maintenance',
+        branchName: '{{branchPrefix}}{{additionalBranchPrefix}}{{branchTopic}}',
       });
       generateBranchName(upgrade);
       expect(upgrade.branchName).toBe('lock-file-maintenance');
-      expect(logger.logger.debug).toHaveBeenCalledExactlyOnceWith(
-        { depName: 'axios' },
-        'Ignoring grouped branch name for lockFileMaintenance update',
-      );
     });
 
     it('uses groupName if no slug defined, ignores sharedVariableName', () => {

--- a/lib/workers/repository/updates/branch-name.ts
+++ b/lib/workers/repository/updates/branch-name.ts
@@ -67,7 +67,7 @@ export function generateBranchName(update: BranchUpgradeConfig): void {
   }
 
   if (update.groupName) {
-    if (['lockFileMaintenance', 'replacement'].includes(update.updateType!)) {
+    if (update.updateType === 'replacement') {
       logger.debug(
         { depName: update.depName },
         `Ignoring grouped branch name for ${update.updateType} update`,
@@ -99,6 +99,9 @@ export function generateBranchName(update: BranchUpgradeConfig): void {
       }
       if (update.updateType === 'patch' && update.separateMinorPatch) {
         update.groupSlug = `patch-${update.groupSlug}`;
+      }
+      if (update.updateType === 'lockFileMaintenance') {
+        update.groupSlug = `lock-file-maintenance-${update.groupSlug}`;
       }
       update.branchTopic = update.group!.branchTopic ?? update.branchTopic;
       update.branchName = update.group!.branchName ?? update.branchName;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- allow grouping of `lockFileMaintenance` updates
<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #41208 
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/Rahul-renovate-testing/renovate-repro-lockfile-grouping

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
