### PR TITLE
fix(libyear): skip disabled dependencies

### DIFF
--- a/lib/workers/repository/process/libyear.spec.ts
+++ b/lib/workers/repository/process/libyear.spec.ts
@@ -197,13 +197,13 @@ describe('workers/repository/process/libyear', () => {
         {
           libYears: {
             managers: {
-              npm: 2,
+              npm: 1,
             },
-            total: 2,
+            total: 1,
           },
           dependencyStatus: {
-            outdated: 2,
-            total: 2,
+            outdated: 1,
+            total: 1,
           },
         },
         'Repository libYears',
@@ -211,13 +211,13 @@ describe('workers/repository/process/libyear', () => {
       expect(addLibYears).toHaveBeenCalledExactlyOnceWith(config, {
         libYears: {
           managers: {
-            npm: 2,
+            npm: 1,
           },
-          total: 2,
+          total: 1,
         },
         dependencyStatus: {
-          outdated: 2,
-          total: 2,
+          outdated: 1,
+          total: 1,
         },
       });
     });

--- a/lib/workers/repository/process/libyear.spec.ts
+++ b/lib/workers/repository/process/libyear.spec.ts
@@ -301,7 +301,7 @@ describe('workers/repository/process/libyear', () => {
       );
     });
 
-    it('ignores disabled dependencies without currentVersionTimestamp', () => {
+    it('ignores disabled dependencies', () => {
       const packageFiles: Record<string, PackageFile[]> = {
         npm: [
           {

--- a/lib/workers/repository/process/libyear.spec.ts
+++ b/lib/workers/repository/process/libyear.spec.ts
@@ -300,5 +300,48 @@ describe('workers/repository/process/libyear', () => {
         'Repository libYears',
       );
     });
+
+    it('ignores disabled dependencies without currentVersionTimestamp', () => {
+      const packageFiles: Record<string, PackageFile[]> = {
+        npm: [
+          {
+            packageFile: 'package.json',
+            deps: [
+              {
+                depName: 'disabled-dep',
+                datasource: 'npm',
+                currentVersion: '1.0.0',
+                enabled: false,
+                updates: [
+                  {
+                    newVersion: '2.0.0',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      calculateLibYears(config, packageFiles);
+
+      expect(logger.logger.once.debug).not.toHaveBeenCalledWith(
+        'No currentVersionTimestamp for disabled-dep',
+      );
+
+      expect(logger.logger.debug).toHaveBeenCalledWith(
+        {
+          libYears: {
+            managers: {},
+            total: 0,
+          },
+          dependencyStatus: {
+            outdated: 0,
+            total: 0,
+          },
+        },
+        'Repository libYears',
+      );
+    });
   });
 });

--- a/lib/workers/repository/process/libyear.spec.ts
+++ b/lib/workers/repository/process/libyear.spec.ts
@@ -141,7 +141,7 @@ describe('workers/repository/process/libyear', () => {
     });
 
     // NOTE that it shouldn't be possible for `updates` to be set when `enabled: false`
-    it('calculates libYears whether dependencies are enabled or disabled', () => {
+    it('skips disabled dependencies when calculating libYears', () => {
       const packageFiles: Record<string, PackageFile[]> = {
         npm: [
           {

--- a/lib/workers/repository/process/libyear.ts
+++ b/lib/workers/repository/process/libyear.ts
@@ -26,6 +26,10 @@ export function calculateLibYears(
   for (const [manager, files] of Object.entries(packageFiles)) {
     for (const file of files) {
       for (const dep of file.deps) {
+        if (dep.enabled === false) {
+          continue;
+        }
+
         const depInfo: DepInfo = {
           depName: dep.depName!,
           manager,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This PR updates libyear calculation to skip disabled dependencies (`enabled: false`) entirely.

Following discussion, it was confirmed that disabled dependencies should not have updates available and therefore should not contribute to LibYears calculations or related logging.

This change skips them at the start of the loop and updates the tests accordingly.

## Context

Please select one of the following:

- [ ] This closes an existing Issue
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Details:
AI assistance was used to help analyse the existing codebase, identify the correct location for the fix, and draft the initial implementation and unit test structure. All code was reviewed, adapted, and validated locally.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: N/A (unit tests added and full test suite run locally)

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
