### PR TITLE
refactor(manager/npm): extract function for resolving `.npmrc`

### DIFF
--- a/lib/modules/manager/npm/extract/index.ts
+++ b/lib/modules/manager/npm/extract/index.ts
@@ -5,14 +5,12 @@ import {
   isString,
 } from '@sindresorhus/is';
 import upath from 'upath';
-import { GlobalConfig } from '../../../../config/global.ts';
 import { logger } from '../../../../logger/index.ts';
 import {
   findLocalSiblingOrParent,
   getSiblingFileName,
   readLocalFile,
 } from '../../../../util/fs/index.ts';
-import { newlineRegex, regEx } from '../../../../util/regex.ts';
 import { NpmDatasource } from '../../../datasource/npm/index.ts';
 
 import type {
@@ -20,6 +18,7 @@ import type {
   PackageFile,
   PackageFileContent,
 } from '../../types.ts';
+import { resolveNpmrc } from '../npmrc.ts';
 import type { YarnConfig } from '../schema.ts';
 import type { NpmLockFiles, NpmManagerData } from '../types.ts';
 import { getExtractedConstraints } from './common/dependency.ts';
@@ -96,47 +95,7 @@ export async function extractPackageFile(
     );
   }
 
-  let npmrc: string | undefined;
-  const npmrcFileName = await findLocalSiblingOrParent(packageFile, '.npmrc');
-  if (npmrcFileName) {
-    let repoNpmrc = await readLocalFile(npmrcFileName, 'utf8');
-    if (isString(repoNpmrc)) {
-      if (isString(config.npmrc) && !config.npmrcMerge) {
-        logger.debug(
-          { npmrcFileName },
-          'Repo .npmrc file is ignored due to config.npmrc with config.npmrcMerge=false',
-        );
-        npmrc = config.npmrc;
-      } else {
-        npmrc = config.npmrc ?? '';
-        if (npmrc.length) {
-          if (!npmrc.endsWith('\n')) {
-            npmrc += '\n';
-          }
-        }
-        if (repoNpmrc?.includes('package-lock')) {
-          logger.debug('Stripping package-lock setting from .npmrc');
-          repoNpmrc = repoNpmrc.replace(
-            regEx(/(^|\n)package-lock.*?(\n|$)/g),
-            '\n',
-          );
-        }
-        if (repoNpmrc.includes('=${') && !GlobalConfig.get('exposeAllEnv')) {
-          logger.debug(
-            { npmrcFileName },
-            'Stripping .npmrc file of lines with variables',
-          );
-          repoNpmrc = repoNpmrc
-            .split(newlineRegex)
-            .filter((line) => !line.includes('=${'))
-            .join('\n');
-        }
-        npmrc += repoNpmrc;
-      }
-    }
-  } else if (isString(config.npmrc)) {
-    npmrc = config.npmrc;
-  }
+  const { npmrc, npmrcFileName } = await resolveNpmrc(packageFile, config);
 
   const yarnrcYmlFileName = await findLocalSiblingOrParent(
     packageFile,

--- a/lib/modules/manager/npm/npmrc.spec.ts
+++ b/lib/modules/manager/npm/npmrc.spec.ts
@@ -1,0 +1,155 @@
+import { fs } from '~test/util.ts';
+import { GlobalConfig } from '../../../config/global.ts';
+import { logger } from '../../../logger/index.ts';
+import { resolveNpmrc } from './npmrc.ts';
+
+vi.mock('../../../util/fs/index.ts');
+
+describe('modules/manager/npm/npmrc', () => {
+  describe('resolveNpmrc', () => {
+    beforeEach(async () => {
+      const realFs = await vi.importActual<typeof fs>('../../../util/fs');
+      fs.readLocalFile.mockResolvedValue(null);
+      fs.findLocalSiblingOrParent.mockResolvedValue(null);
+      fs.getSiblingFileName.mockImplementation(realFs.getSiblingFileName);
+    });
+
+    it('returns undefined if no .npmrc exists and no config.npmrc', async () => {
+      const res = await resolveNpmrc('package.json', {});
+      expect(res).toStrictEqual({ npmrc: undefined, npmrcFileName: null });
+    });
+
+    it('uses config.npmrc if no .npmrc is found', async () => {
+      const res = await resolveNpmrc('package.json', {
+        npmrc: 'config-npmrc',
+      });
+      expect(res).toStrictEqual({ npmrc: 'config-npmrc', npmrcFileName: null });
+    });
+
+    it('finds and filters .npmrc', async () => {
+      fs.findLocalSiblingOrParent.mockImplementation(
+        (packageFile, configFile): Promise<string | null> => {
+          if (packageFile === 'package.json' && configFile === '.npmrc') {
+            return Promise.resolve('.npmrc');
+          }
+          return Promise.resolve(null);
+        },
+      );
+      fs.readLocalFile.mockImplementation((fileName): Promise<any> => {
+        if (fileName === '.npmrc') {
+          return Promise.resolve('save-exact = true\npackage-lock = false\n');
+        }
+        return Promise.resolve(null);
+      });
+      const res = await resolveNpmrc('package.json', {});
+      expect(res).toStrictEqual({
+        npmrc: 'save-exact = true\n',
+        npmrcFileName: '.npmrc',
+      });
+    });
+
+    it('uses config.npmrc if .npmrc does exist but npmrcMerge=false', async () => {
+      fs.findLocalSiblingOrParent.mockImplementation(
+        (packageFile, configFile): Promise<string | null> => {
+          if (packageFile === 'package.json' && configFile === '.npmrc') {
+            return Promise.resolve('.npmrc');
+          }
+          return Promise.resolve(null);
+        },
+      );
+      fs.readLocalFile.mockImplementation((fileName): Promise<any> => {
+        if (fileName === '.npmrc') {
+          return Promise.resolve('repo-npmrc\n');
+        }
+        return Promise.resolve(null);
+      });
+      const res = await resolveNpmrc('package.json', {
+        npmrc: 'config-npmrc',
+      });
+      expect(res).toStrictEqual({
+        npmrc: 'config-npmrc',
+        npmrcFileName: '.npmrc',
+      });
+      expect(logger.debug).toHaveBeenCalledWith(
+        { npmrcFileName: '.npmrc' },
+        'Repo .npmrc file is ignored due to config.npmrc with config.npmrcMerge=false',
+      );
+    });
+
+    it('merges config.npmrc and repo .npmrc when npmrcMerge=true', async () => {
+      fs.findLocalSiblingOrParent.mockImplementation(
+        (packageFile, configFile): Promise<string | null> => {
+          if (packageFile === 'package.json' && configFile === '.npmrc') {
+            return Promise.resolve('.npmrc');
+          }
+          return Promise.resolve(null);
+        },
+      );
+      fs.readLocalFile.mockImplementation((fileName): Promise<any> => {
+        if (fileName === '.npmrc') {
+          return Promise.resolve('repo-npmrc\n');
+        }
+        return Promise.resolve(null);
+      });
+      const res = await resolveNpmrc('package.json', {
+        npmrc: 'config-npmrc',
+        npmrcMerge: true,
+      });
+      expect(res).toStrictEqual({
+        npmrc: `config-npmrc\nrepo-npmrc\n`,
+        npmrcFileName: '.npmrc',
+      });
+    });
+
+    it('finds and filters .npmrc with variables', async () => {
+      fs.findLocalSiblingOrParent.mockImplementation(
+        (packageFile, configFile): Promise<string | null> => {
+          if (packageFile === 'package.json' && configFile === '.npmrc') {
+            return Promise.resolve('.npmrc');
+          }
+          return Promise.resolve(null);
+        },
+      );
+      fs.readLocalFile.mockImplementation((fileName): Promise<any> => {
+        if (fileName === '.npmrc') {
+          return Promise.resolve(
+            'registry=https://registry.npmjs.org\n//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}\n',
+          );
+        }
+        return Promise.resolve(null);
+      });
+      const res = await resolveNpmrc('package.json', {});
+      expect(res).toStrictEqual({
+        npmrc: 'registry=https://registry.npmjs.org\n',
+        npmrcFileName: '.npmrc',
+      });
+    });
+
+    it('keeps variables when exposeAllEnv is true', async () => {
+      GlobalConfig.set({ exposeAllEnv: true });
+      fs.findLocalSiblingOrParent.mockImplementation(
+        (packageFile, configFile): Promise<string | null> => {
+          if (packageFile === 'package.json' && configFile === '.npmrc') {
+            return Promise.resolve('.npmrc');
+          }
+          return Promise.resolve(null);
+        },
+      );
+      fs.readLocalFile.mockImplementation((fileName): Promise<any> => {
+        if (fileName === '.npmrc') {
+          return Promise.resolve(
+            'registry=https://registry.npmjs.org\n//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}\n',
+          );
+        }
+        return Promise.resolve(null);
+      });
+      const res = await resolveNpmrc('package.json', {});
+      expect(res).toStrictEqual({
+        npmrc:
+          'registry=https://registry.npmjs.org\n//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}\n',
+        npmrcFileName: '.npmrc',
+      });
+      GlobalConfig.reset();
+    });
+  });
+});

--- a/lib/modules/manager/npm/npmrc.ts
+++ b/lib/modules/manager/npm/npmrc.ts
@@ -1,0 +1,61 @@
+import { isString } from '@sindresorhus/is';
+import { GlobalConfig } from '../../../config/global.ts';
+import { logger } from '../../../logger/index.ts';
+import {
+  findLocalSiblingOrParent,
+  readLocalFile,
+} from '../../../util/fs/index.ts';
+import { newlineRegex, regEx } from '../../../util/regex.ts';
+
+export interface NpmrcResult {
+  npmrc: string | undefined;
+  npmrcFileName: string | null;
+}
+
+export async function resolveNpmrc(
+  packageFile: string,
+  config: { npmrc?: string; npmrcMerge?: boolean },
+): Promise<NpmrcResult> {
+  let npmrc: string | undefined;
+  const npmrcFileName = await findLocalSiblingOrParent(packageFile, '.npmrc');
+  if (npmrcFileName) {
+    let repoNpmrc = await readLocalFile(npmrcFileName, 'utf8');
+    if (isString(repoNpmrc)) {
+      if (isString(config.npmrc) && !config.npmrcMerge) {
+        logger.debug(
+          { npmrcFileName },
+          'Repo .npmrc file is ignored due to config.npmrc with config.npmrcMerge=false',
+        );
+        npmrc = config.npmrc;
+      } else {
+        npmrc = config.npmrc ?? '';
+        if (npmrc.length) {
+          if (!npmrc.endsWith('\n')) {
+            npmrc += '\n';
+          }
+        }
+        if (repoNpmrc?.includes('package-lock')) {
+          logger.debug('Stripping package-lock setting from .npmrc');
+          repoNpmrc = repoNpmrc.replace(
+            regEx(/(^|\n)package-lock.*?(\n|$)/g),
+            '\n',
+          );
+        }
+        if (repoNpmrc.includes('=${') && !GlobalConfig.get('exposeAllEnv')) {
+          logger.debug(
+            { npmrcFileName },
+            'Stripping .npmrc file of lines with variables',
+          );
+          repoNpmrc = repoNpmrc
+            .split(newlineRegex)
+            .filter((line) => !line.includes('=${'))
+            .join('\n');
+        }
+        npmrc += repoNpmrc;
+      }
+    }
+  } else if (isString(config.npmrc)) {
+    npmrc = config.npmrc;
+  }
+  return { npmrc, npmrcFileName };
+}


### PR DESCRIPTION


<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
As part of future changes in #41215 and/or #41216, we will resolve the
`.npmrc`, if it can be found, in multiple places.

Before we do this, we can prefactor this logic to extract this out into
its own function that can be used independently.


## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe): Claude Sonnet 4.5

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
