### PR TITLE
feat(workers/repository): discover + set `.npmrc`

### DIFF
--- a/lib/modules/manager/bun/extract.ts
+++ b/lib/modules/manager/bun/extract.ts
@@ -41,6 +41,7 @@ export async function processPackageFile(
     return null;
   }
 
+  // TODO deprecated: now performed in mergeRenovateConfig() in lib/workers/repository/init/merge.ts
   const { npmrc } = await resolveNpmrc(packageFile, config);
 
   return {

--- a/lib/modules/manager/npm/extract/index.ts
+++ b/lib/modules/manager/npm/extract/index.ts
@@ -95,6 +95,7 @@ export async function extractPackageFile(
     );
   }
 
+  // TODO deprecated: now performed in mergeRenovateConfig() in lib/workers/repository/init/merge.ts
   const { npmrc, npmrcFileName } = await resolveNpmrc(packageFile, config);
 
   const yarnrcYmlFileName = await findLocalSiblingOrParent(

--- a/lib/workers/repository/init/merge.ts
+++ b/lib/workers/repository/init/merge.ts
@@ -20,6 +20,7 @@ import {
 } from '../../../constants/error-messages.ts';
 import { logger } from '../../../logger/index.ts';
 import * as npmApi from '../../../modules/datasource/npm/index.ts';
+import { resolveNpmrc } from '../../../modules/manager/npm/npmrc.ts';
 import { platform } from '../../../modules/platform/index.ts';
 import { scm } from '../../../modules/platform/scm.ts';
 import { ExternalHostError } from '../../../types/errors/external-host-error.ts';
@@ -266,7 +267,14 @@ export async function mergeRenovateConfig(
       'Ignoring any .npmrc files in repository due to configured npmrc',
     );
     npmApi.setNpmrc(resolvedConfig.npmrc);
+  } else {
+    const { npmrc } = await resolveNpmrc('.', config);
+    if (npmrc) {
+      resolvedConfig.npmrc = npmrc;
+      npmApi.setNpmrc(resolvedConfig.npmrc);
+    }
   }
+
   resolvedConfig = applySecretsAndVariablesToConfig({
     config: resolvedConfig,
     secrets: mergeChildConfig(


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
As noted in #41216, if the Renovate config does not include a `npmrc`
override, we can look at whether the repo has a `.npmrc`.

Instead of doing this in each of the managers that may need
authentication and/or npm configuration for Host Rules, we can instead
perform this centrally.

Then, the `convertNpmrcToRules` function in the npm Datasource can use
this `npmrc` configuration when necessary.

We can mark the usages in the npm and Bun managers as deprecated, and
remove them in the future.

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #41216
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/ladzaretti-testing/bun-npmrc

(Tested before https://github.com/renovatebot/renovate/pull/41245 was merged onto this branch)

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
