### PR TITLE
refactor(config): use brace expansion for filenames

### DIFF
--- a/lib/config/app-strings.spec.ts
+++ b/lib/config/app-strings.spec.ts
@@ -13,6 +13,19 @@ describe('config/app-strings', () => {
     expect(filenames.includes('def')).toBeTrue();
   });
 
+  it('globs for .json and .json5 files', () => {
+    const filenames = getConfigFileNames();
+
+    expect(filenames.includes('renovate.json')).toBeTrue();
+    expect(filenames.includes('renovate.json5')).toBeTrue();
+
+    // does not include the raw pattern
+    expect(filenames.includes('renovate.json{,5}')).toBeFalse();
+
+    // but does not support this for package.json
+    expect(filenames.includes('package.json5')).toBeFalse();
+  });
+
   it('filters based on platform', () => {
     const filenames = getConfigFileNames('gitea');
     expect(filenames.includes('.github/renovate.json')).toBeFalse();

--- a/lib/config/app-strings.ts
+++ b/lib/config/app-strings.ts
@@ -1,17 +1,14 @@
 import { isNonEmptyString } from '@sindresorhus/is';
+import { braceExpand } from 'minimatch';
 import type { PlatformId } from '../constants/index.ts';
 import { regEx } from '../util/regex.ts';
 
-const configFileNames = [
-  'renovate.json',
-  'renovate.json5',
-  '.github/renovate.json',
-  '.github/renovate.json5',
-  '.gitlab/renovate.json',
-  '.gitlab/renovate.json5',
+const configFilePatterns = [
+  'renovate.json{,5}',
+  '.github/renovate.json{,5}',
+  '.gitlab/renovate.json{,5}',
   '.renovaterc',
-  '.renovaterc.json',
-  '.renovaterc.json5',
+  '.renovaterc.json{,5}',
   'package.json',
 ];
 
@@ -22,11 +19,14 @@ export function setUserConfigFileNames(fileNames: string[]): void {
 }
 
 export function getConfigFileNames(platform?: PlatformId): string[] {
-  let filteredConfigFileNames = [...configFileNames];
+  let filteredConfigFileNames = configFilePatterns.flatMap((p) =>
+    braceExpand(p),
+  );
+  console.log({ filteredConfigFileNames });
 
   if (isNonEmptyString(platform)) {
     const platfromRe = regEx('\\.(?<platform>.*)\\/renovate\\.json[5]?$');
-    filteredConfigFileNames = configFileNames.filter((filename) => {
+    filteredConfigFileNames = configFilePatterns.filter((filename) => {
       const matchResult = platfromRe.exec(filename);
       if (!matchResult) {
         return true;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
As per discussion in #41143, it was noted that using brace expansion (or
globs) for the various config filenames.

Using a brace expansion is more straightforward and clearer to a reader,
compared to a glob potentially including other patterns.


## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
