### PR TITLE
fix(mutex): support per-call-site acquire timeouts

### DIFF
--- a/lib/modules/datasource/crate/index.ts
+++ b/lib/modules/datasource/crate/index.ts
@@ -338,7 +338,14 @@ export class CrateDatasource extends Datasource {
       const cacheKey = `crate-datasource/registry-clone-path/${registryFetchUrl}`;
       const lockKey = registryFetchUrl;
 
-      const releaseLock = await acquireLock(lockKey, 'crate-registry');
+      const executionTimeout =
+        GlobalConfig.get('executionTimeout', 15) * 60 * 1000;
+      const gitTimeout = GlobalConfig.get('gitTimeout', executionTimeout);
+      const releaseLock = await acquireLock(
+        lockKey,
+        'crate-registry',
+        gitTimeout,
+      );
       try {
         const cached = memCache.get<CloneResult>(cacheKey);
 

--- a/lib/util/http/http.ts
+++ b/lib/util/http/http.ts
@@ -159,7 +159,8 @@ export abstract class HttpBase<
       throw new Error(HOST_DISABLED);
     }
     options = applyAuthorization(options);
-    options.timeout ??= 60000;
+    const timeout = options.timeout ?? 60000;
+    options.timeout = timeout;
 
     let cacheProvider: HttpCacheProvider | undefined;
     if (isReadMethod && options.cacheProvider) {
@@ -205,6 +206,7 @@ export abstract class HttpBase<
           releaseLock = await acquireLock(
             `${options.method} ${url}`,
             'http-mutex',
+            timeout * 2,
           );
         }
         try {

--- a/lib/util/http/types.ts
+++ b/lib/util/http/types.ts
@@ -25,6 +25,7 @@ export type GotStreamOptions = Options & GotExtraOptions;
 export interface GotExtraOptions {
   abortOnError?: boolean;
   abortIgnoreStatusCodes?: number[];
+  timeout?: number;
   token?: string;
   hostType?: string;
   enabled?: boolean;

--- a/lib/util/mutex.ts
+++ b/lib/util/mutex.ts
@@ -1,7 +1,8 @@
 import { Mutex, type MutexInterface, withTimeout } from 'async-mutex';
 
 const DEFAULT_NAMESPACE = 'default';
-let mutexes: Record<string, Record<string, MutexInterface>> = {};
+const DEFAULT_TIMEOUT_MS = 2 * 60 * 1000;
+let mutexes: Record<string, Record<string, Mutex>> = {};
 
 export function initMutexes(): void {
   mutexes = {};
@@ -10,16 +11,16 @@ export function initMutexes(): void {
 export function getMutex(
   key: string,
   namespace: string = DEFAULT_NAMESPACE,
-): MutexInterface {
+): Mutex {
   mutexes[namespace] ??= {};
-  // create a new mutex if it doesn't exist with a timeout of 2 minutes
-  mutexes[namespace][key] ??= withTimeout(new Mutex(), 1000 * 60 * 2);
+  mutexes[namespace][key] ??= new Mutex();
   return mutexes[namespace][key];
 }
 
 export function acquireLock(
   key: string,
   namespace: string = DEFAULT_NAMESPACE,
+  timeoutMs: number = DEFAULT_TIMEOUT_MS,
 ): Promise<MutexInterface.Releaser> {
-  return getMutex(key, namespace).acquire();
+  return withTimeout(getMutex(key, namespace), timeoutMs).acquire();
 }


### PR DESCRIPTION
## Changes

The mutex utility previously used a hardcoded 2-minute acquire timeout for all call sites. This caused failures for operations that legitimately take longer (e.g. cloning private cargo registries over slow connections).

This PR:

- Adds an optional `timeoutMs` parameter to `acquireLock`, defaulting to the existing 2 minutes
- Stores raw `Mutex` instances in the cache and wraps with `withTimeout` per `acquire()` call, so timeout is truly per-acquisition
- HTTP dedup mutex: derives timeout from the effective HTTP request timeout (`options.timeout * 2`)
- Crate clone mutex: derives timeout from `gitTimeout` (if configured) or `executionTimeout` (default 15 min)
- Narrows got's `Delays | number` type to `number` via `GotExtraOptions` intersection, avoiding unsafe casts

No new configuration options — reuses existing `hostRules.timeout`, `gitTimeout`, and `executionTimeout`.

## Context

- #41210

## AI assistance disclosure

- [x] Yes — substantive assistance

## Documentation (please check one with an [x])

- [x] No documentation update is required

## How I've tested my work (please select one)

- [x] Code inspection only