### PR TITLE
ci: lint commit messages for `Closes` actions

### DIFF
--- a/.github/workflows/check-commit-messages.yml
+++ b/.github/workflows/check-commit-messages.yml
@@ -30,8 +30,8 @@ jobs:
 
             // Check each commit message for closing keywords
             const violatingCommits = [];
-            // Matches: closes #123, fixes #123, resolves #123, etc.
-            const closingPattern = /(closes|fixes|resolves|fixed|closed|resolved)\s+#\d+/i;
+            // Matches: closes #123, fixes #123, closes: #123, etc.
+            const closingPattern = /(closes|fixes|resolves|fixed|closed|resolved):?\s+#\d+/i;
 
             for (const commit of commits) {
               const message = commit.commit.message;

--- a/.github/workflows/check-commit-messages.yml
+++ b/.github/workflows/check-commit-messages.yml
@@ -28,13 +28,14 @@ jobs:
               pull_number: context.payload.pull_request.number,
             });
 
-            // Check each commit message for "Closes #"
+            // Check each commit message for closing keywords
             const violatingCommits = [];
-            const closesPattern = /closes\s+#\d+/i;
+            // Matches: closes #123, fixes #123, resolves #123, etc.
+            const closingPattern = /(closes|fixes|resolves|fixed|closed|resolved)\s+#\d+/i;
 
             for (const commit of commits) {
               const message = commit.commit.message;
-              if (closesPattern.test(message)) {
+              if (closingPattern.test(message)) {
                 const shortSha = commit.sha.substring(0, 7);
                 const firstLine = message.split('\n')[0];
                 violatingCommits.push({ sha: shortSha, message: firstLine });
@@ -43,12 +44,12 @@ jobs:
 
             // Report results
             if (violatingCommits.length > 0) {
-              let errorMessage = `Found ${violatingCommits.length} commit(s) with 'Closes #' pattern:\n\n`;
+              let errorMessage = `Found ${violatingCommits.length} commit(s) with issue closing keywords:\n\n`;
               for (const commit of violatingCommits) {
                 errorMessage += `- ${commit.sha}: ${commit.message}\n`;
               }
-              errorMessage += `\nCommit messages should not contain 'Closes #'. Use the PR description instead.`;
+              errorMessage += `\nCommit messages should not contain closing keywords (closes, fixes, resolves, etc.). Use the PR description instead.`;
               core.setFailed(errorMessage);
             } else {
-              core.info('✓ No commits with "Closes #" pattern found');
+              core.info('✓ No commits with issue closing keywords found');
             }

--- a/.github/workflows/check-commit-messages.yml
+++ b/.github/workflows/check-commit-messages.yml
@@ -1,0 +1,54 @@
+name: Check Commit Messages
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+permissions:
+  contents: read
+  statuses: write
+
+jobs:
+  closes-issue-or-discussion:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for 'Closes \#' in commit messages
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            // Co-authored-by: Claude Sonnet 4.5 (GitHub Copilot)
+
+            // Get all commits in this PR using the GitHub API
+            const { data: commits } = await github.rest.pulls.listCommits({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+            });
+
+            // Check each commit message for "Closes #"
+            const violatingCommits = [];
+            const closesPattern = /closes\s+#\d+/i;
+
+            for (const commit of commits) {
+              const message = commit.commit.message;
+              if (closesPattern.test(message)) {
+                const shortSha = commit.sha.substring(0, 7);
+                const firstLine = message.split('\n')[0];
+                violatingCommits.push({ sha: shortSha, message: firstLine });
+              }
+            }
+
+            // Report results
+            if (violatingCommits.length > 0) {
+              let errorMessage = `Found ${violatingCommits.length} commit(s) with 'Closes #' pattern:\n\n`;
+              for (const commit of violatingCommits) {
+                errorMessage += `- ${commit.sha}: ${commit.message}\n`;
+              }
+              errorMessage += `\nCommit messages should not contain 'Closes #'. Use the PR description instead.`;
+              core.setFailed(errorMessage);
+            } else {
+              core.info('✓ No commits with "Closes #" pattern found');
+            }


### PR DESCRIPTION


<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

We periodically (accidentally) merge PRs where the commit message from
the author contains a `Closes` message in them.

Although this is technically OK, we prefer to close the Issues as part
of the PR's description / with the Development tab.

When Semantic Release looks up what issue(s) are closed for a given
commit, it will look up any `Closes #...` patterns.

Sometimes these `Closes` actions are set to a Discussion number, which
Semantic Release does not support, so the post-release announcement
fails.

To prevent this happening, we can catch this on PRs by checking commits
for the known pattern for `Closes ...`.

However, because we also don't want users to close issues from their
commits anyway, we can instead enforce this across any `Closes #`
messages.

Also adds for `Fixes #...`, etc

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #39397
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: <URL>

In https://github.com/renovatebot/renovate/actions/runs/22134680099 we tested with commits from https://github.com/renovatebot/renovate/pull/41259 and see the failure

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
