### PR TITLE
fix(workers/global): migrate string-based `repositoryCacheForceLocal`

### DIFF
--- a/lib/workers/global/config/parse/env.spec.ts
+++ b/lib/workers/global/config/parse/env.spec.ts
@@ -331,6 +331,14 @@ describe('workers/global/config/parse/env', () => {
       });
     });
 
+    it('does not migrate empty RENOVATE_X_REPO_CACHE_FORCE_LOCAL', async () => {
+      const envParam: NodeJS.ProcessEnv = {
+        RENOVATE_X_REPO_CACHE_FORCE_LOCAL: '',
+      };
+      const config = await env.getConfig(envParam);
+      expect(config.repositoryCacheForceLocal).toBeUndefined();
+    });
+
     describe('RENOVATE_CONFIG tests', () => {
       let processExit: MockInstance<(code?: number | string | null) => never>;
 

--- a/lib/workers/global/config/parse/env.spec.ts
+++ b/lib/workers/global/config/parse/env.spec.ts
@@ -314,7 +314,8 @@ describe('workers/global/config/parse/env', () => {
         RENOVATE_X_DELETE_CONFIG_FILE: 'true',
         RENOVATE_X_S3_ENDPOINT: 'endpoint',
         RENOVATE_X_S3_PATH_STYLE: 'true',
-        RENOVATE_X_REPO_CACHE_FORCE_LOCAL: 'true',
+        // NOTE that a non-empty string is treated as `true`
+        RENOVATE_X_REPO_CACHE_FORCE_LOCAL: 'enabled',
       };
       const config = await env.getConfig(envParam);
       expect(config).toMatchObject({

--- a/lib/workers/global/config/parse/env.ts
+++ b/lib/workers/global/config/parse/env.ts
@@ -1,4 +1,4 @@
-import { isArray } from '@sindresorhus/is';
+import { isArray, isNonEmptyString } from '@sindresorhus/is';
 import JSON5 from 'json5';
 import { getOptions } from '../../../../config/options/index.ts';
 import type { AllConfig } from '../../../../config/types.ts';
@@ -117,6 +117,9 @@ function massageConvertedExperimentalVars(
       // special case to use a more consistent prefix with other `repositoryCache` options
       if (key === 'RENOVATE_X_REPO_CACHE_FORCE_LOCAL') {
         newKey = 'RENOVATE_REPOSITORY_CACHE_FORCE_LOCAL';
+        if (isNonEmptyString(env[key])) {
+          env[key] = 'true';
+        }
       }
 
       result[newKey] = env[key];


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->


For users who had previously set `RENOVATE_X_REPO_CACHE_FORCE_LOCAL` to
a non-empty string, we can make sure to auto-migrate them to the
expected value of `true`.

Because this is an environment variable, we cannot use a migration, and
so instead need to handle it when we're performing the manual migration.



## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository


The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
