### PR TITLE
chore(workers/global): improve error message on parsing environment vars

### DIFF
--- a/lib/workers/global/config/parse/env.spec.ts
+++ b/lib/workers/global/config/parse/env.spec.ts
@@ -28,7 +28,7 @@ describe('workers/global/config/parse/env', () => {
       };
       await expect(env.getConfig(envParam)).rejects.toThrow(
         Error(
-          "Invalid boolean value: expected 'true' or 'false', but got 'badvalue'",
+          "RENOVATE_CONFIG_MIGRATION was invalid: Error: Invalid boolean value: expected 'true' or 'false', but got 'badvalue'",
         ),
       );
     });

--- a/lib/workers/global/config/parse/env.ts
+++ b/lib/workers/global/config/parse/env.ts
@@ -167,8 +167,13 @@ export async function getConfig(
       }
     } else {
       const coerce = coersions[option.type];
-      // @ts-expect-error -- type can't be narrowed
-      config[option.name] = coerce(envVal);
+      try {
+        // @ts-expect-error -- type can't be narrowed
+        config[option.name] = coerce(envVal);
+      } catch (e) {
+        throw new Error(`${envName} was invalid: ${e}`);
+      }
+
       if (option.name === 'dryRun') {
         if ((config[option.name] as string) === 'true') {
           logger.warn('env config dryRun property has been changed to full');


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
As part of #41323, we noticed that the error that's thrown isn't super
helpful, as it doesn't include the environment variable name.

To improve this, we can wrap the `Error` with the environment variable
name that's in use, as well as the error message.

In the future we can improve this further.

## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
