### PR TITLE
test(logger): clarify that `logger.once` doesn't use function parameters

### DIFF
--- a/lib/logger/once.spec.ts
+++ b/lib/logger/once.spec.ts
@@ -100,6 +100,19 @@ describe('logger/once', () => {
       expect(debug).toHaveBeenNthCalledWith(3, 'baz');
     });
 
+    it('only the line number is taken into account when de-duplicating calls', () => {
+      const debug = vi.spyOn(logger, 'debug');
+
+      function doSomething(s: string) {
+        // the `once` call is only based on what file+line the function is called from, so this will only be called the first time, regardless of parameters
+        logger.once.debug({ param: s }, s);
+      }
+
+      doSomething('foo');
+      doSomething('bar');
+      expect(debug).toHaveBeenCalledExactlyOnceWith({ param: 'foo' }, 'foo');
+    });
+
     it('allows mixing single-time and regular logging', () => {
       const debug = vi.spyOn(logger, 'debug');
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
As part of future changes, we'll be looking at making so `logger.once`
can be called with different parameters, and each distinct set of
parameters will be used to check if we have already been called.

Before we do this, we should add a test to capture the current
behaviour, where the parameters are ignored.

## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
