### PR TITLE
fix(vulnerability): handle alerts with null or missing `firstPatchedVersion`

### DIFF
--- a/lib/workers/repository/init/vulnerability.spec.ts
+++ b/lib/workers/repository/init/vulnerability.spec.ts
@@ -381,5 +381,50 @@ describe('workers/repository/init/vulnerability', () => {
       expect(res.packageRules).toMatchSnapshot();
       expect(res.packageRules).toHaveLength(1);
     });
+
+    it('skips package rule if no valid firstPatchedVersion found across multiple alerts', async () => {
+      platform.getVulnerabilityAlerts.mockResolvedValue([
+        {
+          dismissed_reason: null,
+          dependency: {
+            manifest_path: 'package.json',
+          },
+          security_advisory: {
+            description: 'First vulnerability',
+            identifiers: [{ type: 'GHSA', value: 'GHSA-xxxx-xxxx-xxx1' }],
+            references: [{ url: 'https://example.com/vuln1' }],
+          },
+          security_vulnerability: {
+            package: { name: 'vulnerable-pkg', ecosystem: 'npm' },
+            first_patched_version: { identifier: 'invalid-version-1' },
+            vulnerable_version_range: '< 1.0.0',
+          },
+        },
+        {
+          dismissed_reason: null,
+          dependency: {
+            manifest_path: 'package.json',
+          },
+          security_advisory: {
+            description: 'Second vulnerability',
+            identifiers: [{ type: 'GHSA', value: 'GHSA-xxxx-xxxx-xxx2' }],
+            references: [{ url: 'https://example.com/vuln2' }],
+          },
+          security_vulnerability: {
+            package: { name: 'vulnerable-pkg', ecosystem: 'npm' },
+            first_patched_version: { identifier: 'also-invalid' },
+            vulnerable_version_range: '< 1.0.0',
+          },
+        },
+      ]);
+      const res = await detectVulnerabilityAlerts(config);
+      expect(logger.debug).toHaveBeenCalledWith(
+        'Invalid firstPatchedVersion: invalid-version-1',
+      );
+      expect(logger.debug).toHaveBeenCalledWith(
+        'Invalid firstPatchedVersion: also-invalid',
+      );
+      expect(res.packageRules).toBeEmpty();
+    });
   });
 });

--- a/lib/workers/repository/init/vulnerability.ts
+++ b/lib/workers/repository/init/vulnerability.ts
@@ -144,6 +144,10 @@ export async function detectVulnerabilityAlerts(
   for (const [fileName, files] of Object.entries(combinedAlerts)) {
     for (const [datasource, dependencies] of Object.entries(files)) {
       for (const [depName, val] of Object.entries(dependencies)) {
+        if (!val.firstPatchedVersion) {
+          continue;
+        }
+
         let prBodyNotes: string[] = [];
         try {
           prBodyNotes = ['### GitHub Vulnerability Alerts'].concat(


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Fixes handling of GitHub vulnerability alerts where `alertDetails.firstPatchedVersion` is undefined in more than one alert. 

The current code works such that before creating a package rule, it combines indiviudal GitHub alerts and attempts figuring out the best value for `firstPatchedVersion`. An edge case that is currently not handled is if no plausible value is found among several alerts: https://github.com/renovatebot/renovate/blob/d955edf7943d1b41f61517012d22d06d6b0078e6/lib/workers/repository/init/vulnerability.ts#L126-L133

In that case, a garbage package rule is added that includes:
```json
"matchCurrentVersion": "< undefined",
"vulnerabilityFixVersion": "undefined",
```

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
