### PR TITLE
feat(presets): add changelogUrl link for gitea.com-based digest updates

### DIFF
--- a/lib/config/presets/index.spec.ts
+++ b/lib/config/presets/index.spec.ts
@@ -629,6 +629,7 @@ describe('config/presets/index', () => {
           'mergeConfidence:age-confidence-badges',
           'replacements:all',
           'workarounds:all',
+          'helpers:giteaDigestChangelogs',
           'helpers:githubDigestChangelogs',
           'helpers:goXPackagesChangelogLink',
           'helpers:goXPackagesNameLink',

--- a/lib/config/presets/internal/config.preset.ts
+++ b/lib/config/presets/internal/config.preset.ts
@@ -35,6 +35,7 @@ export const presets: Record<string, Preset> = {
       'mergeConfidence:age-confidence-badges',
       'replacements:all',
       'workarounds:all',
+      'helpers:giteaDigestChangelogs',
       'helpers:githubDigestChangelogs',
       'helpers:goXPackagesChangelogLink',
       'helpers:goXPackagesNameLink',

--- a/lib/config/presets/internal/helpers.preset.ts
+++ b/lib/config/presets/internal/helpers.preset.ts
@@ -19,6 +19,23 @@ export const presets: Record<string, Preset> = {
     description: 'Keep `typescript` version in sync with the `rc` tag.',
     extends: [':followTag(typescript, rc)'],
   },
+  giteaDigestChangelogs: {
+    description:
+      'Ensure that every dependency pinned by digest and sourced from gitea.com contains a link to the commit-to-commit diff',
+    packageRules: [
+      {
+        changelogUrl: '{{sourceUrl}}/compare/{{currentDigest}}..{{newDigest}}',
+        matchDatasources: [
+          'git-refs',
+          'git-tags',
+          'gitea-releases',
+          'gitea-tags',
+        ],
+        matchSourceUrls: ['https://gitea.com/**'],
+        matchUpdateTypes: ['digest'],
+      },
+    ],
+  },
   githubDigestChangelogs: {
     description:
       'Ensure that every dependency pinned by digest and sourced from GitHub.com contains a link to the commit-to-commit diff',


### PR DESCRIPTION
## Changes

Add a `giteaDigestChangelogs` helper preset that provides a link to the
commit-to-commit diff for dependencies pinned by digest and sourced from
gitea.com. This mirrors the existing `githubDigestChangelogs` preset
(added in #39650), but targets `gitea-releases` and `gitea-tags`
datasources with `https://gitea.com/**` source URLs.

The preset is also included in `config:recommended` so users get gitea.com
changelog links out of the box.

## Context

- [x] This closes an existing Issue, Closes: #39735

## AI assistance disclosure

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

*This PR was created with the assistance of Claude Opus 4.6 by Anthropic. Happy to make any adjustments!*

## Documentation (please check one with an [x])

- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository