### PR TITLE
feat(platform-azure): initial bearer token auth support for Azure DevOps

### DIFF
--- a/lib/modules/platform/azure/__snapshots__/util.spec.ts.snap
+++ b/lib/modules/platform/azure/__snapshots__/util.spec.ts.snap
@@ -65,12 +65,6 @@ exports[`modules/platform/azure/util > getStorageExtraCloneOpts > should configu
 }
 `;
 
-exports[`modules/platform/azure/util > getStorageExtraCloneOpts > should configure bearer token 1`] = `
-{
-  "-c": "http.extraHeader=AUTHORIZATION: bearer token",
-}
-`;
-
 exports[`modules/platform/azure/util > getStorageExtraCloneOpts > should configure personal access token 1`] = `
 {
   "-c": "http.extraHeader=AUTHORIZATION: basic OjEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3OHRlc3Q=",

--- a/lib/modules/platform/azure/azure-got-wrapper.ts
+++ b/lib/modules/platform/azure/azure-got-wrapper.ts
@@ -1,11 +1,16 @@
 import * as azure from 'azure-devops-node-api';
-import { getBasicHandler, getHandlerFromToken } from 'azure-devops-node-api';
+import {
+  getBasicHandler,
+  getBearerHandler,
+  getPersonalAccessTokenHandler,
+} from 'azure-devops-node-api';
 import type { ICoreApi } from 'azure-devops-node-api/CoreApi.js';
 import type { IGitApi } from 'azure-devops-node-api/GitApi.js';
 import type { IRequestHandler } from 'azure-devops-node-api/interfaces/common/VsoBaseInterfaces.js';
 import type { IPolicyApi } from 'azure-devops-node-api/PolicyApi.js';
 import type { HostRule } from '../../../types/index.ts';
 import * as hostRules from '../../../util/host-rules.ts';
+import { isProbablyJwt } from './util.ts';
 
 const hostType = 'azure';
 let endpoint: string;
@@ -15,7 +20,10 @@ function getAuthenticationHandler(config: HostRule): IRequestHandler {
     return getBasicHandler(config.username, config.password, true);
   }
   // TODO: token can be undefined here (#22198)
-  return getHandlerFromToken(config.token!, true);
+  if (isProbablyJwt(config.token!)) {
+    return getBearerHandler(config.token!, true);
+  }
+  return getPersonalAccessTokenHandler(config.token!, true);
 }
 
 export function azureObj(): azure.WebApi {

--- a/lib/modules/platform/azure/index.spec.ts
+++ b/lib/modules/platform/azure/index.spec.ts
@@ -15,6 +15,7 @@ import type { Mocked, MockedObject } from 'vitest';
 import { vi } from 'vitest';
 import { mockDeep } from 'vitest-mock-extended';
 import { partial } from '~test/util.ts';
+import type { GlobalConfig as _GlobalConfig } from '../../../config/global.ts';
 import {
   REPOSITORY_ARCHIVED,
   REPOSITORY_NOT_FOUND,

--- a/lib/modules/platform/azure/index.spec.ts
+++ b/lib/modules/platform/azure/index.spec.ts
@@ -15,7 +15,6 @@ import type { Mocked, MockedObject } from 'vitest';
 import { vi } from 'vitest';
 import { mockDeep } from 'vitest-mock-extended';
 import { partial } from '~test/util.ts';
-import type { GlobalConfig as _GlobalConfig } from '../../../config/global.ts';
 import {
   REPOSITORY_ARCHIVED,
   REPOSITORY_NOT_FOUND,

--- a/lib/modules/platform/azure/util.ts
+++ b/lib/modules/platform/azure/util.ts
@@ -1,3 +1,4 @@
+import { isPlainObject } from '@sindresorhus/is';
 import type {
   GitPullRequest,
   GitRepository,
@@ -136,11 +137,7 @@ export function isProbablyJwt(token: string): boolean {
     const header = JSON.parse(
       Buffer.from(parts[0], 'base64url').toString('utf8'),
     );
-    return (
-      typeof header === 'object' &&
-      header !== null &&
-      ('typ' in header || 'alg' in header)
-    );
+    return isPlainObject(header) && ('typ' in header || 'alg' in header);
   } catch {
     return false;
   }


### PR DESCRIPTION
## Changes

Add automatic support for Microsoft Entra ID (AAD) Bearer token authentication for Azure DevOps, alongside existing Personal Access Token (PAT) support. Token type is auto-detected — no new configuration options required.

### What changed:
- `util.ts`: Added `isProbablyJwt(token)` helper that detects JWT tokens by checking for 3 dot-separated base64url segments with a decodable JSON header containing `typ` or `alg` fields
- `util.ts`: `getStorageExtraCloneOpts()` now uses `isProbablyJwt()` instead of the `token.length === 52` heuristic to choose between `Bearer` and `Basic` auth headers for git clone
- `azure-got-wrapper.ts`: `getAuthenticationHandler()` uses `isProbablyJwt()` to select `BearerCredentialHandler` for JWT tokens or `PersonalAccessTokenCredentialHandler` for PATs, replacing the library's length-based heuristic
- Added documentation in `lib/modules/platform/azure/readme.md`

### Why:
The previous implementation relied on a fragile heuristic (token length === 52 or regex pattern) from the `azure-devops-node-api` library to distinguish PATs from Bearer tokens. Microsoft Entra ID tokens (OAuth/JWT) are increasingly the recommended authentication method for Azure DevOps Services, especially for service principals and managed identities. This change makes token type detection deterministic by inspecting the token structure (JWT format) rather than relying on length.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

GitHub Copilot (Claude Opus 4.6) was used to design, implement, and test the feature, including: code changes across 4 files, unit tests (16 new test cases), documentation, and this PR description.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

All 208 Azure platform tests pass (`pnpm vitest lib/modules/platform/azure/` — 13 test files, 0 failures), including 16 new tests covering:
- `isProbablyJwt()`: valid JWT, 52-char PAT, new-format PAT, empty string, invalid base64, wrong segment count, non-object header, header missing typ/alg, non-JWT opaque token
- `getStorageExtraCloneOpts()`: JWT token → Bearer header, PAT token → Basic header, opaque token → Bearer fallback, invalid-JWT → Basic fallback
- `getAuthenticationHandler()`: JWT → BearerCredentialHandler, 52-char PAT → PersonalAccessTokenCredentialHandler, opaque non-JWT → PersonalAccessTokenCredentialHandler