### PR TITLE
feat(util): log warning if file(s) contain hidden Unicode characters

### DIFF
--- a/lib/util/fs/index.ts
+++ b/lib/util/fs/index.ts
@@ -6,6 +6,7 @@ import fs from 'fs-extra';
 import upath from 'upath';
 import { GlobalConfig } from '../../config/global.ts';
 import { logger } from '../../logger/index.ts';
+import { logWarningIfUnicodeHiddenCharactersInPackageFile } from '../unicode.ts';
 import { ensureCachePath, ensureLocalPath, isValidPath } from './util.ts';
 
 export const pipeline = util.promisify(stream.pipeline);
@@ -36,6 +37,9 @@ export async function readLocalFile(
     const fileContent = encoding
       ? await fs.readFile(localFileName, encoding)
       : await fs.readFile(localFileName);
+
+    logWarningIfUnicodeHiddenCharactersInPackageFile(fileName, fileContent);
+
     return fileContent;
   } catch (err) {
     logger.trace({ err }, 'Error reading local file');

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -31,6 +31,7 @@ import { getEnv } from '../env.ts';
 import { getChildEnv } from '../exec/utils.ts';
 import { newlineRegex, regEx } from '../regex.ts';
 import { matchRegexOrGlobList } from '../string-match.ts';
+import { logWarningIfUnicodeHiddenCharactersInPackageFile } from '../unicode.ts';
 import { getGitEnvironmentVariables } from './auth.ts';
 import { parseGitAuthor } from './author.ts';
 import {
@@ -1106,6 +1107,9 @@ export async function getFile(
     const content = await git.show([
       'origin/' + (branchName ?? config.currentBranch) + ':' + filePath,
     ]);
+
+    logWarningIfUnicodeHiddenCharactersInPackageFile(filePath, content);
+
     return content;
   } catch (err) {
     const errChecked = checkForPlatformFailure(err);

--- a/lib/util/regex.ts
+++ b/lib/util/regex.ts
@@ -73,3 +73,39 @@ export function escapeRegExp(input: string): string {
 }
 
 export const newlineRegex = regEx(/\r?\n/);
+
+/**
+ * Matches hidden or invisible Unicode characters, including:
+ * - Non-breaking space (\u00A0)
+ * - Ogham space mark (\u1680)
+ * - Various spaces (\u2000-\u200A)
+ * - Line separator (\u2028)
+ * - Paragraph separator (\u2029)
+ * - Narrow no-break space (\u202F)
+ * - Medium mathematical space (\u205F)
+ * - Ideographic space (\u3000)
+ * - Zero-width space (\u200B)
+ * - Zero-width non-joiner (\u200C)
+ * - Zero-width joiner (\u200D)
+ * - Zero-width no-break space (\uFEFF)
+ * - Left-to-right mark (\u200E)
+ * - Right-to-left mark (\u200F)
+ * - Bidirectional formatting characters (\u202A-\u202E)
+ * - Soft hyphen (\u00AD)
+ */
+export const hiddenUnicodeCharactersRegex = regEx(
+  /([\u00A0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000\u200B\u200C\uFEFF\u200E\u200F\u202A-\u202E\u00AD\u200D])/g,
+);
+
+/**
+ * Given unicode character(s), convert them to the \u0123 representation, to be output to a user.
+ */
+export function toUnicodeEscape(str: string): string {
+  return str
+    .split('')
+    .map((char) => {
+      const code = char.charCodeAt(0);
+      return '\\u' + code.toString(16).padStart(4, '0').toUpperCase();
+    })
+    .join('');
+}

--- a/lib/util/unicode.ts
+++ b/lib/util/unicode.ts
@@ -1,0 +1,20 @@
+import { logger } from '../logger/index.ts';
+import { hiddenUnicodeCharactersRegex, toUnicodeEscape } from './regex.ts';
+
+export function logWarningIfUnicodeHiddenCharactersInPackageFile(
+  file: string,
+  content: string | Buffer,
+): void {
+  const hiddenCharacters = content
+    .toString('utf8')
+    .match(hiddenUnicodeCharactersRegex);
+  if (hiddenCharacters) {
+    logger.once.warn(
+      {
+        file,
+        hiddenCharacters: toUnicodeEscape(hiddenCharacters.join('')),
+      },
+      `Hidden Unicode characters have been discovered in the file \`${file}\`. Please confirm that they are intended to be there, as they could be an attempt to "smuggle" text into your codebase, or used to confuse tools like Renovate or Large Language Models (LLMs)`,
+    );
+  }
+}


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
With the rise of prompt injection, there is an increased number of
attacks occurring using hidden Unicode characters.

These hidden characters can also confuse other tools, so it's best for
Renovate to surface these to repository owners, as we read files that
may be problematic.

To avoid multiple reads of files, we can do this every time our
`readLocalFile` function is called, as we already have the file content.

An alternate option would be that in `workers/repository` we could check
the read package files, but given `extractAllPackageFiles` may be used
by a Manager, we can't inject the logic in, without Managers needing to
implement the logic themselves.

This should be performant, and not introduce too many false-positives,
but this will also depend on how (package) files are set up in
repositories.

The list of suspicious characters has been largely compiled by Claude
Sonnet 4.5.


## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
