### PR TITLE
chore(logger): serialize `DateTime` to ISO strings

### DIFF
--- a/lib/logger/index.spec.ts
+++ b/lib/logger/index.spec.ts
@@ -1,6 +1,7 @@
 import type { WriteStream } from 'node:fs';
 import bunyan from 'bunyan';
 import fs from 'fs-extra';
+import { DateTime } from 'luxon';
 import { partial } from '~test/util.ts';
 import { add } from '../util/host-rules.ts';
 import { addSecretForSanitizing as addSecret } from '../util/sanitize.ts';
@@ -472,6 +473,8 @@ describe('logger/index', () => {
       secrets: {
         foo: 'barsecret',
       },
+      someDate: DateTime.fromISO('2020-02-29'),
+      someDateTime: DateTime.fromISO('2020-02-29T01:40:21.345+00:00'),
       someFn: () => 'secret"password',
       someObject: new SomeClass('secret"password'),
     });
@@ -487,6 +490,8 @@ describe('logger/index', () => {
     expect(logged.content).toBe('[content]');
     expect(logged.prBody).toBe(prBody);
     expect(logged.secrets.foo).toBe('***********');
+    expect(logged.someDate).toBe('2020-02-29T00:00:00.000+00:00');
+    expect(logged.someDateTime).toBe('2020-02-29T01:40:21.345+00:00');
     expect(logged.someFn).toBe('[function]');
     expect(logged.someObject.field).toBe('**redacted**');
   });

--- a/lib/logger/index.spec.ts
+++ b/lib/logger/index.spec.ts
@@ -473,9 +473,9 @@ describe('logger/index', () => {
       secrets: {
         foo: 'barsecret',
       },
-      someDate: DateTime.fromISO('2020-02-29'),
-      someDateTime: DateTime.fromISO('2020-02-29T01:40:21.345+00:00'),
       someFn: () => 'secret"password',
+      someLuxonDate: DateTime.fromISO('2020-02-29'),
+      someLuxonDateTime: DateTime.fromISO('2020-02-29T01:40:21.345+00:00'),
       someObject: new SomeClass('secret"password'),
     });
 
@@ -490,9 +490,9 @@ describe('logger/index', () => {
     expect(logged.content).toBe('[content]');
     expect(logged.prBody).toBe(prBody);
     expect(logged.secrets.foo).toBe('***********');
-    expect(logged.someDate).toBe('2020-02-29T00:00:00.000+00:00');
-    expect(logged.someDateTime).toBe('2020-02-29T01:40:21.345+00:00');
     expect(logged.someFn).toBe('[function]');
+    expect(logged.someLuxonDate).toBe('2020-02-29T00:00:00.000+00:00');
+    expect(logged.someLuxonDateTime).toBe('2020-02-29T01:40:21.345+00:00');
     expect(logged.someObject.field).toBe('**redacted**');
   });
 

--- a/lib/logger/utils.ts
+++ b/lib/logger/utils.ts
@@ -16,6 +16,7 @@ import {
 import bunyan from 'bunyan';
 import fs from 'fs-extra';
 import { RequestError as HttpError } from 'got';
+import { DateTime } from 'luxon';
 import { ZodError } from 'zod/v3';
 import { ExecError } from '../util/exec/exec-error.ts';
 import { regEx } from '../util/regex.ts';
@@ -204,6 +205,10 @@ export function sanitizeValue(
 
   if (isDate(value)) {
     return value;
+  }
+
+  if (DateTime.isDateTime(value)) {
+    return value.toISO();
   }
 
   if (isFunction(value)) {

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -626,11 +626,7 @@ export async function checkoutBranch(
     // v8 ignore else -- TODO: add test #40625
     if (latestCommitDate) {
       logger.debug(
-        {
-          branchName,
-          latestCommitDate: latestCommitDate.toISO(),
-          sha: config.currentBranchSha,
-        },
+        { branchName, latestCommitDate, sha: config.currentBranchSha },
         'latest commit',
       );
     }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

As an alternative to 2228a7901593072af3763cf57e5a4270c452bd64, we can
instead serialize any `DateTime` objects that are present in our logging
fields.


## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->

```
DEBUG: latest repository commit (repository=JamieTanna-Mend-testing/renovate-iss-41260-gomod-bug-test)
       "latestCommit": {
         "hash": "fc47f18e463d1ce2e811e73b4f3e1c188bdbb3fe",
         "date": "2026-02-17T18:54:05+01:00",
         "message": "Update main.go",
         "refs": "HEAD -> master, origin/master, origin/HEAD",
         "body": "",
         "author_name": "Michael Walsh",
         "author_email": "59025052+walsm232@users.noreply.github.com"
       }
```