### PR TITLE
fix: resolve cache TTL lazily in `PackageHttpCacheProvider`

### DIFF
--- a/lib/util/http/cache/package-http-cache-provider.ts
+++ b/lib/util/http/cache/package-http-cache-provider.ts
@@ -19,9 +19,7 @@ export interface PackageHttpCacheProviderOptions {
 
 export class PackageHttpCacheProvider extends AbstractHttpCacheProvider {
   private namespace: PackageCacheNamespace;
-
-  private softTtlMinutes: number;
-  private hardTtlMinutes: number;
+  private defaultTtlMinutes: number;
 
   checkCacheControlHeader: boolean;
   checkAuthorizationHeader: boolean;
@@ -34,11 +32,25 @@ export class PackageHttpCacheProvider extends AbstractHttpCacheProvider {
   }: PackageHttpCacheProviderOptions) {
     super();
     this.namespace = namespace;
-    const ttlValues = resolveTtlValues(this.namespace, softTtlMinutes);
-    this.softTtlMinutes = ttlValues.softTtlMinutes;
-    this.hardTtlMinutes = ttlValues.hardTtlMinutes;
+    this.defaultTtlMinutes = softTtlMinutes;
     this.checkCacheControlHeader = checkCacheControlHeader;
     this.checkAuthorizationHeader = checkAuthorizationHeader;
+  }
+
+  private get softTtlMinutes(): number {
+    const { softTtlMinutes } = resolveTtlValues(
+      this.namespace,
+      this.defaultTtlMinutes,
+    );
+    return softTtlMinutes;
+  }
+
+  private get hardTtlMinutes(): number {
+    const { hardTtlMinutes } = resolveTtlValues(
+      this.namespace,
+      this.defaultTtlMinutes,
+    );
+    return hardTtlMinutes;
   }
 
   private cacheKey(method: string, url: string): string {


### PR DESCRIPTION
## Changes

`PackageHttpCacheProvider` resolved `cacheTtlOverride` eagerly in its constructor.
The Maven datasource creates its instance at module level, before `GlobalConfig.set()`, so the override was silently ignored.

Defer `resolveTtlValues()` to usage time so it always reads current config.

## Context

- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

Discussion: https://github.com/renovatebot/renovate/discussions/41320

## AI assistance disclosure

- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).

## Documentation (please check one with an [x])

- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only