### PR TITLE
feat(vendir): support extracting HTTP sources

### DIFF
--- a/lib/modules/manager/vendir/__fixtures__/valid-contents.yaml
+++ b/lib/modules/manager/vendir/__fixtures__/valid-contents.yaml
@@ -41,3 +41,6 @@ directories:
     githubRelease:
       slug: test/test
       tag: "7.10.1"
+  - path: openapi
+    http:
+      url: https://raw.githubusercontent.com/mend/renovate-ce-ee/refs/heads/main/docs/openapi-community.yaml

--- a/lib/modules/manager/vendir/extract.spec.ts
+++ b/lib/modules/manager/vendir/extract.spec.ts
@@ -84,6 +84,13 @@ describe('modules/manager/vendir/extract', () => {
             packageName: 'test/test',
             datasource: 'github-releases',
           },
+          {
+            currentValue: 'latest',
+            packageName:
+              'https://raw.githubusercontent.com/mend/renovate-ce-ee/refs/heads/main/docs/openapi-community.yaml',
+            depType: 'HttpSource',
+            skipReason: 'unsupported-datasource',
+          },
         ],
       });
       // git-refs datasource does not support custom registries

--- a/lib/modules/manager/vendir/extract.ts
+++ b/lib/modules/manager/vendir/extract.ts
@@ -15,6 +15,7 @@ import type {
   GitRefDefinition,
   GithubReleaseDefinition,
   HelmChartDefinition,
+  HttpReleaseDefinition,
   VendirDefinition,
 } from './schema.ts';
 import { Vendir } from './schema.ts';
@@ -71,6 +72,17 @@ export function extractGithubReleaseSource(
   };
 }
 
+export function extractHttpReleaseSource(
+  httpRelease: HttpReleaseDefinition,
+): PackageDependency {
+  return {
+    packageName: httpRelease.url,
+    currentValue: 'latest',
+    depType: 'HttpSource',
+    skipReason: 'unsupported-datasource',
+  };
+}
+
 export function parseVendir(
   content: string,
   packageFile?: string,
@@ -110,6 +122,9 @@ export function extractPackageFile(
       deps.push(dep);
     } else if ('githubRelease' in content && content.githubRelease) {
       const dep = extractGithubReleaseSource(content.githubRelease);
+      deps.push(dep);
+    } else if ('http' in content && content.http) {
+      const dep = extractHttpReleaseSource(content.http);
       deps.push(dep);
     }
   }

--- a/lib/modules/manager/vendir/extract.ts
+++ b/lib/modules/manager/vendir/extract.ts
@@ -123,7 +123,9 @@ export function extractPackageFile(
     } else if ('githubRelease' in content && content.githubRelease) {
       const dep = extractGithubReleaseSource(content.githubRelease);
       deps.push(dep);
-    } else if ('http' in content && content.http) {
+    }
+    // v8 ignore else -- hard to test
+    else if ('http' in content && content.http) {
       const dep = extractHttpReleaseSource(content.http);
       deps.push(dep);
     }

--- a/lib/modules/manager/vendir/readme.md
+++ b/lib/modules/manager/vendir/readme.md
@@ -80,3 +80,22 @@ directories:
         # optional if tagSelection is specified (available in v0.22.0+)
         tag: v0.1.0
 ```
+
+### HTTP
+
+<!-- prettier-ignore -->
+!!! note
+    Updates to dependencies tracked through the HTTP source can only be updated using [`lockFileMaintenance`](../../../configuration-options.md#lockfilemaintenance).
+
+Renovate can extract HTTP dependency sources, but will not update them without [`lockFileMaintenance`](../../../configuration-options.md#lockfilemaintenance).
+
+```yaml title="Example vendir.yml for syncing a remote file"
+apiVersion: vendir.k14s.io/v1alpha1
+kind: Config
+directories:
+  - path: internal
+    contents:
+      - path: renovate-ce
+        http:
+          url: https://raw.githubusercontent.com/mend/renovate-ce-ee/refs/main/docs/openapi-community.yaml
+```

--- a/lib/modules/manager/vendir/schema.ts
+++ b/lib/modules/manager/vendir/schema.ts
@@ -41,10 +41,20 @@ export const GithubReleaseContent = z.object({
   githubRelease: GithubRelease,
 });
 
+export const HttpRelease = z.object({
+  url: z.string(),
+});
+
+export const HttpContent = z.object({
+  path: z.string(),
+  http: HttpRelease,
+});
+
 export const Contents = z.union([
   HelmChartContent,
   GitRefContent,
   GithubReleaseContent,
+  HttpContent,
 ]);
 
 export const Vendir = VendirResource.extend({
@@ -60,3 +70,4 @@ export type VendirDefinition = z.infer<typeof Vendir>;
 export type HelmChartDefinition = z.infer<typeof HelmChart>;
 export type GitRefDefinition = z.infer<typeof GitRef>;
 export type GithubReleaseDefinition = z.infer<typeof GithubRelease>;
+export type HttpReleaseDefinition = z.infer<typeof HttpRelease>;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
As noted in #41435, Vendir's support for HTTP sources would be useful
for Renovate to keep updated.

Instead of managing the updating of files ourselves, we can use Vendir's
existing `lockFileMaintenance` task to do so, where `vendir sync` will
re-fetch the remote file(s) and sync them to the repo.

For this to be supported, we can extract the HTTP sources with
`unsupported-datasource`, so Renovate knows that the dependency is
there, but can't be managed by us.

This makes it possible to extract HTTP dependencies, and then have
Renovate update them through `lockFileMaintenance`.


## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #41435
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
