### PR TITLE
refactor(vendir): remove nullable return from extraction methods

### DIFF
--- a/lib/modules/manager/vendir/extract.ts
+++ b/lib/modules/manager/vendir/extract.ts
@@ -22,7 +22,7 @@ import { Vendir } from './schema.ts';
 export function extractHelmChart(
   helmChart: HelmChartDefinition,
   aliases?: Record<string, string>,
-): PackageDependency | null {
+): PackageDependency {
   if (isOCIRegistry(helmChart.repository.url)) {
     const dep = getDep(
       `${removeOCIPrefix(helmChart.repository.url)}/${helmChart.name}:${helmChart.version}`,
@@ -49,7 +49,7 @@ export function extractHelmChart(
 
 export function extractGitSource(
   gitSource: GitRefDefinition,
-): PackageDependency | null {
+): PackageDependency {
   const httpUrl = getHttpUrl(gitSource.url);
   return {
     depName: httpUrl,
@@ -61,7 +61,7 @@ export function extractGitSource(
 
 export function extractGithubReleaseSource(
   githubRelease: GithubReleaseDefinition,
-): PackageDependency | null {
+): PackageDependency {
   return {
     depName: githubRelease.slug,
     packageName: githubRelease.slug,
@@ -104,19 +104,13 @@ export function extractPackageFile(
   for (const content of contents) {
     if ('helmChart' in content && content.helmChart) {
       const dep = extractHelmChart(content.helmChart, config.registryAliases);
-      if (dep) {
-        deps.push(dep);
-      }
+      deps.push(dep);
     } else if ('git' in content && content.git) {
       const dep = extractGitSource(content.git);
-      if (dep) {
-        deps.push(dep);
-      }
+      deps.push(dep);
     } else if ('githubRelease' in content && content.githubRelease) {
       const dep = extractGithubReleaseSource(content.githubRelease);
-      if (dep) {
-        deps.push(dep);
-      }
+      deps.push(dep);
     }
   }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
As we're always returning a dependency, we can remove the nullable
return type.

This also allows us to increase test coverage, because we now don't have
code paths that aren't tested.

Helps with https://github.com/renovatebot/renovate/pull/41443

## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
