### PR TITLE
fix(util): don't include filename in "Hidden Unicode" warning

### DIFF
--- a/lib/util/fs/index.spec.ts
+++ b/lib/util/fs/index.spec.ts
@@ -132,7 +132,7 @@ describe('util/fs/index', () => {
       // NOTE that we cannot test that this is called once across multiple `readLocalFile` as we're mocking the logger, so we're testing that it's called, not validating the nubmer of times
       expect(logger.logger.once.warn).toHaveBeenCalledWith(
         { file: 'file.txt', hiddenCharacters: '\\u00A0\\u200D' },
-        'Hidden Unicode characters have been discovered in the file `file.txt`. Please confirm that they are intended to be there, as they could be an attempt to "smuggle" text into your codebase, or used to confuse tools like Renovate or Large Language Models (LLMs)',
+        'Hidden Unicode characters have been discovered in file(s) in your repository. See your Renovate logs for more details. Please confirm that they are intended to be there, as they could be an attempt to "smuggle" text into your codebase, or used to confuse tools like Renovate or Large Language Models (LLMs)',
       );
     });
 
@@ -162,7 +162,7 @@ describe('util/fs/index', () => {
 
         expect(logger.logger.once.warn).toHaveBeenCalledWith(
           { file: 'example.csproj', hiddenCharacters: '\\uFEFF\\u200B' },
-          'Hidden Unicode characters have been discovered in the file `example.csproj`. Please confirm that they are intended to be there, as they could be an attempt to "smuggle" text into your codebase, or used to confuse tools like Renovate or Large Language Models (LLMs)',
+          'Hidden Unicode characters have been discovered in file(s) in your repository. See your Renovate logs for more details. Please confirm that they are intended to be there, as they could be an attempt to "smuggle" text into your codebase, or used to confuse tools like Renovate or Large Language Models (LLMs)',
         );
       });
     });

--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -615,7 +615,7 @@ describe('util/git/index', { timeout: 10000 }, () => {
 
       expect(logger.logger.once.warn).toHaveBeenCalledWith(
         { file: 'Dockerfile', hiddenCharacters: '\\u00A0' },
-        'Hidden Unicode characters have been discovered in the file `Dockerfile`. Please confirm that they are intended to be there, as they could be an attempt to "smuggle" text into your codebase, or used to confuse tools like Renovate or Large Language Models (LLMs)',
+        'Hidden Unicode characters have been discovered in file(s) in your repository. See your Renovate logs for more details. Please confirm that they are intended to be there, as they could be an attempt to "smuggle" text into your codebase, or used to confuse tools like Renovate or Large Language Models (LLMs)',
       );
     });
   });

--- a/lib/util/unicode.ts
+++ b/lib/util/unicode.ts
@@ -23,7 +23,7 @@ export function logWarningIfUnicodeHiddenCharactersInPackageFile(
           file,
           hiddenCharacters: toUnicodeEscape(hiddenCharacters.join('')),
         },
-        `Hidden Unicode characters have been discovered in the file \`${file}\`. Please confirm that they are intended to be there, as they could be an attempt to "smuggle" text into your codebase, or used to confuse tools like Renovate or Large Language Models (LLMs)`,
+        `Hidden Unicode characters have been discovered in file(s) in your repository. See your Renovate logs for more details. Please confirm that they are intended to be there, as they could be an attempt to "smuggle" text into your codebase, or used to confuse tools like Renovate or Large Language Models (LLMs)`,
       );
     }
   }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
As noted in #41467, if a repository has many files with these warnings,
the Dependency Dashboard can be flooded, which can reduce the utility,
especially if some of these may be false positives.

We can remove the filename from the WARN message, which will ensure that
only a single message is logged.

However, this will reduce the utility of the log message, as then users
need to check their logs to see the `file`.


## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #41467
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
