### PR TITLE
fix(util): don't log "Hidden Unicode" warning when reading a binary file

### DIFF
--- a/lib/util/unicode.spec.ts
+++ b/lib/util/unicode.spec.ts
@@ -1,0 +1,71 @@
+import { logger } from '~test/util.ts';
+import { logWarningIfUnicodeHiddenCharactersInPackageFile } from './unicode.ts';
+
+describe('util/unicode', () => {
+  describe('logWarningIfUnicodeHiddenCharactersInPackageFile', () => {
+    it('logs a warning for hidden Unicode characters in text files', () => {
+      const content = 'some\u00A0content\u200Bfoo';
+      logWarningIfUnicodeHiddenCharactersInPackageFile('file.txt', content);
+
+      expect(logger.logger.once.warn).toHaveBeenCalledWith(
+        { file: 'file.txt', hiddenCharacters: '\\u00A0\\u200B' },
+        `Hidden Unicode characters have been discovered in file(s) in your repository. See your Renovate logs for more details. Please confirm that they are intended to be there, as they could be an attempt to "smuggle" text into your codebase, or used to confuse tools like Renovate or Large Language Models (LLMs)`,
+      );
+    });
+
+    it('logs a trace message for BOM character only', () => {
+      const content = '\uFEFF<Project Sdk="Microsoft.NET.Sdk">';
+      logWarningIfUnicodeHiddenCharactersInPackageFile(
+        'example.csproj',
+        content,
+      );
+
+      expect(logger.logger.once.warn).toHaveBeenCalledTimes(0);
+      expect(logger.logger.once.trace).toHaveBeenCalledWith(
+        { file: 'example.csproj', hiddenCharacters: '\\uFEFF' },
+        'Hidden Byte Order Mark (BOM) Unicode characters has been discovered in the file `example.csproj`. This is likely safe, if you are using Microsoft Windows, but please confirm that they are intended to be there, as they could be an attempt to "smuggle" text into your codebase, or used to confuse tools like Renovate or Large Language Models (LLMs)',
+      );
+    });
+
+    it('does not log a warning for binary files with null bytes but no hidden unicode', () => {
+      const binaryContent = Buffer.from([
+        0x50, 0x4b, 0x03, 0x04, 0x00, 0x00, 0x00, 0x00, 0x74, 0x65, 0x78, 0x74,
+      ]);
+      logWarningIfUnicodeHiddenCharactersInPackageFile(
+        'binary.zip',
+        binaryContent,
+      );
+
+      expect(logger.logger.once.warn).toHaveBeenCalledTimes(0);
+      expect(logger.logger.trace).toHaveBeenCalledTimes(0);
+    });
+
+    it('logs a trace message (not warning) for binary files with hidden unicode characters', () => {
+      // Binary file with null byte (making it binary) followed by 0x200B (zero-width space)
+      const binaryContent = Buffer.from([
+        0x50, 0x4b, 0x03, 0x04, 0x00, 0x00, 0xe2, 0x80, 0x8b, 0x74, 0x65, 0x78,
+      ]); // 0xe2 0x80 0x8b is UTF-8 encoding of U+200B (zero-width space)
+      logWarningIfUnicodeHiddenCharactersInPackageFile(
+        'binary.dat',
+        binaryContent,
+      );
+
+      expect(logger.logger.once.warn).toHaveBeenCalledTimes(0);
+      expect(logger.logger.trace).toHaveBeenCalledWith(
+        {
+          file: 'binary.dat',
+          hiddenCharacters: expect.stringContaining('\\u200B'),
+        },
+        'Hidden Unicode characters discovered in file `binary.dat`, but not logging higher than TRACE as it appears to be a binary file',
+      );
+    });
+
+    it('does not log a warning when no hidden characters are present', () => {
+      const content = 'normal text content';
+      logWarningIfUnicodeHiddenCharactersInPackageFile('file.txt', content);
+
+      expect(logger.logger.once.warn).toHaveBeenCalledTimes(0);
+      expect(logger.logger.once.trace).toHaveBeenCalledTimes(0);
+    });
+  });
+});

--- a/lib/util/unicode.ts
+++ b/lib/util/unicode.ts
@@ -1,13 +1,38 @@
 import { logger } from '../logger/index.ts';
 import { hiddenUnicodeCharactersRegex, toUnicodeEscape } from './regex.ts';
 
+function isBinaryContent(content: Buffer): boolean {
+  // Check for null bytes in the first 8KB - a common indicator of binary content
+  const sampleSize = Math.min(content.length, 8192);
+  for (let i = 0; i < sampleSize; i++) {
+    if (content[i] === 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
 export function logWarningIfUnicodeHiddenCharactersInPackageFile(
   file: string,
   content: string | Buffer,
 ): void {
-  const hiddenCharacters = content
+  const buffer = Buffer.isBuffer(content) ? content : Buffer.from(content);
+  const hiddenCharacters = buffer
     .toString('utf8')
     .match(hiddenUnicodeCharactersRegex);
+
+  if (isBinaryContent(buffer) && hiddenCharacters) {
+    logger.trace(
+      {
+        file,
+        hiddenCharacters: toUnicodeEscape(hiddenCharacters.join('')),
+      },
+
+      `Hidden Unicode characters discovered in file \`${file}\`, but not logging higher than TRACE as it appears to be a binary file`,
+    );
+    return;
+  }
+
   if (hiddenCharacters) {
     if (hiddenCharacters.length === 1 && hiddenCharacters[0] === '\uFEFF') {
       logger.once.trace(


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
In the case that we are reading binary files in repositories, we should
not log a WARN that there are "hidden" characters in it, as it's a
binary file.

We can use a common heuristic (at least according to Claude Sonnet 4.5)
to look for null bytes at the beginning of our files, and not log the
warning in that case.


## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #41466
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe): Claude Sonnet 4.5 (GitHub Copilot + `crush`)

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/mu88/BlazorFotoManager

(doesn't show the warning)

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
