### PR TITLE
refactor(libyears): clarify log messages are LibYear related

### DIFF
--- a/lib/workers/repository/process/libyear.spec.ts
+++ b/lib/workers/repository/process/libyear.spec.ts
@@ -96,15 +96,15 @@ describe('workers/repository/process/libyear', () => {
       calculateLibYears(config, packageFiles);
 
       expect(logger.logger.once.debug).toHaveBeenCalledWith(
-        'No currentVersionTimestamp for some/image',
+        'LibYears: no currentVersionTimestamp for some/image',
       );
 
       expect(logger.logger.once.debug).toHaveBeenCalledWith(
-        'No releaseTimestamp for dep1 update to 3.0.0',
+        'LibYears: no releaseTimestamp for dep1 update to 3.0.0',
       );
 
       expect(logger.logger.once.debug).toHaveBeenCalledWith(
-        'No currentVersionTimestamp for dep3',
+        'LibYears: no currentVersionTimestamp for dep3',
       );
 
       expect(logger.logger.debug).toHaveBeenCalledWith(

--- a/lib/workers/repository/process/libyear.ts
+++ b/lib/workers/repository/process/libyear.ts
@@ -41,7 +41,9 @@ export function calculateLibYears(
 
         depInfo.outdated = true;
         if (!dep.currentVersionTimestamp) {
-          logger.once.debug(`No currentVersionTimestamp for ${dep.depName}`);
+          logger.once.debug(
+            `LibYears: no currentVersionTimestamp for ${dep.depName}`,
+          );
           allDeps.push(depInfo);
           continue;
         }
@@ -53,7 +55,7 @@ export function calculateLibYears(
         for (const update of dep.updates) {
           if (!update.releaseTimestamp) {
             logger.once.debug(
-              `No releaseTimestamp for ${dep.depName} update to ${update.newVersion}`,
+              `LibYears: no releaseTimestamp for ${dep.depName} update to ${update.newVersion}`,
             );
             continue;
           }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
As it can be a little confusing exactly where this log message is coming
from, otherwise.

Relates to #41244.

## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
