### PR TITLE
fix(lookup): write back sourceUrl from packageRules after source-url stage

### DIFF
--- a/lib/workers/repository/process/lookup/index.spec.ts
+++ b/lib/workers/repository/process/lookup/index.spec.ts
@@ -4545,6 +4545,32 @@ describe('workers/repository/process/lookup/index', () => {
       });
     });
 
+    it('allows packageRules to override sourceUrl from datasource', async () => {
+      config.packageName = 'openjdk';
+      config.currentValue = '17.0.0';
+      config.datasource = DockerDatasource.id;
+      config.versioning = dockerVersioningId;
+      config.packageRules = [
+        {
+          matchDatasources: ['docker'],
+          sourceUrl: 'https://harbor.example.com',
+        },
+      ];
+      getDockerReleases.mockResolvedValueOnce({
+        sourceUrl: 'https://github.com/upstream/repo',
+        releases: [
+          { version: '17.0.0' },
+          { version: '18.0.0' },
+        ],
+      });
+
+      const res = await Result.wrap(
+        lookup.lookupUpdates(config),
+      ).unwrapOrThrow();
+
+      expect(res.sourceUrl).toBe('https://harbor.example.com');
+    });
+
     it('handles current age packageRules with version restrictions', async () => {
       config.packageName = 'openjdk';
       config.currentValue = '17.0.0';

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -232,6 +232,12 @@ export async function lookupUpdates(
         { ...config, sourceUrl: res.sourceUrl },
         'source-url',
       );
+      // Write back sourceUrl if overridden by packageRules, so the
+      // user-configured value takes precedence over the datasource value
+      // (e.g. OCI image labels on mirrored Docker images)
+      if (config.sourceUrl && config.sourceUrl !== res.sourceUrl) {
+        res.sourceUrl = config.sourceUrl;
+      }
       if (config.followTag) {
         const taggedVersion = dependency.tags?.[config.followTag];
         if (!taggedVersion) {


### PR DESCRIPTION
Fixes an issue where `sourceUrl` set via `packageRules` doesn't override the value provided by a datasource (e.g. Docker OCI image labels).

**The problem:** When `applyPackageRules` runs at the `'source-url'` stage in `lookupUpdates`, any user-configured `sourceUrl` override is applied to `config` — but it's never written back to `res.sourceUrl`. So the datasource value always wins.

This doesn't matter for datasources that don't provide a `sourceUrl`, since there's nothing in `res` to compete with. But for Docker images with `org.opencontainers.image.source` OCI labels, the label value always takes precedence over the user's packageRule.

**The fix:** After the `'source-url'` call to `applyPackageRules`, write `config.sourceUrl` back to `res.sourceUrl` when the two differ. This lets the user's explicit override win.

**Testing:**
- Added a test case that sets up a Docker datasource returning a sourceUrl and a packageRule overriding it, then asserts the override is reflected in the result
- All 374 existing tests in the lookup suite pass
- Verified with a self-hosted dry-run against a repo with mirrored Harbor images

Discussion: #41505