### PR TITLE
feat(gradle): set `toolSettings`' JVM limits when invoking `./gradlew`

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -4712,7 +4712,7 @@ Please see the above link for valid timezone names.
 
 ## toolSettings
 
-When Renovate updates a dependency and needs to invoke processes leveraging Java, for example Gradle for [the `gradle-wrapper` manager](./modules/manager/gradle-wrapper/index.md), the repository's Gradle Wrapper will be invoked, if present.
+When Renovate updates a dependency and needs to invoke processes leveraging Java, for example Gradle for [the `gradle`](./modules/manager/gradle/index.md) or [the `gradle-wrapper`](./modules/manager/gradle-wrapper/index.md) managers, the repository's Gradle Wrapper will be invoked, if present.
 
 The JVM heap size for the Java invocations is 512m by default.
 This can be overridden using the following options.
@@ -4726,14 +4726,14 @@ This option can be used on the repository level and in the [Renovate configurati
 
 <!-- prettier-ignore -->
 !!! note
-    The JVM memory settings are considered for the `gradle-wrapper` manager.
+    The JVM memory settings are considered for the `gradle` and `gradle-wrapper` manager.
 
 ### jvmMaxMemory
 
 Maximum heap size in MB for Java VMs.
 Defaults to `512` for both the repository level and self-hosted configuration.
 
-To allow repositories to use _more_ than 512m of heap during the Gradle Wrapper update, configure the `jvmMaxMemory` option in the [`toolSettings.jvmMaxMemory`](./self-hosted-configuration.md).
+To allow repositories to use _more_ than 512m of heap during any invocations of the Gradle Wrapper, configure the `jvmMaxMemory` option in the [`toolSettings.jvmMaxMemory`](./self-hosted-configuration.md).
 
 ### jvmMemory
 

--- a/lib/modules/manager/gradle/artifacts.spec.ts
+++ b/lib/modules/manager/gradle/artifacts.spec.ts
@@ -199,6 +199,51 @@ describe('modules/manager/gradle/artifacts', () => {
       expect(execSnapshots).toBeEmptyArray();
     });
 
+    it('uses custom JVM heap settings when toolSettings are configured', async () => {
+      const execSnapshots = mockExecAll();
+      GlobalConfig.set({
+        ...adminConfig,
+        toolSettings: { jvmMaxMemory: 600 },
+      });
+
+      const res = await updateArtifacts({
+        packageFileName: 'build.gradle',
+        updatedDeps: [
+          { depName: 'org.junit.jupiter:junit-jupiter-api' },
+          { depName: 'org.junit.jupiter:junit-jupiter-engine' },
+        ],
+        newPackageFileContent: '',
+        config: {},
+      });
+
+      expect(res).toEqual([
+        {
+          file: {
+            type: 'addition',
+            path: 'gradle.lockfile',
+            contents: 'New gradle.lockfile',
+          },
+        },
+      ]);
+      expect(execSnapshots).toMatchObject([
+        {
+          cmd: './gradlew -Dorg.gradle.jvmargs="-Xms600m -Xmx600m" --console=plain --dependency-verification lenient -q properties',
+          options: {
+            cwd: '/tmp/github/some/repo',
+          },
+        },
+        {
+          cmd: './gradlew -Dorg.gradle.jvmargs="-Xms600m -Xmx600m" --console=plain --dependency-verification lenient -q :dependencies --update-locks org.junit.jupiter:junit-jupiter-api,org.junit.jupiter:junit-jupiter-engine',
+          options: {
+            cwd: '/tmp/github/some/repo',
+            stdin: 'pipe',
+            stdout: 'ignore',
+            stderr: 'pipe',
+          },
+        },
+      ]);
+    });
+
     it('updates lock file', async () => {
       const execSnapshots = mockExecAll();
 
@@ -223,13 +268,13 @@ describe('modules/manager/gradle/artifacts', () => {
       ]);
       expect(execSnapshots).toMatchObject([
         {
-          cmd: './gradlew --console=plain --dependency-verification lenient -q properties',
+          cmd: './gradlew -Dorg.gradle.jvmargs="-Xms512m -Xmx512m" --console=plain --dependency-verification lenient -q properties',
           options: {
             cwd: '/tmp/github/some/repo',
           },
         },
         {
-          cmd: './gradlew --console=plain --dependency-verification lenient -q :dependencies --update-locks org.junit.jupiter:junit-jupiter-api,org.junit.jupiter:junit-jupiter-engine',
+          cmd: './gradlew -Dorg.gradle.jvmargs="-Xms512m -Xmx512m" --console=plain --dependency-verification lenient -q :dependencies --update-locks org.junit.jupiter:junit-jupiter-api,org.junit.jupiter:junit-jupiter-engine',
           options: {
             cwd: '/tmp/github/some/repo',
             stdin: 'pipe',
@@ -268,13 +313,13 @@ describe('modules/manager/gradle/artifacts', () => {
       // In win32, gradle.bat will be used and /dev/null redirection isn't used yet
       expect(execSnapshots).toMatchObject([
         {
-          cmd: 'gradlew.bat --console=plain --dependency-verification lenient -q properties',
+          cmd: 'gradlew.bat -Dorg.gradle.jvmargs="-Xms512m -Xmx512m" --console=plain --dependency-verification lenient -q properties',
           options: {
             cwd: '/tmp/github/some/repo',
           },
         },
         {
-          cmd: 'gradlew.bat --console=plain --dependency-verification lenient -q :dependencies --update-locks org.junit.jupiter:junit-jupiter-api,org.junit.jupiter:junit-jupiter-engine',
+          cmd: 'gradlew.bat -Dorg.gradle.jvmargs="-Xms512m -Xmx512m" --console=plain --dependency-verification lenient -q :dependencies --update-locks org.junit.jupiter:junit-jupiter-api,org.junit.jupiter:junit-jupiter-engine',
           options: {
             cwd: '/tmp/github/some/repo',
             stdin: 'pipe',
@@ -313,13 +358,13 @@ describe('modules/manager/gradle/artifacts', () => {
       ]);
       expect(execSnapshots).toMatchObject([
         {
-          cmd: './gradlew --console=plain --dependency-verification lenient -q properties',
+          cmd: './gradlew -Dorg.gradle.jvmargs="-Xms512m -Xmx512m" --console=plain --dependency-verification lenient -q properties',
           options: {
             cwd: '/tmp/github/some/repo',
           },
         },
         {
-          cmd: './gradlew --console=plain --dependency-verification lenient -q :dependencies --update-locks org.springframework.boot:org.springframework.boot.gradle.plugin',
+          cmd: './gradlew -Dorg.gradle.jvmargs="-Xms512m -Xmx512m" --console=plain --dependency-verification lenient -q :dependencies --update-locks org.springframework.boot:org.springframework.boot.gradle.plugin',
           options: {
             cwd: '/tmp/github/some/repo',
             stdin: 'pipe',
@@ -366,13 +411,13 @@ describe('modules/manager/gradle/artifacts', () => {
       ]);
       expect(execSnapshots).toMatchObject([
         {
-          cmd: './gradlew --console=plain --dependency-verification lenient -q properties',
+          cmd: './gradlew -Dorg.gradle.jvmargs="-Xms512m -Xmx512m" --console=plain --dependency-verification lenient -q properties',
           options: {
             cwd: '/tmp/github/some/repo',
           },
         },
         {
-          cmd: './gradlew --console=plain --dependency-verification lenient -q :dependencies --write-locks',
+          cmd: './gradlew -Dorg.gradle.jvmargs="-Xms512m -Xmx512m" --console=plain --dependency-verification lenient -q :dependencies --write-locks',
           options: {
             cwd: '/tmp/github/some/repo',
             stdin: 'pipe',
@@ -418,7 +463,7 @@ describe('modules/manager/gradle/artifacts', () => {
             ' bash -l -c "' +
             'install-tool java 16.0.1' +
             ' && ' +
-            './gradlew --console=plain --dependency-verification lenient -q properties' +
+            './gradlew -Dorg.gradle.jvmargs=\\"-Xms512m -Xmx512m\\" --console=plain --dependency-verification lenient -q properties' +
             '"',
           options: { cwd: '/tmp/github/some/repo' },
         },
@@ -435,7 +480,7 @@ describe('modules/manager/gradle/artifacts', () => {
             ' bash -l -c "' +
             'install-tool java 16.0.1' +
             ' && ' +
-            './gradlew --console=plain --dependency-verification lenient -q :dependencies --write-locks' +
+            './gradlew -Dorg.gradle.jvmargs=\\"-Xms512m -Xmx512m\\" --console=plain --dependency-verification lenient -q :dependencies --write-locks' +
             '"',
           options: {
             cwd: '/tmp/github/some/repo',
@@ -470,12 +515,12 @@ describe('modules/manager/gradle/artifacts', () => {
       expect(execSnapshots).toMatchObject([
         { cmd: 'install-tool java 16.0.1' },
         {
-          cmd: './gradlew --console=plain --dependency-verification lenient -q properties',
+          cmd: './gradlew -Dorg.gradle.jvmargs="-Xms512m -Xmx512m" --console=plain --dependency-verification lenient -q properties',
           options: { cwd: '/tmp/github/some/repo' },
         },
         { cmd: 'install-tool java 16.0.1' },
         {
-          cmd: './gradlew --console=plain --dependency-verification lenient -q :dependencies --write-locks',
+          cmd: './gradlew -Dorg.gradle.jvmargs="-Xms512m -Xmx512m" --console=plain --dependency-verification lenient -q :dependencies --write-locks',
           options: {
             cwd: '/tmp/github/some/repo',
             stdin: 'pipe',
@@ -513,13 +558,13 @@ describe('modules/manager/gradle/artifacts', () => {
       ]);
       expect(execSnapshots).toMatchObject([
         {
-          cmd: './gradlew --console=plain --dependency-verification lenient -q properties',
+          cmd: './gradlew -Dorg.gradle.jvmargs="-Xms512m -Xmx512m" --console=plain --dependency-verification lenient -q properties',
           options: {
             cwd: '/tmp/github/some/repo',
           },
         },
         {
-          cmd: './gradlew --console=plain --dependency-verification lenient -q :dependencies :sub1:dependencies :sub2:dependencies --write-locks',
+          cmd: './gradlew -Dorg.gradle.jvmargs="-Xms512m -Xmx512m" --console=plain --dependency-verification lenient -q :dependencies :sub1:dependencies :sub2:dependencies --write-locks',
           options: {
             cwd: '/tmp/github/some/repo',
             stdin: 'pipe',
@@ -565,7 +610,7 @@ describe('modules/manager/gradle/artifacts', () => {
 
       expect(execSnapshots).toMatchObject([
         {
-          cmd: './gradlew --console=plain --dependency-verification lenient -q properties',
+          cmd: './gradlew -Dorg.gradle.jvmargs="-Xms512m -Xmx512m" --console=plain --dependency-verification lenient -q properties',
           options: {
             cwd: '/tmp/github/some/repo',
           },
@@ -618,12 +663,12 @@ describe('modules/manager/gradle/artifacts', () => {
       expect(execSnapshots).toMatchObject([
         { cmd: 'install-tool java 11.0.1' },
         {
-          cmd: './gradlew --console=plain --dependency-verification lenient -q properties',
+          cmd: './gradlew -Dorg.gradle.jvmargs="-Xms512m -Xmx512m" --console=plain --dependency-verification lenient -q properties',
           options: { cwd: '/tmp/github/some/repo' },
         },
         { cmd: 'install-tool java 11.0.1' },
         {
-          cmd: './gradlew --console=plain --dependency-verification lenient -q :dependencies --write-locks',
+          cmd: './gradlew -Dorg.gradle.jvmargs="-Xms512m -Xmx512m" --console=plain --dependency-verification lenient -q :dependencies --write-locks',
           options: {
             cwd: '/tmp/github/some/repo',
             stdin: 'pipe',
@@ -672,7 +717,7 @@ describe('modules/manager/gradle/artifacts', () => {
       ]);
       expect(execSnapshots).toMatchObject([
         {
-          cmd: './gradlew --console=plain --dependency-verification lenient -q --write-verification-metadata sha256 dependencies',
+          cmd: './gradlew -Dorg.gradle.jvmargs="-Xms512m -Xmx512m" --console=plain --dependency-verification lenient -q --write-verification-metadata sha256 dependencies',
           options: {
             cwd: '/tmp/github/some/repo',
             stdin: 'pipe',
@@ -761,7 +806,7 @@ describe('modules/manager/gradle/artifacts', () => {
       ]);
       expect(execSnapshots).toMatchObject([
         {
-          cmd: './gradlew --console=plain --dependency-verification lenient -q --write-verification-metadata sha256 dependencies',
+          cmd: './gradlew -Dorg.gradle.jvmargs="-Xms512m -Xmx512m" --console=plain --dependency-verification lenient -q --write-verification-metadata sha256 dependencies',
           options: {
             cwd: '/tmp/github/some/repo',
             stdin: 'pipe',
@@ -820,13 +865,13 @@ describe('modules/manager/gradle/artifacts', () => {
       ]);
       expect(execSnapshots).toMatchObject([
         {
-          cmd: './gradlew --console=plain --dependency-verification lenient -q properties',
+          cmd: './gradlew -Dorg.gradle.jvmargs="-Xms512m -Xmx512m" --console=plain --dependency-verification lenient -q properties',
           options: {
             cwd: '/tmp/github/some/repo',
           },
         },
         {
-          cmd: './gradlew --console=plain --dependency-verification lenient -q :dependencies --update-locks org.junit.jupiter:junit-jupiter-api,org.junit.jupiter:junit-jupiter-engine',
+          cmd: './gradlew -Dorg.gradle.jvmargs="-Xms512m -Xmx512m" --console=plain --dependency-verification lenient -q :dependencies --update-locks org.junit.jupiter:junit-jupiter-api,org.junit.jupiter:junit-jupiter-engine',
           options: {
             cwd: '/tmp/github/some/repo',
             stdin: 'pipe',
@@ -835,7 +880,7 @@ describe('modules/manager/gradle/artifacts', () => {
           },
         },
         {
-          cmd: './gradlew --console=plain --dependency-verification lenient -q --write-verification-metadata sha256 dependencies',
+          cmd: './gradlew -Dorg.gradle.jvmargs="-Xms512m -Xmx512m" --console=plain --dependency-verification lenient -q --write-verification-metadata sha256 dependencies',
           options: {
             cwd: '/tmp/github/some/repo',
             stdin: 'pipe',
@@ -880,7 +925,7 @@ describe('modules/manager/gradle/artifacts', () => {
 
       expect(execSnapshots).toMatchObject([
         {
-          cmd: './gradlew --console=plain --dependency-verification lenient -q --write-verification-metadata sha256 dependencies',
+          cmd: './gradlew -Dorg.gradle.jvmargs="-Xms512m -Xmx512m" --console=plain --dependency-verification lenient -q --write-verification-metadata sha256 dependencies',
           options: {
             cwd: '/tmp/github/some/repo',
             stdin: 'pipe',
@@ -924,7 +969,7 @@ describe('modules/manager/gradle/artifacts', () => {
 
       expect(execSnapshots).toMatchObject([
         {
-          cmd: './gradlew --console=plain --dependency-verification lenient -q --write-verification-metadata sha256,pgp dependencies',
+          cmd: './gradlew -Dorg.gradle.jvmargs="-Xms512m -Xmx512m" --console=plain --dependency-verification lenient -q --write-verification-metadata sha256,pgp dependencies',
           options: {
             cwd: '/tmp/github/some/repo',
             stdin: 'pipe',

--- a/lib/modules/manager/gradle/artifacts.ts
+++ b/lib/modules/manager/gradle/artifacts.ts
@@ -4,7 +4,11 @@ import upath from 'upath';
 import { GlobalConfig } from '../../../config/global.ts';
 import { TEMPORARY_ERROR } from '../../../constants/error-messages.ts';
 import { logger } from '../../../logger/index.ts';
-import { exec } from '../../../util/exec/index.ts';
+import {
+  exec,
+  getToolSettingsOptions,
+  gradleJvmArg,
+} from '../../../util/exec/index.ts';
 import type { ExecOptions } from '../../../util/exec/types.ts';
 import {
   findUpLocal,
@@ -208,7 +212,7 @@ export async function updateArtifacts({
     const oldLockFileContentMap = await getFiles(lockFiles);
     await prepareGradleCommand(gradlewFile);
 
-    const baseCmd = `${gradlewName} --console=plain --dependency-verification lenient -q`;
+    const baseCmd = `${gradlewName}${gradleJvmArg(getToolSettingsOptions(config.toolSettings))} --console=plain --dependency-verification lenient -q`;
     const execOptions: ExecOptions = {
       cwdFile: gradlewFile,
       docker: {},


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
As noted in #39559, we should also make it possible to use Renovate's
`toolSettings` to tune the Java Virtual Machine that's used to spawn
Gradle, via the Gradle Wrapper.

This will affect any `gradle` manager invocations, but will not apply to
`postUpgradeTasks`, as this is passed in as a parameter.

> [!NOTE]
> This may be breaking for users who have JVM settings configured in their Gradle projects' configuration, which is now higher than what the self-hosted administrator has set (or the default, `512MB`)


## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #39559
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe): Claude Sonnet 4.5 (GitHub Copilot + `crush`)

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
