### PR TITLE
fix(gomod): skip placeholder pseudo versions

### DIFF
--- a/lib/modules/manager/gomod/extract.spec.ts
+++ b/lib/modules/manager/gomod/extract.spec.ts
@@ -348,4 +348,99 @@ describe('modules/manager/gomod/extract', () => {
     const res = extractPackageFile(goMod);
     expect(res).toBeNull();
   });
+
+  it('marks placeholder pseudo versions with skipReason invalid-version', () => {
+    const goMod = codeBlock`
+        module github.com/renovate-tests/gomod
+        go 1.19
+        require (
+          github.com/foo/bar v1.2.3
+          github.com/baz/qux v0.0.0-00010101000000-000000000000
+          github.com/example/local v0.0.0-00010101000000-000000000000 // indirect
+          github.com/non/placeholder v1.2.4-0.20230101120000-abcdef123456
+          monorepo v0.0.0-00010101000000-000000000000
+        )
+      `;
+    const res = extractPackageFile(goMod);
+    expect(res).toEqual({
+      deps: [
+        {
+          managerData: {
+            lineNumber: 1,
+          },
+          depName: 'go',
+          depType: 'golang',
+          currentValue: '1.19',
+          datasource: 'golang-version',
+          versioning: 'go-mod-directive',
+        },
+        {
+          managerData: {
+            lineNumber: 3,
+            multiLine: true,
+          },
+          depName: 'github.com/foo/bar',
+          depType: 'require',
+          currentValue: 'v1.2.3',
+          datasource: 'go',
+        },
+        {
+          managerData: {
+            lineNumber: 4,
+            multiLine: true,
+          },
+          depName: 'github.com/baz/qux',
+          depType: 'require',
+          currentValue: 'v0.0.0-00010101000000-000000000000',
+          datasource: 'go',
+          skipReason: 'invalid-version',
+          currentDigest: '000000000000',
+          digestOneAndOnly: true,
+          versioning: 'loose',
+        },
+        {
+          managerData: {
+            lineNumber: 5,
+            multiLine: true,
+          },
+          depName: 'github.com/example/local',
+          depType: 'indirect',
+          currentValue: 'v0.0.0-00010101000000-000000000000',
+          datasource: 'go',
+          skipReason: 'invalid-version',
+          enabled: false,
+          currentDigest: '000000000000',
+          digestOneAndOnly: true,
+          versioning: 'loose',
+        },
+        {
+          managerData: {
+            lineNumber: 6,
+            multiLine: true,
+          },
+          depName: 'github.com/non/placeholder',
+          depType: 'require',
+          currentValue: 'v1.2.4-0.20230101120000-abcdef123456',
+          datasource: 'go',
+          currentDigest: 'abcdef123456',
+          digestOneAndOnly: true,
+          versioning: 'loose',
+        },
+        {
+          managerData: {
+            lineNumber: 7,
+            multiLine: true,
+          },
+          depName: 'monorepo',
+          depType: 'require',
+          currentValue: 'v0.0.0-00010101000000-000000000000',
+          datasource: 'go',
+          currentDigest: '000000000000',
+          digestOneAndOnly: true,
+          versioning: 'loose',
+          skipReason: 'invalid-version',
+        },
+      ],
+    });
+  });
 });

--- a/lib/modules/manager/gomod/line-parser.spec.ts
+++ b/lib/modules/manager/gomod/line-parser.spec.ts
@@ -80,6 +80,21 @@ describe('modules/manager/gomod/line-parser', () => {
     });
   });
 
+  it('should parse require definition with placeholder pseudo-version', () => {
+    const line = 'require foo/foo v0.0.0-00010101000000-000000000000';
+    const res = parseLine(line);
+    expect(res).toStrictEqual({
+      currentDigest: '000000000000',
+      currentValue: 'v0.0.0-00010101000000-000000000000',
+      datasource: 'go',
+      depName: 'foo/foo',
+      depType: 'require',
+      digestOneAndOnly: true,
+      skipReason: 'invalid-version',
+      versioning: 'loose',
+    });
+  });
+
   it('should parse require multi-line', () => {
     const line = '        foo/foo v1.2';
     const res = parseLine(line);
@@ -246,6 +261,22 @@ describe('modules/manager/gomod/line-parser', () => {
       depName: 'bar/bar',
       depType: 'replace',
       digestOneAndOnly: true,
+      versioning: 'loose',
+    });
+  });
+
+  it('should parse replace definition with placeholder pseudo-version', () => {
+    const line =
+      'replace foo/foo => bar/bar v0.0.0-00010101000000-000000000000';
+    const res = parseLine(line);
+    expect(res).toStrictEqual({
+      currentDigest: '000000000000',
+      currentValue: 'v0.0.0-00010101000000-000000000000',
+      datasource: 'go',
+      depName: 'bar/bar',
+      depType: 'replace',
+      digestOneAndOnly: true,
+      skipReason: 'invalid-version',
       versioning: 'loose',
     });
   });

--- a/lib/modules/manager/gomod/line-parser.ts
+++ b/lib/modules/manager/gomod/line-parser.ts
@@ -29,9 +29,15 @@ const toolchainVersionRegex = regEx(/^\s*toolchain\s+go(?<version>[^\s]+)\s*$/);
 
 const pseudoVersionRegex = regEx(GoDatasource.pversionRegexp);
 
+const placeholderPseudoVersion = 'v0.0.0-00010101000000-000000000000';
+
 function extractDigest(input: string): string | undefined {
   const match = pseudoVersionRegex.exec(input);
   return match?.groups?.digest;
+}
+
+function isPlaceholderPseudoVersion(version: string): boolean {
+  return version === placeholderPseudoVersion;
 }
 
 export function parseLine(input: string): PackageDependency | null {
@@ -91,6 +97,9 @@ export function parseLine(input: string): PackageDependency | null {
         dep.currentDigest = digest;
         dep.digestOneAndOnly = true;
         dep.versioning = 'loose';
+        if (isPlaceholderPseudoVersion(currentValue)) {
+          dep.skipReason = 'invalid-version';
+        }
       }
     } else {
       dep.skipReason = 'invalid-version';
@@ -132,6 +141,9 @@ export function parseLine(input: string): PackageDependency | null {
         dep.currentDigest = digest;
         dep.digestOneAndOnly = true;
         dep.versioning = 'loose';
+        if (isPlaceholderPseudoVersion(currentValue)) {
+          dep.skipReason = 'invalid-version';
+        }
       }
     } else if (currentValue) {
       dep.skipReason = 'invalid-version';


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
As a follow-up to #41517, when we have a placeholder pseudo version, we
attempt to look up updates for the module.

However, because these are handled by a `replace` directive, there's no
point attempting to look them up.

Especially, as noted in #41517, this could be a non-public module, so
the lookup will fail unnecessarily.

## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe): Claude Sonnet 4.5 (GitHub Copilot + `crush`)

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/JamieTanna-Mend-testing/tka-9783-golang-pro-main/blob/4dba19799260db3fa8d08c9a918cdad7c6dc674b/go.mod

(it doesn't look up `pro-lib`)

```
 INFO: Dependency extraction complete (repository=JamieTanna-Mend-testing/tka-9783-golang-pro-main, baseBranch=main)
       "stats": {
         "managers": {"gomod": {"fileCount": 1, "depCount": 4}},
         "total": {"fileCount": 1, "depCount": 4}
       }
DEBUG: Dependency: github.com/google/go-cmp, is disabled (repository=JamieTanna-Mend-testing/tka-9783-golang-pro-main)
DEBUG: hostRules: no authentication for raw.githubusercontent.com (repository=JamieTanna-Mend-testing/tka-9783-golang-pro-main)
DEBUG: Using queue: host=raw.githubusercontent.com, concurrency=16 (repository=JamieTanna-Mend-testing/tka-9783-golang-pro-main)
DEBUG: hostRules: no authentication for proxy.golang.org (repository=JamieTanna-Mend-testing/tka-9783-golang-pro-main)
DEBUG: Using queue: host=proxy.golang.org, concurrency=16 (repository=JamieTanna-Mend-testing/tka-9783-golang-pro-main)
DEBUG: GET https://proxy.golang.org/github.com/twharmon/gouid/v2/@v/list = (code=ERR_NON_2XX_3XX_RESPONSE, statusCode=404 retryCount=0, duration=205) (repository=JamieTanna-Mend-testing/tka-9783-golang-pro-main)
DEBUG: PackageFiles.add() - Package file saved for base branch (repository=JamieTanna-Mend-testing/tka-9783-golang-pro-main, baseBranch=main)
DEBUG: Package releases lookups complete (repository=JamieTanna-Mend-testing/tka-9783-golang-pro-main, baseBranch=main)
```

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
