### PR TITLE
fix(crate): respect config.json in indices

### DIFF
--- a/lib/modules/datasource/crate/__snapshots__/index.spec.ts.snap
+++ b/lib/modules/datasource/crate/__snapshots__/index.spec.ts.snap
@@ -34,7 +34,7 @@ exports[`modules/datasource/crate/index > getReleases > processes real data: ame
 {
   "dependencyUrl": "https://crates.io/crates/amethyst",
   "homepage": "https://amethyst.rs/",
-  "registryUrl": "https://crates.io",
+  "registryUrl": "sparse+https://index.crates.io",
   "releases": [
     {
       "version": "0.1.0",
@@ -102,7 +102,7 @@ exports[`modules/datasource/crate/index > getReleases > processes real data: ame
 exports[`modules/datasource/crate/index > getReleases > processes real data: libc 1`] = `
 {
   "dependencyUrl": "https://crates.io/crates/libc",
-  "registryUrl": "https://crates.io",
+  "registryUrl": "sparse+https://index.crates.io",
   "releases": [
     {
       "version": "0.1.0",

--- a/lib/modules/datasource/crate/index.spec.ts
+++ b/lib/modules/datasource/crate/index.spec.ts
@@ -55,6 +55,11 @@ function setupGitMocks(delayMs?: number): {
         const path = `${clonePath}/my/pk/mypkg`;
         fs.mkdirSync(upath.dirname(path), { recursive: true });
         fs.writeFileSync(path, Fixtures.get('mypkg'), { encoding: 'utf8' });
+        fs.writeFileSync(
+          `${clonePath}/config.json`,
+          JSON.stringify({ dl: 'https://example.com/crates' }),
+          { encoding: 'utf8' },
+        );
       },
     );
 
@@ -351,6 +356,19 @@ describe('modules/datasource/crate/index', () => {
         registryUrls: [url],
       });
       expect(mockClone).toHaveBeenCalledTimes(1);
+    });
+
+    it('reads config.json from cloned registry', async () => {
+      const { mockClone } = setupGitMocks();
+      GlobalConfig.set({ ...adminConfig, allowCustomCrateRegistries: true });
+      const url = 'https://github.com/mcorbin/testregistry';
+      const res = await getPkgReleases({
+        datasource,
+        packageName: 'mypkg',
+        registryUrls: [url],
+      });
+      expect(mockClone).toHaveBeenCalled();
+      expect(res).not.toBeNull();
     });
 
     it('guards against race conditions while cloning', async () => {

--- a/lib/modules/datasource/crate/index.spec.ts
+++ b/lib/modules/datasource/crate/index.spec.ts
@@ -16,7 +16,6 @@ import * as memCache from '../../../util/cache/memory/index.ts';
 import type { Timestamp } from '../../../util/timestamp.ts';
 import { getPkgReleases } from '../index.ts';
 import { CrateDatasource } from './index.ts';
-import type { RegistryInfo } from './types.ts';
 
 vi.mock('simple-git');
 const simpleGit = vi.mocked(_simpleGit);
@@ -545,21 +544,6 @@ describe('modules/datasource/crate/index', () => {
       });
       expect(mockClone).toHaveBeenCalledTimes(2);
       expect(res).toBeNull();
-    });
-  });
-
-  describe('fetchCrateRecordsPayload', () => {
-    it('rejects if it has neither clonePath nor sparse protocol', async () => {
-      const info: RegistryInfo = {
-        rawUrl: 'https://example.com',
-        url: new URL('https://example.com'),
-        flavor: 'cloudsmith',
-        isSparse: false,
-      };
-      const crateDatasource = new CrateDatasource();
-      await expect(
-        crateDatasource.fetchCrateRecordsPayload(info, 'benedict'),
-      ).toReject();
     });
   });
 

--- a/lib/modules/datasource/crate/index.spec.ts
+++ b/lib/modules/datasource/crate/index.spec.ts
@@ -16,6 +16,7 @@ import * as memCache from '../../../util/cache/memory/index.ts';
 import type { Timestamp } from '../../../util/timestamp.ts';
 import { getPkgReleases } from '../index.ts';
 import { CrateDatasource } from './index.ts';
+import type { RegistryConfigSchema } from './schema.ts';
 
 vi.mock('simple-git');
 const simpleGit = vi.mocked(_simpleGit);
@@ -27,7 +28,7 @@ const CRATES_IO_REGISTRY_URL_PARSED = 'https://index.crates.io/';
 
 const datasource = CrateDatasource.id;
 
-const cratesIoConfig = {
+const cratesIoConfig: RegistryConfigSchema = {
   dl: DL_BASE_URL,
   api: API_BASE_URL,
 };

--- a/lib/modules/datasource/crate/index.ts
+++ b/lib/modules/datasource/crate/index.ts
@@ -183,7 +183,7 @@ export class CrateDatasource extends Datasource {
           'Could not read config.json from cloned registry',
         );
       }
-    } else if (info.isSparse) {
+    } else {
       try {
         const configUrl = joinUrlParts(info.rawUrl, 'config.json');
         const { body } = await this.http.getJson(
@@ -267,18 +267,16 @@ export class CrateDatasource extends Datasource {
       return readCacheFile(path, 'utf8');
     }
 
-    if (info.isSparse) {
-      const packageSuffix = CrateDatasource.getIndexSuffix(
-        packageName.toLowerCase(),
-      );
-      const crateUrl = joinUrlParts(info.rawUrl, ...packageSuffix);
-      try {
-        return (await this.http.getText(crateUrl)).body;
-      } catch (err) {
-        this.handleGenericErrors(err);
-      }
+    // sparse index
+    const packageSuffix = CrateDatasource.getIndexSuffix(
+      packageName.toLowerCase(),
+    );
+    const crateUrl = joinUrlParts(info.rawUrl, ...packageSuffix);
+    try {
+      return (await this.http.getText(crateUrl)).body;
+    } catch (err) {
+      this.handleGenericErrors(err);
     }
-    throw new Error(`unsupported crate registry flavor: ${info.flavor}`);
   }
 
   /**
@@ -363,7 +361,6 @@ export class CrateDatasource extends Datasource {
       flavor,
       rawUrl: registryFetchUrl,
       url,
-      isSparse: isSparseRegistry,
     };
 
     if (
@@ -375,7 +372,7 @@ export class CrateDatasource extends Datasource {
       );
       return null;
     }
-    if (!registry.isSparse) {
+    if (!isSparseRegistry) {
       const cacheKey = `crate-datasource/registry-clone-path/${registryFetchUrl}`;
       const lockKey = registryFetchUrl;
 

--- a/lib/modules/datasource/crate/index.ts
+++ b/lib/modules/datasource/crate/index.ts
@@ -376,7 +376,7 @@ export class CrateDatasource extends Datasource {
       );
       return null;
     }
-    if (registry.flavor !== 'crates.io' && !registry.isSparse) {
+    if (!registry.isSparse) {
       const cacheKey = `crate-datasource/registry-clone-path/${registryFetchUrl}`;
       const lockKey = registryFetchUrl;
 

--- a/lib/modules/datasource/crate/index.ts
+++ b/lib/modules/datasource/crate/index.ts
@@ -11,6 +11,7 @@ import { toSha256 } from '../../../util/hash.ts';
 import { memCacheProvider } from '../../../util/http/cache/memory-http-cache-provider.ts';
 import { acquireLock } from '../../../util/mutex.ts';
 import { newlineRegex, regEx } from '../../../util/regex.ts';
+import { Json } from '../../../util/schema-utils/index.ts';
 import { asTimestamp } from '../../../util/timestamp.ts';
 import { joinUrlParts, parseUrl } from '../../../util/url.ts';
 import * as cargoVersioning from '../../versioning/cargo/index.ts';
@@ -29,7 +30,6 @@ import type {
   RegistryFlavor,
   RegistryInfo,
 } from './types.ts';
-import { Json } from '../../../util/schema-utils/index.ts';
 
 type CloneResult =
   | {

--- a/lib/modules/datasource/crate/index.ts
+++ b/lib/modules/datasource/crate/index.ts
@@ -22,7 +22,7 @@ import type {
   Release,
   ReleaseResult,
 } from '../types.ts';
-import { ReleaseTimestamp } from './schema.ts';
+import { RegistryConfigSchema, ReleaseTimestamp } from './schema.ts';
 import type {
   CrateMetadata,
   CrateRecord,
@@ -47,14 +47,9 @@ export class CrateDatasource extends Datasource {
     super(CrateDatasource.id);
   }
 
-  override defaultRegistryUrls = ['https://crates.io'];
+  override defaultRegistryUrls = ['sparse+https://index.crates.io/'];
 
   override defaultVersioning = cargoVersioning.id;
-
-  static readonly CRATES_IO_BASE_URL =
-    'https://raw.githubusercontent.com/rust-lang/crates.io-index/master/';
-
-  static readonly CRATES_IO_API_BASE_URL = 'https://crates.io/api/v1/';
 
   override readonly sourceUrlSupport = 'package';
   override readonly sourceUrlNote =
@@ -153,25 +148,77 @@ export class CrateDatasource extends Datasource {
         namespace: `datasource-${CrateDatasource.id}`,
         // TODO: types (#22198)
         key: `${config.registryUrl}/${config.packageName}`,
-        cacheable: CrateDatasource.areReleasesCacheable(config.registryUrl),
+        cacheable: CrateDatasource.isCratesIo(config.registryUrl),
         fallback: true,
       },
       () => this._getReleases(config),
     );
   }
 
+  /**
+   * Fetches the registry's config.json which provides the API base URL
+   * and download URL template.
+   * See: https://doc.rust-lang.org/cargo/reference/registry-index.html#index-configuration
+   */
+  private async fetchRegistryConfig(
+    info: RegistryInfo,
+  ): Promise<{ dl: string; api?: string } | null> {
+    const cacheKey = `crate-datasource/registry-config/${info.rawUrl}`;
+    const cached = memCache.get<{ dl: string; api?: string }>(cacheKey);
+    if (cached) {
+      return cached;
+    }
+
+    if (info.clonePath) {
+      try {
+        const configPath = upath.join(info.clonePath, 'config.json');
+        const content = await readCacheFile(configPath, 'utf8');
+        const parsed = RegistryConfigSchema.safeParse(JSON.parse(content));
+        if (parsed.success) {
+          memCache.set(cacheKey, parsed.data);
+          return parsed.data;
+        }
+      } catch {
+        logger.debug(
+          { registryUrl: info.rawUrl },
+          'Could not read config.json from cloned registry',
+        );
+      }
+    } else if (info.isSparse) {
+      try {
+        const configUrl = joinUrlParts(info.rawUrl, 'config.json');
+        const { body } = await this.http.getJsonUnchecked<unknown>(configUrl);
+        const parsed = RegistryConfigSchema.safeParse(body);
+        if (parsed.success) {
+          memCache.set(cacheKey, parsed.data);
+          return parsed.data;
+        }
+      } catch {
+        logger.debug(
+          { registryUrl: info.rawUrl },
+          'Could not fetch registry config.json',
+        );
+      }
+    }
+
+    return null;
+  }
+
   private async _getCrateMetadata(
     info: RegistryInfo,
     packageName: string,
   ): Promise<CrateMetadata | null> {
-    if (info.flavor !== 'crates.io') {
+    const registryConfig = await this.fetchRegistryConfig(info);
+    if (!registryConfig?.api) {
       return null;
     }
+
+    const apiBaseUrl = joinUrlParts(registryConfig.api, 'api/v1/');
 
     // The `?include=` suffix is required to avoid unnecessary database queries
     // on the crates.io server. This lets us work around the regular request
     // throttling of one request per second.
-    const crateUrl = `${CrateDatasource.CRATES_IO_API_BASE_URL}crates/${packageName}?include=`;
+    const crateUrl = `${apiBaseUrl}crates/${packageName}?include=`;
 
     logger.debug(
       { crateUrl, packageName, registryUrl: info.rawUrl },
@@ -202,7 +249,7 @@ export class CrateDatasource extends Datasource {
       {
         namespace: `datasource-${CrateDatasource.id}-metadata`,
         key: `${info.rawUrl}/${packageName}`,
-        cacheable: CrateDatasource.areReleasesCacheable(info.rawUrl),
+        cacheable: info.flavor === 'crates.io',
         ttlMinutes: 24 * 60, // 24 hours
       },
       () => this._getCrateMetadata(info, packageName),
@@ -221,16 +268,11 @@ export class CrateDatasource extends Datasource {
       return readCacheFile(path, 'utf8');
     }
 
-    const baseUrl =
-      info.flavor === 'crates.io'
-        ? CrateDatasource.CRATES_IO_BASE_URL
-        : info.rawUrl;
-
-    if (info.flavor === 'crates.io' || info.isSparse) {
+    if (info.isSparse) {
       const packageSuffix = CrateDatasource.getIndexSuffix(
         packageName.toLowerCase(),
       );
-      const crateUrl = joinUrlParts(baseUrl, ...packageSuffix);
+      const crateUrl = joinUrlParts(info.rawUrl, ...packageSuffix);
       try {
         return (await this.http.getText(crateUrl)).body;
       } catch (err) {
@@ -259,7 +301,7 @@ export class CrateDatasource extends Datasource {
         return `https://cloudsmith.io/~${org}/repos/${repo}/packages/detail/cargo/${packageName}`;
       }
       default:
-        return `${info.rawUrl}/${packageName}`;
+        return `${info.url}/${packageName}`;
     }
   }
 
@@ -310,7 +352,7 @@ export class CrateDatasource extends Datasource {
     }
 
     let flavor: RegistryFlavor;
-    if (url.hostname === 'crates.io') {
+    if (url.hostname === 'index.crates.io') {
       flavor = 'crates.io';
     } else if (url.hostname === 'dl.cloudsmith.io') {
       flavor = 'cloudsmith';
@@ -442,12 +484,13 @@ export class CrateDatasource extends Datasource {
     }
   }
 
-  private static areReleasesCacheable(
-    registryUrl: string | undefined,
-  ): boolean {
-    // We only cache public releases, we don't want to cache private
-    // cloned data between runs.
-    return registryUrl === 'https://crates.io';
+  private static isCratesIo(registryUrl: string | undefined): boolean {
+    if (!registryUrl) {
+      return false;
+    }
+    const normalized = registryUrl.replace(/^sparse\+/, '');
+    const parsed = parseUrl(normalized);
+    return parsed?.hostname === 'index.crates.io';
   }
 
   public static getIndexSuffix(packageName: string): string[] {
@@ -470,11 +513,23 @@ export class CrateDatasource extends Datasource {
     { packageName, registryUrl }: PostprocessReleaseConfig,
     release: Release,
   ): Promise<PostprocessReleaseResult> {
-    if (release.releaseTimestamp || registryUrl !== 'https://crates.io') {
+    if (release.releaseTimestamp) {
       return release;
     }
 
-    const url = `https://crates.io/api/v1/crates/${packageName}/${release.versionOrig ?? release.version}`;
+    // Look up the registry config from cache (populated during getReleases)
+    const rawUrl = registryUrl?.replace(/^sparse\+/, '');
+    if (!rawUrl) {
+      return release;
+    }
+    const cacheKey = `crate-datasource/registry-config/${rawUrl}`;
+    const config = memCache.get<{ dl: string; api?: string }>(cacheKey);
+    if (!config?.api) {
+      return release;
+    }
+
+    const apiBaseUrl = joinUrlParts(config.api, 'api/v1/');
+    const url = `${apiBaseUrl}crates/${packageName}/${release.versionOrig ?? release.version}`;
     // Getting release timestamp could become unnecessary if the manual backfill of `pubtime` mentioned in
     // https://github.com/rust-lang/cargo/issues/15491 is done for all packages.
     const { body: releaseTimestamp } = await this.http.getJson(
@@ -495,7 +550,7 @@ export class CrateDatasource extends Datasource {
         namespace: `datasource-crate`,
         key: `postprocessRelease:${config.registryUrl}:${config.packageName}:${release.version}`,
         ttlMinutes: 7 * 24 * 60,
-        cacheable: config.registryUrl === 'https://crates.io',
+        cacheable: CrateDatasource.isCratesIo(config.registryUrl ?? undefined),
       },
       () => this._postprocessRelease(config, release),
     );

--- a/lib/modules/datasource/crate/schema.ts
+++ b/lib/modules/datasource/crate/schema.ts
@@ -5,6 +5,7 @@ export const RegistryConfigSchema = z.object({
   dl: z.string(),
   api: z.string().optional(),
 });
+export type RegistryConfigSchema = z.infer<typeof RegistryConfigSchema>;
 
 export const ReleaseTimestamp = z
   .object({

--- a/lib/modules/datasource/crate/schema.ts
+++ b/lib/modules/datasource/crate/schema.ts
@@ -1,6 +1,11 @@
 import { z } from 'zod/v3';
 import { MaybeTimestamp } from '../../../util/timestamp.ts';
 
+export const RegistryConfigSchema = z.object({
+  dl: z.string(),
+  api: z.string().optional(),
+});
+
 export const ReleaseTimestamp = z
   .object({
     version: z.object({

--- a/lib/modules/datasource/crate/types.ts
+++ b/lib/modules/datasource/crate/types.ts
@@ -17,10 +17,7 @@ export interface RegistryInfo {
   /** parsed URL of the registry */
   url: URL;
 
-  /** whether the registry uses sparse indexing (rfc-2789) */
-  isSparse: boolean;
-
-  /** path where the registry is cloned */
+  /** path where the registry is cloned, otherwise a sparse registry */
   clonePath?: string;
 }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- #41452.

This PR implements proper handling of cargo registries by respecting their config.json file. Each cargo registry serves this file at the root. It contains base urls for downloading and optionally for the web api.

https://doc.rust-lang.org/cargo/reference/registry-index.html

The change implements this behavior by always consulting `config.json` to retrieve the correct base urls. Additionally, it removes most of the special treatment for "crates.io" since it is just a normal cargo registry.

A potentially breaking change is, that the user-defined registry "https://crates.io" does not work anymore since it has been replace with "sparse+https://index.crates.io". For most users this shouldn't be a problem, since they just use the default registry. A possible solution is to automatically map the old url to the new sparse version.

Also, the `registryUrl` field for a detected dependency changes as can be seen in the test files.

## Context

Please select one of the following:

- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
