### PR TITLE
fix(cargo): skip `--precise` for range-bumped crates to avoid stale `Cargo.lock` errors

### DIFF
--- a/lib/modules/manager/cargo/artifacts.ts
+++ b/lib/modules/manager/cargo/artifacts.ts
@@ -51,6 +51,12 @@ async function cargoUpdatePrecise(
   // First update individual dependencies to their `newVersion`. Necessary when
   // using the `update-lockfile` rangeStrategy which doesn't touch Cargo.toml.
   for (const dep of updatedDeps) {
+    // Range bumped for an existing crate. The old lockedVersion is gone from Cargo's
+    // dependency graph, so let the --workspace update at the end re-resolve it instead.
+    if (dep.currentValue && dep.newValue && dep.currentValue !== dep.newValue) {
+      continue;
+    }
+
     cmds.push(
       `cargo update --config net.git-fetch-with-cli=true` +
         ` --manifest-path ${quote(manifestPath)}` +

--- a/lib/modules/manager/cargo/artifacts.ts
+++ b/lib/modules/manager/cargo/artifacts.ts
@@ -51,8 +51,9 @@ async function cargoUpdatePrecise(
   // First update individual dependencies to their `newVersion`. Necessary when
   // using the `update-lockfile` rangeStrategy which doesn't touch Cargo.toml.
   for (const dep of updatedDeps) {
-    // Range bumped for an existing crate. The old lockedVersion is gone from Cargo's
-    // dependency graph, so let the --workspace update at the end re-resolve it instead.
+    // If the range is bumped in Cargo.toml, the old lockedVersion may no longer
+    // exist in Cargo's dependency graph, so let the --workspace update at the
+    // end re-resolve it instead.
     if (dep.currentValue && dep.newValue && dep.currentValue !== dep.newValue) {
       continue;
     }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Skips updating a specific entry with the `--precise` flag for Crates where the `Cargo.toml` range was bumped, delegating the resolution to the later update call with the `--workspace` flag. 

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #39137
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

I put a bit of thought into this and iterated over a few possible solutions:
1. Omitting the `@lockedVersion` from `--package`. It keeps the `--precise` but doesn't work when there are multiple versions of the same crate in the `Cargo.lock`.
2. Proactively reading `Cargo.lock` to skip crates already at their target version. This introduced unnecessary complexity and duplicated the existing retry logic in `artifacts.ts`.
3. [Current Approach] Skips `--precise` entirely for range-bumped crates, letting the later `--workspace` update command re-resolve them. This avoids both the stale version and ambiguity issues cleanly.

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Claude Code was used to help generate the unit and real repository tests.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/just-in-chang/renovate-39137-tests

Please read the `README.md` there for more details about the tests.

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
