### PR TITLE
feat(manager/cake): Take nuget.config into account for registryUrls of nuget packages

### DIFF
--- a/lib/modules/manager/cake/index.spec.ts
+++ b/lib/modules/manager/cake/index.spec.ts
@@ -18,11 +18,6 @@ describe('modules/manager/cake/index', () => {
     GlobalConfig.set(adminConfig);
   });
 
-  afterEach(() => {
-    // Clean up
-    GlobalConfig.reset();
-  });
-
   it('extracts', async () => {
     expect(
       await extractPackageFile(

--- a/lib/modules/manager/cake/index.spec.ts
+++ b/lib/modules/manager/cake/index.spec.ts
@@ -1,10 +1,36 @@
 import { codeBlock } from 'common-tags';
+import upath from 'upath';
 import { Fixtures } from '~test/fixtures.ts';
+import { GlobalConfig } from '../../../config/global.ts';
+import type { RepoGlobalConfig } from '../../../config/types.ts';
+import * as nugetExtractUtil from '../nuget/util.ts';
+import type { ExtractConfig } from '../types.ts';
 import { extractPackageFile } from './index.ts';
 
+const config: ExtractConfig = {};
+const adminConfig: RepoGlobalConfig = {
+  localDir: upath.resolve('lib/modules/manager/cake/__fixtures__'),
+};
+
 describe('modules/manager/cake/index', () => {
-  it('extracts', () => {
-    expect(extractPackageFile(Fixtures.get('build.cake'))).toMatchObject({
+  beforeEach(() => {
+    // Initialize GlobalConfig with required values
+    GlobalConfig.set(adminConfig);
+  });
+
+  afterEach(() => {
+    // Clean up
+    GlobalConfig.reset();
+  });
+
+  it('extracts', async () => {
+    expect(
+      await extractPackageFile(
+        Fixtures.get('build.cake'),
+        'build.cake',
+        config,
+      ),
+    ).toMatchObject({
       deps: [
         { depName: 'Foo.Foo', currentValue: undefined },
         { depName: 'Bim.Bim', currentValue: '6.6.6' },
@@ -21,7 +47,7 @@ describe('modules/manager/cake/index', () => {
     });
   });
 
-  it('extracts dotnet tools from single sdk style build file', () => {
+  it('extracts dotnet tools from single sdk style build file', async () => {
     const content = codeBlock`
     #:sdk Cake.Sdk
 
@@ -47,35 +73,37 @@ describe('modules/manager/cake/index', () => {
 
     RunTarget(target);
     `;
-    expect(extractPackageFile(content)).toMatchObject({
-      deps: [
-        {
-          depName: 'SingleTool.Install.First',
-          currentValue: '1.0.0',
-          datasource: 'nuget',
-          registryUrls: ['https://api.nuget.org/v3/index.json'],
-        },
-        {
-          depName: 'SingleTool.Install.Second',
-          currentValue: '1.2.0',
-          datasource: 'nuget',
-        },
-        {
-          depName: 'MultipleTools.Install.First',
-          currentValue: '2.0.0',
-          datasource: 'nuget',
-          registryUrls: ['https://api.nuget.org/v3/index.json'],
-        },
-        {
-          depName: 'MultipleTools.Install.Second',
-          currentValue: '2.1.1',
-          datasource: 'nuget',
-        },
-      ],
-    });
+    expect(await extractPackageFile(content, 'build.cs', config)).toMatchObject(
+      {
+        deps: [
+          {
+            depName: 'SingleTool.Install.First',
+            currentValue: '1.0.0',
+            datasource: 'nuget',
+            registryUrls: ['https://api.nuget.org/v3/index.json'],
+          },
+          {
+            depName: 'SingleTool.Install.Second',
+            currentValue: '1.2.0',
+            datasource: 'nuget',
+          },
+          {
+            depName: 'MultipleTools.Install.First',
+            currentValue: '2.0.0',
+            datasource: 'nuget',
+            registryUrls: ['https://api.nuget.org/v3/index.json'],
+          },
+          {
+            depName: 'MultipleTools.Install.Second',
+            currentValue: '2.1.1',
+            datasource: 'nuget',
+          },
+        ],
+      },
+    );
   });
 
-  it('skips invalid entries in InstallTools', () => {
+  it('skips invalid entries in InstallTools', async () => {
     const content = codeBlock`
     #:sdk Cake.Sdk
 
@@ -85,14 +113,42 @@ describe('modules/manager/cake/index', () => {
       "dotnet:?package=Good.Tool&version=1.2.3"
     );
     `;
-    expect(extractPackageFile(content)).toMatchObject({
-      deps: [
-        {
-          depName: 'Good.Tool',
-          currentValue: '1.2.3',
-          datasource: 'nuget',
-        },
-      ],
-    });
+    expect(await extractPackageFile(content, 'build.cs', config)).toMatchObject(
+      {
+        deps: [
+          {
+            depName: 'Good.Tool',
+            currentValue: '1.2.3',
+            datasource: 'nuget',
+          },
+        ],
+      },
+    );
+  });
+
+  it('calls applyRegistries to honor nuget.config files if present for .cake files', async () => {
+    const applyRegistriesSpy = vi
+      .spyOn(nugetExtractUtil, 'applyRegistries')
+      .mockImplementation((deps: any) => deps);
+
+    const content = codeBlock`#addin nuget:?package=Contoso.SomePackage&version=1.2.3`;
+    await extractPackageFile(content, 'build.cake', config);
+
+    expect(applyRegistriesSpy).toHaveBeenCalled();
+  });
+
+  it('calls applyRegistries to honor nuget.config files if present for InstallTools', async () => {
+    const applyRegistriesSpy = vi
+      .spyOn(nugetExtractUtil, 'applyRegistries')
+      .mockImplementation((deps: any) => deps);
+
+    const content = codeBlock`
+      #:sdk Cake.Sdk
+
+      InstallTools("dotnet:?package=Good.Tool&version=1.2.3");
+      `;
+    await extractPackageFile(content, 'build.cs', config);
+
+    expect(applyRegistriesSpy).toHaveBeenCalled();
   });
 });

--- a/lib/modules/manager/cake/index.spec.ts
+++ b/lib/modules/manager/cake/index.spec.ts
@@ -124,7 +124,7 @@ describe('modules/manager/cake/index', () => {
   it('calls applyRegistries to honor nuget.config files if present for .cake files', async () => {
     const applyRegistriesSpy = vi
       .spyOn(nugetExtractUtil, 'applyRegistries')
-      .mockImplementation((deps: any) => deps);
+      .mockImplementation((deps) => deps);
 
     const content = codeBlock`#addin nuget:?package=Contoso.SomePackage&version=1.2.3`;
     await extractPackageFile(content, 'build.cake', config);
@@ -135,7 +135,7 @@ describe('modules/manager/cake/index', () => {
   it('calls applyRegistries to honor nuget.config files if present for InstallTools', async () => {
     const applyRegistriesSpy = vi
       .spyOn(nugetExtractUtil, 'applyRegistries')
-      .mockImplementation((deps: any) => deps);
+      .mockImplementation((deps) => deps);
 
     const content = codeBlock`
       #:sdk Cake.Sdk

--- a/lib/modules/manager/cake/index.spec.ts
+++ b/lib/modules/manager/cake/index.spec.ts
@@ -129,7 +129,13 @@ describe('modules/manager/cake/index', () => {
     const content = codeBlock`#addin nuget:?package=Contoso.SomePackage&version=1.2.3`;
     await extractPackageFile(content, 'build.cake', config);
 
-    expect(applyRegistriesSpy).toHaveBeenCalled();
+    expect(applyRegistriesSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        depName: 'Contoso.SomePackage',
+        currentValue: '1.2.3',
+      }),
+      undefined,
+    );
   });
 
   it('calls applyRegistries to honor nuget.config files if present for InstallTools', async () => {
@@ -144,6 +150,12 @@ describe('modules/manager/cake/index', () => {
       `;
     await extractPackageFile(content, 'build.cs', config);
 
-    expect(applyRegistriesSpy).toHaveBeenCalled();
+    expect(applyRegistriesSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        depName: 'Good.Tool',
+        currentValue: '1.2.3',
+      }),
+      undefined,
+    );
   });
 });

--- a/lib/modules/manager/cake/index.ts
+++ b/lib/modules/manager/cake/index.ts
@@ -52,7 +52,6 @@ function parseDependencyLine(line: string): NugetPackageDependency | null {
     const result: NugetPackageDependency = {
       datasource: NugetDatasource.id,
       depName,
-      depType: 'nuget',
       currentValue,
     };
 

--- a/lib/modules/manager/cake/index.ts
+++ b/lib/modules/manager/cake/index.ts
@@ -85,7 +85,7 @@ export async function extractPackageFile(
   content: string,
   packageFile: string,
   _config: ExtractConfig,
-): Promise<PackageFileContent | null> {
+): Promise<PackageFileContent> {
   const deps: NugetPackageDependency[] = [];
   const registries = await getConfiguredRegistries(packageFile);
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

When using nuget packages in cake build files, the `nuget.config` file (if present) is not taken into account when trying to retrieve new package versions. The nuget manager does this correctly. This PR extends the cake manager so it uses the same mechanism as the nuget manager to honor the `nuget.config` file.

After the change, the registryUrls for nuget packages should be correctly set according to the `nuget.config`.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

There is a discussion that also mentions this here: https://github.com/renovatebot/renovate/discussions/33883

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The new unit tests make sure the mechanism of the nuget manager is also called in the cake manager.

I ran this command to see if the nuget.config was honored:
```bash
LOG_LEVEL=debug pnpm start papauorg/renovate-cakebuild --dry-run=full --token=MY_GITHUB_TOKEN
```
Here is the log (I cut it to the relevant parts)
You can see that the contents of the nuget.config are used. In the log there are errors because the versions of the packages can not be determined - this is expected because the alternative nuget registry is made up and not available.

```txt
> renovate@0.0.0-semantic-release prestart /workspaces/renovate
> run-s 'generate:*'


> renovate@0.0.0-semantic-release generate:imports /workspaces/renovate
> node tools/generate-imports.mjs


> renovate@0.0.0-semantic-release start /workspaces/renovate
> node lib/renovate.ts papauorg/renovate-cakebuild --dry-run=full --token=MY_GITHUB_TOKEN

 INFO: Renovate started
       "renovateVersion": "0.0.0-semantic-release"
/*snipped*/
DEBUG: Setting current branch to main (repository=papauorg/renovate-cakebuild)
DEBUG: latest commit (repository=papauorg/renovate-cakebuild)
       "branchName": "main",
       "latestCommitDate": "2026-02-27T08:01:38.000Z",
       "sha": "e416bb7f79fac66c1dcba4b3e76ee07ddaf791cb"
/* snipped */
DEBUG: Matched 1 file(s) for manager renovate-config-presets: renovate.json (repository=papauorg/renovate-cakebuild)
DEBUG: Found NuGet.config at nuget.config (repository=papauorg/renovate-cakebuild)
DEBUG: clearing registry URLs (repository=papauorg/renovate-cakebuild)
DEBUG: Adding registry URL https://some.third-party.url/nuget/Default/v3/index.json (repository=papauorg/renovate-cakebuild)
       "registryUrl": "https://some.third-party.url/nuget/Default/v3/index.json",
       "sourceMappedPackagePatterns": ["*"]
DEBUG: manager extract durations (ms) (repository=papauorg/renovate-cakebuild)
       "managers": {"cake": 14, "renovate-config-presets": 3}
DEBUG: Found cake package files (repository=papauorg/renovate-cakebuild)
DEBUG: Found 1 package file(s) (repository=papauorg/renovate-cakebuild)
 INFO: Dependency extraction complete (repository=papauorg/renovate-cakebuild, baseBranch=main)
       "stats": {
         "managers": {"cake": {"fileCount": 1, "depCount": 3}},
         "total": {"fileCount": 1, "depCount": 3}
       }
DEBUG: hostRules: no authentication for some.third-party.url (repository=papauorg/renovate-cakebuild)
DEBUG: Using queue: host=some.third-party.url, concurrency=16 (repository=papauorg/renovate-cakebuild)
DEBUG: GET https://some.third-party.url/nuget/Default/v3/index.json = (code=ENOTFOUND, statusCode=-1 retryCount=2, duration=6) (repository=papauorg/renovate-cakebuild)
DEBUG: nuget registry failure: can't get RegistrationsBaseUrl (repository=papauorg/renovate-cakebuild)
       "err": {
         "name": "RequestError",
         "code": "ENOTFOUND",
         "timings": {
           "start": 1772179337355,
           "socket": 1772179337355,
           "lookup": 1772179337360,
           "error": 1772179337361,
           "phases": {"wait": 0, "dns": 5, "total": 6}
         },
         "options": {
           "headers": {
             "user-agent": "Renovate/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
             "accept": "application/json",
             "accept-encoding": "gzip, deflate, br, zstd"
           },
           "url": "https://some.third-party.url/nuget/Default/v3/index.json",
           "hostType": "nuget",
           "username": "",
           "password": "",
           "method": "GET",
           "http2": false
         },
         "message": "getaddrinfo ENOTFOUND some.third-party.url",
         "stack": "RequestError: getaddrinfo ENOTFOUND some.third-party.url\n    at ClientRequest.<anonymous> (file:///workspaces/renovate/node_modules/.pnpm/got@14.6.6/node_modules/got/dist/source/core/index.js:868:107)\n    at Object.onceWrapper (node:events:623:26)\n    at ClientRequest.emit (node:events:520:35)\n    at ClientRequest.emit (node:domain:489:12)\n    at emitErrorEvent (node:_http_client:108:11)\n    at TLSSocket.socketErrorListener (node:_http_client:575:5)\n    at TLSSocket.emit (node:events:508:28)\n    at TLSSocket.emit (node:domain:489:12)\n    at emitErrorNT (node:internal/streams/destroy:170:8)\n    at emitErrorCloseNT (node:internal/streams/destroy:129:3)\n    at processTicksAndRejections (node:internal/process/task_queues:89:21)\n    at GetAddrInfoReqWrap.onlookupall [as oncomplete] (node:dns:122:26)"
       },
       "url": "https://some.third-party.url/nuget/Default/v3/index.json",
       "servicesIndexRaw": undefined
DEBUG: Failed to look up nuget package Octopus.DotNet.Cli (repository=papauorg/renovate-cakebuild, packageFile=build.cs, dependency=Octopus.DotNet.Cli)
DEBUG: GET https://some.third-party.url/nuget/Default/v3/index.json = (code=ENOTFOUND, statusCode=-1 retryCount=2, duration=6) (repository=papauorg/renovate-cakebuild)
DEBUG: nuget registry failure: can't get RegistrationsBaseUrl (repository=papauorg/renovate-cakebuild)
       "err": {
         "name": "RequestError",
         "code": "ENOTFOUND",
         "timings": {
           "start": 1772179337435,
           "socket": 1772179337436,
           "lookup": 1772179337440,
           "error": 1772179337441,
           "phases": {"wait": 1, "dns": 4, "total": 6}
         },
         "options": {
           "headers": {
             "user-agent": "Renovate/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
             "accept": "application/json",
             "accept-encoding": "gzip, deflate, br, zstd"
           },
           "url": "https://some.third-party.url/nuget/Default/v3/index.json",
           "hostType": "nuget",
           "username": "",
           "password": "",
           "method": "GET",
           "http2": false
         },
         "message": "getaddrinfo ENOTFOUND some.third-party.url",
         "stack": "RequestError: getaddrinfo ENOTFOUND some.third-party.url\n    at ClientRequest.<anonymous> (file:///workspaces/renovate/node_modules/.pnpm/got@14.6.6/node_modules/got/dist/source/core/index.js:868:107)\n    at Object.onceWrapper (node:events:623:26)\n    at ClientRequest.emit (node:events:520:35)\n    at ClientRequest.emit (node:domain:489:12)\n    at emitErrorEvent (node:_http_client:108:11)\n    at TLSSocket.socketErrorListener (node:_http_client:575:5)\n    at TLSSocket.emit (node:events:508:28)\n    at TLSSocket.emit (node:domain:489:12)\n    at emitErrorNT (node:internal/streams/destroy:170:8)\n    at emitErrorCloseNT (node:internal/streams/destroy:129:3)\n    at processTicksAndRejections (node:internal/process/task_queues:89:21)\n    at GetAddrInfoReqWrap.onlookupall [as oncomplete] (node:dns:122:26)"
       },
       "url": "https://some.third-party.url/nuget/Default/v3/index.json",
       "servicesIndexRaw": undefined
DEBUG: Failed to look up nuget package GitVersion.Tool (repository=papauorg/renovate-cakebuild, packageFile=build.cs, dependency=GitVersion.Tool)
DEBUG: GET https://some.third-party.url/nuget/Default/v3/index.json = (code=ENOTFOUND, statusCode=-1 retryCount=2, duration=73) (repository=papauorg/renovate-cakebuild)
DEBUG: nuget registry failure: can't get RegistrationsBaseUrl (repository=papauorg/renovate-cakebuild)
       "err": {
         "name": "RequestError",
         "code": "ENOTFOUND",
         "timings": {
           "start": 1772179337467,
           "socket": 1772179337468,
           "lookup": 1772179337540,
           "error": 1772179337540,
           "phases": {"wait": 1, "dns": 72, "total": 73}
         },
         "options": {
           "headers": {
             "user-agent": "Renovate/0.0.0-semantic-release (https://github.com/renovatebot/renovate)",
             "accept": "application/json",
             "accept-encoding": "gzip, deflate, br, zstd"
           },
           "url": "https://some.third-party.url/nuget/Default/v3/index.json",
           "hostType": "nuget",
           "username": "",
           "password": "",
           "method": "GET",
           "http2": false
         },
         "message": "getaddrinfo ENOTFOUND some.third-party.url",
         "stack": "RequestError: getaddrinfo ENOTFOUND some.third-party.url\n    at ClientRequest.<anonymous> (file:///workspaces/renovate/node_modules/.pnpm/got@14.6.6/node_modules/got/dist/source/core/index.js:868:107)\n    at Object.onceWrapper (node:events:623:26)\n    at ClientRequest.emit (node:events:520:35)\n    at ClientRequest.emit (node:domain:489:12)\n    at emitErrorEvent (node:_http_client:108:11)\n    at TLSSocket.socketErrorListener (node:_http_client:575:5)\n    at TLSSocket.emit (node:events:508:28)\n    at TLSSocket.emit (node:domain:489:12)\n    at emitErrorNT (node:internal/streams/destroy:170:8)\n    at emitErrorCloseNT (node:internal/streams/destroy:129:3)\n    at processTicksAndRejections (node:internal/process/task_queues:89:21)\n    at GetAddrInfoReqWrap.onlookupall [as oncomplete] (node:dns:122:26)"
       },
       "url": "https://some.third-party.url/nuget/Default/v3/index.json",
       "servicesIndexRaw": undefined
DEBUG: Failed to look up nuget package dotnet-trace (repository=papauorg/renovate-cakebuild, packageFile=build.cs, dependency=dotnet-trace)
DEBUG: PackageFiles.add() - Package file saved for base branch (repository=papauorg/renovate-cakebuild, baseBranch=main)
DEBUG: Package releases lookups complete (repository=papauorg/renovate-cakebuild, baseBranch=main)
DEBUG: Repository libYears (repository=papauorg/renovate-cakebuild)
       "libYears": {"managers": {"cake": 0}, "total": 0},
       "dependencyStatus": {"outdated": 0, "total": 3}
DEBUG: branchifyUpgrades (repository=papauorg/renovate-cakebuild)
DEBUG: detectSemanticCommits() (repository=papauorg/renovate-cakebuild)
DEBUG: getCommitMessages (repository=papauorg/renovate-cakebuild)
DEBUG: semanticCommits: detected "unknown" (repository=papauorg/renovate-cakebuild)
DEBUG: semanticCommits: disabled (repository=papauorg/renovate-cakebuild)
DEBUG: 0 flattened updates found:  (repository=papauorg/renovate-cakebuild)
DEBUG: Returning 0 branch(es) (repository=papauorg/renovate-cakebuild)
DEBUG: config.repoIsOnboarded=true (repository=papauorg/renovate-cakebuild)
DEBUG: packageFiles with updates (repository=papauorg/renovate-cakebuild, baseBranch=main)
       "config": {
         "cake": [
           {
             "deps": [
               {
                 "datasource": "nuget",
                 "depName": "GitVersion.Tool",
                 "currentValue": "6.5.0",
                 "registryUrls": [
                   "https://some.third-party.url/nuget/Default/v3/index.json"
                 ],
                 "updates": [],
                 "packageName": "GitVersion.Tool",
                 "versioning": "nuget",
                 "warnings": [
                   {
                     "topic": "GitVersion.Tool",
                     "message": "Failed to look up nuget package GitVersion.Tool"
                   }
                 ]
               },
               {
                 "datasource": "nuget",
                 "depName": "dotnet-trace",
                 "currentValue": "9.0.621003",
                 "registryUrls": [
                   "https://some.third-party.url/nuget/Default/v3/index.json"
                 ],
                 "updates": [],
                 "packageName": "dotnet-trace",
                 "versioning": "nuget",
                 "warnings": [
                   {
                     "topic": "dotnet-trace",
                     "message": "Failed to look up nuget package dotnet-trace"
                   }
                 ]
               },
               {
                 "datasource": "nuget",
                 "depName": "Octopus.DotNet.Cli",
                 "currentValue": "9.1.6",
                 "registryUrls": [
                   "https://some.third-party.url/nuget/Default/v3/index.json"
                 ],
                 "updates": [],
                 "packageName": "Octopus.DotNet.Cli",
                 "versioning": "nuget",
                 "warnings": [
                   {
                     "topic": "Octopus.DotNet.Cli",
                     "message": "Failed to look up nuget package Octopus.DotNet.Cli"
                   }
                 ]
               }
             ],
             "packageFile": "build.cs"
           }
         ]
       }
/*snipped*/
```

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
