### PR TITLE
feat(git-refs): use dereferenced commit hash for annotated tags

### DIFF
--- a/lib/modules/datasource/git-refs/__snapshots__/index.spec.ts.snap
+++ b/lib/modules/datasource/git-refs/__snapshots__/index.spec.ts.snap
@@ -5,32 +5,32 @@ exports[`modules/datasource/git-refs/index > getReleases > returns versions filt
   "releases": [
     {
       "gitRef": "v1.0.0",
-      "newDigest": "a9920c014aebc28dc1b23e7efcc006d045512345",
+      "newDigest": "7b756026fb2de270240a889a413e7e3a9d4d4d85",
       "version": "v1.0.0",
     },
     {
       "gitRef": "v1.0.1",
-      "newDigest": "281fbfb58990ec98b237a923d67904c102bec34c",
+      "newDigest": "e173183f932ba8a31d0e4f23cc1070e8ebfa59d6",
       "version": "v1.0.1",
     },
     {
       "gitRef": "v1.0.2",
-      "newDigest": "9cb93e0b236385a4e2efd089d7c6a458f5ff321f",
+      "newDigest": "3936a6bced3587dc9fd464b0a910e0dfd4cfe10d",
       "version": "v1.0.2",
     },
     {
       "gitRef": "v1.0.3",
-      "newDigest": "8b0d0e0aec21ea059448ef0255387dbb82c61973",
+      "newDigest": "125ca9f3df4151e50046e5327ecb29ec4c13efab",
       "version": "v1.0.3",
     },
     {
       "gitRef": "v1.0.4",
-      "newDigest": "2b52829c7c1bd65b3501c450849c53b90b11fa0e",
+      "newDigest": "3ed9e7d7094fd4ee7751c24a3e6b706060f461ff",
       "version": "v1.0.4",
     },
     {
       "gitRef": "v1.0.5",
-      "newDigest": "2d138c34e4c6939d0a8686943e851c6528aa04db",
+      "newDigest": "6d7a933c2e6b7b39e992b1f93b6b42de083b28f0",
       "version": "v1.0.5",
     },
   ],

--- a/lib/modules/datasource/git-refs/base.ts
+++ b/lib/modules/datasource/git-refs/base.ts
@@ -78,7 +78,7 @@ export abstract class GitDatasource extends Datasource {
     for (const ref of allRefs) {
       if (ref.value.endsWith('^{}')) {
         // Store the commit hash for the base tag name (without ^{})
-        dereferencedTag[ref.value.slice(0, -3)] = ref.hash;
+        dereferencedTags[ref.value.slice(0, -3)] = ref.hash;
       }
     }
 

--- a/lib/modules/datasource/git-refs/base.ts
+++ b/lib/modules/datasource/git-refs/base.ts
@@ -74,11 +74,11 @@ export abstract class GitDatasource extends Datasource {
     // We need to use the dereferenced commit hash (^{}) for annotated tags
     // to match what `git submodule status` returns (the actual commit hash).
     // This prevents false-positive updates that result in empty commits.
-    const dereferencedTags = new Map<string, string>();
+    const dereferencedTags: Record<string, string> = {};
     for (const ref of allRefs) {
       if (ref.value.endsWith('^{}')) {
         // Store the commit hash for the base tag name (without ^{})
-        dereferencedTags.set(ref.value.slice(0, -3), ref.hash);
+        dereferencedTag[ref.value.slice(0, -3)] = ref.hash;
       }
     }
 
@@ -86,7 +86,7 @@ export abstract class GitDatasource extends Datasource {
       .filter((ref) => !ref.value.endsWith('^{}'))
       .map((ref) => {
         // For annotated tags, use the dereferenced commit hash
-        const dereferencedHash = dereferencedTags.get(ref.value);
+        const dereferencedHash = dereferencedTags[ref.value];
         if (dereferencedHash) {
           return { ...ref, hash: dereferencedHash };
         }

--- a/lib/modules/datasource/git-refs/index.spec.ts
+++ b/lib/modules/datasource/git-refs/index.spec.ts
@@ -98,7 +98,9 @@ describe('modules/datasource/git-refs/index', () => {
         { packageName: 'a tag to look up' },
         'v1.0.4',
       );
-      expect(digest).toBe('2b52829c7c1bd65b3501c450849c53b90b11fa0e');
+      // For annotated tags, we return the dereferenced commit hash (^{})
+      // to match what `git submodule status` returns
+      expect(digest).toBe('3ed9e7d7094fd4ee7751c24a3e6b706060f461ff');
     });
 
     it('ignores refs/for/', async () => {

--- a/lib/modules/datasource/git-tags/__snapshots__/index.spec.ts.snap
+++ b/lib/modules/datasource/git-tags/__snapshots__/index.spec.ts.snap
@@ -5,32 +5,32 @@ exports[`modules/datasource/git-tags/index > getReleases > returns versions filt
   "releases": [
     {
       "gitRef": "v1.0.0",
-      "newDigest": "0be9ffb1ae0c8d0846cd88b58dfef42d74674673",
+      "newDigest": "7b756026fb2de270240a889a413e7e3a9d4d4d85",
       "version": "v1.0.0",
     },
     {
       "gitRef": "v1.0.1",
-      "newDigest": "281fbfb58990ec98b237a923d67904c102bec34c",
+      "newDigest": "e173183f932ba8a31d0e4f23cc1070e8ebfa59d6",
       "version": "v1.0.1",
     },
     {
       "gitRef": "v1.0.2",
-      "newDigest": "9cb93e0b236385a4e2efd089d7c6a458f5ff321f",
+      "newDigest": "3936a6bced3587dc9fd464b0a910e0dfd4cfe10d",
       "version": "v1.0.2",
     },
     {
       "gitRef": "v1.0.3",
-      "newDigest": "8b0d0e0aec21ea059448ef0255387dbb82c61973",
+      "newDigest": "125ca9f3df4151e50046e5327ecb29ec4c13efab",
       "version": "v1.0.3",
     },
     {
       "gitRef": "v1.0.4",
-      "newDigest": "2b52829c7c1bd65b3501c450849c53b90b11fa0e",
+      "newDigest": "3ed9e7d7094fd4ee7751c24a3e6b706060f461ff",
       "version": "v1.0.4",
     },
     {
       "gitRef": "v1.0.5",
-      "newDigest": "2d138c34e4c6939d0a8686943e851c6528aa04db",
+      "newDigest": "6d7a933c2e6b7b39e992b1f93b6b42de083b28f0",
       "version": "v1.0.5",
     },
   ],

--- a/lib/modules/datasource/git-tags/index.spec.ts
+++ b/lib/modules/datasource/git-tags/index.spec.ts
@@ -81,7 +81,7 @@ describe('modules/datasource/git-tags/index', () => {
         { packageName: 'a tag to look up' },
         'v1.0.2',
       );
-      expect(digest).toBe('9cb93e0b236385a4e2efd089d7c6a458f5ff321f');
+      expect(digest).toBe('3936a6bced3587dc9fd464b0a910e0dfd4cfe10d');
     });
 
     it('returns digest for HEAD', async () => {


### PR DESCRIPTION
> [!NOTE]
> This code changes in this PR were written primarily by Claude Code. 

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
When git ls-remote lists annotated tags, it returns two entries:
1. The tag object hash: refs/tags/v1.0.0 -> abc123
2. The dereferenced commit hash: refs/tags/v1.0.0^{} -> def456

Previously, Renovate used the tag object hash (abc123).  However, `git submodule status` returns the actual commit hash (def456).  This mismatch caused false-positive dependency updates that resulted in empty commits, since the tag object and commit hash differ even when pointing to the same version.

This feature:
- Parses both entries from git ls-remote into allRefs
- Builds a lookup map of tag names to their dereferenced commit hashes
- For annotated tags, replaces the tag object hash with the commit hash
- Lightweight tags are unaffected (they already return the commit hash)

This ensures Renovate's detected digest matches what git submodule operations actually use, preventing unnecessary update PRs.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation  It relates to the discussion https://github.com/renovatebot/renovate/discussions/40365.

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: Private repository

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
