### PR TITLE
fix(versioning/hex): handle Elixir == pin prefix in isSingleVersion

### DIFF
--- a/lib/modules/versioning/hex/index.spec.ts
+++ b/lib/modules/versioning/hex/index.spec.ts
@@ -39,6 +39,21 @@ describe('modules/versioning/hex/index', () => {
   });
 
   it.each`
+    version       | expected
+    ${'1.2.3'}    | ${true}
+    ${'== 1.2.3'} | ${true}
+    ${'~> 1.2'}   | ${false}
+    ${'~> 1.2.0'} | ${false}
+    ${'>= 1.0.0'} | ${false}
+  `('isSingleVersion("$version") === $expected', ({ version, expected }) => {
+    expect(hexScheme.isSingleVersion(version)).toBe(expected);
+  });
+
+  it('getPinnedValue returns == prefixed version', () => {
+    expect(hexScheme.getPinnedValue?.('1.2.3')).toBe('== 1.2.3');
+  });
+
+  it.each`
     version    | range                      | expected
     ${'0.1.0'} | ${'>= 1.0.0 and <= 2.0.0'} | ${true}
     ${'1.9.0'} | ${'>= 1.0.0 and <= 2.0.0'} | ${false}

--- a/lib/modules/versioning/hex/index.spec.ts
+++ b/lib/modules/versioning/hex/index.spec.ts
@@ -50,7 +50,7 @@ describe('modules/versioning/hex/index', () => {
   });
 
   it('getPinnedValue returns == prefixed version', () => {
-    expect(hexScheme.getPinnedValue?.('1.2.3')).toBe('== 1.2.3');
+    expect(hexScheme.getPinnedValue!('1.2.3')).toBe('== 1.2.3');
   });
 
   it.each`

--- a/lib/modules/versioning/hex/index.ts
+++ b/lib/modules/versioning/hex/index.ts
@@ -54,6 +54,18 @@ function isLessThanRange(version: string, range: string): boolean {
 
 const isValid = (input: string): boolean => !!npm.isValid(hex2npm(input));
 
+function isSingleVersion(constraint: string): boolean {
+  return (
+    npm.isVersion(constraint) ||
+    (constraint?.startsWith('==') &&
+      npm.isVersion(constraint.substring(2).trim()))
+  );
+}
+
+function getPinnedValue(newVersion: string): string {
+  return `== ${newVersion}`;
+}
+
 const matches = (version: string, range: string): boolean =>
   npm.matches(hex2npm(version), hex2npm(range));
 
@@ -111,11 +123,13 @@ export { isValid };
 export const api: VersioningApi = {
   ...npm,
   isLessThanRange,
+  isSingleVersion,
   isValid,
   matches,
   getSatisfyingVersion,
   minSatisfyingVersion,
   getNewValue,
+  getPinnedValue,
 };
 
 export default api;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Hex versioning inherited npm's `isSingleVersion()` which only strips a single = prefix. Elixir uses == for pinning (e.g. `== 1.7.16`), so pinned versions were not recognized as single versions. This caused the centralized pin logic in `lookup/index.ts` to trigger again after every merge, creating duplicate PRs that strip the == prefix.

This adds two overrides to the hex versioning module:
- `isSingleVersion()`: recognizes Elixir's == prefix as a pinned version
- `getPinnedValue()`: emits the correct == <version> syntax when pinning

This is a regression from https://github.com/renovatebot/renovate/commit/0d5d7a866 which moved pin logic out of individual `getNewValue` implementations into a centralized check using `isSingleVersion()`/`getPinnedValue()`, but Hex never received the necessary overrides.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

Related discussion: #40796

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
