### PR TITLE
fix(gomod): write full pseudo-version instead of bare hash on digest updates

### DIFF
--- a/lib/modules/manager/gomod/update.spec.ts
+++ b/lib/modules/manager/gomod/update.spec.ts
@@ -370,6 +370,36 @@ describe('modules/manager/gomod/update', () => {
       expect(res).toEqual(gomod2);
     });
 
+    it('updates pseudo-version with digest updateType', () => {
+      const fileContent = codeBlock`
+        module example.com/test
+        require (
+          knative.dev/pkg v0.0.0-20250312035536-b7bbf4be5dbd
+          k8s.io/utils v0.0.0-20251002143259-bc988d571ff4
+        )
+      `;
+      const upgrade = {
+        depName: 'knative.dev/pkg',
+        managerData: { lineNumber: 2, multiLine: true },
+        updateType: 'digest' as const,
+        currentValue: 'v0.0.0-20250312035536-b7bbf4be5dbd',
+        currentDigest: 'b7bbf4be5dbd',
+        newValue: 'v0.0.0-20260120122510-4a022ed9999a',
+        newDigest: '4a022ed9999a',
+        depType: 'require',
+      };
+      const res = updateDependency({
+        fileContent,
+        packageFile: 'go.mod',
+        upgrade,
+      });
+      // Should write the full pseudo-version, not just the digest
+      expect(res).toContain(
+        'knative.dev/pkg v0.0.0-20260120122510-4a022ed9999a',
+      );
+      expect(res).not.toContain('knative.dev/pkg 4a022ed9999a');
+    });
+
     it('handles multiline mismatch', () => {
       const upgrade = {
         depName: 'github.com/fatih/color',

--- a/lib/modules/manager/gomod/update.ts
+++ b/lib/modules/manager/gomod/update.ts
@@ -80,22 +80,41 @@ export function updateDependency({
     }
     let newLine: string;
     if (upgrade.updateType === 'digest') {
-      const newDigestRightSized = upgrade.newDigest!.substring(
-        0,
-        upgrade.currentDigest!.length,
-      );
-      if (lineToChange.includes(newDigestRightSized)) {
-        return fileContent;
+      // Since the 2024 goproxy datasource changes, newValue and newDigest are
+      // both extracted from the same proxy version string and always reference
+      // the same commit, so newValue can be written directly for pseudo-versions.
+      if (upgrade.newValue?.startsWith('v0.0.0-')) {
+        logger.debug(
+          { depName: currentName, lineToChange, newValue: upgrade.newValue },
+          'gomod: updating pseudo-version digest',
+        );
+        newLine = lineToChange.replace(
+          // TODO: can be undefined? (#22198)
+          updateLineExp!,
+          `$<depPart>$<divider>${upgrade.newValue}`,
+        );
+      } else {
+        // Defensive fallback for non-pseudo-version digest updates.
+        // Unreachable for gomod in practice: currentDigest is only extracted
+        // for pseudo-versions, and the gomod override in lookup/index.ts that
+        // sets updateType='digest' requires newValue to start with 'v0.0.0-'.
+        const newDigestRightSized = upgrade.newDigest!.substring(
+          0,
+          upgrade.currentDigest!.length,
+        );
+        if (lineToChange.includes(newDigestRightSized)) {
+          return fileContent;
+        }
+        logger.debug(
+          { depName: currentName, lineToChange, newDigestRightSized },
+          'gomod: need to update digest',
+        );
+        newLine = lineToChange.replace(
+          // TODO: can be undefined? (#22198)
+          updateLineExp!,
+          `$<depPart>$<divider>${newDigestRightSized}`,
+        );
       }
-      logger.debug(
-        { depName: currentName, lineToChange, newDigestRightSized },
-        'gomod: need to update digest',
-      );
-      newLine = lineToChange.replace(
-        // TODO: can be undefined? (#22198)
-        updateLineExp!,
-        `$<depPart>$<divider>${newDigestRightSized}`,
-      );
     } else {
       newLine = lineToChange.replace(
         // TODO: can be undefined? (#22198)


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

When a Go dependency uses a pseudo-version (v0.0.0-timestamp-hash) and Renovate detects a newer pseudo-version, updateType is set to 'digest' via the gomod special-case in lookup/index.ts. The digest update code path was then writing only the 12-character bare commit hash, producing invalid go.mod syntax:
```
  - knative.dev/pkg v0.0.0-20250312035536-b7bbf4be5dbd
  + knative.dev/pkg 4a022ed9999a
```
Historical cause:

In 2018, the Go module proxy did not yet exist. Renovate queried the GitHub API for the latest commit SHA and had no way to obtain the correct commit timestamp, so it fabricated a pseudo-version using the wall-clock time when Renovate ran. The result was syntactically valid but semantically wrong. Go 1.11 and 1.12 did not validate pseudo-version timestamps, and `go get` would normalise the fabricated version to the correct one anyway, so this worked in practice.

Go 1.13 (2019) introduced strict pseudo-version timestamp validation, rejecting any pseudo-version whose timestamp does not match the actual commit time. Renovate's fix (31ce47297) was to drop the fabricated timestamp entirely and write just the bare commit hash, then rely on `go get` to expand it into a canonical pseudo-version. However, when the `go get` command or other subsequent operations fail, Renovate may leave the go.mod file containing dependencies pinned to bare commit hashes.

Why the fix is now safe:

Since the 2024 goproxy datasource changes, both newValue and newDigest are extracted from the same proxy version string via pseudoVersionToRelease(). They always reference the same commit, so writing newValue directly produces correct, syntactically valid go.mod output without depending on `go get` to clean it up afterward.

This should fix the issue mentioned in discussion - #33596 

## Context

Please select one of the following:

- [] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: <none>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
