### PR TITLE
Revert "fix(crate): respect config.json in indices"

### DIFF
--- a/lib/modules/datasource/crate/__snapshots__/index.spec.ts.snap
+++ b/lib/modules/datasource/crate/__snapshots__/index.spec.ts.snap
@@ -34,7 +34,7 @@ exports[`modules/datasource/crate/index > getReleases > processes real data: ame
 {
   "dependencyUrl": "https://crates.io/crates/amethyst",
   "homepage": "https://amethyst.rs/",
-  "registryUrl": "sparse+https://index.crates.io",
+  "registryUrl": "https://crates.io",
   "releases": [
     {
       "version": "0.1.0",
@@ -102,7 +102,7 @@ exports[`modules/datasource/crate/index > getReleases > processes real data: ame
 exports[`modules/datasource/crate/index > getReleases > processes real data: libc 1`] = `
 {
   "dependencyUrl": "https://crates.io/crates/libc",
-  "registryUrl": "sparse+https://index.crates.io",
+  "registryUrl": "https://crates.io",
   "releases": [
     {
       "version": "0.1.0",

--- a/lib/modules/datasource/crate/index.spec.ts
+++ b/lib/modules/datasource/crate/index.spec.ts
@@ -16,29 +16,17 @@ import * as memCache from '../../../util/cache/memory/index.ts';
 import type { Timestamp } from '../../../util/timestamp.ts';
 import { getPkgReleases } from '../index.ts';
 import { CrateDatasource } from './index.ts';
-import type { RegistryConfigSchema } from './schema.ts';
+import type { RegistryInfo } from './types.ts';
 
 vi.mock('simple-git');
 const simpleGit = vi.mocked(_simpleGit);
 
-const API_BASE_URL = 'https://crates.io';
-const DL_BASE_URL = 'https://static.crates.io/crates';
-const CRATES_IO_REGISTRY_URL = 'sparse+https://index.crates.io/';
-const CRATES_IO_REGISTRY_URL_PARSED = 'https://index.crates.io/';
+const API_BASE_URL = CrateDatasource.CRATES_IO_API_BASE_URL;
+
+const baseUrl =
+  'https://raw.githubusercontent.com/rust-lang/crates.io-index/master/';
 
 const datasource = CrateDatasource.id;
-
-const cratesIoConfig: RegistryConfigSchema = {
-  dl: DL_BASE_URL,
-  api: API_BASE_URL,
-};
-
-function mockCratesIoConfig(): void {
-  httpMock
-    .scope(CRATES_IO_REGISTRY_URL_PARSED)
-    .get('/config.json')
-    .reply(200, cratesIoConfig);
-}
 
 function setupGitMocks(delayMs?: number): {
   mockClone: MockedFunction<SimpleGit['clone']>;
@@ -55,11 +43,6 @@ function setupGitMocks(delayMs?: number): {
         const path = `${clonePath}/my/pk/mypkg`;
         fs.mkdirSync(upath.dirname(path), { recursive: true });
         fs.writeFileSync(path, Fixtures.get('mypkg'), { encoding: 'utf8' });
-        fs.writeFileSync(
-          `${clonePath}/config.json`,
-          JSON.stringify({ dl: 'https://example.com/crates' }),
-          { encoding: 'utf8' },
-        );
       },
     );
 
@@ -91,7 +74,7 @@ function setupErrorGitMock(): {
 function mockCratesApiCallFor(crateName: string, response?: httpMock.Body) {
   httpMock
     .scope(API_BASE_URL)
-    .get(`/api/v1/crates/${crateName}?include=`)
+    .get(`/crates/${crateName}?include=`)
     .reply(response ? 200 : 404, response);
 }
 
@@ -149,10 +132,7 @@ describe('modules/datasource/crate/index', () => {
 
     it('returns null for missing registry url', async () => {
       // FIXME: should not call default registry?
-      httpMock
-        .scope(CRATES_IO_REGISTRY_URL_PARSED)
-        .get('/no/n_/non_existent_crate')
-        .reply(404, {});
+      httpMock.scope(baseUrl).get('/no/n_/non_existent_crate').reply(404, {});
       expect(
         await getPkgReleases({
           datasource,
@@ -173,107 +153,88 @@ describe('modules/datasource/crate/index', () => {
     });
 
     it('returns null for empty result', async () => {
-      mockCratesIoConfig();
       mockCratesApiCallFor('non_existent_crate');
-      httpMock
-        .scope(CRATES_IO_REGISTRY_URL_PARSED)
-        .get('/no/n_/non_existent_crate')
-        .reply(200, {});
+      httpMock.scope(baseUrl).get('/no/n_/non_existent_crate').reply(200, {});
       expect(
         await getPkgReleases({
           datasource,
           packageName: 'non_existent_crate',
-          registryUrls: [CRATES_IO_REGISTRY_URL],
+          registryUrls: ['https://crates.io'],
         }),
       ).toBeNull();
     });
 
     it('returns null for missing fields', async () => {
-      mockCratesIoConfig();
       mockCratesApiCallFor('non_existent_crate');
       httpMock
-        .scope(CRATES_IO_REGISTRY_URL_PARSED)
+        .scope(baseUrl)
         .get('/no/n_/non_existent_crate')
         .reply(200, undefined);
       expect(
         await getPkgReleases({
           datasource,
           packageName: 'non_existent_crate',
-          registryUrls: [CRATES_IO_REGISTRY_URL],
+          registryUrls: ['https://crates.io'],
         }),
       ).toBeNull();
     });
 
     it('returns null for empty list', async () => {
-      mockCratesIoConfig();
       mockCratesApiCallFor('non_existent_crate');
-      httpMock
-        .scope(CRATES_IO_REGISTRY_URL_PARSED)
-        .get('/no/n_/non_existent_crate')
-        .reply(200, '\n');
+      httpMock.scope(baseUrl).get('/no/n_/non_existent_crate').reply(200, '\n');
       expect(
         await getPkgReleases({
           datasource,
           packageName: 'non_existent_crate',
-          registryUrls: [CRATES_IO_REGISTRY_URL],
+          registryUrls: ['https://crates.io'],
         }),
       ).toBeNull();
     });
 
     it('returns null for 404', async () => {
-      httpMock
-        .scope(CRATES_IO_REGISTRY_URL_PARSED)
-        .get('/so/me/some_crate')
-        .reply(404);
+      httpMock.scope(baseUrl).get('/so/me/some_crate').reply(404);
       expect(
         await getPkgReleases({
           datasource,
           packageName: 'some_crate',
-          registryUrls: [CRATES_IO_REGISTRY_URL],
+          registryUrls: ['https://crates.io'],
         }),
       ).toBeNull();
     });
 
     it('throws for 5xx', async () => {
-      httpMock
-        .scope(CRATES_IO_REGISTRY_URL_PARSED)
-        .get('/so/me/some_crate')
-        .reply(502);
+      httpMock.scope(baseUrl).get('/so/me/some_crate').reply(502);
       await expect(
         getPkgReleases({
           datasource,
           packageName: 'some_crate',
-          registryUrls: [CRATES_IO_REGISTRY_URL],
+          registryUrls: ['https://crates.io'],
         }),
       ).rejects.toThrow(EXTERNAL_HOST_ERROR);
     });
 
     it('returns null for unknown error', async () => {
-      httpMock
-        .scope(CRATES_IO_REGISTRY_URL_PARSED)
-        .get('/so/me/some_crate')
-        .replyWithError('');
+      httpMock.scope(baseUrl).get('/so/me/some_crate').replyWithError('');
       expect(
         await getPkgReleases({
           datasource,
           packageName: 'some_crate',
-          registryUrls: [CRATES_IO_REGISTRY_URL],
+          registryUrls: ['https://crates.io'],
         }),
       ).toBeNull();
     });
 
     it('processes real data: libc', async () => {
-      mockCratesIoConfig();
       mockCratesApiCallFor('libc', Fixtures.get('libc.json'));
 
       httpMock
-        .scope(CRATES_IO_REGISTRY_URL_PARSED)
+        .scope(baseUrl)
         .get('/li/bc/libc')
         .reply(200, Fixtures.get('libc'));
       const res = await getPkgReleases({
         datasource,
         packageName: 'libc',
-        registryUrls: [CRATES_IO_REGISTRY_URL],
+        registryUrls: ['https://crates.io'],
       });
       expect(res).toMatchSnapshot();
       expect(res).not.toBeNull();
@@ -281,51 +242,20 @@ describe('modules/datasource/crate/index', () => {
     });
 
     it('processes real data: amethyst', async () => {
-      mockCratesIoConfig();
       mockCratesApiCallFor('amethyst', Fixtures.get('amethyst.json'));
 
       httpMock
-        .scope(CRATES_IO_REGISTRY_URL_PARSED)
+        .scope(baseUrl)
         .get('/am/et/amethyst')
         .reply(200, Fixtures.get('amethyst'));
       const res = await getPkgReleases({
         datasource,
         packageName: 'amethyst',
-        registryUrls: [CRATES_IO_REGISTRY_URL],
+        registryUrls: ['https://crates.io'],
       });
       expect(res).toMatchSnapshot();
       expect(res).not.toBeNull();
       expect(res).toBeDefined();
-    });
-
-    it('uses cached registry config for subsequent packages', async () => {
-      mockCratesIoConfig();
-      mockCratesApiCallFor('libc', Fixtures.get('libc.json'));
-      httpMock
-        .scope(CRATES_IO_REGISTRY_URL_PARSED)
-        .get('/li/bc/libc')
-        .reply(200, Fixtures.get('libc'));
-
-      const res1 = await getPkgReleases({
-        datasource,
-        packageName: 'libc',
-        registryUrls: [CRATES_IO_REGISTRY_URL],
-      });
-      expect(res1).not.toBeNull();
-
-      // Second package: config.json should come from memCache (no extra HTTP mock needed)
-      mockCratesApiCallFor('amethyst', Fixtures.get('amethyst.json'));
-      httpMock
-        .scope(CRATES_IO_REGISTRY_URL_PARSED)
-        .get('/am/et/amethyst')
-        .reply(200, Fixtures.get('amethyst'));
-
-      const res2 = await getPkgReleases({
-        datasource,
-        packageName: 'amethyst',
-        registryUrls: [CRATES_IO_REGISTRY_URL],
-      });
-      expect(res2).not.toBeNull();
     });
 
     it('refuses to clone if allowCustomCrateRegistries is not true', async () => {
@@ -388,19 +318,6 @@ describe('modules/datasource/crate/index', () => {
       expect(mockClone).toHaveBeenCalledTimes(1);
     });
 
-    it('reads config.json from cloned registry', async () => {
-      const { mockClone } = setupGitMocks();
-      GlobalConfig.set({ ...adminConfig, allowCustomCrateRegistries: true });
-      const url = 'https://github.com/mcorbin/testregistry';
-      const res = await getPkgReleases({
-        datasource,
-        packageName: 'mypkg',
-        registryUrls: [url],
-      });
-      expect(mockClone).toHaveBeenCalled();
-      expect(res).not.toBeNull();
-    });
-
     it('guards against race conditions while cloning', async () => {
       vi.unmock('../../../util/mutex');
 
@@ -456,7 +373,6 @@ describe('modules/datasource/crate/index', () => {
 
       const url = 'https://github.com/mcorbin/othertestregistry';
       const sparseUrl = `sparse+${url}`;
-      httpMock.scope(url).get('/config.json').reply(404);
       httpMock.scope(url).get('/my/pk/mypkg').reply(200, {});
 
       const res = await getPkgReleases({
@@ -548,34 +464,31 @@ describe('modules/datasource/crate/index', () => {
     });
   });
 
+  describe('fetchCrateRecordsPayload', () => {
+    it('rejects if it has neither clonePath nor crates.io flavor', async () => {
+      const info: RegistryInfo = {
+        rawUrl: 'https://example.com',
+        url: new URL('https://example.com'),
+        flavor: 'cloudsmith',
+        isSparse: false,
+      };
+      const crateDatasource = new CrateDatasource();
+      await expect(
+        crateDatasource.fetchCrateRecordsPayload(info, 'benedict'),
+      ).toReject();
+    });
+  });
+
   describe('postprocessRelease', () => {
     const datasource = new CrateDatasource();
 
-    beforeEach(() => {
-      memCache.init();
-    });
-
-    it('no-op for registries without cached config', async () => {
+    it('no-op for registries other than crates.io', async () => {
       const releaseOrig = { version: '4.5.17' };
 
       const res = await datasource.postprocessRelease(
         {
           packageName: 'clap',
           registryUrl: 'https://example.com',
-        },
-        releaseOrig,
-      );
-
-      expect(res).toBe(releaseOrig);
-    });
-
-    it('no-op when registryUrl is null', async () => {
-      const releaseOrig = { version: '4.5.17' };
-
-      const res = await datasource.postprocessRelease(
-        {
-          packageName: 'clap',
-          registryUrl: null,
         },
         releaseOrig,
       );
@@ -592,7 +505,7 @@ describe('modules/datasource/crate/index', () => {
       const res = await datasource.postprocessRelease(
         {
           packageName: 'clap',
-          registryUrl: CRATES_IO_REGISTRY_URL,
+          registryUrl: 'https://crates.io',
         },
         releaseOrig,
       );
@@ -601,14 +514,9 @@ describe('modules/datasource/crate/index', () => {
     });
 
     it('fetches releaseTimestamp', async () => {
-      memCache.set(
-        `crate-datasource/registry-config/${CRATES_IO_REGISTRY_URL_PARSED}`,
-        cratesIoConfig,
-      );
-
       httpMock
         .scope(API_BASE_URL)
-        .get('/api/v1/crates/clap/4.5.17')
+        .get('/crates/clap/4.5.17')
         .reply(200, {
           version: {
             created_at: '2024-09-04T19:16:41.355243+00:00',
@@ -618,7 +526,7 @@ describe('modules/datasource/crate/index', () => {
       const res = await datasource.postprocessRelease(
         {
           packageName: 'clap',
-          registryUrl: CRATES_IO_REGISTRY_URL,
+          registryUrl: 'https://crates.io',
         },
         { version: '4.5.17' },
       );

--- a/lib/modules/datasource/crate/index.ts
+++ b/lib/modules/datasource/crate/index.ts
@@ -11,7 +11,6 @@ import { toSha256 } from '../../../util/hash.ts';
 import { memCacheProvider } from '../../../util/http/cache/memory-http-cache-provider.ts';
 import { acquireLock } from '../../../util/mutex.ts';
 import { newlineRegex, regEx } from '../../../util/regex.ts';
-import { Json } from '../../../util/schema-utils/index.ts';
 import { asTimestamp } from '../../../util/timestamp.ts';
 import { joinUrlParts, parseUrl } from '../../../util/url.ts';
 import * as cargoVersioning from '../../versioning/cargo/index.ts';
@@ -23,7 +22,7 @@ import type {
   Release,
   ReleaseResult,
 } from '../types.ts';
-import { RegistryConfigSchema, ReleaseTimestamp } from './schema.ts';
+import { ReleaseTimestamp } from './schema.ts';
 import type {
   CrateMetadata,
   CrateRecord,
@@ -48,9 +47,14 @@ export class CrateDatasource extends Datasource {
     super(CrateDatasource.id);
   }
 
-  override defaultRegistryUrls = ['sparse+https://index.crates.io/'];
+  override defaultRegistryUrls = ['https://crates.io'];
 
   override defaultVersioning = cargoVersioning.id;
+
+  static readonly CRATES_IO_BASE_URL =
+    'https://raw.githubusercontent.com/rust-lang/crates.io-index/master/';
+
+  static readonly CRATES_IO_API_BASE_URL = 'https://crates.io/api/v1/';
 
   override readonly sourceUrlSupport = 'package';
   override readonly sourceUrlNote =
@@ -149,75 +153,25 @@ export class CrateDatasource extends Datasource {
         namespace: `datasource-${CrateDatasource.id}`,
         // TODO: types (#22198)
         key: `${config.registryUrl}/${config.packageName}`,
-        cacheable: CrateDatasource.isCratesIo(config.registryUrl),
+        cacheable: CrateDatasource.areReleasesCacheable(config.registryUrl),
         fallback: true,
       },
       () => this._getReleases(config),
     );
   }
 
-  /**
-   * Fetches the registry's config.json which provides the API base URL
-   * and download URL template.
-   * See: https://doc.rust-lang.org/cargo/reference/registry-index.html#index-configuration
-   */
-  private async fetchRegistryConfig(
-    info: RegistryInfo,
-  ): Promise<RegistryConfigSchema | null> {
-    const cacheKey = `crate-datasource/registry-config/${info.rawUrl}`;
-    const cached = memCache.get<RegistryConfigSchema>(cacheKey);
-    if (cached) {
-      return cached;
-    }
-
-    if (info.clonePath) {
-      try {
-        const configPath = upath.join(info.clonePath, 'config.json');
-        const content = await readCacheFile(configPath, 'utf8');
-        const parsed = Json.pipe(RegistryConfigSchema).parse(content);
-        memCache.set(cacheKey, parsed);
-        return parsed;
-      } catch {
-        logger.debug(
-          { registryUrl: info.rawUrl },
-          'Could not read config.json from cloned registry',
-        );
-      }
-    } else {
-      try {
-        const configUrl = joinUrlParts(info.rawUrl, 'config.json');
-        const { body } = await this.http.getJson(
-          configUrl,
-          RegistryConfigSchema,
-        );
-        memCache.set(cacheKey, body);
-        return body;
-      } catch {
-        logger.debug(
-          { registryUrl: info.rawUrl },
-          'Could not fetch registry config.json',
-        );
-      }
-    }
-
-    return null;
-  }
-
   private async _getCrateMetadata(
     info: RegistryInfo,
     packageName: string,
   ): Promise<CrateMetadata | null> {
-    const registryConfig = await this.fetchRegistryConfig(info);
-    if (!registryConfig?.api) {
+    if (info.flavor !== 'crates.io') {
       return null;
     }
-
-    const apiBaseUrl = joinUrlParts(registryConfig.api, 'api/v1/');
 
     // The `?include=` suffix is required to avoid unnecessary database queries
     // on the crates.io server. This lets us work around the regular request
     // throttling of one request per second.
-    const crateUrl = `${apiBaseUrl}crates/${packageName}?include=`;
+    const crateUrl = `${CrateDatasource.CRATES_IO_API_BASE_URL}crates/${packageName}?include=`;
 
     logger.debug(
       { crateUrl, packageName, registryUrl: info.rawUrl },
@@ -248,7 +202,7 @@ export class CrateDatasource extends Datasource {
       {
         namespace: `datasource-${CrateDatasource.id}-metadata`,
         key: `${info.rawUrl}/${packageName}`,
-        cacheable: info.flavor === 'crates.io',
+        cacheable: CrateDatasource.areReleasesCacheable(info.rawUrl),
         ttlMinutes: 24 * 60, // 24 hours
       },
       () => this._getCrateMetadata(info, packageName),
@@ -267,16 +221,23 @@ export class CrateDatasource extends Datasource {
       return readCacheFile(path, 'utf8');
     }
 
-    // sparse index
-    const packageSuffix = CrateDatasource.getIndexSuffix(
-      packageName.toLowerCase(),
-    );
-    const crateUrl = joinUrlParts(info.rawUrl, ...packageSuffix);
-    try {
-      return (await this.http.getText(crateUrl)).body;
-    } catch (err) {
-      this.handleGenericErrors(err);
+    const baseUrl =
+      info.flavor === 'crates.io'
+        ? CrateDatasource.CRATES_IO_BASE_URL
+        : info.rawUrl;
+
+    if (info.flavor === 'crates.io' || info.isSparse) {
+      const packageSuffix = CrateDatasource.getIndexSuffix(
+        packageName.toLowerCase(),
+      );
+      const crateUrl = joinUrlParts(baseUrl, ...packageSuffix);
+      try {
+        return (await this.http.getText(crateUrl)).body;
+      } catch (err) {
+        this.handleGenericErrors(err);
+      }
     }
+    throw new Error(`unsupported crate registry flavor: ${info.flavor}`);
   }
 
   /**
@@ -298,7 +259,7 @@ export class CrateDatasource extends Datasource {
         return `https://cloudsmith.io/~${org}/repos/${repo}/packages/detail/cargo/${packageName}`;
       }
       default:
-        return `${info.url}/${packageName}`;
+        return `${info.rawUrl}/${packageName}`;
     }
   }
 
@@ -349,7 +310,7 @@ export class CrateDatasource extends Datasource {
     }
 
     let flavor: RegistryFlavor;
-    if (url.hostname === 'index.crates.io') {
+    if (url.hostname === 'crates.io') {
       flavor = 'crates.io';
     } else if (url.hostname === 'dl.cloudsmith.io') {
       flavor = 'cloudsmith';
@@ -361,6 +322,7 @@ export class CrateDatasource extends Datasource {
       flavor,
       rawUrl: registryFetchUrl,
       url,
+      isSparse: isSparseRegistry,
     };
 
     if (
@@ -372,7 +334,7 @@ export class CrateDatasource extends Datasource {
       );
       return null;
     }
-    if (!isSparseRegistry) {
+    if (registry.flavor !== 'crates.io' && !registry.isSparse) {
       const cacheKey = `crate-datasource/registry-clone-path/${registryFetchUrl}`;
       const lockKey = registryFetchUrl;
 
@@ -480,13 +442,12 @@ export class CrateDatasource extends Datasource {
     }
   }
 
-  private static isCratesIo(registryUrl: string | undefined): boolean {
-    if (!registryUrl) {
-      return false;
-    }
-    const normalized = registryUrl.replace(regEx(/^sparse\+/), '');
-    const parsed = parseUrl(normalized);
-    return parsed?.hostname === 'index.crates.io';
+  private static areReleasesCacheable(
+    registryUrl: string | undefined,
+  ): boolean {
+    // We only cache public releases, we don't want to cache private
+    // cloned data between runs.
+    return registryUrl === 'https://crates.io';
   }
 
   public static getIndexSuffix(packageName: string): string[] {
@@ -509,23 +470,11 @@ export class CrateDatasource extends Datasource {
     { packageName, registryUrl }: PostprocessReleaseConfig,
     release: Release,
   ): Promise<PostprocessReleaseResult> {
-    if (release.releaseTimestamp) {
+    if (release.releaseTimestamp || registryUrl !== 'https://crates.io') {
       return release;
     }
 
-    // Look up the registry config from cache (populated during getReleases)
-    const rawUrl = registryUrl?.replace(/^sparse\+/, '');
-    if (!rawUrl) {
-      return release;
-    }
-    const cacheKey = `crate-datasource/registry-config/${rawUrl}`;
-    const config = memCache.get<{ dl: string; api?: string }>(cacheKey);
-    if (!config?.api) {
-      return release;
-    }
-
-    const apiBaseUrl = joinUrlParts(config.api, 'api/v1/');
-    const url = `${apiBaseUrl}crates/${packageName}/${release.versionOrig ?? release.version}`;
+    const url = `https://crates.io/api/v1/crates/${packageName}/${release.versionOrig ?? release.version}`;
     // Getting release timestamp could become unnecessary if the manual backfill of `pubtime` mentioned in
     // https://github.com/rust-lang/cargo/issues/15491 is done for all packages.
     const { body: releaseTimestamp } = await this.http.getJson(
@@ -546,7 +495,7 @@ export class CrateDatasource extends Datasource {
         namespace: `datasource-crate`,
         key: `postprocessRelease:${config.registryUrl}:${config.packageName}:${release.version}`,
         ttlMinutes: 7 * 24 * 60,
-        cacheable: CrateDatasource.isCratesIo(config.registryUrl ?? undefined),
+        cacheable: config.registryUrl === 'https://crates.io',
       },
       () => this._postprocessRelease(config, release),
     );

--- a/lib/modules/datasource/crate/schema.ts
+++ b/lib/modules/datasource/crate/schema.ts
@@ -1,12 +1,6 @@
 import { z } from 'zod/v3';
 import { MaybeTimestamp } from '../../../util/timestamp.ts';
 
-export const RegistryConfigSchema = z.object({
-  dl: z.string(),
-  api: z.string().optional(),
-});
-export type RegistryConfigSchema = z.infer<typeof RegistryConfigSchema>;
-
 export const ReleaseTimestamp = z
   .object({
     version: z.object({

--- a/lib/modules/datasource/crate/types.ts
+++ b/lib/modules/datasource/crate/types.ts
@@ -17,7 +17,10 @@ export interface RegistryInfo {
   /** parsed URL of the registry */
   url: URL;
 
-  /** path where the registry is cloned, otherwise a sparse registry */
+  /** whether the registry uses sparse indexing (rfc-2789) */
+  isSparse: boolean;
+
+  /** path where the registry is cloned */
   clonePath?: string;
 }
 


### PR DESCRIPTION
Reverts renovatebot/renovate#41536

Sorry, this doesn't work. The index is not hosted at the "dl" endpoint as I assumed but at the baseUrl directly. I do not know how I could oversee such a crucial detail. Sometimes I am just blind, I guess.