### PR TITLE
feat(postUpgradeTasks): allow specifying `installTools`

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -4032,6 +4032,37 @@ These must be known by [Containerbase](https://github.com/containerbase/base).
 !!! note
     When using [`binarySource=global`](./self-hosted-configuration.md#binarysource), the `installTools` options do not take effect.
 
+For example:
+
+```json title="Adding a tool requirement"
+{
+  "postUpgradeTasks": {
+    "commands": ["make generate"],
+    "installTools": {
+      "golang": {}
+    }
+  }
+}
+```
+
+```json title="Utilising constraints for tool requirements"
+{
+  "constraints": {
+    "node": "^18.0.0 || >=20.0.0"
+  },
+  "postUpgradeTasks": {
+    "commands": ["npm install", "npm run update-readme"],
+    "installTools": {
+      "node": {}
+    }
+  }
+}
+```
+
+<!-- prettier-ignore -->
+!!! note
+    The tool objects inside `installTools` currently do not expose any additional configurability.
+
 ### workingDirTemplate
 
 A template describing the working directory in which the commands should be executed, relative to the repository root. If the template evaluates to a false value, then the command will be executed from the root of the repository.

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -4022,6 +4022,16 @@ Dotfiles are included.
 Optional field which defaults to any non-ignored file in the repo (`**/*` glob pattern).
 Specify a custom value for this if you wish to exclude certain files which are modified by your `postUpgradeTasks` and you don't want committed.
 
+### installTools
+
+Whether to install any additional tools dynamically before executing the `commands`.
+
+These must be known by [Containerbase](https://github.com/containerbase/base).
+
+<!-- prettier-ignore -->
+!!! note
+    When using [`binarySource=global`](./self-hosted-configuration.md#binarysource), the `installTools` options do not take effect.
+
 ### workingDirTemplate
 
 A template describing the working directory in which the commands should be executed, relative to the repository root. If the template evaluates to a false value, then the command will be executed from the root of the repository.

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -169,6 +169,7 @@ const options: Readonly<RenovateOptions>[] = [
       commands: [],
       fileFilters: [],
       executionMode: 'update',
+      installTools: {},
     },
   },
   {
@@ -206,6 +207,21 @@ const options: Readonly<RenovateOptions>[] = [
     subType: 'string',
     parents: ['postUpgradeTasks'],
     default: ['**/*'],
+    cli: false,
+  },
+  {
+    name: 'installTools',
+    description: 'Install tools before executing commands',
+    type: 'object',
+    parents: ['postUpgradeTasks'],
+    default: {},
+    additionalProperties: {
+      type: 'object',
+      properties: {},
+      additionalProperties: false,
+    },
+    mergeable: false,
+    freeChoice: true,
     cli: false,
   },
   {

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -304,6 +304,7 @@ export interface PostUpgradeTasks {
   dataFileTemplate?: string;
   fileFilters?: string[];
   executionMode: ExecutionMode;
+  installTools?: Record<string, Record<never, never>>;
 }
 
 export type UpdateConfig<

--- a/lib/workers/repository/update/branch/execute-post-upgrade-commands.spec.ts
+++ b/lib/workers/repository/update/branch/execute-post-upgrade-commands.spec.ts
@@ -906,5 +906,111 @@ describe('workers/repository/update/branch/execute-post-upgrade-commands', () =>
         }),
       );
     });
+
+    describe('when using installTools', () => {
+      interface TestCase {
+        description: string;
+        constraints?: Record<string, string>;
+        installTools: Record<string, Record<never, never>>;
+        expected: { toolName: string; constraint: string | undefined }[];
+      }
+
+      it.each<TestCase>([
+        {
+          description: 'constraints are passed',
+          constraints: { npm: '10.2.3' },
+          installTools: { npm: {} },
+          expected: [{ toolName: 'npm', constraint: '10.2.3' }],
+        },
+        {
+          description:
+            'constraints are passed for only the tools specified in installTools',
+          constraints: { composer: '> 2.3', npm: '10.2.3' },
+          installTools: { npm: {} },
+          expected: [
+            // but not composer
+            { toolName: 'npm', constraint: '10.2.3' },
+          ],
+        },
+        {
+          description: 'tools without a constraint are still used',
+          constraints: {
+            // node does not have a constraint
+          },
+          installTools: { node: {} },
+          expected: [{ toolName: 'node', constraint: undefined }],
+        },
+        {
+          description: 'tools with undefined `constraints` are still used',
+          constraints: undefined,
+          installTools: { node: {} },
+          expected: [{ toolName: 'node', constraint: undefined }],
+        },
+      ])('$description', async ({ constraints, installTools, expected }) => {
+        const commands = partial<BranchUpgradeConfig>([
+          {
+            constraints,
+            manager: 'some-manager',
+            branchName: 'main',
+            postUpgradeTasks: {
+              commands: ['some-command'],
+              executionMode: 'update',
+              installTools,
+            },
+          },
+        ]);
+        const config: BranchConfig = {
+          manager: 'some-manager',
+          updatedPackageFiles: [
+            { type: 'addition', path: 'some-existing-dir', contents: '' },
+            { type: 'addition', path: 'artifact', contents: '' },
+          ],
+          upgrades: [
+            {
+              manager: 'some-manager',
+              branchName: 'main',
+              depName: 'some-dep1',
+            },
+            {
+              manager: 'some-manager',
+              branchName: 'main',
+              depName: 'some-dep2',
+            },
+          ],
+          branchName: 'main',
+          baseBranch: 'base',
+        };
+        exec.exec.mockResolvedValueOnce({
+          stdout: 'success',
+          stderr: '',
+        });
+        git.getRepoStatus.mockResolvedValueOnce(
+          partial<StatusResult>({
+            modified: [],
+            not_added: [],
+            deleted: [],
+          }),
+        );
+        const localDir = upath.join(tmpDir.path, 'local');
+        GlobalConfig.set({
+          localDir,
+          allowedCommands: ['some-command'],
+        });
+        fs.localPathIsFile.mockResolvedValueOnce(true);
+
+        const res = await postUpgradeCommands.postUpgradeCommandsExecutor(
+          commands,
+          config,
+        );
+
+        expect(exec.exec).toHaveBeenCalledExactlyOnceWith(
+          'some-command',
+          expect.objectContaining({
+            toolConstraints: expected,
+          }),
+        );
+        expect(res.artifactErrors).toHaveLength(0);
+      });
+    });
   });
 });

--- a/lib/workers/repository/update/branch/execute-post-upgrade-commands.ts
+++ b/lib/workers/repository/update/branch/execute-post-upgrade-commands.ts
@@ -144,6 +144,18 @@ export async function postUpgradeCommandsExecutor(
                 RENOVATE_POST_UPGRADE_COMMAND_DATA_FILE: dataFilePath,
               };
             }
+            if (upgrade.postUpgradeTasks?.installTools) {
+              execOpts.toolConstraints ??= [];
+
+              for (const [tool] of Object.entries(
+                upgrade.postUpgradeTasks?.installTools,
+              )) {
+                execOpts.toolConstraints.push({
+                  toolName: tool,
+                  constraint: upgrade.constraints?.[tool],
+                });
+              }
+            }
             const execResult = await exec(compiledCmd, execOpts);
 
             logger.debug(

--- a/lib/workers/types.ts
+++ b/lib/workers/types.ts
@@ -119,6 +119,8 @@ export interface BranchUpgradeConfig
   sourceRepo?: string;
   sourceRepoOrg?: string;
   sourceRepoName?: string;
+
+  constraints?: Record<string, string>;
 }
 
 export type PrBlockedBy =


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
As noted in #8111 and #41569, it is possible that when using
`binarySource=install`, you can execute a `postUpgradeTasks`' given
command without Renovate having the right tools installed, dependent on
the Manager used for the update.

To make it possible for users to indicate that they explicitly need
given tools (at a given `constraint`), we can introduce a new
`installTools` option which will allow specifying which tools +
constraints to use when invoking the `postUpgradeTasks`'s command.

Right now, we're not defining what the `installTools'` interior type is,
but leaving it open to extension.


## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #8111, #41569
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe): GPT-4.1 (GitHub Coplit)

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/jamietanna-testing/rootly-go/pull/2 vs https://github.com/rootlyhq/rootly-go/pull/50

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->

