### PR TITLE
feat(manager/pep723): support uv lock file

### DIFF
--- a/lib/modules/manager/pep723/artifacts.spec.ts
+++ b/lib/modules/manager/pep723/artifacts.spec.ts
@@ -1,0 +1,211 @@
+import upath from 'upath';
+import { mockExecAll } from '~test/exec-util.ts';
+import { fs, logger } from '~test/util.ts';
+import { GlobalConfig } from '../../../config/global.ts';
+import type { RepoGlobalConfig } from '../../../config/types.ts';
+import { TEMPORARY_ERROR } from '../../../constants/error-messages.ts';
+import { getPkgReleases as _getPkgReleases } from '../../datasource/index.ts';
+import type { Upgrade } from '../types.ts';
+import { updateArtifacts } from './artifacts.ts';
+
+vi.mock('../../../util/fs/index.ts');
+vi.mock('../../datasource/index.ts');
+
+const getPkgReleases = vi.mocked(_getPkgReleases);
+
+const adminConfig: RepoGlobalConfig = {
+  localDir: upath.join('/tmp/github/some/repo'),
+  cacheDir: upath.join('/tmp/cache'),
+  containerbaseDir: upath.join('/tmp/cache/containerbase'),
+};
+
+describe('modules/manager/pep723/artifacts', () => {
+  describe('updateArtifacts', () => {
+    it('throws TEMPORARY_ERROR', async () => {
+      fs.readLocalFile.mockRejectedValueOnce(new Error(TEMPORARY_ERROR));
+
+      const updatedDeps = [{ depName: 'dep1' }, { depName: 'dep2' }];
+
+      const result = updateArtifacts({
+        packageFileName: 'foo.py',
+        newPackageFileContent: '',
+        config: {},
+        updatedDeps,
+      });
+
+      await expect(result).rejects.toThrow(TEMPORARY_ERROR);
+    });
+
+    it('returns null if no lock file is found', async () => {
+      fs.readLocalFile.mockResolvedValueOnce(null);
+
+      const updatedDeps = [{ depName: 'dep1' }];
+
+      const result = await updateArtifacts({
+        packageFileName: 'foo.py',
+        newPackageFileContent: '',
+        config: {},
+        updatedDeps,
+      });
+
+      expect(result).toBeNull();
+      expect(logger.logger.debug).toHaveBeenCalledWith(
+        { lockFileName: 'foo.py.lock' },
+        'No uv lock file found',
+      );
+    });
+
+    it('returns null if the lock file is unchanged', async () => {
+      const execSnapshots = mockExecAll();
+      GlobalConfig.set(adminConfig);
+      fs.readLocalFile.mockResolvedValueOnce('test content');
+      fs.readLocalFile.mockResolvedValueOnce('test content');
+
+      const updatedDeps = [{ depName: 'dep1' }, { depName: 'dep2' }];
+
+      const result = await updateArtifacts({
+        packageFileName: 'foo.py',
+        newPackageFileContent: '',
+        config: {},
+        updatedDeps,
+      });
+      expect(result).toBeNull();
+      expect(execSnapshots).toMatchObject([
+        {
+          cmd: 'uv lock --script foo.py --upgrade-package dep1 --upgrade-package dep2',
+        },
+      ]);
+    });
+
+    it('returns null on non-lock file maintenance empty updates', async () => {
+      GlobalConfig.set(adminConfig);
+
+      const updatedDeps: Upgrade[] = [];
+
+      const result = await updateArtifacts({
+        packageFileName: 'foo.py',
+        newPackageFileContent: '',
+        config: {},
+        updatedDeps,
+      });
+      expect(result).toBeNull();
+      expect(logger.logger.debug).toHaveBeenCalledWith(
+        'No dependencies to update',
+      );
+    });
+
+    it('returns artifact error', async () => {
+      const execSnapshots = mockExecAll();
+      GlobalConfig.set(adminConfig);
+      fs.readLocalFile.mockImplementationOnce(() => {
+        throw new Error('test error');
+      });
+
+      const updatedDeps = [{ depName: 'dep1' }];
+      const result = await updateArtifacts({
+        packageFileName: 'foo.py',
+        newPackageFileContent: '',
+        config: {},
+        updatedDeps,
+      });
+
+      expect(result).toEqual([
+        { artifactError: { lockFile: 'foo.py.lock', stderr: 'test error' } },
+      ]);
+      expect(execSnapshots).toEqual([]);
+    });
+
+    it('return update on dep update', async () => {
+      const execSnapshots = mockExecAll();
+      GlobalConfig.set({
+        ...adminConfig,
+        binarySource: 'docker',
+        dockerSidecarImage: 'ghcr.io/renovatebot/base-image',
+      });
+      fs.readLocalFile.mockResolvedValueOnce('test content');
+      fs.readLocalFile.mockResolvedValueOnce('changed test content');
+
+      // python
+      getPkgReleases.mockResolvedValueOnce({
+        releases: [{ version: '3.11.1' }, { version: '3.11.2' }],
+      });
+      // uv
+      getPkgReleases.mockResolvedValueOnce({
+        releases: [{ version: '0.2.28' }, { version: '0.2.35' }],
+      });
+
+      const updatedDeps = [{ depName: 'dep1' }, { depName: 'dep2' }];
+      const result = await updateArtifacts({
+        packageFileName: 'foo.py',
+        newPackageFileContent: '',
+        config: {},
+        updatedDeps,
+      });
+
+      expect(result).toEqual([
+        {
+          file: {
+            contents: 'changed test content',
+            path: 'foo.py.lock',
+            type: 'addition',
+          },
+        },
+      ]);
+      expect(execSnapshots).toMatchObject([
+        {
+          cmd: 'docker pull ghcr.io/renovatebot/base-image',
+        },
+        {
+          cmd: 'docker ps --filter name=renovate_sidecar -aq',
+        },
+        {
+          cmd:
+            'docker run --rm --name=renovate_sidecar --label=renovate_child ' +
+            '-v "/tmp/github/some/repo":"/tmp/github/some/repo" ' +
+            '-v "/tmp/cache":"/tmp/cache" ' +
+            '-e CONTAINERBASE_CACHE_DIR ' +
+            '-w "/tmp/github/some/repo" ' +
+            'ghcr.io/renovatebot/base-image ' +
+            'bash -l -c "' +
+            'install-tool python 3.11.2 ' +
+            '&& ' +
+            'install-tool uv 0.2.35 ' +
+            '&& ' +
+            'uv lock --script foo.py --upgrade-package dep1 --upgrade-package dep2' +
+            '"',
+        },
+      ]);
+    });
+
+    it('return update on lockfileMaintenance', async () => {
+      const execSnapshots = mockExecAll();
+      GlobalConfig.set(adminConfig);
+      fs.readLocalFile.mockResolvedValueOnce('test content');
+      fs.readLocalFile.mockResolvedValueOnce('changed test content');
+
+      const result = await updateArtifacts({
+        packageFileName: 'foo.py',
+        newPackageFileContent: '',
+        config: {
+          isLockFileMaintenance: true,
+        },
+        updatedDeps: [],
+      });
+
+      expect(result).toEqual([
+        {
+          file: {
+            contents: 'changed test content',
+            path: 'foo.py.lock',
+            type: 'addition',
+          },
+        },
+      ]);
+      expect(execSnapshots).toMatchObject([
+        {
+          cmd: 'uv lock --script foo.py --upgrade',
+        },
+      ]);
+    });
+  });
+});

--- a/lib/modules/manager/pep723/artifacts.ts
+++ b/lib/modules/manager/pep723/artifacts.ts
@@ -58,9 +58,9 @@ export async function updateArtifacts({
 
     let cmd: string;
     if (isLockFileMaintenance) {
-      cmd = `uv lock --script ${packageFileName} --upgrade`;
+      cmd = `uv lock --script ${quote(packageFileName)} --upgrade`;
     } else {
-      cmd = `uv lock --script ${packageFileName} ${updatedDeps.map((dep) => `--upgrade-package ${quote(dep.depName!)}`).join(' ')}`;
+      cmd = `uv lock --script ${quote(packageFileName)} ${updatedDeps.map((dep) => `--upgrade-package ${quote(dep.depName!)}`).join(' ')}`;
     }
 
     await exec(cmd, execOptions);

--- a/lib/modules/manager/pep723/artifacts.ts
+++ b/lib/modules/manager/pep723/artifacts.ts
@@ -6,11 +6,7 @@ import { exec } from '../../../util/exec/index.ts';
 import type { ExecOptions, ToolConstraint } from '../../../util/exec/types.ts';
 import { readLocalFile } from '../../../util/fs/index.ts';
 import { getGitEnvironmentVariables } from '../../../util/git/auth.ts';
-import type {
-  UpdateArtifact,
-  UpdateArtifactsResult,
-  Upgrade,
-} from '../types.ts';
+import type { UpdateArtifact, UpdateArtifactsResult } from '../types.ts';
 import { extractPep723 } from './utils.ts';
 
 export async function updateArtifacts({
@@ -64,7 +60,7 @@ export async function updateArtifacts({
     if (isLockFileMaintenance) {
       cmd = `uv lock --script ${packageFileName} --upgrade`;
     } else {
-      cmd = generateCMD(packageFileName, updatedDeps);
+      cmd = `uv lock --script ${packageFileName} ${updatedDeps.map((dep) => `--upgrade-package ${quote(dep.depName!)}`).join(' ')}`;
     }
 
     await exec(cmd, execOptions);
@@ -103,8 +99,4 @@ export async function updateArtifacts({
       },
     ];
   }
-}
-
-function generateCMD(packageFileName: string, updatedDeps: Upgrade[]): string {
-  return `uv lock --script ${packageFileName} ${updatedDeps.map((dep) => `--upgrade-package ${quote(dep.depName!)}`).join(' ')}`;
 }

--- a/lib/modules/manager/pep723/artifacts.ts
+++ b/lib/modules/manager/pep723/artifacts.ts
@@ -1,0 +1,110 @@
+import { isNonEmptyArray } from '@sindresorhus/is';
+import { quote } from 'shlex';
+import { TEMPORARY_ERROR } from '../../../constants/error-messages.ts';
+import { logger } from '../../../logger/index.ts';
+import { exec } from '../../../util/exec/index.ts';
+import type { ExecOptions, ToolConstraint } from '../../../util/exec/types.ts';
+import { readLocalFile } from '../../../util/fs/index.ts';
+import { getGitEnvironmentVariables } from '../../../util/git/auth.ts';
+import type {
+  UpdateArtifact,
+  UpdateArtifactsResult,
+  Upgrade,
+} from '../types.ts';
+import { extractPep723 } from './utils.ts';
+
+export async function updateArtifacts({
+  packageFileName,
+  updatedDeps,
+  newPackageFileContent,
+  config,
+}: UpdateArtifact): Promise<UpdateArtifactsResult[] | null> {
+  const { isLockFileMaintenance } = config;
+
+  if (!isNonEmptyArray(updatedDeps) && !isLockFileMaintenance) {
+    logger.debug('No dependencies to update');
+    return null;
+  }
+
+  const lockFileName = `${packageFileName}.lock`;
+
+  try {
+    const existingLockFileContent = await readLocalFile(lockFileName, 'utf8');
+
+    if (!existingLockFileContent) {
+      logger.debug({ lockFileName }, 'No uv lock file found');
+      return null;
+    }
+
+    const parsedPackageFile = extractPep723(
+      newPackageFileContent,
+      packageFileName,
+    );
+
+    const pythonConstraint: ToolConstraint = {
+      toolName: 'python',
+      constraint:
+        config.constraints?.python ??
+        parsedPackageFile?.extractedConstraints?.python,
+    };
+    const uvConstraint: ToolConstraint = {
+      toolName: 'uv',
+      constraint: config.constraints?.uv,
+    };
+
+    // TODO: Set credentials if indexes are set (https://docs.astral.sh/uv/guides/scripts/#using-alternative-package-indexes).
+    const extraEnv = getGitEnvironmentVariables(['pep723']);
+    const execOptions: ExecOptions = {
+      extraEnv,
+      docker: {},
+      toolConstraints: [pythonConstraint, uvConstraint],
+    };
+
+    let cmd: string;
+    if (isLockFileMaintenance) {
+      cmd = `uv lock --script ${packageFileName} --upgrade`;
+    } else {
+      cmd = generateCMD(packageFileName, updatedDeps);
+    }
+
+    await exec(cmd, execOptions);
+
+    // check for changes
+    const fileChanges: UpdateArtifactsResult[] = [];
+    const newLockContent = await readLocalFile(lockFileName, 'utf8');
+    const isLockFileChanged = existingLockFileContent !== newLockContent;
+
+    if (isLockFileChanged) {
+      fileChanges.push({
+        file: {
+          type: 'addition',
+          path: lockFileName,
+          contents: newLockContent,
+        },
+      });
+    } else {
+      logger.debug({ lockFileName }, 'uv lock file is unchanged');
+    }
+
+    return fileChanges.length ? fileChanges : null;
+  } catch (err) {
+    if (err.message === TEMPORARY_ERROR) {
+      throw err;
+    }
+
+    logger.debug({ err }, 'Failed to update uv lock file');
+
+    return [
+      {
+        artifactError: {
+          lockFile: lockFileName,
+          stderr: err.message,
+        },
+      },
+    ];
+  }
+}
+
+function generateCMD(packageFileName: string, updatedDeps: Upgrade[]): string {
+  return `uv lock --script ${packageFileName} ${updatedDeps.map((dep) => `--upgrade-package ${quote(dep.depName!)}`).join(' ')}`;
+}

--- a/lib/modules/manager/pep723/extract.spec.ts
+++ b/lib/modules/manager/pep723/extract.spec.ts
@@ -1,0 +1,21 @@
+import { extractPackageFile } from './extract.ts';
+import { extractPep723 as _extractPep723 } from './utils.ts';
+
+vi.mock('./utils.ts');
+
+const extractPep723 = vi.mocked(_extractPep723);
+
+describe('modules/manager/pep723/extract', () => {
+  describe('extractPackageFile()', () => {
+    it('should extract dependencies', () => {
+      const extractedDeps = {
+        deps: [{ depName: 'dep1' }, { depName: 'dep2' }],
+      };
+      extractPep723.mockReturnValueOnce(extractedDeps);
+
+      const res = extractPackageFile('foo', 'foo.py');
+
+      expect(res).toEqual(extractedDeps);
+    });
+  });
+});

--- a/lib/modules/manager/pep723/extract.ts
+++ b/lib/modules/manager/pep723/extract.ts
@@ -1,40 +1,9 @@
-import { logger } from '../../../logger/index.ts';
-import { newlineRegex, regEx } from '../../../util/regex.ts';
 import type { PackageFileContent } from '../types.ts';
-import { Pep723 } from './schema.ts';
-
-// Adapted regex from the Python reference implementation: https://packaging.python.org/en/latest/specifications/inline-script-metadata/#reference-implementation
-const regex = regEx(
-  /^# \/\/\/ (?<type>[a-zA-Z0-9-]+)$\s(?<content>(^#(| .*)$\s)+)^# \/\/\/$/,
-  'm',
-);
+import { extractPep723 } from './utils.ts';
 
 export function extractPackageFile(
   content: string,
   packageFile: string,
 ): PackageFileContent | null {
-  const match = regex.exec(content);
-  const matchedContent = match?.groups?.content;
-
-  if (!matchedContent) {
-    return null;
-  }
-
-  // Adapted code from the Python reference implementation: https://packaging.python.org/en/latest/specifications/inline-script-metadata/#reference-implementation
-  const parsedToml = matchedContent
-    .split(newlineRegex)
-    .map((line) => line.substring(line.startsWith('# ') ? 2 : 1))
-    .join('\n');
-
-  const { data: res, error } = Pep723.safeParse(parsedToml);
-
-  if (error) {
-    logger.debug(
-      { packageFile, error },
-      `Error parsing PEP 723 inline script metadata`,
-    );
-    return null;
-  }
-
-  return res.deps.length ? res : null;
+  return extractPep723(content, packageFile);
 }

--- a/lib/modules/manager/pep723/index.ts
+++ b/lib/modules/manager/pep723/index.ts
@@ -1,7 +1,11 @@
 import type { Category } from '../../../constants/index.ts';
 import { PypiDatasource } from '../../datasource/pypi/index.ts';
 
+export { updateArtifacts } from './artifacts.ts';
 export { extractPackageFile } from './extract.ts';
+
+export const supportsLockFileMaintenance = true;
+export const lockFileNames = ['*.py.lock'];
 
 export const displayName = 'PEP 723';
 export const url = 'https://peps.python.org/pep-0723';

--- a/lib/modules/manager/pep723/utils.spec.ts
+++ b/lib/modules/manager/pep723/utils.spec.ts
@@ -1,10 +1,10 @@
 import { codeBlock } from 'common-tags';
-import { extractPackageFile } from './index.ts';
+import { extractPep723 } from './utils.ts';
 
-describe('modules/manager/pep723/extract', () => {
-  describe('extractPackageFile()', () => {
+describe('modules/manager/pep723/utils', () => {
+  describe('parsePep723()', () => {
     it('should extract dependencies', () => {
-      const res = extractPackageFile(
+      const res = extractPep723(
         codeBlock`
           # /// script
           # requires-python = ">=3.11"
@@ -40,7 +40,7 @@ describe('modules/manager/pep723/extract', () => {
     });
 
     it('should skip invalid dependencies', () => {
-      const res = extractPackageFile(
+      const res = extractPep723(
         codeBlock`
           # /// script
           # requires-python = "==3.11"
@@ -69,7 +69,7 @@ describe('modules/manager/pep723/extract', () => {
     });
 
     it('should return null on missing dependencies', () => {
-      const res = extractPackageFile(
+      const res = extractPep723(
         codeBlock`
           # /// script
           # requires-python = ">=3.11"
@@ -82,7 +82,7 @@ describe('modules/manager/pep723/extract', () => {
     });
 
     it('should return null on invalid TOML', () => {
-      const res = extractPackageFile(
+      const res = extractPep723(
         codeBlock`
           # /// script
           # requires-python
@@ -99,7 +99,7 @@ describe('modules/manager/pep723/extract', () => {
     });
 
     it('should return null if there is no PEP 723 metadata', () => {
-      const res = extractPackageFile(
+      const res = extractPep723(
         codeBlock`
           if True:
               print("requires-python>=3.11")

--- a/lib/modules/manager/pep723/utils.ts
+++ b/lib/modules/manager/pep723/utils.ts
@@ -1,0 +1,40 @@
+import { logger } from '../../../logger/index.ts';
+import { newlineRegex, regEx } from '../../../util/regex.ts';
+import type { PackageFileContent } from '../types.ts';
+import { Pep723 } from './schema.ts';
+
+// Adapted regex from the Python reference implementation: https://packaging.python.org/en/latest/specifications/inline-script-metadata/#reference-implementation
+const regex = regEx(
+  /^# \/\/\/ (?<type>[a-zA-Z0-9-]+)$\s(?<content>(^#(| .*)$\s)+)^# \/\/\/$/,
+  'm',
+);
+
+export function extractPep723(
+  content: string,
+  packageFile: string,
+): PackageFileContent | null {
+  const match = regex.exec(content);
+  const matchedContent = match?.groups?.content;
+
+  if (!matchedContent) {
+    return null;
+  }
+
+  // Adapted code from the Python reference implementation: https://packaging.python.org/en/latest/specifications/inline-script-metadata/#reference-implementation
+  const parsedToml = matchedContent
+    .split(newlineRegex)
+    .map((line) => line.substring(line.startsWith('# ') ? 2 : 1))
+    .join('\n');
+
+  const { data: res, error } = Pep723.safeParse(parsedToml);
+
+  if (error) {
+    logger.debug(
+      { packageFile, error },
+      `Error parsing PEP 723 inline script metadata`,
+    );
+    return null;
+  }
+
+  return res.deps.length ? res : null;
+}


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

uv supports [lock files](https://docs.astral.sh/uv/guides/scripts/#locking-dependencies) for inline script metadata (PEP 723). Renovate currently doesn't support that, so if this feature is used, it leads to Renovate updating the dependencies in a script without updating the associated lock file.

This PR adds support for this, by checking whether a `<file-name>.lock` exists (e.g., for `foo.py`, we search for `foo.py.lock`).

Technically, this is a uv-specific feature, so I wondered if we should go the same way as PEP 621, meaning having a processor submodule per package manager, but since AFAIK only uv supports lock files for inline script metadata, I'm not sure making the architecture more complex is worth. If other package managers end up supporting that as well, it's always possible to revisit.

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #33591
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

Technically I did not update the documentation, but I've updated `index.ts` that affects the auto-generated documentation for lock file supports.

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/mkniewallner/renovate-pep723-uv-lockfile

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
