### PR TITLE
feat(workers/repository): raise artifact error if `pending` version used in an update

### DIFF
--- a/lib/workers/repository/update/branch/get-updated.spec.ts
+++ b/lib/workers/repository/update/branch/get-updated.spec.ts
@@ -1580,13 +1580,14 @@ describe('workers/repository/update/branch/get-updated', () => {
       gomod.extractPackageFile.mockResolvedValueOnce(null);
       await getUpdatedPackageFiles(config);
 
-      expect(logger.logger.debug).toHaveBeenCalledWith(
+      expect(logger.logger.warn).toHaveBeenCalledWith(
         { packageFile: 'go.mod', manager: 'gomod' },
         'Could not re-extract the packageFile after updating it',
       );
     });
 
-    it('skips deps without a depName when checking for pending versions', async () => {
+    // should never happen, but our types allow this
+    it('rejects when an updated dependency has no depName', async () => {
       config.upgrades.push({
         packageFile: 'composer.json',
         manager: 'composer',
@@ -1608,24 +1609,35 @@ describe('workers/repository/update/branch/get-updated', () => {
       composer.extractPackageFile.mockResolvedValueOnce({
         deps: [
           {
+            depName: undefined,
             lockedVersion: '1.3.0',
-          },
-          {
-            depName: 'some-dep',
-            lockedVersion: '1.2.3',
           },
         ],
       });
-      const res = await getUpdatedPackageFiles(config);
-      expect(res.artifactErrors).toHaveLength(0);
+
+      await expect(getUpdatedPackageFiles(config)).rejects.toThrowError(
+        'update-failure',
+      );
+
+      expect(logger.logger.error).toHaveBeenCalledWith(
+        {
+          packageFile: 'composer.json',
+          manager: 'composer',
+          branchName: 'renovate/pin',
+          depName: undefined,
+        },
+        "No depName found after updating 'composer.json'",
+      );
     });
 
-    it('does not include expected version in artifact error when upgrade has no newVersion', async () => {
+    // should never happen, but our types allow this
+    it('rejects when an updated dependency has no new version', async () => {
       config.upgrades.push({
         packageFile: 'composer.json',
         manager: 'composer',
         branchName: '',
         depName: 'some-dep',
+        newVersion: '1.2.3',
         pendingVersions: ['1.3.0'],
       });
       autoReplace.doAutoReplace.mockResolvedValueOnce('some new content');
@@ -1642,14 +1654,57 @@ describe('workers/repository/update/branch/get-updated', () => {
         deps: [
           {
             depName: 'some-dep',
-            lockedVersion: '1.3.0',
+            lockedVersion: undefined,
+            newVersion: undefined,
+            currentVersion: undefined,
+            currentValue: undefined,
           },
         ],
       });
-      const res = await getUpdatedPackageFiles(config);
-      expect(res.artifactErrors).toHaveLength(1);
-      expect(res.artifactErrors[0].stderr).not.toContain(
-        'Renovate was attempting to update to',
+
+      await expect(getUpdatedPackageFiles(config)).rejects.toThrowError(
+        'update-failure',
+      );
+
+      expect(logger.logger.error).toHaveBeenCalledWith(
+        {
+          packageFile: 'composer.json',
+          manager: 'composer',
+          branchName: 'renovate/pin',
+          depName: 'some-dep',
+          newVersion: undefined,
+        },
+        "No new version found for 'some-dep' after updating 'composer.json'",
+      );
+    });
+
+    // should never happen, but our types allow this
+    it('rejects when upgrade has no depName', async () => {
+      config.upgrades.push({
+        packageFile: 'composer.json',
+        manager: 'composer',
+        branchName: 'renovate/pin',
+        depName: undefined,
+        newVersion: '5.6.7',
+      });
+
+      await expect(getUpdatedPackageFiles(config)).rejects.toThrowError(
+        'update-failure',
+      );
+    });
+
+    // should never happen, but our types allow this
+    it('rejects when upgrade has no depName', async () => {
+      config.upgrades.push({
+        packageFile: 'composer.json',
+        manager: 'composer',
+        branchName: '',
+        depName: 'some-dep',
+        newVersion: undefined,
+      });
+
+      await expect(getUpdatedPackageFiles(config)).rejects.toThrowError(
+        'update-failure',
       );
     });
 

--- a/lib/workers/repository/update/branch/get-updated.spec.ts
+++ b/lib/workers/repository/update/branch/get-updated.spec.ts
@@ -1,6 +1,6 @@
 import { isArray } from '@sindresorhus/is';
 import { mockDeep } from 'vitest-mock-extended';
-import { git } from '~test/util.ts';
+import { git, logger } from '~test/util.ts';
 import { GitRefsDatasource } from '../../../../modules/datasource/git-refs/index.ts';
 import * as _batectWrapper from '../../../../modules/manager/batect-wrapper/index.ts';
 import * as _bundler from '../../../../modules/manager/bundler/index.ts';
@@ -14,6 +14,7 @@ import * as _pipCompile from '../../../../modules/manager/pip-compile/index.ts';
 import * as _poetry from '../../../../modules/manager/poetry/index.ts';
 import type {
   LookupUpdate,
+  PackageDependency,
   PackageFile,
   UpdateArtifact,
 } from '../../../../modules/manager/types.ts';
@@ -1218,6 +1219,475 @@ describe('workers/repository/update/branch/get-updated', () => {
           2,
           expect.objectContaining({ packageFileName: 'requirements-dev.in' }),
         );
+      });
+    });
+  });
+
+  // As per #41622
+  describe('checks if an artifact update introduces a pending version', () => {
+    let config: BranchConfig;
+
+    beforeEach(() => {
+      config = {
+        baseBranch: 'base-branch',
+        manager: 'some-manager',
+        branchName: 'renovate/pin',
+        upgrades: [],
+        minimumReleaseAgeBehaviour: 'timestamp-required',
+      } satisfies BranchConfig;
+      git.getFile.mockResolvedValueOnce('existing content');
+    });
+
+    describe('when artifact update introduces a pending version', () => {
+      it('logs an artifact error', async () => {
+        config.upgrades.push({
+          packageFile: 'composer.json',
+          manager: 'composer',
+          branchName: '',
+          depName: 'some-dep',
+          newVersion: '1.2.3',
+          pendingVersions: ['1.3.0', '1.4.0'],
+        });
+        autoReplace.doAutoReplace.mockResolvedValueOnce('some new content');
+        composer.updateArtifacts.mockResolvedValueOnce([
+          {
+            file: {
+              type: 'addition',
+              path: 'composer.lock',
+              contents: 'some lock contents',
+            },
+          },
+        ]);
+        composer.extractPackageFile.mockResolvedValueOnce({
+          deps: [
+            {
+              depName: 'some-dep',
+              lockedVersion: '1.3.0',
+            },
+          ],
+        });
+        const res = await getUpdatedPackageFiles(config);
+        expect(res.artifactErrors).toHaveLength(1);
+        expect(res.artifactErrors[0]).toMatchObject({
+          lockFile: 'composer.json',
+          stderr: expect.stringContaining('1.3.0'),
+        });
+        expect(res.artifactErrors[0].stderr).toContain(
+          'Artifact update for some-dep resolved to version 1.3.0, which is a pending version that has not yet passed the Minimum Release Age threshold.\nRenovate was attempting to update to 1.2.3\nThis is (likely) not a bug in Renovate, but due to the way your project pins dependencies, _and_ how Renovate calls your package manager to update them.\nUntil Renovate supports specifying an exact update to your package manager (https://github.com/renovatebot/renovate/issues/41624), it is recommended to directly pin your dependencies (with `rangeStrategy=pin` for apps, or `rangeStrategy=widen` for libraries)\nSee also: https://docs.renovatebot.com/dependency-pinning/',
+        );
+      });
+
+      // TODO doesn't fire for **??**
+
+      it.each<{
+        description: string;
+        dep: PackageDependency;
+      }>([
+        {
+          description: 'detects lockedVersion',
+          dep: {
+            depName: 'some-dep',
+            lockedVersion: '1.3.0',
+          },
+        },
+        {
+          description: 'detects newVersion',
+          dep: {
+            depName: 'some-dep',
+            newVersion: '1.3.0',
+          },
+        },
+        {
+          description: 'detects currentVersion',
+          dep: {
+            depName: 'some-dep',
+            currentVersion: '1.3.0',
+          },
+        },
+        {
+          description: 'detects currentValue',
+          dep: {
+            depName: 'some-dep',
+            currentValue: '1.3.0',
+          },
+        },
+      ])(`$description`, async ({ dep }) => {
+        config.upgrades.push({
+          packageFile: 'composer.json',
+          manager: 'composer',
+          branchName: '',
+          depName: 'some-dep',
+          newVersion: '1.2.3',
+          pendingVersions: ['1.3.0', '1.4.0'],
+        });
+        autoReplace.doAutoReplace.mockResolvedValueOnce('some new content');
+        composer.updateArtifacts.mockResolvedValueOnce([
+          {
+            file: {
+              type: 'addition',
+              path: 'composer.lock',
+              contents: 'some lock contents',
+            },
+          },
+        ]);
+        composer.extractPackageFile.mockResolvedValueOnce({
+          deps: [dep],
+        });
+        const res = await getUpdatedPackageFiles(config);
+        expect(res.artifactErrors).toHaveLength(1);
+        expect(res.artifactErrors[0]).toMatchObject({
+          lockFile: 'composer.json',
+          stderr: expect.stringContaining('1.3.0'),
+        });
+      });
+    });
+
+    it('does not add artifact error when no deps match pending versions', async () => {
+      config.upgrades.push({
+        packageFile: 'composer.json',
+        manager: 'composer',
+        branchName: '',
+        depName: 'some-dep',
+        newVersion: '1.2.3',
+        pendingVersions: ['1.3.0', '1.4.0'],
+      });
+      autoReplace.doAutoReplace.mockResolvedValueOnce('some new content');
+      composer.updateArtifacts.mockResolvedValueOnce([
+        {
+          file: {
+            type: 'addition',
+            path: 'composer.lock',
+            contents: 'some lock contents',
+          },
+        },
+      ]);
+      composer.extractPackageFile.mockResolvedValueOnce({
+        deps: [
+          {
+            depName: 'some-dep',
+            currentVersion: '1.2.5',
+          },
+        ],
+      });
+      const res = await getUpdatedPackageFiles(config);
+      expect(res.artifactErrors).toHaveLength(0);
+    });
+
+    it('does not add artifact error when a different dependency has the same version as the pending version', async () => {
+      config.upgrades.push({
+        packageFile: 'composer.json',
+        manager: 'composer',
+        branchName: '',
+        depName: 'some-dep',
+        newVersion: '1.2.3',
+        pendingVersions: ['1.2.5'],
+      });
+      autoReplace.doAutoReplace.mockResolvedValueOnce('some new content');
+      composer.updateArtifacts.mockResolvedValueOnce([
+        {
+          file: {
+            type: 'addition',
+            path: 'composer.lock',
+            contents: 'some lock contents',
+          },
+        },
+      ]);
+      composer.extractPackageFile.mockResolvedValueOnce({
+        deps: [
+          {
+            depName: 'some-dep',
+            currentVersion: '1.2.3',
+          },
+          {
+            depName: 'transitive-dep',
+            currentVersion: '1.2.5',
+          },
+        ],
+      });
+      const res = await getUpdatedPackageFiles(config);
+      expect(res.artifactErrors).toHaveLength(0);
+    });
+
+    it('skips pending version check when upgrade has no pendingVersions', async () => {
+      config.upgrades.push({
+        packageFile: 'composer.json',
+        manager: 'composer',
+        branchName: '',
+        depName: 'some-dep',
+        newVersion: '1.2.3',
+      });
+      autoReplace.doAutoReplace.mockResolvedValueOnce('some new content');
+      composer.updateArtifacts.mockResolvedValueOnce([
+        {
+          file: {
+            type: 'addition',
+            path: 'composer.lock',
+            contents: 'some lock contents',
+          },
+        },
+      ]);
+      const res = await getUpdatedPackageFiles(config);
+      expect(res.artifactErrors).toHaveLength(0);
+      expect(composer.extractPackageFile).not.toHaveBeenCalled();
+    });
+
+    it('skips pending version check when no artifact results', async () => {
+      config.upgrades.push({
+        packageFile: 'composer.json',
+        manager: 'composer',
+        branchName: '',
+        depName: 'some-dep',
+        newVersion: '1.2.3',
+        pendingVersions: ['1.3.0'],
+      });
+      autoReplace.doAutoReplace.mockResolvedValueOnce('some new content');
+      composer.updateArtifacts.mockResolvedValueOnce([]);
+      const res = await getUpdatedPackageFiles(config);
+      expect(res.artifactErrors).toHaveLength(0);
+      expect(composer.extractPackageFile).not.toHaveBeenCalled();
+    });
+
+    it('does not add artifact error when extractPackageFile returns null', async () => {
+      config.upgrades.push({
+        packageFile: 'composer.json',
+        manager: 'composer',
+        branchName: '',
+        depName: 'some-dep',
+        newVersion: '1.2.3',
+        pendingVersions: ['1.3.0'],
+      });
+      autoReplace.doAutoReplace.mockResolvedValueOnce('some new content');
+      composer.updateArtifacts.mockResolvedValueOnce([
+        {
+          file: {
+            type: 'addition',
+            path: 'composer.lock',
+            contents: 'some lock contents',
+          },
+        },
+      ]);
+      composer.extractPackageFile.mockResolvedValueOnce(null);
+      const res = await getUpdatedPackageFiles(config);
+      expect(res.artifactErrors).toHaveLength(0);
+    });
+
+    it('adds multiple artifact errors when multiple deps match pending versions', async () => {
+      config.upgrades.push({
+        packageFile: 'composer.json',
+        manager: 'composer',
+        branchName: '',
+        depName: 'some-dep',
+        newVersion: '1.2.3',
+        pendingVersions: ['1.3.0', '1.4.0'],
+      });
+      autoReplace.doAutoReplace.mockResolvedValueOnce('some new content');
+      composer.updateArtifacts.mockResolvedValueOnce([
+        {
+          file: {
+            type: 'addition',
+            path: 'composer.lock',
+            contents: 'some lock contents',
+          },
+        },
+      ]);
+      composer.extractPackageFile.mockResolvedValueOnce({
+        deps: [
+          {
+            depName: 'some-dep',
+            lockedVersion: '1.3.0',
+          },
+          {
+            depName: 'some-dep',
+            lockedVersion: '1.4.0',
+          },
+          {
+            depName: 'dep-c',
+            lockedVersion: '1.2.5',
+          },
+        ],
+      });
+      const res = await getUpdatedPackageFiles(config);
+      expect(res.artifactErrors).toHaveLength(2);
+      expect(res.artifactErrors[0]).toMatchObject({
+        stderr: expect.stringContaining('1.3.0'),
+      });
+      expect(res.artifactErrors[1]).toMatchObject({
+        stderr: expect.stringContaining('1.4.0'),
+      });
+    });
+
+    it('skips pending version check when minimumReleaseAgeBehaviour is not timestamp-required', async () => {
+      config.minimumReleaseAgeBehaviour = 'timestamp-optional';
+      config.upgrades.push({
+        packageFile: 'composer.json',
+        manager: 'composer',
+        branchName: '',
+        depName: 'some-dep',
+        newVersion: '1.2.3',
+        pendingVersions: ['1.3.0'],
+      });
+      autoReplace.doAutoReplace.mockResolvedValueOnce('some new content');
+      composer.updateArtifacts.mockResolvedValueOnce([
+        {
+          file: {
+            type: 'addition',
+            path: 'composer.lock',
+            contents: 'some lock contents',
+          },
+        },
+      ]);
+      composer.extractPackageFile.mockResolvedValueOnce({
+        deps: [
+          {
+            depName: 'some-dep',
+            lockedVersion: '1.3.0',
+          },
+        ],
+      });
+      const res = await getUpdatedPackageFiles(config);
+      expect(res.artifactErrors).toHaveLength(0);
+      expect(composer.extractPackageFile).toHaveBeenCalled();
+      expect(logger.logger.once.warn).toHaveBeenCalledWith(
+        {
+          packageFileName: 'composer.json',
+          depName: 'some-dep',
+          expectedVersion: '1.2.3',
+          resolvedVersion: '1.3.0',
+        },
+        "Artifact error would be reported due to a pending version in use which hasn't passed Minimum Release Age, but as we're running with minimumReleaseAgeBehaviour=timestamp-optional, proceeding. See debug logs for more information",
+      );
+    });
+
+    it('adds logs a debug log if it fails to re-extract the package file', async () => {
+      config.upgrades.push({
+        packageFile: 'go.mod',
+        manager: 'gomod',
+        branchName: '',
+        depName: 'github.com/foo/bar',
+        newVersion: '0.5.1',
+        pendingVersions: ['0.6.0'],
+      });
+      gomod.updateDependency.mockReturnValue('some new content');
+      gomod.updateArtifacts.mockResolvedValueOnce([
+        {
+          file: {
+            type: 'addition',
+            path: 'go.mod',
+            contents: 'some content',
+          },
+        },
+      ]);
+      gomod.extractPackageFile.mockResolvedValueOnce(null);
+      await getUpdatedPackageFiles(config);
+
+      expect(logger.logger.debug).toHaveBeenCalledWith(
+        { packageFile: 'go.mod', manager: 'gomod' },
+        'Could not re-extract the packageFile after updating it',
+      );
+    });
+
+    it('skips deps without a depName when checking for pending versions', async () => {
+      config.upgrades.push({
+        packageFile: 'composer.json',
+        manager: 'composer',
+        branchName: '',
+        depName: 'some-dep',
+        newVersion: '1.2.3',
+        pendingVersions: ['1.3.0'],
+      });
+      autoReplace.doAutoReplace.mockResolvedValueOnce('some new content');
+      composer.updateArtifacts.mockResolvedValueOnce([
+        {
+          file: {
+            type: 'addition',
+            path: 'composer.lock',
+            contents: 'some lock contents',
+          },
+        },
+      ]);
+      composer.extractPackageFile.mockResolvedValueOnce({
+        deps: [
+          {
+            lockedVersion: '1.3.0',
+          },
+          {
+            depName: 'some-dep',
+            lockedVersion: '1.2.3',
+          },
+        ],
+      });
+      const res = await getUpdatedPackageFiles(config);
+      expect(res.artifactErrors).toHaveLength(0);
+    });
+
+    it('does not include expected version in artifact error when upgrade has no newVersion', async () => {
+      config.upgrades.push({
+        packageFile: 'composer.json',
+        manager: 'composer',
+        branchName: '',
+        depName: 'some-dep',
+        pendingVersions: ['1.3.0'],
+      });
+      autoReplace.doAutoReplace.mockResolvedValueOnce('some new content');
+      composer.updateArtifacts.mockResolvedValueOnce([
+        {
+          file: {
+            type: 'addition',
+            path: 'composer.lock',
+            contents: 'some lock contents',
+          },
+        },
+      ]);
+      composer.extractPackageFile.mockResolvedValueOnce({
+        deps: [
+          {
+            depName: 'some-dep',
+            lockedVersion: '1.3.0',
+          },
+        ],
+      });
+      const res = await getUpdatedPackageFiles(config);
+      expect(res.artifactErrors).toHaveLength(1);
+      expect(res.artifactErrors[0].stderr).not.toContain(
+        'Renovate was attempting to update to',
+      );
+    });
+
+    it('adds artifact error for nonUpdatedPackageFiles (lockfile update scenario)', async () => {
+      config.upgrades.push({
+        packageFile: 'composer.json',
+        manager: 'composer',
+        branchName: '',
+        depName: 'some-dep',
+        newVersion: '1.2.3',
+        pendingVersions: ['1.3.0'],
+        isLockfileUpdate: true,
+      });
+      composer.updateLockedDependency.mockReturnValueOnce({
+        status: 'unsupported',
+      });
+      composer.updateArtifacts.mockResolvedValueOnce([
+        {
+          file: {
+            type: 'addition',
+            path: 'composer.lock',
+            contents: 'some lock contents',
+          },
+        },
+      ]);
+      composer.extractPackageFile.mockResolvedValueOnce({
+        deps: [
+          {
+            depName: 'some-dep',
+            lockedVersion: '1.3.0',
+          },
+        ],
+      });
+      const res = await getUpdatedPackageFiles(config);
+      expect(res.artifactErrors).toHaveLength(1);
+      expect(res.artifactErrors[0]).toMatchObject({
+        lockFile: 'composer.json',
+        stderr: expect.stringContaining('1.3.0'),
       });
     });
   });

--- a/lib/workers/repository/update/branch/get-updated.ts
+++ b/lib/workers/repository/update/branch/get-updated.ts
@@ -615,7 +615,7 @@ async function checkForPendingVersions(
 
     if (resolvedVersion && upgradeInfo.pendingVersions.has(resolvedVersion)) {
       const expectedVersion = upgradeInfo.newVersion;
-      /* v8 ignore next 10 -- should not happen */
+      /* v8 ignore next if -- should not happen */
       if (!expectedVersion) {
         logger.error(
           {

--- a/lib/workers/repository/update/branch/get-updated.ts
+++ b/lib/workers/repository/update/branch/get-updated.ts
@@ -1,11 +1,10 @@
 import { isNonEmptyArray } from '@sindresorhus/is';
 import { WORKER_FILE_UPDATE_FAILED } from '../../../../constants/error-messages.ts';
 import { logger } from '../../../../logger/index.ts';
-import { get } from '../../../../modules/manager/index.ts';
+import { extractPackageFile, get } from '../../../../modules/manager/index.ts';
 import type {
   ArtifactError,
   ArtifactNotice,
-  PackageDependency,
   PackageFile,
   UpdateArtifact,
   UpdateArtifactsConfig,
@@ -103,7 +102,7 @@ export async function getUpdatedPackageFiles(
   let updatedFileContents: Record<string, string> = {};
   const nonUpdatedFileContents: Record<string, string> = {};
   const managerPackageFiles: Record<string, Set<string>> = {};
-  const packageFileUpdatedDeps: Record<string, PackageDependency[]> = {};
+  const packageFileUpdatedDeps: Record<string, BranchUpgradeConfig[]> = {};
   const lockFileMaintenanceFiles: string[] = [];
   let firstUpdate = true;
   for (const upgrade of config.upgrades) {
@@ -348,6 +347,16 @@ export async function getUpdatedPackageFiles(
           artifactErrors,
           artifactNotices,
         );
+        if (isNonEmptyArray(results)) {
+          await checkForPendingVersions(
+            manager,
+            packageFile.path,
+            packageFile.contents!.toString(),
+            updatedDeps,
+            artifactErrors,
+            config,
+          );
+        }
       }
     }
   }
@@ -391,6 +400,14 @@ export async function getUpdatedPackageFiles(
         );
         if (isNonEmptyArray(results)) {
           updatedPackageFiles.push(packageFile);
+          await checkForPendingVersions(
+            manager,
+            packageFile.path,
+            packageFile.contents!.toString(),
+            updatedDeps,
+            artifactErrors,
+            config,
+          );
         }
       }
     }
@@ -508,6 +525,105 @@ function processUpdateArtifactResults(
       if (notice) {
         artifactNotices.push(notice);
       }
+    }
+  }
+}
+
+/**
+ * When using Minimum Release Age, and a package manager that doesn't support being told an explicit version to update to (#41624) it is possible that an artifact update leads to a different version of a dependency being used compared to what Renovate is expecting.
+ *
+ * We should report these cases more explicitly with an Artifact Error, to allow the reviewers to decide what to do with the changes.
+ */
+async function checkForPendingVersions(
+  manager: string,
+  packageFileName: string,
+  packageFileContent: string,
+  updatedDeps: BranchUpgradeConfig[],
+  artifactErrors: ArtifactError[],
+  config: BranchConfig,
+): Promise<void> {
+  const depNameToUpgradeInfo = new Map<
+    string,
+    {
+      pendingVersions: Set<string>;
+      newVersion: string | undefined;
+    }
+  >();
+  for (const dep of updatedDeps) {
+    if (dep.depName && isNonEmptyArray(dep.pendingVersions)) {
+      depNameToUpgradeInfo.set(dep.depName, {
+        pendingVersions: new Set(dep.pendingVersions),
+        newVersion: dep.newVersion,
+      });
+    }
+  }
+  if (!depNameToUpgradeInfo.size) {
+    return;
+  }
+
+  const extracted = await extractPackageFile(
+    manager,
+    packageFileContent,
+    packageFileName,
+    config,
+  );
+  if (!extracted) {
+    logger.debug(
+      { packageFile: packageFileName, manager },
+      'Could not re-extract the packageFile after updating it',
+    );
+    return;
+  }
+
+  for (const dep of extracted.deps) {
+    if (!dep.depName) {
+      continue;
+    }
+    const upgradeInfo = depNameToUpgradeInfo.get(dep.depName);
+    if (!upgradeInfo) {
+      continue;
+    }
+    const resolvedVersion =
+      dep.lockedVersion ??
+      dep.newVersion ??
+      dep.currentVersion ??
+      dep.currentValue;
+    if (resolvedVersion && upgradeInfo.pendingVersions.has(resolvedVersion)) {
+      const expectedVersion = upgradeInfo.newVersion;
+      if (config.minimumReleaseAgeBehaviour === 'timestamp-optional') {
+        logger.once.warn(
+          {
+            packageFileName,
+            depName: dep.depName,
+            expectedVersion,
+            resolvedVersion,
+          },
+          "Artifact error would be reported due to a pending version in use which hasn't passed Minimum Release Age, but as we're running with minimumReleaseAgeBehaviour=timestamp-optional, proceeding. See debug logs for more information",
+        );
+        continue;
+      }
+
+      logger.debug(
+        {
+          packageFileName,
+          depName: dep.depName,
+          expectedVersion,
+          resolvedVersion,
+        },
+        'Artifact update introduced a pending version',
+      );
+      let stderr = `Artifact update for ${dep.depName} resolved to version ${resolvedVersion}, which is a pending version that has not yet passed the Minimum Release Age threshold.`;
+
+      if (expectedVersion) {
+        stderr += `\nRenovate was attempting to update to ${expectedVersion}`;
+      }
+
+      stderr += `\nThis is (likely) not a bug in Renovate, but due to the way your project pins dependencies, _and_ how Renovate calls your package manager to update them.\nUntil Renovate supports specifying an exact update to your package manager (https://github.com/renovatebot/renovate/issues/41624), it is recommended to directly pin your dependencies (with \`rangeStrategy=pin\` for apps, or \`rangeStrategy=widen\` for libraries)\nSee also: https://docs.renovatebot.com/dependency-pinning/`;
+
+      artifactErrors.push({
+        lockFile: packageFileName,
+        stderr,
+      });
     }
   }
 }

--- a/lib/workers/repository/update/branch/get-updated.ts
+++ b/lib/workers/repository/update/branch/get-updated.ts
@@ -654,11 +654,7 @@ async function checkForPendingVersions(
         'Artifact update introduced a pending version',
       );
       let stderr = `Artifact update for ${dep.depName} resolved to version ${resolvedVersion}, which is a pending version that has not yet passed the Minimum Release Age threshold.`;
-
-      if (expectedVersion) {
-        stderr += `\nRenovate was attempting to update to ${expectedVersion}`;
-      }
-
+      stderr += `\nRenovate was attempting to update to ${expectedVersion}`;
       stderr += `\nThis is (likely) not a bug in Renovate, but due to the way your project pins dependencies, _and_ how Renovate calls your package manager to update them.\nUntil Renovate supports specifying an exact update to your package manager (https://github.com/renovatebot/renovate/issues/41624), it is recommended to directly pin your dependencies (with \`rangeStrategy=pin\` for apps, or \`rangeStrategy=widen\` for libraries)\nSee also: https://docs.renovatebot.com/dependency-pinning/`;
 
       artifactErrors.push({

--- a/lib/workers/repository/update/branch/get-updated.ts
+++ b/lib/workers/repository/update/branch/get-updated.ts
@@ -568,7 +568,7 @@ async function checkForPendingVersions(
     config,
   );
   if (!extracted) {
-    logger.debug(
+    logger.warn(
       { packageFile: packageFileName, manager },
       'Could not re-extract the packageFile after updating it',
     );
@@ -576,9 +576,20 @@ async function checkForPendingVersions(
   }
 
   for (const dep of extracted.deps) {
+    // shouldn't ever happen
     if (!dep.depName) {
-      continue;
+      logger.error(
+        {
+          packageFile: packageFileName,
+          manager,
+          branchName: config.branchName,
+          depName: dep.depName,
+        },
+        `No depName found after updating '${packageFileName}'`,
+      );
+      throw new Error(WORKER_FILE_UPDATE_FAILED);
     }
+
     const upgradeInfo = depNameToUpgradeInfo.get(dep.depName);
     if (!upgradeInfo) {
       continue;
@@ -588,8 +599,38 @@ async function checkForPendingVersions(
       dep.newVersion ??
       dep.currentVersion ??
       dep.currentValue;
+    if (!resolvedVersion) {
+      logger.error(
+        {
+          packageFile: packageFileName,
+          manager,
+          branchName: config.branchName,
+          depName: dep.depName,
+          newVersion: resolvedVersion,
+        },
+        `No new version found for '${dep.depName}' after updating '${packageFileName}'`,
+      );
+      throw new Error(WORKER_FILE_UPDATE_FAILED);
+    }
+
     if (resolvedVersion && upgradeInfo.pendingVersions.has(resolvedVersion)) {
       const expectedVersion = upgradeInfo.newVersion;
+      /* v8 ignore next 10 -- should not happen */
+      if (!expectedVersion) {
+        logger.error(
+          {
+            packageFile: packageFileName,
+            manager,
+            branchName: config.branchName,
+            depName: dep.depName,
+            newVersion: resolvedVersion,
+            expectedVersion,
+          },
+          `No expectedVersion found for '${dep.depName}' after updating '${packageFileName}'`,
+        );
+        continue;
+      }
+
       if (config.minimumReleaseAgeBehaviour === 'timestamp-optional') {
         logger.once.warn(
           {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes


When using Minimum Release Age, and a package manager that doesn't
support being told an explicit version to update to (#41624) it is
possible that an artifact update leads to a different version of a
dependency being used compared to what Renovate is expecting.

This can lead to, at best, a surprising PR update, and at worst, a
supply chain attack.

We should report these cases more explicitly with an Artifact Error, to
allow the reviewers to decide what to do with the changes.

To do this, we need to re-extract package files after an update, and
determine if any of the version(s) of that dependency are using any of
the `pendingVersions`.

This may be slightly breaking to users, which is why this is a `feat`
not a `fix`, but isn't so breaking that it's worth leaving until the
next breaking change .

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #41622
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe): Claude Sonnet 4.6 (GitHub Copilot + `crush`)

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/JamieTanna-Mend-testing/renovate-iss-41607/pull/1

When skipping checks:

```
 WARN: Artifact error would be reported due to a pending version in use which hasn't passed Minimum Release Age, but as we're running with minimumReleaseAgeBehaviour=timestamp-optional, proceeding. See debug logs for more in
formation (repository=JamieTanna-Mend-testing/renovate-iss-41607, branch=renovate/boto3-1.x-lockfile)
       "packageFileName": "pyproject.toml",
       "depName": "boto3",
       "expectedVersion": "1.42.55",
       "resolvedVersion": "1.42.59"

```

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
