### PR TITLE
refactor(types): rename `lockFile` to `fileName` in `ArtifactError`

### DIFF
--- a/lib/modules/manager/batect-wrapper/artifacts.spec.ts
+++ b/lib/modules/manager/batect-wrapper/artifacts.spec.ts
@@ -102,14 +102,14 @@ describe('modules/manager/batect-wrapper/artifacts', () => {
       expect(result).toEqual([
         {
           artifactError: {
-            lockFile: 'batect',
+            fileName: 'batect',
             stderr:
               'HTTP GET https://github.com/batect/batect/releases/download/3.4.5/batect failed: HTTPError: Request failed with status code 404 (Not Found): GET https://github.com/batect/batect/releases/download/3.4.5/batect',
           },
         },
         {
           artifactError: {
-            lockFile: 'batect.cmd',
+            fileName: 'batect.cmd',
             stderr:
               "HTTP GET https://github.com/batect/batect/releases/download/3.4.5/batect.cmd failed: HTTPError: Request failed with status code 418 (I'm a Teapot): GET https://github.com/batect/batect/releases/download/3.4.5/batect.cmd",
           },

--- a/lib/modules/manager/batect-wrapper/artifacts.ts
+++ b/lib/modules/manager/batect-wrapper/artifacts.ts
@@ -23,7 +23,7 @@ async function updateArtifact(
 
     return {
       artifactError: {
-        lockFile: path,
+        fileName: path,
         stderr: `HTTP GET ${url} failed: ${errorDescription}`,
       },
     };

--- a/lib/modules/manager/bun/artifacts.spec.ts
+++ b/lib/modules/manager/bun/artifacts.spec.ts
@@ -187,7 +187,7 @@ describe('modules/manager/bun/artifacts', () => {
         fs.readFile.mockResolvedValueOnce(oldLock as never);
         exec.mockRejectedValueOnce(execError);
         expect(await updateArtifacts(updateArtifact)).toEqual([
-          { artifactError: { lockFile: 'bun.lockb', stderr: 'nope' } },
+          { artifactError: { fileName: 'bun.lockb', stderr: 'nope' } },
         ]);
       });
     });
@@ -305,7 +305,7 @@ describe('modules/manager/bun/artifacts', () => {
         fs.readFile.mockResolvedValueOnce(oldLock as never);
         exec.mockRejectedValueOnce(execError);
         expect(await updateArtifacts(updateArtifact)).toEqual([
-          { artifactError: { lockFile: 'bun.lock', stderr: 'nope' } },
+          { artifactError: { fileName: 'bun.lock', stderr: 'nope' } },
         ]);
       });
     });

--- a/lib/modules/manager/bun/artifacts.ts
+++ b/lib/modules/manager/bun/artifacts.ts
@@ -103,7 +103,7 @@ export async function updateArtifacts(
     return [
       {
         artifactError: {
-          lockFile: lockFileName,
+          fileName: lockFileName,
           stderr: err.message,
         },
       },

--- a/lib/modules/manager/bundler/artifacts.spec.ts
+++ b/lib/modules/manager/bundler/artifacts.spec.ts
@@ -509,7 +509,7 @@ describe('modules/manager/bundler/artifacts', () => {
             isLockFileMaintenance: true,
           },
         }),
-      ).toMatchObject([{ artifactError: { lockFile: 'Gemfile.lock' } }]);
+      ).toMatchObject([{ artifactError: { fileName: 'Gemfile.lock' } }]);
       expect(execSnapshots).toMatchObject([{ cmd: 'bundler lock --update' }]);
     });
 
@@ -566,7 +566,7 @@ describe('modules/manager/bundler/artifacts', () => {
         ).toMatchObject([
           {
             artifactError: {
-              lockFile: 'Gemfile.lock',
+              fileName: 'Gemfile.lock',
             },
           },
         ]);
@@ -614,7 +614,7 @@ describe('modules/manager/bundler/artifacts', () => {
               isLockFileMaintenance: true,
             },
           }),
-        ).toMatchObject([{ artifactError: { lockFile: 'Gemfile.lock' } }]);
+        ).toMatchObject([{ artifactError: { fileName: 'Gemfile.lock' } }]);
       });
 
       it('throws on authentication errors', async () => {

--- a/lib/modules/manager/bundler/artifacts.ts
+++ b/lib/modules/manager/bundler/artifacts.ts
@@ -201,7 +201,7 @@ export async function updateArtifacts(
       return [
         {
           artifactError: {
-            lockFile: lockFileName,
+            fileName: lockFileName,
             stderr: output,
           },
         },
@@ -255,7 +255,7 @@ export async function updateArtifacts(
     return [
       {
         artifactError: {
-          lockFile: lockFileName,
+          fileName: lockFileName,
           stderr: `${String(err.stdout)}\n${String(err.stderr)}`,
         },
       },

--- a/lib/modules/manager/cargo/artifacts.spec.ts
+++ b/lib/modules/manager/cargo/artifacts.spec.ts
@@ -275,7 +275,7 @@ describe('modules/manager/cargo/artifacts', () => {
         config,
       }),
     ).toEqual([
-      { artifactError: { lockFile: 'Cargo.lock', stderr: 'Exec error' } },
+      { artifactError: { fileName: 'Cargo.lock', stderr: 'Exec error' } },
     ]);
     expect(execSnapshots).toMatchObject([{ cmd }]);
   });
@@ -946,7 +946,7 @@ describe('modules/manager/cargo/artifacts', () => {
         config,
       }),
     ).toEqual([
-      { artifactError: { lockFile: 'Cargo.lock', stderr: 'not found' } },
+      { artifactError: { fileName: 'Cargo.lock', stderr: 'not found' } },
     ]);
   });
 });

--- a/lib/modules/manager/cargo/artifacts.ts
+++ b/lib/modules/manager/cargo/artifacts.ts
@@ -221,7 +221,7 @@ async function updateArtifactsImpl(
     return [
       {
         artifactError: {
-          lockFile: lockFileName,
+          fileName: lockFileName,
           stderr: err.message,
         },
       },

--- a/lib/modules/manager/cocoapods/artifacts.spec.ts
+++ b/lib/modules/manager/cocoapods/artifacts.spec.ts
@@ -202,7 +202,7 @@ describe('modules/manager/cocoapods/artifacts', () => {
         config,
       }),
     ).toEqual([
-      { artifactError: { lockFile: 'Podfile.lock', stderr: 'not found' } },
+      { artifactError: { fileName: 'Podfile.lock', stderr: 'not found' } },
     ]);
     expect(execSnapshots).toBeEmpty();
   });
@@ -223,7 +223,7 @@ describe('modules/manager/cocoapods/artifacts', () => {
         config,
       }),
     ).toEqual([
-      { artifactError: { lockFile: 'Podfile.lock', stderr: 'exec exception' } },
+      { artifactError: { fileName: 'Podfile.lock', stderr: 'exec exception' } },
     ]);
     expect(execSnapshots).toMatchSnapshot();
   });

--- a/lib/modules/manager/cocoapods/artifacts.ts
+++ b/lib/modules/manager/cocoapods/artifacts.ts
@@ -51,7 +51,7 @@ export async function updateArtifacts({
     return [
       {
         artifactError: {
-          lockFile: lockFileName,
+          fileName: lockFileName,
           stderr: err.message,
         },
       },
@@ -97,7 +97,7 @@ export async function updateArtifacts({
     return [
       {
         artifactError: {
-          lockFile: lockFileName,
+          fileName: lockFileName,
           stderr: err.stderr ?? err.stdout ?? err.message,
         },
       },

--- a/lib/modules/manager/composer/artifacts.spec.ts
+++ b/lib/modules/manager/composer/artifacts.spec.ts
@@ -927,7 +927,7 @@ describe('modules/manager/composer/artifacts', () => {
     ).toEqual([
       {
         artifactError: {
-          lockFile: 'composer.lock',
+          fileName: 'composer.lock',
           stderr: 'not found',
         },
       },
@@ -950,7 +950,7 @@ describe('modules/manager/composer/artifacts', () => {
         newPackageFileContent: '{}',
         config,
       }),
-    ).toEqual([{ artifactError: { lockFile: 'composer.lock', stderr } }]);
+    ).toEqual([{ artifactError: { fileName: 'composer.lock', stderr } }]);
     expect(execSnapshots).toBeEmptyArray();
   });
 

--- a/lib/modules/manager/composer/artifacts.ts
+++ b/lib/modules/manager/composer/artifacts.ts
@@ -271,7 +271,7 @@ export async function updateArtifacts({
     return [
       {
         artifactError: {
-          lockFile: lockFileName,
+          fileName: lockFileName,
           stderr: err.message,
         },
       },

--- a/lib/modules/manager/conan/artifacts.spec.ts
+++ b/lib/modules/manager/conan/artifacts.spec.ts
@@ -337,7 +337,7 @@ describe('modules/manager/conan/artifacts', () => {
         config: { ...config, updateType: 'lockFileMaintenance' },
       }),
     ).toEqual([
-      { artifactError: { lockFile: 'conan.lock', stderr: errorMessage } },
+      { artifactError: { fileName: 'conan.lock', stderr: errorMessage } },
     ]);
   });
 });

--- a/lib/modules/manager/conan/artifacts.ts
+++ b/lib/modules/manager/conan/artifacts.ts
@@ -114,7 +114,7 @@ export async function updateArtifacts(
     return [
       {
         artifactError: {
-          lockFile: lockFileName,
+          fileName: lockFileName,
           stderr: err.message,
         },
       },

--- a/lib/modules/manager/copier/artifacts.spec.ts
+++ b/lib/modules/manager/copier/artifacts.spec.ts
@@ -76,7 +76,7 @@ describe('modules/manager/copier/artifacts', () => {
       expect(result).toEqual([
         {
           artifactError: {
-            lockFile: '.copier-answers.yml',
+            fileName: '.copier-answers.yml',
             stderr: 'Missing copier template version to update to',
           },
         },
@@ -126,7 +126,7 @@ describe('modules/manager/copier/artifacts', () => {
       expect(result).toEqual([
         {
           artifactError: {
-            lockFile: '.copier-answers.yml',
+            fileName: '.copier-answers.yml',
             stderr: 'Unexpected number of dependencies: 0 (should be 1)',
           },
         },
@@ -147,7 +147,7 @@ describe('modules/manager/copier/artifacts', () => {
       expect(result).toEqual([
         {
           artifactError: {
-            lockFile: '.copier-answers.yml',
+            fileName: '.copier-answers.yml',
             stderr:
               'Unexpected number of dependencies: undefined (should be 1)',
           },
@@ -347,7 +347,7 @@ describe('modules/manager/copier/artifacts', () => {
       expect(result).toEqual([
         {
           artifactError: {
-            lockFile: '.copier-answers.yml',
+            fileName: '.copier-answers.yml',
             stderr: 'exec exception',
           },
         },

--- a/lib/modules/manager/copier/artifacts.ts
+++ b/lib/modules/manager/copier/artifacts.ts
@@ -44,7 +44,7 @@ function artifactError(
   return [
     {
       artifactError: {
-        lockFile: packageFileName,
+        fileName: packageFileName,
         stderr: message,
       },
     },

--- a/lib/modules/manager/devbox/artifacts.spec.ts
+++ b/lib/modules/manager/devbox/artifacts.spec.ts
@@ -468,7 +468,7 @@ describe('modules/manager/devbox/artifacts', () => {
       ).toEqual([
         {
           artifactError: {
-            lockFile: 'devbox.lock',
+            fileName: 'devbox.lock',
             stderr: "Cannot read properties of undefined (reading 'stdout')",
           },
         },

--- a/lib/modules/manager/devbox/artifacts.ts
+++ b/lib/modules/manager/devbox/artifacts.ts
@@ -99,7 +99,7 @@ export async function updateArtifacts({
     return [
       {
         artifactError: {
-          lockFile: lockFileName,
+          fileName: lockFileName,
           stderr: err.message,
         },
       },

--- a/lib/modules/manager/flux/artifacts.spec.ts
+++ b/lib/modules/manager/flux/artifacts.spec.ts
@@ -141,7 +141,7 @@ describe('modules/manager/flux/artifacts', () => {
     expect(res).toStrictEqual([
       {
         artifactError: {
-          lockFile: 'clusters/my-cluster/flux-system/gotk-components.yaml',
+          fileName: 'clusters/my-cluster/flux-system/gotk-components.yaml',
           stderr: 'failed',
         },
       },
@@ -162,7 +162,7 @@ describe('modules/manager/flux/artifacts', () => {
     expect(res).toStrictEqual([
       {
         artifactError: {
-          lockFile: 'clusters/my-cluster/flux-system/gotk-components.yaml',
+          fileName: 'clusters/my-cluster/flux-system/gotk-components.yaml',
           stderr: 'Error',
         },
       },

--- a/lib/modules/manager/flux/artifacts.ts
+++ b/lib/modules/manager/flux/artifacts.ts
@@ -41,7 +41,7 @@ export async function updateArtifacts({
       return [
         {
           artifactError: {
-            lockFile: packageFileName,
+            fileName: packageFileName,
             stderr: result.stderr,
           },
         },
@@ -66,7 +66,7 @@ export async function updateArtifacts({
     return [
       {
         artifactError: {
-          lockFile: packageFileName,
+          fileName: packageFileName,
           stderr: err.message,
         },
       },

--- a/lib/modules/manager/gleam/artifacts.spec.ts
+++ b/lib/modules/manager/gleam/artifacts.spec.ts
@@ -157,7 +157,7 @@ describe('modules/manager/gleam/artifacts', () => {
       expect(await updateArtifacts(updateArtifact)).toEqual([
         {
           artifactError: {
-            lockFile: 'manifest.toml',
+            fileName: 'manifest.toml',
             stderr: 'fake_gleam_failure',
           },
         },

--- a/lib/modules/manager/gleam/artifacts.ts
+++ b/lib/modules/manager/gleam/artifacts.ts
@@ -86,7 +86,7 @@ export async function updateArtifacts(
     return [
       {
         artifactError: {
-          lockFile: lockFileName,
+          fileName: lockFileName,
           stderr: err.message,
         },
       },

--- a/lib/modules/manager/gomod/artifacts.spec.ts
+++ b/lib/modules/manager/gomod/artifacts.spec.ts
@@ -1726,7 +1726,7 @@ describe('modules/manager/gomod/artifacts', () => {
     ).toEqual([
       {
         artifactError: {
-          lockFile: 'go.sum',
+          fileName: 'go.sum',
           stderr: 'This update totally doesnt work',
         },
       },
@@ -2671,7 +2671,7 @@ describe('modules/manager/gomod/artifacts', () => {
         },
       }),
     ).toEqual([
-      { artifactError: { lockFile: 'go.sum', stderr: 'Invalid goGetDirs' } },
+      { artifactError: { fileName: 'go.sum', stderr: 'Invalid goGetDirs' } },
     ]);
     expect(execSnapshots).toMatchObject([]);
   });

--- a/lib/modules/manager/gomod/artifacts.ts
+++ b/lib/modules/manager/gomod/artifacts.ts
@@ -498,7 +498,7 @@ export async function updateArtifacts({
     return [
       {
         artifactError: {
-          lockFile: sumFileName,
+          fileName: sumFileName,
           stderr: err.message,
         },
       },

--- a/lib/modules/manager/gradle-wrapper/artifacts.spec.ts
+++ b/lib/modules/manager/gradle-wrapper/artifacts.spec.ts
@@ -356,7 +356,7 @@ describe('modules/manager/gradle-wrapper/artifacts', () => {
       expect(result).toEqual([
         {
           artifactError: {
-            lockFile: 'gradle/wrapper/gradle-wrapper.properties',
+            fileName: 'gradle/wrapper/gradle-wrapper.properties',
             stderr:
               'Request failed with status code 404 (Not Found): GET https://services.gradle.org/distributions/gradle-6.3-bin.zip.sha256',
           },

--- a/lib/modules/manager/gradle-wrapper/artifacts.ts
+++ b/lib/modules/manager/gradle-wrapper/artifacts.ts
@@ -247,7 +247,7 @@ export async function updateArtifacts({
     return [
       {
         artifactError: {
-          lockFile: packageFileName,
+          fileName: packageFileName,
           stderr: err.message,
         },
       },

--- a/lib/modules/manager/gradle/artifacts.spec.ts
+++ b/lib/modules/manager/gradle/artifacts.spec.ts
@@ -602,7 +602,7 @@ describe('modules/manager/gradle/artifacts', () => {
       ).toEqual([
         {
           artifactError: {
-            lockFile: 'build.gradle',
+            fileName: 'build.gradle',
             stderr: 'failed',
           },
         },

--- a/lib/modules/manager/gradle/artifacts.ts
+++ b/lib/modules/manager/gradle/artifacts.ts
@@ -286,7 +286,7 @@ export async function updateArtifacts({
     return [
       {
         artifactError: {
-          lockFile: packageFileName,
+          fileName: packageFileName,
           stderr: err.message,
         },
       },

--- a/lib/modules/manager/helmfile/artifacts.spec.ts
+++ b/lib/modules/manager/helmfile/artifacts.spec.ts
@@ -411,7 +411,7 @@ describe('modules/manager/helmfile/artifacts', () => {
     ).toEqual([
       {
         artifactError: {
-          lockFile: 'helmfile.lock',
+          fileName: 'helmfile.lock',
           stderr: errorMessage,
         },
       },

--- a/lib/modules/manager/helmfile/artifacts.ts
+++ b/lib/modules/manager/helmfile/artifacts.ts
@@ -122,7 +122,7 @@ export async function updateArtifacts({
     return [
       {
         artifactError: {
-          lockFile: lockFileName,
+          fileName: lockFileName,
           stderr: err.message,
         },
       },

--- a/lib/modules/manager/helmv3/artifacts.spec.ts
+++ b/lib/modules/manager/helmv3/artifacts.spec.ts
@@ -268,7 +268,7 @@ describe('modules/manager/helmv3/artifacts', () => {
     ).toMatchObject([
       {
         artifactError: {
-          lockFile: 'Chart.lock',
+          fileName: 'Chart.lock',
           stderr: 'not found',
         },
       },

--- a/lib/modules/manager/helmv3/artifacts.ts
+++ b/lib/modules/manager/helmv3/artifacts.ts
@@ -214,7 +214,7 @@ export async function updateArtifacts({
     return [
       {
         artifactError: {
-          lockFile: lockFileName,
+          fileName: lockFileName,
           stderr: err.message,
         },
       },

--- a/lib/modules/manager/hermit/artifacts.spec.ts
+++ b/lib/modules/manager/hermit/artifacts.spec.ts
@@ -361,7 +361,7 @@ describe('modules/manager/hermit/artifacts', () => {
       expect(res).toEqual([
         {
           artifactError: {
-            lockFile: 'from: openjdk-17.0.3, to: openjdk',
+            fileName: 'from: openjdk-17.0.3, to: openjdk',
             stderr: 'error executing hermit uninstall',
           },
         },
@@ -448,7 +448,7 @@ describe('modules/manager/hermit/artifacts', () => {
       expect(res).toStrictEqual([
         {
           artifactError: {
-            lockFile: 'from: go-1.17 jq-1.5, to: go-1.17.1 jq-1.6',
+            fileName: 'from: go-1.17 jq-1.5, to: go-1.17.1 jq-1.6',
             stderr: 'error executing hermit install',
           },
         },
@@ -471,7 +471,7 @@ describe('modules/manager/hermit/artifacts', () => {
       expect(res).toStrictEqual([
         {
           artifactError: {
-            lockFile: 'from: -1.17, to: -1.17.1',
+            fileName: 'from: -1.17, to: -1.17.1',
             stderr: `invalid package to update`,
           },
         },
@@ -492,7 +492,7 @@ describe('modules/manager/hermit/artifacts', () => {
       expect(res).toStrictEqual([
         {
           artifactError: {
-            lockFile: 'from: go-, to: go-1.17.1',
+            fileName: 'from: go-, to: go-1.17.1',
             stderr: `invalid package to update`,
           },
         },
@@ -513,7 +513,7 @@ describe('modules/manager/hermit/artifacts', () => {
       expect(res).toStrictEqual([
         {
           artifactError: {
-            lockFile: 'from: go-1.17, to: go-',
+            fileName: 'from: go-1.17, to: go-',
             stderr: `invalid package to update`,
           },
         },

--- a/lib/modules/manager/hermit/artifacts.ts
+++ b/lib/modules/manager/hermit/artifacts.ts
@@ -27,7 +27,7 @@ export async function updateArtifacts(
     return [
       {
         artifactError: {
-          lockFile: `from: ${execErr.from}, to: ${execErr.to}`,
+          fileName: `from: ${execErr.from}, to: ${execErr.to}`,
           stderr: execErr.stderr,
         },
       },

--- a/lib/modules/manager/jsonnet-bundler/artifacts.spec.ts
+++ b/lib/modules/manager/jsonnet-bundler/artifacts.spec.ts
@@ -198,7 +198,7 @@ describe('modules/manager/jsonnet-bundler/artifacts', () => {
     ).toMatchObject([
       {
         artifactError: {
-          lockFile: 'jsonnetfile.lock.json',
+          fileName: 'jsonnetfile.lock.json',
           stderr: 'jb released the magic smoke',
         },
       },

--- a/lib/modules/manager/jsonnet-bundler/artifacts.ts
+++ b/lib/modules/manager/jsonnet-bundler/artifacts.ts
@@ -102,7 +102,7 @@ export async function updateArtifacts(
     return [
       {
         artifactError: {
-          lockFile: lockFileName,
+          fileName: lockFileName,
           stderr: err.stderr,
         },
       },

--- a/lib/modules/manager/maven-wrapper/artifacts.spec.ts
+++ b/lib/modules/manager/maven-wrapper/artifacts.spec.ts
@@ -265,7 +265,7 @@ describe('modules/manager/maven-wrapper/artifacts', () => {
     expect(updatedDeps).toEqual([
       {
         artifactError: {
-          lockFile: 'maven',
+          fileName: 'maven',
           stderr: 'temporary-error',
         },
       },

--- a/lib/modules/manager/maven-wrapper/artifacts.ts
+++ b/lib/modules/manager/maven-wrapper/artifacts.ts
@@ -96,7 +96,7 @@ export async function updateArtifacts({
     return [
       {
         artifactError: {
-          lockFile: packageFileName,
+          fileName: packageFileName,
           stderr: err.message,
         },
       },

--- a/lib/modules/manager/mix/artifacts.spec.ts
+++ b/lib/modules/manager/mix/artifacts.spec.ts
@@ -478,7 +478,7 @@ describe('modules/manager/mix/artifacts', () => {
         config,
       }),
     ).toEqual([
-      { artifactError: { lockFile: 'mix.lock', stderr: 'not found' } },
+      { artifactError: { fileName: 'mix.lock', stderr: 'not found' } },
     ]);
   });
 
@@ -494,7 +494,7 @@ describe('modules/manager/mix/artifacts', () => {
         config,
       }),
     ).toEqual([
-      { artifactError: { lockFile: 'mix.lock', stderr: 'exec-error' } },
+      { artifactError: { fileName: 'mix.lock', stderr: 'exec-error' } },
     ]);
   });
 
@@ -512,7 +512,7 @@ describe('modules/manager/mix/artifacts', () => {
     ).toEqual([
       {
         artifactError: {
-          lockFile: 'mix.lock',
+          fileName: 'mix.lock',
           stderr: 'Error reading mix.lock',
         },
       },
@@ -536,7 +536,7 @@ describe('modules/manager/mix/artifacts', () => {
     ).toEqual([
       {
         artifactError: {
-          lockFile: 'mix.lock',
+          fileName: 'mix.lock',
           stderr: 'Error reading mix.lock',
         },
       },

--- a/lib/modules/manager/mix/artifacts.ts
+++ b/lib/modules/manager/mix/artifacts.ts
@@ -89,7 +89,7 @@ export async function updateArtifacts({
     return [
       {
         artifactError: {
-          lockFile: lockFileName,
+          fileName: lockFileName,
           stderr: err.message,
         },
       },
@@ -196,7 +196,7 @@ export async function updateArtifacts({
     return [
       {
         artifactError: {
-          lockFile: lockFileName,
+          fileName: lockFileName,
           stderr: err.message,
         },
       },
@@ -227,7 +227,7 @@ async function checkLockFileReadError(
     return [
       {
         artifactError: {
-          lockFile: lockFileName,
+          fileName: lockFileName,
           stderr: `Error reading ${lockFileName}`,
         },
       },

--- a/lib/modules/manager/nix/artifacts.spec.ts
+++ b/lib/modules/manager/nix/artifacts.spec.ts
@@ -266,7 +266,7 @@ describe('modules/manager/nix/artifacts', () => {
 
     expect(res).toEqual([
       {
-        artifactError: { lockFile: 'flake.lock', stderr: 'exec error' },
+        artifactError: { fileName: 'flake.lock', stderr: 'exec error' },
       },
     ]);
     expect(execSnapshots).toMatchObject([{ cmd: updateInputCmd }]);

--- a/lib/modules/manager/nix/artifacts.ts
+++ b/lib/modules/manager/nix/artifacts.ts
@@ -78,7 +78,7 @@ export async function updateArtifacts({
     return [
       {
         artifactError: {
-          lockFile: lockFileName,
+          fileName: lockFileName,
           stderr: err.message,
         },
       },

--- a/lib/modules/manager/npm/post-update/index.spec.ts
+++ b/lib/modules/manager/npm/post-update/index.spec.ts
@@ -624,7 +624,7 @@ describe('modules/manager/npm/post-update/index', () => {
         await getAdditionalFiles({ ...updateConfig }, additionalFiles),
       ).toStrictEqual({
         artifactErrors: [
-          { lockFile: 'package-lock.json', stderr: 'some-error' },
+          { fileName: 'package-lock.json', stderr: 'some-error' },
         ],
         updatedArtifacts: [],
       });
@@ -638,7 +638,7 @@ describe('modules/manager/npm/post-update/index', () => {
           additionalFiles,
         ),
       ).toStrictEqual({
-        artifactErrors: [{ lockFile: 'yarn.lock', stderr: 'some-error' }],
+        artifactErrors: [{ fileName: 'yarn.lock', stderr: 'some-error' }],
         updatedArtifacts: [],
       });
     });
@@ -660,7 +660,7 @@ describe('modules/manager/npm/post-update/index', () => {
         ),
       ).toStrictEqual({
         artifactErrors: [
-          { lockFile: 'packages/pnpm/pnpm-lock.yaml', stderr: 'some-error' },
+          { fileName: 'packages/pnpm/pnpm-lock.yaml', stderr: 'some-error' },
         ],
         updatedArtifacts: [],
       });

--- a/lib/modules/manager/npm/post-update/index.ts
+++ b/lib/modules/manager/npm/post-update/index.ts
@@ -469,7 +469,7 @@ export async function getAdditionalFiles(
       }
 
       artifactErrors.push({
-        lockFile: npmLock,
+        fileName: npmLock,
         stderr: res.stderr,
       });
     } else if (res.lockFile) {
@@ -556,7 +556,7 @@ export async function getAdditionalFiles(
       }
 
       artifactErrors.push({
-        lockFile: yarnLock,
+        fileName: yarnLock,
         // oxlint-disable-next-line typescript/prefer-nullish-coalescing
         stderr: res.stderr || res.stdout,
       });
@@ -628,7 +628,7 @@ export async function getAdditionalFiles(
       }
 
       artifactErrors.push({
-        lockFile: pnpmShrinkwrap,
+        fileName: pnpmShrinkwrap,
         // oxlint-disable-next-line typescript/prefer-nullish-coalescing
         stderr: res.stderr || res.stdout,
       });

--- a/lib/modules/manager/npm/post-update/types.ts
+++ b/lib/modules/manager/npm/post-update/types.ts
@@ -13,7 +13,7 @@ export interface AdditionalPackageFiles {
 }
 
 export interface ArtifactError {
-  lockFile: string;
+  fileName: string;
   stderr?: string;
 }
 

--- a/lib/modules/manager/nuget/artifacts.spec.ts
+++ b/lib/modules/manager/nuget/artifacts.spec.ts
@@ -435,7 +435,7 @@ describe('modules/manager/nuget/artifacts', () => {
     ).toEqual([
       {
         artifactError: {
-          lockFile: 'packages.lock.json',
+          fileName: 'packages.lock.json',
           stderr: 'not found',
         },
       },

--- a/lib/modules/manager/nuget/artifacts.ts
+++ b/lib/modules/manager/nuget/artifacts.ts
@@ -212,7 +212,7 @@ export async function updateArtifacts({
     return [
       {
         artifactError: {
-          lockFile: lockFileNames.join(', '),
+          fileName: lockFileNames.join(', '),
           // error is written to stdout
           stderr: err.stdout ?? err.message,
         },

--- a/lib/modules/manager/pep621/processors/pdm.spec.ts
+++ b/lib/modules/manager/pep621/processors/pdm.spec.ts
@@ -127,7 +127,7 @@ describe('modules/manager/pep621/processors/pdm', () => {
         parsePyProject('')!,
       );
       expect(result).toEqual([
-        { artifactError: { lockFile: 'pdm.lock', stderr: 'test error' } },
+        { artifactError: { fileName: 'pdm.lock', stderr: 'test error' } },
       ]);
       expect(execSnapshots).toEqual([]);
     });

--- a/lib/modules/manager/pep621/processors/pdm.ts
+++ b/lib/modules/manager/pep621/processors/pdm.ts
@@ -153,7 +153,7 @@ export class PdmProcessor extends BasePyProjectProcessor {
       return [
         {
           artifactError: {
-            lockFile: lockFileName,
+            fileName: lockFileName,
             stderr: err.message,
           },
         },

--- a/lib/modules/manager/pep621/processors/uv.spec.ts
+++ b/lib/modules/manager/pep621/processors/uv.spec.ts
@@ -480,7 +480,7 @@ describe('modules/manager/pep621/processors/uv', () => {
         parsePyProject('')!,
       );
       expect(result).toEqual([
-        { artifactError: { lockFile: 'uv.lock', stderr: 'test error' } },
+        { artifactError: { fileName: 'uv.lock', stderr: 'test error' } },
       ]);
       expect(execSnapshots).toEqual([]);
     });

--- a/lib/modules/manager/pep621/processors/uv.ts
+++ b/lib/modules/manager/pep621/processors/uv.ts
@@ -242,7 +242,7 @@ export class UvProcessor extends BasePyProjectProcessor {
       return [
         {
           artifactError: {
-            lockFile: lockFileName,
+            fileName: lockFileName,
             stderr: err.message,
           },
         },

--- a/lib/modules/manager/pip-compile/artifacts.spec.ts
+++ b/lib/modules/manager/pip-compile/artifacts.spec.ts
@@ -444,7 +444,7 @@ describe('modules/manager/pip-compile/artifacts', () => {
       }),
     ).toEqual([
       {
-        artifactError: { lockFile: 'requirements.txt', stderr: 'not found' },
+        artifactError: { fileName: 'requirements.txt', stderr: 'not found' },
       },
     ]);
     expect(execSnapshots).toEqual([]);
@@ -759,7 +759,7 @@ describe('modules/manager/pip-compile/artifacts', () => {
       });
       expect(results).toMatchObject([
         {
-          artifactError: { lockFile: 'requirements1.txt', stderr: 'Oh noes!' },
+          artifactError: { fileName: 'requirements1.txt', stderr: 'Oh noes!' },
         },
       ]);
     });

--- a/lib/modules/manager/pip-compile/artifacts.ts
+++ b/lib/modules/manager/pip-compile/artifacts.ts
@@ -168,7 +168,7 @@ export async function updateArtifacts({
       logger.debug({ err }, 'pip-compile: Failed to run command');
       result.push({
         artifactError: {
-          lockFile: outputFileName,
+          fileName: outputFileName,
           stderr: err.message,
         },
       });

--- a/lib/modules/manager/pip_requirements/artifacts.spec.ts
+++ b/lib/modules/manager/pip_requirements/artifacts.spec.ts
@@ -173,7 +173,7 @@ describe('modules/manager/pip_requirements/artifacts', () => {
     ).toEqual([
       {
         artifactError: {
-          lockFile: 'requirements.txt',
+          fileName: 'requirements.txt',
           stderr: `undefined\nundefined`,
         },
       },

--- a/lib/modules/manager/pip_requirements/artifacts.ts
+++ b/lib/modules/manager/pip_requirements/artifacts.ts
@@ -102,7 +102,7 @@ export async function updateArtifacts({
     return [
       {
         artifactError: {
-          lockFile: packageFileName,
+          fileName: packageFileName,
           stderr: `${String(err.stdout)}\n${String(err.stderr)}`,
         },
       },

--- a/lib/modules/manager/pipenv/artifacts.spec.ts
+++ b/lib/modules/manager/pipenv/artifacts.spec.ts
@@ -774,7 +774,7 @@ describe('modules/manager/pipenv/artifacts', () => {
         config,
       }),
     ).toEqual([
-      { artifactError: { lockFile: 'Pipfile.lock', stderr: 'not found' } },
+      { artifactError: { fileName: 'Pipfile.lock', stderr: 'not found' } },
     ]);
 
     expect(fsExtra.ensureDir.mock.calls).toEqual([]);

--- a/lib/modules/manager/pipenv/artifacts.ts
+++ b/lib/modules/manager/pipenv/artifacts.ts
@@ -197,7 +197,7 @@ export async function updateArtifacts({
     return [
       {
         artifactError: {
-          lockFile: lockFileName,
+          fileName: lockFileName,
           stderr: err.message,
         },
       },

--- a/lib/modules/manager/pixi/artifacts.spec.ts
+++ b/lib/modules/manager/pixi/artifacts.spec.ts
@@ -340,7 +340,7 @@ describe('modules/manager/pixi/artifacts', () => {
           newPackageFileContent: '{}',
           config,
         }),
-      ).toMatchObject([{ artifactError: { lockFile: 'pixi.lock' } }]);
+      ).toMatchObject([{ artifactError: { fileName: 'pixi.lock' } }]);
       expect(execSnapshots).toMatchObject([]);
     });
 

--- a/lib/modules/manager/pixi/artifacts.ts
+++ b/lib/modules/manager/pixi/artifacts.ts
@@ -87,7 +87,7 @@ export async function updateArtifacts({
     return [
       {
         artifactError: {
-          lockFile: lockFileName,
+          fileName: lockFileName,
           stderr: `${err}`,
         },
       },

--- a/lib/modules/manager/poetry/artifacts.spec.ts
+++ b/lib/modules/manager/poetry/artifacts.spec.ts
@@ -665,7 +665,7 @@ describe('modules/manager/poetry/artifacts', () => {
           newPackageFileContent: '{}',
           config,
         }),
-      ).toMatchObject([{ artifactError: { lockFile: 'poetry.lock' } }]);
+      ).toMatchObject([{ artifactError: { fileName: 'poetry.lock' } }]);
       expect(execSnapshots).toMatchObject([]);
     });
 

--- a/lib/modules/manager/poetry/artifacts.ts
+++ b/lib/modules/manager/poetry/artifacts.ts
@@ -258,7 +258,7 @@ export async function updateArtifacts({
     return [
       {
         artifactError: {
-          lockFile: lockFileName,
+          fileName: lockFileName,
           stderr: `${String(err.stdout)}\n${String(err.stderr)}`,
         },
       },

--- a/lib/modules/manager/pub/artifacts.spec.ts
+++ b/lib/modules/manager/pub/artifacts.spec.ts
@@ -288,7 +288,7 @@ describe('modules/manager/pub/artifacts', () => {
           ...updateArtifact,
           newPackageFileContent: params.packageFileContent,
         }),
-      ).toEqual([{ artifactError: { lockFile, stderr } }]);
+      ).toEqual([{ artifactError: { fileName: lockFile, stderr } }]);
     });
   });
 

--- a/lib/modules/manager/pub/artifacts.ts
+++ b/lib/modules/manager/pub/artifacts.ts
@@ -93,7 +93,7 @@ export async function updateArtifacts({
     return [
       {
         artifactError: {
-          lockFile: lockFileName,
+          fileName: lockFileName,
           stderr: err.message,
         },
       },

--- a/lib/modules/manager/terraform/lockfile/index.spec.ts
+++ b/lib/modules/manager/terraform/lockfile/index.spec.ts
@@ -46,7 +46,7 @@ describe('modules/manager/terraform/lockfile/index', () => {
     ).toEqual([
       {
         artifactError: {
-          lockFile: '.terraform.lock.hcl',
+          fileName: '.terraform.lock.hcl',
           stderr: 'File not found',
         },
       },

--- a/lib/modules/manager/terraform/lockfile/index.ts
+++ b/lib/modules/manager/terraform/lockfile/index.ts
@@ -228,7 +228,7 @@ export async function updateArtifacts({
     return [
       {
         artifactError: {
-          lockFile: lockFilePath,
+          fileName: lockFilePath,
           stderr: err.message,
         },
       },

--- a/lib/modules/manager/types.ts
+++ b/lib/modules/manager/types.ts
@@ -227,7 +227,6 @@ export interface ArtifactNotice {
 
 export interface ArtifactError {
   fileName?: string;
-  lockFile?: string;
   stderr?: string;
 }
 

--- a/lib/modules/manager/vendir/artifacts.spec.ts
+++ b/lib/modules/manager/vendir/artifacts.spec.ts
@@ -178,7 +178,7 @@ describe('modules/manager/vendir/artifacts', () => {
     ).toEqual([
       {
         artifactError: {
-          lockFile: 'vendir.yml',
+          fileName: 'vendir.yml',
           stderr: 'not found',
         },
       },

--- a/lib/modules/manager/vendir/artifacts.ts
+++ b/lib/modules/manager/vendir/artifacts.ts
@@ -105,7 +105,7 @@ export async function updateArtifacts({
     return [
       {
         artifactError: {
-          lockFile: lockFileName,
+          fileName: lockFileName,
           stderr: err.message,
         },
       },

--- a/lib/workers/repository/update/branch/__snapshots__/get-updated.spec.ts.snap
+++ b/lib/workers/repository/update/branch/__snapshots__/get-updated.spec.ts.snap
@@ -132,7 +132,7 @@ exports[`workers/repository/update/branch/get-updated > getUpdatedPackageFiles()
 {
   "artifactErrors": [
     {
-      "lockFile": "composer.lock",
+      "fileName": "composer.lock",
       "stderr": "some error",
     },
   ],
@@ -191,7 +191,7 @@ exports[`workers/repository/update/branch/get-updated > getUpdatedPackageFiles()
 {
   "artifactErrors": [
     {
-      "lockFile": "composer.lock",
+      "fileName": "composer.lock",
       "stderr": "some error",
     },
   ],

--- a/lib/workers/repository/update/branch/artifacts.spec.ts
+++ b/lib/workers/repository/update/branch/artifacts.spec.ts
@@ -15,7 +15,7 @@ describe('workers/repository/update/branch/artifacts', () => {
       manager: 'some-manager',
       branchName: 'renovate/pin',
       upgrades: [],
-      artifactErrors: [{ lockFile: 'some' }],
+      artifactErrors: [{ fileName: 'some' }],
       statusCheckNames: partial<RenovateConfig['statusCheckNames']>({
         artifactError: 'renovate/artifact',
       }),

--- a/lib/workers/repository/update/branch/execute-post-upgrade-commands.ts
+++ b/lib/workers/repository/update/branch/execute-post-upgrade-commands.ts
@@ -164,7 +164,7 @@ export async function postUpgradeCommandsExecutor(
             );
           } catch (error) {
             artifactErrors.push({
-              lockFile: upgrade.packageFile,
+              fileName: upgrade.packageFile,
               stderr: sanitize(error.message),
             });
           }
@@ -177,7 +177,7 @@ export async function postUpgradeCommandsExecutor(
             'Post-upgrade task did not match any on allowedCommands list',
           );
           artifactErrors.push({
-            lockFile: upgrade.packageFile,
+            fileName: upgrade.packageFile,
             stderr: sanitize(
               `Post-upgrade command '${compiledCmd}' has not been added to the allowed list in allowedCommands`,
             ),

--- a/lib/workers/repository/update/branch/get-updated.spec.ts
+++ b/lib/workers/repository/update/branch/get-updated.spec.ts
@@ -456,14 +456,14 @@ describe('workers/repository/update/branch/get-updated', () => {
       composer.updateArtifacts.mockResolvedValueOnce([
         {
           artifactError: {
-            lockFile: 'composer.lock',
+            fileName: 'composer.lock',
             stderr: 'some error',
           },
         },
       ]);
       const res = await getUpdatedPackageFiles(config);
       expect(res).toMatchSnapshot({
-        artifactErrors: [{ lockFile: 'composer.lock', stderr: 'some error' }],
+        artifactErrors: [{ fileName: 'composer.lock', stderr: 'some error' }],
       });
     });
 
@@ -478,14 +478,14 @@ describe('workers/repository/update/branch/get-updated', () => {
       composer.updateArtifacts.mockResolvedValueOnce([
         {
           artifactError: {
-            lockFile: 'composer.lock',
+            fileName: 'composer.lock',
             stderr: 'some error',
           },
         },
       ]);
       const res = await getUpdatedPackageFiles(config);
       expect(res).toMatchSnapshot({
-        artifactErrors: [{ lockFile: 'composer.lock', stderr: 'some error' }],
+        artifactErrors: [{ fileName: 'composer.lock', stderr: 'some error' }],
       });
     });
 
@@ -1269,7 +1269,7 @@ describe('workers/repository/update/branch/get-updated', () => {
         const res = await getUpdatedPackageFiles(config);
         expect(res.artifactErrors).toHaveLength(1);
         expect(res.artifactErrors[0]).toMatchObject({
-          lockFile: 'composer.json',
+          fileName: 'composer.json',
           stderr: expect.stringContaining('1.3.0'),
         });
         expect(res.artifactErrors[0].stderr).toContain(
@@ -1336,7 +1336,7 @@ describe('workers/repository/update/branch/get-updated', () => {
         const res = await getUpdatedPackageFiles(config);
         expect(res.artifactErrors).toHaveLength(1);
         expect(res.artifactErrors[0]).toMatchObject({
-          lockFile: 'composer.json',
+          fileName: 'composer.json',
           stderr: expect.stringContaining('1.3.0'),
         });
       });
@@ -1778,7 +1778,7 @@ describe('workers/repository/update/branch/get-updated', () => {
       const res = await getUpdatedPackageFiles(config);
       expect(res.artifactErrors).toHaveLength(1);
       expect(res.artifactErrors[0]).toMatchObject({
-        lockFile: 'composer.json',
+        fileName: 'composer.json',
         stderr: expect.stringContaining('1.3.0'),
       });
     });

--- a/lib/workers/repository/update/branch/get-updated.ts
+++ b/lib/workers/repository/update/branch/get-updated.ts
@@ -659,7 +659,7 @@ async function checkForPendingVersions(
       stderr += `\nThis is (likely) not a bug in Renovate, but due to the way your project pins dependencies, _and_ how Renovate calls your package manager to update them.\nUntil Renovate supports specifying an exact update to your package manager (https://github.com/renovatebot/renovate/issues/41624), it is recommended to directly pin your dependencies (with \`rangeStrategy=pin\` for apps, or \`rangeStrategy=widen\` for libraries)\nSee also: https://docs.renovatebot.com/dependency-pinning/`;
 
       artifactErrors.push({
-        lockFile: packageFileName,
+        fileName: packageFileName,
         stderr,
       });
     }

--- a/lib/workers/repository/update/branch/index.ts
+++ b/lib/workers/repository/update/branch/index.ts
@@ -1030,7 +1030,7 @@ export async function processBranch(
         content += '\n\nThe artifact failure details are included below:\n\n';
         // TODO: types (#22198)
         config.artifactErrors.forEach((error) => {
-          content += `##### File name: ${error.lockFile!}\n\n`;
+          content += `##### File name: ${error.fileName!}\n\n`;
           content += `\`\`\`\n${error.stderr!}\n\`\`\`\n\n`;
         });
         content = platform.massageMarkdown(content, config.rebaseLabel);

--- a/lib/workers/repository/update/pr/index.spec.ts
+++ b/lib/workers/repository/update/pr/index.spec.ts
@@ -630,7 +630,7 @@ describe('workers/repository/update/pr/index', () => {
           ...config,
           automerge: true,
           automergeType: 'branch',
-          artifactErrors: [{ lockFile: 'foo', stderr: 'bar' }],
+          artifactErrors: [{ fileName: 'foo', stderr: 'bar' }],
         });
 
         expect(res).toEqual({ type: 'with-pr', pr });


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
As `fileName` makes more sense (as it's not always a lock file we're
updating).

Also, if you set `fileName`, it would never actually output the
filename.

<img width="397" height="96" alt="Screenshot 2026-03-03 at 14 24 20" src="https://github.com/user-attachments/assets/efec1f90-d5f2-4438-814c-3c5a22820ab2" />


This renames the usages of `lockFile` to `fileName`.


## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe): Claude Sonnet 4.5 (GitHub Copilot + `crush`) - used to fix tests after the refactor

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
