### PR TITLE
fix(datasource/github): skip GraphQL requests for non-GitHub registry URLs

### DIFF
--- a/lib/util/github/graphql/datasource-fetcher.spec.ts
+++ b/lib/util/github/graphql/datasource-fetcher.spec.ts
@@ -116,6 +116,16 @@ describe('util/github/graphql/datasource-fetcher', () => {
       http = new GithubHttp();
     });
 
+    it('returns empty result for non-GitHub registryUrl', async () => {
+      const res = await Datasource.query(
+        { packageName: 'foo/bar', registryUrl: 'https://pypi.org/pypi/' },
+        http,
+        adapter,
+      );
+
+      expect(res).toEqual([]);
+    });
+
     it('can perform query and receive result', async () => {
       httpMock
         .scope('https://api.github.com/')

--- a/lib/util/github/graphql/datasource-fetcher.ts
+++ b/lib/util/github/graphql/datasource-fetcher.ts
@@ -11,7 +11,8 @@ import type {
   GithubHttpOptions,
 } from '../../http/github.ts';
 import type { HttpResponse } from '../../http/types.ts';
-import { getApiBaseUrl } from '../url.ts';
+import { parseUrl } from '../../url.ts';
+import { getApiBaseUrl, getSourceUrlBase } from '../url.ts';
 import { GithubGraphqlMemoryCacheStrategy } from './cache-strategies/memory-cache-strategy.ts';
 import { GithubGraphqlPackageCacheStrategy } from './cache-strategies/package-cache-strategy.ts';
 import type {
@@ -36,6 +37,33 @@ function isUnknownGraphqlError(err: Error): boolean {
   return message.startsWith('Something went wrong while executing your query.');
 }
 
+function isGithubHost(registryUrl: string | undefined): boolean {
+  if (!registryUrl) {
+    return true; // defaults to github.com
+  }
+
+  const sourceUrlBase = getSourceUrlBase(registryUrl);
+  if (
+    sourceUrlBase === 'https://github.com/' ||
+    sourceUrlBase === 'https://api.github.com/'
+  ) {
+    return true;
+  }
+
+  // GHE with explicit API path
+  if (sourceUrlBase.endsWith('/api/v3/')) {
+    return true;
+  }
+
+  // GHE with 'github' in hostname
+  const { hostname } = parseUrl(registryUrl) ?? {};
+  if (hostname?.includes('github')) {
+    return true;
+  }
+
+  return false;
+}
+
 function canBeSolvedByShrinking(err: Error): boolean {
   const errors: Error[] = err instanceof AggregateError ? err.errors : [err];
   return errors.some(
@@ -52,6 +80,13 @@ export class GithubGraphqlDatasourceFetcher<
     http: GithubHttp,
     adapter: GithubGraphqlDatasourceAdapter<T, U>,
   ): Promise<U[]> {
+    if (!isGithubHost(config.registryUrl)) {
+      logger.once.debug(
+        { registryUrl: config.registryUrl },
+        'GitHub GraphQL datasource: skipping non-GitHub registryUrl',
+      );
+      return [];
+    }
     const instance = new GithubGraphqlDatasourceFetcher<T, U>(
       config,
       http,


### PR DESCRIPTION
## Changes

<!-- Describe what behavior is changed by this PR. -->

When a non-GitHub registryUrl (e.g. https://pypi.org/pypi/) reaches the GitHub GraphQL datasource fetcher — via user config applying registryUrls or defaultRegistryUrls to github-tags/github-releases datasources — the fetcher blindly constructs a GraphQL endpoint from it:

```
  getApiBaseUrl('https://pypi.org/pypi/')
  → 'https://pypi.org/pypi/api/v3/'  (assumes GHE)
  → 'https://pypi.org/pypi/api/'     (strip v3)
  → POST /pypi/api/graphql            (append graphql)
```

This produces always-failing POST requests to hosts like PyPI that have no GraphQL endpoint (HTTP 405).

Add an `isGithubHost()` check in `GithubGraphqlDatasourceFetcher.query()` that validates the registryUrl before issuing requests. Non-GitHub URLs now return empty results immediately with a debug log.

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Context

- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation). This PR was written primarily by Claude Code with my guidance and review.

## Documentation (please check one with an [x])

- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [x] Newly added/modified unit tests, or

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
