### PR TITLE
refactor(manager/pep723): move parsing to `utils`

### DIFF
--- a/lib/modules/manager/pep723/extract.spec.ts
+++ b/lib/modules/manager/pep723/extract.spec.ts
@@ -1,0 +1,21 @@
+import { extractPackageFile } from './extract.ts';
+import { extractPep723 as _extractPep723 } from './utils.ts';
+
+vi.mock('./utils.ts');
+
+const extractPep723 = vi.mocked(_extractPep723);
+
+describe('modules/manager/pep723/extract', () => {
+  describe('extractPackageFile()', () => {
+    it('should extract dependencies', () => {
+      const extractedDeps = {
+        deps: [{ depName: 'dep1' }, { depName: 'dep2' }],
+      };
+      extractPep723.mockReturnValueOnce(extractedDeps);
+
+      const res = extractPackageFile('foo', 'foo.py');
+
+      expect(res).toEqual(extractedDeps);
+    });
+  });
+});

--- a/lib/modules/manager/pep723/extract.ts
+++ b/lib/modules/manager/pep723/extract.ts
@@ -1,40 +1,9 @@
-import { logger } from '../../../logger/index.ts';
-import { newlineRegex, regEx } from '../../../util/regex.ts';
 import type { PackageFileContent } from '../types.ts';
-import { Pep723 } from './schema.ts';
-
-// Adapted regex from the Python reference implementation: https://packaging.python.org/en/latest/specifications/inline-script-metadata/#reference-implementation
-const regex = regEx(
-  /^# \/\/\/ (?<type>[a-zA-Z0-9-]+)$\s(?<content>(^#(| .*)$\s)+)^# \/\/\/$/,
-  'm',
-);
+import { extractPep723 } from './utils.ts';
 
 export function extractPackageFile(
   content: string,
   packageFile: string,
 ): PackageFileContent | null {
-  const match = regex.exec(content);
-  const matchedContent = match?.groups?.content;
-
-  if (!matchedContent) {
-    return null;
-  }
-
-  // Adapted code from the Python reference implementation: https://packaging.python.org/en/latest/specifications/inline-script-metadata/#reference-implementation
-  const parsedToml = matchedContent
-    .split(newlineRegex)
-    .map((line) => line.substring(line.startsWith('# ') ? 2 : 1))
-    .join('\n');
-
-  const { data: res, error } = Pep723.safeParse(parsedToml);
-
-  if (error) {
-    logger.debug(
-      { packageFile, error },
-      `Error parsing PEP 723 inline script metadata`,
-    );
-    return null;
-  }
-
-  return res.deps.length ? res : null;
+  return extractPep723(content, packageFile);
 }

--- a/lib/modules/manager/pep723/utils.spec.ts
+++ b/lib/modules/manager/pep723/utils.spec.ts
@@ -1,10 +1,10 @@
 import { codeBlock } from 'common-tags';
-import { extractPackageFile } from './index.ts';
+import { extractPep723 } from './utils.ts';
 
-describe('modules/manager/pep723/extract', () => {
-  describe('extractPackageFile()', () => {
+describe('modules/manager/pep723/utils', () => {
+  describe('parsePep723()', () => {
     it('should extract dependencies', () => {
-      const res = extractPackageFile(
+      const res = extractPep723(
         codeBlock`
           # /// script
           # requires-python = ">=3.11"
@@ -40,7 +40,7 @@ describe('modules/manager/pep723/extract', () => {
     });
 
     it('should skip invalid dependencies', () => {
-      const res = extractPackageFile(
+      const res = extractPep723(
         codeBlock`
           # /// script
           # requires-python = "==3.11"
@@ -69,7 +69,7 @@ describe('modules/manager/pep723/extract', () => {
     });
 
     it('should return null on missing dependencies', () => {
-      const res = extractPackageFile(
+      const res = extractPep723(
         codeBlock`
           # /// script
           # requires-python = ">=3.11"
@@ -82,7 +82,7 @@ describe('modules/manager/pep723/extract', () => {
     });
 
     it('should return null on invalid TOML', () => {
-      const res = extractPackageFile(
+      const res = extractPep723(
         codeBlock`
           # /// script
           # requires-python
@@ -99,7 +99,7 @@ describe('modules/manager/pep723/extract', () => {
     });
 
     it('should return null if there is no PEP 723 metadata', () => {
-      const res = extractPackageFile(
+      const res = extractPep723(
         codeBlock`
           if True:
               print("requires-python>=3.11")

--- a/lib/modules/manager/pep723/utils.ts
+++ b/lib/modules/manager/pep723/utils.ts
@@ -1,0 +1,40 @@
+import { logger } from '../../../logger/index.ts';
+import { newlineRegex, regEx } from '../../../util/regex.ts';
+import type { PackageFileContent } from '../types.ts';
+import { Pep723 } from './schema.ts';
+
+// Adapted regex from the Python reference implementation: https://packaging.python.org/en/latest/specifications/inline-script-metadata/#reference-implementation
+const regex = regEx(
+  /^# \/\/\/ (?<type>[a-zA-Z0-9-]+)$\s(?<content>(^#(| .*)$\s)+)^# \/\/\/$/,
+  'm',
+);
+
+export function extractPep723(
+  content: string,
+  packageFile: string,
+): PackageFileContent | null {
+  const match = regex.exec(content);
+  const matchedContent = match?.groups?.content;
+
+  if (!matchedContent) {
+    return null;
+  }
+
+  // Adapted code from the Python reference implementation: https://packaging.python.org/en/latest/specifications/inline-script-metadata/#reference-implementation
+  const parsedToml = matchedContent
+    .split(newlineRegex)
+    .map((line) => line.substring(line.startsWith('# ') ? 2 : 1))
+    .join('\n');
+
+  const { data: res, error } = Pep723.safeParse(parsedToml);
+
+  if (error) {
+    logger.debug(
+      { packageFile, error },
+      `Error parsing PEP 723 inline script metadata`,
+    );
+    return null;
+  }
+
+  return res.deps.length ? res : null;
+}


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

As requested in https://github.com/renovatebot/renovate/pull/41606#discussion_r2884766530, this extracts https://github.com/renovatebot/renovate/commit/ccf12c2a5d05f86b755285bc1ccdbe2ba0d49fb2 and https://github.com/renovatebot/renovate/commit/9aba7468d01c629bc02e9d3be8460508a6ec0ba6.

This change is required because we also need to do the same parsing [in `updateArtifacts`](https://github.com/renovatebot/renovate/blob/9aba7468d01c629bc02e9d3be8460508a6ec0ba6/lib/modules/manager/pep723/artifacts.ts#L39) as we currently do in `extractPackageFile`.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
