### PR TITLE
docs: reword `.` in `parents` to `(the root document)`

### DIFF
--- a/tools/docs/test/utils.spec.ts
+++ b/tools/docs/test/utils.spec.ts
@@ -9,10 +9,10 @@ describe('tools/docs/test/utils', () => {
     expect(parentsRowHeader).toEqual('<td>parents</td>');
   });
 
-  it('parents content should be multiple code blocks', () => {
+  it('parents content should be multiple code blocks, and . be display with "the root document"', () => {
     const parents = formatCell(['parents', '.,packageRules,argocd,ansible'], 1);
     expect(parents).toEqual(
-      '<td class="parents"><span><code>.</code></span><span><code>ansible</code></span><span><code>argocd</code></span><span><code>packageRules</code></span></td>',
+      '<td class="parents"><span><code>the root document</code></span><span><code>ansible</code></span><span><code>argocd</code></span><span><code>packageRules</code></span></td>',
     );
   });
 });

--- a/tools/docs/test/utils.spec.ts
+++ b/tools/docs/test/utils.spec.ts
@@ -9,10 +9,20 @@ describe('tools/docs/test/utils', () => {
     expect(parentsRowHeader).toEqual('<td>parents</td>');
   });
 
-  it('parents content should be multiple code blocks, and . be display with "the root document"', () => {
+  it('parents content should be multiple code blocks, and . be display with "(the root document)"', () => {
     const parents = formatCell(['parents', '.,packageRules,argocd,ansible'], 1);
     expect(parents).toEqual(
-      '<td class="parents"><span><code>the root document</code></span><span><code>ansible</code></span><span><code>argocd</code></span><span><code>packageRules</code></span></td>',
+      '<td class="parents"><span><code>(the root document)</code></span><span><code>ansible</code></span><span><code>argocd</code></span><span><code>packageRules</code></span></td>',
+    );
+  });
+
+  it('parent named ".foo" should be not display with ".foo (the root document)"', () => {
+    const parents = formatCell(
+      ['parents', '.foo,packageRules,argocd,ansible'],
+      1,
+    );
+    expect(parents).toEqual(
+      '<td class="parents"><span><code>.foo</code></span><span><code>ansible</code></span><span><code>argocd</code></span><span><code>packageRules</code></span></td>',
     );
   });
 });

--- a/tools/docs/utils.ts
+++ b/tools/docs/utils.ts
@@ -96,7 +96,8 @@ export function formatCell(row: string[], colIndex: number): string {
       .sort((a, b) => a.localeCompare(b))
       .map((s) => `<code>${s.trim()}</code>`)
       .map((item) => `<span>${item}</span>`)
-      .join('');
+      .join('')
+      .replace('.', 'the root document');
     return `<td class="parents">${items}</td>`;
   }
 

--- a/tools/docs/utils.ts
+++ b/tools/docs/utils.ts
@@ -97,7 +97,7 @@ export function formatCell(row: string[], colIndex: number): string {
       .map((s) => `<code>${s.trim()}</code>`)
       .map((item) => `<span>${item}</span>`)
       .join('')
-      .replace('.', 'the root document');
+      .replace('>.<', '>(the root document)<');
     return `<td class="parents">${items}</td>`;
   }
 


### PR DESCRIPTION
## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #41126 
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

Change can be seen at the bottom of the list below
<img width="664" height="935" alt="image" src="https://github.com/user-attachments/assets/d4213a17-530d-4688-a9fc-6af877b66a5c" />

