### PR TITLE
Handle Redis connection issues gracefully by falling back to other cache strategies

### DIFF
--- a/lib/util/cache/package/backend.spec.ts
+++ b/lib/util/cache/package/backend.spec.ts
@@ -76,6 +76,21 @@ describe('util/cache/package/backend', () => {
     expect(backend.getCacheType()).toBe('redis');
   });
 
+  it('falls back to file backend when redis fails', async () => {
+    vi.mocked(PackageCacheRedis.create).mockRejectedValueOnce(
+      new Error('Redis timeout'),
+    );
+
+    await backend.init({ redisUrl: 'some-url', cacheDir: 'some-dir' });
+
+    expect(PackageCacheRedis.create).toHaveBeenCalledWith(
+      'some-url',
+      undefined,
+    );
+    expect(PackageCacheFile.create).toHaveBeenCalledWith('some-dir');
+    expect(backend.getCacheType()).toBe('file');
+  });
+
   it('initializes sqlite backend', async () => {
     process.env.RENOVATE_X_SQLITE_PACKAGE_CACHE = 'true';
 

--- a/lib/util/cache/package/backend.ts
+++ b/lib/util/cache/package/backend.ts
@@ -1,4 +1,5 @@
 import type { AllConfig } from '../../../config/types.ts';
+import { logger } from '../../../logger/index.ts';
 import { getEnv } from '../../env.ts';
 import type { PackageCacheBase } from './impl/base.ts';
 import { PackageCacheFile } from './impl/file.ts';
@@ -17,12 +18,19 @@ export async function init(config: AllConfig): Promise<void> {
   await destroy();
 
   if (config.redisUrl) {
-    cacheProxy = await PackageCacheRedis.create(
-      config.redisUrl,
-      config.redisPrefix,
-    );
-    cacheType = 'redis';
-    return;
+    try {
+      cacheProxy = await PackageCacheRedis.create(
+        config.redisUrl,
+        config.redisPrefix,
+      );
+      cacheType = 'redis';
+      return;
+    } catch (err) {
+      logger.once.warn(
+        { err },
+        'Redis cache initialization failed, falling back to alternative cache',
+      );
+    }
   }
 
   if (getEnv().RENOVATE_X_SQLITE_PACKAGE_CACHE && config.cacheDir) {

--- a/lib/util/cache/package/impl/redis.spec.ts
+++ b/lib/util/cache/package/impl/redis.spec.ts
@@ -42,6 +42,7 @@ describe('util/cache/package/impl/redis', () => {
 
         expect(createClient).toHaveBeenCalledWith({
           pingInterval: 30000,
+          connectTimeout: 5000,
           socket: { reconnectStrategy: expect.any(Function) },
           url: 'redis://host',
         });
@@ -57,7 +58,10 @@ describe('util/cache/package/impl/redis', () => {
         await PackageCacheRedis.create('rediss://host', '');
 
         expect(createClient).toHaveBeenCalledWith(
-          expect.objectContaining({ url: 'rediss://host' }),
+          expect.objectContaining({
+            url: 'rediss://host',
+            connectTimeout: 5000,
+          }),
         );
       });
 
@@ -68,6 +72,7 @@ describe('util/cache/package/impl/redis', () => {
           rootNodes: [
             {
               pingInterval: 30000,
+              connectTimeout: 5000,
               socket: { reconnectStrategy: expect.any(Function) },
               url: 'redis://host',
             },
@@ -83,6 +88,7 @@ describe('util/cache/package/impl/redis', () => {
           rootNodes: [
             expect.objectContaining({
               url: 'redis://user:pass@host',
+              connectTimeout: 5000,
             }),
           ],
         });
@@ -96,6 +102,7 @@ describe('util/cache/package/impl/redis', () => {
           rootNodes: [
             expect.objectContaining({
               url: 'redis://user@host',
+              connectTimeout: 5000,
             }),
           ],
         });
@@ -109,6 +116,7 @@ describe('util/cache/package/impl/redis', () => {
           rootNodes: [
             expect.objectContaining({
               url: 'redis://:pass@host',
+              connectTimeout: 5000,
             }),
           ],
         });

--- a/lib/util/cache/package/impl/redis.ts
+++ b/lib/util/cache/package/impl/redis.ts
@@ -33,6 +33,7 @@ export class PackageCacheRedis extends PackageCacheBase {
         reconnectStrategy: (retries: number) => Math.min(retries * 100, 3000),
       },
       pingInterval: 30000,
+      connectTimeout: 5000,
     };
 
     let client: RedisClient;
@@ -57,8 +58,13 @@ export class PackageCacheRedis extends PackageCacheBase {
       client = createClient(config);
     }
 
-    await client.connect();
-    logger.debug('Redis cache connected');
+    try {
+      await client.connect();
+      logger.debug('Redis cache connected');
+    } catch (err) {
+      logger.once.warn({ err }, 'Redis cache connection failed');
+      throw err;
+    }
     return new PackageCacheRedis(client, rprefix);
   }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Catch Redis connection timeouts and gracefully log them falling back to the next caching strategy.
If a cache is not accessible, it should behave as if the cache had a miss, not as a fatal error.

```
DEBUG: Redis cache init
FATAL: Unknown error
       "err": {
         "message": "Connection timeout",
         "stack": "Error: Connection timeout\n    at Socket.onTimeout (/usr/local/renovate/node_modules/.pnpm/@redis+client@5.11.0/node_modules/@redis/client/lib/client/socket.ts:274:40)\n    at Object.onceWrapper (node:events:622:28)\n    at Socket.emit (node:events:508:28)\n    at Socket.emit (node:domain:489:12)\n    at Socket._onTimeout (node:net:604:8)\n    at listOnTimeout (node:internal/timers:605:17)\n    at processTimers (node:internal/timers:541:7)"
       }
 INFO: Renovate is exiting with a non-zero code due to the following logged errors
       "loggerErrors": [
         {
           "name": "renovate",
           "level": 60,
           "logContext": "503e5b3c-cd2a-42b4-9d94-81900d7e0cca",
           "err": {
             "message": "Connection timeout",
             "stack": "Error: Connection timeout\n    at Socket.onTimeout (/usr/local/renovate/node_modules/.pnpm/@redis+client@5.11.0/node_modules/@redis/client/lib/client/socket.ts:274:40)\n    at Object.onceWrapper (node:events:622:28)\n    at Socket.emit (node:events:508:28)\n    at Socket.emit (node:domain:489:12)\n    at Socket._onTimeout (node:net:604:8)\n    at listOnTimeout (node:internal/timers:605:17)\n    at processTimers (node:internal/timers:541:7)"
           },
           "msg": "Unknown error"
         }
       ]
```

## Context

Please select one of the following:

- [ ] This closes an existing Issue
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
