### PR TITLE
feat(dry-run): log commit contents

### DIFF
--- a/lib/workers/repository/update/branch/commit.spec.ts
+++ b/lib/workers/repository/update/branch/commit.spec.ts
@@ -71,7 +71,7 @@ describe('workers/repository/update/branch/commit', () => {
       await commitFilesToBranch(config);
       expect(scm.commitAndPush).toHaveBeenCalledTimes(0);
       expect(logger.logger.info).toHaveBeenCalledWith(
-        'DRY-RUN: Would commit files to branch renovate/some-branch',
+        'DRY-RUN: Would commit files to branch renovate/some-branch. See debug logs for raw commit information',
       );
     });
   });

--- a/lib/workers/repository/update/branch/commit.ts
+++ b/lib/workers/repository/update/branch/commit.ts
@@ -4,7 +4,10 @@ import { GlobalConfig } from '../../../../config/global.ts';
 import { CONFIG_SECRETS_EXPOSED } from '../../../../constants/error-messages.ts';
 import { logger } from '../../../../logger/index.ts';
 import { scm } from '../../../../modules/platform/scm.ts';
-import type { LongCommitSha } from '../../../../util/git/types.ts';
+import type {
+  CommitFilesConfig,
+  LongCommitSha,
+} from '../../../../util/git/types.ts';
 import { minimatch } from '../../../../util/minimatch.ts';
 import { sanitize } from '../../../../util/sanitize.ts';
 import type { BranchConfig } from '../../../types.ts';
@@ -35,10 +38,6 @@ export function commitFilesToBranch(
   }
   const fileLength = [...new Set(updatedFiles.map((file) => file.path))].length;
   logger.debug(`${fileLength} file(s) to commit`);
-  if (GlobalConfig.get('dryRun')) {
-    logger.info('DRY-RUN: Would commit files to branch ' + config.branchName);
-    return Promise.resolve(null);
-  }
   // istanbul ignore if
   if (
     config.branchName !== sanitize(config.branchName) ||
@@ -51,8 +50,7 @@ export function commitFilesToBranch(
     throw new Error(CONFIG_SECRETS_EXPOSED);
   }
 
-  // API will know whether to create new branch or not
-  return scm.commitAndPush({
+  const commitFilesConfig: CommitFilesConfig = {
     baseBranch: config.baseBranch,
     branchName: config.branchName,
     files: updatedFiles,
@@ -65,5 +63,31 @@ export function commitFilesToBranch(
     autoApprove: config.autoApprove,
     // Only needed by Gerrit platform
     labels: config.labels,
-  });
+  };
+
+  // istanbul ignore if
+  if (GlobalConfig.get('dryRun')) {
+    const logExtra = {
+      ...commitFilesConfig,
+    };
+
+    for (const file of logExtra.files) {
+      if (file.type === 'addition') {
+        // NOTE that we're copying this field with a different name so we get the raw contents logged, otherwise it'll be logged as `[content]`
+        (file as any).rawContents = file.contents;
+      }
+    }
+
+    logger.info(
+      `DRY-RUN: Would commit files to branch ${config.branchName}. See debug logs for raw commit information`,
+    );
+    logger.debug(
+      { ...logExtra },
+      `DRY-RUN: Would commit files to branch ${config.branchName}`,
+    );
+    return Promise.resolve(null);
+  }
+
+  // API will know whether to create new branch or not
+  return scm.commitAndPush(commitFilesConfig);
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
As a means to make the dry-run functionality a little more useful, we
can log out what commit(s) a given Renovate run would have created
outside of Dry Run.

Because the meta key `contents` is automagically replaced with
`[contents]`, we need to move this into a new field, `rawContents`.

This can also lead to longer lines being output, but provides additional
utility that we've had requests for before.

## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: <URL>

```
INFO: DRY-RUN: Would commit files to branch renovate/go.mod/go-1.x. See debug logs for raw commit information (repository=oapi-codegen/oapi-codegen, branch=renovate/go.mod/go-1.x)
DEBUG: DRY-RUN: Would commit files to branch renovate/go.mod/go-1.x (repository=oapi-codegen/oapi-codegen, baseBranch=main, branch=renovate/go.mod/go-1.x)
       "branchName": "renovate/go.mod/go-1.x",
       "files": [
         {
           "type": "addition",
           "path": "go.mod",
           "contents": "[content]",
           "rawContents": "module github.com/oapi-codegen/oapi-codegen/v2\n\ngo 1.24.3\n\ntoolchain go1.26.1\n\nrequire (\n\tgithub.com/getkin/kin-openapi v0.134.0\n\tgithub.com/speakeasy-api/openapi-overlay v0.10.2\n\tgithu
b.com/stretchr/testify v1.11.1\n\tgolang.org/x/mod v0.33.0\n\tgolang.org/x/text v0.34.0\n\tgolang.org/x/tools v0.42.0\n\tgopkg.in/yaml.v2 v2.4.0\n\tgopkg.in/yaml.v3 v3.0.1\n)\n\nrequire (\n\tgithub.com/davecgh/go-spew v1.1.2
-0.20180830191138-d8f796af33cc // indirect\n\tgithub.com/dprotaso/go-yit v0.0.0-20220510233725-9ba8df137936 // indirect\n\tgithub.com/go-openapi/jsonpointer v0.22.4 // indirect\n\tgithub.com/go-openapi/swag/jsonname v0.25.4
// indirect\n\tgithub.com/josharian/intern v1.0.0 // indirect\n\tgithub.com/mailru/easyjson v0.9.1 // indirect\n\tgithub.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect\n\tgithub.com/oasdiff/yaml v0.0.0-202
60313112342-a3ea61cb4d4c // indirect\n\tgithub.com/oasdiff/yaml3 v0.0.0-20260224194419-61cd415a242b // indirect\n\tgithub.com/perimeterx/marshmallow v1.1.5 // indirect\n\tgithub.com/pmezard/go-difflib v1.0.1-0.20181226105442
-5d4384ee4fb2 // indirect\n\tgithub.com/speakeasy-api/jsonpath v0.6.0 // indirect\n\tgithub.com/ugorji/go/codec v1.2.11 // indirect\n\tgithub.com/vmware-labs/yaml-jsonpath v0.3.2 // indirect\n\tgithub.com/woodsbury/decimal12
8 v1.4.0 // indirect\n\tgolang.org/x/sync v0.19.0 // indirect\n)\n"
         }
       ],
       "message": "chore(deps): update dependency go to v1.26.1 (go.mod)",
       "force": true,
       "platformCommit": "auto",
       "prTitle": "chore(deps): update dependency go to v1.26.1 (go.mod)",
       "autoApprove": false,
       "labels": ["dependencies"]
```

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
