### PR TITLE
fix(workers/repository): handle no `depName` but `packageName`

### DIFF
--- a/lib/workers/repository/update/branch/get-updated.spec.ts
+++ b/lib/workers/repository/update/branch/get-updated.spec.ts
@@ -1587,7 +1587,7 @@ describe('workers/repository/update/branch/get-updated', () => {
     });
 
     // should never happen, but our types allow this
-    it('rejects when an updated dependency has no depName', async () => {
+    it('rejects when an updated dependency has no depName or packageName', async () => {
       config.upgrades.push({
         packageFile: 'composer.json',
         manager: 'composer',
@@ -1610,6 +1610,7 @@ describe('workers/repository/update/branch/get-updated', () => {
         deps: [
           {
             depName: undefined,
+            packageName: undefined,
             lockedVersion: '1.3.0',
           },
         ],
@@ -1628,6 +1629,42 @@ describe('workers/repository/update/branch/get-updated', () => {
         },
         "No depName found after updating 'composer.json'",
       );
+    });
+
+    it('adds an artifact error when an updated dependency has no depName, but does have a packageName', async () => {
+      config.upgrades.push({
+        packageFile: 'composer.json',
+        manager: 'composer',
+        branchName: '',
+        depName: 'some-dep',
+        newVersion: '1.2.3',
+        pendingVersions: ['1.3.0'],
+      });
+      autoReplace.doAutoReplace.mockResolvedValueOnce('some new content');
+      composer.updateArtifacts.mockResolvedValueOnce([
+        {
+          file: {
+            type: 'addition',
+            path: 'composer.lock',
+            contents: 'some lock contents',
+          },
+        },
+      ]);
+      composer.extractPackageFile.mockResolvedValueOnce({
+        deps: [
+          {
+            depName: undefined,
+            packageName: 'some-dep',
+            lockedVersion: '1.3.0',
+          },
+        ],
+      });
+
+      const res = await getUpdatedPackageFiles(config);
+      expect(res.artifactErrors).toHaveLength(1);
+      expect(res.artifactErrors[0]).toMatchObject({
+        stderr: expect.stringContaining('some-dep'),
+      });
     });
 
     // should never happen, but our types allow this

--- a/lib/workers/repository/update/branch/get-updated.ts
+++ b/lib/workers/repository/update/branch/get-updated.ts
@@ -576,8 +576,9 @@ async function checkForPendingVersions(
   }
 
   for (const dep of extracted.deps) {
+    const depName = dep.depName ?? dep.packageName;
     // shouldn't ever happen
-    if (!dep.depName) {
+    if (!depName) {
       logger.error(
         {
           packageFile: packageFileName,
@@ -590,7 +591,7 @@ async function checkForPendingVersions(
       throw new Error(WORKER_FILE_UPDATE_FAILED);
     }
 
-    const upgradeInfo = depNameToUpgradeInfo.get(dep.depName);
+    const upgradeInfo = depNameToUpgradeInfo.get(depName);
     if (!upgradeInfo) {
       continue;
     }
@@ -605,10 +606,10 @@ async function checkForPendingVersions(
           packageFile: packageFileName,
           manager,
           branchName: config.branchName,
-          depName: dep.depName,
+          depName,
           newVersion: resolvedVersion,
         },
-        `No new version found for '${dep.depName}' after updating '${packageFileName}'`,
+        `No new version found for '${depName}' after updating '${packageFileName}'`,
       );
       throw new Error(WORKER_FILE_UPDATE_FAILED);
     }
@@ -622,11 +623,11 @@ async function checkForPendingVersions(
             packageFile: packageFileName,
             manager,
             branchName: config.branchName,
-            depName: dep.depName,
+            depName,
             newVersion: resolvedVersion,
             expectedVersion,
           },
-          `No expectedVersion found for '${dep.depName}' after updating '${packageFileName}'`,
+          `No expectedVersion found for '${depName}' after updating '${packageFileName}'`,
         );
         continue;
       }
@@ -635,7 +636,7 @@ async function checkForPendingVersions(
         logger.once.warn(
           {
             packageFileName,
-            depName: dep.depName,
+            depName,
             expectedVersion,
             resolvedVersion,
           },
@@ -647,13 +648,13 @@ async function checkForPendingVersions(
       logger.debug(
         {
           packageFileName,
-          depName: dep.depName,
+          depName,
           expectedVersion,
           resolvedVersion,
         },
         'Artifact update introduced a pending version',
       );
-      let stderr = `Artifact update for ${dep.depName} resolved to version ${resolvedVersion}, which is a pending version that has not yet passed the Minimum Release Age threshold.`;
+      let stderr = `Artifact update for ${depName} resolved to version ${resolvedVersion}, which is a pending version that has not yet passed the Minimum Release Age threshold.`;
       stderr += `\nRenovate was attempting to update to ${expectedVersion}`;
       stderr += `\nThis is (likely) not a bug in Renovate, but due to the way your project pins dependencies, _and_ how Renovate calls your package manager to update them.\nUntil Renovate supports specifying an exact update to your package manager (https://github.com/renovatebot/renovate/issues/41624), it is recommended to directly pin your dependencies (with \`rangeStrategy=pin\` for apps, or \`rangeStrategy=widen\` for libraries)\nSee also: https://docs.renovatebot.com/dependency-pinning/`;
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
As noted in #41716, there are cases where a `depName` may be absent, but
a `packageName` is present.

We should handle this accordingly, and check for the `packageName`, and
only error if neither of these are set.

## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/JamieTanna-Mend-testing/renovate-iss-41716

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
