### PR TITLE
fix(copier): allow git+ and ssh+ for copier

### DIFF
--- a/lib/modules/manager/copier/extract.spec.ts
+++ b/lib/modules/manager/copier/extract.spec.ts
@@ -80,6 +80,48 @@ describe('modules/manager/copier/extract', () => {
       });
     });
 
+    it('extracts and strips git+ prefix from git+https URL', () => {
+      const content = `
+        _commit: v1.0.0
+        _src_path: git+https://bitbucket.some-org/scm/some-project/some-template.git
+      `;
+      const result = extractPackageFile(content);
+      expect(result).toEqual({
+        deps: [
+          {
+            depName:
+              'git+https://bitbucket.some-org/scm/some-project/some-template.git',
+            packageName:
+              'https://bitbucket.some-org/scm/some-project/some-template.git',
+            currentValue: 'v1.0.0',
+            datasource: 'git-tags',
+            depType: 'template',
+          },
+        ],
+      });
+    });
+
+    it('extracts and strips git+ prefix from git+ssh URL', () => {
+      const content = `
+        _commit: v2.0.0
+        _src_path: git+ssh://git@bitbucket.some-org/some-project/some-template.git
+      `;
+      const result = extractPackageFile(content);
+      expect(result).toEqual({
+        deps: [
+          {
+            depName:
+              'git+ssh://git@bitbucket.some-org/some-project/some-template.git',
+            packageName:
+              'ssh://git@bitbucket.some-org/some-project/some-template.git',
+            currentValue: 'v2.0.0',
+            datasource: 'git-tags',
+            depType: 'template',
+          },
+        ],
+      });
+    });
+
     it('returns null for invalid .copier-answers.yml', () => {
       const content = `
         not_valid:

--- a/lib/modules/manager/copier/extract.spec.ts
+++ b/lib/modules/manager/copier/extract.spec.ts
@@ -1,3 +1,4 @@
+import { codeBlock } from 'common-tags';
 import { extractPackageFile } from './index.ts';
 
 describe('modules/manager/copier/extract', () => {
@@ -80,47 +81,40 @@ describe('modules/manager/copier/extract', () => {
       });
     });
 
-    it('extracts and strips git+ prefix from git+https URL', () => {
-      const content = `
-        _commit: v1.0.0
-        _src_path: git+https://bitbucket.some-org/scm/some-project/some-template.git
-      `;
-      const result = extractPackageFile(content);
-      expect(result).toEqual({
-        deps: [
-          {
-            depName:
-              'git+https://bitbucket.some-org/scm/some-project/some-template.git',
-            packageName:
-              'https://bitbucket.some-org/scm/some-project/some-template.git',
-            currentValue: 'v1.0.0',
-            datasource: 'git-tags',
-            depType: 'template',
-          },
-        ],
-      });
-    });
-
-    it('extracts and strips git+ prefix from git+ssh URL', () => {
-      const content = `
-        _commit: v2.0.0
-        _src_path: git+ssh://git@bitbucket.some-org/some-project/some-template.git
-      `;
-      const result = extractPackageFile(content);
-      expect(result).toEqual({
-        deps: [
-          {
-            depName:
-              'git+ssh://git@bitbucket.some-org/some-project/some-template.git',
-            packageName:
-              'ssh://git@bitbucket.some-org/some-project/some-template.git',
-            currentValue: 'v2.0.0',
-            datasource: 'git-tags',
-            depType: 'template',
-          },
-        ],
-      });
-    });
+    it.each([
+      {
+        srcPath:
+          'git+https://bitbucket.some-org/scm/some-project/some-template.git',
+        expectedPackageName:
+          'https://bitbucket.some-org/scm/some-project/some-template.git',
+      },
+      {
+        srcPath:
+          'git+ssh://git@bitbucket.some-org/some-project/some-template.git',
+        expectedPackageName:
+          'ssh://git@bitbucket.some-org/some-project/some-template.git',
+      },
+    ])(
+      'extracts and strips git+ prefix from $srcPath',
+      ({ srcPath, expectedPackageName }) => {
+        const content = codeBlock`
+          _commit: v1.0.0
+          _src_path: ${srcPath}
+        `;
+        const result = extractPackageFile(content);
+        expect(result).toEqual({
+          deps: [
+            {
+              depName: srcPath,
+              packageName: expectedPackageName,
+              currentValue: 'v1.0.0',
+              datasource: 'git-tags',
+              depType: 'template',
+            },
+          ],
+        });
+      },
+    );
 
     it('returns null for invalid .copier-answers.yml', () => {
       const content = `

--- a/lib/modules/manager/copier/extract.ts
+++ b/lib/modules/manager/copier/extract.ts
@@ -1,7 +1,19 @@
 import { logger } from '../../../logger/index.ts';
+import { regEx } from '../../../util/regex.ts';
 import { GitTagsDatasource } from '../../datasource/git-tags/index.ts';
 import type { PackageDependency, PackageFileContent } from '../types.ts';
 import { CopierAnswersFile } from './schema.ts';
+
+const gitPrefixRegex = regEx(/^git\+/);
+
+/**
+ * Copier supports `git+https://` and `git+ssh://` URL prefixes,
+ * but git itself does not understand them.
+ * Strip the `git+` prefix so the URL can be used with git directly.
+ */
+function stripGitPrefix(url: string): string {
+  return url.replace(gitPrefixRegex, '');
+}
 
 export function extractPackageFile(
   content: string,
@@ -19,7 +31,7 @@ export function extractPackageFile(
     {
       datasource: GitTagsDatasource.id,
       depName: parsed._src_path,
-      packageName: parsed._src_path,
+      packageName: stripGitPrefix(parsed._src_path),
       depType: 'template',
       currentValue: parsed._commit,
     },


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Allows the copier update to work with git+http and ssh+http.

## Context

Please select one of the following:

- [X] This closes an existing Issue, Closes: #31516 <!-- NOTE that this should NOT be a Discussion -->
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request? Yes

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [X] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Claude did all of the work. I pasted the issue in and it wrote the code. I ran the build version against an existing repo manually.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [X] Both unit tests + ran on a real repository

The public repository: Private 

Logs from --local run pertinent to this PR:

```
  "copier": [
    {
      "deps": [
        {
          "datasource": "git-tags",
          "depName": "git+https://<SNIP>/_git/project_template",
          "packageName": "https://<SNIP>/_git/project_template",
          "depType": "template",
          "currentValue": "0.112",
          ...
          "branchName":
  "renovate/git+https-<SNIP>-python%20governance%20council-_git-project_template-0.x"
        }
      ],
      "packageFile": ".copier-answers.yml"
    }
  ]
```

Note: + is valid in a git branch name

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
