### PR TITLE
fix(gradle): skip exclusiveContent registries if all filters are invalid or unsupported

### DIFF
--- a/lib/modules/manager/gradle/parser.spec.ts
+++ b/lib/modules/manager/gradle/parser.spec.ts
@@ -957,9 +957,20 @@ describe('modules/manager/gradle/parser', () => {
             mavenCentral()
           }
         }
+        exclusiveContent {
+          forRepository {
+            maven("https://private.repo/packages")
+          }
+          filter {
+            includeVersionByRegex("com.myorg.*", ".+", "^(.(?!-SNAPSHOT))+$")
+          }
+        }
       `;
 
       const { urls } = parseGradle(input);
+      expect(logger.logger.debug).toHaveBeenCalledWith(
+        'Skipping exclusive registry https://private.repo/packages with unsupported content descriptors',
+      );
       expect(urls).toMatchObject([
         {
           registryUrl: 'https://foo.bar.com/repository/public/',

--- a/lib/modules/manager/gradle/parser/handlers.ts
+++ b/lib/modules/manager/gradle/parser/handlers.ts
@@ -379,9 +379,17 @@ export function handleRegistryUrl(ctx: Ctx): Ctx {
     registryUrl = registryUrl.replace(regEx(/\\/g), '');
     const url = parseUrl(registryUrl);
     if (url?.host && url.protocol) {
+      const registryType = isExclusiveRegistry(ctx) ? 'exclusive' : 'regular';
+      if (registryType === 'exclusive' && !ctx.tmpRegistryContent.length) {
+        logger.debug(
+          `Skipping exclusive registry ${registryUrl} with unsupported content descriptors`,
+        );
+        return ctx;
+      }
+
       ctx.registryUrls.push({
         registryUrl,
-        registryType: isExclusiveRegistry(ctx) ? 'exclusive' : 'regular',
+        registryType,
         scope: isPluginRegistry(ctx) ? 'plugin' : 'dep',
         content: ctx.tmpRegistryContent,
       });


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds a guard when parsing gradle registries to skip `exclusiveContent` registries without valid (or supported) content descriptor filters Before this PR, they were added like normal registries and applied to all dependencies. This was wrong, considering that the whole purpose of `exclusiveContent` is to restrict a registry to only a specific set of dependencies.

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

https://github.com/renovatebot/renovate/discussions/41035

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/renovate-demo/41035-renovate-regex/issues/1

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
