### PR TITLE
fix(json-schema): allow free-string text if option has `allowString`

### DIFF
--- a/tools/docs/schema.ts
+++ b/tools/docs/schema.ts
@@ -66,7 +66,14 @@ function createSingleConfig(option: RenovateOptions): Record<string, unknown> {
         temp.items.format = option.format;
       }
       if (option.allowedValues) {
-        temp.items.enum = option.allowedValues;
+        if (option.allowString) {
+          temp.items.oneOf = [
+            { enum: option.allowedValues },
+            { type: 'string' },
+          ];
+        } else {
+          temp.items.enum = option.allowedValues;
+        }
       }
     }
     if (option.subType === 'string' && option.allowString === true) {
@@ -89,7 +96,11 @@ function createSingleConfig(option: RenovateOptions): Record<string, unknown> {
         { type: 'string', pattern: '^regex:' },
       ];
     } else if (option.allowedValues) {
-      temp.enum = option.allowedValues;
+      if (option.allowString) {
+        temp.oneOf = [{ enum: option.allowedValues }, { type: 'string' }];
+      } else {
+        temp.enum = option.allowedValues;
+      }
     }
   }
   if (option.default !== undefined) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
As noted in #40804, `matchUpdateTypes` can either be an `UpdateType`, or
it can be a glob.

This makes sure that the schema is aware it's either an enum, or it's an
arbitrary string.


## Context

Please select one of the below:

- [x] This closes an existing Issue: Closes: #40804
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
