### PR TITLE
feat: add `home-operations` replacement rule

### DIFF
--- a/lib/data/replacements.json
+++ b/lib/data/replacements.json
@@ -768,10 +768,7 @@
     "packageRules": [
       {
         "matchCurrentVersion": ">=1.18.6",
-        "matchDatasources": [
-          "helm",
-          "docker"
-        ],
+        "matchDatasources": ["helm", "docker"],
         "matchPackageNames": ["ghcr.io/home-operations/charts-mirror/cilium"],
         "replacementName": "quay.io/cilium/charts/cilium",
         "replacementVersion": "1.18.6"

--- a/lib/data/replacements.json
+++ b/lib/data/replacements.json
@@ -22,6 +22,7 @@
       "replacements:google-github-action-release-please-to-googleapis",
       "replacements:grafana-oss-to-grafana",
       "replacements:hapi-to-scoped",
+      "replacements:home-operations-to-official",
       "replacements:jade-to-pug",
       "replacements:joi-to-scoped",
       "replacements:joi-to-unscoped",
@@ -759,6 +760,21 @@
         "matchPackageNames": ["hapi"],
         "replacementName": "@hapi/hapi",
         "replacementVersion": "18.2.0"
+      }
+    ]
+  },
+  "home-operations-to-official": {
+    "description": "`home-operations` only builts these until official versions are released",
+    "packageRules": [
+      {
+        "matchCurrentVersion": ">=1.18.6",
+        "matchDatasources": [
+          "helm",
+          "docker"
+        ],
+        "matchPackageNames": ["ghcr.io/home-operations/charts-mirror/cilium"],
+        "replacementName": "quay.io/cilium/charts/cilium",
+        "replacementVersion": "1.18.6"
       }
     ]
   },


### PR DESCRIPTION
## Changes

Adds a replacement rule for using helm charts from the [home-operations/charts-mirror](https://github.com/home-operations/charts-mirror). These are exact mirrors of the normal helm charts but provide OCI charts for those. Thus, the mirrors usually get deleted as soon as the official sources provide an OCI artifact.
This only adds a cilium replacement rule, since it's the one that is the most current one, but it could be extended for other home-operations projects, [like the containers](https://github.com/home-operations/containers) or any other currently provided OCI artifacts.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

