### PR TITLE
fix(swift): don't use `v` prefix with `Package.resolved`

### DIFF
--- a/lib/modules/manager/swift/artifacts.spec.ts
+++ b/lib/modules/manager/swift/artifacts.spec.ts
@@ -1,4 +1,4 @@
-import { fs, scm } from '~test/util.ts';
+import { fs, logger, scm } from '~test/util.ts';
 import { GitTagsDatasource } from '../../datasource/git-tags/index.ts';
 import { GithubTagsDatasource } from '../../datasource/github-tags/index.ts';
 import { GitlabTagsDatasource } from '../../datasource/gitlab-tags/index.ts';
@@ -70,7 +70,13 @@ describe('modules/manager/swift/artifacts', () => {
 
     const result = await updateArtifacts({
       packageFileName: 'Package.swift',
-      updatedDeps: [{ depName: 'Alamofire/Alamofire', newVersion: '5.10.0' }],
+      updatedDeps: [
+        {
+          depName: 'Alamofire/Alamofire',
+          newVersion: 'v5.10.0',
+          newValue: '5.10.0',
+        },
+      ],
       newPackageFileContent: '',
       config: {},
     });
@@ -96,7 +102,13 @@ describe('modules/manager/swift/artifacts', () => {
 
     const result = await updateArtifacts({
       packageFileName: 'Package.swift',
-      updatedDeps: [{ depName: 'Alamofire/Alamofire', newVersion: '5.10.0' }],
+      updatedDeps: [
+        {
+          depName: 'Alamofire/Alamofire',
+          newVersion: 'v5.10.0',
+          newValue: '5.10.0',
+        },
+      ],
       newPackageFileContent: '',
       config: { isLockFileMaintenance: true },
     });
@@ -110,7 +122,13 @@ describe('modules/manager/swift/artifacts', () => {
 
     const result = await updateArtifacts({
       packageFileName: 'Package.swift',
-      updatedDeps: [{ depName: 'Alamofire/Alamofire', newVersion: '5.10.0' }],
+      updatedDeps: [
+        {
+          depName: 'Alamofire/Alamofire',
+          newVersion: 'v5.10.0',
+          newValue: '5.10.0',
+        },
+      ],
       newPackageFileContent: '',
       config: {},
     });
@@ -129,7 +147,13 @@ describe('modules/manager/swift/artifacts', () => {
 
     const result = await updateArtifacts({
       packageFileName: 'Package.swift',
-      updatedDeps: [{ depName: 'Alamofire/Alamofire', newVersion: '5.10.0' }],
+      updatedDeps: [
+        {
+          depName: 'Alamofire/Alamofire',
+          newVersion: 'v5.10.0',
+          newValue: '5.10.0',
+        },
+      ],
       newPackageFileContent: '',
       config: {},
     });
@@ -148,7 +172,8 @@ describe('modules/manager/swift/artifacts', () => {
         {
           depName: 'Alamofire/Alamofire',
           datasource: GithubTagsDatasource.id,
-          newVersion: '5.10.0',
+          newVersion: 'v5.10.0',
+          newValue: '5.10.0',
         },
       ],
       newPackageFileContent: '',
@@ -179,12 +204,14 @@ describe('modules/manager/swift/artifacts', () => {
         {
           depName: 'Alamofire/Alamofire',
           datasource: GithubTagsDatasource.id,
-          newVersion: '5.10.0',
+          newVersion: 'v5.10.0',
+          newValue: '5.10.0',
         },
         {
           depName: 'apple/swift-argument-parser',
           datasource: GithubTagsDatasource.id,
-          newVersion: '1.5.0',
+          newVersion: 'v1.5.0',
+          newValue: '1.5.0',
         },
       ],
       newPackageFileContent: '',
@@ -209,7 +236,8 @@ describe('modules/manager/swift/artifacts', () => {
         {
           depName: 'nonexistent/package',
           datasource: GithubTagsDatasource.id,
-          newVersion: '1.0.0',
+          newVersion: 'v1.0.0',
+          newValue: '1.0.0',
         },
       ],
       newPackageFileContent: '',
@@ -230,7 +258,8 @@ describe('modules/manager/swift/artifacts', () => {
         {
           depName: 'Alamofire/Alamofire',
           datasource: GithubTagsDatasource.id,
-          newVersion: '5.10.0',
+          newVersion: 'v5.10.0',
+          newValue: '5.10.0',
         },
       ],
       newPackageFileContent: '',
@@ -260,7 +289,8 @@ describe('modules/manager/swift/artifacts', () => {
         {
           depName: 'Alamofire/Alamofire',
           datasource: GithubTagsDatasource.id,
-          newVersion: '5.10.0',
+          newVersion: 'v5.10.0',
+          newValue: '5.10.0',
         },
       ],
       newPackageFileContent: '',
@@ -286,7 +316,8 @@ describe('modules/manager/swift/artifacts', () => {
         {
           depName: 'apple/swift-argument-parser',
           datasource: GithubTagsDatasource.id,
-          newVersion: '1.5.0',
+          newVersion: 'v1.5.0',
+          newValue: '1.5.0',
         },
       ],
       newPackageFileContent: '',
@@ -313,7 +344,8 @@ describe('modules/manager/swift/artifacts', () => {
         {
           depName: 'Alamofire/Alamofire',
           datasource: GithubTagsDatasource.id,
-          newVersion: '5.10.0',
+          newVersion: 'v5.10.0',
+          newValue: '5.10.0',
         },
       ],
       newPackageFileContent: '',
@@ -334,7 +366,8 @@ describe('modules/manager/swift/artifacts', () => {
         {
           depName: 'alamofire/alamofire',
           datasource: GithubTagsDatasource.id,
-          newVersion: '5.10.0',
+          newVersion: 'v5.10.0',
+          newValue: '5.10.0',
         },
       ],
       newPackageFileContent: '',
@@ -355,7 +388,8 @@ describe('modules/manager/swift/artifacts', () => {
         {
           depName: 'https://github.com/Alamofire/Alamofire.git',
           datasource: GitTagsDatasource.id,
-          newVersion: '5.10.0',
+          newVersion: 'v5.10.0',
+          newValue: '5.10.0',
         },
       ],
       newPackageFileContent: '',
@@ -397,7 +431,8 @@ describe('modules/manager/swift/artifacts', () => {
           depName: 'org/my-lib',
           datasource: GitlabTagsDatasource.id,
           registryUrls: ['https://gitlab.example.com'],
-          newVersion: '2.0.0',
+          newVersion: 'v2.0.0',
+          newValue: '2.0.0',
         },
       ],
       newPackageFileContent: '',
@@ -420,7 +455,8 @@ describe('modules/manager/swift/artifacts', () => {
         {
           depName: 'Alamofire/Alamofire',
           datasource: GithubTagsDatasource.id,
-          newVersion: '5.10.0',
+          newVersion: 'v5.10.0',
+          newValue: '5.10.0',
           newDigest: 'precomputedsha456',
         },
       ],
@@ -446,7 +482,8 @@ describe('modules/manager/swift/artifacts', () => {
         {
           depName: 'Alamofire/Alamofire',
           datasource: GithubTagsDatasource.id,
-          newVersion: '5.10.0',
+          newVersion: 'v5.10.0',
+          newValue: '5.10.0',
         },
       ],
       newPackageFileContent: '',
@@ -469,7 +506,8 @@ describe('modules/manager/swift/artifacts', () => {
         {
           depName: 'Alamofire/Alamofire',
           datasource: GithubTagsDatasource.id,
-          newVersion: '5.9.1', // same as fixture
+          newVersion: 'v5.9.1', // same as fixture
+          newValue: '5.9.1',
         },
       ],
       newPackageFileContent: '',
@@ -490,7 +528,8 @@ describe('modules/manager/swift/artifacts', () => {
         {
           depName: 'Alamofire/Alamofire',
           datasource: GithubTagsDatasource.id,
-          newVersion: '5.10.0',
+          newVersion: 'v5.10.0',
+          newValue: '5.10.0',
         },
       ],
       newPackageFileContent: '',
@@ -513,7 +552,8 @@ describe('modules/manager/swift/artifacts', () => {
       updatedDeps: [
         {
           depName: 'Alamofire/Alamofire',
-          newVersion: '5.10.0',
+          newVersion: 'v5.10.0',
+          newValue: '5.10.0',
         },
       ],
       newPackageFileContent: '',
@@ -523,7 +563,7 @@ describe('modules/manager/swift/artifacts', () => {
     expect(result).toBeNull();
   });
 
-  it('skips dep with no newVersion', async () => {
+  it('skips dep with no newValue', async () => {
     scm.getFileList.mockResolvedValue(['Package.resolved']);
     fs.readLocalFile.mockResolvedValue(v2Fixture);
 
@@ -533,7 +573,7 @@ describe('modules/manager/swift/artifacts', () => {
         {
           depName: 'Alamofire/Alamofire',
           datasource: GithubTagsDatasource.id,
-          // no newVersion
+          // no newValue
         },
       ],
       newPackageFileContent: '',
@@ -553,7 +593,8 @@ describe('modules/manager/swift/artifacts', () => {
         {
           depName: 'Alamofire/Alamofire',
           // no datasource — resolveCommitSha returns null
-          newVersion: '5.10.0',
+          newVersion: 'v5.10.0',
+          newValue: '5.10.0',
         },
       ],
       newPackageFileContent: '',
@@ -580,7 +621,8 @@ describe('modules/manager/swift/artifacts', () => {
       updatedDeps: [
         {
           depName: 'Alamofire/Alamofire',
-          newVersion: '5.10.0',
+          newVersion: 'v5.10.0',
+          newValue: '5.10.0',
         },
       ],
       newPackageFileContent: '',
@@ -603,7 +645,8 @@ describe('modules/manager/swift/artifacts', () => {
         {
           depName: 'Alamofire/Alamofire',
           datasource: GithubTagsDatasource.id,
-          newVersion: '5.10.0',
+          newVersion: 'v5.10.0',
+          newValue: '5.10.0',
         },
       ],
       newPackageFileContent: '',
@@ -616,6 +659,64 @@ describe('modules/manager/swift/artifacts', () => {
     // Revision unchanged — getDigest threw
     expect(contents).toContain(
       '"revision": "f455c2975872ccd2d9c81594c658af65716e9b9a"',
+    );
+  });
+
+  it('if newValue is present, but newVersion is absent, no update is performed', async () => {
+    scm.getFileList.mockResolvedValue(['Package.resolved']);
+    fs.readLocalFile.mockResolvedValue(v2Fixture);
+    vi.mocked(datasource.getDigest).mockResolvedValue('newrevisionsha123');
+
+    const result = await updateArtifacts({
+      packageFileName: 'Package.swift',
+      updatedDeps: [
+        {
+          depName: 'Alamofire/Alamofire',
+          datasource: GithubTagsDatasource.id,
+          newVersion: undefined,
+          newValue: '5.10.0',
+        },
+      ],
+      newPackageFileContent: '',
+      config: {},
+    });
+
+    expect(result).toBeNull();
+    expect(logger.logger.debug).toHaveBeenCalledWith(
+      {
+        depName: 'Alamofire/Alamofire',
+        newVersion: undefined,
+        newValue: '5.10.0',
+      },
+      'swift: found a newValue but not a newVersion',
+    );
+  });
+
+  it('newValue is used to look up digest', async () => {
+    scm.getFileList.mockResolvedValue(['Package.resolved']);
+    fs.readLocalFile.mockResolvedValue(v2Fixture);
+    vi.mocked(datasource.getDigest).mockResolvedValue('newrevisionsha123');
+
+    const result = await updateArtifacts({
+      packageFileName: 'Package.swift',
+      updatedDeps: [
+        {
+          depName: 'Alamofire/Alamofire',
+          datasource: GithubTagsDatasource.id,
+          newVersion: 'v5.10.0',
+          newValue: '5.10.0',
+        },
+      ],
+      newPackageFileContent: '',
+      config: {},
+    });
+
+    expect(result).toHaveLength(1);
+
+    // getDigest should have been called with the v-prefixed newVersion tag
+    expect(datasource.getDigest).toHaveBeenCalledWith(
+      expect.objectContaining({ datasource: GithubTagsDatasource.id }),
+      'v5.10.0',
     );
   });
 });

--- a/lib/modules/manager/swift/artifacts.ts
+++ b/lib/modules/manager/swift/artifacts.ts
@@ -181,8 +181,21 @@ export async function updateArtifacts({
     let updated = content;
 
     for (const dep of updatedDeps) {
-      const newVersion = dep.newVersion;
-      if (!newVersion) {
+      const newValue = dep.newValue;
+      if (!newValue) {
+        continue;
+      }
+
+      // shouldn't happen
+      if (!dep.newVersion) {
+        logger.debug(
+          {
+            depName: dep.depName,
+            newVersion: dep.newVersion,
+            newValue: dep.newValue,
+          },
+          'swift: found a newValue but not a newVersion',
+        );
         continue;
       }
 
@@ -196,16 +209,16 @@ export async function updateArtifacts({
       }
 
       // Skip if already up-to-date
-      if (pin.state.version === newVersion) {
+      if (pin.state.version === newValue) {
         logger.debug(
-          { depName: dep.depName, newVersion },
+          { depName: dep.depName, newValue },
           'swift: pin already at target version',
         );
         continue;
       }
 
-      const newRevision = await resolveCommitSha(dep, newVersion);
-      updated = updatePinInJson(updated, pin, newVersion, newRevision);
+      const newRevision = await resolveCommitSha(dep, dep.newVersion);
+      updated = updatePinInJson(updated, pin, newValue, newRevision);
     }
 
     if (updated !== content) {


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

As noted in #41780, in the case that a `newVersion` has the `v` prefix,
we use that version, which then results in `xcodebuild` failing to build
the project.

We should instead use `newValue`, which does not include the `v` prefix.

To make this clear in our tests, we can align the test data with the
expected input from our Datasources.

Because we need to use the `newVersion` for digest lookups, we need to
make sure that we still require it (or log when it's not found for some
reason).





## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe): Claude Sonnet 4.6

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/JamieTanna-Mend-testing/element-x-ios/pull/1

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
