### PR TITLE
feat(presets): add changelogUrl link for Forgejo and Gitea digest updates

### DIFF
--- a/lib/config/presets/index.spec.ts
+++ b/lib/config/presets/index.spec.ts
@@ -637,6 +637,8 @@ describe('config/presets/index', () => {
           'mergeConfidence:age-confidence-badges',
           'replacements:all',
           'workarounds:all',
+          'helpers:forgejoDigestChangelogs',
+          'helpers:giteaDigestChangelogs',
           'helpers:githubDigestChangelogs',
           'helpers:goXPackagesChangelogLink',
           'helpers:goXPackagesNameLink',

--- a/lib/config/presets/internal/config.preset.ts
+++ b/lib/config/presets/internal/config.preset.ts
@@ -35,6 +35,8 @@ export const presets: Record<string, Preset> = {
       'mergeConfidence:age-confidence-badges',
       'replacements:all',
       'workarounds:all',
+      'helpers:forgejoDigestChangelogs',
+      'helpers:giteaDigestChangelogs',
       'helpers:githubDigestChangelogs',
       'helpers:goXPackagesChangelogLink',
       'helpers:goXPackagesNameLink',

--- a/lib/config/presets/internal/helpers.preset.ts
+++ b/lib/config/presets/internal/helpers.preset.ts
@@ -31,7 +31,7 @@ export const presets: Record<string, Preset> = {
       {
         changelogUrl: '{{sourceUrl}}/compare/{{currentDigest}}..{{newDigest}}',
         matchDatasources: ['git-refs', 'git-tags'],
-        matchJsonata: ["$detectPlatform({{ sourceUrl }}) = 'forgejo'"],
+        matchJsonata: ["$detectPlatform(sourceUrl) = 'forgejo'"],
         matchUpdateTypes: ['digest'],
       },
     ],
@@ -48,7 +48,7 @@ export const presets: Record<string, Preset> = {
       {
         changelogUrl: '{{sourceUrl}}/compare/{{currentDigest}}..{{newDigest}}',
         matchDatasources: ['git-refs', 'git-tags'],
-        matchJsonata: ["$detectPlatform({{ sourceUrl }}) = 'gitea'"],
+        matchJsonata: ["$detectPlatform(sourceUrl) = 'gitea'"],
         matchUpdateTypes: ['digest'],
       },
     ],
@@ -65,7 +65,7 @@ export const presets: Record<string, Preset> = {
       {
         changelogUrl: '{{sourceUrl}}/compare/{{currentDigest}}..{{newDigest}}',
         matchDatasources: ['git-refs', 'git-tags'],
-        matchJsonata: ["$detectPlatform({{ sourceUrl }}) = 'github'"],
+        matchJsonata: ["$detectPlatform(sourceUrl) = 'github'"],
         matchUpdateTypes: ['digest'],
       },
     ],

--- a/lib/config/presets/internal/helpers.preset.ts
+++ b/lib/config/presets/internal/helpers.preset.ts
@@ -19,19 +19,53 @@ export const presets: Record<string, Preset> = {
     description: 'Keep `typescript` version in sync with the `rc` tag.',
     extends: [':followTag(typescript, rc)'],
   },
-  githubDigestChangelogs: {
+  forgejoDigestChangelogs: {
     description:
-      'Ensure that every dependency pinned by digest and sourced from GitHub.com contains a link to the commit-to-commit diff',
+      'Ensure that every dependency pinned by digest and sourced from Forgejo contains a link to the commit-to-commit diff',
     packageRules: [
       {
         changelogUrl: '{{sourceUrl}}/compare/{{currentDigest}}..{{newDigest}}',
-        matchDatasources: [
-          'git-refs',
-          'git-tags',
-          'github-releases',
-          'github-tags',
-        ],
-        matchSourceUrls: ['https://github.com/**'],
+        matchDatasources: ['forgejo-releases', 'forgejo-tags'],
+        matchUpdateTypes: ['digest'],
+      },
+      {
+        changelogUrl: '{{sourceUrl}}/compare/{{currentDigest}}..{{newDigest}}',
+        matchDatasources: ['git-refs', 'git-tags'],
+        matchJsonata: ["$detectPlatform({{ sourceUrl }}) = 'forgejo'"],
+        matchUpdateTypes: ['digest'],
+      },
+    ],
+  },
+  giteaDigestChangelogs: {
+    description:
+      'Ensure that every dependency pinned by digest and sourced from Gitea contains a link to the commit-to-commit diff',
+    packageRules: [
+      {
+        changelogUrl: '{{sourceUrl}}/compare/{{currentDigest}}..{{newDigest}}',
+        matchDatasources: ['gitea-releases', 'gitea-tags'],
+        matchUpdateTypes: ['digest'],
+      },
+      {
+        changelogUrl: '{{sourceUrl}}/compare/{{currentDigest}}..{{newDigest}}',
+        matchDatasources: ['git-refs', 'git-tags'],
+        matchJsonata: ["$detectPlatform({{ sourceUrl }}) = 'gitea'"],
+        matchUpdateTypes: ['digest'],
+      },
+    ],
+  },
+  githubDigestChangelogs: {
+    description:
+      'Ensure that every dependency pinned by digest and sourced from GitHub.com and Github enterprise contains a link to the commit-to-commit diff',
+    packageRules: [
+      {
+        changelogUrl: '{{sourceUrl}}/compare/{{currentDigest}}..{{newDigest}}',
+        matchDatasources: ['github-digest', 'github-releases', 'github-tags'],
+        matchUpdateTypes: ['digest'],
+      },
+      {
+        changelogUrl: '{{sourceUrl}}/compare/{{currentDigest}}..{{newDigest}}',
+        matchDatasources: ['git-refs', 'git-tags'],
+        matchJsonata: ["$detectPlatform({{ sourceUrl }}) = 'github'"],
         matchUpdateTypes: ['digest'],
       },
     ],


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Similar to the github preset.
Splitted to two rules:
- first with known platform datasources (no source url matcher required)
- second for `git-*` datasources, which need a source url to match

- #41700

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #39733, #39734
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
