### PR TITLE
fix(manager/swift): strip v prefix from version in Package.resolved

### DIFF
--- a/lib/modules/manager/swift/artifacts.spec.ts
+++ b/lib/modules/manager/swift/artifacts.spec.ts
@@ -590,6 +590,52 @@ describe('modules/manager/swift/artifacts', () => {
     expect(result).toBeNull();
   });
 
+  it('strips v prefix from newVersion when updating Package.resolved', async () => {
+    scm.getFileList.mockResolvedValue(['Package.resolved']);
+    fs.readLocalFile.mockResolvedValue(v2Fixture);
+    vi.mocked(datasource.getDigest).mockResolvedValue('newsha');
+
+    const result = await updateArtifacts({
+      packageFileName: 'Package.swift',
+      updatedDeps: [
+        {
+          depName: 'Alamofire/Alamofire',
+          datasource: GithubTagsDatasource.id,
+          newVersion: 'v5.10.0',
+        },
+      ],
+      newPackageFileContent: '',
+      config: {},
+    });
+
+    expect(result).toHaveLength(1);
+    const { contents } = result![0].file as { contents: string };
+    // version in Package.resolved should NOT have the v prefix
+    expect(contents).toContain('"version": "5.10.0"');
+    expect(contents).not.toContain('"version": "v5.10.0"');
+    expect(contents).toContain('"revision": "newsha"');
+  });
+
+  it('skips already up-to-date pin even with v-prefixed newVersion', async () => {
+    scm.getFileList.mockResolvedValue(['Package.resolved']);
+    fs.readLocalFile.mockResolvedValue(v2Fixture);
+
+    const result = await updateArtifacts({
+      packageFileName: 'Package.swift',
+      updatedDeps: [
+        {
+          depName: 'Alamofire/Alamofire',
+          datasource: GithubTagsDatasource.id,
+          newVersion: 'v5.9.1', // same as fixture but with v prefix
+        },
+      ],
+      newPackageFileContent: '',
+      config: {},
+    });
+
+    expect(result).toBeNull();
+  });
+
   it('handles getDigest throwing an error', async () => {
     scm.getFileList.mockResolvedValue(['Package.resolved']);
     fs.readLocalFile.mockResolvedValue(v2Fixture);

--- a/lib/modules/manager/swift/artifacts.ts
+++ b/lib/modules/manager/swift/artifacts.ts
@@ -186,6 +186,9 @@ export async function updateArtifacts({
         continue;
       }
 
+      // Package.resolved stores pure semver versions without the "v" prefix
+      const resolvedVersion = newVersion.replace(regEx(/^v/i), '');
+
       const pin = matchPinForDep(dep, parsed.pins);
       if (!pin) {
         logger.debug(
@@ -196,7 +199,7 @@ export async function updateArtifacts({
       }
 
       // Skip if already up-to-date
-      if (pin.state.version === newVersion) {
+      if (pin.state.version === resolvedVersion) {
         logger.debug(
           { depName: dep.depName, newVersion },
           'swift: pin already at target version',
@@ -205,7 +208,7 @@ export async function updateArtifacts({
       }
 
       const newRevision = await resolveCommitSha(dep, newVersion);
-      updated = updatePinInJson(updated, pin, newVersion, newRevision);
+      updated = updatePinInJson(updated, pin, resolvedVersion, newRevision);
     }
 
     if (updated !== content) {


### PR DESCRIPTION
## Summary

When a dependency uses v-prefixed git tags (e.g., `v4.2.2`), the `updateArtifacts` function introduced in #41534 writes the raw tag name (including the `v` prefix) into `Package.resolved`. However, Swift Package Manager expects pure semver versions in `Package.resolved`, causing dependency resolution to fail with:

```
Could not resolve package dependencies:
Package.resolved file is corrupted or malformed; fix or delete the file to continue:
non-numerical characters in version core identifier 'v4'
```

This PR strips the `v` prefix from `newVersion` before writing it to `Package.resolved`, while preserving the original tag name for `resolveCommitSha` (which needs the actual git tag to look up the commit SHA).

## Changes

- Strip `v`/`V` prefix from `newVersion` when writing to `Package.resolved`
- Use the stripped version for the "already up-to-date" comparison as well
- Add two test cases covering v-prefixed version handling

## Example

Here is a real-world Renovate PR that demonstrates the issue:

- **PR diff**: https://github.com/shimastripe/InAppPurchaseViewer/pull/263/changes
  - `Package.swift` was correctly updated: `exact: "4.2.0"` → `exact: "4.2.2"` (no `v` prefix)
  - `Package.resolved` was incorrectly updated: `"version" : "4.2.0"` → `"version" : "v4.2.2"` (has `v` prefix)
- **CI failure**: https://github.com/shimastripe/InAppPurchaseViewer/pull/263/checks?check_run_id=66471890890
  - SPM fails with `non-numerical characters in version core identifier 'v4'`

The upstream dependency ([kishikawakatsumi/KeychainAccess](https://github.com/kishikawakatsumi/KeychainAccess)) uses v-prefixed git tags (`v4.2.0`, `v4.2.2`), which is a common convention.