### PR TITLE
feat(gradle): add support for short dependency notation in version catalogs

### DIFF
--- a/lib/modules/manager/gradle/parser.spec.ts
+++ b/lib/modules/manager/gradle/parser.spec.ts
@@ -1025,11 +1025,14 @@ describe('modules/manager/gradle/parser', () => {
       ${'f = "foo"; b = "bar"; v = "1.2.3"'}        | ${'library("foo.bar", property("f"), "${b}").version(v)'}       | ${{ depName: 'foo:bar', currentValue: '1.2.3' }}
       ${'f = "foo"; b = "bar"'}                     | ${'library("foo.bar", "${f}" + f, "${b}").version("1.2.3")'}    | ${{ depName: 'foofoo:bar', currentValue: '1.2.3' }}
       ${'version("baz", "1.2.3")'}                  | ${'library("foo.bar", "foo", "bar").versionRef("baz")'}         | ${{ depName: 'foo:bar', currentValue: '1.2.3', sharedVariableName: 'baz' }}
+      ${''}                                         | ${'library("foo.bar", "foo:bar:1.2.3")'}                        | ${{ depName: 'foo:bar', currentValue: '1.2.3' }}
+      ${'group = "foo"; artifact = "bar"'}          | ${'library("foo.bar", group + ":" + artifact + ":1.2.3")'}      | ${{ depName: 'foo:bar', currentValue: '1.2.3' }}
       ${'library("foo-bar_baz-qux", "foo", "bar")'} | ${'"${libs.foo.bar.baz.qux}:1.2.3"'}                            | ${{ depName: 'foo:bar', currentValue: '1.2.3' }}
       ${''}                                         | ${'library(["foo.bar", "foo", "bar"]).version("1.2.3")'}        | ${null}
       ${''}                                         | ${'library("foo", "bar", "baz", "qux").version("1.2.3")'}       | ${null}
       ${''}                                         | ${'library("foo.bar", "foo", "bar").version("1.2.3", "4.5.6")'} | ${null}
       ${''}                                         | ${'library("foo", bar, "baz").version("1.2.3")'}                | ${null}
+      ${''}                                         | ${'library("foo", "bar" + baz).version("1.2.3")'}               | ${null}
       ${''}                                         | ${'plugin("foo.bar", "foo")'}                                   | ${null}
       ${''}                                         | ${'plugin("foo.bar", "foo").version("1.2.3")'}                  | ${{ depName: 'foo', currentValue: '1.2.3' }}
       ${''}                                         | ${'alias("foo.bar").to("foo", "bar").version("1.2.3")'}         | ${{ depName: 'foo:bar', currentValue: '1.2.3' }}

--- a/lib/modules/manager/gradle/parser/handlers.ts
+++ b/lib/modules/manager/gradle/parser/handlers.ts
@@ -399,7 +399,7 @@ export function handleRegistryUrl(ctx: Ctx): Ctx {
   return ctx;
 }
 
-export function handleLibraryDep(ctx: Ctx): Ctx {
+export function handleCatalogLongFormDep(ctx: Ctx): Ctx {
   const groupIdTokens = loadFromTokenMap(ctx, 'groupId');
   const artifactIdTokens = loadFromTokenMap(ctx, 'artifactId');
 
@@ -427,6 +427,26 @@ export function handleLibraryDep(ctx: Ctx): Ctx {
   }
 
   return ctx;
+}
+
+export function handleCatalogDepString(ctx: Ctx): Ctx {
+  const templateStringTokens = loadFromTokenMap(ctx, 'templateStringTokens');
+  const templateString = interpolateString(templateStringTokens, ctx);
+  if (!templateString) {
+    return ctx;
+  }
+
+  const aliasToken = loadFromTokenMap(ctx, 'alias')[0];
+  const key = `libs.${aliasToken.value.replace(regEx(/[-_]/g), '.')}`;
+
+  ctx.globalVars[key] = {
+    key,
+    value: templateString,
+    fileReplacePosition: aliasToken.offset,
+    packageFile: ctx.packageFile,
+  };
+
+  return handleDepString(ctx);
 }
 
 export function handleApplyFrom(ctx: Ctx): Ctx {

--- a/lib/modules/manager/gradle/parser/version-catalogs.ts
+++ b/lib/modules/manager/gradle/parser/version-catalogs.ts
@@ -10,7 +10,11 @@ import {
   storeInTokenMap,
   storeVarToken,
 } from './common.ts';
-import { handleLibraryDep, handlePlugin } from './handlers.ts';
+import {
+  handleCatalogDepString,
+  handleCatalogLongFormDep,
+  handlePlugin,
+} from './handlers.ts';
 
 const qAlias = qStringValue.handler((ctx) => storeInTokenMap(ctx, 'alias'));
 
@@ -35,7 +39,7 @@ const qVersionCatalogVersion = q
   .handler((ctx) => storeInTokenMap(ctx, 'version'));
 
 // library("foo.bar", "foo", "bar")
-const qVersionCatalogDependencies = q
+const qVersionCatalogLongFormDependencies = q
   .sym<Ctx>('library')
   .tree({
     type: 'wrapped-tree',
@@ -52,7 +56,26 @@ const qVersionCatalogDependencies = q
       .end(),
   })
   .opt(qVersionCatalogVersion)
-  .handler(handleLibraryDep)
+  .handler(handleCatalogLongFormDep)
+  .handler(cleanupTempVars);
+
+// library("foo.bar", "foo:bar:1.2.3")
+const qVersionCatalogShortDependencies = q
+  .sym<Ctx>('library')
+  .tree({
+    type: 'wrapped-tree',
+    maxDepth: 1,
+    startsWith: '(',
+    endsWith: ')',
+    search: q
+      .begin<Ctx>()
+      .join(qAlias)
+      .op(',')
+      .join(qValueMatcher)
+      .handler((ctx) => storeInTokenMap(ctx, 'templateStringTokens'))
+      .end(),
+  })
+  .handler(handleCatalogDepString)
   .handler(cleanupTempVars);
 
 // plugin("foo.bar", "foo:bar")
@@ -96,11 +119,12 @@ const qVersionCatalogAliasDependencies = q
     search: q.begin<Ctx>().join(qGroupId).op(',').join(qArtifactId).end(),
   })
   .opt(qVersionCatalogVersion)
-  .handler(handleLibraryDep)
+  .handler(handleCatalogLongFormDep)
   .handler(cleanupTempVars);
 
 export const qVersionCatalogs = q.alt(
-  qVersionCatalogDependencies,
+  qVersionCatalogLongFormDependencies,
+  qVersionCatalogShortDependencies,
   qVersionCatalogPlugins,
   qVersionCatalogAliasDependencies,
 );


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

gradle supports an alternative format for library declarations in programmatically created version catalogs, which renovate couldn't handle so far: `library(String alias, String groupArtifactVersion)` (see [VersionCatalogBuilder](https://docs.gradle.org/current/javadoc/org/gradle/api/initialization/dsl/VersionCatalogBuilder.html)).

This PR adds parsing and handling for definitions like `library("foo.bar", "foo:bar:1.2.3")`.

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
