### PR TITLE
feat(package-rules): add detectPlatform helper function

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -3439,9 +3439,14 @@ $exists(deprecationMessage)
 $exists(vulnerabilityFixVersion)
 manager = 'dockerfile' and depType = 'final'
 updateType = 'major' and newVersionAgeInDays < 7
+$detectPlatform(sourceUrl) = "github"
 ```
 
 `matchJsonata` accepts an array of strings, and will return `true` if any of those JSONata expressions evaluate to `true`.
+
+Renovate provides the following custom JSONata functions:
+
+- `$detectPlatform(url)` - Takes a URL string and returns the detected platform (`azure`, `bitbucket`, `bitbucket-server`, `forgejo`, `gitea`, `github`, `gitlab`) or `null`.
 
 ### matchManagers
 

--- a/lib/util/jsonata.spec.ts
+++ b/lib/util/jsonata.spec.ts
@@ -11,6 +11,34 @@ describe('util/jsonata', () => {
       expect(getExpression('foo[')).toBeInstanceOf(Error);
     });
 
+    describe('$detectPlatform', () => {
+      it('should return platform for known URL', async () => {
+        const expression = getExpression(
+          '$detectPlatform("https://github.com/foo/bar")',
+        );
+        expect(expression).not.toBeInstanceOf(Error);
+        // make typescript happy
+        if (expression instanceof Error) {
+          throw expression;
+        }
+        const result = await expression.evaluate({});
+        expect(result).toBe('github');
+      });
+
+      it('should return null for unknown URL', async () => {
+        const expression = getExpression(
+          '$detectPlatform("https://unknown.example.com")',
+        );
+        expect(expression).not.toBeInstanceOf(Error);
+        // make typescript happy
+        if (expression instanceof Error) {
+          throw expression;
+        }
+        const result = await expression.evaluate({});
+        expect(result).toBeNull();
+      });
+    });
+
     describe('concurrent evaluation', () => {
       beforeEach(() => {
         memCache.init();

--- a/lib/util/jsonata.ts
+++ b/lib/util/jsonata.ts
@@ -1,5 +1,6 @@
 import jsonata from 'jsonata';
 import * as memCache from './cache/memory/index.ts';
+import { detectPlatform } from './common.ts';
 import { toSha256 } from './hash.ts';
 
 export interface JsonataExpression {
@@ -16,6 +17,11 @@ export function getExpression(input: string): JsonataExpression | Error {
   let result: jsonata.Expression | Error;
   try {
     const expression = jsonata(input);
+    expression.registerFunction(
+      'detectPlatform',
+      (url: string) => detectPlatform(url),
+      '<s-:s>',
+    );
     // Wrap the evaluate method to default bindings to {} for concurrent evaluation safety.
     // This prevents race conditions when the same cached expression is evaluated
     // concurrently with different data. See #40311 for background.

--- a/lib/util/package-rules/jsonata.spec.ts
+++ b/lib/util/package-rules/jsonata.spec.ts
@@ -83,4 +83,22 @@ describe('util/package-rules/jsonata', () => {
     );
     expect(result).toBeFalse();
   });
+
+  describe('$detectPlatform', () => {
+    it('should return true when sourceUrl matches platform', async () => {
+      const result = await matcher.matches(
+        { sourceUrl: 'https://github.com/foo/bar' },
+        { matchJsonata: ['$detectPlatform(sourceUrl) = "github"'] },
+      );
+      expect(result).toBeTrue();
+    });
+
+    it('should return false when sourceUrl does not match platform', async () => {
+      const result = await matcher.matches(
+        { sourceUrl: 'https://gitlab.com/foo/bar' },
+        { matchJsonata: ['$detectPlatform(sourceUrl) = "github"'] },
+      );
+      expect(result).toBeFalse();
+    });
+  });
 });


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds a `detectPlatform` helper function for `jsonata` expressions. 
This makes the function accessible for all usage in the code base

<!-- Describe what behavior is changed by this PR. -->

## Context

https://github.com/renovatebot/renovate/pull/41786#issuecomment-4032952338

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
