### PR TITLE
chore: correctly initialise logger for `tools/`

### DIFF
--- a/tools/docker.ts
+++ b/tools/docker.ts
@@ -1,7 +1,9 @@
 import { Command } from 'commander';
-import { logger } from '../lib/logger/index.ts';
+import { init, logger } from '../lib/logger/index.ts';
 import { bake } from './utils/docker.ts';
 import { parsePositiveInt, parseVersion } from './utils/index.ts';
+
+await init();
 
 const program = new Command('pnpm build:docker');
 

--- a/tools/generate-docs.ts
+++ b/tools/generate-docs.ts
@@ -1,6 +1,8 @@
 import { Command } from 'commander';
-import { logger } from '../lib/logger/index.ts';
+import { init, logger } from '../lib/logger/index.ts';
 import { generateDocs } from './docs/index.ts';
+
+await init();
 
 process.on('unhandledRejection', (err) => {
   // Will print "unhandledRejection err is not defined"

--- a/tools/mkdocs.ts
+++ b/tools/mkdocs.ts
@@ -1,9 +1,11 @@
 import { Command } from 'commander';
 import type { ExecaSyncReturnValue } from 'execa';
 import fs from 'fs-extra';
-import { logger } from '../lib/logger/index.ts';
+import { init, logger } from '../lib/logger/index.ts';
 import { generateDocs } from './docs/index.ts';
 import { exec } from './utils/exec.ts';
+
+await init();
 
 process.on('unhandledRejection', (err) => {
   // Will print "unhandledRejection err is not defined"

--- a/tools/prepare-release.ts
+++ b/tools/prepare-release.ts
@@ -1,10 +1,12 @@
 import { Command } from 'commander';
 import fs from 'fs-extra';
-import { logger } from '../lib/logger/index.ts';
+import { init, logger } from '../lib/logger/index.ts';
 import { generateDocs } from './docs/index.ts';
 import { bake } from './utils/docker.ts';
 import { exec } from './utils/exec.ts';
 import { parseVersion } from './utils/index.ts';
+
+await init();
 
 process.on('unhandledRejection', (err) => {
   // Will print "unhandledRejection err is not defined"

--- a/tools/publish-release.ts
+++ b/tools/publish-release.ts
@@ -1,7 +1,9 @@
 import { Command } from 'commander';
-import { logger } from '../lib/logger/index.ts';
+import { init, logger } from '../lib/logger/index.ts';
 import { bake, sign } from './utils/docker.ts';
 import { parseVersion } from './utils/index.ts';
+
+await init();
 
 process.on('unhandledRejection', (err) => {
   // Will print "unhandledRejection err is not defined"


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
As part of changes in #41425, we'd
missed the fact that `tools/` would need to have the logger initialized
too.


## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe): Claude Sonnet 4.6 (Claude Code)

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
