### PR TITLE
chore: log a warning when logger isn't initialized (yet)

### DIFF
--- a/lib/logger/renovate-logger.spec.ts
+++ b/lib/logger/renovate-logger.spec.ts
@@ -22,4 +22,26 @@ describe('logger/renovate-logger', () => {
     logger.bunyan = fakeLogger as unknown as BunyanLogger;
     expect(fakeLogger.info).toHaveBeenCalledTimes(1);
   });
+
+  describe('before bunyan is initialized', () => {
+    it('should log to console', () => {
+      const consoleSpy = vi.spyOn(console, 'warn');
+      const logger = new RenovateLogger('test', {});
+      logger.info('hello before init');
+      expect(consoleSpy).toHaveBeenCalledWith(
+        `⚠️ NOTE ⚠️: Renovate's logger has not yet been initialized. If you see no other output, this is a bug`,
+      );
+    });
+
+    it('should not log more than once', () => {
+      const consoleSpy = vi.spyOn(console, 'warn');
+      const logger = new RenovateLogger('test', {});
+      logger.info('hello before init');
+      logger.info('hello before init');
+      logger.info('hello before init');
+      expect(consoleSpy).toHaveBeenCalledExactlyOnceWith(
+        `⚠️ NOTE ⚠️: Renovate's logger has not yet been initialized. If you see no other output, this is a bug`,
+      );
+    });
+  });
 });

--- a/lib/logger/renovate-logger.ts
+++ b/lib/logger/renovate-logger.ts
@@ -28,6 +28,7 @@ export class RenovateLogger implements Logger {
   readonly logger: Logger = { once: { reset: onceReset } } as any;
   readonly once = this.logger.once;
   private bunyanLogger: BunyanLogger | undefined;
+  private uninitializedWarningFired: boolean;
   private context: string;
   private meta: Record<string, unknown>;
 
@@ -43,6 +44,7 @@ export class RenovateLogger implements Logger {
       this.logger[level] = this.logFactory(level) as never;
       this.logger.once[level] = this.logOnceFn(level);
     }
+    this.uninitializedWarningFired = false;
   }
 
   trace(p1: string): void;
@@ -195,6 +197,13 @@ export class RenovateLogger implements Logger {
     if (!this.bunyanLogger) {
       // defer logging until bunyan logger is initialized, to avoid losing logs during initialization
       this.queue.push(() => this.log(level, p1, p2));
+      if (!this.uninitializedWarningFired) {
+        // oxlint-disable-next-line no-console -- intentional: display warning when bunyan isn't initialized
+        console.warn(
+          `⚠️ NOTE ⚠️: Renovate's logger has not yet been initialized. If you see no other output, this is a bug`,
+        );
+        this.uninitializedWarningFired = true;
+      }
       return;
     }
     const logFn = this.logger[level];


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
In an alternative to #41842, we can also introduce a warning when the
logger has been called before any initialization, as a way to surface
this misconfiguration.


## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
