### PR TITLE
fix(datasource/rpm): accept repomd.xml without xml declaration

### DIFF
--- a/lib/modules/datasource/rpm/index.spec.ts
+++ b/lib/modules/datasource/rpm/index.spec.ts
@@ -27,6 +27,26 @@ describe('modules/datasource/rpm/index', () => {
       );
     });
 
+    it('returns the correct primary.xml URL when repomd.xml omits xml declaration', async () => {
+      const repomdXml = `<repomd xmlns="http://linux.duke.edu/metadata/repo"
+  xmlns:rpm="http://linux.duke.edu/metadata/rpm">
+  <data type="primary">
+    <location href="repodata/somesha256-primary.xml.gz"/>
+  </data>
+</repomd>`;
+
+      httpMock
+        .scope(registryUrl)
+        .get('/repomd.xml')
+        .reply(200, repomdXml, { 'Content-Type': 'application/xml' });
+
+      const primaryXmlUrl = await rpmDatasource.getPrimaryGzipUrl(registryUrl);
+
+      expect(primaryXmlUrl).toBe(
+        'https://example.com/repo/repodata/somesha256-primary.xml.gz',
+      );
+    });
+
     it('throws an error if repomd.xml is missing', async () => {
       httpMock.scope(registryUrl).get('/repomd.xml').reply(404, 'Not Found');
 

--- a/lib/modules/datasource/rpm/index.ts
+++ b/lib/modules/datasource/rpm/index.ts
@@ -85,8 +85,10 @@ export class RpmDatasource extends Datasource {
     );
     const response = await this.http.getText(repomdUrl.toString());
 
-    // check if repomd.xml is in XML format
-    if (!response.body.startsWith('<?xml')) {
+    const repomdBody = response.body.trimStart();
+
+    // repomd.xml may omit the XML declaration and start directly with the root element
+    if (!(repomdBody.startsWith('<?xml') || repomdBody.startsWith('<repomd'))) {
       logger.debug(
         { datasource: RpmDatasource.id, url: repomdUrl },
         'Invalid response format',
@@ -97,7 +99,7 @@ export class RpmDatasource extends Datasource {
     }
 
     // parse repomd.xml using XmlDocument
-    const xml = new XmlDocument(response.body);
+    const xml = new XmlDocument(repomdBody);
 
     const primaryData = xml.childWithAttribute('type', 'primary');
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Amazon Linux 2023 serves a valid `repomd.xml` file without an XML declaration at the top, so the RPM datasource rejected it even though the document starts directly with the `<repomd>` root element.

This PR updates the RPM datasource validation to accept `repomd.xml` responses that start with either `<?xml` or `<repomd>`, while continuing to reject non-XML responses.

References

* https://cdn.amazonlinux.com/al2023/core/mirrors/latest/x86_64/mirror.list
* https://cdn.amazonlinux.com/al2023/core/guids/3acc34dc82a9f39726a050b9ba8ca743102a8a68cb3a07bfe53950a9a892c1c2/x86_64/repodata/repomd.xml

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Used Codex to explore codebase and pinpoint the place where issue occurs.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
