### PR TITLE
fix(config)!: don't allow options with a parent to be set in CLI

### DIFF
--- a/lib/config/options/index.spec.ts
+++ b/lib/config/options/index.spec.ts
@@ -91,13 +91,13 @@ describe('config/options/index', () => {
     }
   });
 
-  describe('options with a parent cannot be cli=true', () => {
+  describe('options with a parent cannot be set on the command-line', () => {
     const opts = getOptions();
     for (const option of opts) {
       if (option.name !== 'enabled' && option.name !== 'managerFilePatterns') {
         if (!isUndefined(option.parents)) {
           for (const parent of option.parents) {
-            it(`${parent}.${option.name}: cli=false`, () => {
+            it(`${parent}.${option.name}: should be cli=false`, () => {
               expect(option.cli).toBeFalse();
             });
           }

--- a/lib/config/options/index.spec.ts
+++ b/lib/config/options/index.spec.ts
@@ -1,4 +1,4 @@
-import { isNullOrUndefined } from '@sindresorhus/is';
+import { isNullOrUndefined, isUndefined } from '@sindresorhus/is';
 import * as manager from '../../modules/manager/index.ts';
 import * as platform from '../../modules/platform/index.ts';
 import { getOptions } from './index.ts';
@@ -85,6 +85,21 @@ describe('config/options/index', () => {
                 expect(foundOption[0].allowedValues).toContain(prop.value);
               });
             }
+          }
+        }
+      }
+    }
+  });
+
+  describe('options with a parent cannot be cli=true', () => {
+    const opts = getOptions();
+    for (const option of opts) {
+      if (option.name !== 'enabled' && option.name !== 'managerFilePatterns') {
+        if (!isUndefined(option.parents)) {
+          for (const parent of option.parents) {
+            it(`${parent}.${option.name}: cli=false`, () => {
+              expect(option.cli).toBeFalse();
+            });
           }
         }
       }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
As per #40813, it does not make sense for an option that has a parent to
be configurable through CLI arguments, as it is difficult to set them
with how we currently derive the flags.

We can also enforce this with a test.


## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #40813
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
