### PR TITLE
feat(config-migration): add commitBody to ConfigMigration commit message

### DIFF
--- a/lib/workers/repository/config-migration/branch/create.spec.ts
+++ b/lib/workers/repository/config-migration/branch/create.spec.ts
@@ -150,6 +150,63 @@ describe('workers/repository/config-migration/branch/create', () => {
       });
     });
 
+    describe('appends the commitBody value', () => {
+      it('to the default commit message', async () => {
+        config.gitAuthor = 'renovate@renovatebot.com';
+        config.commitBody = 'Signed-off-by: {{{gitAuthor}}}';
+        config.commitMessage = '';
+
+        const message = `Migrate config renovate.json\n\nSigned-off-by: renovate@renovatebot.com`;
+        await createConfigMigrationBranch(config, migratedConfigData);
+
+        expect(scm.checkoutBranch).toHaveBeenCalledExactlyOnceWith(
+          config.defaultBranch,
+        );
+        expect(scm.commitAndPush).toHaveBeenCalledExactlyOnceWith({
+          branchName: 'renovate/migrate-config',
+          baseBranch: 'dev',
+          files: [
+            {
+              type: 'addition',
+              path: 'renovate.json',
+              contents: renovateConfig,
+            },
+          ],
+          message,
+          platformCommit: 'auto',
+          force: true,
+          labels: [],
+        });
+      });
+      it('to the supplied commit message', async () => {
+        config.gitAuthor = 'renovate@renovatebot.com';
+        config.commitBody = 'Signed-off-by: {{{gitAuthor}}}';
+        config.commitMessage = 'Supplied Commit Message';
+
+        const message = `Supplied Commit Message\n\nSigned-off-by: renovate@renovatebot.com`;
+        await createConfigMigrationBranch(config, migratedConfigData);
+
+        expect(scm.checkoutBranch).toHaveBeenCalledExactlyOnceWith(
+          config.defaultBranch,
+        );
+        expect(scm.commitAndPush).toHaveBeenCalledExactlyOnceWith({
+          branchName: 'renovate/migrate-config',
+          baseBranch: 'dev',
+          files: [
+            {
+              type: 'addition',
+              path: 'renovate.json',
+              contents: renovateConfig,
+            },
+          ],
+          message,
+          platformCommit: 'auto',
+          force: true,
+          labels: [],
+        });
+      });
+    });
+
     describe('applies semanticCommit prefix', () => {
       it('to the default commit message', async () => {
         const prefix = 'chore(config)';

--- a/lib/workers/repository/config-migration/branch/create.ts
+++ b/lib/workers/repository/config-migration/branch/create.ts
@@ -5,6 +5,7 @@ import { scm } from '../../../../modules/platform/scm.ts';
 import { parseJson } from '../../../../util/common.ts';
 import { readLocalFile } from '../../../../util/fs/index.ts';
 import type { FileChange } from '../../../../util/git/types.ts';
+import { compile } from '../../../../util/template/index.ts';
 import { getMigrationBranchName } from '../common.ts';
 import { ConfigMigrationCommitMessageFactory } from './commit-message.ts';
 import type { MigratedData } from './migrated-data.ts';
@@ -29,7 +30,16 @@ export async function createConfigMigrationBranch(
     configFileName,
   );
 
-  const commitMessage = commitMessageFactory.getCommitMessage();
+  let commitMessage = commitMessageFactory.getCommitMessage();
+  if (config.commitBody) {
+    commitMessage = `${commitMessage}\n\n${compile(
+      config.commitBody,
+      // only allow gitAuthor template value in the commitBody
+      { gitAuthor: config.gitAuthor },
+    )}`;
+
+    logger.trace(`config migration commitMessage: ${commitMessage}`);
+  }
 
   // istanbul ignore if
   if (GlobalConfig.get('dryRun')) {


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This enables the addition of 'Signed-off-by' trailers, or any other `commitBody` configuration to the ConfigMigration commit message.

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #40124
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
