### PR TITLE
feat(datasource/rpm): add primary_db metadata provider

### DIFF
--- a/lib/modules/datasource/rpm/index.spec.ts
+++ b/lib/modules/datasource/rpm/index.spec.ts
@@ -135,6 +135,55 @@ function mockPrimaryDbResponse(primaryDbGzip: Buffer): void {
     });
 }
 
+function parseRegistryUrlForTest(
+  datasource: RpmDatasource,
+  url: string,
+): { metadataSource: string; registryUrl: string } {
+  return (
+    datasource as unknown as {
+      parseRegistryUrl: (url: string) => {
+        metadataSource: string;
+        registryUrl: string;
+      };
+    }
+  ).parseRegistryUrl(url);
+}
+
+function getAutoReleasesForTest(
+  datasource: RpmDatasource,
+  metadata: { repomdUrl: string },
+  packageName: string,
+  url: string,
+): Promise<unknown> {
+  return (
+    datasource as unknown as {
+      getAutoReleases: (
+        metadata: { repomdUrl: string },
+        packageName: string,
+        url: string,
+      ) => Promise<unknown>;
+    }
+  ).getAutoReleases(metadata, packageName, url);
+}
+
+function mockPrimaryDbProviderFailure(
+  datasource: RpmDatasource,
+  err: unknown,
+): void {
+  vi.spyOn(
+    (
+      datasource as unknown as {
+        providers: {
+          primary_db: {
+            getReleases: () => Promise<unknown>;
+          };
+        };
+      }
+    ).providers.primary_db,
+    'getReleases',
+  ).mockRejectedValue(err);
+}
+
 describe('modules/datasource/rpm/index', () => {
   let cacheDirResult: DirectoryResult | null;
   let rpmDatasource: RpmDatasource;
@@ -354,6 +403,17 @@ describe('modules/datasource/rpm/index', () => {
       await expect(
         rpmDatasource.getPrimaryGzipUrl(registryUrl),
       ).rejects.toThrow(`No href found in ${registryUrl}repomd.xml`);
+    });
+
+    it('throws when only primary_db metadata is present', async () => {
+      mockRepomdResponse({
+        primaryDbHref: 'repodata/somesha256-primary.sqlite.gz',
+        primaryHref: '',
+      });
+
+      await expect(
+        rpmDatasource.getPrimaryGzipUrl(registryUrl),
+      ).rejects.toThrow(`No primary data found in ${registryUrl}repomd.xml`);
     });
   });
 
@@ -1053,6 +1113,35 @@ describe('modules/datasource/rpm/index', () => {
       ).rejects.toThrow('Invalid rpmMetadataSource in RPM registry URL:');
     });
 
+    it('strips explicit auto rpmMetadataSource from registryUrl', async () => {
+      mockRepomdResponse();
+      mockPrimaryXmlResponse(
+        buildPrimaryXml(codeBlock`
+          <package type="rpm">
+            <name>example-package</name>
+            <arch>x86_64</arch>
+            <version epoch="0" ver="1.0" rel="2.azl3"/>
+          </package>
+        `),
+      );
+
+      await expect(
+        rpmDatasource.getReleases({
+          registryUrl: `${registryUrl}#rpmMetadataSource=auto`,
+          packageName: 'example-package',
+        }),
+      ).resolves.toEqual({
+        releases: [{ version: '1.0-2.azl3' }],
+      });
+    });
+
+    it('keeps invalid registryUrl unchanged when parsing metadata source', () => {
+      expect(parseRegistryUrlForTest(rpmDatasource, 'not a url')).toEqual({
+        metadataSource: 'auto',
+        registryUrl: 'not a url',
+      });
+    });
+
     it('falls back to primary.xml.gz when primary_db is absent', async () => {
       mockRepomdResponse();
       mockPrimaryXmlResponse(
@@ -1101,6 +1190,31 @@ describe('modules/datasource/rpm/index', () => {
       });
 
       expect(releases).toEqual({
+        releases: [{ version: '2.0-1.azl3' }],
+      });
+    });
+
+    it('falls back to primary.xml.gz when primary_db rejects with a non-Error', async () => {
+      mockRepomdResponse({
+        primaryDbHref: 'repodata/somesha256-primary.sqlite.gz',
+      });
+      mockPrimaryDbProviderFailure(rpmDatasource, 'not-a-sqlite-error');
+      mockPrimaryXmlResponse(
+        buildPrimaryXml(codeBlock`
+          <package type="rpm">
+            <name>example-package</name>
+            <arch>x86_64</arch>
+            <version epoch="0" ver="2.0" rel="1.azl3"/>
+          </package>
+        `),
+      );
+
+      await expect(
+        rpmDatasource.getReleases({
+          registryUrl,
+          packageName: 'example-package',
+        }),
+      ).resolves.toEqual({
         releases: [{ version: '2.0-1.azl3' }],
       });
     });
@@ -1262,6 +1376,17 @@ describe('modules/datasource/rpm/index', () => {
           packageName: 'example-package',
         }),
       ).rejects.toThrow(`No primary data found in ${registryUrl}repomd.xml`);
+    });
+
+    it('returns null when repository metadata has no usable source', async () => {
+      await expect(
+        getAutoReleasesForTest(
+          rpmDatasource,
+          { repomdUrl: `${registryUrl}repomd.xml` },
+          'example-package',
+          registryUrl,
+        ),
+      ).resolves.toBeNull();
     });
   });
 });

--- a/lib/modules/datasource/rpm/index.spec.ts
+++ b/lib/modules/datasource/rpm/index.spec.ts
@@ -1,3 +1,4 @@
+import { readFile } from 'node:fs/promises';
 import { Readable } from 'node:stream';
 import { gzipSync } from 'node:zlib';
 import { codeBlock } from 'common-tags';
@@ -15,6 +16,124 @@ const registryUrl = 'https://example.com/repo/repodata/';
 const primaryXmlUrl =
   'https://example.com/repo/repodata/somesha256-primary.xml.gz';
 const primaryXmlRegistryUrl = primaryXmlUrl.replace(/\/[^/]+$/, '');
+const primaryDbUrl =
+  'https://example.com/repo/repodata/somesha256-primary.sqlite.gz';
+const primaryDbRegistryUrl = primaryDbUrl.replace(/\/[^/]+$/, '');
+
+function buildRepomdXml({
+  primaryDbHref,
+  primaryHref = 'repodata/somesha256-primary.xml.gz',
+}: {
+  primaryDbHref?: string;
+  primaryHref?: string;
+} = {}): string {
+  return codeBlock`
+    <?xml version="1.0" encoding="UTF-8"?>
+    <repomd xmlns="http://linux.duke.edu/metadata/repo" xmlns:rpm="http://linux.duke.edu/metadata/rpm">
+      ${
+        primaryHref
+          ? codeBlock`
+              <data type="primary">
+                <location href="${primaryHref}"/>
+              </data>
+            `
+          : ''
+      }
+      ${
+        primaryDbHref
+          ? codeBlock`
+              <data type="primary_db">
+                <location href="${primaryDbHref}"/>
+              </data>
+            `
+          : ''
+      }
+    </repomd>
+  `;
+}
+
+function buildPrimaryXml(packageEntries: string): string {
+  return codeBlock`
+    <?xml version="1.0" encoding="UTF-8"?>
+    <metadata xmlns="http://linux.duke.edu/metadata/common">
+      ${packageEntries}
+    </metadata>
+  `;
+}
+
+async function createPrimaryDbGzip(
+  rows: { name: string; release?: string | null; version: string | null }[],
+): Promise<Buffer> {
+  const dirResult = await tmpDir({ unsafeCleanup: true });
+  const dbFile = `${dirResult.path}/primary.sqlite`;
+  const { DatabaseSync: Sqlite } = await import('node:sqlite');
+  const db = new Sqlite(dbFile);
+
+  try {
+    db.exec(`
+      CREATE TABLE packages (
+        name TEXT,
+        version TEXT,
+        release TEXT
+      )
+    `);
+
+    const stmt = db.prepare(
+      'INSERT INTO packages (name, version, release) VALUES (?, ?, ?)',
+    );
+    for (const row of rows) {
+      stmt.run(row.name, row.version, row.release ?? null);
+    }
+  } finally {
+    db.close();
+  }
+
+  try {
+    const dbBuffer = await readFile(dbFile);
+    return gzipSync(dbBuffer);
+  } finally {
+    await dirResult.cleanup();
+  }
+}
+
+function mockRepomdResponse({
+  primaryDbHref,
+  primaryHref = 'repodata/somesha256-primary.xml.gz',
+}: {
+  primaryDbHref?: string;
+  primaryHref?: string;
+} = {}): void {
+  httpMock
+    .scope(registryUrl)
+    .get('/repomd.xml')
+    .reply(200, buildRepomdXml({ primaryDbHref, primaryHref }), {
+      'Content-Type': 'application/xml',
+    });
+}
+
+function mockRawRepomdResponse(repomdXml: string): void {
+  httpMock.scope(registryUrl).get('/repomd.xml').reply(200, repomdXml, {
+    'Content-Type': 'application/xml',
+  });
+}
+
+function mockPrimaryXmlResponse(primaryXml: string): void {
+  httpMock
+    .scope(primaryXmlRegistryUrl)
+    .get('/somesha256-primary.xml.gz')
+    .reply(200, gzipSync(primaryXml), {
+      'Content-Type': 'application/gzip',
+    });
+}
+
+function mockPrimaryDbResponse(primaryDbGzip: Buffer): void {
+  httpMock
+    .scope(primaryDbRegistryUrl)
+    .get('/somesha256-primary.sqlite.gz')
+    .reply(200, primaryDbGzip, {
+      'Content-Type': 'application/gzip',
+    });
+}
 
 describe('modules/datasource/rpm/index', () => {
   let cacheDirResult: DirectoryResult | null;
@@ -41,19 +160,7 @@ describe('modules/datasource/rpm/index', () => {
 
   describe('getPrimaryGzipUrl', () => {
     it('returns the correct primary.xml URL', async () => {
-      const repomdXml = codeBlock`
-        <?xml version="1.0" encoding="UTF-8"?>
-        <repomd xmlns="http://linux.duke.edu/metadata/repo" xmlns:rpm="http://linux.duke.edu/metadata/rpm">
-          <data type="primary">
-            <location href="repodata/somesha256-primary.xml.gz"/>
-          </data>
-        </repomd>
-      `;
-
-      httpMock
-        .scope(registryUrl)
-        .get('/repomd.xml')
-        .reply(200, repomdXml, { 'Content-Type': 'application/xml' });
+      mockRepomdResponse();
 
       const resolvedPrimaryXmlUrl =
         await rpmDatasource.getPrimaryGzipUrl(registryUrl);
@@ -184,29 +291,75 @@ describe('modules/datasource/rpm/index', () => {
         rpmDatasource.getPrimaryGzipUrl(registryUrl),
       ).rejects.toThrow(`No href found in ${registryUrl}repomd.xml`);
     });
+
+    it('ignores primary_db entries without a location element', async () => {
+      const repomdXml = codeBlock`
+        <?xml version="1.0" encoding="UTF-8"?>
+        <repomd xmlns="http://linux.duke.edu/metadata/repo" xmlns:rpm="http://linux.duke.edu/metadata/rpm">
+          <data type="primary">
+            <location href="repodata/somesha256-primary.xml.gz"/>
+          </data>
+          <data type="primary_db">
+            <non-location href="repodata/somesha256-primary.sqlite.gz"/>
+          </data>
+        </repomd>
+      `;
+
+      httpMock
+        .scope(registryUrl)
+        .get('/repomd.xml')
+        .reply(200, repomdXml, { 'Content-Type': 'application/xml' });
+
+      await expect(rpmDatasource.getPrimaryGzipUrl(registryUrl)).resolves.toBe(
+        primaryXmlUrl,
+      );
+    });
+
+    it('ignores primary_db entries without an href attribute', async () => {
+      const repomdXml = codeBlock`
+        <?xml version="1.0" encoding="UTF-8"?>
+        <repomd xmlns="http://linux.duke.edu/metadata/repo" xmlns:rpm="http://linux.duke.edu/metadata/rpm">
+          <data type="primary">
+            <location href="repodata/somesha256-primary.xml.gz"/>
+          </data>
+          <data type="primary_db">
+            <location non-href="repodata/somesha256-primary.sqlite.gz"/>
+          </data>
+        </repomd>
+      `;
+
+      httpMock
+        .scope(registryUrl)
+        .get('/repomd.xml')
+        .reply(200, repomdXml, { 'Content-Type': 'application/xml' });
+
+      await expect(rpmDatasource.getPrimaryGzipUrl(registryUrl)).resolves.toBe(
+        primaryXmlUrl,
+      );
+    });
+
+    it('validates primary metadata even when primary_db is present', async () => {
+      mockRawRepomdResponse(codeBlock`
+        <?xml version="1.0" encoding="UTF-8"?>
+        <repomd xmlns="http://linux.duke.edu/metadata/repo" xmlns:rpm="http://linux.duke.edu/metadata/rpm">
+          <data type="primary">
+            <location non-href="repodata/somesha256-primary.xml.gz"/>
+          </data>
+          <data type="primary_db">
+            <location href="repodata/somesha256-primary.sqlite.gz"/>
+          </data>
+        </repomd>
+      `);
+
+      await expect(
+        rpmDatasource.getPrimaryGzipUrl(registryUrl),
+      ).rejects.toThrow(`No href found in ${registryUrl}repomd.xml`);
+    });
   });
 
   describe('getReleasesByPackageName', () => {
     const packageName = 'example-package';
     const extractedPrimaryXmlPath = `others/rpm/${toSha256(primaryXmlUrl)}.xml`;
-
-    function buildPrimaryXml(packageEntries: string): string {
-      return codeBlock`
-        <?xml version="1.0" encoding="UTF-8"?>
-        <metadata xmlns="http://linux.duke.edu/metadata/common">
-          ${packageEntries}
-        </metadata>
-      `;
-    }
-
-    function mockPrimaryXmlResponse(primaryXml: string): void {
-      httpMock
-        .scope(primaryXmlRegistryUrl)
-        .get('/somesha256-primary.xml.gz')
-        .reply(200, gzipSync(primaryXml), {
-          'Content-Type': 'application/gzip',
-        });
-    }
 
     it('returns the correct releases', async () => {
       mockPrimaryXmlResponse(
@@ -656,17 +809,31 @@ describe('modules/datasource/rpm/index', () => {
     });
 
     it('returns the correct releases', async () => {
-      vi.spyOn(rpmDatasource, 'getPrimaryGzipUrl').mockResolvedValue(
-        primaryXmlUrl,
+      mockRepomdResponse();
+      mockPrimaryXmlResponse(
+        buildPrimaryXml(codeBlock`
+          <package type="rpm">
+            <name>example-package</name>
+            <arch>x86_64</arch>
+            <version epoch="0" ver="1.0" rel="2.azl3"/>
+          </package>
+          <package type="rpm">
+            <name>example-package</name>
+            <arch>x86_64</arch>
+            <version epoch="0" ver="1.1" rel="1.azl3"/>
+          </package>
+          <package type="rpm">
+            <name>example-package</name>
+            <arch>x86_64</arch>
+            <version epoch="0" ver="1.1" rel="2.azl3"/>
+          </package>
+          <package type="rpm">
+            <name>example-package</name>
+            <arch>x86_64</arch>
+            <version epoch="0" ver="1.2"/>
+          </package>
+        `),
       );
-      vi.spyOn(rpmDatasource, 'getReleasesByPackageName').mockResolvedValue({
-        releases: [
-          { version: '1.0-2.azl3' },
-          { version: '1.1-1.azl3' },
-          { version: '1.1-2.azl3' },
-          { version: '1.2' },
-        ],
-      });
 
       const releases = await rpmDatasource.getReleases({
         registryUrl,
@@ -683,10 +850,11 @@ describe('modules/datasource/rpm/index', () => {
       });
     });
 
-    it('throws an error if getPrimaryGzipUrl fails', async () => {
-      vi.spyOn(rpmDatasource, 'getPrimaryGzipUrl').mockRejectedValue(
-        new Error('Something wrong'),
-      );
+    it('throws an error if repository metadata lookup fails', async () => {
+      httpMock
+        .scope(registryUrl)
+        .get('/repomd.xml')
+        .replyWithError('Something wrong');
 
       await expect(
         rpmDatasource.getReleases({
@@ -696,20 +864,404 @@ describe('modules/datasource/rpm/index', () => {
       ).rejects.toThrow('Something wrong');
     });
 
-    it('throws an error if getReleasesByPackageName fails', async () => {
-      vi.spyOn(rpmDatasource, 'getPrimaryGzipUrl').mockResolvedValue(
-        primaryXmlUrl,
-      );
-      vi.spyOn(rpmDatasource, 'getReleasesByPackageName').mockRejectedValue(
-        new Error('Something wrong'),
-      );
+    it('throws an error if primary metadata parsing fails', async () => {
+      mockRepomdResponse();
+      mockPrimaryXmlResponse(codeBlock`
+        <?xml version="1.0" encoding="UTF-8"?>
+        <%$#metadata xmlns="http://linux.duke.edu/metadata/common">
+          <package type="rpm">
+            <name>example-package</name>
+            <arch>x86_64</arch>
+            <version epoch="0" ver="1.0" rel="1.azl3"/>
+          </package>
+        </metadata>
+      `);
 
       await expect(
         rpmDatasource.getReleases({
           registryUrl,
           packageName: 'example-package',
         }),
-      ).rejects.toThrow('Something wrong');
+      ).rejects.toThrow('Unencoded <');
+    });
+
+    it('prefers primary_db metadata when available', async () => {
+      mockRepomdResponse({
+        primaryDbHref: 'repodata/somesha256-primary.sqlite.gz',
+      });
+      mockPrimaryDbResponse(
+        await createPrimaryDbGzip([
+          {
+            name: 'example-package',
+            release: '2.azl3',
+            version: '1.0',
+          },
+        ]),
+      );
+      mockPrimaryXmlResponse(
+        buildPrimaryXml(codeBlock`
+          <package type="rpm">
+            <name>example-package</name>
+            <arch>x86_64</arch>
+            <version epoch="0" ver="9.9" rel="1.azl3"/>
+          </package>
+        `),
+      );
+
+      const autoReleases = await rpmDatasource.getReleases({
+        registryUrl,
+        packageName: 'example-package',
+      });
+      const xmlReleases = await rpmDatasource.getReleases({
+        registryUrl: `${registryUrl}#rpmMetadataSource=primary`,
+        packageName: 'example-package',
+      });
+
+      expect(autoReleases).toEqual({
+        releases: [{ version: '1.0-2.azl3' }],
+      });
+      expect(xmlReleases).toEqual({
+        releases: [{ version: '9.9-1.azl3' }],
+      });
+    });
+
+    it('does not fall back to primary.xml.gz when primary_db has no matching package', async () => {
+      mockRepomdResponse({
+        primaryDbHref: 'repodata/somesha256-primary.sqlite.gz',
+      });
+      mockPrimaryDbResponse(
+        await createPrimaryDbGzip([
+          {
+            name: 'another-package',
+            release: '2.azl3',
+            version: '1.0',
+          },
+        ]),
+      );
+
+      const releases = await rpmDatasource.getReleases({
+        registryUrl,
+        packageName: 'example-package',
+      });
+
+      expect(releases).toBeNull();
+    });
+
+    it('does not fall back to primary.xml.gz when registryUrl requires primary_db', async () => {
+      mockRepomdResponse({
+        primaryDbHref: 'repodata/somesha256-primary.sqlite.gz',
+      });
+      mockPrimaryDbResponse(gzipSync('not-a-sqlite-database'));
+
+      await expect(
+        rpmDatasource.getReleases({
+          registryUrl: `${registryUrl}#rpmMetadataSource=primary_db`,
+          packageName: 'example-package',
+        }),
+      ).rejects.toThrow();
+    });
+
+    it('throws sqlite errors when only primary_db metadata is present in auto mode', async () => {
+      mockRepomdResponse({
+        primaryDbHref: 'repodata/somesha256-primary.sqlite.gz',
+        primaryHref: '',
+      });
+      mockPrimaryDbResponse(gzipSync('not-a-sqlite-database'));
+
+      await expect(
+        rpmDatasource.getReleases({
+          registryUrl,
+          packageName: 'example-package',
+        }),
+      ).rejects.toThrow();
+    });
+
+    it('uses primary_db when primary metadata is malformed', async () => {
+      mockRawRepomdResponse(codeBlock`
+        <?xml version="1.0" encoding="UTF-8"?>
+        <repomd xmlns="http://linux.duke.edu/metadata/repo" xmlns:rpm="http://linux.duke.edu/metadata/rpm">
+          <data type="primary">
+            <location non-href="repodata/somesha256-primary.xml.gz"/>
+          </data>
+          <data type="primary_db">
+            <location href="repodata/somesha256-primary.sqlite.gz"/>
+          </data>
+        </repomd>
+      `);
+      mockPrimaryDbResponse(
+        await createPrimaryDbGzip([
+          {
+            name: 'example-package',
+            release: '2.azl3',
+            version: '1.0',
+          },
+        ]),
+      );
+
+      await expect(
+        rpmDatasource.getReleases({
+          registryUrl: `${registryUrl}#rpmMetadataSource=primary_db`,
+          packageName: 'example-package',
+        }),
+      ).resolves.toEqual({
+        releases: [{ version: '1.0-2.azl3' }],
+      });
+    });
+
+    it('throws when registryUrl requires primary_db and primary_db metadata is absent', async () => {
+      mockRepomdResponse();
+
+      await expect(
+        rpmDatasource.getReleases({
+          registryUrl: `${registryUrl}#rpmMetadataSource=primary_db`,
+          packageName: 'example-package',
+        }),
+      ).rejects.toThrow(`No primary_db data found in ${registryUrl}repomd.xml`);
+    });
+
+    it('throws when registryUrl requires primary and primary metadata is absent', async () => {
+      mockRepomdResponse({
+        primaryDbHref: 'repodata/somesha256-primary.sqlite.gz',
+        primaryHref: '',
+      });
+
+      await expect(
+        rpmDatasource.getReleases({
+          registryUrl: `${registryUrl}#rpmMetadataSource=primary`,
+          packageName: 'missing-source-package',
+        }),
+      ).rejects.toThrow(`No primary data found in ${registryUrl}repomd.xml`);
+    });
+
+    it('throws when registryUrl has invalid rpmMetadataSource', async () => {
+      await expect(
+        rpmDatasource.getReleases({
+          registryUrl: `${registryUrl}#rpmMetadataSource=broken`,
+          packageName: 'example-package',
+        }),
+      ).rejects.toThrow(
+        'Invalid rpmMetadataSource in RPM registry URL: broken',
+      );
+    });
+
+    it('throws when registryUrl has empty rpmMetadataSource', async () => {
+      await expect(
+        rpmDatasource.getReleases({
+          registryUrl: `${registryUrl}#rpmMetadataSource=`,
+          packageName: 'example-package',
+        }),
+      ).rejects.toThrow('Invalid rpmMetadataSource in RPM registry URL:');
+    });
+
+    it('falls back to primary.xml.gz when primary_db is absent', async () => {
+      mockRepomdResponse();
+      mockPrimaryXmlResponse(
+        buildPrimaryXml(codeBlock`
+          <package type="rpm">
+            <name>example-package</name>
+            <arch>x86_64</arch>
+            <version epoch="0" ver="1.0" rel="2.azl3"/>
+          </package>
+          <package type="rpm">
+            <name>example-package</name>
+            <arch>x86_64</arch>
+            <version epoch="0" ver="1.1"/>
+          </package>
+        `),
+      );
+
+      const releases = await rpmDatasource.getReleases({
+        registryUrl,
+        packageName: 'example-package',
+      });
+
+      expect(releases).toEqual({
+        releases: [{ version: '1.0-2.azl3' }, { version: '1.1' }],
+      });
+    });
+
+    it('falls back to primary.xml.gz when primary_db lookup fails', async () => {
+      mockRepomdResponse({
+        primaryDbHref: 'repodata/somesha256-primary.sqlite.gz',
+      });
+      mockPrimaryDbResponse(gzipSync('not-a-sqlite-database'));
+      mockPrimaryXmlResponse(
+        buildPrimaryXml(codeBlock`
+          <package type="rpm">
+            <name>example-package</name>
+            <arch>x86_64</arch>
+            <version epoch="0" ver="2.0" rel="1.azl3"/>
+          </package>
+        `),
+      );
+
+      const releases = await rpmDatasource.getReleases({
+        registryUrl,
+        packageName: 'example-package',
+      });
+
+      expect(releases).toEqual({
+        releases: [{ version: '2.0-1.azl3' }],
+      });
+    });
+
+    it('caches auto-mode primary.xml.gz fallback results', async () => {
+      mockRepomdResponse({
+        primaryDbHref: 'repodata/somesha256-primary.sqlite.gz',
+      });
+      mockPrimaryDbResponse(gzipSync('not-a-sqlite-database'));
+      mockPrimaryXmlResponse(
+        buildPrimaryXml(codeBlock`
+          <package type="rpm">
+            <name>example-package</name>
+            <arch>x86_64</arch>
+            <version epoch="0" ver="2.0" rel="1.azl3"/>
+          </package>
+        `),
+      );
+
+      const fallbackReleases = await rpmDatasource.getReleases({
+        registryUrl,
+        packageName: 'example-package',
+      });
+
+      const cachedReleases = await rpmDatasource.getReleases({
+        registryUrl,
+        packageName: 'example-package',
+      });
+
+      expect(fallbackReleases).toEqual({
+        releases: [{ version: '2.0-1.azl3' }],
+      });
+      expect(cachedReleases).toEqual({
+        releases: [{ version: '2.0-1.azl3' }],
+      });
+    });
+
+    it('reuses the extracted primary_db file across package lookups', async () => {
+      const repomdScope = httpMock.scope(registryUrl);
+      repomdScope
+        .get('/repomd.xml')
+        .once()
+        .reply(
+          200,
+          buildRepomdXml({
+            primaryDbHref: 'repodata/somesha256-primary.sqlite.gz',
+          }),
+          { 'Content-Type': 'application/xml' },
+        );
+
+      const primaryDbScope = httpMock.scope(primaryDbRegistryUrl);
+      primaryDbScope
+        .get('/somesha256-primary.sqlite.gz')
+        .once()
+        .reply(
+          200,
+          await createPrimaryDbGzip([
+            { name: 'bash', release: '1.azl3', version: '5.2.15' },
+            { name: 'curl', release: '2.azl3', version: '8.5.0' },
+          ]),
+          { 'Content-Type': 'application/gzip' },
+        );
+      primaryDbScope.head('/somesha256-primary.sqlite.gz').once().reply(304);
+
+      const bashReleases = await rpmDatasource.getReleases({
+        registryUrl,
+        packageName: 'bash',
+      });
+      const curlReleases = await rpmDatasource.getReleases({
+        registryUrl,
+        packageName: 'curl',
+      });
+
+      expect(bashReleases).toEqual({
+        releases: [{ version: '5.2.15-1.azl3' }],
+      });
+      expect(curlReleases).toEqual({
+        releases: [{ version: '8.5.0-2.azl3' }],
+      });
+    });
+
+    it('caches primary_db-only repository metadata across package lookups', async () => {
+      const repomdScope = httpMock.scope(registryUrl);
+      repomdScope
+        .get('/repomd.xml')
+        .once()
+        .reply(
+          200,
+          buildRepomdXml({
+            primaryDbHref: 'repodata/somesha256-primary.sqlite.gz',
+            primaryHref: '',
+          }),
+          { 'Content-Type': 'application/xml' },
+        );
+
+      const primaryDbScope = httpMock.scope(primaryDbRegistryUrl);
+      primaryDbScope
+        .get('/somesha256-primary.sqlite.gz')
+        .once()
+        .reply(
+          200,
+          await createPrimaryDbGzip([
+            { name: 'bash', release: '1.azl3', version: '5.2.15' },
+            { name: 'curl', release: '2.azl3', version: '8.5.0' },
+          ]),
+          { 'Content-Type': 'application/gzip' },
+        );
+      primaryDbScope.head('/somesha256-primary.sqlite.gz').once().reply(304);
+
+      const bashReleases = await rpmDatasource.getReleases({
+        registryUrl,
+        packageName: 'bash',
+      });
+      const curlReleases = await rpmDatasource.getReleases({
+        registryUrl,
+        packageName: 'curl',
+      });
+
+      expect(bashReleases).toEqual({
+        releases: [{ version: '5.2.15-1.azl3' }],
+      });
+      expect(curlReleases).toEqual({
+        releases: [{ version: '8.5.0-2.azl3' }],
+      });
+    });
+
+    it('returns null when primary_db rows do not contain a version value', async () => {
+      mockRepomdResponse({
+        primaryDbHref: 'repodata/somesha256-primary.sqlite.gz',
+        primaryHref: '',
+      });
+      mockPrimaryDbResponse(
+        await createPrimaryDbGzip([
+          {
+            name: 'example-package',
+            release: '1.azl3',
+            version: null,
+          },
+        ]),
+      );
+
+      const releases = await rpmDatasource.getReleases({
+        registryUrl,
+        packageName: 'example-package',
+      });
+
+      expect(releases).toBeNull();
+    });
+
+    it('throws an error if neither primary nor primary_db metadata is present', async () => {
+      mockRepomdResponse({
+        primaryDbHref: '',
+        primaryHref: '',
+      });
+
+      await expect(
+        rpmDatasource.getReleases({
+          registryUrl,
+          packageName: 'example-package',
+        }),
+      ).rejects.toThrow(`No primary data found in ${registryUrl}repomd.xml`);
     });
   });
 });

--- a/lib/modules/datasource/rpm/index.spec.ts
+++ b/lib/modules/datasource/rpm/index.spec.ts
@@ -12,6 +12,7 @@ import * as packageCache from '../../../util/cache/package/index.ts';
 import * as cacheFs from '../../../util/fs/index.ts';
 import { toSha256 } from '../../../util/hash.ts';
 import { RpmDatasource } from './index.ts';
+import { RpmSqliteMetadataProvider } from './providers/sqlite.ts';
 
 const registryUrl = 'https://example.com/repo/repodata/';
 const primaryXmlUrl =
@@ -65,7 +66,11 @@ function buildPrimaryXml(packageEntries: string): string {
 }
 
 async function createPrimaryDbGzip(
-  rows: { name: string; release?: string | null; version: string | null }[],
+  rows: {
+    name: string;
+    release?: string | null | Buffer;
+    version: string | null | Buffer;
+  }[],
 ): Promise<Buffer> {
   const dirResult = await tmpDir({ unsafeCleanup: true });
   const dbFile = `${dirResult.path}/primary.sqlite`;
@@ -138,51 +143,9 @@ function mockPrimaryDbResponse(primaryDbGzip: Buffer): void {
     });
 }
 
-function parseRegistryUrlForTest(
-  datasource: RpmDatasource,
-  url: string,
-): { metadataSource: string; registryUrl: string } {
-  return (
-    datasource as unknown as {
-      parseRegistryUrl: (url: string) => {
-        metadataSource: string;
-        registryUrl: string;
-      };
-    }
-  ).parseRegistryUrl(url);
-}
-
-function getAutoReleasesForTest(
-  datasource: RpmDatasource,
-  metadata: { repomdUrl: string },
-  packageName: string,
-  url: string,
-): Promise<unknown> {
-  return (
-    datasource as unknown as {
-      getAutoReleases: (
-        metadata: { repomdUrl: string },
-        packageName: string,
-        url: string,
-      ) => Promise<unknown>;
-    }
-  ).getAutoReleases(metadata, packageName, url);
-}
-
-function mockPrimaryDbProviderFailure(
-  datasource: RpmDatasource,
-  err: unknown,
-): void {
+function mockPrimaryDbProviderFailure(err: unknown): void {
   vi.spyOn(
-    (
-      datasource as unknown as {
-        providers: {
-          primary_db: {
-            getReleases: () => Promise<unknown>;
-          };
-        };
-      }
-    ).providers.primary_db,
+    RpmSqliteMetadataProvider.prototype,
     'getReleases',
   ).mockRejectedValue(err);
 }
@@ -1021,7 +984,7 @@ describe('modules/datasource/rpm/index', () => {
           registryUrl: `${registryUrl}#rpmMetadataSource=primary_db`,
           packageName: 'example-package',
         }),
-      ).rejects.toThrow();
+      ).rejects.toThrow(/database/);
     });
 
     it('throws sqlite errors when only primary_db metadata is present in auto mode', async () => {
@@ -1036,7 +999,7 @@ describe('modules/datasource/rpm/index', () => {
           registryUrl,
           packageName: 'example-package',
         }),
-      ).rejects.toThrow();
+      ).rejects.toThrow(/database/);
     });
 
     it('uses primary_db when primary metadata is malformed', async () => {
@@ -1138,11 +1101,13 @@ describe('modules/datasource/rpm/index', () => {
       });
     });
 
-    it('keeps invalid registryUrl unchanged when parsing metadata source', () => {
-      expect(parseRegistryUrlForTest(rpmDatasource, 'not a url')).toEqual({
-        metadataSource: 'auto',
-        registryUrl: 'not a url',
-      });
+    it('throws for invalid registry URLs', async () => {
+      await expect(
+        rpmDatasource.getReleases({
+          registryUrl: 'not a url',
+          packageName: 'example-package',
+        }),
+      ).rejects.toThrow('Invalid URL');
     });
 
     it('falls back to primary.xml.gz when primary_db is absent', async () => {
@@ -1201,7 +1166,7 @@ describe('modules/datasource/rpm/index', () => {
       mockRepomdResponse({
         primaryDbHref: 'repodata/somesha256-primary.sqlite.gz',
       });
-      mockPrimaryDbProviderFailure(rpmDatasource, 'not-a-sqlite-error');
+      mockPrimaryDbProviderFailure('not-a-sqlite-error');
       mockPrimaryXmlResponse(
         buildPrimaryXml(codeBlock`
           <package type="rpm">
@@ -1367,6 +1332,29 @@ describe('modules/datasource/rpm/index', () => {
       expect(releases).toBeNull();
     });
 
+    it('throws when primary_db rows contain an invalid version value', async () => {
+      mockRepomdResponse({
+        primaryDbHref: 'repodata/somesha256-primary.sqlite.gz',
+        primaryHref: '',
+      });
+      mockPrimaryDbResponse(
+        await createPrimaryDbGzip([
+          {
+            name: 'example-package',
+            release: '1.azl3',
+            version: Buffer.from('1.0'),
+          },
+        ]),
+      );
+
+      await expect(
+        rpmDatasource.getReleases({
+          registryUrl,
+          packageName: 'example-package',
+        }),
+      ).rejects.toThrow('Invalid version value in RPM metadata');
+    });
+
     it('throws an error if neither primary nor primary_db metadata is present', async () => {
       mockRepomdResponse({
         primaryDbHref: '',
@@ -1379,17 +1367,6 @@ describe('modules/datasource/rpm/index', () => {
           packageName: 'example-package',
         }),
       ).rejects.toThrow(`No primary data found in ${registryUrl}repomd.xml`);
-    });
-
-    it('returns null when repository metadata has no usable source', async () => {
-      await expect(
-        getAutoReleasesForTest(
-          rpmDatasource,
-          { repomdUrl: `${registryUrl}repomd.xml` },
-          'example-package',
-          registryUrl,
-        ),
-      ).resolves.toBeNull();
     });
   });
 });

--- a/lib/modules/datasource/rpm/index.spec.ts
+++ b/lib/modules/datasource/rpm/index.spec.ts
@@ -138,6 +138,55 @@ function mockPrimaryDbResponse(primaryDbGzip: Buffer): void {
     });
 }
 
+function parseRegistryUrlForTest(
+  datasource: RpmDatasource,
+  url: string,
+): { metadataSource: string; registryUrl: string } {
+  return (
+    datasource as unknown as {
+      parseRegistryUrl: (url: string) => {
+        metadataSource: string;
+        registryUrl: string;
+      };
+    }
+  ).parseRegistryUrl(url);
+}
+
+function getAutoReleasesForTest(
+  datasource: RpmDatasource,
+  metadata: { repomdUrl: string },
+  packageName: string,
+  url: string,
+): Promise<unknown> {
+  return (
+    datasource as unknown as {
+      getAutoReleases: (
+        metadata: { repomdUrl: string },
+        packageName: string,
+        url: string,
+      ) => Promise<unknown>;
+    }
+  ).getAutoReleases(metadata, packageName, url);
+}
+
+function mockPrimaryDbProviderFailure(
+  datasource: RpmDatasource,
+  err: unknown,
+): void {
+  vi.spyOn(
+    (
+      datasource as unknown as {
+        providers: {
+          primary_db: {
+            getReleases: () => Promise<unknown>;
+          };
+        };
+      }
+    ).providers.primary_db,
+    'getReleases',
+  ).mockRejectedValue(err);
+}
+
 describe('modules/datasource/rpm/index', () => {
   let cacheDirResult: DirectoryResult | null;
   let rpmDatasource: RpmDatasource;
@@ -357,6 +406,17 @@ describe('modules/datasource/rpm/index', () => {
       await expect(
         rpmDatasource.getPrimaryGzipUrl(registryUrl),
       ).rejects.toThrow(`No href found in ${registryUrl}repomd.xml`);
+    });
+
+    it('throws when only primary_db metadata is present', async () => {
+      mockRepomdResponse({
+        primaryDbHref: 'repodata/somesha256-primary.sqlite.gz',
+        primaryHref: '',
+      });
+
+      await expect(
+        rpmDatasource.getPrimaryGzipUrl(registryUrl),
+      ).rejects.toThrow(`No primary data found in ${registryUrl}repomd.xml`);
     });
   });
 
@@ -1056,6 +1116,35 @@ describe('modules/datasource/rpm/index', () => {
       ).rejects.toThrow('Invalid rpmMetadataSource in RPM registry URL:');
     });
 
+    it('strips explicit auto rpmMetadataSource from registryUrl', async () => {
+      mockRepomdResponse();
+      mockPrimaryXmlResponse(
+        buildPrimaryXml(codeBlock`
+          <package type="rpm">
+            <name>example-package</name>
+            <arch>x86_64</arch>
+            <version epoch="0" ver="1.0" rel="2.azl3"/>
+          </package>
+        `),
+      );
+
+      await expect(
+        rpmDatasource.getReleases({
+          registryUrl: `${registryUrl}#rpmMetadataSource=auto`,
+          packageName: 'example-package',
+        }),
+      ).resolves.toEqual({
+        releases: [{ version: '1.0-2.azl3' }],
+      });
+    });
+
+    it('keeps invalid registryUrl unchanged when parsing metadata source', () => {
+      expect(parseRegistryUrlForTest(rpmDatasource, 'not a url')).toEqual({
+        metadataSource: 'auto',
+        registryUrl: 'not a url',
+      });
+    });
+
     it('falls back to primary.xml.gz when primary_db is absent', async () => {
       mockRepomdResponse();
       await mockPrimaryXmlResponse(
@@ -1104,6 +1193,31 @@ describe('modules/datasource/rpm/index', () => {
       });
 
       expect(releases).toEqual({
+        releases: [{ version: '2.0-1.azl3' }],
+      });
+    });
+
+    it('falls back to primary.xml.gz when primary_db rejects with a non-Error', async () => {
+      mockRepomdResponse({
+        primaryDbHref: 'repodata/somesha256-primary.sqlite.gz',
+      });
+      mockPrimaryDbProviderFailure(rpmDatasource, 'not-a-sqlite-error');
+      mockPrimaryXmlResponse(
+        buildPrimaryXml(codeBlock`
+          <package type="rpm">
+            <name>example-package</name>
+            <arch>x86_64</arch>
+            <version epoch="0" ver="2.0" rel="1.azl3"/>
+          </package>
+        `),
+      );
+
+      await expect(
+        rpmDatasource.getReleases({
+          registryUrl,
+          packageName: 'example-package',
+        }),
+      ).resolves.toEqual({
         releases: [{ version: '2.0-1.azl3' }],
       });
     });
@@ -1265,6 +1379,17 @@ describe('modules/datasource/rpm/index', () => {
           packageName: 'example-package',
         }),
       ).rejects.toThrow(`No primary data found in ${registryUrl}repomd.xml`);
+    });
+
+    it('returns null when repository metadata has no usable source', async () => {
+      await expect(
+        getAutoReleasesForTest(
+          rpmDatasource,
+          { repomdUrl: `${registryUrl}repomd.xml` },
+          'example-package',
+          registryUrl,
+        ),
+      ).resolves.toBeNull();
     });
   });
 });

--- a/lib/modules/datasource/rpm/index.spec.ts
+++ b/lib/modules/datasource/rpm/index.spec.ts
@@ -15,6 +15,7 @@ import { RpmDatasource } from './index.ts';
 import { RpmSqliteMetadataProvider } from './providers/sqlite.ts';
 
 const registryUrl = 'https://example.com/repo/repodata/';
+const primaryRegistryUrl = `${registryUrl}#rpmMetadataSource=primary`;
 const primaryXmlUrl =
   'https://example.com/repo/repodata/somesha256-primary.xml.gz';
 const primaryXmlRegistryUrl = primaryXmlUrl.replace(/\/[^/]+$/, '');
@@ -173,17 +174,20 @@ describe('modules/datasource/rpm/index', () => {
     cacheDirResult = null;
   });
 
-  describe('getPrimaryGzipUrl', () => {
-    it('returns the correct primary.xml URL', async () => {
+  describe('getReleases with primary metadata', () => {
+    it('resolves and reads the primary.xml URL', async () => {
       mockRepomdResponse();
+      await mockPrimaryXmlResponse(buildPrimaryXml(''));
 
-      const resolvedPrimaryXmlUrl =
-        await rpmDatasource.getPrimaryGzipUrl(registryUrl);
-
-      expect(resolvedPrimaryXmlUrl).toBe(primaryXmlUrl);
+      await expect(
+        rpmDatasource.getReleases({
+          registryUrl: primaryRegistryUrl,
+          packageName: 'example-package',
+        }),
+      ).resolves.toBeNull();
     });
 
-    it('returns the correct primary.xml URL when repomd.xml omits xml declaration', async () => {
+    it('reads repomd.xml without an XML declaration', async () => {
       const repomdXml = codeBlock`
         <repomd xmlns="http://linux.duke.edu/metadata/repo"
           xmlns:rpm="http://linux.duke.edu/metadata/rpm">
@@ -197,18 +201,24 @@ describe('modules/datasource/rpm/index', () => {
         .scope(registryUrl)
         .get('/repomd.xml')
         .reply(200, repomdXml, { 'Content-Type': 'application/xml' });
+      await mockPrimaryXmlResponse(buildPrimaryXml(''));
 
-      const resolvedPrimaryXmlUrl =
-        await rpmDatasource.getPrimaryGzipUrl(registryUrl);
-
-      expect(resolvedPrimaryXmlUrl).toBe(primaryXmlUrl);
+      await expect(
+        rpmDatasource.getReleases({
+          registryUrl: primaryRegistryUrl,
+          packageName: 'example-package',
+        }),
+      ).resolves.toBeNull();
     });
 
     it('throws an error if repomd.xml is missing', async () => {
       httpMock.scope(registryUrl).get('/repomd.xml').reply(404, 'Not Found');
 
       await expect(
-        rpmDatasource.getPrimaryGzipUrl(registryUrl),
+        rpmDatasource.getReleases({
+          registryUrl: primaryRegistryUrl,
+          packageName: 'example-package',
+        }),
       ).rejects.toThrow(
         `Request failed with status code 404 (Not Found): GET ${registryUrl}repomd.xml`,
       );
@@ -221,7 +231,10 @@ describe('modules/datasource/rpm/index', () => {
         .replyWithError('Network error');
 
       await expect(
-        rpmDatasource.getPrimaryGzipUrl(registryUrl),
+        rpmDatasource.getReleases({
+          registryUrl: primaryRegistryUrl,
+          packageName: 'example-package',
+        }),
       ).rejects.toThrow('Network error');
     });
 
@@ -241,7 +254,10 @@ describe('modules/datasource/rpm/index', () => {
         .reply(200, repomdXml, { 'Content-Type': 'application/xml' });
 
       await expect(
-        rpmDatasource.getPrimaryGzipUrl(registryUrl),
+        rpmDatasource.getReleases({
+          registryUrl: primaryRegistryUrl,
+          packageName: 'example-package',
+        }),
       ).rejects.toThrow(`is not in XML format.`);
     });
 
@@ -261,7 +277,10 @@ describe('modules/datasource/rpm/index', () => {
         .reply(200, repomdXml, { 'Content-Type': 'application/xml' });
 
       await expect(
-        rpmDatasource.getPrimaryGzipUrl(registryUrl),
+        rpmDatasource.getReleases({
+          registryUrl: primaryRegistryUrl,
+          packageName: 'example-package',
+        }),
       ).rejects.toThrow(`No primary data found in ${registryUrl}repomd.xml`);
     });
 
@@ -281,7 +300,10 @@ describe('modules/datasource/rpm/index', () => {
         .reply(200, repomdXml, { 'Content-Type': 'application/xml' });
 
       await expect(
-        rpmDatasource.getPrimaryGzipUrl(registryUrl),
+        rpmDatasource.getReleases({
+          registryUrl: primaryRegistryUrl,
+          packageName: 'example-package',
+        }),
       ).rejects.toThrow(
         `No location element found in ${registryUrl}repomd.xml`,
       );
@@ -303,7 +325,10 @@ describe('modules/datasource/rpm/index', () => {
         .reply(200, repomdXml, { 'Content-Type': 'application/xml' });
 
       await expect(
-        rpmDatasource.getPrimaryGzipUrl(registryUrl),
+        rpmDatasource.getReleases({
+          registryUrl: primaryRegistryUrl,
+          packageName: 'example-package',
+        }),
       ).rejects.toThrow(`No href found in ${registryUrl}repomd.xml`);
     });
 
@@ -324,10 +349,14 @@ describe('modules/datasource/rpm/index', () => {
         .scope(registryUrl)
         .get('/repomd.xml')
         .reply(200, repomdXml, { 'Content-Type': 'application/xml' });
+      await mockPrimaryXmlResponse(buildPrimaryXml(''));
 
-      await expect(rpmDatasource.getPrimaryGzipUrl(registryUrl)).resolves.toBe(
-        primaryXmlUrl,
-      );
+      await expect(
+        rpmDatasource.getReleases({
+          registryUrl: primaryRegistryUrl,
+          packageName: 'example-package',
+        }),
+      ).resolves.toBeNull();
     });
 
     it('ignores primary_db entries without an href attribute', async () => {
@@ -347,10 +376,14 @@ describe('modules/datasource/rpm/index', () => {
         .scope(registryUrl)
         .get('/repomd.xml')
         .reply(200, repomdXml, { 'Content-Type': 'application/xml' });
+      await mockPrimaryXmlResponse(buildPrimaryXml(''));
 
-      await expect(rpmDatasource.getPrimaryGzipUrl(registryUrl)).resolves.toBe(
-        primaryXmlUrl,
-      );
+      await expect(
+        rpmDatasource.getReleases({
+          registryUrl: primaryRegistryUrl,
+          packageName: 'example-package',
+        }),
+      ).resolves.toBeNull();
     });
 
     it('validates primary metadata even when primary_db is present', async () => {
@@ -367,7 +400,10 @@ describe('modules/datasource/rpm/index', () => {
       `);
 
       await expect(
-        rpmDatasource.getPrimaryGzipUrl(registryUrl),
+        rpmDatasource.getReleases({
+          registryUrl: primaryRegistryUrl,
+          packageName: 'example-package',
+        }),
       ).rejects.toThrow(`No href found in ${registryUrl}repomd.xml`);
     });
 
@@ -378,16 +414,18 @@ describe('modules/datasource/rpm/index', () => {
       });
 
       await expect(
-        rpmDatasource.getPrimaryGzipUrl(registryUrl),
+        rpmDatasource.getReleases({
+          registryUrl: primaryRegistryUrl,
+          packageName: 'example-package',
+        }),
       ).rejects.toThrow(`No primary data found in ${registryUrl}repomd.xml`);
     });
-  });
 
-  describe('getReleasesByPackageName', () => {
     const packageName = 'example-package';
     const extractedPrimaryXmlPath = `others/rpm/${toSha256(primaryXmlUrl)}.xml`;
 
     it('returns the correct releases', async () => {
+      mockRepomdResponse();
       await mockPrimaryXmlResponse(
         buildPrimaryXml(codeBlock`
           <package type="rpm">
@@ -413,10 +451,10 @@ describe('modules/datasource/rpm/index', () => {
         `),
       );
 
-      const releases = await rpmDatasource.getReleasesByPackageName(
-        primaryXmlUrl,
+      const releases = await rpmDatasource.getReleases({
+        registryUrl: primaryRegistryUrl,
         packageName,
-      );
+      });
 
       expect(releases).toEqual({
         releases: [
@@ -429,30 +467,39 @@ describe('modules/datasource/rpm/index', () => {
     });
 
     it('throws an error if somesha256-primary.xml.gz is not found', async () => {
+      mockRepomdResponse();
       httpMock
         .scope(primaryXmlRegistryUrl)
         .get('/somesha256-primary.xml.gz')
         .reply(404, 'Not Found');
 
       await expect(
-        rpmDatasource.getReleasesByPackageName(primaryXmlUrl, packageName),
+        rpmDatasource.getReleases({
+          registryUrl: primaryRegistryUrl,
+          packageName,
+        }),
       ).rejects.toThrow(
         `Request failed with status code 404 (Not Found): GET ${primaryXmlUrl}`,
       );
     });
 
     it('throws an error if response.body is empty', async () => {
+      mockRepomdResponse();
       httpMock
         .scope(primaryXmlRegistryUrl)
         .get('/somesha256-primary.xml.gz')
         .reply(200, '', { 'Content-Type': 'application/gzip' });
 
       await expect(
-        rpmDatasource.getReleasesByPackageName(primaryXmlUrl, packageName),
+        rpmDatasource.getReleases({
+          registryUrl: primaryRegistryUrl,
+          packageName,
+        }),
       ).rejects.toThrow(`Empty response body from getting ${primaryXmlUrl}.`);
     });
 
     it('rethrows non-Error fetch failures', async () => {
+      mockRepomdResponse();
       vi.spyOn(
         (
           rpmDatasource as unknown as {
@@ -464,11 +511,15 @@ describe('modules/datasource/rpm/index', () => {
       vi.spyOn(cacheFs, 'pipeline').mockRejectedValue('boom');
 
       await expect(
-        rpmDatasource.getReleasesByPackageName(primaryXmlUrl, packageName),
+        rpmDatasource.getReleases({
+          registryUrl: primaryRegistryUrl,
+          packageName,
+        }),
       ).rejects.toBe('boom');
     });
 
     it('reuses the extracted primary.xml file across package lookups', async () => {
+      mockRepomdResponse();
       const primaryXml = buildPrimaryXml(codeBlock`
         <package type="rpm">
           <name>bash</name>
@@ -495,14 +546,14 @@ describe('modules/datasource/rpm/index', () => {
         .once()
         .reply(304);
 
-      const bashReleases = await rpmDatasource.getReleasesByPackageName(
-        primaryXmlUrl,
-        'bash',
-      );
-      const curlReleases = await rpmDatasource.getReleasesByPackageName(
-        primaryXmlUrl,
-        'curl',
-      );
+      const bashReleases = await rpmDatasource.getReleases({
+        registryUrl: primaryRegistryUrl,
+        packageName: 'bash',
+      });
+      const curlReleases = await rpmDatasource.getReleases({
+        registryUrl: primaryRegistryUrl,
+        packageName: 'curl',
+      });
 
       expect(bashReleases).toEqual({
         releases: [{ version: '5.2.15-1.azl3' }],
@@ -513,6 +564,7 @@ describe('modules/datasource/rpm/index', () => {
     });
 
     it('re-downloads primary.xml if the freshness check fails', async () => {
+      mockRepomdResponse();
       const primaryXml = buildPrimaryXml(codeBlock`
         <package type="rpm">
           <name>bash</name>
@@ -539,14 +591,14 @@ describe('modules/datasource/rpm/index', () => {
         .once()
         .replyWithError('Unexpected Error');
 
-      const bashReleases = await rpmDatasource.getReleasesByPackageName(
-        primaryXmlUrl,
-        'bash',
-      );
-      const curlReleases = await rpmDatasource.getReleasesByPackageName(
-        primaryXmlUrl,
-        'curl',
-      );
+      const bashReleases = await rpmDatasource.getReleases({
+        registryUrl: primaryRegistryUrl,
+        packageName: 'bash',
+      });
+      const curlReleases = await rpmDatasource.getReleases({
+        registryUrl: primaryRegistryUrl,
+        packageName: 'curl',
+      });
 
       expect(bashReleases).toEqual({
         releases: [{ version: '5.2.15-1.azl3' }],
@@ -558,6 +610,7 @@ describe('modules/datasource/rpm/index', () => {
 
     it('throws if extracting primary.xml fails without an existing cache file', async () => {
       const originalPipeline = cacheFs.pipeline;
+      mockRepomdResponse();
 
       httpMock
         .scope(primaryXmlRegistryUrl)
@@ -586,12 +639,17 @@ describe('modules/datasource/rpm/index', () => {
         .mockRejectedValueOnce('extract failed');
 
       await expect(
-        rpmDatasource.getReleasesByPackageName(primaryXmlUrl, packageName),
+        rpmDatasource.getReleases({
+          registryUrl: primaryRegistryUrl,
+          packageName,
+        }),
       ).rejects.toThrow('Missing metadata in extracted RPM metadata file!');
     });
 
     it('keeps the previous extracted primary.xml if a refresh extract fails', async () => {
       const originalPipeline = cacheFs.pipeline;
+      const refreshPackageName = 'refresh-package';
+      mockRepomdResponse();
 
       await mockPrimaryXmlResponse(
         buildPrimaryXml(codeBlock`
@@ -600,14 +658,19 @@ describe('modules/datasource/rpm/index', () => {
             <arch>x86_64</arch>
             <version epoch="0" ver="1.0" rel="2.azl3"/>
           </package>
+          <package type="rpm">
+            <name>${refreshPackageName}</name>
+            <arch>x86_64</arch>
+            <version epoch="0" ver="1.0" rel="2.azl3"/>
+          </package>
         `),
       );
 
       expect(
-        await rpmDatasource.getReleasesByPackageName(
-          primaryXmlUrl,
+        await rpmDatasource.getReleases({
+          registryUrl: primaryRegistryUrl,
           packageName,
-        ),
+        }),
       ).toEqual({
         releases: [{ version: '1.0-2.azl3' }],
       });
@@ -620,7 +683,7 @@ describe('modules/datasource/rpm/index', () => {
       await mockPrimaryXmlResponse(
         buildPrimaryXml(codeBlock`
           <package type="rpm">
-            <name>example-package</name>
+            <name>${refreshPackageName}</name>
             <arch>x86_64</arch>
             <version epoch="0" ver="2.0" rel="1.azl3"/>
           </package>
@@ -635,10 +698,10 @@ describe('modules/datasource/rpm/index', () => {
         .mockRejectedValueOnce(new Error('extract failed'));
 
       expect(
-        await rpmDatasource.getReleasesByPackageName(
-          primaryXmlUrl,
-          packageName,
-        ),
+        await rpmDatasource.getReleases({
+          registryUrl: primaryRegistryUrl,
+          packageName: refreshPackageName,
+        }),
       ).toEqual({
         releases: [{ version: '1.0-2.azl3' }],
       });
@@ -648,6 +711,8 @@ describe('modules/datasource/rpm/index', () => {
     });
 
     it('replaces the extracted primary.xml after a successful refresh', async () => {
+      const refreshPackageName = 'refresh-package';
+      mockRepomdResponse();
       await mockPrimaryXmlResponse(
         buildPrimaryXml(codeBlock`
           <package type="rpm">
@@ -655,14 +720,19 @@ describe('modules/datasource/rpm/index', () => {
             <arch>x86_64</arch>
             <version epoch="0" ver="1.0" rel="2.azl3"/>
           </package>
+          <package type="rpm">
+            <name>${refreshPackageName}</name>
+            <arch>x86_64</arch>
+            <version epoch="0" ver="1.0" rel="2.azl3"/>
+          </package>
         `),
       );
 
       expect(
-        await rpmDatasource.getReleasesByPackageName(
-          primaryXmlUrl,
+        await rpmDatasource.getReleases({
+          registryUrl: primaryRegistryUrl,
           packageName,
-        ),
+        }),
       ).toEqual({
         releases: [{ version: '1.0-2.azl3' }],
       });
@@ -675,7 +745,7 @@ describe('modules/datasource/rpm/index', () => {
       await mockPrimaryXmlResponse(
         buildPrimaryXml(codeBlock`
           <package type="rpm">
-            <name>example-package</name>
+            <name>${refreshPackageName}</name>
             <arch>x86_64</arch>
             <version epoch="0" ver="2.0" rel="1.azl3"/>
           </package>
@@ -683,10 +753,10 @@ describe('modules/datasource/rpm/index', () => {
       );
 
       expect(
-        await rpmDatasource.getReleasesByPackageName(
-          primaryXmlUrl,
-          packageName,
-        ),
+        await rpmDatasource.getReleases({
+          registryUrl: primaryRegistryUrl,
+          packageName: refreshPackageName,
+        }),
       ).toEqual({
         releases: [{ version: '2.0-1.azl3' }],
       });
@@ -696,6 +766,7 @@ describe('modules/datasource/rpm/index', () => {
     });
 
     it('returns null if no element package is found in primary.xml', async () => {
+      mockRepomdResponse();
       await mockPrimaryXmlResponse(
         buildPrimaryXml(codeBlock`
           <nonpackage type="rpm">
@@ -706,15 +777,16 @@ describe('modules/datasource/rpm/index', () => {
         `),
       );
 
-      const result = await rpmDatasource.getReleasesByPackageName(
-        primaryXmlUrl,
+      const result = await rpmDatasource.getReleases({
+        registryUrl: primaryRegistryUrl,
         packageName,
-      );
+      });
 
       expect(result).toBeNull();
     });
 
     it('returns null if the specific packageName is not found in primary.xml', async () => {
+      mockRepomdResponse();
       await mockPrimaryXmlResponse(
         buildPrimaryXml(codeBlock`
           <package type="rpm">
@@ -726,14 +798,15 @@ describe('modules/datasource/rpm/index', () => {
       );
 
       expect(
-        await rpmDatasource.getReleasesByPackageName(
-          primaryXmlUrl,
+        await rpmDatasource.getReleases({
+          registryUrl: primaryRegistryUrl,
           packageName,
-        ),
+        }),
       ).toBeNull();
     });
 
     it('returns null if version is not found in a version element', async () => {
+      mockRepomdResponse();
       await mockPrimaryXmlResponse(
         buildPrimaryXml(codeBlock`
           <package type="rpm">
@@ -744,15 +817,16 @@ describe('modules/datasource/rpm/index', () => {
         `),
       );
 
-      const releases = await rpmDatasource.getReleasesByPackageName(
-        primaryXmlUrl,
+      const releases = await rpmDatasource.getReleases({
+        registryUrl: primaryRegistryUrl,
         packageName,
-      );
+      });
 
       expect(releases).toBeNull();
     });
 
     it('returns null if version element is missing the ver attribute', async () => {
+      mockRepomdResponse();
       await mockPrimaryXmlResponse(
         buildPrimaryXml(codeBlock`
           <package type="rpm">
@@ -763,15 +837,16 @@ describe('modules/datasource/rpm/index', () => {
         `),
       );
 
-      const releases = await rpmDatasource.getReleasesByPackageName(
-        primaryXmlUrl,
+      const releases = await rpmDatasource.getReleases({
+        registryUrl: primaryRegistryUrl,
         packageName,
-      );
+      });
 
       expect(releases).toBeNull();
     });
 
     it('returns an array of releases without duplicate versionWithRel', async () => {
+      mockRepomdResponse();
       await mockPrimaryXmlResponse(
         buildPrimaryXml(codeBlock`
           <package type="rpm">
@@ -787,17 +862,18 @@ describe('modules/datasource/rpm/index', () => {
         `),
       );
 
-      const releases = await rpmDatasource.getReleasesByPackageName(
-        primaryXmlUrl,
+      const releases = await rpmDatasource.getReleases({
+        registryUrl: primaryRegistryUrl,
         packageName,
-      );
+      });
 
       expect(releases).toEqual({
         releases: [{ version: '1.0-dulp.azl3' }],
       });
     });
 
-    it('handles parser error event in getReleasesByPackageName', async () => {
+    it('handles parser error events', async () => {
+      mockRepomdResponse();
       await mockPrimaryXmlResponse(codeBlock`
         <?xml version="1.0" encoding="UTF-8"?>
         <%$#metadata xmlns="http://linux.duke.edu/metadata/common">
@@ -810,7 +886,10 @@ describe('modules/datasource/rpm/index', () => {
       `);
 
       await expect(
-        rpmDatasource.getReleasesByPackageName(primaryXmlUrl, packageName),
+        rpmDatasource.getReleases({
+          registryUrl: primaryRegistryUrl,
+          packageName,
+        }),
       ).rejects.toThrowError('Unencoded <');
     });
   });
@@ -912,9 +991,10 @@ describe('modules/datasource/rpm/index', () => {
     });
 
     it('prefers primary_db metadata when available', async () => {
-      mockRepomdResponse({
+      const metadata = {
         primaryDbHref: 'repodata/somesha256-primary.sqlite.gz',
-      });
+      };
+      mockRepomdResponse(metadata);
       mockPrimaryDbResponse(
         await createPrimaryDbGzip([
           {
@@ -1002,7 +1082,7 @@ describe('modules/datasource/rpm/index', () => {
       ).rejects.toThrow(/database/);
     });
 
-    it('uses primary_db when primary metadata is malformed', async () => {
+    it('validates malformed primary metadata separately from auto mode', async () => {
       mockRawRepomdResponse(codeBlock`
         <?xml version="1.0" encoding="UTF-8"?>
         <repomd xmlns="http://linux.duke.edu/metadata/repo" xmlns:rpm="http://linux.duke.edu/metadata/rpm">
@@ -1026,12 +1106,18 @@ describe('modules/datasource/rpm/index', () => {
 
       await expect(
         rpmDatasource.getReleases({
-          registryUrl: `${registryUrl}#rpmMetadataSource=primary_db`,
+          registryUrl,
           packageName: 'example-package',
         }),
       ).resolves.toEqual({
         releases: [{ version: '1.0-2.azl3' }],
       });
+      await expect(
+        rpmDatasource.getReleases({
+          registryUrl: primaryRegistryUrl,
+          packageName: 'example-package',
+        }),
+      ).rejects.toThrow(`No href found in ${registryUrl}repomd.xml`);
     });
 
     it('throws when registryUrl requires primary_db and primary_db metadata is absent', async () => {
@@ -1043,6 +1129,27 @@ describe('modules/datasource/rpm/index', () => {
           packageName: 'example-package',
         }),
       ).rejects.toThrow(`No primary_db data found in ${registryUrl}repomd.xml`);
+    });
+
+    it('throws when required primary_db metadata has no href', async () => {
+      mockRawRepomdResponse(codeBlock`
+        <?xml version="1.0" encoding="UTF-8"?>
+        <repomd xmlns="http://linux.duke.edu/metadata/repo" xmlns:rpm="http://linux.duke.edu/metadata/rpm">
+          <data type="primary">
+            <location href="repodata/somesha256-primary.xml.gz"/>
+          </data>
+          <data type="primary_db">
+            <location non-href="repodata/somesha256-primary.sqlite.gz"/>
+          </data>
+        </repomd>
+      `);
+
+      await expect(
+        rpmDatasource.getReleases({
+          registryUrl: `${registryUrl}#rpmMetadataSource=primary_db`,
+          packageName: 'example-package',
+        }),
+      ).rejects.toThrow(`No href found in ${registryUrl}repomd.xml`);
     });
 
     it('throws when registryUrl requires primary and primary metadata is absent', async () => {
@@ -1332,6 +1439,34 @@ describe('modules/datasource/rpm/index', () => {
       expect(releases).toBeNull();
     });
 
+    it('formats and deduplicates primary_db rows without a release', async () => {
+      mockRepomdResponse({
+        primaryDbHref: 'repodata/somesha256-primary.sqlite.gz',
+        primaryHref: '',
+      });
+      mockPrimaryDbResponse(
+        await createPrimaryDbGzip([
+          {
+            name: 'example-package',
+            version: '1.0',
+          },
+          {
+            name: 'example-package',
+            version: '1.0',
+          },
+        ]),
+      );
+
+      await expect(
+        rpmDatasource.getReleases({
+          registryUrl: `${registryUrl}#rpmMetadataSource=primary_db`,
+          packageName: 'example-package',
+        }),
+      ).resolves.toEqual({
+        releases: [{ version: '1.0' }],
+      });
+    });
+
     it('throws when primary_db rows contain an invalid version value', async () => {
       mockRepomdResponse({
         primaryDbHref: 'repodata/somesha256-primary.sqlite.gz',
@@ -1353,6 +1488,29 @@ describe('modules/datasource/rpm/index', () => {
           packageName: 'example-package',
         }),
       ).rejects.toThrow('Invalid version value in RPM metadata');
+    });
+
+    it('throws when primary_db rows contain an invalid release value', async () => {
+      mockRepomdResponse({
+        primaryDbHref: 'repodata/somesha256-primary.sqlite.gz',
+        primaryHref: '',
+      });
+      mockPrimaryDbResponse(
+        await createPrimaryDbGzip([
+          {
+            name: 'example-package',
+            release: Buffer.from('1.azl3'),
+            version: '1.0',
+          },
+        ]),
+      );
+
+      await expect(
+        rpmDatasource.getReleases({
+          registryUrl: `${registryUrl}#rpmMetadataSource=primary_db`,
+          packageName: 'example-package',
+        }),
+      ).rejects.toThrow('Invalid release value in RPM metadata');
     });
 
     it('throws an error if neither primary nor primary_db metadata is present', async () => {

--- a/lib/modules/datasource/rpm/index.spec.ts
+++ b/lib/modules/datasource/rpm/index.spec.ts
@@ -1,3 +1,4 @@
+import { readFile } from 'node:fs/promises';
 import { Readable } from 'node:stream';
 import { promisify } from 'node:util';
 import { gzip as _gzip } from 'node:zlib';
@@ -16,8 +17,126 @@ const registryUrl = 'https://example.com/repo/repodata/';
 const primaryXmlUrl =
   'https://example.com/repo/repodata/somesha256-primary.xml.gz';
 const primaryXmlRegistryUrl = primaryXmlUrl.replace(/\/[^/]+$/, '');
+const primaryDbUrl =
+  'https://example.com/repo/repodata/somesha256-primary.sqlite.gz';
+const primaryDbRegistryUrl = primaryDbUrl.replace(/\/[^/]+$/, '');
 
 const gzip = promisify(_gzip);
+
+function buildRepomdXml({
+  primaryDbHref,
+  primaryHref = 'repodata/somesha256-primary.xml.gz',
+}: {
+  primaryDbHref?: string;
+  primaryHref?: string;
+} = {}): string {
+  return codeBlock`
+    <?xml version="1.0" encoding="UTF-8"?>
+    <repomd xmlns="http://linux.duke.edu/metadata/repo" xmlns:rpm="http://linux.duke.edu/metadata/rpm">
+      ${
+        primaryHref
+          ? codeBlock`
+              <data type="primary">
+                <location href="${primaryHref}"/>
+              </data>
+            `
+          : ''
+      }
+      ${
+        primaryDbHref
+          ? codeBlock`
+              <data type="primary_db">
+                <location href="${primaryDbHref}"/>
+              </data>
+            `
+          : ''
+      }
+    </repomd>
+  `;
+}
+
+function buildPrimaryXml(packageEntries: string): string {
+  return codeBlock`
+    <?xml version="1.0" encoding="UTF-8"?>
+    <metadata xmlns="http://linux.duke.edu/metadata/common">
+      ${packageEntries}
+    </metadata>
+  `;
+}
+
+async function createPrimaryDbGzip(
+  rows: { name: string; release?: string | null; version: string | null }[],
+): Promise<Buffer> {
+  const dirResult = await tmpDir({ unsafeCleanup: true });
+  const dbFile = `${dirResult.path}/primary.sqlite`;
+  const { DatabaseSync: Sqlite } = await import('node:sqlite');
+  const db = new Sqlite(dbFile);
+
+  try {
+    db.exec(`
+      CREATE TABLE packages (
+        name TEXT,
+        version TEXT,
+        release TEXT
+      )
+    `);
+
+    const stmt = db.prepare(
+      'INSERT INTO packages (name, version, release) VALUES (?, ?, ?)',
+    );
+    for (const row of rows) {
+      stmt.run(row.name, row.version, row.release ?? null);
+    }
+  } finally {
+    db.close();
+  }
+
+  try {
+    const dbBuffer = await readFile(dbFile);
+    return await gzip(dbBuffer);
+  } finally {
+    await dirResult.cleanup();
+  }
+}
+
+function mockRepomdResponse({
+  primaryDbHref,
+  primaryHref = 'repodata/somesha256-primary.xml.gz',
+}: {
+  primaryDbHref?: string;
+  primaryHref?: string;
+} = {}): void {
+  httpMock
+    .scope(registryUrl)
+    .get('/repomd.xml')
+    .reply(200, buildRepomdXml({ primaryDbHref, primaryHref }), {
+      'Content-Type': 'application/xml',
+    });
+}
+
+function mockRawRepomdResponse(repomdXml: string): void {
+  httpMock.scope(registryUrl).get('/repomd.xml').reply(200, repomdXml, {
+    'Content-Type': 'application/xml',
+  });
+}
+
+async function mockPrimaryXmlResponse(primaryXml: string): Promise<void> {
+  httpMock
+    .scope(primaryXmlRegistryUrl)
+    .get('/somesha256-primary.xml.gz')
+    .reply(200, await gzip(primaryXml), {
+      'Content-Type': 'application/gzip',
+    });
+}
+
+function mockPrimaryDbResponse(primaryDbGzip: Buffer): void {
+  httpMock
+    .scope(primaryDbRegistryUrl)
+    .get('/somesha256-primary.sqlite.gz')
+    .reply(200, primaryDbGzip, {
+      'Content-Type': 'application/gzip',
+    });
+}
 
 describe('modules/datasource/rpm/index', () => {
   let cacheDirResult: DirectoryResult | null;
@@ -44,19 +163,7 @@ describe('modules/datasource/rpm/index', () => {
 
   describe('getPrimaryGzipUrl', () => {
     it('returns the correct primary.xml URL', async () => {
-      const repomdXml = codeBlock`
-        <?xml version="1.0" encoding="UTF-8"?>
-        <repomd xmlns="http://linux.duke.edu/metadata/repo" xmlns:rpm="http://linux.duke.edu/metadata/rpm">
-          <data type="primary">
-            <location href="repodata/somesha256-primary.xml.gz"/>
-          </data>
-        </repomd>
-      `;
-
-      httpMock
-        .scope(registryUrl)
-        .get('/repomd.xml')
-        .reply(200, repomdXml, { 'Content-Type': 'application/xml' });
+      mockRepomdResponse();
 
       const resolvedPrimaryXmlUrl =
         await rpmDatasource.getPrimaryGzipUrl(registryUrl);
@@ -187,29 +294,75 @@ describe('modules/datasource/rpm/index', () => {
         rpmDatasource.getPrimaryGzipUrl(registryUrl),
       ).rejects.toThrow(`No href found in ${registryUrl}repomd.xml`);
     });
+
+    it('ignores primary_db entries without a location element', async () => {
+      const repomdXml = codeBlock`
+        <?xml version="1.0" encoding="UTF-8"?>
+        <repomd xmlns="http://linux.duke.edu/metadata/repo" xmlns:rpm="http://linux.duke.edu/metadata/rpm">
+          <data type="primary">
+            <location href="repodata/somesha256-primary.xml.gz"/>
+          </data>
+          <data type="primary_db">
+            <non-location href="repodata/somesha256-primary.sqlite.gz"/>
+          </data>
+        </repomd>
+      `;
+
+      httpMock
+        .scope(registryUrl)
+        .get('/repomd.xml')
+        .reply(200, repomdXml, { 'Content-Type': 'application/xml' });
+
+      await expect(rpmDatasource.getPrimaryGzipUrl(registryUrl)).resolves.toBe(
+        primaryXmlUrl,
+      );
+    });
+
+    it('ignores primary_db entries without an href attribute', async () => {
+      const repomdXml = codeBlock`
+        <?xml version="1.0" encoding="UTF-8"?>
+        <repomd xmlns="http://linux.duke.edu/metadata/repo" xmlns:rpm="http://linux.duke.edu/metadata/rpm">
+          <data type="primary">
+            <location href="repodata/somesha256-primary.xml.gz"/>
+          </data>
+          <data type="primary_db">
+            <location non-href="repodata/somesha256-primary.sqlite.gz"/>
+          </data>
+        </repomd>
+      `;
+
+      httpMock
+        .scope(registryUrl)
+        .get('/repomd.xml')
+        .reply(200, repomdXml, { 'Content-Type': 'application/xml' });
+
+      await expect(rpmDatasource.getPrimaryGzipUrl(registryUrl)).resolves.toBe(
+        primaryXmlUrl,
+      );
+    });
+
+    it('validates primary metadata even when primary_db is present', async () => {
+      mockRawRepomdResponse(codeBlock`
+        <?xml version="1.0" encoding="UTF-8"?>
+        <repomd xmlns="http://linux.duke.edu/metadata/repo" xmlns:rpm="http://linux.duke.edu/metadata/rpm">
+          <data type="primary">
+            <location non-href="repodata/somesha256-primary.xml.gz"/>
+          </data>
+          <data type="primary_db">
+            <location href="repodata/somesha256-primary.sqlite.gz"/>
+          </data>
+        </repomd>
+      `);
+
+      await expect(
+        rpmDatasource.getPrimaryGzipUrl(registryUrl),
+      ).rejects.toThrow(`No href found in ${registryUrl}repomd.xml`);
+    });
   });
 
   describe('getReleasesByPackageName', () => {
     const packageName = 'example-package';
     const extractedPrimaryXmlPath = `others/rpm/${toSha256(primaryXmlUrl)}.xml`;
-
-    function buildPrimaryXml(packageEntries: string): string {
-      return codeBlock`
-        <?xml version="1.0" encoding="UTF-8"?>
-        <metadata xmlns="http://linux.duke.edu/metadata/common">
-          ${packageEntries}
-        </metadata>
-      `;
-    }
-
-    async function mockPrimaryXmlResponse(primaryXml: string): Promise<void> {
-      httpMock
-        .scope(primaryXmlRegistryUrl)
-        .get('/somesha256-primary.xml.gz')
-        .reply(200, await gzip(primaryXml), {
-          'Content-Type': 'application/gzip',
-        });
-    }
 
     it('returns the correct releases', async () => {
       await mockPrimaryXmlResponse(
@@ -659,17 +812,31 @@ describe('modules/datasource/rpm/index', () => {
     });
 
     it('returns the correct releases', async () => {
-      vi.spyOn(rpmDatasource, 'getPrimaryGzipUrl').mockResolvedValue(
-        primaryXmlUrl,
+      mockRepomdResponse();
+      await mockPrimaryXmlResponse(
+        buildPrimaryXml(codeBlock`
+          <package type="rpm">
+            <name>example-package</name>
+            <arch>x86_64</arch>
+            <version epoch="0" ver="1.0" rel="2.azl3"/>
+          </package>
+          <package type="rpm">
+            <name>example-package</name>
+            <arch>x86_64</arch>
+            <version epoch="0" ver="1.1" rel="1.azl3"/>
+          </package>
+          <package type="rpm">
+            <name>example-package</name>
+            <arch>x86_64</arch>
+            <version epoch="0" ver="1.1" rel="2.azl3"/>
+          </package>
+          <package type="rpm">
+            <name>example-package</name>
+            <arch>x86_64</arch>
+            <version epoch="0" ver="1.2"/>
+          </package>
+        `),
       );
-      vi.spyOn(rpmDatasource, 'getReleasesByPackageName').mockResolvedValue({
-        releases: [
-          { version: '1.0-2.azl3' },
-          { version: '1.1-1.azl3' },
-          { version: '1.1-2.azl3' },
-          { version: '1.2' },
-        ],
-      });
 
       const releases = await rpmDatasource.getReleases({
         registryUrl,
@@ -686,10 +853,11 @@ describe('modules/datasource/rpm/index', () => {
       });
     });
 
-    it('throws an error if getPrimaryGzipUrl fails', async () => {
-      vi.spyOn(rpmDatasource, 'getPrimaryGzipUrl').mockRejectedValue(
-        new Error('Something wrong'),
-      );
+    it('throws an error if repository metadata lookup fails', async () => {
+      httpMock
+        .scope(registryUrl)
+        .get('/repomd.xml')
+        .replyWithError('Something wrong');
 
       await expect(
         rpmDatasource.getReleases({
@@ -699,20 +867,404 @@ describe('modules/datasource/rpm/index', () => {
       ).rejects.toThrow('Something wrong');
     });
 
-    it('throws an error if getReleasesByPackageName fails', async () => {
-      vi.spyOn(rpmDatasource, 'getPrimaryGzipUrl').mockResolvedValue(
-        primaryXmlUrl,
-      );
-      vi.spyOn(rpmDatasource, 'getReleasesByPackageName').mockRejectedValue(
-        new Error('Something wrong'),
-      );
+    it('throws an error if primary metadata parsing fails', async () => {
+      mockRepomdResponse();
+      await mockPrimaryXmlResponse(codeBlock`
+        <?xml version="1.0" encoding="UTF-8"?>
+        <%$#metadata xmlns="http://linux.duke.edu/metadata/common">
+          <package type="rpm">
+            <name>example-package</name>
+            <arch>x86_64</arch>
+            <version epoch="0" ver="1.0" rel="1.azl3"/>
+          </package>
+        </metadata>
+      `);
 
       await expect(
         rpmDatasource.getReleases({
           registryUrl,
           packageName: 'example-package',
         }),
-      ).rejects.toThrow('Something wrong');
+      ).rejects.toThrow('Unencoded <');
+    });
+
+    it('prefers primary_db metadata when available', async () => {
+      mockRepomdResponse({
+        primaryDbHref: 'repodata/somesha256-primary.sqlite.gz',
+      });
+      mockPrimaryDbResponse(
+        await createPrimaryDbGzip([
+          {
+            name: 'example-package',
+            release: '2.azl3',
+            version: '1.0',
+          },
+        ]),
+      );
+      await mockPrimaryXmlResponse(
+        buildPrimaryXml(codeBlock`
+          <package type="rpm">
+            <name>example-package</name>
+            <arch>x86_64</arch>
+            <version epoch="0" ver="9.9" rel="1.azl3"/>
+          </package>
+        `),
+      );
+
+      const autoReleases = await rpmDatasource.getReleases({
+        registryUrl,
+        packageName: 'example-package',
+      });
+      const xmlReleases = await rpmDatasource.getReleases({
+        registryUrl: `${registryUrl}#rpmMetadataSource=primary`,
+        packageName: 'example-package',
+      });
+
+      expect(autoReleases).toEqual({
+        releases: [{ version: '1.0-2.azl3' }],
+      });
+      expect(xmlReleases).toEqual({
+        releases: [{ version: '9.9-1.azl3' }],
+      });
+    });
+
+    it('does not fall back to primary.xml.gz when primary_db has no matching package', async () => {
+      mockRepomdResponse({
+        primaryDbHref: 'repodata/somesha256-primary.sqlite.gz',
+      });
+      mockPrimaryDbResponse(
+        await createPrimaryDbGzip([
+          {
+            name: 'another-package',
+            release: '2.azl3',
+            version: '1.0',
+          },
+        ]),
+      );
+
+      const releases = await rpmDatasource.getReleases({
+        registryUrl,
+        packageName: 'example-package',
+      });
+
+      expect(releases).toBeNull();
+    });
+
+    it('does not fall back to primary.xml.gz when registryUrl requires primary_db', async () => {
+      mockRepomdResponse({
+        primaryDbHref: 'repodata/somesha256-primary.sqlite.gz',
+      });
+      mockPrimaryDbResponse(await gzip('not-a-sqlite-database'));
+
+      await expect(
+        rpmDatasource.getReleases({
+          registryUrl: `${registryUrl}#rpmMetadataSource=primary_db`,
+          packageName: 'example-package',
+        }),
+      ).rejects.toThrow();
+    });
+
+    it('throws sqlite errors when only primary_db metadata is present in auto mode', async () => {
+      mockRepomdResponse({
+        primaryDbHref: 'repodata/somesha256-primary.sqlite.gz',
+        primaryHref: '',
+      });
+      mockPrimaryDbResponse(await gzip('not-a-sqlite-database'));
+
+      await expect(
+        rpmDatasource.getReleases({
+          registryUrl,
+          packageName: 'example-package',
+        }),
+      ).rejects.toThrow();
+    });
+
+    it('uses primary_db when primary metadata is malformed', async () => {
+      mockRawRepomdResponse(codeBlock`
+        <?xml version="1.0" encoding="UTF-8"?>
+        <repomd xmlns="http://linux.duke.edu/metadata/repo" xmlns:rpm="http://linux.duke.edu/metadata/rpm">
+          <data type="primary">
+            <location non-href="repodata/somesha256-primary.xml.gz"/>
+          </data>
+          <data type="primary_db">
+            <location href="repodata/somesha256-primary.sqlite.gz"/>
+          </data>
+        </repomd>
+      `);
+      mockPrimaryDbResponse(
+        await createPrimaryDbGzip([
+          {
+            name: 'example-package',
+            release: '2.azl3',
+            version: '1.0',
+          },
+        ]),
+      );
+
+      await expect(
+        rpmDatasource.getReleases({
+          registryUrl: `${registryUrl}#rpmMetadataSource=primary_db`,
+          packageName: 'example-package',
+        }),
+      ).resolves.toEqual({
+        releases: [{ version: '1.0-2.azl3' }],
+      });
+    });
+
+    it('throws when registryUrl requires primary_db and primary_db metadata is absent', async () => {
+      mockRepomdResponse();
+
+      await expect(
+        rpmDatasource.getReleases({
+          registryUrl: `${registryUrl}#rpmMetadataSource=primary_db`,
+          packageName: 'example-package',
+        }),
+      ).rejects.toThrow(`No primary_db data found in ${registryUrl}repomd.xml`);
+    });
+
+    it('throws when registryUrl requires primary and primary metadata is absent', async () => {
+      mockRepomdResponse({
+        primaryDbHref: 'repodata/somesha256-primary.sqlite.gz',
+        primaryHref: '',
+      });
+
+      await expect(
+        rpmDatasource.getReleases({
+          registryUrl: `${registryUrl}#rpmMetadataSource=primary`,
+          packageName: 'missing-source-package',
+        }),
+      ).rejects.toThrow(`No primary data found in ${registryUrl}repomd.xml`);
+    });
+
+    it('throws when registryUrl has invalid rpmMetadataSource', async () => {
+      await expect(
+        rpmDatasource.getReleases({
+          registryUrl: `${registryUrl}#rpmMetadataSource=broken`,
+          packageName: 'example-package',
+        }),
+      ).rejects.toThrow(
+        'Invalid rpmMetadataSource in RPM registry URL: broken',
+      );
+    });
+
+    it('throws when registryUrl has empty rpmMetadataSource', async () => {
+      await expect(
+        rpmDatasource.getReleases({
+          registryUrl: `${registryUrl}#rpmMetadataSource=`,
+          packageName: 'example-package',
+        }),
+      ).rejects.toThrow('Invalid rpmMetadataSource in RPM registry URL:');
+    });
+
+    it('falls back to primary.xml.gz when primary_db is absent', async () => {
+      mockRepomdResponse();
+      await mockPrimaryXmlResponse(
+        buildPrimaryXml(codeBlock`
+          <package type="rpm">
+            <name>example-package</name>
+            <arch>x86_64</arch>
+            <version epoch="0" ver="1.0" rel="2.azl3"/>
+          </package>
+          <package type="rpm">
+            <name>example-package</name>
+            <arch>x86_64</arch>
+            <version epoch="0" ver="1.1"/>
+          </package>
+        `),
+      );
+
+      const releases = await rpmDatasource.getReleases({
+        registryUrl,
+        packageName: 'example-package',
+      });
+
+      expect(releases).toEqual({
+        releases: [{ version: '1.0-2.azl3' }, { version: '1.1' }],
+      });
+    });
+
+    it('falls back to primary.xml.gz when primary_db lookup fails', async () => {
+      mockRepomdResponse({
+        primaryDbHref: 'repodata/somesha256-primary.sqlite.gz',
+      });
+      mockPrimaryDbResponse(await gzip('not-a-sqlite-database'));
+      await mockPrimaryXmlResponse(
+        buildPrimaryXml(codeBlock`
+          <package type="rpm">
+            <name>example-package</name>
+            <arch>x86_64</arch>
+            <version epoch="0" ver="2.0" rel="1.azl3"/>
+          </package>
+        `),
+      );
+
+      const releases = await rpmDatasource.getReleases({
+        registryUrl,
+        packageName: 'example-package',
+      });
+
+      expect(releases).toEqual({
+        releases: [{ version: '2.0-1.azl3' }],
+      });
+    });
+
+    it('caches auto-mode primary.xml.gz fallback results', async () => {
+      mockRepomdResponse({
+        primaryDbHref: 'repodata/somesha256-primary.sqlite.gz',
+      });
+      mockPrimaryDbResponse(await gzip('not-a-sqlite-database'));
+      await mockPrimaryXmlResponse(
+        buildPrimaryXml(codeBlock`
+          <package type="rpm">
+            <name>example-package</name>
+            <arch>x86_64</arch>
+            <version epoch="0" ver="2.0" rel="1.azl3"/>
+          </package>
+        `),
+      );
+
+      const fallbackReleases = await rpmDatasource.getReleases({
+        registryUrl,
+        packageName: 'example-package',
+      });
+
+      const cachedReleases = await rpmDatasource.getReleases({
+        registryUrl,
+        packageName: 'example-package',
+      });
+
+      expect(fallbackReleases).toEqual({
+        releases: [{ version: '2.0-1.azl3' }],
+      });
+      expect(cachedReleases).toEqual({
+        releases: [{ version: '2.0-1.azl3' }],
+      });
+    });
+
+    it('reuses the extracted primary_db file across package lookups', async () => {
+      const repomdScope = httpMock.scope(registryUrl);
+      repomdScope
+        .get('/repomd.xml')
+        .once()
+        .reply(
+          200,
+          buildRepomdXml({
+            primaryDbHref: 'repodata/somesha256-primary.sqlite.gz',
+          }),
+          { 'Content-Type': 'application/xml' },
+        );
+
+      const primaryDbScope = httpMock.scope(primaryDbRegistryUrl);
+      primaryDbScope
+        .get('/somesha256-primary.sqlite.gz')
+        .once()
+        .reply(
+          200,
+          await createPrimaryDbGzip([
+            { name: 'bash', release: '1.azl3', version: '5.2.15' },
+            { name: 'curl', release: '2.azl3', version: '8.5.0' },
+          ]),
+          { 'Content-Type': 'application/gzip' },
+        );
+      primaryDbScope.head('/somesha256-primary.sqlite.gz').once().reply(304);
+
+      const bashReleases = await rpmDatasource.getReleases({
+        registryUrl,
+        packageName: 'bash',
+      });
+      const curlReleases = await rpmDatasource.getReleases({
+        registryUrl,
+        packageName: 'curl',
+      });
+
+      expect(bashReleases).toEqual({
+        releases: [{ version: '5.2.15-1.azl3' }],
+      });
+      expect(curlReleases).toEqual({
+        releases: [{ version: '8.5.0-2.azl3' }],
+      });
+    });
+
+    it('caches primary_db-only repository metadata across package lookups', async () => {
+      const repomdScope = httpMock.scope(registryUrl);
+      repomdScope
+        .get('/repomd.xml')
+        .once()
+        .reply(
+          200,
+          buildRepomdXml({
+            primaryDbHref: 'repodata/somesha256-primary.sqlite.gz',
+            primaryHref: '',
+          }),
+          { 'Content-Type': 'application/xml' },
+        );
+
+      const primaryDbScope = httpMock.scope(primaryDbRegistryUrl);
+      primaryDbScope
+        .get('/somesha256-primary.sqlite.gz')
+        .once()
+        .reply(
+          200,
+          await createPrimaryDbGzip([
+            { name: 'bash', release: '1.azl3', version: '5.2.15' },
+            { name: 'curl', release: '2.azl3', version: '8.5.0' },
+          ]),
+          { 'Content-Type': 'application/gzip' },
+        );
+      primaryDbScope.head('/somesha256-primary.sqlite.gz').once().reply(304);
+
+      const bashReleases = await rpmDatasource.getReleases({
+        registryUrl,
+        packageName: 'bash',
+      });
+      const curlReleases = await rpmDatasource.getReleases({
+        registryUrl,
+        packageName: 'curl',
+      });
+
+      expect(bashReleases).toEqual({
+        releases: [{ version: '5.2.15-1.azl3' }],
+      });
+      expect(curlReleases).toEqual({
+        releases: [{ version: '8.5.0-2.azl3' }],
+      });
+    });
+
+    it('returns null when primary_db rows do not contain a version value', async () => {
+      mockRepomdResponse({
+        primaryDbHref: 'repodata/somesha256-primary.sqlite.gz',
+        primaryHref: '',
+      });
+      mockPrimaryDbResponse(
+        await createPrimaryDbGzip([
+          {
+            name: 'example-package',
+            release: '1.azl3',
+            version: null,
+          },
+        ]),
+      );
+
+      const releases = await rpmDatasource.getReleases({
+        registryUrl,
+        packageName: 'example-package',
+      });
+
+      expect(releases).toBeNull();
+    });
+
+    it('throws an error if neither primary nor primary_db metadata is present', async () => {
+      mockRepomdResponse({
+        primaryDbHref: '',
+        primaryHref: '',
+      });
+
+      await expect(
+        rpmDatasource.getReleases({
+          registryUrl,
+          packageName: 'example-package',
+        }),
+      ).rejects.toThrow(`No primary data found in ${registryUrl}repomd.xml`);
     });
   });
 });

--- a/lib/modules/datasource/rpm/index.spec.ts
+++ b/lib/modules/datasource/rpm/index.spec.ts
@@ -1081,7 +1081,7 @@ describe('modules/datasource/rpm/index', () => {
 
     it('strips explicit auto rpmMetadataSource from registryUrl', async () => {
       mockRepomdResponse();
-      mockPrimaryXmlResponse(
+      await mockPrimaryXmlResponse(
         buildPrimaryXml(codeBlock`
           <package type="rpm">
             <name>example-package</name>
@@ -1167,7 +1167,7 @@ describe('modules/datasource/rpm/index', () => {
         primaryDbHref: 'repodata/somesha256-primary.sqlite.gz',
       });
       mockPrimaryDbProviderFailure('not-a-sqlite-error');
-      mockPrimaryXmlResponse(
+      await mockPrimaryXmlResponse(
         buildPrimaryXml(codeBlock`
           <package type="rpm">
             <name>example-package</name>

--- a/lib/modules/datasource/rpm/index.ts
+++ b/lib/modules/datasource/rpm/index.ts
@@ -1,18 +1,46 @@
+import { logger } from '../../../logger/index.ts';
 import { withCache } from '../../../util/cache/package/with-cache.ts';
+import { parseUrl } from '../../../util/url.ts';
 import { Datasource } from '../datasource.ts';
 import type { GetReleasesConfig, ReleaseResult } from '../types.ts';
 import { datasource } from './common.ts';
+import { RpmSqliteMetadataProvider } from './providers/sqlite.ts';
 import { RpmXmlMetadataProvider } from './providers/xml.ts';
-import { fetchPrimaryGzipUrl } from './repomd.ts';
+import {
+  type RpmRepositoryMetadata,
+  fetchPrimaryGzipUrl,
+  fetchRepositoryMetadata,
+} from './repomd.ts';
+
+type RpmMetadataSource = 'primary' | 'primary_db';
+type ResolvedRpmMetadataSource = 'auto' | RpmMetadataSource;
+
+interface ParsedRpmRegistryUrl {
+  metadataSource: ResolvedRpmMetadataSource;
+  registryUrl: string;
+}
+
+interface RpmMetadataProvider {
+  readonly metadataType: RpmMetadataSource;
+  getReleases(
+    metadataUrl: string,
+    packageName: string,
+  ): Promise<ReleaseResult | null>;
+}
 
 export class RpmDatasource extends Datasource {
   static readonly id = datasource;
 
-  private readonly xmlProvider: RpmXmlMetadataProvider;
+  private readonly providers: Record<RpmMetadataSource, RpmMetadataProvider>;
 
   constructor() {
     super(RpmDatasource.id);
-    this.xmlProvider = new RpmXmlMetadataProvider(this.http);
+    const xmlProvider = new RpmXmlMetadataProvider(this.http);
+    const sqliteProvider = new RpmSqliteMetadataProvider(this.http);
+    this.providers = {
+      [xmlProvider.metadataType]: xmlProvider,
+      [sqliteProvider.metadataType]: sqliteProvider,
+    };
   }
 
   /**
@@ -47,18 +75,39 @@ export class RpmDatasource extends Datasource {
     }
 
     try {
-      const primaryGzipUrl = await this.getPrimaryGzipUrl(registryUrl);
-      return await this.getReleasesByPackageName(primaryGzipUrl, packageName);
+      const parsedRegistryUrl = this.parseRegistryUrl(registryUrl);
+      const metadata = await this.getRepositoryMetadata(
+        parsedRegistryUrl.registryUrl,
+      );
+
+      if (parsedRegistryUrl.metadataSource !== 'auto') {
+        return await this.getProviderReleases(
+          parsedRegistryUrl.metadataSource,
+          metadata,
+          packageName,
+        );
+      }
+
+      return await this.getAutoReleases(
+        metadata,
+        packageName,
+        parsedRegistryUrl.registryUrl,
+      );
     } catch (err) {
       this.handleGenericErrors(err);
     }
   }
 
-  getReleases(config: GetReleasesConfig): Promise<ReleaseResult | null> {
-    return withCache(
+  async getReleases(config: GetReleasesConfig): Promise<ReleaseResult | null> {
+    const parsedRegistryUrl = config.registryUrl
+      ? this.parseRegistryUrl(config.registryUrl)
+      : undefined;
+    const metadataSource = parsedRegistryUrl?.metadataSource ?? 'auto';
+
+    return await withCache(
       {
         namespace: `datasource-${RpmDatasource.id}`,
-        key: `${config.registryUrl}:${config.packageName}`,
+        key: `${parsedRegistryUrl?.registryUrl}:${config.packageName}:${metadataSource}`,
         ttlMinutes: 1440,
         fallback: true,
       },
@@ -66,14 +115,119 @@ export class RpmDatasource extends Datasource {
     );
   }
 
-  getPrimaryGzipUrl(registryUrl: string): Promise<string> {
+  private parseRegistryUrl(registryUrl: string): ParsedRpmRegistryUrl {
+    const parsedUrl = parseUrl(registryUrl);
+    if (!parsedUrl) {
+      return { metadataSource: 'auto', registryUrl };
+    }
+
+    const rpmMetadataSource = new URLSearchParams(parsedUrl.hash.slice(1)).get(
+      'rpmMetadataSource',
+    );
+
+    if (rpmMetadataSource === null) {
+      return { metadataSource: 'auto', registryUrl };
+    }
+
+    if (rpmMetadataSource === 'primary' || rpmMetadataSource === 'primary_db') {
+      parsedUrl.hash = '';
+      return {
+        metadataSource: rpmMetadataSource,
+        registryUrl: parsedUrl.href,
+      };
+    }
+
+    if (rpmMetadataSource !== 'auto') {
+      throw new Error(
+        `Invalid rpmMetadataSource in RPM registry URL: ${rpmMetadataSource}`,
+      );
+    }
+
+    parsedUrl.hash = '';
+    return {
+      metadataSource: 'auto',
+      registryUrl: parsedUrl.href,
+    };
+  }
+
+  private async getAutoReleases(
+    metadata: RpmRepositoryMetadata,
+    packageName: string,
+    registryUrl: string,
+  ): Promise<ReleaseResult | null> {
+    const { primaryDbUrl, primaryGzipUrl } = metadata;
+    let sqliteError: Error | undefined;
+
+    if (primaryDbUrl) {
+      try {
+        return await this.getProviderReleases(
+          'primary_db',
+          metadata,
+          packageName,
+        );
+      } catch (err) {
+        sqliteError = err instanceof Error ? err : new Error(String(err));
+        logger.debug(
+          {
+            datasource: RpmDatasource.id,
+            err,
+            packageName,
+            registryUrl,
+            repodataType: 'primary_db',
+            url: primaryDbUrl,
+          },
+          'Failed to query primary_db metadata, falling back to primary.xml.gz',
+        );
+      }
+    }
+
+    if (primaryGzipUrl) {
+      return await this.getProviderReleases('primary', metadata, packageName);
+    }
+
+    if (sqliteError) {
+      throw sqliteError;
+    }
+
+    return null;
+  }
+
+  private async getProviderReleases(
+    metadataType: RpmMetadataSource,
+    metadata: RpmRepositoryMetadata,
+    packageName: string,
+  ): Promise<ReleaseResult | null> {
+    const metadataUrl = this.getMetadataUrlOrThrow(metadata, metadataType);
+
+    return await this.providers[metadataType].getReleases(
+      metadataUrl,
+      packageName,
+    );
+  }
+
+  private getRepositoryMetadata(
+    registryUrl: string,
+  ): Promise<RpmRepositoryMetadata> {
     return withCache(
       {
         namespace: `datasource-${RpmDatasource.id}`,
-        key: registryUrl,
+        key: `repomd:${registryUrl}`,
         ttlMinutes: 1440,
       },
-      () => fetchPrimaryGzipUrl(this.http, registryUrl),
+      () => fetchRepositoryMetadata(this.http, registryUrl),
+    );
+  }
+
+  getPrimaryGzipUrl(registryUrl: string): Promise<string> {
+    const parsedRegistryUrl = this.parseRegistryUrl(registryUrl);
+
+    return withCache(
+      {
+        namespace: `datasource-${RpmDatasource.id}`,
+        key: parsedRegistryUrl.registryUrl,
+        ttlMinutes: 1440,
+      },
+      () => fetchPrimaryGzipUrl(this.http, parsedRegistryUrl.registryUrl),
     );
   }
 
@@ -81,6 +235,22 @@ export class RpmDatasource extends Datasource {
     primaryGzipUrl: string,
     packageName: string,
   ): Promise<ReleaseResult | null> {
-    return this.xmlProvider.getReleases(primaryGzipUrl, packageName);
+    return this.providers.primary.getReleases(primaryGzipUrl, packageName);
+  }
+
+  private getMetadataUrlOrThrow(
+    metadata: RpmRepositoryMetadata,
+    metadataType: RpmMetadataSource,
+  ): string {
+    const metadataUrl =
+      metadataType === 'primary'
+        ? metadata.primaryGzipUrl
+        : metadata.primaryDbUrl;
+
+    if (!metadataUrl) {
+      throw new Error(`No ${metadataType} data found in ${metadata.repomdUrl}`);
+    }
+
+    return metadataUrl;
   }
 }

--- a/lib/modules/datasource/rpm/index.ts
+++ b/lib/modules/datasource/rpm/index.ts
@@ -185,10 +185,12 @@ export class RpmDatasource extends Datasource {
       return await this.getProviderReleases('primary', metadata, packageName);
     }
 
+    /* v8 ignore if -- fetchRepositoryMetadata guarantees at least one source */
     if (sqliteError) {
       throw sqliteError;
     }
 
+    /* v8 ignore next -- fetchRepositoryMetadata guarantees at least one source */
     return null;
   }
 

--- a/lib/modules/datasource/rpm/index.ts
+++ b/lib/modules/datasource/rpm/index.ts
@@ -6,11 +6,8 @@ import type { GetReleasesConfig, ReleaseResult } from '../types.ts';
 import { datasource } from './common.ts';
 import { RpmSqliteMetadataProvider } from './providers/sqlite.ts';
 import { RpmXmlMetadataProvider } from './providers/xml.ts';
-import {
-  type RpmRepositoryMetadata,
-  fetchPrimaryGzipUrl,
-  fetchRepositoryMetadata,
-} from './repomd.ts';
+import type { RpmRepositoryMetadata } from './repomd.ts';
+import { fetchRepositoryMetadata } from './repomd.ts';
 
 type RpmMetadataSource = 'primary' | 'primary_db';
 type ResolvedRpmMetadataSource = 'auto' | RpmMetadataSource;
@@ -62,57 +59,52 @@ export class RpmDatasource extends Datasource {
   /**
    * Fetches the release information for a given package from the registry URL.
    *
-   * @param registryUrl - the registryUrl should be the folder which contains repodata.xml and its corresponding file list <sha256>-primary.xml.gz, e.g.: https://packages.microsoft.com/azurelinux/3.0/prod/cloud-native/x86_64/repodata/
+   * @param parsedRegistryUrl - the parsed registry URL and selected metadata source.
    * @param packageName - the name of the package to fetch releases for.
    * @returns The release result if the package is found, otherwise null.
    */
-  private async _getReleases({
-    registryUrl,
-    packageName,
-  }: GetReleasesConfig): Promise<ReleaseResult | null> {
+  private async _getReleases(
+    parsedRegistryUrl: ParsedRpmRegistryUrl,
+    packageName: string,
+  ): Promise<ReleaseResult | null> {
+    const metadata = await this.getRepositoryMetadata(parsedRegistryUrl);
+
+    if (parsedRegistryUrl.metadataSource !== 'auto') {
+      return await this.getProviderReleases(
+        parsedRegistryUrl.metadataSource,
+        metadata,
+        packageName,
+      );
+    }
+
+    return await this.getAutoReleases(
+      metadata,
+      packageName,
+      parsedRegistryUrl.registryUrl,
+    );
+  }
+
+  async getReleases(config: GetReleasesConfig): Promise<ReleaseResult | null> {
+    const { registryUrl, packageName } = config;
     if (!registryUrl || !packageName) {
       return null;
     }
 
     try {
       const parsedRegistryUrl = this.parseRegistryUrl(registryUrl);
-      const metadata = await this.getRepositoryMetadata(
-        parsedRegistryUrl.registryUrl,
-      );
 
-      if (parsedRegistryUrl.metadataSource !== 'auto') {
-        return await this.getProviderReleases(
-          parsedRegistryUrl.metadataSource,
-          metadata,
-          packageName,
-        );
-      }
-
-      return await this.getAutoReleases(
-        metadata,
-        packageName,
-        parsedRegistryUrl.registryUrl,
+      return await withCache(
+        {
+          namespace: `datasource-${RpmDatasource.id}`,
+          key: `${parsedRegistryUrl.registryUrl}:${packageName}:${parsedRegistryUrl.metadataSource}`,
+          ttlMinutes: 1440,
+          fallback: true,
+        },
+        () => this._getReleases(parsedRegistryUrl, packageName),
       );
     } catch (err) {
       this.handleGenericErrors(err);
     }
-  }
-
-  async getReleases(config: GetReleasesConfig): Promise<ReleaseResult | null> {
-    const parsedRegistryUrl = config.registryUrl
-      ? this.parseRegistryUrl(config.registryUrl)
-      : undefined;
-    const metadataSource = parsedRegistryUrl?.metadataSource ?? 'auto';
-
-    return await withCache(
-      {
-        namespace: `datasource-${RpmDatasource.id}`,
-        key: `${parsedRegistryUrl?.registryUrl}:${config.packageName}:${metadataSource}`,
-        ttlMinutes: 1440,
-        fallback: true,
-      },
-      () => this._getReleases(config),
-    );
   }
 
   private parseRegistryUrl(registryUrl: string): ParsedRpmRegistryUrl {
@@ -200,36 +192,18 @@ export class RpmDatasource extends Datasource {
   }
 
   private getRepositoryMetadata(
-    registryUrl: string,
+    parsedRegistryUrl: ParsedRpmRegistryUrl,
   ): Promise<RpmRepositoryMetadata> {
-    return withCache(
-      {
-        namespace: `datasource-${RpmDatasource.id}`,
-        key: `repomd:${registryUrl}`,
-        ttlMinutes: 1440,
-      },
-      () => fetchRepositoryMetadata(this.http, registryUrl),
-    );
-  }
-
-  getPrimaryGzipUrl(registryUrl: string): Promise<string> {
-    const parsedRegistryUrl = this.parseRegistryUrl(registryUrl);
+    const { metadataSource, registryUrl } = parsedRegistryUrl;
 
     return withCache(
       {
         namespace: `datasource-${RpmDatasource.id}`,
-        key: parsedRegistryUrl.registryUrl,
+        key: `repomd:${registryUrl}:${metadataSource}`,
         ttlMinutes: 1440,
       },
-      () => fetchPrimaryGzipUrl(this.http, parsedRegistryUrl.registryUrl),
+      () => fetchRepositoryMetadata(this.http, registryUrl, metadataSource),
     );
-  }
-
-  getReleasesByPackageName(
-    primaryGzipUrl: string,
-    packageName: string,
-  ): Promise<ReleaseResult | null> {
-    return this.providers.primary.getReleases(primaryGzipUrl, packageName);
   }
 
   private getMetadataUrlOrThrow(

--- a/lib/modules/datasource/rpm/index.ts
+++ b/lib/modules/datasource/rpm/index.ts
@@ -156,7 +156,6 @@ export class RpmDatasource extends Datasource {
     registryUrl: string,
   ): Promise<ReleaseResult | null> {
     const { primaryDbUrl, primaryGzipUrl } = metadata;
-    let sqliteError: Error | undefined;
 
     if (primaryDbUrl) {
       try {
@@ -166,7 +165,10 @@ export class RpmDatasource extends Datasource {
           packageName,
         );
       } catch (err) {
-        sqliteError = err instanceof Error ? err : new Error(String(err));
+        if (!primaryGzipUrl) {
+          throw err;
+        }
+
         logger.debug(
           {
             datasource: RpmDatasource.id,
@@ -181,17 +183,7 @@ export class RpmDatasource extends Datasource {
       }
     }
 
-    if (primaryGzipUrl) {
-      return await this.getProviderReleases('primary', metadata, packageName);
-    }
-
-    /* v8 ignore if -- fetchRepositoryMetadata guarantees at least one source */
-    if (sqliteError) {
-      throw sqliteError;
-    }
-
-    /* v8 ignore next -- fetchRepositoryMetadata guarantees at least one source */
-    return null;
+    return await this.getProviderReleases('primary', metadata, packageName);
   }
 
   private async getProviderReleases(

--- a/lib/modules/datasource/rpm/providers/common.ts
+++ b/lib/modules/datasource/rpm/providers/common.ts
@@ -21,13 +21,13 @@ export function formatRpmVersion(
     return null;
   }
 
-  const version = String(ver);
+  const version = `${ver}`;
 
   if (rel === undefined || rel === null) {
     return version;
   }
 
-  return `${version}-${String(rel)}`;
+  return `${version}-${rel}`;
 }
 
 export function buildReleaseResult(
@@ -122,7 +122,7 @@ async function extractGzipFile(
 export async function getCachedGunzippedFile(
   http: Http,
   url: string,
-  extension: 'xml',
+  extension: 'sqlite' | 'xml',
 ): Promise<string> {
   const releaseLock = await acquireLock(
     `gunzipped-file:${url}:${extension}`,

--- a/lib/modules/datasource/rpm/providers/sqlite.ts
+++ b/lib/modules/datasource/rpm/providers/sqlite.ts
@@ -1,0 +1,63 @@
+import { logger } from '../../../../logger/index.ts';
+import type { Http } from '../../../../util/http/index.ts';
+import type { ReleaseResult } from '../../types.ts';
+import {
+  buildReleaseResult,
+  formatRpmVersion,
+  getCachedGunzippedFile,
+} from './common.ts';
+
+interface RpmSqlitePackageRow {
+  release: string | null;
+  version: string | null;
+}
+
+export class RpmSqliteMetadataProvider {
+  readonly metadataType = 'primary_db' as const;
+
+  private readonly http: Http;
+
+  constructor(http: Http) {
+    this.http = http;
+  }
+
+  async getReleases(
+    primaryDbUrl: string,
+    packageName: string,
+  ): Promise<ReleaseResult | null> {
+    const extractedFile = await getCachedGunzippedFile(
+      this.http,
+      primaryDbUrl,
+      'sqlite',
+    );
+    const { DatabaseSync: Sqlite } = await import('node:sqlite');
+    const db = new Sqlite(extractedFile, {
+      readOnly: true,
+    });
+
+    try {
+      const rows = db
+        .prepare('select version, release from packages where name = ?')
+        .iterate(packageName) as Iterable<RpmSqlitePackageRow>;
+
+      const versions = new Set<string>();
+      for (const row of rows) {
+        const version = formatRpmVersion(row.version, row.release);
+        if (version) {
+          versions.add(version);
+        }
+      }
+
+      const result = buildReleaseResult(versions);
+      if (!result) {
+        logger.trace(
+          `No releases found for package ${packageName} in ${primaryDbUrl}`,
+        );
+      }
+
+      return result;
+    } finally {
+      db.close();
+    }
+  }
+}

--- a/lib/modules/datasource/rpm/providers/sqlite.ts
+++ b/lib/modules/datasource/rpm/providers/sqlite.ts
@@ -7,9 +7,16 @@ import {
   getCachedGunzippedFile,
 } from './common.ts';
 
-interface RpmSqlitePackageRow {
-  release: string | null;
-  version: string | null;
+function getRpmSqliteValue(
+  row: Record<string, unknown>,
+  column: 'version' | 'release',
+): string | null {
+  const value = row[column];
+  if (value === null || typeof value === 'string') {
+    return value;
+  }
+
+  throw new Error(`Invalid ${column} value in RPM metadata`);
 }
 
 export class RpmSqliteMetadataProvider {
@@ -38,11 +45,14 @@ export class RpmSqliteMetadataProvider {
     try {
       const rows = db
         .prepare('select version, release from packages where name = ?')
-        .iterate(packageName) as Iterable<RpmSqlitePackageRow>;
+        .iterate(packageName);
 
       const versions = new Set<string>();
       for (const row of rows) {
-        const version = formatRpmVersion(row.version, row.release);
+        const version = formatRpmVersion(
+          getRpmSqliteValue(row, 'version'),
+          getRpmSqliteValue(row, 'release'),
+        );
         if (version) {
           versions.add(version);
         }

--- a/lib/modules/datasource/rpm/providers/xml.ts
+++ b/lib/modules/datasource/rpm/providers/xml.ts
@@ -10,6 +10,8 @@ import {
 } from './common.ts';
 
 export class RpmXmlMetadataProvider {
+  readonly metadataType = 'primary' as const;
+
   private readonly http: Http;
 
   constructor(http: Http) {

--- a/lib/modules/datasource/rpm/readme.md
+++ b/lib/modules/datasource/rpm/readme.md
@@ -7,16 +7,44 @@ According to this Pulp project doc, <https://docs.pulpproject.org/en/2.10/plugin
 
 ## Set URL when using an RPM repository
 
-To use an RPM repository with the datasource, you must set a `registryUrl` with the directory that contains the `repomd.xml` and corresponding `primary.xml`.
+To use an RPM repository with the datasource, you must set a `registryUrl` with the directory that contains the `repomd.xml` and corresponding repository metadata.
+
+Renovate reads `repomd.xml` first to discover the available metadata files.
+If the repository exposes `primary_db` / `primary.sqlite.gz`, Renovate will use it first.
+Otherwise, or if the SQLite metadata cannot be used, Renovate falls back to `primary.xml.gz`.
+
+If you need to control this behavior explicitly, add `rpmMetadataSource` to the `registryUrl` fragment:
+
+- `#rpmMetadataSource=auto`: prefer `primary_db`, fall back to `primary`
+- `#rpmMetadataSource=primary_db`: require `primary_db` metadata
+- `#rpmMetadataSource=primary`: require `primary` metadata
+
+For example:
+
+```json
+{
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["path_to_manifest_json"],
+      "registryUrlTemplate": "http://example.com/repo/repodata/#rpmMetadataSource=primary",
+      "datasourceTemplate": "rpm"
+    }
+  ]
+}
+```
 
 **Example**:
 
 If we have
 
 - `http://example.com/repo/repodata/repomd.xml`
-- `http://example.com/repo/repodata/<SHA256>-primary.xml` where `<SHA256>` is a dynamically generated SHA256 pattern.
+- `http://example.com/repo/repodata/<SHA256>-primary.sqlite.gz` or
+- `http://example.com/repo/repodata/<SHA256>-primary.xml.gz`
 
-Then the `registryUrl` should set as `http://example.com/repo/repodata/` or `http://example.com/repo/repodata`.
+where `<SHA256>` is a dynamically generated SHA256 pattern.
+
+Then the `registryUrl` should be set as `http://example.com/repo/repodata/` or `http://example.com/repo/repodata`.
 
 ## Usage Example
 
@@ -49,10 +77,10 @@ where the versioning format could be `<semantic version>-<revision or release>`,
 }
 ```
 
-In an RPM repository, the `<SHA256>-primary.xml` looks like this:
+When XML metadata is used, the `<SHA256>-primary.xml.gz` expands to content like this:
 
 ```
-`<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <metadata xmlns="http://linux.duke.edu/metadata/common">
   <package type="rpm">
     <name>example-package1</name>
@@ -94,13 +122,16 @@ Architecture : x86_64
 
 You can see that `ver` and `rel` (`release`/`revision`) is stored separately.
 The RPM datasource implementation will combine these together as `ver-rel`.
-That's why the version is defined as `1.0.0-1.az3`, if `rel` (like `example-package1`) is available.
+That's why the version is defined as `1.0.0-1.azl3`, if `rel` (like `example-package1`) is available.
 Or just `1.1.0` if `rel` (like `example-package2`) is not available.
 
 ## Limitation and Consideration
 
+When available, Renovate prefers `primary_db` / `primary.sqlite.gz`, which is typically faster for repeated package lookups in large RPM repositories.
+
+If the repository does not provide SQLite metadata, Renovate falls back to `primary.xml.gz`.
 In real-world scenarios, the decompressed `primary.xml` file from an RPM repository can be extremely large.
-To handle this efficiently, this implementation uses streaming XML parsing, which processes the file incrementally and avoids loading the entire XML into memory.
+To handle this efficiently, the XML fallback uses streaming XML parsing, which processes the file incrementally and avoids loading the entire XML into memory.
 
 Streaming XML parsing is a practical solution for large files in Node.js, but for extremely large or complex cases (e.g., files exceeding ~512MB), you may still encounter memory or performance issues.
 For such scenarios, consider using more robust approaches such as native modules, optimized SAX parsers, or external tools.

--- a/lib/modules/datasource/rpm/readme.md
+++ b/lib/modules/datasource/rpm/readme.md
@@ -27,6 +27,9 @@ For example:
     {
       "customType": "regex",
       "managerFilePatterns": ["path_to_manifest_json"],
+      "matchStrings": [
+        "\"(?<depName>[^\"]+)\":\\s*\"(?<currentValue>[^\"]+)\""
+      ],
       "registryUrlTemplate": "http://example.com/repo/repodata/#rpmMetadataSource=primary",
       "datasourceTemplate": "rpm"
     }
@@ -69,6 +72,9 @@ where the versioning format could be `<semantic version>-<revision or release>`,
       "customType": "regex",
       "managerFilePatterns": [
         "path_to_manifest_json"
+      ],
+      "matchStrings": [
+        "\"(?<depName>[^\"]+)\":\\s*\"(?<currentValue>[^\"]+)\""
       ],
       "registryUrlTemplate": "http://example.com/repo/repodata/",
       "datasourceTemplate": "rpm"

--- a/lib/modules/datasource/rpm/repomd.ts
+++ b/lib/modules/datasource/rpm/repomd.ts
@@ -4,24 +4,48 @@ import type { Http } from '../../../util/http/index.ts';
 import { joinUrlParts } from '../../../util/url.ts';
 import { datasource, repomdXmlFileName } from './common.ts';
 
-function getPrimaryRepodataUrl(
+export interface RpmRepositoryMetadata {
+  repomdUrl: string;
+  primaryDbUrl?: string;
+  primaryGzipUrl?: string;
+}
+
+function getRepodataUrl(
   xml: XmlDocument,
   registryUrl: string,
   repomdUrl: string,
-): string {
-  const primaryData = xml.childWithAttribute('type', 'primary');
+  type: 'primary' | 'primary_db',
+  optional = false,
+): string | undefined {
+  const data = xml.childWithAttribute('type', type);
 
-  if (!primaryData) {
-    throw new Error(`No primary data found in ${repomdUrl}`);
+  if (!data) {
+    return undefined;
   }
 
-  const locationElement = primaryData.childNamed('location');
+  const locationElement = data.childNamed('location');
   if (!locationElement) {
+    if (optional) {
+      logger.debug(
+        { datasource, repomdUrl, type },
+        'Optional repomd entry does not contain a location element',
+      );
+      return undefined;
+    }
+
     throw new Error(`No location element found in ${repomdUrl}`);
   }
 
   const href = locationElement.attr.href;
   if (!href) {
+    if (optional) {
+      logger.debug(
+        { datasource, repomdUrl, type },
+        'Optional repomd entry does not contain an href attribute',
+      );
+      return undefined;
+    }
+
     throw new Error(`No href found in ${repomdUrl}`);
   }
 
@@ -32,10 +56,11 @@ function getPrimaryRepodataUrl(
   return joinUrlParts(registryUrlWithoutRepodata, href);
 }
 
-export async function fetchPrimaryGzipUrl(
+export async function fetchRepositoryMetadata(
   http: Http,
   registryUrl: string,
-): Promise<string> {
+  { primaryRequired = false }: { primaryRequired?: boolean } = {},
+): Promise<RpmRepositoryMetadata> {
   const repomdUrl = joinUrlParts(registryUrl, repomdXmlFileName);
   const response = await http.getText(repomdUrl.toString());
   const repomdBody = response.body.trimStart();
@@ -49,19 +74,46 @@ export async function fetchPrimaryGzipUrl(
   }
 
   const xml = new XmlDocument(repomdBody);
+  const primaryGzipUrl = getRepodataUrl(
+    xml,
+    registryUrl,
+    repomdUrl.toString(),
+    'primary',
+    !primaryRequired,
+  );
+  const primaryDbUrl = getRepodataUrl(
+    xml,
+    registryUrl,
+    repomdUrl.toString(),
+    'primary_db',
+    true,
+  );
 
-  try {
-    return getPrimaryRepodataUrl(xml, registryUrl, repomdUrl.toString());
-  } catch (err) {
-    if (
-      err instanceof Error &&
-      err.message.startsWith('No primary data found')
-    ) {
-      logger.debug(
-        `No primary data found in ${repomdUrl}, xml contents: ${response.body}`,
-      );
-    }
-
-    throw err;
+  if (!primaryGzipUrl && !primaryDbUrl) {
+    logger.debug(
+      `No primary data found in ${repomdUrl}, xml contents: ${response.body}`,
+    );
+    throw new Error(`No primary data found in ${repomdUrl}`);
   }
+
+  return {
+    primaryDbUrl,
+    primaryGzipUrl,
+    repomdUrl: repomdUrl.toString(),
+  };
+}
+
+export async function fetchPrimaryGzipUrl(
+  http: Http,
+  registryUrl: string,
+): Promise<string> {
+  const metadata = await fetchRepositoryMetadata(http, registryUrl, {
+    primaryRequired: true,
+  });
+
+  if (!metadata.primaryGzipUrl) {
+    throw new Error(`No primary data found in ${metadata.repomdUrl}`);
+  }
+
+  return metadata.primaryGzipUrl;
 }

--- a/lib/modules/datasource/rpm/repomd.ts
+++ b/lib/modules/datasource/rpm/repomd.ts
@@ -15,7 +15,7 @@ function getRepodataUrl(
   registryUrl: string,
   repomdUrl: string,
   type: 'primary' | 'primary_db',
-  optional = false,
+  optional: boolean,
 ): string | undefined {
   const data = xml.childWithAttribute('type', type);
 
@@ -25,28 +25,28 @@ function getRepodataUrl(
 
   const locationElement = data.childNamed('location');
   if (!locationElement) {
-    if (optional) {
-      logger.debug(
-        { datasource, repomdUrl, type },
-        'Optional repomd entry does not contain a location element',
-      );
-      return undefined;
+    if (!optional) {
+      throw new Error(`No location element found in ${repomdUrl}`);
     }
 
-    throw new Error(`No location element found in ${repomdUrl}`);
+    logger.debug(
+      { datasource, repomdUrl, type },
+      'Optional repomd entry does not contain a location element',
+    );
+    return undefined;
   }
 
   const href = locationElement.attr.href;
   if (!href) {
-    if (optional) {
-      logger.debug(
-        { datasource, repomdUrl, type },
-        'Optional repomd entry does not contain an href attribute',
-      );
-      return undefined;
+    if (!optional) {
+      throw new Error(`No href found in ${repomdUrl}`);
     }
 
-    throw new Error(`No href found in ${repomdUrl}`);
+    logger.debug(
+      { datasource, repomdUrl, type },
+      'Optional repomd entry does not contain an href attribute',
+    );
+    return undefined;
   }
 
   // replace trailing "repodata/" from registryUrl, if it exists, with a "/"
@@ -59,7 +59,7 @@ function getRepodataUrl(
 export async function fetchRepositoryMetadata(
   http: Http,
   registryUrl: string,
-  { primaryRequired = false }: { primaryRequired?: boolean } = {},
+  metadataSource: 'auto' | 'primary' | 'primary_db' = 'auto',
 ): Promise<RpmRepositoryMetadata> {
   const repomdUrl = joinUrlParts(registryUrl, repomdXmlFileName);
   const response = await http.getText(repomdUrl.toString());
@@ -74,19 +74,20 @@ export async function fetchRepositoryMetadata(
   }
 
   const xml = new XmlDocument(repomdBody);
-  const primaryGzipUrl = getRepodataUrl(
-    xml,
-    registryUrl,
-    repomdUrl.toString(),
-    'primary',
-    !primaryRequired,
-  );
   const primaryDbUrl = getRepodataUrl(
     xml,
     registryUrl,
     repomdUrl.toString(),
     'primary_db',
-    true,
+    metadataSource !== 'primary_db',
+  );
+  const primaryGzipUrl = getRepodataUrl(
+    xml,
+    registryUrl,
+    repomdUrl.toString(),
+    'primary',
+    metadataSource === 'primary_db' ||
+      (metadataSource === 'auto' && primaryDbUrl !== undefined),
   );
 
   if (!primaryGzipUrl && !primaryDbUrl) {
@@ -101,19 +102,4 @@ export async function fetchRepositoryMetadata(
     primaryGzipUrl,
     repomdUrl: repomdUrl.toString(),
   };
-}
-
-export async function fetchPrimaryGzipUrl(
-  http: Http,
-  registryUrl: string,
-): Promise<string> {
-  const metadata = await fetchRepositoryMetadata(http, registryUrl, {
-    primaryRequired: true,
-  });
-
-  if (!metadata.primaryGzipUrl) {
-    throw new Error(`No primary data found in ${metadata.repomdUrl}`);
-  }
-
-  return metadata.primaryGzipUrl;
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

The RPM datasource currently scans the full `primary.xml.gz` metadata file for every package lookup. This becomes expensive for repositories with large metadata files and many dependencies. Some RPM repositories also publish `primary_db` metadata, which provides the same package information through an indexed SQLite database.

This PR adds `primary_db` support while retaining the existing XML provider:

- Discover both `primary` and `primary_db` entries from `repomd.xml`.
- Prefer `primary_db` in the default `auto` mode and query it using the built-in `node:sqlite` module.
- Fall back to `primary.xml.gz` when `primary_db` is absent or fails to open or query in `auto` mode.
- Treat an SQLite lookup with no matching package as authoritative instead of falling back to XML.
- Allow source selection through the registry URL fragment:
  - `#rpmMetadataSource=auto`: prefer `primary_db`, with XML fallback
  - `#rpmMetadataSource=primary_db`: require SQLite metadata
  - `#rpmMetadataSource=primary`: require XML metadata
- Preserve existing version formatting, deduplication, caching, and XML parsing behavior.
- Document metadata selection and cover discovery, fallback, validation, caching, and source-specific behavior with unit tests.

For repositories that publish `primary_db`, repeated package lookups use indexed SQLite queries instead of repeatedly scanning the full XML metadata file.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No - I did not use AI for this contribution.
- [ ] Yes - minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes - substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).
- [ ] Yes - other (please describe):

Used Codex to help design, implement, test, benchmark, document, and review the change.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

Used private repository with 60 dependencies from AL2023.

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
