### PR TITLE
docs(json-schema): set `markdownDescription` for rich-text editor previews

### DIFF
--- a/tools/docs/schema.ts
+++ b/tools/docs/schema.ts
@@ -55,6 +55,7 @@ function createSingleConfig(option: RenovateOptions): Record<string, unknown> {
   } & Omit<Partial<RenovateOptions>, 'type'> = {};
   if (option.description) {
     temp.description = option.description;
+    temp.markdownDescription = option.description;
   }
   temp.type = option.type;
   if (option.type === 'array') {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
Editors such as VSCode will look for `markdownDescription` to render the
description, if present, and will render that as Markdown, instead of
plain text.

Before:

<img width="763" height="54" alt="Screenshot 2026-03-13 at 12 05 36" src="https://github.com/user-attachments/assets/1a122bdc-6ccc-4f0f-b6c1-f65adcdc8b26" />


After:

<img width="721" height="57" alt="Screenshot 2026-03-13 at 12 05 14" src="https://github.com/user-attachments/assets/745b2668-a1bd-4d03-a0c6-6fe37889db96" />


## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
