### PR TITLE
test(rpm): use codeBlock in spec fixtures

### DIFF
--- a/lib/modules/datasource/rpm/index.spec.ts
+++ b/lib/modules/datasource/rpm/index.spec.ts
@@ -1,4 +1,5 @@
 import { gzipSync } from 'node:zlib';
+import { codeBlock } from 'common-tags';
 import * as httpMock from '~test/http-mock.ts';
 import { RpmDatasource } from './index.ts';
 
@@ -8,12 +9,14 @@ describe('modules/datasource/rpm/index', () => {
     const rpmDatasource = new RpmDatasource();
 
     it('returns the correct primary.xml URL', async () => {
-      const repomdXml = `<?xml version="1.0" encoding="UTF-8"?>
-<repomd xmlns="http://linux.duke.edu/metadata/repo" xmlns:rpm="http://linux.duke.edu/metadata/rpm">
-  <data type="primary">
-    <location href="repodata/somesha256-primary.xml.gz"/>
-  </data>
-</repomd>`;
+      const repomdXml = codeBlock`
+        <?xml version="1.0" encoding="UTF-8"?>
+        <repomd xmlns="http://linux.duke.edu/metadata/repo" xmlns:rpm="http://linux.duke.edu/metadata/rpm">
+          <data type="primary">
+            <location href="repodata/somesha256-primary.xml.gz"/>
+          </data>
+        </repomd>
+      `;
 
       httpMock
         .scope(registryUrl)
@@ -28,12 +31,14 @@ describe('modules/datasource/rpm/index', () => {
     });
 
     it('returns the correct primary.xml URL when repomd.xml omits xml declaration', async () => {
-      const repomdXml = `<repomd xmlns="http://linux.duke.edu/metadata/repo"
-  xmlns:rpm="http://linux.duke.edu/metadata/rpm">
-  <data type="primary">
-    <location href="repodata/somesha256-primary.xml.gz"/>
-  </data>
-</repomd>`;
+      const repomdXml = codeBlock`
+        <repomd xmlns="http://linux.duke.edu/metadata/repo"
+          xmlns:rpm="http://linux.duke.edu/metadata/rpm">
+          <data type="primary">
+            <location href="repodata/somesha256-primary.xml.gz"/>
+          </data>
+        </repomd>
+      `;
 
       httpMock
         .scope(registryUrl)
@@ -69,12 +74,14 @@ describe('modules/datasource/rpm/index', () => {
     });
 
     it('throws an error if repomdXml is not in XML format', async () => {
-      const repomdXml = `<?invalidxml version="1.0" encoding="UTF-8"?>
-<repomd xmlns="http://linux.duke.edu/metadata/repo" xmlns:rpm="http://linux.duke.edu/metadata/rpm">
-  <data type="primary">
-    <location href="repodata/somesha256-primary.xml.gz"/>
-  </data>
-</repomd>`;
+      const repomdXml = codeBlock`
+        <?invalidxml version="1.0" encoding="UTF-8"?>
+        <repomd xmlns="http://linux.duke.edu/metadata/repo" xmlns:rpm="http://linux.duke.edu/metadata/rpm">
+          <data type="primary">
+            <location href="repodata/somesha256-primary.xml.gz"/>
+          </data>
+        </repomd>
+      `;
       httpMock
         .scope(registryUrl)
         .get('/repomd.xml')
@@ -85,12 +92,14 @@ describe('modules/datasource/rpm/index', () => {
     });
 
     it('throws an error if no primary data is found', async () => {
-      const repomdXml = `<?xml version="1.0" encoding="UTF-8"?>
-<repomd xmlns="http://linux.duke.edu/metadata/repo" xmlns:rpm="http://linux.duke.edu/metadata/rpm">
-  <data type="non-primary">
-    <location href="repodata/somesha256-primary.xml.gz"/>
-  </data>
-</repomd>`;
+      const repomdXml = codeBlock`
+        <?xml version="1.0" encoding="UTF-8"?>
+        <repomd xmlns="http://linux.duke.edu/metadata/repo" xmlns:rpm="http://linux.duke.edu/metadata/rpm">
+          <data type="non-primary">
+            <location href="repodata/somesha256-primary.xml.gz"/>
+          </data>
+        </repomd>
+      `;
 
       httpMock
         .scope(registryUrl)
@@ -105,12 +114,14 @@ describe('modules/datasource/rpm/index', () => {
     });
 
     it('throws an error if no location element is found', async () => {
-      const repomdXml = `<?xml version="1.0" encoding="UTF-8"?>
-<repomd xmlns="http://linux.duke.edu/metadata/repo" xmlns:rpm="http://linux.duke.edu/metadata/rpm">
-  <data type="primary">
-    <non-location href="repodata/somesha256-primary.xml.gz"/>
-  </data>
-</repomd>`;
+      const repomdXml = codeBlock`
+        <?xml version="1.0" encoding="UTF-8"?>
+        <repomd xmlns="http://linux.duke.edu/metadata/repo" xmlns:rpm="http://linux.duke.edu/metadata/rpm">
+          <data type="primary">
+            <non-location href="repodata/somesha256-primary.xml.gz"/>
+          </data>
+        </repomd>
+      `;
 
       httpMock
         .scope(registryUrl)
@@ -125,12 +136,14 @@ describe('modules/datasource/rpm/index', () => {
     });
 
     it('throws an error if location href is missing', async () => {
-      const repomdXml = `<?xml version="1.0" encoding="UTF-8"?>
-<repomd xmlns="http://linux.duke.edu/metadata/repo" xmlns:rpm="http://linux.duke.edu/metadata/rpm">
-  <data type="primary">
-    <location non-href="repodata/somesha256-primary.xml.gz"/>
-  </data>
-</repomd>`;
+      const repomdXml = codeBlock`
+        <?xml version="1.0" encoding="UTF-8"?>
+        <repomd xmlns="http://linux.duke.edu/metadata/repo" xmlns:rpm="http://linux.duke.edu/metadata/rpm">
+          <data type="primary">
+            <location non-href="repodata/somesha256-primary.xml.gz"/>
+          </data>
+        </repomd>
+      `;
 
       httpMock
         .scope(registryUrl)
@@ -152,30 +165,31 @@ describe('modules/datasource/rpm/index', () => {
       'https://example.com/repo/repodata/somesha256-primary.xml.gz';
 
     it('returns the correct releases', async () => {
-      const primaryXml = `<?xml version="1.0" encoding="UTF-8"?>
-<metadata xmlns="http://linux.duke.edu/metadata/common">
-  <package type="rpm">
-    <name>example-package</name>
-    <arch>x86_64</arch>
-    <version epoch="0" ver="1.0" rel="2.azl3"/>
-  </package>
-  <package type="rpm">
-    <name>example-package</name>
-    <arch>x86_64</arch>
-    <version epoch="0" ver="1.1" rel="1.azl3"/>
-  </package>
-  <package type="rpm">
-    <name>example-package</name>
-    <arch>x86_64</arch>
-    <version epoch="0" ver="1.1" rel="2.azl3"/>
-  </package>
-  <package type="rpm">
-    <name>example-package</name>
-    <arch>x86_64</arch>
-    <version epoch="0" ver="1.2"/>
-  </package>
-</metadata>
-`;
+      const primaryXml = codeBlock`
+        <?xml version="1.0" encoding="UTF-8"?>
+        <metadata xmlns="http://linux.duke.edu/metadata/common">
+          <package type="rpm">
+            <name>example-package</name>
+            <arch>x86_64</arch>
+            <version epoch="0" ver="1.0" rel="2.azl3"/>
+          </package>
+          <package type="rpm">
+            <name>example-package</name>
+            <arch>x86_64</arch>
+            <version epoch="0" ver="1.1" rel="1.azl3"/>
+          </package>
+          <package type="rpm">
+            <name>example-package</name>
+            <arch>x86_64</arch>
+            <version epoch="0" ver="1.1" rel="2.azl3"/>
+          </package>
+          <package type="rpm">
+            <name>example-package</name>
+            <arch>x86_64</arch>
+            <version epoch="0" ver="1.2"/>
+          </package>
+        </metadata>
+      `;
       // gzip the primaryXml content
       const gzippedPrimaryXml = gzipSync(primaryXml);
       httpMock
@@ -233,15 +247,16 @@ describe('modules/datasource/rpm/index', () => {
     });
 
     it('returns null if no element package is found in primary.xml', async () => {
-      const primaryXml = `<?xml version="1.0" encoding="UTF-8"?>
-<metadata xmlns="http://linux.duke.edu/metadata/common">
-  <nonpackage type="rpm">
-    <name>example-package</name>
-    <arch>x86_64</arch>
-    <version epoch="0" ver="1.0" rel="2.azl3"/>
-  </nonpackage>
-</metadata>
-`;
+      const primaryXml = codeBlock`
+        <?xml version="1.0" encoding="UTF-8"?>
+        <metadata xmlns="http://linux.duke.edu/metadata/common">
+          <nonpackage type="rpm">
+            <name>example-package</name>
+            <arch>x86_64</arch>
+            <version epoch="0" ver="1.0" rel="2.azl3"/>
+          </nonpackage>
+        </metadata>
+      `;
       // gzip the primaryXml content
       const gzippedprimaryXml = gzipSync(primaryXml);
       httpMock
@@ -258,15 +273,16 @@ describe('modules/datasource/rpm/index', () => {
     });
 
     it('returns null if the specific packageName is not found in primary.xml', async () => {
-      const primaryXml = `<?xml version="1.0" encoding="UTF-8"?>
-<metadata xmlns="http://linux.duke.edu/metadata/common">
-  <nonpackage type="rpm">
-    <name>wrong-package</name>
-    <arch>x86_64</arch>
-    <version epoch="0" ver="1.0" rel="2.azl3"/>
-  </nonpackage>
-</metadata>
-`;
+      const primaryXml = codeBlock`
+        <?xml version="1.0" encoding="UTF-8"?>
+        <metadata xmlns="http://linux.duke.edu/metadata/common">
+          <nonpackage type="rpm">
+            <name>wrong-package</name>
+            <arch>x86_64</arch>
+            <version epoch="0" ver="1.0" rel="2.azl3"/>
+          </nonpackage>
+        </metadata>
+      `;
       // gzip the primaryXml content
       const gzippedprimaryXml = gzipSync(primaryXml);
       httpMock
@@ -284,15 +300,16 @@ describe('modules/datasource/rpm/index', () => {
     });
 
     it('returns an empty array if version is not found in a version element', async () => {
-      const primaryXml = `<?xml version="1.0" encoding="UTF-8"?>
-<metadata xmlns="http://linux.duke.edu/metadata/common">
-  <package type="rpm">
-    <name>example-package</name>
-    <arch>x86_64</arch>
-    <non-version epoch="0" ver="1.0" rel="2.azl3"/>
-  </package>
-</metadata>
-`;
+      const primaryXml = codeBlock`
+        <?xml version="1.0" encoding="UTF-8"?>
+        <metadata xmlns="http://linux.duke.edu/metadata/common">
+          <package type="rpm">
+            <name>example-package</name>
+            <arch>x86_64</arch>
+            <non-version epoch="0" ver="1.0" rel="2.azl3"/>
+          </package>
+        </metadata>
+      `;
       // gzip the primaryXml content
       const gzippedprimaryXml = gzipSync(primaryXml);
       httpMock
@@ -312,20 +329,21 @@ describe('modules/datasource/rpm/index', () => {
     it('returns an array of releases without duplicate versionWithRel', async () => {
       const primaryXmlUrl =
         'https://example.com/repo/repodata/somesha256-primary.xml.gz';
-      const primaryXml = `<?xml version="1.0" encoding="UTF-8"?>
-<metadata xmlns="http://linux.duke.edu/metadata/common">
-  <package type="rpm">
-    <name>example-package</name>
-    <arch>x86_64</arch>
-    <version epoch="0" ver="1.0" rel="dulp.azl3"/>
-  </package>
-  <package type="rpm">
-    <name>example-package</name>
-    <arch>x86_64</arch>
-    <version epoch="0" ver="1.0" rel="dulp.azl3"/>
-  </package>
-</metadata>
-`;
+      const primaryXml = codeBlock`
+        <?xml version="1.0" encoding="UTF-8"?>
+        <metadata xmlns="http://linux.duke.edu/metadata/common">
+          <package type="rpm">
+            <name>example-package</name>
+            <arch>x86_64</arch>
+            <version epoch="0" ver="1.0" rel="dulp.azl3"/>
+          </package>
+          <package type="rpm">
+            <name>example-package</name>
+            <arch>x86_64</arch>
+            <version epoch="0" ver="1.0" rel="dulp.azl3"/>
+          </package>
+        </metadata>
+      `;
       // gzip the primaryXml content
       const gzippedprimaryXml = gzipSync(primaryXml);
       httpMock
@@ -348,14 +366,16 @@ describe('modules/datasource/rpm/index', () => {
     });
 
     it('handles parser error event in getReleasesByPackageName', async () => {
-      const primaryXmlMalformed = `<?xml version="1.0" encoding="UTF-8"?>
-<%$#metadata xmlns="http://linux.duke.edu/metadata/common">
-  <package type="rpm">
-    <name>example-package</name>
-    <arch>x86_64</arch>
-    <version epoch="0" ver="1.0" rel="dulp.azl3"/>
-  </package>
-</metadata>`;
+      const primaryXmlMalformed = codeBlock`
+        <?xml version="1.0" encoding="UTF-8"?>
+        <%$#metadata xmlns="http://linux.duke.edu/metadata/common">
+          <package type="rpm">
+            <name>example-package</name>
+            <arch>x86_64</arch>
+            <version epoch="0" ver="1.0" rel="dulp.azl3"/>
+          </package>
+        </metadata>
+      `;
       // gzip the primaryXml content
       const gzippedprimaryXml = gzipSync(primaryXmlMalformed);
       httpMock


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

A follow-up to the comment https://github.com/renovatebot/renovate/pull/41850#discussion_r2926295722 in my previous MR for RPM. Switches all tests for RPM data source to use `codeBlock`.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
