### PR TITLE
feat(replacements): `rolldown-vite` to `vite`

### DIFF
--- a/lib/data/replacements.json
+++ b/lib/data/replacements.json
@@ -46,6 +46,7 @@
       "replacements:rollup-json-to-scoped",
       "replacements:rollup-node-resolve-to-scoped",
       "replacements:rollup-terser-to-scoped",
+      "replacements:rolldown-vite-to-vite",
       "replacements:rome-to-biome",
       "replacements:semantic-release-replace-plugin-to-unscoped",
       "replacements:spectre-cli-to-spectre-console-cli",
@@ -1049,6 +1050,17 @@
         "matchPackageNames": ["rollup-plugin-terser"],
         "replacementName": "@rollup/plugin-terser",
         "replacementVersion": "0.1.0"
+      }
+    ]
+  },
+  "rolldown-vite-to-vite": {
+    "description": "`rolldown-vite` was merged to `vite` in version 8.0.0.",
+    "packageRules": [
+      {
+        "matchDatasources": ["npm"],
+        "matchPackageNames": ["rolldown-vite"],
+        "replacementName": "vite",
+        "replacementVersion": "8.0.0"
       }
     ]
   },

--- a/lib/data/replacements.json
+++ b/lib/data/replacements.json
@@ -42,11 +42,11 @@
       "replacements:read-pkg-up-rename",
       "replacements:redux-devtools-extension-to-scope",
       "replacements:renovate-pep440-to-renovatebot-pep440",
+      "replacements:rolldown-vite-to-vite",
       "replacements:rollup-babel-to-scoped",
       "replacements:rollup-json-to-scoped",
       "replacements:rollup-node-resolve-to-scoped",
       "replacements:rollup-terser-to-scoped",
-      "replacements:rolldown-vite-to-vite",
       "replacements:rome-to-biome",
       "replacements:semantic-release-replace-plugin-to-unscoped",
       "replacements:spectre-cli-to-spectre-console-cli",
@@ -1008,6 +1008,17 @@
       }
     ]
   },
+  "rolldown-vite-to-vite": {
+    "description": "`rolldown-vite` was merged to `vite` in version 8.0.0.",
+    "packageRules": [
+      {
+        "matchDatasources": ["npm"],
+        "matchPackageNames": ["rolldown-vite"],
+        "replacementName": "vite",
+        "replacementVersion": "8.0.0"
+      }
+    ]
+  },
   "rollup-babel-to-scoped": {
     "description": "The babel plugin for rollup became scoped.",
     "packageRules": [
@@ -1050,17 +1061,6 @@
         "matchPackageNames": ["rollup-plugin-terser"],
         "replacementName": "@rollup/plugin-terser",
         "replacementVersion": "0.1.0"
-      }
-    ]
-  },
-  "rolldown-vite-to-vite": {
-    "description": "`rolldown-vite` was merged to `vite` in version 8.0.0.",
-    "packageRules": [
-      {
-        "matchDatasources": ["npm"],
-        "matchPackageNames": ["rolldown-vite"],
-        "replacementName": "vite",
-        "replacementVersion": "8.0.0"
       }
     ]
   },


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Created a replacement rule for the [`rolldown-vite`](https://npmx.dev/package/rolldown-vite) package with [`vite`](https://npmx.dev/package/vite) package as it was merged in version 8.0.0.
<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
