### PR TITLE
refactor(datasource/rpm): extract xml metadata provider

### DIFF
--- a/lib/modules/datasource/rpm/common.ts
+++ b/lib/modules/datasource/rpm/common.ts
@@ -1,0 +1,2 @@
+export const datasource = 'rpm';
+export const repomdXmlFileName = 'repomd.xml';

--- a/lib/modules/datasource/rpm/index.spec.ts
+++ b/lib/modules/datasource/rpm/index.spec.ts
@@ -8,6 +8,7 @@ import { GlobalConfig } from '../../../config/global.ts';
 import * as memCache from '../../../util/cache/memory/index.ts';
 import * as packageCache from '../../../util/cache/package/index.ts';
 import * as cacheFs from '../../../util/fs/index.ts';
+import { toSha256 } from '../../../util/hash.ts';
 import { RpmDatasource } from './index.ts';
 
 const registryUrl = 'https://example.com/repo/repodata/';
@@ -187,6 +188,7 @@ describe('modules/datasource/rpm/index', () => {
 
   describe('getReleasesByPackageName', () => {
     const packageName = 'example-package';
+    const extractedPrimaryXmlPath = `others/rpm/${toSha256(primaryXmlUrl)}.xml`;
 
     function buildPrimaryXml(packageEntries: string): string {
       return codeBlock`
@@ -407,6 +409,111 @@ describe('modules/datasource/rpm/index', () => {
       await expect(
         rpmDatasource.getReleasesByPackageName(primaryXmlUrl, packageName),
       ).rejects.toThrow('Missing metadata in extracted RPM metadata file!');
+    });
+
+    it('keeps the previous extracted primary.xml if a refresh extract fails', async () => {
+      const originalPipeline = cacheFs.pipeline;
+
+      mockPrimaryXmlResponse(
+        buildPrimaryXml(codeBlock`
+          <package type="rpm">
+            <name>example-package</name>
+            <arch>x86_64</arch>
+            <version epoch="0" ver="1.0" rel="2.azl3"/>
+          </package>
+        `),
+      );
+
+      expect(
+        await rpmDatasource.getReleasesByPackageName(
+          primaryXmlUrl,
+          packageName,
+        ),
+      ).toEqual({
+        releases: [{ version: '1.0-2.azl3' }],
+      });
+
+      httpMock
+        .scope(primaryXmlRegistryUrl)
+        .head('/somesha256-primary.xml.gz')
+        .once()
+        .reply(200);
+      mockPrimaryXmlResponse(
+        buildPrimaryXml(codeBlock`
+          <package type="rpm">
+            <name>example-package</name>
+            <arch>x86_64</arch>
+            <version epoch="0" ver="2.0" rel="1.azl3"/>
+          </package>
+        `),
+      );
+
+      vi.spyOn(cacheFs, 'pipeline')
+        .mockImplementationOnce(
+          (...args: Parameters<typeof cacheFs.pipeline>) =>
+            originalPipeline(...args),
+        )
+        .mockRejectedValueOnce(new Error('extract failed'));
+
+      expect(
+        await rpmDatasource.getReleasesByPackageName(
+          primaryXmlUrl,
+          packageName,
+        ),
+      ).toEqual({
+        releases: [{ version: '1.0-2.azl3' }],
+      });
+      await expect(
+        cacheFs.readCacheFile(extractedPrimaryXmlPath, 'utf8'),
+      ).resolves.toContain('ver="1.0"');
+    });
+
+    it('replaces the extracted primary.xml after a successful refresh', async () => {
+      mockPrimaryXmlResponse(
+        buildPrimaryXml(codeBlock`
+          <package type="rpm">
+            <name>example-package</name>
+            <arch>x86_64</arch>
+            <version epoch="0" ver="1.0" rel="2.azl3"/>
+          </package>
+        `),
+      );
+
+      expect(
+        await rpmDatasource.getReleasesByPackageName(
+          primaryXmlUrl,
+          packageName,
+        ),
+      ).toEqual({
+        releases: [{ version: '1.0-2.azl3' }],
+      });
+
+      httpMock
+        .scope(primaryXmlRegistryUrl)
+        .head('/somesha256-primary.xml.gz')
+        .once()
+        .reply(200);
+      mockPrimaryXmlResponse(
+        buildPrimaryXml(codeBlock`
+          <package type="rpm">
+            <name>example-package</name>
+            <arch>x86_64</arch>
+            <version epoch="0" ver="2.0" rel="1.azl3"/>
+          </package>
+        `),
+      );
+
+      expect(
+        await rpmDatasource.getReleasesByPackageName(
+          primaryXmlUrl,
+          packageName,
+        ),
+      ).toEqual({
+        releases: [{ version: '2.0-1.azl3' }],
+      });
+      await expect(
+        cacheFs.readCacheFile(extractedPrimaryXmlPath, 'utf8'),
+      ).resolves.toContain('ver="2.0"');
     });
 
     it('returns null if no element package is found in primary.xml', async () => {

--- a/lib/modules/datasource/rpm/index.spec.ts
+++ b/lib/modules/datasource/rpm/index.spec.ts
@@ -1,16 +1,44 @@
+import { Readable } from 'node:stream';
 import { gzipSync } from 'node:zlib';
 import { codeBlock } from 'common-tags';
+import type { DirectoryResult } from 'tmp-promise';
+import { dir as tmpDir } from 'tmp-promise';
 import * as httpMock from '~test/http-mock.ts';
+import { GlobalConfig } from '../../../config/global.ts';
+import * as memCache from '../../../util/cache/memory/index.ts';
+import * as packageCache from '../../../util/cache/package/index.ts';
+import * as cacheFs from '../../../util/fs/index.ts';
 import { RpmDatasource } from './index.ts';
 
 const registryUrl = 'https://example.com/repo/repodata/';
 const primaryXmlUrl =
   'https://example.com/repo/repodata/somesha256-primary.xml.gz';
+const primaryXmlRegistryUrl = primaryXmlUrl.replace(/\/[^/]+$/, '');
 
 describe('modules/datasource/rpm/index', () => {
-  describe('getPrimaryGzipUrl', () => {
-    const rpmDatasource = new RpmDatasource();
+  let cacheDirResult: DirectoryResult | null;
+  let rpmDatasource: RpmDatasource;
 
+  beforeEach(async () => {
+    rpmDatasource = new RpmDatasource();
+    cacheDirResult = await tmpDir({ unsafeCleanup: true });
+
+    GlobalConfig.reset();
+    memCache.init();
+    GlobalConfig.set({ cacheDir: cacheDirResult.path });
+    await packageCache.init({ cacheDir: cacheDirResult.path });
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await packageCache.cleanup({});
+    memCache.reset();
+    GlobalConfig.reset();
+    await cacheDirResult?.cleanup();
+    cacheDirResult = null;
+  });
+
+  describe('getPrimaryGzipUrl', () => {
     it('returns the correct primary.xml URL', async () => {
       const repomdXml = codeBlock`
         <?xml version="1.0" encoding="UTF-8"?>
@@ -159,8 +187,6 @@ describe('modules/datasource/rpm/index', () => {
 
   describe('getReleasesByPackageName', () => {
     const packageName = 'example-package';
-    const rpmDatasource = new RpmDatasource();
-    const primaryXmlRegistryUrl = primaryXmlUrl.replace(/\/[^/]+$/, '');
 
     function buildPrimaryXml(packageEntries: string): string {
       return codeBlock`
@@ -249,15 +275,60 @@ describe('modules/datasource/rpm/index', () => {
       vi.spyOn(
         (
           rpmDatasource as unknown as {
-            http: { getBuffer: (url: string) => unknown };
+            http: { stream: (url: string) => NodeJS.ReadableStream };
           }
         ).http,
-        'getBuffer',
-      ).mockRejectedValue('boom');
+        'stream',
+      ).mockReturnValue(Readable.from([]));
+      vi.spyOn(cacheFs, 'pipeline').mockRejectedValue('boom');
 
       await expect(
         rpmDatasource.getReleasesByPackageName(primaryXmlUrl, packageName),
       ).rejects.toBe('boom');
+    });
+
+    it('reuses the extracted primary.xml file across package lookups', async () => {
+      const primaryXml = buildPrimaryXml(codeBlock`
+        <package type="rpm">
+          <name>bash</name>
+          <arch>x86_64</arch>
+          <version epoch="0" ver="5.2.15" rel="1.azl3"/>
+        </package>
+        <package type="rpm">
+          <name>curl</name>
+          <arch>x86_64</arch>
+          <version epoch="0" ver="8.5.0" rel="2.azl3"/>
+        </package>
+      `);
+
+      httpMock
+        .scope(primaryXmlRegistryUrl)
+        .get('/somesha256-primary.xml.gz')
+        .once()
+        .reply(200, gzipSync(primaryXml), {
+          'Content-Type': 'application/gzip',
+        });
+      httpMock
+        .scope(primaryXmlRegistryUrl)
+        .head('/somesha256-primary.xml.gz')
+        .once()
+        .reply(304);
+
+      const bashReleases = await rpmDatasource.getReleasesByPackageName(
+        primaryXmlUrl,
+        'bash',
+      );
+      const curlReleases = await rpmDatasource.getReleasesByPackageName(
+        primaryXmlUrl,
+        'curl',
+      );
+
+      expect(bashReleases).toEqual({
+        releases: [{ version: '5.2.15-1.azl3' }],
+      });
+      expect(curlReleases).toEqual({
+        releases: [{ version: '8.5.0-2.azl3' }],
+      });
     });
 
     it('returns null if no element package is found in primary.xml', async () => {
@@ -381,8 +452,6 @@ describe('modules/datasource/rpm/index', () => {
   });
 
   describe('getReleases', () => {
-    const rpmDatasource = new RpmDatasource();
-
     it('returns null if registryUrl is not provided', async () => {
       const releases = await rpmDatasource.getReleases({
         registryUrl: undefined,

--- a/lib/modules/datasource/rpm/index.spec.ts
+++ b/lib/modules/datasource/rpm/index.spec.ts
@@ -331,6 +331,84 @@ describe('modules/datasource/rpm/index', () => {
       });
     });
 
+    it('re-downloads primary.xml if the freshness check fails', async () => {
+      const primaryXml = buildPrimaryXml(codeBlock`
+        <package type="rpm">
+          <name>bash</name>
+          <arch>x86_64</arch>
+          <version epoch="0" ver="5.2.15" rel="1.azl3"/>
+        </package>
+        <package type="rpm">
+          <name>curl</name>
+          <arch>x86_64</arch>
+          <version epoch="0" ver="8.5.0" rel="2.azl3"/>
+        </package>
+      `);
+
+      httpMock
+        .scope(primaryXmlRegistryUrl)
+        .get('/somesha256-primary.xml.gz')
+        .twice()
+        .reply(200, gzipSync(primaryXml), {
+          'Content-Type': 'application/gzip',
+        });
+      httpMock
+        .scope(primaryXmlRegistryUrl)
+        .head('/somesha256-primary.xml.gz')
+        .once()
+        .replyWithError('Unexpected Error');
+
+      const bashReleases = await rpmDatasource.getReleasesByPackageName(
+        primaryXmlUrl,
+        'bash',
+      );
+      const curlReleases = await rpmDatasource.getReleasesByPackageName(
+        primaryXmlUrl,
+        'curl',
+      );
+
+      expect(bashReleases).toEqual({
+        releases: [{ version: '5.2.15-1.azl3' }],
+      });
+      expect(curlReleases).toEqual({
+        releases: [{ version: '8.5.0-2.azl3' }],
+      });
+    });
+
+    it('throws if extracting primary.xml fails without an existing cache file', async () => {
+      const originalPipeline = cacheFs.pipeline;
+
+      httpMock
+        .scope(primaryXmlRegistryUrl)
+        .get('/somesha256-primary.xml.gz')
+        .reply(
+          200,
+          gzipSync(
+            buildPrimaryXml(codeBlock`
+              <package type="rpm">
+                <name>example-package</name>
+                <arch>x86_64</arch>
+                <version epoch="0" ver="1.0" rel="2.azl3"/>
+              </package>
+            `),
+          ),
+          {
+            'Content-Type': 'application/gzip',
+          },
+        );
+
+      vi.spyOn(cacheFs, 'pipeline')
+        .mockImplementationOnce(
+          (...args: Parameters<typeof cacheFs.pipeline>) =>
+            originalPipeline(...args),
+        )
+        .mockRejectedValueOnce('extract failed');
+
+      await expect(
+        rpmDatasource.getReleasesByPackageName(primaryXmlUrl, packageName),
+      ).rejects.toThrow('Missing metadata in extracted RPM metadata file!');
+    });
+
     it('returns null if no element package is found in primary.xml', async () => {
       mockPrimaryXmlResponse(
         buildPrimaryXml(codeBlock`

--- a/lib/modules/datasource/rpm/index.spec.ts
+++ b/lib/modules/datasource/rpm/index.spec.ts
@@ -3,9 +3,12 @@ import { codeBlock } from 'common-tags';
 import * as httpMock from '~test/http-mock.ts';
 import { RpmDatasource } from './index.ts';
 
+const registryUrl = 'https://example.com/repo/repodata/';
+const primaryXmlUrl =
+  'https://example.com/repo/repodata/somesha256-primary.xml.gz';
+
 describe('modules/datasource/rpm/index', () => {
   describe('getPrimaryGzipUrl', () => {
-    const registryUrl = 'https://example.com/repo/repodata/';
     const rpmDatasource = new RpmDatasource();
 
     it('returns the correct primary.xml URL', async () => {
@@ -21,13 +24,12 @@ describe('modules/datasource/rpm/index', () => {
       httpMock
         .scope(registryUrl)
         .get('/repomd.xml')
-        .reply(200, repomdXml, { 'Content-Type': 'application/gzip' });
+        .reply(200, repomdXml, { 'Content-Type': 'application/xml' });
 
-      const primaryXmlUrl = await rpmDatasource.getPrimaryGzipUrl(registryUrl);
+      const resolvedPrimaryXmlUrl =
+        await rpmDatasource.getPrimaryGzipUrl(registryUrl);
 
-      expect(primaryXmlUrl).toBe(
-        'https://example.com/repo/repodata/somesha256-primary.xml.gz',
-      );
+      expect(resolvedPrimaryXmlUrl).toBe(primaryXmlUrl);
     });
 
     it('returns the correct primary.xml URL when repomd.xml omits xml declaration', async () => {
@@ -45,11 +47,10 @@ describe('modules/datasource/rpm/index', () => {
         .get('/repomd.xml')
         .reply(200, repomdXml, { 'Content-Type': 'application/xml' });
 
-      const primaryXmlUrl = await rpmDatasource.getPrimaryGzipUrl(registryUrl);
+      const resolvedPrimaryXmlUrl =
+        await rpmDatasource.getPrimaryGzipUrl(registryUrl);
 
-      expect(primaryXmlUrl).toBe(
-        'https://example.com/repo/repodata/somesha256-primary.xml.gz',
-      );
+      expect(resolvedPrimaryXmlUrl).toBe(primaryXmlUrl);
     });
 
     it('throws an error if repomd.xml is missing', async () => {
@@ -58,7 +59,7 @@ describe('modules/datasource/rpm/index', () => {
       await expect(
         rpmDatasource.getPrimaryGzipUrl(registryUrl),
       ).rejects.toThrow(
-        `Request failed with status code 404 (Not Found): GET https://example.com/repo/repodata/repomd.xml`,
+        `Request failed with status code 404 (Not Found): GET ${registryUrl}repomd.xml`,
       );
     });
 
@@ -82,10 +83,12 @@ describe('modules/datasource/rpm/index', () => {
           </data>
         </repomd>
       `;
+
       httpMock
         .scope(registryUrl)
         .get('/repomd.xml')
         .reply(200, repomdXml, { 'Content-Type': 'application/xml' });
+
       await expect(
         rpmDatasource.getPrimaryGzipUrl(registryUrl),
       ).rejects.toThrow(`is not in XML format.`);
@@ -108,9 +111,7 @@ describe('modules/datasource/rpm/index', () => {
 
       await expect(
         rpmDatasource.getPrimaryGzipUrl(registryUrl),
-      ).rejects.toThrow(
-        'No primary data found in https://example.com/repo/repodata/repomd.xml',
-      );
+      ).rejects.toThrow(`No primary data found in ${registryUrl}repomd.xml`);
     });
 
     it('throws an error if no location element is found', async () => {
@@ -131,7 +132,7 @@ describe('modules/datasource/rpm/index', () => {
       await expect(
         rpmDatasource.getPrimaryGzipUrl(registryUrl),
       ).rejects.toThrow(
-        'No location element found in https://example.com/repo/repodata/repomd.xml',
+        `No location element found in ${registryUrl}repomd.xml`,
       );
     });
 
@@ -152,22 +153,36 @@ describe('modules/datasource/rpm/index', () => {
 
       await expect(
         rpmDatasource.getPrimaryGzipUrl(registryUrl),
-      ).rejects.toThrow(
-        `No href found in https://example.com/repo/repodata/repomd.xml`,
-      );
+      ).rejects.toThrow(`No href found in ${registryUrl}repomd.xml`);
     });
   });
 
   describe('getReleasesByPackageName', () => {
     const packageName = 'example-package';
     const rpmDatasource = new RpmDatasource();
-    const primaryXmlUrl =
-      'https://example.com/repo/repodata/somesha256-primary.xml.gz';
+    const primaryXmlRegistryUrl = primaryXmlUrl.replace(/\/[^/]+$/, '');
 
-    it('returns the correct releases', async () => {
-      const primaryXml = codeBlock`
+    function buildPrimaryXml(packageEntries: string): string {
+      return codeBlock`
         <?xml version="1.0" encoding="UTF-8"?>
         <metadata xmlns="http://linux.duke.edu/metadata/common">
+          ${packageEntries}
+        </metadata>
+      `;
+    }
+
+    function mockPrimaryXmlResponse(primaryXml: string): void {
+      httpMock
+        .scope(primaryXmlRegistryUrl)
+        .get('/somesha256-primary.xml.gz')
+        .reply(200, gzipSync(primaryXml), {
+          'Content-Type': 'application/gzip',
+        });
+    }
+
+    it('returns the correct releases', async () => {
+      mockPrimaryXmlResponse(
+        buildPrimaryXml(codeBlock`
           <package type="rpm">
             <name>example-package</name>
             <arch>x86_64</arch>
@@ -188,109 +203,93 @@ describe('modules/datasource/rpm/index', () => {
             <arch>x86_64</arch>
             <version epoch="0" ver="1.2"/>
           </package>
-        </metadata>
-      `;
-      // gzip the primaryXml content
-      const gzippedPrimaryXml = gzipSync(primaryXml);
-      httpMock
-        .scope(primaryXmlUrl.replace(/\/[^/]+$/, ''))
-        .get('/somesha256-primary.xml.gz')
-        .reply(200, gzippedPrimaryXml, {
-          'Content-Type': 'application/gzip',
-        });
+        `),
+      );
+
       const releases = await rpmDatasource.getReleasesByPackageName(
         primaryXmlUrl,
         packageName,
       );
+
       expect(releases).toEqual({
         releases: [
-          {
-            version: '1.0-2.azl3',
-          },
-          {
-            version: '1.1-1.azl3',
-          },
-          {
-            version: '1.1-2.azl3',
-          },
-          {
-            version: '1.2',
-          },
+          { version: '1.0-2.azl3' },
+          { version: '1.1-1.azl3' },
+          { version: '1.1-2.azl3' },
+          { version: '1.2' },
         ],
       });
     });
 
     it('throws an error if somesha256-primary.xml.gz is not found', async () => {
       httpMock
-        .scope(primaryXmlUrl.replace(/\/[^/]+$/, ''))
+        .scope(primaryXmlRegistryUrl)
         .get('/somesha256-primary.xml.gz')
         .reply(404, 'Not Found');
 
       await expect(
         rpmDatasource.getReleasesByPackageName(primaryXmlUrl, packageName),
       ).rejects.toThrow(
-        `Request failed with status code 404 (Not Found): GET https://example.com/repo/repodata/somesha256-primary.xml.gz`,
+        `Request failed with status code 404 (Not Found): GET ${primaryXmlUrl}`,
       );
     });
 
     it('throws an error if response.body is empty', async () => {
       httpMock
-        .scope(primaryXmlUrl.replace(/\/[^/]+$/, ''))
+        .scope(primaryXmlRegistryUrl)
         .get('/somesha256-primary.xml.gz')
         .reply(200, '', { 'Content-Type': 'application/gzip' });
 
       await expect(
         rpmDatasource.getReleasesByPackageName(primaryXmlUrl, packageName),
-      ).rejects.toThrowError(
-        'Empty response body from getting ' + primaryXmlUrl + '.',
-      );
+      ).rejects.toThrow(`Empty response body from getting ${primaryXmlUrl}.`);
+    });
+
+    it('rethrows non-Error fetch failures', async () => {
+      vi.spyOn(
+        (
+          rpmDatasource as unknown as {
+            http: { getBuffer: (url: string) => unknown };
+          }
+        ).http,
+        'getBuffer',
+      ).mockRejectedValue('boom');
+
+      await expect(
+        rpmDatasource.getReleasesByPackageName(primaryXmlUrl, packageName),
+      ).rejects.toBe('boom');
     });
 
     it('returns null if no element package is found in primary.xml', async () => {
-      const primaryXml = codeBlock`
-        <?xml version="1.0" encoding="UTF-8"?>
-        <metadata xmlns="http://linux.duke.edu/metadata/common">
+      mockPrimaryXmlResponse(
+        buildPrimaryXml(codeBlock`
           <nonpackage type="rpm">
             <name>example-package</name>
             <arch>x86_64</arch>
             <version epoch="0" ver="1.0" rel="2.azl3"/>
           </nonpackage>
-        </metadata>
-      `;
-      // gzip the primaryXml content
-      const gzippedprimaryXml = gzipSync(primaryXml);
-      httpMock
-        .scope(primaryXmlUrl.replace(/\/[^/]+$/, ''))
-        .get('/somesha256-primary.xml.gz')
-        .reply(200, gzippedprimaryXml, {
-          'Content-Type': 'application/gzip',
-        });
+        `),
+      );
+
       const result = await rpmDatasource.getReleasesByPackageName(
         primaryXmlUrl,
         packageName,
       );
+
       expect(result).toBeNull();
     });
 
     it('returns null if the specific packageName is not found in primary.xml', async () => {
-      const primaryXml = codeBlock`
-        <?xml version="1.0" encoding="UTF-8"?>
-        <metadata xmlns="http://linux.duke.edu/metadata/common">
-          <nonpackage type="rpm">
+      mockPrimaryXmlResponse(
+        buildPrimaryXml(codeBlock`
+          <package type="rpm">
             <name>wrong-package</name>
             <arch>x86_64</arch>
             <version epoch="0" ver="1.0" rel="2.azl3"/>
-          </nonpackage>
-        </metadata>
-      `;
-      // gzip the primaryXml content
-      const gzippedprimaryXml = gzipSync(primaryXml);
-      httpMock
-        .scope(primaryXmlUrl.replace(/\/[^/]+$/, ''))
-        .get('/somesha256-primary.xml.gz')
-        .reply(200, gzippedprimaryXml, {
-          'Content-Type': 'application/gzip',
-        });
+          </package>
+        `),
+      );
+
       expect(
         await rpmDatasource.getReleasesByPackageName(
           primaryXmlUrl,
@@ -299,74 +298,72 @@ describe('modules/datasource/rpm/index', () => {
       ).toBeNull();
     });
 
-    it('returns an empty array if version is not found in a version element', async () => {
-      const primaryXml = codeBlock`
-        <?xml version="1.0" encoding="UTF-8"?>
-        <metadata xmlns="http://linux.duke.edu/metadata/common">
+    it('returns null if version is not found in a version element', async () => {
+      mockPrimaryXmlResponse(
+        buildPrimaryXml(codeBlock`
           <package type="rpm">
             <name>example-package</name>
             <arch>x86_64</arch>
             <non-version epoch="0" ver="1.0" rel="2.azl3"/>
           </package>
-        </metadata>
-      `;
-      // gzip the primaryXml content
-      const gzippedprimaryXml = gzipSync(primaryXml);
-      httpMock
-        .scope(primaryXmlUrl.replace(/\/[^/]+$/, ''))
-        .get('/somesha256-primary.xml.gz')
-        .reply(200, gzippedprimaryXml, {
-          'Content-Type': 'application/gzip',
-        });
+        `),
+      );
+
       const releases = await rpmDatasource.getReleasesByPackageName(
         primaryXmlUrl,
         packageName,
       );
+
       expect(releases).toBeNull();
     });
 
-    // this is most likely a bug in the RPM XML file, but we can still handle it gracefully
-    it('returns an array of releases without duplicate versionWithRel', async () => {
-      const primaryXmlUrl =
-        'https://example.com/repo/repodata/somesha256-primary.xml.gz';
-      const primaryXml = codeBlock`
-        <?xml version="1.0" encoding="UTF-8"?>
-        <metadata xmlns="http://linux.duke.edu/metadata/common">
+    it('returns null if version element is missing the ver attribute', async () => {
+      mockPrimaryXmlResponse(
+        buildPrimaryXml(codeBlock`
           <package type="rpm">
             <name>example-package</name>
             <arch>x86_64</arch>
-            <version epoch="0" ver="1.0" rel="dulp.azl3"/>
+            <version epoch="0" rel="2.azl3"/>
           </package>
-          <package type="rpm">
-            <name>example-package</name>
-            <arch>x86_64</arch>
-            <version epoch="0" ver="1.0" rel="dulp.azl3"/>
-          </package>
-        </metadata>
-      `;
-      // gzip the primaryXml content
-      const gzippedprimaryXml = gzipSync(primaryXml);
-      httpMock
-        .scope(primaryXmlUrl.replace(/\/[^/]+$/, ''))
-        .get('/somesha256-primary.xml.gz')
-        .reply(200, gzippedprimaryXml, {
-          'Content-Type': 'application/gzip',
-        });
+        `),
+      );
+
       const releases = await rpmDatasource.getReleasesByPackageName(
         primaryXmlUrl,
         packageName,
       );
+
+      expect(releases).toBeNull();
+    });
+
+    it('returns an array of releases without duplicate versionWithRel', async () => {
+      mockPrimaryXmlResponse(
+        buildPrimaryXml(codeBlock`
+          <package type="rpm">
+            <name>example-package</name>
+            <arch>x86_64</arch>
+            <version epoch="0" ver="1.0" rel="dulp.azl3"/>
+          </package>
+          <package type="rpm">
+            <name>example-package</name>
+            <arch>x86_64</arch>
+            <version epoch="0" ver="1.0" rel="dulp.azl3"/>
+          </package>
+        `),
+      );
+
+      const releases = await rpmDatasource.getReleasesByPackageName(
+        primaryXmlUrl,
+        packageName,
+      );
+
       expect(releases).toEqual({
-        releases: [
-          {
-            version: '1.0-dulp.azl3',
-          },
-        ],
+        releases: [{ version: '1.0-dulp.azl3' }],
       });
     });
 
     it('handles parser error event in getReleasesByPackageName', async () => {
-      const primaryXmlMalformed = codeBlock`
+      mockPrimaryXmlResponse(codeBlock`
         <?xml version="1.0" encoding="UTF-8"?>
         <%$#metadata xmlns="http://linux.duke.edu/metadata/common">
           <package type="rpm">
@@ -375,15 +372,8 @@ describe('modules/datasource/rpm/index', () => {
             <version epoch="0" ver="1.0" rel="dulp.azl3"/>
           </package>
         </metadata>
-      `;
-      // gzip the primaryXml content
-      const gzippedprimaryXml = gzipSync(primaryXmlMalformed);
-      httpMock
-        .scope(primaryXmlUrl.replace(/\/[^/]+$/, ''))
-        .get('/somesha256-primary.xml.gz')
-        .reply(200, gzippedprimaryXml, {
-          'Content-Type': 'application/gzip',
-        });
+      `);
+
       await expect(
         rpmDatasource.getReleasesByPackageName(primaryXmlUrl, packageName),
       ).rejects.toThrowError('Unencoded <');
@@ -391,7 +381,6 @@ describe('modules/datasource/rpm/index', () => {
   });
 
   describe('getReleases', () => {
-    const registryUrl = 'https://example.com/repo/repodata/';
     const rpmDatasource = new RpmDatasource();
 
     it('returns null if registryUrl is not provided', async () => {
@@ -399,15 +388,7 @@ describe('modules/datasource/rpm/index', () => {
         registryUrl: undefined,
         packageName: 'example-package',
       });
-      expect(releases).toBeNull();
-    });
 
-    it('returns null if primaryXmlUrl is empty', async () => {
-      vi.spyOn(rpmDatasource, 'getPrimaryGzipUrl').mockResolvedValue(null);
-      const releases = await rpmDatasource.getReleases({
-        registryUrl: 'someurl',
-        packageName: 'example-package',
-      });
       expect(releases).toBeNull();
     });
 
@@ -416,28 +397,20 @@ describe('modules/datasource/rpm/index', () => {
         registryUrl,
         packageName: '',
       });
+
       expect(releases).toBeNull();
     });
 
     it('returns the correct releases', async () => {
-      //mock the getPrimaryGzipUrl method to return the primaryXmlUrl
       vi.spyOn(rpmDatasource, 'getPrimaryGzipUrl').mockResolvedValue(
-        'https://example.com/repo/repodata/',
+        primaryXmlUrl,
       );
       vi.spyOn(rpmDatasource, 'getReleasesByPackageName').mockResolvedValue({
         releases: [
-          {
-            version: '1.0-2.azl3',
-          },
-          {
-            version: '1.1-1.azl3',
-          },
-          {
-            version: '1.1-2.azl3',
-          },
-          {
-            version: '1.2',
-          },
+          { version: '1.0-2.azl3' },
+          { version: '1.1-1.azl3' },
+          { version: '1.1-2.azl3' },
+          { version: '1.2' },
         ],
       });
 
@@ -445,20 +418,13 @@ describe('modules/datasource/rpm/index', () => {
         registryUrl,
         packageName: 'example-package',
       });
+
       expect(releases).toEqual({
         releases: [
-          {
-            version: '1.0-2.azl3',
-          },
-          {
-            version: '1.1-1.azl3',
-          },
-          {
-            version: '1.1-2.azl3',
-          },
-          {
-            version: '1.2',
-          },
+          { version: '1.0-2.azl3' },
+          { version: '1.1-1.azl3' },
+          { version: '1.1-2.azl3' },
+          { version: '1.2' },
         ],
       });
     });
@@ -478,7 +444,7 @@ describe('modules/datasource/rpm/index', () => {
 
     it('throws an error if getReleasesByPackageName fails', async () => {
       vi.spyOn(rpmDatasource, 'getPrimaryGzipUrl').mockResolvedValue(
-        'https://example.com/repo/repodata/',
+        primaryXmlUrl,
       );
       vi.spyOn(rpmDatasource, 'getReleasesByPackageName').mockRejectedValue(
         new Error('Something wrong'),

--- a/lib/modules/datasource/rpm/index.ts
+++ b/lib/modules/datasource/rpm/index.ts
@@ -54,7 +54,7 @@ export class RpmDatasource extends Datasource {
       const primaryGzipUrl = await this.getPrimaryGzipUrl(registryUrl);
       return await this.getReleasesByPackageName(primaryGzipUrl, packageName);
     } catch (err) {
-      this.handleGenericErrors(err as Error);
+      this.handleGenericErrors(err);
     }
   }
 

--- a/lib/modules/datasource/rpm/index.ts
+++ b/lib/modules/datasource/rpm/index.ts
@@ -1,16 +1,10 @@
-import { Readable } from 'node:stream';
-import { gunzip } from 'node:zlib';
-import sax from 'sax';
-import { promisify } from 'util';
 import { XmlDocument } from 'xmldoc';
 import { logger } from '../../../logger/index.ts';
 import { withCache } from '../../../util/cache/package/with-cache.ts';
-import type { HttpResponse } from '../../../util/http/index.ts';
 import { joinUrlParts } from '../../../util/url.ts';
 import { Datasource } from '../datasource.ts';
-import type { GetReleasesConfig, Release, ReleaseResult } from '../types.ts';
-
-const gunzipAsync = promisify(gunzip);
+import type { GetReleasesConfig, ReleaseResult } from '../types.ts';
+import { RpmXmlMetadataProvider } from './providers/xml.ts';
 
 export class RpmDatasource extends Datasource {
   static readonly id = 'rpm';
@@ -18,8 +12,11 @@ export class RpmDatasource extends Datasource {
   // repomd.xml is a standard file name in RPM repositories which contains metadata about the repository
   static readonly repomdXmlFileName = 'repomd.xml';
 
+  private readonly xmlProvider: RpmXmlMetadataProvider;
+
   constructor() {
     super(RpmDatasource.id);
+    this.xmlProvider = new RpmXmlMetadataProvider(this.http);
   }
 
   /**
@@ -52,14 +49,12 @@ export class RpmDatasource extends Datasource {
     if (!registryUrl || !packageName) {
       return null;
     }
+
     try {
       const primaryGzipUrl = await this.getPrimaryGzipUrl(registryUrl);
-      if (!primaryGzipUrl) {
-        return null;
-      }
       return await this.getReleasesByPackageName(primaryGzipUrl, packageName);
     } catch (err) {
-      this.handleGenericErrors(err);
+      this.handleGenericErrors(err as Error);
     }
   }
 
@@ -75,10 +70,37 @@ export class RpmDatasource extends Datasource {
     );
   }
 
-  // Fetches the primary.xml.gz URL from the repomd.xml file.
-  private async _getPrimaryGzipUrl(
+  private getPrimaryRepodataUrl(
+    xml: XmlDocument,
     registryUrl: string,
-  ): Promise<string | null> {
+    repomdUrl: string,
+  ): string {
+    const primaryData = xml.childWithAttribute('type', 'primary');
+
+    if (!primaryData) {
+      throw new Error(`No primary data found in ${repomdUrl}`);
+    }
+
+    const locationElement = primaryData.childNamed('location');
+    if (!locationElement) {
+      throw new Error(`No location element found in ${repomdUrl}`);
+    }
+
+    const href = locationElement.attr.href;
+    if (!href) {
+      throw new Error(`No href found in ${repomdUrl}`);
+    }
+
+    // replace trailing "repodata/" from registryUrl, if it exists, with a "/" because href includes "repodata/"
+    const registryUrlWithoutRepodata = registryUrl.replace(
+      /\/repodata\/?$/,
+      '/',
+    );
+
+    return joinUrlParts(registryUrlWithoutRepodata, href);
+  }
+
+  private async _getPrimaryGzipUrl(registryUrl: string): Promise<string> {
     const repomdUrl = joinUrlParts(
       registryUrl,
       RpmDatasource.repomdXmlFileName,
@@ -98,35 +120,25 @@ export class RpmDatasource extends Datasource {
       );
     }
 
-    // parse repomd.xml using XmlDocument
     const xml = new XmlDocument(repomdBody);
 
-    const primaryData = xml.childWithAttribute('type', 'primary');
+    try {
+      return this.getPrimaryRepodataUrl(xml, registryUrl, repomdUrl.toString());
+    } catch (err) {
+      if (
+        err instanceof Error &&
+        err.message.startsWith('No primary data found')
+      ) {
+        logger.debug(
+          `No primary data found in ${repomdUrl}, xml contents: ${response.body}`,
+        );
+      }
 
-    if (!primaryData) {
-      logger.debug(
-        `No primary data found in ${repomdUrl}, xml contents: ${response.body}`,
-      );
-      throw new Error(`No primary data found in ${repomdUrl}`);
+      throw err;
     }
-
-    const locationElement = primaryData.childNamed('location');
-    if (!locationElement) {
-      throw new Error(`No location element found in ${repomdUrl}`);
-    }
-    const href = locationElement.attr.href;
-    if (!href) {
-      throw new Error(`No href found in ${repomdUrl}`);
-    }
-    // replace trailing "repodata/" from registryUrl, if it exists, with a "/" because href includes "repodata/"
-    const registryUrlWithoutRepodata = registryUrl.replace(
-      /\/repodata\/?$/,
-      '/',
-    );
-    return joinUrlParts(registryUrlWithoutRepodata, href);
   }
 
-  getPrimaryGzipUrl(registryUrl: string): Promise<string | null> {
+  getPrimaryGzipUrl(registryUrl: string): Promise<string> {
     return withCache(
       {
         namespace: `datasource-${RpmDatasource.id}`,
@@ -141,104 +153,6 @@ export class RpmDatasource extends Datasource {
     primaryGzipUrl: string,
     packageName: string,
   ): Promise<ReleaseResult | null> {
-    let response: HttpResponse<Buffer>;
-    let decompressedBuffer: Buffer;
-    try {
-      // primaryGzipUrl is a .gz file, need to extract it before parsing
-      response = await this.http.getBuffer(primaryGzipUrl);
-      if (response.body.length === 0) {
-        logger.debug(`Empty response body from getting ${primaryGzipUrl}.`);
-        throw new Error(`Empty response body from getting ${primaryGzipUrl}.`);
-      }
-      // decompress the gzipped file
-      decompressedBuffer = await gunzipAsync(response.body);
-    } catch (err) {
-      logger.debug(
-        `Failed to fetch or decompress ${primaryGzipUrl}: ${
-          err instanceof Error ? err.message : err
-        }`,
-      );
-      throw err;
-    }
-
-    // Use sax streaming parser to handle large XML files efficiently
-    // This allows us to parse the XML file without loading the entire file into memory.
-    const releases: Record<string, Release> = {};
-    let insidePackage = false;
-    let isTargetPackage = false;
-    let insideName = false;
-
-    // Create a SAX parser in strict mode
-    const saxParser = sax.createStream(true, {
-      lowercase: true, // normalize tag names to lowercase
-      trim: true,
-    });
-
-    saxParser.on('opentag', (node: sax.Tag) => {
-      if (node.name === 'package' && node.attributes.type === 'rpm') {
-        insidePackage = true;
-        isTargetPackage = false;
-      }
-      if (insidePackage && node.name === 'name') {
-        insideName = true;
-      }
-      if (insidePackage && isTargetPackage && node.name === 'version') {
-        // rel is optional
-        if (node.attributes.rel === undefined) {
-          const version = `${node.attributes.ver}`;
-          releases[version] = { version };
-        } else {
-          const version = `${node.attributes.ver}-${node.attributes.rel}`;
-          releases[version] = { version };
-        }
-      }
-    });
-    saxParser.on('text', (text: string) => {
-      if (insidePackage && insideName) {
-        if (text.trim() === packageName) {
-          isTargetPackage = true;
-        }
-      }
-    });
-    saxParser.on('closetag', (tag: string) => {
-      if (tag === 'name' && insidePackage) {
-        insideName = false;
-      }
-      if (tag === 'package') {
-        insidePackage = false;
-        isTargetPackage = false;
-      }
-    });
-
-    await new Promise<void>((resolve, reject) => {
-      let settled = false;
-      saxParser.on('error', (err: Error) => {
-        if (settled) {
-          return;
-        }
-        settled = true;
-        logger.debug(`SAX parsing error in ${primaryGzipUrl}: ${err.message}`);
-        setImmediate(() => saxParser.removeAllListeners());
-        reject(err);
-      });
-      saxParser.on('end', () => {
-        settled = true;
-        setImmediate(() => saxParser.removeAllListeners());
-        resolve();
-      });
-      Readable.from(decompressedBuffer).pipe(saxParser);
-    });
-
-    if (Object.keys(releases).length === 0) {
-      logger.trace(
-        `No releases found for package ${packageName} in ${primaryGzipUrl}`,
-      );
-      return null;
-    }
-    return {
-      releases: Object.values(releases).map((release) => ({
-        version: release.version,
-      })),
-    };
+    return await this.xmlProvider.getReleases(primaryGzipUrl, packageName);
   }
 }

--- a/lib/modules/datasource/rpm/index.ts
+++ b/lib/modules/datasource/rpm/index.ts
@@ -1,16 +1,12 @@
-import { XmlDocument } from 'xmldoc';
-import { logger } from '../../../logger/index.ts';
 import { withCache } from '../../../util/cache/package/with-cache.ts';
-import { joinUrlParts } from '../../../util/url.ts';
 import { Datasource } from '../datasource.ts';
 import type { GetReleasesConfig, ReleaseResult } from '../types.ts';
+import { datasource } from './common.ts';
 import { RpmXmlMetadataProvider } from './providers/xml.ts';
+import { fetchPrimaryGzipUrl } from './repomd.ts';
 
 export class RpmDatasource extends Datasource {
-  static readonly id = 'rpm';
-
-  // repomd.xml is a standard file name in RPM repositories which contains metadata about the repository
-  static readonly repomdXmlFileName = 'repomd.xml';
+  static readonly id = datasource;
 
   private readonly xmlProvider: RpmXmlMetadataProvider;
 
@@ -70,74 +66,6 @@ export class RpmDatasource extends Datasource {
     );
   }
 
-  private getPrimaryRepodataUrl(
-    xml: XmlDocument,
-    registryUrl: string,
-    repomdUrl: string,
-  ): string {
-    const primaryData = xml.childWithAttribute('type', 'primary');
-
-    if (!primaryData) {
-      throw new Error(`No primary data found in ${repomdUrl}`);
-    }
-
-    const locationElement = primaryData.childNamed('location');
-    if (!locationElement) {
-      throw new Error(`No location element found in ${repomdUrl}`);
-    }
-
-    const href = locationElement.attr.href;
-    if (!href) {
-      throw new Error(`No href found in ${repomdUrl}`);
-    }
-
-    // replace trailing "repodata/" from registryUrl, if it exists, with a "/" because href includes "repodata/"
-    const registryUrlWithoutRepodata = registryUrl.replace(
-      /\/repodata\/?$/,
-      '/',
-    );
-
-    return joinUrlParts(registryUrlWithoutRepodata, href);
-  }
-
-  private async _getPrimaryGzipUrl(registryUrl: string): Promise<string> {
-    const repomdUrl = joinUrlParts(
-      registryUrl,
-      RpmDatasource.repomdXmlFileName,
-    );
-    const response = await this.http.getText(repomdUrl.toString());
-
-    const repomdBody = response.body.trimStart();
-
-    // repomd.xml may omit the XML declaration and start directly with the root element
-    if (!(repomdBody.startsWith('<?xml') || repomdBody.startsWith('<repomd'))) {
-      logger.debug(
-        { datasource: RpmDatasource.id, url: repomdUrl },
-        'Invalid response format',
-      );
-      throw new Error(
-        `${repomdUrl} is not in XML format. Response body: ${response.body}`,
-      );
-    }
-
-    const xml = new XmlDocument(repomdBody);
-
-    try {
-      return this.getPrimaryRepodataUrl(xml, registryUrl, repomdUrl.toString());
-    } catch (err) {
-      if (
-        err instanceof Error &&
-        err.message.startsWith('No primary data found')
-      ) {
-        logger.debug(
-          `No primary data found in ${repomdUrl}, xml contents: ${response.body}`,
-        );
-      }
-
-      throw err;
-    }
-  }
-
   getPrimaryGzipUrl(registryUrl: string): Promise<string> {
     return withCache(
       {
@@ -145,14 +73,14 @@ export class RpmDatasource extends Datasource {
         key: registryUrl,
         ttlMinutes: 1440,
       },
-      () => this._getPrimaryGzipUrl(registryUrl),
+      () => fetchPrimaryGzipUrl(this.http, registryUrl),
     );
   }
 
-  async getReleasesByPackageName(
+  getReleasesByPackageName(
     primaryGzipUrl: string,
     packageName: string,
   ): Promise<ReleaseResult | null> {
-    return await this.xmlProvider.getReleases(primaryGzipUrl, packageName);
+    return this.xmlProvider.getReleases(primaryGzipUrl, packageName);
   }
 }

--- a/lib/modules/datasource/rpm/providers/common.ts
+++ b/lib/modules/datasource/rpm/providers/common.ts
@@ -1,0 +1,62 @@
+import { gunzip } from 'node:zlib';
+import { promisify } from 'util';
+import { logger } from '../../../../logger/index.ts';
+import type { Http } from '../../../../util/http/index.ts';
+import type { ReleaseResult } from '../../types.ts';
+
+const gunzipAsync = promisify(gunzip);
+
+type RpmVersionValue = boolean | number | string | null | undefined;
+
+export function formatRpmVersion(
+  ver: RpmVersionValue,
+  rel?: RpmVersionValue,
+): string | null {
+  if (ver === undefined || ver === null) {
+    return null;
+  }
+
+  const version = String(ver);
+
+  if (rel === undefined || rel === null) {
+    return version;
+  }
+
+  return `${version}-${String(rel)}`;
+}
+
+export function buildReleaseResult(
+  versions: Iterable<string>,
+): ReleaseResult | null {
+  const uniqueVersions = [...new Set(versions)];
+
+  if (uniqueVersions.length === 0) {
+    return null;
+  }
+
+  return {
+    releases: uniqueVersions.map((version) => ({ version })),
+  };
+}
+
+export async function getGunzippedBuffer(
+  http: Http,
+  url: string,
+): Promise<Buffer> {
+  try {
+    const response = await http.getBuffer(url);
+    if (response.body.length === 0) {
+      logger.debug(`Empty response body from getting ${url}.`);
+      throw new Error(`Empty response body from getting ${url}.`);
+    }
+
+    return await gunzipAsync(response.body);
+  } catch (err) {
+    logger.debug(
+      `Failed to fetch or decompress ${url}: ${
+        err instanceof Error ? err.message : err
+      }`,
+    );
+    throw err;
+  }
+}

--- a/lib/modules/datasource/rpm/providers/common.ts
+++ b/lib/modules/datasource/rpm/providers/common.ts
@@ -139,6 +139,10 @@ export async function getCachedGunzippedFile(
       cacheDir,
       `${randomUUID()}_${urlHash}.gz`,
     );
+    const extractedTempFile = upath.join(
+      cacheDir,
+      `${randomUUID()}_${urlHash}.${extension}`,
+    );
 
     try {
       const wasUpdated = await downloadGzipFile(
@@ -150,7 +154,9 @@ export async function getCachedGunzippedFile(
 
       if (wasUpdated || !lastTimestamp) {
         try {
-          await extractGzipFile(compressedFile, extractedFile);
+          // Only replace the shared cache file after a successful extract.
+          await extractGzipFile(compressedFile, extractedTempFile);
+          await fs.renameCacheFile(extractedTempFile, extractedFile);
           lastTimestamp = await getFileCreationTime(extractedFile);
         } catch (err) {
           logger.warn(
@@ -174,6 +180,9 @@ export async function getCachedGunzippedFile(
     } finally {
       if (await fs.cachePathExists(compressedFile)) {
         await fs.rmCache(compressedFile);
+      }
+      if (await fs.cachePathExists(extractedTempFile)) {
+        await fs.rmCache(extractedTempFile);
       }
     }
   } finally {

--- a/lib/modules/datasource/rpm/providers/common.ts
+++ b/lib/modules/datasource/rpm/providers/common.ts
@@ -65,10 +65,10 @@ async function checkIfModified(
   try {
     const response = await http.head(url, options);
     return response.statusCode !== 304;
-  } catch (error) {
+  } catch (err) {
     logger.warn(
       {
-        errorMessage: error instanceof Error ? error.message : error,
+        err,
         lastDownloadTimestamp,
         url,
       },
@@ -152,11 +152,11 @@ export async function getCachedGunzippedFile(
         try {
           await extractGzipFile(compressedFile, extractedFile);
           lastTimestamp = await getFileCreationTime(extractedFile);
-        } catch (error) {
+        } catch (err) {
           logger.warn(
             {
               compressedFile,
-              error: error instanceof Error ? error.message : error,
+              err,
               extension,
               extractedFile,
               url,

--- a/lib/modules/datasource/rpm/providers/common.ts
+++ b/lib/modules/datasource/rpm/providers/common.ts
@@ -1,10 +1,15 @@
-import { gunzip } from 'node:zlib';
-import { promisify } from 'util';
+import { randomUUID } from 'node:crypto';
+import { createGunzip } from 'node:zlib';
+import upath from 'upath';
 import { logger } from '../../../../logger/index.ts';
-import type { Http } from '../../../../util/http/index.ts';
+import * as fs from '../../../../util/fs/index.ts';
+import { toSha256 } from '../../../../util/hash.ts';
+import type { Http, HttpOptions } from '../../../../util/http/index.ts';
+import { acquireLock } from '../../../../util/mutex.ts';
 import type { ReleaseResult } from '../../types.ts';
+import { datasource } from '../common.ts';
 
-const gunzipAsync = promisify(gunzip);
+const cacheSubDir = datasource;
 
 type RpmVersionValue = boolean | number | string | null | undefined;
 
@@ -39,24 +44,139 @@ export function buildReleaseResult(
   };
 }
 
-export async function getGunzippedBuffer(
+async function getFileCreationTime(
+  filePath: string,
+): Promise<Date | undefined> {
+  const stats = await fs.statCacheFile(filePath);
+  return stats?.ctime;
+}
+
+async function checkIfModified(
+  url: string,
+  lastDownloadTimestamp: Date,
+  http: Http,
+): Promise<boolean> {
+  const options: HttpOptions = {
+    headers: {
+      'If-Modified-Since': lastDownloadTimestamp.toUTCString(),
+    },
+  };
+
+  try {
+    const response = await http.head(url, options);
+    return response.statusCode !== 304;
+  } catch (error) {
+    logger.warn(
+      {
+        errorMessage: error instanceof Error ? error.message : error,
+        lastDownloadTimestamp,
+        url,
+      },
+      'Could not determine if metadata file is modified since last download',
+    );
+    return true;
+  }
+}
+
+async function downloadGzipFile(
+  url: string,
+  compressedFile: string,
+  http: Http,
+  lastDownloadTimestamp?: Date,
+): Promise<boolean> {
+  let needsToDownload = true;
+
+  if (lastDownloadTimestamp) {
+    needsToDownload = await checkIfModified(url, lastDownloadTimestamp, http);
+  }
+
+  if (!needsToDownload) {
+    logger.debug(`No need to download ${url}, file is up to date.`);
+    return false;
+  }
+
+  const readStream = http.stream(url);
+  const writeStream = fs.createCacheWriteStream(compressedFile);
+  await fs.pipeline(readStream, writeStream);
+
+  const compressedStats = await fs.statCacheFile(compressedFile);
+  if (!compressedStats || compressedStats.size === 0) {
+    logger.debug(`Empty response body from getting ${url}.`);
+    throw new Error(`Empty response body from getting ${url}.`);
+  }
+
+  return true;
+}
+
+async function extractGzipFile(
+  compressedFile: string,
+  extractedFile: string,
+): Promise<void> {
+  await fs.pipeline(
+    fs.createCacheReadStream(compressedFile),
+    createGunzip(),
+    fs.createCacheWriteStream(extractedFile),
+  );
+}
+
+export async function getCachedGunzippedFile(
   http: Http,
   url: string,
-): Promise<Buffer> {
-  try {
-    const response = await http.getBuffer(url);
-    if (response.body.length === 0) {
-      logger.debug(`Empty response body from getting ${url}.`);
-      throw new Error(`Empty response body from getting ${url}.`);
-    }
+  extension: 'xml',
+): Promise<string> {
+  const releaseLock = await acquireLock(
+    `gunzipped-file:${url}:${extension}`,
+    'datasource-rpm',
+  );
 
-    return await gunzipAsync(response.body);
-  } catch (err) {
-    logger.debug(
-      `Failed to fetch or decompress ${url}: ${
-        err instanceof Error ? err.message : err
-      }`,
+  try {
+    const cacheDir = await fs.ensureCacheDir(cacheSubDir);
+    const urlHash = toSha256(url);
+    const extractedFile = upath.join(cacheDir, `${urlHash}.${extension}`);
+    let lastTimestamp = await getFileCreationTime(extractedFile);
+
+    const compressedFile = upath.join(
+      cacheDir,
+      `${randomUUID()}_${urlHash}.gz`,
     );
-    throw err;
+
+    try {
+      const wasUpdated = await downloadGzipFile(
+        url,
+        compressedFile,
+        http,
+        lastTimestamp,
+      );
+
+      if (wasUpdated || !lastTimestamp) {
+        try {
+          await extractGzipFile(compressedFile, extractedFile);
+          lastTimestamp = await getFileCreationTime(extractedFile);
+        } catch (error) {
+          logger.warn(
+            {
+              compressedFile,
+              error: error instanceof Error ? error.message : error,
+              extension,
+              extractedFile,
+              url,
+            },
+            'Failed to extract RPM metadata file from compressed file',
+          );
+        }
+      }
+
+      if (!lastTimestamp) {
+        throw new Error('Missing metadata in extracted RPM metadata file!');
+      }
+
+      return extractedFile;
+    } finally {
+      if (await fs.cachePathExists(compressedFile)) {
+        await fs.rmCache(compressedFile);
+      }
+    }
+  } finally {
+    releaseLock();
   }
 }

--- a/lib/modules/datasource/rpm/providers/xml.ts
+++ b/lib/modules/datasource/rpm/providers/xml.ts
@@ -1,12 +1,12 @@
-import { Readable } from 'node:stream';
 import sax from 'sax';
 import { logger } from '../../../../logger/index.ts';
+import * as fs from '../../../../util/fs/index.ts';
 import type { Http } from '../../../../util/http/index.ts';
 import type { ReleaseResult } from '../../types.ts';
 import {
   buildReleaseResult,
   formatRpmVersion,
-  getGunzippedBuffer,
+  getCachedGunzippedFile,
 } from './common.ts';
 
 export class RpmXmlMetadataProvider {
@@ -20,9 +20,10 @@ export class RpmXmlMetadataProvider {
     primaryGzipUrl: string,
     packageName: string,
   ): Promise<ReleaseResult | null> {
-    const decompressedBuffer = await getGunzippedBuffer(
+    const primaryXmlFile = await getCachedGunzippedFile(
       this.http,
       primaryGzipUrl,
+      'xml',
     );
     const releases = new Set<string>();
     let insidePackage = false;
@@ -83,7 +84,7 @@ export class RpmXmlMetadataProvider {
         setImmediate(() => saxParser.removeAllListeners());
         resolve();
       });
-      Readable.from(decompressedBuffer).pipe(saxParser);
+      fs.createCacheReadStream(primaryXmlFile).pipe(saxParser);
     });
 
     const result = buildReleaseResult(releases);

--- a/lib/modules/datasource/rpm/providers/xml.ts
+++ b/lib/modules/datasource/rpm/providers/xml.ts
@@ -1,0 +1,98 @@
+import { Readable } from 'node:stream';
+import sax from 'sax';
+import { logger } from '../../../../logger/index.ts';
+import type { Http } from '../../../../util/http/index.ts';
+import type { ReleaseResult } from '../../types.ts';
+import {
+  buildReleaseResult,
+  formatRpmVersion,
+  getGunzippedBuffer,
+} from './common.ts';
+
+export class RpmXmlMetadataProvider {
+  private readonly http: Http;
+
+  constructor(http: Http) {
+    this.http = http;
+  }
+
+  async getReleases(
+    primaryGzipUrl: string,
+    packageName: string,
+  ): Promise<ReleaseResult | null> {
+    const decompressedBuffer = await getGunzippedBuffer(
+      this.http,
+      primaryGzipUrl,
+    );
+    const releases = new Set<string>();
+    let insidePackage = false;
+    let isTargetPackage = false;
+    let insideName = false;
+
+    const saxParser = sax.createStream(true, {
+      lowercase: true,
+      trim: true,
+    });
+
+    saxParser.on('opentag', (node: sax.Tag) => {
+      if (node.name === 'package' && node.attributes.type === 'rpm') {
+        insidePackage = true;
+        isTargetPackage = false;
+      }
+      if (insidePackage && node.name === 'name') {
+        insideName = true;
+      }
+      if (insidePackage && isTargetPackage && node.name === 'version') {
+        const version = formatRpmVersion(
+          node.attributes.ver,
+          node.attributes.rel,
+        );
+        if (version) {
+          releases.add(version);
+        }
+      }
+    });
+    saxParser.on('text', (text: string) => {
+      if (insidePackage && insideName && text.trim() === packageName) {
+        isTargetPackage = true;
+      }
+    });
+    saxParser.on('closetag', (tag: string) => {
+      if (tag === 'name' && insidePackage) {
+        insideName = false;
+      }
+      if (tag === 'package') {
+        insidePackage = false;
+        isTargetPackage = false;
+      }
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      let settled = false;
+      saxParser.on('error', (err: Error) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        logger.debug(`SAX parsing error in ${primaryGzipUrl}: ${err.message}`);
+        setImmediate(() => saxParser.removeAllListeners());
+        reject(err);
+      });
+      saxParser.on('end', () => {
+        settled = true;
+        setImmediate(() => saxParser.removeAllListeners());
+        resolve();
+      });
+      Readable.from(decompressedBuffer).pipe(saxParser);
+    });
+
+    const result = buildReleaseResult(releases);
+    if (!result) {
+      logger.trace(
+        `No releases found for package ${packageName} in ${primaryGzipUrl}`,
+      );
+    }
+
+    return result;
+  }
+}

--- a/lib/modules/datasource/rpm/repomd.ts
+++ b/lib/modules/datasource/rpm/repomd.ts
@@ -1,0 +1,67 @@
+import { XmlDocument } from 'xmldoc';
+import { logger } from '../../../logger/index.ts';
+import type { Http } from '../../../util/http/index.ts';
+import { joinUrlParts } from '../../../util/url.ts';
+import { datasource, repomdXmlFileName } from './common.ts';
+
+function getPrimaryRepodataUrl(
+  xml: XmlDocument,
+  registryUrl: string,
+  repomdUrl: string,
+): string {
+  const primaryData = xml.childWithAttribute('type', 'primary');
+
+  if (!primaryData) {
+    throw new Error(`No primary data found in ${repomdUrl}`);
+  }
+
+  const locationElement = primaryData.childNamed('location');
+  if (!locationElement) {
+    throw new Error(`No location element found in ${repomdUrl}`);
+  }
+
+  const href = locationElement.attr.href;
+  if (!href) {
+    throw new Error(`No href found in ${repomdUrl}`);
+  }
+
+  // replace trailing "repodata/" from registryUrl, if it exists, with a "/"
+  // because href includes "repodata/"
+  const registryUrlWithoutRepodata = registryUrl.replace(/\/repodata\/?$/, '/');
+
+  return joinUrlParts(registryUrlWithoutRepodata, href);
+}
+
+export async function fetchPrimaryGzipUrl(
+  http: Http,
+  registryUrl: string,
+): Promise<string> {
+  const repomdUrl = joinUrlParts(registryUrl, repomdXmlFileName);
+  const response = await http.getText(repomdUrl.toString());
+  const repomdBody = response.body.trimStart();
+
+  // repomd.xml may omit the XML declaration and start directly with the root element
+  if (!(repomdBody.startsWith('<?xml') || repomdBody.startsWith('<repomd'))) {
+    logger.debug({ datasource, url: repomdUrl }, 'Invalid response format');
+    throw new Error(
+      `${repomdUrl} is not in XML format. Response body: ${response.body}`,
+    );
+  }
+
+  const xml = new XmlDocument(repomdBody);
+
+  try {
+    return getPrimaryRepodataUrl(xml, registryUrl, repomdUrl.toString());
+  } catch (err) {
+    if (
+      err instanceof Error &&
+      err.message.startsWith('No primary data found')
+    ) {
+      logger.debug(
+        `No primary data found in ${repomdUrl}, xml contents: ${response.body}`,
+      );
+    }
+
+    throw err;
+  }
+}

--- a/lib/util/fs/index.spec.ts
+++ b/lib/util/fs/index.spec.ts
@@ -32,6 +32,7 @@ import {
   readLocalFile,
   readLocalSymlink,
   readSystemFile,
+  renameCacheFile,
   renameLocalFile,
   rmCache,
   statCacheFile,
@@ -236,6 +237,21 @@ describe('util/fs/index', () => {
       await renameLocalFile('foo.txt', 'bar.txt');
       expect(await fs.pathExists(sourcePath)).toBeFalse();
       expect(await fs.pathExists(targetPath)).toBeTrue();
+    });
+  });
+
+  describe('renameCacheFile', () => {
+    it('renames file and replaces existing target', async () => {
+      const sourcePath = `${cacheDir}/foo.txt`;
+      const targetPath = `${cacheDir}/bar.txt`;
+      await fs.outputFile(sourcePath, 'source');
+      await fs.outputFile(targetPath, 'target');
+
+      expect(await fs.pathExists(sourcePath)).toBeTrue();
+      expect(await fs.readFile(targetPath, 'utf8')).toBe('target');
+      await renameCacheFile('foo.txt', 'bar.txt');
+      expect(await fs.pathExists(sourcePath)).toBeFalse();
+      expect(await fs.readFile(targetPath, 'utf8')).toBe('source');
     });
   });
 

--- a/lib/util/fs/index.ts
+++ b/lib/util/fs/index.ts
@@ -89,6 +89,15 @@ export async function renameLocalFile(
   await fs.move(fromPath, toPath);
 }
 
+export async function renameCacheFile(
+  fromFile: string,
+  toFile: string,
+): Promise<void> {
+  const fromPath = ensureCachePath(fromFile);
+  const toPath = ensureCachePath(toFile);
+  await fs.rename(fromPath, toPath);
+}
+
 export async function ensureDir(dirName: string): Promise<void> {
   // v8 ignore else -- TODO: add test #40625
   if (isNonEmptyString(dirName)) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This pull request was split from https://github.com/renovatebot/renovate/pull/41866, and only contains the basic refactoring of the RPM data source to extract `primary` (XML) package format.

Previously, the RPM datasource mixed repository metadata discovery and XML package parsing inside a single class. That made the code harder to extend for additional metadata backends and made the later SQLite work more invasive than it needed to be.

> [!NOTE]
> This refactor intentionally keeps one small behavior improvement that was already folded into the extraction: malformed RPM XML entries with a `<version>` element missing the `ver` attribute are now ignored instead of producing a release with version `undefined`.
>
> That is a behavior change for invalid metadata, but it is a safer outcome and aligns better with the intended RPM parsing behavior.

In the https://github.com/renovatebot/renovate/pull/41910#discussion_r2945024337 discussion an additional improvement was proposed to use a file on disk for unpacking the XML, which led to significant memory savings. In the benchmark over 50 Amazon Linux 2 dependencies, the results are:

| Version | Avg Wall Time (3 runs) | Avg Peak RSS (3 runs) |
|---|---:|---:|
| Before (`upstream/main`) | 416.55s | 1578.2 MiB |
| After (`rpm-xml-provider`) | 416.93s (`+0.09%`) | 533.8 MiB (`-66.2%`) |

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
