### PR TITLE
feat(pip_requirements): detect requirements files with underscores

### DIFF
--- a/lib/modules/manager/pip_requirements/index.spec.ts
+++ b/lib/modules/manager/pip_requirements/index.spec.ts
@@ -7,8 +7,16 @@ describe('modules/manager/pip_requirements/index', () => {
 
     expect(matchRegexOrGlobList('requirements.txt', patterns)).toBe(true);
     expect(matchRegexOrGlobList('requirements-dev.txt', patterns)).toBe(true);
+    expect(matchRegexOrGlobList('requirements_test.txt', patterns)).toBe(true);
+    expect(matchRegexOrGlobList('requirements_test_all.txt', patterns)).toBe(
+      true,
+    );
     expect(matchRegexOrGlobList('requirements.dev.txt', patterns)).toBe(true);
     expect(matchRegexOrGlobList('requirements-dev.pip', patterns)).toBe(true);
+    expect(matchRegexOrGlobList('requirements_test.pip', patterns)).toBe(true);
+    expect(matchRegexOrGlobList('requirements_test_all.pip', patterns)).toBe(
+      true,
+    );
     expect(matchRegexOrGlobList('requirements.dev.pip', patterns)).toBe(true);
   });
 });

--- a/lib/modules/manager/pip_requirements/index.ts
+++ b/lib/modules/manager/pip_requirements/index.ts
@@ -11,7 +11,7 @@ export const url =
 export const categories: Category[] = ['python'];
 
 export const defaultConfig = {
-  managerFilePatterns: ['/(^|/)[\\w-]*requirements([-.]\\w+)?\\.(txt|pip)$/'],
+  managerFilePatterns: ['/(^|/)[\\w-]*requirements([-._]\\w+)?\\.(txt|pip)$/'],
 };
 
 export const supportedDatasources = [PypiDatasource.id, GitTagsDatasource.id];


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

This PR extends `pip_requirements`'s `managerFilePatterns` to also match files with _underscores_ as separators, in addition to _dashes_ and _dots_.

For example, this will match the requirements files used in [home-assistant/core](https://github.com/home-assistant/core):

- `requirements.txt` (already matched)
- `requirements_all.txt`
- `requirements_test.txt`
- `requirements_test_all.txt`
- `requirements_test_pre_commit.txt`

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: N/A

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
