### PR TITLE
feat(pep621): use exclude-newer during uv lock when minimumReleaseAge is set

### DIFF
--- a/docs/usage/key-concepts/minimum-release-age.md
+++ b/docs/usage/key-concepts/minimum-release-age.md
@@ -44,15 +44,7 @@ To protect against this, it's recommended to ensure that your package manager co
 There is ongoing work to [integrate more closely with package manager checks](https://github.com/renovatebot/renovate/issues/41652) to make sure that Renovate's minimum release age configuration is specified when calling package managers that support it.
 If you have a package manager you'd like supported, please raise a [Suggest an Idea Discussion](https://github.com/renovatebot/renovate/discussions/new?category=suggest-an-idea).
 
-#### npm
-
-When `minimumReleaseAge` is configured, Renovate passes `--before=<date>` to npm commands during lock file generation.
-This ensures that npm only resolves package versions that were available before the cooldown threshold, protecting against newly published (and potentially malicious) transitive dependencies.
-
-The `--before` date is calculated as `now - minimumReleaseAge`.
-If a `before=<date>` or `min-release-age=<days>` setting already exists in the project's `.npmrc`, Renovate uses the stricter (older) of the two dates.
-
-### uv
+#### uv
 
 <!-- prettier-ignore -->
 For uv, Renovate reads `[tool.uv] exclude-newer` from `pyproject.toml` and uses the more restrictive (older) date between it and `minimumReleaseAge`.

--- a/docs/usage/key-concepts/minimum-release-age.md
+++ b/docs/usage/key-concepts/minimum-release-age.md
@@ -55,6 +55,7 @@ If a `before=<date>` or `min-release-age=<days>` setting already exists in the p
 <!-- prettier-ignore -->
 !!! note
     For uv, Renovate reads `[tool.uv] exclude-newer` from `pyproject.toml` and uses the more restrictive (older) date between it and `minimumReleaseAge`.
+    The `exclude-newer` value can be an RFC 3339 timestamp (e.g. `2025-01-01T00:00:00Z`) or a friendly duration (e.g. `2 weeks`), but ISO 8601 durations (e.g. `P14D`) are not supported.
     See uv's [dependency bot integration guide](https://docs.astral.sh/uv/guides/integration/dependency-bots/#dependency-cooldown) for details on configuring `exclude-newer`.
 
 ### What happens if the datasource and/or registry does not provide a release timestamp, when using `minimumReleaseAge`?

--- a/docs/usage/key-concepts/minimum-release-age.md
+++ b/docs/usage/key-concepts/minimum-release-age.md
@@ -52,11 +52,12 @@ This ensures that npm only resolves package versions that were available before 
 The `--before` date is calculated as `now - minimumReleaseAge`.
 If a `before=<date>` or `min-release-age=<days>` setting already exists in the project's `.npmrc`, Renovate uses the stricter (older) of the two dates.
 
+### uv
+
 <!-- prettier-ignore -->
-!!! note
-    For uv, Renovate reads `[tool.uv] exclude-newer` from `pyproject.toml` and uses the more restrictive (older) date between it and `minimumReleaseAge`.
-    The `exclude-newer` value can be an RFC 3339 timestamp (e.g. `2025-01-01T00:00:00Z`) or a friendly duration (e.g. `2 weeks`), but ISO 8601 durations (e.g. `P14D`) are not supported.
-    See uv's [dependency bot integration guide](https://docs.astral.sh/uv/guides/integration/dependency-bots/#dependency-cooldown) for details on configuring `exclude-newer`.
+For uv, Renovate reads `[tool.uv] exclude-newer` from `pyproject.toml` and uses the more restrictive (older) date between it and `minimumReleaseAge`.
+The `exclude-newer` value can be an RFC 3339 timestamp (e.g. `2025-01-01T00:00:00Z`) or a friendly duration (e.g. `2 weeks`), but ISO 8601 durations (e.g. `P14D`) are not supported.
+See uv's [dependency bot integration guide](https://docs.astral.sh/uv/guides/integration/dependency-bots/#dependency-cooldown) for details on configuring `exclude-newer`.
 
 ### What happens if the datasource and/or registry does not provide a release timestamp, when using `minimumReleaseAge`?
 

--- a/docs/usage/key-concepts/minimum-release-age.md
+++ b/docs/usage/key-concepts/minimum-release-age.md
@@ -44,6 +44,19 @@ To protect against this, it's recommended to ensure that your package manager co
 There is ongoing work to [integrate more closely with package manager checks](https://github.com/renovatebot/renovate/issues/41652) to make sure that Renovate's minimum release age configuration is specified when calling package managers that support it.
 If you have a package manager you'd like supported, please raise a [Suggest an Idea Discussion](https://github.com/renovatebot/renovate/discussions/new?category=suggest-an-idea).
 
+#### npm
+
+When `minimumReleaseAge` is configured, Renovate passes `--before=<date>` to npm commands during lock file generation.
+This ensures that npm only resolves package versions that were available before the cooldown threshold, protecting against newly published (and potentially malicious) transitive dependencies.
+
+The `--before` date is calculated as `now - minimumReleaseAge`.
+If a `before=<date>` or `min-release-age=<days>` setting already exists in the project's `.npmrc`, Renovate uses the stricter (older) of the two dates.
+
+<!-- prettier-ignore -->
+!!! note
+    For uv, Renovate reads `[tool.uv] exclude-newer` from `pyproject.toml` and uses the more restrictive (older) date between it and `minimumReleaseAge`.
+    See uv's [dependency bot integration guide](https://docs.astral.sh/uv/guides/integration/dependency-bots/#dependency-cooldown) for details on configuring `exclude-newer`.
+
 ### What happens if the datasource and/or registry does not provide a release timestamp, when using `minimumReleaseAge`?
 
 <!-- prettier-ignore -->

--- a/lib/modules/manager/pep621/processors/uv.spec.ts
+++ b/lib/modules/manager/pep621/processors/uv.spec.ts
@@ -14,7 +14,6 @@ import { getPkgReleases as _getPkgReleases } from '../../../datasource/index.ts'
 import { PypiDatasource } from '../../../datasource/pypi/index.ts';
 import type { UpdateArtifact, UpdateArtifactsConfig } from '../../types.ts';
 import { parsePyProject } from '../extract.ts';
-import { PyProject } from '../schema.ts';
 import { depTypes } from '../utils.ts';
 import { UvProcessor } from './uv.ts';
 
@@ -1056,17 +1055,6 @@ describe('modules/manager/pep621/processors/uv', () => {
         });
         expect(logger.logger.debug).toHaveBeenCalledWith(
           "Invalid exclude-newer value 'not-a-date' in pyproject.toml, ignoring",
-        );
-      });
-
-      it('handles exclude-newer as Date object in schema', () => {
-        const result = PyProject.parse({
-          tool: {
-            uv: { 'exclude-newer': new Date('2026-03-05T00:00:00.000Z') },
-          },
-        });
-        expect(result.tool?.uv?.['exclude-newer']).toBe(
-          '2026-03-05T00:00:00.000Z',
         );
       });
     });

--- a/lib/modules/manager/pep621/processors/uv.spec.ts
+++ b/lib/modules/manager/pep621/processors/uv.spec.ts
@@ -934,6 +934,27 @@ describe('modules/manager/pep621/processors/uv', () => {
         });
       });
 
+      it('sets UV_EXCLUDE_NEWER for non-maintenance upgrade-package command', async () => {
+        const updatedDeps = [
+          { packageName: 'dep1', depType: depTypes.dependencies },
+        ];
+        await processor.updateArtifacts(
+          {
+            packageFileName: 'folder/pyproject.toml',
+            newPackageFileContent: '',
+            config: {
+              minimumReleaseAge: '3 days',
+            },
+            updatedDeps,
+          },
+          parsePyProject('')!,
+        );
+        expect(execSnapshots[0].cmd).toBe('uv lock --upgrade-package dep1');
+        expect(execSnapshots[0].options?.env).toMatchObject({
+          UV_EXCLUDE_NEWER: '2026-03-10T00:00:00.000Z',
+        });
+      });
+
       it('skips UV_EXCLUDE_NEWER when minimumReleaseAge absent', async () => {
         await processor.updateArtifacts(
           {

--- a/lib/modules/manager/pep621/processors/uv.spec.ts
+++ b/lib/modules/manager/pep621/processors/uv.spec.ts
@@ -14,6 +14,7 @@ import { getPkgReleases as _getPkgReleases } from '../../../datasource/index.ts'
 import { PypiDatasource } from '../../../datasource/pypi/index.ts';
 import type { UpdateArtifact, UpdateArtifactsConfig } from '../../types.ts';
 import { parsePyProject } from '../extract.ts';
+import { PyProject } from '../schema.ts';
 import { depTypes } from '../utils.ts';
 import { UvProcessor } from './uv.ts';
 
@@ -1293,6 +1294,17 @@ describe('modules/manager/pep621/processors/uv', () => {
         expect(execSnapshots[0].options?.env).toMatchObject({
           UV_EXCLUDE_NEWER: '2026-03-05T00:00:00.000Z',
         });
+      });
+
+      it('handles exclude-newer as Date object in schema', () => {
+        const result = PyProject.parse({
+          tool: {
+            uv: { 'exclude-newer': new Date('2026-03-05T00:00:00.000Z') },
+          },
+        });
+        expect(result.tool?.uv?.['exclude-newer']).toBe(
+          '2026-03-05T00:00:00.000Z',
+        );
       });
     });
   });

--- a/lib/modules/manager/pep621/processors/uv.spec.ts
+++ b/lib/modules/manager/pep621/processors/uv.spec.ts
@@ -897,9 +897,8 @@ describe('modules/manager/pep621/processors/uv', () => {
       let execSnapshots: ReturnType<typeof mockExecAll>;
 
       beforeEach(() => {
-        vi.spyOn(Date, 'now').mockReturnValue(
-          new Date('2026-03-13T00:00:00.000Z').getTime(),
-        );
+         vi.useFakeTimers();
+         vi.setSystemTime(new Date('2026-03-13T00:00:00.000Z'));
         execSnapshots = mockExecAll();
         GlobalConfig.set(adminConfig);
         fs.findLocalSiblingOrParent.mockResolvedValueOnce('uv.lock');
@@ -915,6 +914,7 @@ describe('modules/manager/pep621/processors/uv', () => {
 
       afterEach(() => {
         vi.restoreAllMocks();
+        vi.useRealTimers();
       });
 
       it('sets UV_EXCLUDE_NEWER from minimumReleaseAge', async () => {

--- a/lib/modules/manager/pep621/processors/uv.spec.ts
+++ b/lib/modules/manager/pep621/processors/uv.spec.ts
@@ -894,29 +894,31 @@ describe('modules/manager/pep621/processors/uv', () => {
     });
 
     describe('UV_EXCLUDE_NEWER with minimumReleaseAge', () => {
-      beforeEach(() => {
-        vi.restoreAllMocks();
-      });
+      let execSnapshots: ReturnType<typeof mockExecAll>;
 
-      it('sets UV_EXCLUDE_NEWER env var on lockfile maintenance with minimumReleaseAge', async () => {
+      beforeEach(() => {
         vi.spyOn(Date, 'now').mockReturnValue(
           new Date('2026-03-13T00:00:00.000Z').getTime(),
         );
-        const execSnapshots = mockExecAll();
+        execSnapshots = mockExecAll();
         GlobalConfig.set(adminConfig);
         fs.findLocalSiblingOrParent.mockResolvedValueOnce('uv.lock');
         fs.readLocalFile.mockResolvedValueOnce('test content');
         fs.readLocalFile.mockResolvedValueOnce('changed test content');
-        // python
         getPkgReleases.mockResolvedValueOnce({
           releases: [{ version: '3.11.1' }],
         });
-        // uv
         getPkgReleases.mockResolvedValueOnce({
           releases: [{ version: '0.2.35' }],
         });
+      });
 
-        const result = await processor.updateArtifacts(
+      afterEach(() => {
+        vi.restoreAllMocks();
+      });
+
+      it('sets UV_EXCLUDE_NEWER from minimumReleaseAge', async () => {
+        await processor.updateArtifacts(
           {
             packageFileName: 'folder/pyproject.toml',
             newPackageFileContent: '',
@@ -928,122 +930,25 @@ describe('modules/manager/pep621/processors/uv', () => {
           },
           parsePyProject('')!,
         );
-        expect(result).toEqual([
-          {
-            file: {
-              contents: 'changed test content',
-              path: 'uv.lock',
-              type: 'addition',
-            },
-          },
-        ]);
-        expect(execSnapshots).toMatchObject([{ cmd: 'uv lock --upgrade' }]);
-        expect(execSnapshots[0].cmd).not.toContain('--exclude-newer');
         expect(execSnapshots[0].options?.env).toMatchObject({
           UV_EXCLUDE_NEWER: '2026-03-10T00:00:00.000Z',
         });
       });
 
-      it('sets UV_EXCLUDE_NEWER env var on per-package update with minimumReleaseAge', async () => {
-        vi.spyOn(Date, 'now').mockReturnValue(
-          new Date('2026-03-13T00:00:00.000Z').getTime(),
-        );
-        const execSnapshots = mockExecAll();
-        GlobalConfig.set(adminConfig);
-        fs.findLocalSiblingOrParent.mockResolvedValueOnce('uv.lock');
-        fs.readLocalFile.mockResolvedValueOnce('test content');
-        fs.readLocalFile.mockResolvedValueOnce('changed test content');
-        // python
-        getPkgReleases.mockResolvedValueOnce({
-          releases: [{ version: '3.11.1' }],
-        });
-        // uv
-        getPkgReleases.mockResolvedValueOnce({
-          releases: [{ version: '0.2.35' }],
-        });
-
-        const updatedDeps = [
-          { packageName: 'dep1', depType: depTypes.dependencies },
-        ];
-        const result = await processor.updateArtifacts(
-          {
-            packageFileName: 'folder/pyproject.toml',
-            newPackageFileContent: '',
-            config: {
-              minimumReleaseAge: '7 days',
-            },
-            updatedDeps,
-          },
-          parsePyProject('')!,
-        );
-        expect(result).toEqual([
-          {
-            file: {
-              contents: 'changed test content',
-              path: 'uv.lock',
-              type: 'addition',
-            },
-          },
-        ]);
-        expect(execSnapshots).toMatchObject([
-          { cmd: 'uv lock --upgrade-package dep1' },
-        ]);
-        expect(execSnapshots[0].cmd).not.toContain('--exclude-newer');
-        expect(execSnapshots[0].options?.env).toMatchObject({
-          UV_EXCLUDE_NEWER: '2026-03-06T00:00:00.000Z',
-        });
-      });
-
-      it('does not set UV_EXCLUDE_NEWER when no minimumReleaseAge', async () => {
-        const execSnapshots = mockExecAll();
-        GlobalConfig.set(adminConfig);
-        fs.findLocalSiblingOrParent.mockResolvedValueOnce('uv.lock');
-        fs.readLocalFile.mockResolvedValueOnce('test content');
-        fs.readLocalFile.mockResolvedValueOnce('changed test content');
-        // python
-        getPkgReleases.mockResolvedValueOnce({
-          releases: [{ version: '3.11.1' }],
-        });
-        // uv
-        getPkgReleases.mockResolvedValueOnce({
-          releases: [{ version: '0.2.35' }],
-        });
-
+      it('skips UV_EXCLUDE_NEWER when minimumReleaseAge absent', async () => {
         await processor.updateArtifacts(
           {
             packageFileName: 'folder/pyproject.toml',
             newPackageFileContent: '',
-            config: {
-              isLockFileMaintenance: true,
-            },
+            config: { isLockFileMaintenance: true },
             updatedDeps: [],
           },
           parsePyProject('')!,
         );
-        expect(execSnapshots).toMatchObject([
-          {
-            cmd: 'uv lock --upgrade',
-          },
-        ]);
-        expect(execSnapshots[0].cmd).not.toContain('--exclude-newer');
         expect(execSnapshots[0].options?.env?.UV_EXCLUDE_NEWER).toBeUndefined();
       });
 
-      it('does not set UV_EXCLUDE_NEWER on invalid minimumReleaseAge', async () => {
-        const execSnapshots = mockExecAll();
-        GlobalConfig.set(adminConfig);
-        fs.findLocalSiblingOrParent.mockResolvedValueOnce('uv.lock');
-        fs.readLocalFile.mockResolvedValueOnce('test content');
-        fs.readLocalFile.mockResolvedValueOnce('changed test content');
-        // python
-        getPkgReleases.mockResolvedValueOnce({
-          releases: [{ version: '3.11.1' }],
-        });
-        // uv
-        getPkgReleases.mockResolvedValueOnce({
-          releases: [{ version: '0.2.35' }],
-        });
-
+      it('skips UV_EXCLUDE_NEWER on unparseable minimumReleaseAge', async () => {
         await processor.updateArtifacts(
           {
             packageFileName: 'folder/pyproject.toml',
@@ -1056,76 +961,17 @@ describe('modules/manager/pep621/processors/uv', () => {
           },
           parsePyProject('')!,
         );
-        expect(execSnapshots).toMatchObject([
-          {
-            cmd: 'uv lock --upgrade',
-          },
-        ]);
-        expect(execSnapshots[0].cmd).not.toContain('--exclude-newer');
         expect(execSnapshots[0].options?.env?.UV_EXCLUDE_NEWER).toBeUndefined();
         expect(logger.logger.debug).toHaveBeenCalledWith(
-          { minimumReleaseAge: 'invalid garbage' },
-          'Invalid minimumReleaseAge value, skipping UV_EXCLUDE_NEWER for uv lock',
+          "Invalid minimumReleaseAge value 'invalid garbage', skipping UV_EXCLUDE_NEWER for uv lock",
         );
       });
 
-      it('does not set UV_EXCLUDE_NEWER on empty string minimumReleaseAge', async () => {
-        const execSnapshots = mockExecAll();
-        GlobalConfig.set(adminConfig);
-        fs.findLocalSiblingOrParent.mockResolvedValueOnce('uv.lock');
-        fs.readLocalFile.mockResolvedValueOnce('test content');
-        fs.readLocalFile.mockResolvedValueOnce('changed test content');
-        // python
-        getPkgReleases.mockResolvedValueOnce({
-          releases: [{ version: '3.11.1' }],
-        });
-        // uv
-        getPkgReleases.mockResolvedValueOnce({
-          releases: [{ version: '0.2.35' }],
-        });
-
-        await processor.updateArtifacts(
-          {
-            packageFileName: 'folder/pyproject.toml',
-            newPackageFileContent: '',
-            config: {
-              isLockFileMaintenance: true,
-              minimumReleaseAge: '',
-            },
-            updatedDeps: [],
-          },
-          parsePyProject('')!,
-        );
-        expect(execSnapshots).toMatchObject([
-          {
-            cmd: 'uv lock --upgrade',
-          },
-        ]);
-        expect(execSnapshots[0].cmd).not.toContain('--exclude-newer');
-        expect(execSnapshots[0].options?.env?.UV_EXCLUDE_NEWER).toBeUndefined();
-      });
-
-      it('uses pyproject exclude-newer when it is more restrictive than minimumReleaseAge', async () => {
-        vi.spyOn(Date, 'now').mockReturnValue(
-          new Date('2026-03-13T00:00:00.000Z').getTime(),
-        );
-        const execSnapshots = mockExecAll();
-        GlobalConfig.set(adminConfig);
-        fs.findLocalSiblingOrParent.mockResolvedValueOnce('uv.lock');
-        fs.readLocalFile.mockResolvedValueOnce('test content');
-        fs.readLocalFile.mockResolvedValueOnce('changed test content');
-        getPkgReleases.mockResolvedValueOnce({
-          releases: [{ version: '3.11.1' }],
-        });
-        getPkgReleases.mockResolvedValueOnce({
-          releases: [{ version: '0.2.35' }],
-        });
-
+      it('uses pyproject ISO date when more restrictive', async () => {
         const pyproject = parsePyProject(codeBlock`
           [tool.uv]
           exclude-newer = "2026-03-05T00:00:00.000Z"
         `)!;
-
         await processor.updateArtifacts(
           {
             packageFileName: 'folder/pyproject.toml',
@@ -1138,33 +984,16 @@ describe('modules/manager/pep621/processors/uv', () => {
           },
           pyproject,
         );
-        expect(execSnapshots[0].cmd).not.toContain('--exclude-newer');
         expect(execSnapshots[0].options?.env).toMatchObject({
           UV_EXCLUDE_NEWER: '2026-03-05T00:00:00.000Z',
         });
       });
 
-      it('uses minimumReleaseAge date when it is more restrictive than pyproject exclude-newer', async () => {
-        vi.spyOn(Date, 'now').mockReturnValue(
-          new Date('2026-03-13T00:00:00.000Z').getTime(),
-        );
-        const execSnapshots = mockExecAll();
-        GlobalConfig.set(adminConfig);
-        fs.findLocalSiblingOrParent.mockResolvedValueOnce('uv.lock');
-        fs.readLocalFile.mockResolvedValueOnce('test content');
-        fs.readLocalFile.mockResolvedValueOnce('changed test content');
-        getPkgReleases.mockResolvedValueOnce({
-          releases: [{ version: '3.11.1' }],
-        });
-        getPkgReleases.mockResolvedValueOnce({
-          releases: [{ version: '0.2.35' }],
-        });
-
+      it('uses minimumReleaseAge when pyproject less restrictive', async () => {
         const pyproject = parsePyProject(codeBlock`
           [tool.uv]
           exclude-newer = "2026-03-12T00:00:00.000Z"
         `)!;
-
         await processor.updateArtifacts(
           {
             packageFileName: 'folder/pyproject.toml',
@@ -1177,33 +1006,39 @@ describe('modules/manager/pep621/processors/uv', () => {
           },
           pyproject,
         );
-        expect(execSnapshots[0].cmd).not.toContain('--exclude-newer');
         expect(execSnapshots[0].options?.env).toMatchObject({
           UV_EXCLUDE_NEWER: '2026-03-10T00:00:00.000Z',
         });
       });
 
-      it('ignores invalid exclude-newer in pyproject.toml and uses minimumReleaseAge', async () => {
-        vi.spyOn(Date, 'now').mockReturnValue(
-          new Date('2026-03-13T00:00:00.000Z').getTime(),
+      it('uses pyproject relative duration when more restrictive', async () => {
+        const pyproject = parsePyProject(codeBlock`
+          [tool.uv]
+          exclude-newer = "2 weeks"
+        `)!;
+        await processor.updateArtifacts(
+          {
+            packageFileName: 'folder/pyproject.toml',
+            newPackageFileContent: '',
+            config: {
+              isLockFileMaintenance: true,
+              minimumReleaseAge: '3 days',
+            },
+            updatedDeps: [],
+          },
+          pyproject,
         );
-        const execSnapshots = mockExecAll();
-        GlobalConfig.set(adminConfig);
-        fs.findLocalSiblingOrParent.mockResolvedValueOnce('uv.lock');
-        fs.readLocalFile.mockResolvedValueOnce('test content');
-        fs.readLocalFile.mockResolvedValueOnce('changed test content');
-        getPkgReleases.mockResolvedValueOnce({
-          releases: [{ version: '3.11.1' }],
+        // 2 weeks = 14 days ago = 2026-02-27, which is older than 3 days ago = 2026-03-10
+        expect(execSnapshots[0].options?.env).toMatchObject({
+          UV_EXCLUDE_NEWER: '2026-02-27T00:00:00.000Z',
         });
-        getPkgReleases.mockResolvedValueOnce({
-          releases: [{ version: '0.2.35' }],
-        });
+      });
 
+      it('ignores unparseable pyproject exclude-newer and uses minimumReleaseAge', async () => {
         const pyproject = parsePyProject(codeBlock`
           [tool.uv]
           exclude-newer = "not-a-date"
         `)!;
-
         await processor.updateArtifacts(
           {
             packageFileName: 'folder/pyproject.toml',
@@ -1220,80 +1055,8 @@ describe('modules/manager/pep621/processors/uv', () => {
           UV_EXCLUDE_NEWER: '2026-03-10T00:00:00.000Z',
         });
         expect(logger.logger.debug).toHaveBeenCalledWith(
-          { excludeNewer: 'not-a-date' },
-          'Invalid exclude-newer value in pyproject.toml, ignoring',
+          "Invalid exclude-newer value 'not-a-date' in pyproject.toml, ignoring",
         );
-      });
-
-      it('does not set UV_EXCLUDE_NEWER when no minimumReleaseAge even if pyproject has exclude-newer', async () => {
-        const execSnapshots = mockExecAll();
-        GlobalConfig.set(adminConfig);
-        fs.findLocalSiblingOrParent.mockResolvedValueOnce('uv.lock');
-        fs.readLocalFile.mockResolvedValueOnce('test content');
-        fs.readLocalFile.mockResolvedValueOnce('changed test content');
-        getPkgReleases.mockResolvedValueOnce({
-          releases: [{ version: '3.11.1' }],
-        });
-        getPkgReleases.mockResolvedValueOnce({
-          releases: [{ version: '0.2.35' }],
-        });
-
-        const pyproject = parsePyProject(codeBlock`
-          [tool.uv]
-          exclude-newer = "2026-03-05T00:00:00.000Z"
-        `)!;
-
-        await processor.updateArtifacts(
-          {
-            packageFileName: 'folder/pyproject.toml',
-            newPackageFileContent: '',
-            config: {
-              isLockFileMaintenance: true,
-            },
-            updatedDeps: [],
-          },
-          pyproject,
-        );
-        expect(execSnapshots[0].cmd).not.toContain('--exclude-newer');
-        expect(execSnapshots[0].options?.env?.UV_EXCLUDE_NEWER).toBeUndefined();
-      });
-
-      it('handles pyproject exclude-newer as local date without time component', async () => {
-        vi.spyOn(Date, 'now').mockReturnValue(
-          new Date('2026-03-13T00:00:00.000Z').getTime(),
-        );
-        const execSnapshots = mockExecAll();
-        GlobalConfig.set(adminConfig);
-        fs.findLocalSiblingOrParent.mockResolvedValueOnce('uv.lock');
-        fs.readLocalFile.mockResolvedValueOnce('test content');
-        fs.readLocalFile.mockResolvedValueOnce('changed test content');
-        getPkgReleases.mockResolvedValueOnce({
-          releases: [{ version: '3.11.1' }],
-        });
-        getPkgReleases.mockResolvedValueOnce({
-          releases: [{ version: '0.2.35' }],
-        });
-
-        const pyproject = parsePyProject(codeBlock`
-          [tool.uv]
-          exclude-newer = "2026-03-05"
-        `)!;
-
-        await processor.updateArtifacts(
-          {
-            packageFileName: 'folder/pyproject.toml',
-            newPackageFileContent: '',
-            config: {
-              isLockFileMaintenance: true,
-              minimumReleaseAge: '3 days',
-            },
-            updatedDeps: [],
-          },
-          pyproject,
-        );
-        expect(execSnapshots[0].options?.env).toMatchObject({
-          UV_EXCLUDE_NEWER: '2026-03-05T00:00:00.000Z',
-        });
       });
 
       it('handles exclude-newer as Date object in schema', () => {

--- a/lib/modules/manager/pep621/processors/uv.spec.ts
+++ b/lib/modules/manager/pep621/processors/uv.spec.ts
@@ -891,5 +891,213 @@ describe('modules/manager/pep621/processors/uv', () => {
         },
       ]);
     });
+
+    describe('--exclude-newer with minimumReleaseAge', () => {
+      beforeEach(() => {
+        vi.restoreAllMocks();
+      });
+
+      it('adds --exclude-newer on lockfile maintenance with minimumReleaseAge', async () => {
+        vi.spyOn(Date, 'now').mockReturnValue(
+          new Date('2026-03-13T00:00:00.000Z').getTime(),
+        );
+        const execSnapshots = mockExecAll();
+        GlobalConfig.set(adminConfig);
+        fs.findLocalSiblingOrParent.mockResolvedValueOnce('uv.lock');
+        fs.readLocalFile.mockResolvedValueOnce('test content');
+        fs.readLocalFile.mockResolvedValueOnce('changed test content');
+        // python
+        getPkgReleases.mockResolvedValueOnce({
+          releases: [{ version: '3.11.1' }],
+        });
+        // uv
+        getPkgReleases.mockResolvedValueOnce({
+          releases: [{ version: '0.2.35' }],
+        });
+
+        const result = await processor.updateArtifacts(
+          {
+            packageFileName: 'folder/pyproject.toml',
+            newPackageFileContent: '',
+            config: {
+              isLockFileMaintenance: true,
+              minimumReleaseAge: '3 days',
+            },
+            updatedDeps: [],
+          },
+          parsePyProject('')!,
+        );
+        expect(result).toEqual([
+          {
+            file: {
+              contents: 'changed test content',
+              path: 'uv.lock',
+              type: 'addition',
+            },
+          },
+        ]);
+        expect(execSnapshots).toMatchObject([
+          {
+            cmd: 'uv lock --upgrade --exclude-newer=2026-03-10T00:00:00.000Z',
+          },
+        ]);
+      });
+
+      it('adds --exclude-newer on per-package update with minimumReleaseAge', async () => {
+        vi.spyOn(Date, 'now').mockReturnValue(
+          new Date('2026-03-13T00:00:00.000Z').getTime(),
+        );
+        const execSnapshots = mockExecAll();
+        GlobalConfig.set(adminConfig);
+        fs.findLocalSiblingOrParent.mockResolvedValueOnce('uv.lock');
+        fs.readLocalFile.mockResolvedValueOnce('test content');
+        fs.readLocalFile.mockResolvedValueOnce('changed test content');
+        // python
+        getPkgReleases.mockResolvedValueOnce({
+          releases: [{ version: '3.11.1' }],
+        });
+        // uv
+        getPkgReleases.mockResolvedValueOnce({
+          releases: [{ version: '0.2.35' }],
+        });
+
+        const updatedDeps = [
+          { packageName: 'dep1', depType: depTypes.dependencies },
+        ];
+        const result = await processor.updateArtifacts(
+          {
+            packageFileName: 'folder/pyproject.toml',
+            newPackageFileContent: '',
+            config: {
+              minimumReleaseAge: '7 days',
+            },
+            updatedDeps,
+          },
+          parsePyProject('')!,
+        );
+        expect(result).toEqual([
+          {
+            file: {
+              contents: 'changed test content',
+              path: 'uv.lock',
+              type: 'addition',
+            },
+          },
+        ]);
+        expect(execSnapshots).toMatchObject([
+          {
+            cmd: 'uv lock --upgrade-package dep1 --exclude-newer=2026-03-06T00:00:00.000Z',
+          },
+        ]);
+      });
+
+      it('does not add --exclude-newer when no minimumReleaseAge', async () => {
+        const execSnapshots = mockExecAll();
+        GlobalConfig.set(adminConfig);
+        fs.findLocalSiblingOrParent.mockResolvedValueOnce('uv.lock');
+        fs.readLocalFile.mockResolvedValueOnce('test content');
+        fs.readLocalFile.mockResolvedValueOnce('changed test content');
+        // python
+        getPkgReleases.mockResolvedValueOnce({
+          releases: [{ version: '3.11.1' }],
+        });
+        // uv
+        getPkgReleases.mockResolvedValueOnce({
+          releases: [{ version: '0.2.35' }],
+        });
+
+        await processor.updateArtifacts(
+          {
+            packageFileName: 'folder/pyproject.toml',
+            newPackageFileContent: '',
+            config: {
+              isLockFileMaintenance: true,
+            },
+            updatedDeps: [],
+          },
+          parsePyProject('')!,
+        );
+        expect(execSnapshots).toMatchObject([
+          {
+            cmd: 'uv lock --upgrade',
+          },
+        ]);
+        expect(execSnapshots[0].cmd).not.toContain('--exclude-newer');
+      });
+
+      it('skips --exclude-newer on invalid minimumReleaseAge', async () => {
+        const execSnapshots = mockExecAll();
+        GlobalConfig.set(adminConfig);
+        fs.findLocalSiblingOrParent.mockResolvedValueOnce('uv.lock');
+        fs.readLocalFile.mockResolvedValueOnce('test content');
+        fs.readLocalFile.mockResolvedValueOnce('changed test content');
+        // python
+        getPkgReleases.mockResolvedValueOnce({
+          releases: [{ version: '3.11.1' }],
+        });
+        // uv
+        getPkgReleases.mockResolvedValueOnce({
+          releases: [{ version: '0.2.35' }],
+        });
+
+        await processor.updateArtifacts(
+          {
+            packageFileName: 'folder/pyproject.toml',
+            newPackageFileContent: '',
+            config: {
+              isLockFileMaintenance: true,
+              minimumReleaseAge: 'invalid garbage',
+            },
+            updatedDeps: [],
+          },
+          parsePyProject('')!,
+        );
+        expect(execSnapshots).toMatchObject([
+          {
+            cmd: 'uv lock --upgrade',
+          },
+        ]);
+        expect(execSnapshots[0].cmd).not.toContain('--exclude-newer');
+        expect(logger.logger.debug).toHaveBeenCalledWith(
+          { minimumReleaseAge: 'invalid garbage' },
+          'Invalid minimumReleaseAge value, skipping --exclude-newer for uv lock',
+        );
+      });
+
+      it('skips --exclude-newer on empty string minimumReleaseAge', async () => {
+        const execSnapshots = mockExecAll();
+        GlobalConfig.set(adminConfig);
+        fs.findLocalSiblingOrParent.mockResolvedValueOnce('uv.lock');
+        fs.readLocalFile.mockResolvedValueOnce('test content');
+        fs.readLocalFile.mockResolvedValueOnce('changed test content');
+        // python
+        getPkgReleases.mockResolvedValueOnce({
+          releases: [{ version: '3.11.1' }],
+        });
+        // uv
+        getPkgReleases.mockResolvedValueOnce({
+          releases: [{ version: '0.2.35' }],
+        });
+
+        await processor.updateArtifacts(
+          {
+            packageFileName: 'folder/pyproject.toml',
+            newPackageFileContent: '',
+            config: {
+              isLockFileMaintenance: true,
+              minimumReleaseAge: '',
+            },
+            updatedDeps: [],
+          },
+          parsePyProject('')!,
+        );
+        expect(execSnapshots).toMatchObject([
+          {
+            cmd: 'uv lock --upgrade',
+          },
+        ]);
+        expect(execSnapshots[0].cmd).not.toContain('--exclude-newer');
+      });
+    });
   });
 });

--- a/lib/modules/manager/pep621/processors/uv.spec.ts
+++ b/lib/modules/manager/pep621/processors/uv.spec.ts
@@ -896,8 +896,8 @@ describe('modules/manager/pep621/processors/uv', () => {
       let execSnapshots: ReturnType<typeof mockExecAll>;
 
       beforeEach(() => {
-         vi.useFakeTimers();
-         vi.setSystemTime(new Date('2026-03-13T00:00:00.000Z'));
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-03-13T00:00:00.000Z'));
         execSnapshots = mockExecAll();
         GlobalConfig.set(adminConfig);
         fs.findLocalSiblingOrParent.mockResolvedValueOnce('uv.lock');

--- a/lib/modules/manager/pep621/processors/uv.spec.ts
+++ b/lib/modules/manager/pep621/processors/uv.spec.ts
@@ -892,12 +892,12 @@ describe('modules/manager/pep621/processors/uv', () => {
       ]);
     });
 
-    describe('--exclude-newer with minimumReleaseAge', () => {
+    describe('UV_EXCLUDE_NEWER with minimumReleaseAge', () => {
       beforeEach(() => {
         vi.restoreAllMocks();
       });
 
-      it('adds --exclude-newer on lockfile maintenance with minimumReleaseAge', async () => {
+      it('sets UV_EXCLUDE_NEWER env var on lockfile maintenance with minimumReleaseAge', async () => {
         vi.spyOn(Date, 'now').mockReturnValue(
           new Date('2026-03-13T00:00:00.000Z').getTime(),
         );
@@ -936,14 +936,14 @@ describe('modules/manager/pep621/processors/uv', () => {
             },
           },
         ]);
-        expect(execSnapshots).toMatchObject([
-          {
-            cmd: 'uv lock --upgrade --exclude-newer=2026-03-10T00:00:00.000Z',
-          },
-        ]);
+        expect(execSnapshots).toMatchObject([{ cmd: 'uv lock --upgrade' }]);
+        expect(execSnapshots[0].cmd).not.toContain('--exclude-newer');
+        expect(execSnapshots[0].options?.env).toMatchObject({
+          UV_EXCLUDE_NEWER: '2026-03-10T00:00:00.000Z',
+        });
       });
 
-      it('adds --exclude-newer on per-package update with minimumReleaseAge', async () => {
+      it('sets UV_EXCLUDE_NEWER env var on per-package update with minimumReleaseAge', async () => {
         vi.spyOn(Date, 'now').mockReturnValue(
           new Date('2026-03-13T00:00:00.000Z').getTime(),
         );
@@ -985,13 +985,15 @@ describe('modules/manager/pep621/processors/uv', () => {
           },
         ]);
         expect(execSnapshots).toMatchObject([
-          {
-            cmd: 'uv lock --upgrade-package dep1 --exclude-newer=2026-03-06T00:00:00.000Z',
-          },
+          { cmd: 'uv lock --upgrade-package dep1' },
         ]);
+        expect(execSnapshots[0].cmd).not.toContain('--exclude-newer');
+        expect(execSnapshots[0].options?.env).toMatchObject({
+          UV_EXCLUDE_NEWER: '2026-03-06T00:00:00.000Z',
+        });
       });
 
-      it('does not add --exclude-newer when no minimumReleaseAge', async () => {
+      it('does not set UV_EXCLUDE_NEWER when no minimumReleaseAge', async () => {
         const execSnapshots = mockExecAll();
         GlobalConfig.set(adminConfig);
         fs.findLocalSiblingOrParent.mockResolvedValueOnce('uv.lock');
@@ -1023,9 +1025,10 @@ describe('modules/manager/pep621/processors/uv', () => {
           },
         ]);
         expect(execSnapshots[0].cmd).not.toContain('--exclude-newer');
+        expect(execSnapshots[0].options?.env?.UV_EXCLUDE_NEWER).toBeUndefined();
       });
 
-      it('skips --exclude-newer on invalid minimumReleaseAge', async () => {
+      it('does not set UV_EXCLUDE_NEWER on invalid minimumReleaseAge', async () => {
         const execSnapshots = mockExecAll();
         GlobalConfig.set(adminConfig);
         fs.findLocalSiblingOrParent.mockResolvedValueOnce('uv.lock');
@@ -1058,13 +1061,14 @@ describe('modules/manager/pep621/processors/uv', () => {
           },
         ]);
         expect(execSnapshots[0].cmd).not.toContain('--exclude-newer');
+        expect(execSnapshots[0].options?.env?.UV_EXCLUDE_NEWER).toBeUndefined();
         expect(logger.logger.debug).toHaveBeenCalledWith(
           { minimumReleaseAge: 'invalid garbage' },
-          'Invalid minimumReleaseAge value, skipping --exclude-newer for uv lock',
+          'Invalid minimumReleaseAge value, skipping UV_EXCLUDE_NEWER for uv lock',
         );
       });
 
-      it('skips --exclude-newer on empty string minimumReleaseAge', async () => {
+      it('does not set UV_EXCLUDE_NEWER on empty string minimumReleaseAge', async () => {
         const execSnapshots = mockExecAll();
         GlobalConfig.set(adminConfig);
         fs.findLocalSiblingOrParent.mockResolvedValueOnce('uv.lock');
@@ -1097,6 +1101,198 @@ describe('modules/manager/pep621/processors/uv', () => {
           },
         ]);
         expect(execSnapshots[0].cmd).not.toContain('--exclude-newer');
+        expect(execSnapshots[0].options?.env?.UV_EXCLUDE_NEWER).toBeUndefined();
+      });
+
+      it('uses pyproject exclude-newer when it is more restrictive than minimumReleaseAge', async () => {
+        vi.spyOn(Date, 'now').mockReturnValue(
+          new Date('2026-03-13T00:00:00.000Z').getTime(),
+        );
+        const execSnapshots = mockExecAll();
+        GlobalConfig.set(adminConfig);
+        fs.findLocalSiblingOrParent.mockResolvedValueOnce('uv.lock');
+        fs.readLocalFile.mockResolvedValueOnce('test content');
+        fs.readLocalFile.mockResolvedValueOnce('changed test content');
+        getPkgReleases.mockResolvedValueOnce({
+          releases: [{ version: '3.11.1' }],
+        });
+        getPkgReleases.mockResolvedValueOnce({
+          releases: [{ version: '0.2.35' }],
+        });
+
+        const pyproject = parsePyProject(codeBlock`
+          [tool.uv]
+          exclude-newer = "2026-03-05T00:00:00.000Z"
+        `)!;
+
+        await processor.updateArtifacts(
+          {
+            packageFileName: 'folder/pyproject.toml',
+            newPackageFileContent: '',
+            config: {
+              isLockFileMaintenance: true,
+              minimumReleaseAge: '3 days',
+            },
+            updatedDeps: [],
+          },
+          pyproject,
+        );
+        expect(execSnapshots[0].cmd).not.toContain('--exclude-newer');
+        expect(execSnapshots[0].options?.env).toMatchObject({
+          UV_EXCLUDE_NEWER: '2026-03-05T00:00:00.000Z',
+        });
+      });
+
+      it('uses minimumReleaseAge date when it is more restrictive than pyproject exclude-newer', async () => {
+        vi.spyOn(Date, 'now').mockReturnValue(
+          new Date('2026-03-13T00:00:00.000Z').getTime(),
+        );
+        const execSnapshots = mockExecAll();
+        GlobalConfig.set(adminConfig);
+        fs.findLocalSiblingOrParent.mockResolvedValueOnce('uv.lock');
+        fs.readLocalFile.mockResolvedValueOnce('test content');
+        fs.readLocalFile.mockResolvedValueOnce('changed test content');
+        getPkgReleases.mockResolvedValueOnce({
+          releases: [{ version: '3.11.1' }],
+        });
+        getPkgReleases.mockResolvedValueOnce({
+          releases: [{ version: '0.2.35' }],
+        });
+
+        const pyproject = parsePyProject(codeBlock`
+          [tool.uv]
+          exclude-newer = "2026-03-12T00:00:00.000Z"
+        `)!;
+
+        await processor.updateArtifacts(
+          {
+            packageFileName: 'folder/pyproject.toml',
+            newPackageFileContent: '',
+            config: {
+              isLockFileMaintenance: true,
+              minimumReleaseAge: '3 days',
+            },
+            updatedDeps: [],
+          },
+          pyproject,
+        );
+        expect(execSnapshots[0].cmd).not.toContain('--exclude-newer');
+        expect(execSnapshots[0].options?.env).toMatchObject({
+          UV_EXCLUDE_NEWER: '2026-03-10T00:00:00.000Z',
+        });
+      });
+
+      it('ignores invalid exclude-newer in pyproject.toml and uses minimumReleaseAge', async () => {
+        vi.spyOn(Date, 'now').mockReturnValue(
+          new Date('2026-03-13T00:00:00.000Z').getTime(),
+        );
+        const execSnapshots = mockExecAll();
+        GlobalConfig.set(adminConfig);
+        fs.findLocalSiblingOrParent.mockResolvedValueOnce('uv.lock');
+        fs.readLocalFile.mockResolvedValueOnce('test content');
+        fs.readLocalFile.mockResolvedValueOnce('changed test content');
+        getPkgReleases.mockResolvedValueOnce({
+          releases: [{ version: '3.11.1' }],
+        });
+        getPkgReleases.mockResolvedValueOnce({
+          releases: [{ version: '0.2.35' }],
+        });
+
+        const pyproject = parsePyProject(codeBlock`
+          [tool.uv]
+          exclude-newer = "not-a-date"
+        `)!;
+
+        await processor.updateArtifacts(
+          {
+            packageFileName: 'folder/pyproject.toml',
+            newPackageFileContent: '',
+            config: {
+              isLockFileMaintenance: true,
+              minimumReleaseAge: '3 days',
+            },
+            updatedDeps: [],
+          },
+          pyproject,
+        );
+        expect(execSnapshots[0].options?.env).toMatchObject({
+          UV_EXCLUDE_NEWER: '2026-03-10T00:00:00.000Z',
+        });
+        expect(logger.logger.debug).toHaveBeenCalledWith(
+          { excludeNewer: 'not-a-date' },
+          'Invalid exclude-newer value in pyproject.toml, ignoring',
+        );
+      });
+
+      it('does not set UV_EXCLUDE_NEWER when no minimumReleaseAge even if pyproject has exclude-newer', async () => {
+        const execSnapshots = mockExecAll();
+        GlobalConfig.set(adminConfig);
+        fs.findLocalSiblingOrParent.mockResolvedValueOnce('uv.lock');
+        fs.readLocalFile.mockResolvedValueOnce('test content');
+        fs.readLocalFile.mockResolvedValueOnce('changed test content');
+        getPkgReleases.mockResolvedValueOnce({
+          releases: [{ version: '3.11.1' }],
+        });
+        getPkgReleases.mockResolvedValueOnce({
+          releases: [{ version: '0.2.35' }],
+        });
+
+        const pyproject = parsePyProject(codeBlock`
+          [tool.uv]
+          exclude-newer = "2026-03-05T00:00:00.000Z"
+        `)!;
+
+        await processor.updateArtifacts(
+          {
+            packageFileName: 'folder/pyproject.toml',
+            newPackageFileContent: '',
+            config: {
+              isLockFileMaintenance: true,
+            },
+            updatedDeps: [],
+          },
+          pyproject,
+        );
+        expect(execSnapshots[0].cmd).not.toContain('--exclude-newer');
+        expect(execSnapshots[0].options?.env?.UV_EXCLUDE_NEWER).toBeUndefined();
+      });
+
+      it('handles pyproject exclude-newer as local date without time component', async () => {
+        vi.spyOn(Date, 'now').mockReturnValue(
+          new Date('2026-03-13T00:00:00.000Z').getTime(),
+        );
+        const execSnapshots = mockExecAll();
+        GlobalConfig.set(adminConfig);
+        fs.findLocalSiblingOrParent.mockResolvedValueOnce('uv.lock');
+        fs.readLocalFile.mockResolvedValueOnce('test content');
+        fs.readLocalFile.mockResolvedValueOnce('changed test content');
+        getPkgReleases.mockResolvedValueOnce({
+          releases: [{ version: '3.11.1' }],
+        });
+        getPkgReleases.mockResolvedValueOnce({
+          releases: [{ version: '0.2.35' }],
+        });
+
+        const pyproject = parsePyProject(codeBlock`
+          [tool.uv]
+          exclude-newer = "2026-03-05"
+        `)!;
+
+        await processor.updateArtifacts(
+          {
+            packageFileName: 'folder/pyproject.toml',
+            newPackageFileContent: '',
+            config: {
+              isLockFileMaintenance: true,
+              minimumReleaseAge: '3 days',
+            },
+            updatedDeps: [],
+          },
+          pyproject,
+        );
+        expect(execSnapshots[0].options?.env).toMatchObject({
+          UV_EXCLUDE_NEWER: '2026-03-05T00:00:00.000Z',
+        });
       });
     });
   });

--- a/lib/modules/manager/pep621/processors/uv.spec.ts
+++ b/lib/modules/manager/pep621/processors/uv.spec.ts
@@ -947,6 +947,23 @@ describe('modules/manager/pep621/processors/uv', () => {
         expect(execSnapshots[0].options?.env?.UV_EXCLUDE_NEWER).toBeUndefined();
       });
 
+      it('skips UV_EXCLUDE_NEWER when minimumReleaseAgeBehaviour is timestamp-optional', async () => {
+        await processor.updateArtifacts(
+          {
+            packageFileName: 'folder/pyproject.toml',
+            newPackageFileContent: '',
+            config: {
+              isLockFileMaintenance: true,
+              minimumReleaseAge: '3 days',
+              minimumReleaseAgeBehaviour: 'timestamp-optional',
+            },
+            updatedDeps: [],
+          },
+          parsePyProject('')!,
+        );
+        expect(execSnapshots[0].options?.env?.UV_EXCLUDE_NEWER).toBeUndefined();
+      });
+
       it('skips UV_EXCLUDE_NEWER on unparseable minimumReleaseAge', async () => {
         await processor.updateArtifacts(
           {

--- a/lib/modules/manager/pep621/processors/uv.ts
+++ b/lib/modules/manager/pep621/processors/uv.ts
@@ -14,6 +14,7 @@ import {
 } from '../../../../util/fs/index.ts';
 import { getGitEnvironmentVariables } from '../../../../util/git/auth.ts';
 import { find } from '../../../../util/host-rules.ts';
+import { toMs } from '../../../../util/pretty-time.ts';
 import { Result } from '../../../../util/result.ts';
 import { parseUrl } from '../../../../util/url.ts';
 import { PypiDatasource } from '../../../datasource/pypi/index.ts';
@@ -215,6 +216,20 @@ export class UvProcessor extends BasePyProjectProcessor {
       } else {
         cmd = generateCMD(updatedDeps);
       }
+
+      if (config.minimumReleaseAge) {
+        const ms = toMs(config.minimumReleaseAge);
+        if (ms !== null && ms !== undefined) {
+          const excludeNewer = new Date(Date.now() - ms).toISOString();
+          cmd += ` --exclude-newer=${excludeNewer}`;
+        } else {
+          logger.debug(
+            { minimumReleaseAge: config.minimumReleaseAge },
+            'Invalid minimumReleaseAge value, skipping --exclude-newer for uv lock',
+          );
+        }
+      }
+
       await exec(cmd, execOptions);
 
       // check for changes

--- a/lib/modules/manager/pep621/processors/uv.ts
+++ b/lib/modules/manager/pep621/processors/uv.ts
@@ -1,4 +1,5 @@
-import { isString } from '@sindresorhus/is';
+import { isNullOrUndefined, isString } from '@sindresorhus/is';
+import { DateTime } from 'luxon';
 import { quote } from 'shlex';
 import { TEMPORARY_ERROR } from '../../../../constants/error-messages.ts';
 import { logger } from '../../../../logger/index.ts';
@@ -219,14 +220,14 @@ export class UvProcessor extends BasePyProjectProcessor {
 
       if (config.minimumReleaseAge) {
         const ms = toMs(config.minimumReleaseAge);
-        if (ms !== null && ms !== undefined) {
-          const excludeNewer = new Date(Date.now() - ms).toISOString();
-          cmd += ` --exclude-newer=${excludeNewer}`;
-        } else {
+        if (isNullOrUndefined(ms)) {
           logger.debug(
             { minimumReleaseAge: config.minimumReleaseAge },
             'Invalid minimumReleaseAge value, skipping --exclude-newer for uv lock',
           );
+        } else {
+          const excludeNewer = DateTime.now().minus(ms).toUTC().toISO();
+          cmd += ` --exclude-newer=${excludeNewer}`;
         }
       }
 

--- a/lib/modules/manager/pep621/processors/uv.ts
+++ b/lib/modules/manager/pep621/processors/uv.ts
@@ -219,7 +219,12 @@ export class UvProcessor extends BasePyProjectProcessor {
       }
 
       // See https://docs.astral.sh/uv/guides/integration/dependency-bots/#dependency-cooldown
-      if (config.minimumReleaseAge) {
+      // Skip UV_EXCLUDE_NEWER when minimumReleaseAgeBehaviour is 'timestamp-optional',
+      // as simple API doesn't return releaseTimestamp and the user opted out of requiring it
+      if (
+        config.minimumReleaseAge &&
+        config.minimumReleaseAgeBehaviour !== 'timestamp-optional'
+      ) {
         const ms = toMs(config.minimumReleaseAge);
         if (isNullOrUndefined(ms)) {
           logger.debug(

--- a/lib/modules/manager/pep621/processors/uv.ts
+++ b/lib/modules/manager/pep621/processors/uv.ts
@@ -223,25 +223,29 @@ export class UvProcessor extends BasePyProjectProcessor {
         const ms = toMs(config.minimumReleaseAge);
         if (isNullOrUndefined(ms)) {
           logger.debug(
-            { minimumReleaseAge: config.minimumReleaseAge },
-            'Invalid minimumReleaseAge value, skipping UV_EXCLUDE_NEWER for uv lock',
+            `Invalid minimumReleaseAge value '${config.minimumReleaseAge}', skipping UV_EXCLUDE_NEWER for uv lock`,
           );
         } else {
           let excludeNewerDate = DateTime.now().minus(ms).toUTC();
 
           const pyprojectExcludeNewer = project.tool?.uv?.['exclude-newer'];
           if (pyprojectExcludeNewer) {
-            const pyprojectDate = DateTime.fromISO(pyprojectExcludeNewer, {
+            let pyprojectDate = DateTime.fromISO(pyprojectExcludeNewer, {
               zone: 'utc',
             });
+            if (!pyprojectDate.isValid) {
+              const durationMs = toMs(pyprojectExcludeNewer);
+              if (!isNullOrUndefined(durationMs)) {
+                pyprojectDate = DateTime.now().minus(durationMs).toUTC();
+              }
+            }
             if (pyprojectDate.isValid) {
               if (pyprojectDate < excludeNewerDate) {
                 excludeNewerDate = pyprojectDate;
               }
             } else {
               logger.debug(
-                { excludeNewer: pyprojectExcludeNewer },
-                'Invalid exclude-newer value in pyproject.toml, ignoring',
+                `Invalid exclude-newer value '${pyprojectExcludeNewer}' in pyproject.toml, ignoring`,
               );
             }
           }

--- a/lib/modules/manager/pep621/processors/uv.ts
+++ b/lib/modules/manager/pep621/processors/uv.ts
@@ -250,7 +250,7 @@ export class UvProcessor extends BasePyProjectProcessor {
             }
           }
 
-          extraEnv.UV_EXCLUDE_NEWER = excludeNewerDate.toISO()!;
+          extraEnv.UV_EXCLUDE_NEWER = excludeNewerDate.toISO();
         }
       }
 

--- a/lib/modules/manager/pep621/processors/uv.ts
+++ b/lib/modules/manager/pep621/processors/uv.ts
@@ -218,16 +218,35 @@ export class UvProcessor extends BasePyProjectProcessor {
         cmd = generateCMD(updatedDeps);
       }
 
+      // See https://docs.astral.sh/uv/guides/integration/dependency-bots/#dependency-cooldown
       if (config.minimumReleaseAge) {
         const ms = toMs(config.minimumReleaseAge);
         if (isNullOrUndefined(ms)) {
           logger.debug(
             { minimumReleaseAge: config.minimumReleaseAge },
-            'Invalid minimumReleaseAge value, skipping --exclude-newer for uv lock',
+            'Invalid minimumReleaseAge value, skipping UV_EXCLUDE_NEWER for uv lock',
           );
         } else {
-          const excludeNewer = DateTime.now().minus(ms).toUTC().toISO();
-          cmd += ` --exclude-newer=${excludeNewer}`;
+          let excludeNewerDate = DateTime.now().minus(ms).toUTC();
+
+          const pyprojectExcludeNewer = project.tool?.uv?.['exclude-newer'];
+          if (pyprojectExcludeNewer) {
+            const pyprojectDate = DateTime.fromISO(pyprojectExcludeNewer, {
+              zone: 'utc',
+            });
+            if (pyprojectDate.isValid) {
+              if (pyprojectDate < excludeNewerDate) {
+                excludeNewerDate = pyprojectDate;
+              }
+            } else {
+              logger.debug(
+                { excludeNewer: pyprojectExcludeNewer },
+                'Invalid exclude-newer value in pyproject.toml, ignoring',
+              );
+            }
+          }
+
+          extraEnv.UV_EXCLUDE_NEWER = excludeNewerDate.toISO()!;
         }
       }
 

--- a/lib/modules/manager/pep621/schema.spec.ts
+++ b/lib/modules/manager/pep621/schema.spec.ts
@@ -1,0 +1,16 @@
+import { PyProject } from './schema.ts';
+
+describe('modules/manager/pep621/schema', () => {
+  describe('UvConfig', () => {
+    it('handles exclude-newer as Date object', () => {
+      const result = PyProject.parse({
+        tool: {
+          uv: { 'exclude-newer': new Date('2026-03-05T00:00:00.000Z') },
+        },
+      });
+      expect(result.tool?.uv?.['exclude-newer']).toBe(
+        '2026-03-05T00:00:00.000Z',
+      );
+    });
+  });
+});

--- a/lib/modules/manager/pep621/schema.ts
+++ b/lib/modules/manager/pep621/schema.ts
@@ -152,6 +152,9 @@ const UvConfig = z.object({
   'dev-dependencies': LooseArray(
     Pep508Dependency(depTypes.uvDevDependencies),
   ).catch([]),
+  'exclude-newer': z
+    .union([z.string(), z.date().transform((d) => d.toISOString())])
+    .optional(),
   'required-version': z.string().optional(),
   sources: LooseRecord(
     // uv applies the same normalization as for Python dependencies on sources

--- a/lib/modules/manager/types.ts
+++ b/lib/modules/manager/types.ts
@@ -50,7 +50,7 @@ export interface UpdateArtifactsConfig {
   skipArtifactsUpdate?: boolean;
   lockFiles?: string[];
   toolSettings?: ToolSettingsOptions;
-  minimumReleaseAge?: string;
+  minimumReleaseAge?: Nullish<string>;
 }
 
 export interface RangeConfig<T = Record<string, any>> extends ManagerData<T> {

--- a/lib/modules/manager/types.ts
+++ b/lib/modules/manager/types.ts
@@ -1,6 +1,7 @@
 import type { ReleaseType } from 'semver';
 import type {
   MatchStringsStrategy,
+  MinimumReleaseAgeBehaviour,
   ToolSettingsOptions,
   UpdateType,
   ValidationMessage,
@@ -9,6 +10,7 @@ import type { Category } from '../../constants/index.ts';
 import type {
   MaybePromise,
   ModuleApi,
+  Nullish,
   RangeStrategy,
   SkipReason,
   StageName,

--- a/lib/modules/manager/types.ts
+++ b/lib/modules/manager/types.ts
@@ -51,6 +51,7 @@ export interface UpdateArtifactsConfig {
   lockFiles?: string[];
   toolSettings?: ToolSettingsOptions;
   minimumReleaseAge?: Nullish<string>;
+  minimumReleaseAgeBehaviour?: MinimumReleaseAgeBehaviour;
 }
 
 export interface RangeConfig<T = Record<string, any>> extends ManagerData<T> {

--- a/lib/modules/manager/types.ts
+++ b/lib/modules/manager/types.ts
@@ -50,7 +50,7 @@ export interface UpdateArtifactsConfig {
   skipArtifactsUpdate?: boolean;
   lockFiles?: string[];
   toolSettings?: ToolSettingsOptions;
-  minimumReleaseAge?: string | null;
+  minimumReleaseAge?: string;
 }
 
 export interface RangeConfig<T = Record<string, any>> extends ManagerData<T> {

--- a/lib/modules/manager/types.ts
+++ b/lib/modules/manager/types.ts
@@ -50,6 +50,7 @@ export interface UpdateArtifactsConfig {
   skipArtifactsUpdate?: boolean;
   lockFiles?: string[];
   toolSettings?: ToolSettingsOptions;
+  minimumReleaseAge?: string | null;
 }
 
 export interface RangeConfig<T = Record<string, any>> extends ManagerData<T> {


### PR DESCRIPTION
## Changes

When `minimumReleaseAge` is configured, Renovate now passes `UV_EXCLUDE_NEWER` as an environment variable to `uv lock`.

Additionally, if `pyproject.toml` already defines `[tool.uv] exclude-newer`, Renovate compares it with its own computed date and uses the more restrictive (older) one. This prevents Renovate from accidentally widening the package resolution window beyond what the project intended.

📖 **Related**: uv documents recommended `exclude-newer` usage for dependency bots in their [integration guide](https://docs.astral.sh/uv/guides/integration/dependency-bots/#dependency-cooldown).

Key changes:
- `lib/modules/manager/types.ts` — added `minimumReleaseAge` to `UpdateArtifactsConfig`
- `lib/modules/manager/pep621/schema.ts` — added `exclude-newer` to `UvConfig` Zod schema (handles both TOML string and Date types)
- `lib/modules/manager/pep621/processors/uv.ts` — `UV_EXCLUDE_NEWER` env var with `min(renovate_date, pyproject_date)` logic
- `lib/modules/manager/pep621/processors/uv.spec.ts` — 28 tests covering env var usage, min-date comparison, invalid values, and edge cases

## Context

- [x] This closes an existing Issue, Closes: #41654

## AI assistance disclosure

- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).

opencode (Claude Opus 4.6 / Sonnet 4.6) used for test writing, and code review iteration

## Documentation (please check one with an [x])

- [x] I have updated the documentation

## How I've tested my work (please select one)

- [x] Newly added/modified unit tests
