### PR TITLE
feat: close unclosed markdown structures in truncated PR body

### DIFF
--- a/lib/modules/platform/utils/pr-body.spec.ts
+++ b/lib/modules/platform/utils/pr-body.spec.ts
@@ -102,60 +102,36 @@ describe('modules/platform/utils/pr-body', () => {
     });
 
     describe('case 2: closing tag exceeds limit, trim back', () => {
-      it('trims back unclosed details when closing tag exceeds limit', () => {
+      it('trims content inside tag to fit closing tag', () => {
+        // maxLen = input.length, no room to append </details>
+        // but we can trim content and still close the tag
         const input = '<details>\n<summary>Title</summary>\nContent';
-        const expected = '';
-        const result = closeUnclosedStructures(input, input.length);
-        expect(result).toBe(expected);
+        const maxLen = input.length;
+        const result = closeUnclosedStructures(input, maxLen);
+        // Trimming cuts into </summary>, leaving <summary as partial
+        // (not matched as an open tag), so only </details> is needed
+        expect(result).toBe('<details>\n<summary\n</details>\n');
+        expect(result).toHaveLength(result.length);
+        expect(result.length).toBeLessThanOrEqual(maxLen);
       });
 
-      it('trims back unclosed code fence when closing tag exceeds limit', () => {
+      it('trims content inside code fence to fit closing fence', () => {
         const input = 'text before\n```bash\necho hello';
-        const expected = 'text before\n';
-        const result = closeUnclosedStructures(input, input.length);
-        expect(result).toBe(expected);
-      });
-
-      it('trims back innermost unclosed tag and closes outer if it fits', () => {
-        const input =
-          '<details>\n<summary>Outer</summary>\nText\n<details>\n<summary>Inner</summary>\nLong content here';
-        const trimmedToOuter = '<details>\n<summary>Outer</summary>\nText\n';
-        const expected = trimmedToOuter + '\n</details>\n';
-        const result = closeUnclosedStructures(
-          input,
-          trimmedToOuter.length + 20,
-        );
-        expect(result).toBe(expected);
-      });
-    });
-
-    describe('externalClosingTags', () => {
-      it('leaves one unclosed details when external budget covers it', () => {
-        const input = '<details>\n<summary>Title</summary>\nContent';
-        const result = closeUnclosedStructures(input, 1000, { details: 1 });
-        expect(result).toBe(input);
-        expect(result).toHaveLength(input.length);
-      });
-
-      it('closes inner details but leaves outer for external closing', () => {
-        const input =
-          '<details>\n<summary>Outer</summary>\n<details>\n<summary>Inner</summary>\nContent';
+        const closeFence = '\n```\n';
+        const maxLen = input.length;
         const expected =
-          '<details>\n<summary>Outer</summary>\n<details>\n<summary>Inner</summary>\nContent\n</details>\n';
-        const result = closeUnclosedStructures(input, 1000, { details: 1 });
+          input.slice(0, maxLen - closeFence.length) + closeFence;
+        const result = closeUnclosedStructures(input, maxLen);
         expect(result).toBe(expected);
-        expect(result).toHaveLength(expected.length);
+        expect(result).toHaveLength(maxLen);
       });
 
-      it('trims inner details if closing exceeds limit, leaves outer for external', () => {
-        const input =
-          '<details>\n<summary>Outer</summary>\nText\n<details>\n<summary>Inner</summary>\nLong content here';
-        const expected = '<details>\n<summary>Outer</summary>\nText\n';
-        const result = closeUnclosedStructures(input, input.length, {
-          details: 1,
-        });
-        expect(result).toBe(expected);
-        expect(result).toHaveLength(expected.length);
+      it('removes tag entirely when opening tag + closing tag exceeds limit', () => {
+        // maxLen so small that <details> + </details> alone won't fit
+        const input = '<details>\nContent';
+        const result = closeUnclosedStructures(input, 5);
+        expect(result).toBe('');
+        expect(result).toHaveLength(0);
       });
     });
 

--- a/lib/modules/platform/utils/pr-body.spec.ts
+++ b/lib/modules/platform/utils/pr-body.spec.ts
@@ -13,7 +13,6 @@ describe('modules/platform/utils/pr-body', () => {
         const expected = 'some text\n```bash\necho hello\n```\n';
         const result = closeUnclosedStructures(input, 100);
         expect(result).toBe(expected);
-        expect(result).toHaveLength(expected.length);
       });
 
       it('does not treat inner fence-like content as a new fence', () => {
@@ -23,7 +22,6 @@ describe('modules/platform/utils/pr-body', () => {
         const expected = '```golang\n```typescript\nfunc main()\n```\n';
         const result = closeUnclosedStructures(input, 200);
         expect(result).toBe(expected);
-        expect(result).toHaveLength(expected.length);
       });
 
       it('handles 4-backtick fence containing triple backticks', () => {
@@ -32,7 +30,6 @@ describe('modules/platform/utils/pr-body', () => {
         const expected = '````testa\n```test\n```\n```\nmore content\n````\n';
         const result = closeUnclosedStructures(input, 200);
         expect(result).toBe(expected);
-        expect(result).toHaveLength(expected.length);
       });
 
       it('handles 5-backtick fence', () => {
@@ -40,7 +37,6 @@ describe('modules/platform/utils/pr-body', () => {
         const expected = '`````markdown\nsome code\n````\n```\n`````\n';
         const result = closeUnclosedStructures(input, 200);
         expect(result).toBe(expected);
-        expect(result).toHaveLength(expected.length);
       });
 
       it('closes unclosed details tag', () => {
@@ -128,35 +124,28 @@ describe('modules/platform/utils/pr-body', () => {
         // maxLen = input.length, no room to append </details>
         // but we can trim content and still close the tag
         const input = '<details>\n<summary>Title</summary>\nContent';
+        const expected = '<details>\n<summary\n</details>\n';
         const maxLen = input.length;
         const result = closeUnclosedStructures(input, maxLen);
         // Trimming cuts into </summary>, leaving <summary as partial
         // (not matched as an open tag), so only </details> is needed
-        expect(result).toBe('<details>\n<summary\n</details>\n');
-        expect(result).toHaveLength(result.length);
-        expect(result.length).toBeLessThanOrEqual(maxLen);
+        expect(result).toBe(expected);
       });
 
       it('trims content inside code fence to fit closing fence', () => {
         const input = 'text before\n```bash\necho hello';
-        const closeFence = '\n```\n';
+        const expected = 'text before\n```bash\necho \n```\n';
         const maxLen = input.length;
-        const expected =
-          input.slice(0, maxLen - closeFence.length) + closeFence;
         const result = closeUnclosedStructures(input, maxLen);
         expect(result).toBe(expected);
-        expect(result).toHaveLength(maxLen);
       });
 
       it('trims content inside 4-backtick fence to fit closing fence', () => {
         const input = 'text before\n````bash\necho hello';
-        const closeFence = '\n````\n';
+        const expected = 'text before\n````bash\necho\n````\n';
         const maxLen = input.length;
-        const expected =
-          input.slice(0, maxLen - closeFence.length) + closeFence;
         const result = closeUnclosedStructures(input, maxLen);
         expect(result).toBe(expected);
-        expect(result).toHaveLength(maxLen);
       });
 
       it('removes tag entirely when opening tag + closing tag exceeds limit', () => {
@@ -164,7 +153,6 @@ describe('modules/platform/utils/pr-body', () => {
         const input = '<details>\nContent';
         const result = closeUnclosedStructures(input, 5);
         expect(result).toBe('');
-        expect(result).toHaveLength(0);
       });
     });
 
@@ -173,7 +161,6 @@ describe('modules/platform/utils/pr-body', () => {
         const input = 'some text\n```bash\necho hello\n```\nmore text';
         const result = closeUnclosedStructures(input, 1000);
         expect(result).toBe(input);
-        expect(result).toHaveLength(input.length);
       });
 
       it('does not modify text with balanced details tags', () => {
@@ -181,7 +168,6 @@ describe('modules/platform/utils/pr-body', () => {
           '<details>\n<summary>Title</summary>\nContent\n</details>';
         const result = closeUnclosedStructures(input, 1000);
         expect(result).toBe(input);
-        expect(result).toHaveLength(input.length);
       });
 
       it('does not modify text with balanced tags', () => {
@@ -189,13 +175,11 @@ describe('modules/platform/utils/pr-body', () => {
           '<table>\n<tr><td>Cell</td></tr>\n</table>\n<div>Content</div>';
         const result = closeUnclosedStructures(input, 1000);
         expect(result).toBe(input);
-        expect(result).toHaveLength(input.length);
       });
 
       it('returns empty string unchanged', () => {
         const result = closeUnclosedStructures('', 1000);
         expect(result).toBe('');
-        expect(result).toHaveLength(0);
       });
     });
   });

--- a/lib/modules/platform/utils/pr-body.spec.ts
+++ b/lib/modules/platform/utils/pr-body.spec.ts
@@ -39,6 +39,25 @@ describe('modules/platform/utils/pr-body', () => {
         expect(result).toBe(expected);
       });
 
+      it('does not treat backticks with trailing content as closing fence', () => {
+        // https://github.com/Shion1305/renovate-bug-discussion-41912/issues/14
+        // Per CommonMark, a closing fence must have no content after backticks.
+        // ````` markdown` (space before "markdown") is NOT a valid closer for `````.
+        const input = '`````\nsome code\n````` markdown\nmore code';
+        const expected = '`````\nsome code\n````` markdown\nmore code\n`````\n';
+        const result = closeUnclosedStructures(input, 200);
+        expect(result).toBe(expected);
+      });
+
+      it('does not close a fenced code block when the closing fence has trailing content', () => {
+        // A closing fence is valid when whitespace follows.
+        // https://github.com/Shion1305/renovate-bug-discussion-41912/issues/16
+        const input = '``` lang\nsome code\n```  \nmore code';
+        const expected = input;
+        const result = closeUnclosedStructures(input, 200);
+        expect(result).toBe(expected);
+      });
+
       it('closes unclosed details tag', () => {
         // https://github.com/Shion1305/renovate-bug-discussion-41912/issues/2
         const input = '<details>\n<summary>Title</summary>\nContent';

--- a/lib/modules/platform/utils/pr-body.spec.ts
+++ b/lib/modules/platform/utils/pr-body.spec.ts
@@ -29,7 +29,7 @@ describe('modules/platform/utils/pr-body', () => {
       it('handles 4-backtick fence containing triple backticks', () => {
         // ```` opens a fence that ``` cannot close
         const input = '````testa\n```test\n```\n```\nmore content';
-        const expected = '````testa\n```test\n```\n```\nmore content\n```\n';
+        const expected = '````testa\n```test\n```\n```\nmore content\n````\n';
         const result = closeUnclosedStructures(input, 200);
         expect(result).toBe(expected);
         expect(result).toHaveLength(expected.length);
@@ -37,7 +37,7 @@ describe('modules/platform/utils/pr-body', () => {
 
       it('handles 5-backtick fence', () => {
         const input = '`````markdown\nsome code\n````\n```';
-        const expected = '`````markdown\nsome code\n````\n```\n```\n';
+        const expected = '`````markdown\nsome code\n````\n```\n`````\n';
         const result = closeUnclosedStructures(input, 200);
         expect(result).toBe(expected);
         expect(result).toHaveLength(expected.length);
@@ -99,6 +99,28 @@ describe('modules/platform/utils/pr-body', () => {
         const result = closeUnclosedStructures(input, 200);
         expect(result).toBe(expected);
       });
+
+      it('ignores HTML tags inside a balanced code fence', () => {
+        const input = 'before\n```html\n<div>\n<table>\n```\nafter';
+        const result = closeUnclosedStructures(input, 500);
+        expect(result).toBe(input);
+      });
+
+      it('ignores HTML tags inside an unclosed code fence', () => {
+        const input = 'before\n```html\n<div>\n<table>';
+        const expected = 'before\n```html\n<div>\n<table>\n```\n';
+        const result = closeUnclosedStructures(input, 500);
+        expect(result).toBe(expected);
+      });
+
+      it('closes real HTML tags outside fences while ignoring ones inside', () => {
+        const input =
+          '<details>\n<summary>Title</summary>\n```html\n<div>\n```\nContent';
+        const expected =
+          '<details>\n<summary>Title</summary>\n```html\n<div>\n```\nContent\n</details>\n';
+        const result = closeUnclosedStructures(input, 500);
+        expect(result).toBe(expected);
+      });
     });
 
     describe('case 2: closing tag exceeds limit, trim back', () => {
@@ -118,6 +140,17 @@ describe('modules/platform/utils/pr-body', () => {
       it('trims content inside code fence to fit closing fence', () => {
         const input = 'text before\n```bash\necho hello';
         const closeFence = '\n```\n';
+        const maxLen = input.length;
+        const expected =
+          input.slice(0, maxLen - closeFence.length) + closeFence;
+        const result = closeUnclosedStructures(input, maxLen);
+        expect(result).toBe(expected);
+        expect(result).toHaveLength(maxLen);
+      });
+
+      it('trims content inside 4-backtick fence to fit closing fence', () => {
+        const input = 'text before\n````bash\necho hello';
+        const closeFence = '\n````\n';
         const maxLen = input.length;
         const expected =
           input.slice(0, maxLen - closeFence.length) + closeFence;

--- a/lib/modules/platform/utils/pr-body.spec.ts
+++ b/lib/modules/platform/utils/pr-body.spec.ts
@@ -1,10 +1,196 @@
 import { Fixtures } from '~test/fixtures.ts';
 import { logger } from '~test/util.ts';
-import { smartTruncate } from './pr-body.ts';
+import { closeUnclosedStructures, smartTruncate } from './pr-body.ts';
 
 const prBody = Fixtures.get('pr-body.txt');
 
 describe('modules/platform/utils/pr-body', () => {
+  describe('.closeUnclosedStructures', () => {
+    describe('case 1: closing tag fits within limit', () => {
+      it('closes unclosed fenced code block', () => {
+        // https://github.com/Shion1305/renovate-bug-discussion-41912/issues/7
+        const input = 'some text\n```bash\necho hello';
+        const expected = 'some text\n```bash\necho hello\n```\n';
+        const result = closeUnclosedStructures(input, 100);
+        expect(result).toBe(expected);
+        expect(result).toHaveLength(expected.length);
+      });
+
+      it('does not treat inner fence-like content as a new fence', () => {
+        // ```golang block containing ```typescript is just content,
+        // not a nested fence
+        const input = '```golang\n```typescript\nfunc main()';
+        const expected = '```golang\n```typescript\nfunc main()\n```\n';
+        const result = closeUnclosedStructures(input, 200);
+        expect(result).toBe(expected);
+        expect(result).toHaveLength(expected.length);
+      });
+
+      it('handles 4-backtick fence containing triple backticks', () => {
+        // ```` opens a fence that ``` cannot close
+        const input = '````testa\n```test\n```\n```\nmore content';
+        const expected = '````testa\n```test\n```\n```\nmore content\n```\n';
+        const result = closeUnclosedStructures(input, 200);
+        expect(result).toBe(expected);
+        expect(result).toHaveLength(expected.length);
+      });
+
+      it('handles 5-backtick fence', () => {
+        const input = '`````markdown\nsome code\n````\n```';
+        const expected = '`````markdown\nsome code\n````\n```\n```\n';
+        const result = closeUnclosedStructures(input, 200);
+        expect(result).toBe(expected);
+        expect(result).toHaveLength(expected.length);
+      });
+
+      it('closes unclosed details tag', () => {
+        // https://github.com/Shion1305/renovate-bug-discussion-41912/issues/2
+        const input = '<details>\n<summary>Title</summary>\nContent';
+        const expected =
+          '<details>\n<summary>Title</summary>\nContent\n</details>\n';
+        const result = closeUnclosedStructures(input, 100);
+        expect(result).toBe(expected);
+      });
+
+      it('closes multiple unclosed details tags', () => {
+        // https://github.com/Shion1305/renovate-bug-discussion-41912/issues/10
+        const input =
+          '<details>\n<summary>Outer</summary>\n<details>\n<summary>Inner</summary>\nContent';
+        const expected =
+          '<details>\n<summary>Outer</summary>\n<details>\n<summary>Inner</summary>\nContent\n</details>\n\n</details>\n';
+        const result = closeUnclosedStructures(input, 200);
+        expect(result).toBe(expected);
+      });
+
+      it('closes unclosed table tag', () => {
+        // https://github.com/Shion1305/renovate-bug-discussion-41912/issues/5
+        const input = '<table>\n<tr><td>Cell</td></tr>';
+        const expected = '<table>\n<tr><td>Cell</td></tr>\n</table>\n';
+        const result = closeUnclosedStructures(input, 100);
+        expect(result).toBe(expected);
+      });
+
+      it('closes unclosed div tag', () => {
+        const input = '<div>\nSome content';
+        const expected = '<div>\nSome content\n</div>\n';
+        const result = closeUnclosedStructures(input, 100);
+        expect(result).toBe(expected);
+      });
+
+      it('closes unclosed blockquote tag', () => {
+        const input = '<blockquote>\nQuoted text';
+        const expected = '<blockquote>\nQuoted text\n</blockquote>\n';
+        const result = closeUnclosedStructures(input, 100);
+        expect(result).toBe(expected);
+      });
+
+      it('closes unclosed summary tag', () => {
+        const input = '<details>\n<summary>Title that got cut';
+        const expected =
+          '<details>\n<summary>Title that got cut\n</summary>\n\n</details>\n';
+        const result = closeUnclosedStructures(input, 200);
+        expect(result).toBe(expected);
+      });
+
+      it('closes both unclosed code fence and HTML tags', () => {
+        const input = '<details>\n<summary>Title</summary>\n```js\nconst x = 1';
+        const expected =
+          '<details>\n<summary>Title</summary>\n```js\nconst x = 1\n```\n\n</details>\n';
+        const result = closeUnclosedStructures(input, 200);
+        expect(result).toBe(expected);
+      });
+    });
+
+    describe('case 2: closing tag exceeds limit, trim back', () => {
+      it('trims back unclosed details when closing tag exceeds limit', () => {
+        const input = '<details>\n<summary>Title</summary>\nContent';
+        const expected = '';
+        const result = closeUnclosedStructures(input, input.length);
+        expect(result).toBe(expected);
+      });
+
+      it('trims back unclosed code fence when closing tag exceeds limit', () => {
+        const input = 'text before\n```bash\necho hello';
+        const expected = 'text before\n';
+        const result = closeUnclosedStructures(input, input.length);
+        expect(result).toBe(expected);
+      });
+
+      it('trims back innermost unclosed tag and closes outer if it fits', () => {
+        const input =
+          '<details>\n<summary>Outer</summary>\nText\n<details>\n<summary>Inner</summary>\nLong content here';
+        const trimmedToOuter = '<details>\n<summary>Outer</summary>\nText\n';
+        const expected = trimmedToOuter + '\n</details>\n';
+        const result = closeUnclosedStructures(
+          input,
+          trimmedToOuter.length + 20,
+        );
+        expect(result).toBe(expected);
+      });
+    });
+
+    describe('externalClosingTags', () => {
+      it('leaves one unclosed details when external budget covers it', () => {
+        const input = '<details>\n<summary>Title</summary>\nContent';
+        const result = closeUnclosedStructures(input, 1000, { details: 1 });
+        expect(result).toBe(input);
+        expect(result).toHaveLength(input.length);
+      });
+
+      it('closes inner details but leaves outer for external closing', () => {
+        const input =
+          '<details>\n<summary>Outer</summary>\n<details>\n<summary>Inner</summary>\nContent';
+        const expected =
+          '<details>\n<summary>Outer</summary>\n<details>\n<summary>Inner</summary>\nContent\n</details>\n';
+        const result = closeUnclosedStructures(input, 1000, { details: 1 });
+        expect(result).toBe(expected);
+        expect(result).toHaveLength(expected.length);
+      });
+
+      it('trims inner details if closing exceeds limit, leaves outer for external', () => {
+        const input =
+          '<details>\n<summary>Outer</summary>\nText\n<details>\n<summary>Inner</summary>\nLong content here';
+        const expected = '<details>\n<summary>Outer</summary>\nText\n';
+        const result = closeUnclosedStructures(input, input.length, {
+          details: 1,
+        });
+        expect(result).toBe(expected);
+        expect(result).toHaveLength(expected.length);
+      });
+    });
+
+    describe('no changes needed', () => {
+      it('does not modify text with balanced code fences', () => {
+        const input = 'some text\n```bash\necho hello\n```\nmore text';
+        const result = closeUnclosedStructures(input, 1000);
+        expect(result).toBe(input);
+        expect(result).toHaveLength(input.length);
+      });
+
+      it('does not modify text with balanced details tags', () => {
+        const input =
+          '<details>\n<summary>Title</summary>\nContent\n</details>';
+        const result = closeUnclosedStructures(input, 1000);
+        expect(result).toBe(input);
+        expect(result).toHaveLength(input.length);
+      });
+
+      it('does not modify text with balanced tags', () => {
+        const input =
+          '<table>\n<tr><td>Cell</td></tr>\n</table>\n<div>Content</div>';
+        const result = closeUnclosedStructures(input, 1000);
+        expect(result).toBe(input);
+        expect(result).toHaveLength(input.length);
+      });
+
+      it('returns empty string unchanged', () => {
+        const result = closeUnclosedStructures('', 1000);
+        expect(result).toBe('');
+        expect(result).toHaveLength(0);
+      });
+    });
+  });
+
   describe('.smartTruncate', () => {
     it('truncates to 1000', () => {
       const body = smartTruncate(prBody, 1000);

--- a/lib/modules/platform/utils/pr-body.ts
+++ b/lib/modules/platform/utils/pr-body.ts
@@ -175,13 +175,12 @@ export function closeUnclosedStructures(text: string, maxLen: number): string {
     if (availableForContent > 0) {
       result = result.slice(0, availableForContent);
       // Re-scan: trimming may have changed which tags are unclosed
-      stack = findAllUnclosedTags(result);
     } else {
       // Not enough room even for closing tags alone,
       // remove the outermost unclosed tag entirely
       result = result.slice(0, stack[0].position);
-      stack = findAllUnclosedTags(result);
     }
+    stack = findAllUnclosedTags(result);
   }
 
   return result;

--- a/lib/modules/platform/utils/pr-body.ts
+++ b/lib/modules/platform/utils/pr-body.ts
@@ -7,6 +7,155 @@ const re = regEx(
   's',
 );
 
+const htmlTags = ['summary', 'table', 'div', 'blockquote', 'details'] as const;
+
+/**
+ * Returns the stack of all unclosed opening tags in the text
+ * (outermost first, innermost last), or an empty array if balanced.
+ */
+function findAllUnclosedTags(
+  text: string,
+): { tag: string; position: number }[] {
+  // Collect all open/close tag positions
+  const events: { tag: string; type: 'open' | 'close'; position: number }[] =
+    [];
+
+  for (const tag of htmlTags) {
+    const openRe = regEx(new RegExp(`<${tag}[\\s>]`, 'gi'));
+    let match;
+    while ((match = openRe.exec(text)) !== null) {
+      events.push({ tag, type: 'open', position: match.index });
+    }
+    const closeRe = regEx(new RegExp(`</${tag}>`, 'gi'));
+    while ((match = closeRe.exec(text)) !== null) {
+      events.push({ tag, type: 'close', position: match.index });
+    }
+  }
+
+  // Process in document order to find unclosed tags via a stack
+  events.sort((a, b) => a.position - b.position);
+  const stack: { tag: string; position: number }[] = [];
+  for (const event of events) {
+    if (event.type === 'open') {
+      stack.push({ tag: event.tag, position: event.position });
+    } else if (stack.length > 0 && stack[stack.length - 1].tag === event.tag) {
+      stack.pop();
+    }
+  }
+
+  return stack;
+}
+
+/**
+ * Finds the position of the last unclosed opening code fence, or -1 if
+ * all fences are balanced. Per CommonMark:
+ * - An opening fence is 3+ backticks, optionally followed by an info string
+ * - A closing fence must have >= the same number of backticks, no info string
+ * - Content inside a code block (even if it looks like ```lang) is not a fence
+ */
+function findUnclosedCodeFence(text: string): number {
+  let openPos = -1;
+  let openLen = 0;
+  let inside = false;
+  let match;
+  // Matches 3+ backticks at the start of a line, capturing the backticks
+  // and any trailing info string
+  const re = regEx(/^(`{3,})(\S*)/gm);
+  while ((match = re.exec(text)) !== null) {
+    const backtickLen = match[1].length;
+    const infoString = match[2];
+    if (!inside) {
+      // Any 3+ backticks opens a fence
+      openPos = match.index;
+      openLen = backtickLen;
+      inside = true;
+    } else if (!infoString && backtickLen >= openLen) {
+      // Closes only if: no info string AND at least as many backticks
+      inside = false;
+      openPos = -1;
+      openLen = 0;
+    }
+    // Otherwise it's just content inside the code block
+  }
+  return inside ? openPos : -1;
+}
+
+/**
+ * Closes unclosed fenced code blocks and HTML tags within the given
+ * length budget. If a closing tag would exceed maxLen, the text is
+ * trimmed back to before the unclosed opening tag instead.
+ */
+export function closeUnclosedStructures(
+  text: string,
+  maxLen: number,
+  externalClosingTags?: Partial<Record<string, number>>,
+): string {
+  let result = text;
+
+  // Close unclosed fenced code blocks
+  const unclosedFencePos = findUnclosedCodeFence(result);
+  if (unclosedFencePos >= 0) {
+    const closeFence = '\n```\n';
+    if (result.length + closeFence.length <= maxLen) {
+      result += closeFence;
+    } else {
+      result = result.slice(0, unclosedFencePos);
+    }
+  }
+
+  // Track how many unclosed tags can be left for external closing
+  const externalBudget: Record<string, number> = {};
+  if (externalClosingTags) {
+    for (const [tag, count] of Object.entries(externalClosingTags)) {
+      if (count && count > 0) {
+        externalBudget[tag] = count;
+      }
+    }
+  }
+
+  // Close unclosed HTML tags iteratively.
+  // Re-scan after each modification since trimming changes the stack.
+  let stack = findAllUnclosedTags(result);
+
+  // Consume external budget from the outermost (first) entries
+  while (stack.length > 0) {
+    const outermost = stack[0];
+    if ((externalBudget[outermost.tag] ?? 0) > 0) {
+      externalBudget[outermost.tag]--;
+      stack.shift();
+    } else {
+      break;
+    }
+  }
+
+  // Process remaining unclosed tags from innermost to outermost
+  while (stack.length > 0) {
+    const innermost = stack[stack.length - 1];
+    const closeTag = `\n</${innermost.tag}>\n`;
+    if (result.length + closeTag.length <= maxLen) {
+      result += closeTag;
+    } else {
+      result = result.slice(0, innermost.position);
+    }
+    // Re-scan and re-apply external budget since text changed
+    stack = findAllUnclosedTags(result);
+    // Re-consume external budget from outermost
+    const budgetCopy = { ...externalClosingTags };
+    while (stack.length > 0) {
+      const outer = stack[0];
+      const remaining = budgetCopy[outer.tag] ?? 0;
+      if (remaining > 0) {
+        budgetCopy[outer.tag] = remaining - 1;
+        stack.shift();
+      } else {
+        break;
+      }
+    }
+  }
+
+  return result;
+}
+
 export function smartTruncate(input: string, len: number): string {
   if (input.length < len) {
     return input;
@@ -36,8 +185,11 @@ export function smartTruncate(input: string, len: number): string {
   if (availableLength <= 0) {
     return truncatedInput.substring(0, len);
   } else {
-    return (
-      preNotes + releaseNotes.slice(0, availableLength) + divider + postNotes
+    const truncatedNotes = closeUnclosedStructures(
+      releaseNotes.slice(0, availableLength),
+      availableLength,
+      { details: 1 },
     );
+    return preNotes + truncatedNotes + divider + postNotes;
   }
 }

--- a/lib/modules/platform/utils/pr-body.ts
+++ b/lib/modules/platform/utils/pr-body.ts
@@ -12,12 +12,52 @@ const re = regEx(
 const htmlTags = ['summary', 'table', 'div', 'blockquote', 'details'] as const;
 
 /**
+ * Returns [start, end] ranges for every fenced code block in the text.
+ * For a balanced fence the range covers opener through closer (inclusive).
+ * For an unclosed fence the range extends to the end of the text.
+ */
+function findCodeFenceRanges(text: string): [number, number][] {
+  const ranges: [number, number][] = [];
+  let openPos = -1;
+  let openLen = 0;
+  let inside = false;
+  let match;
+  const fenceRe = regEx(/^(`{3,})(\S*)/gm);
+  while ((match = fenceRe.exec(text)) !== null) {
+    const backtickLen = match[1].length;
+    const infoString = match[2];
+    if (!inside) {
+      openPos = match.index;
+      openLen = backtickLen;
+      inside = true;
+    } else if (!infoString && backtickLen >= openLen) {
+      ranges.push([openPos, match.index + match[0].length]);
+      inside = false;
+    }
+  }
+  if (inside) {
+    ranges.push([openPos, text.length]);
+  }
+  return ranges;
+}
+
+function isInsideCodeFence(
+  position: number,
+  ranges: [number, number][],
+): boolean {
+  return ranges.some(([start, end]) => position >= start && position < end);
+}
+
+/**
  * Returns the stack of all unclosed opening tags in the text
  * (outermost first, innermost last), or an empty array if balanced.
+ * Tags inside fenced code blocks are ignored.
  */
 function findAllUnclosedTags(
   text: string,
 ): { tag: string; position: number }[] {
+  const fenceRanges = findCodeFenceRanges(text);
+
   // Collect all open/close tag positions
   const events: { tag: string; type: 'open' | 'close'; position: number }[] =
     [];
@@ -26,11 +66,15 @@ function findAllUnclosedTags(
     const openRe = regEx(new RegExp(`<${tag}[\\s>]`, 'gi'));
     let match;
     while ((match = openRe.exec(text)) !== null) {
-      events.push({ tag, type: 'open', position: match.index });
+      if (!isInsideCodeFence(match.index, fenceRanges)) {
+        events.push({ tag, type: 'open', position: match.index });
+      }
     }
     const closeRe = regEx(new RegExp(`</${tag}>`, 'gi'));
     while ((match = closeRe.exec(text)) !== null) {
-      events.push({ tag, type: 'close', position: match.index });
+      if (!isInsideCodeFence(match.index, fenceRanges)) {
+        events.push({ tag, type: 'close', position: match.index });
+      }
     }
   }
 
@@ -55,7 +99,9 @@ function findAllUnclosedTags(
  * - A closing fence must have >= the same number of backticks, no info string
  * - Content inside a code block (even if it looks like ```lang) is not a fence
  */
-function findUnclosedCodeFence(text: string): number {
+function findUnclosedCodeFence(
+  text: string,
+): { position: number; backtickLen: number } | null {
   let openPos = -1;
   let openLen = 0;
   let inside = false;
@@ -79,7 +125,7 @@ function findUnclosedCodeFence(text: string): number {
     }
     // Otherwise it's just content inside the code block
   }
-  return inside ? openPos : -1;
+  return inside ? { position: openPos, backtickLen: openLen } : null;
 }
 
 /**
@@ -91,17 +137,17 @@ export function closeUnclosedStructures(text: string, maxLen: number): string {
   let result = text;
 
   // Close unclosed fenced code blocks
-  const unclosedFencePos = findUnclosedCodeFence(result);
-  if (unclosedFencePos >= 0) {
-    const closeFence = '\n```\n';
+  const fence = findUnclosedCodeFence(result);
+  if (fence) {
+    const closeFence = '\n' + '`'.repeat(fence.backtickLen) + '\n';
     if (result.length + closeFence.length <= maxLen) {
       result += closeFence;
     } else {
       const trimmedLen = maxLen - closeFence.length;
-      if (trimmedLen > unclosedFencePos) {
+      if (trimmedLen > fence.position) {
         result = result.slice(0, trimmedLen) + closeFence;
       } else {
-        result = result.slice(0, unclosedFencePos);
+        result = result.slice(0, fence.position);
       }
     }
   }

--- a/lib/modules/platform/utils/pr-body.ts
+++ b/lib/modules/platform/utils/pr-body.ts
@@ -22,15 +22,17 @@ function findCodeFenceRanges(text: string): [number, number][] {
   let openLen = 0;
   let inside = false;
   let match;
-  const fenceRe = regEx(/^(`{3,})(\S*)/gm);
+  const fenceRe = regEx(/^(`{3,})(.*$)/gm);
   while ((match = fenceRe.exec(text)) !== null) {
     const backtickLen = match[1].length;
-    const infoString = match[2];
+    const trailing = match[2];
     if (!inside) {
       openPos = match.index;
       openLen = backtickLen;
       inside = true;
-    } else if (!infoString && backtickLen >= openLen) {
+    } else if (!trailing.trim() && backtickLen >= openLen) {
+      // Per CommonMark, a closing fence must have no content after backticks
+      // (only optional whitespace). ``` markdown` is NOT a valid closer.
       ranges.push([openPos, match.index + match[0].length]);
       inside = false;
     }
@@ -96,7 +98,7 @@ function findAllUnclosedTags(
  * Finds the position of the last unclosed opening code fence, or -1 if
  * all fences are balanced. Per CommonMark:
  * - An opening fence is 3+ backticks, optionally followed by an info string
- * - A closing fence must have >= the same number of backticks, no info string
+ * - A closing fence must have >= the same number of backticks, no trailing content
  * - Content inside a code block (even if it looks like ```lang) is not a fence
  */
 function findUnclosedCodeFence(
@@ -107,18 +109,18 @@ function findUnclosedCodeFence(
   let inside = false;
   let match;
   // Matches 3+ backticks at the start of a line, capturing the backticks
-  // and any trailing info string
-  const re = regEx(/^(`{3,})(\S*)/gm);
+  // and the rest of the line
+  const re = regEx(/^(`{3,})(.*$)/gm);
   while ((match = re.exec(text)) !== null) {
     const backtickLen = match[1].length;
-    const infoString = match[2];
+    const trailing = match[2];
     if (!inside) {
-      // Any 3+ backticks opens a fence
+      // Any 3+ backticks opens a fence (trailing content is the info string)
       openPos = match.index;
       openLen = backtickLen;
       inside = true;
-    } else if (!infoString && backtickLen >= openLen) {
-      // Closes only if: no info string AND at least as many backticks
+    } else if (!trailing.trim() && backtickLen >= openLen) {
+      // Closes only if: no content after backticks AND at least as many backticks
       inside = false;
       openPos = -1;
       openLen = 0;

--- a/lib/modules/platform/utils/pr-body.ts
+++ b/lib/modules/platform/utils/pr-body.ts
@@ -2,8 +2,10 @@ import { logger } from '../../../logger/index.ts';
 import { emojify } from '../../../util/emoji.ts';
 import { regEx } from '../../../util/regex.ts';
 
+// This structure is guaranteed by the changelog template
+// (lib/workers/repository/update/pr/changelog/hbs-template.ts)
 const re = regEx(
-  `(?<preNotes>.*### Release Notes)(?<releaseNotes>.*)### Configuration(?<postNotes>.*)`,
+  `(?<preNotes>.*### Release Notes\\n\\n<details>)(?<releaseNotes>.*)### Configuration(?<postNotes>.*)`,
   's',
 );
 
@@ -85,11 +87,7 @@ function findUnclosedCodeFence(text: string): number {
  * length budget. If a closing tag would exceed maxLen, the text is
  * trimmed back to before the unclosed opening tag instead.
  */
-export function closeUnclosedStructures(
-  text: string,
-  maxLen: number,
-  externalClosingTags?: Partial<Record<string, number>>,
-): string {
+export function closeUnclosedStructures(text: string, maxLen: number): string {
   let result = text;
 
   // Close unclosed fenced code blocks
@@ -99,57 +97,42 @@ export function closeUnclosedStructures(
     if (result.length + closeFence.length <= maxLen) {
       result += closeFence;
     } else {
-      result = result.slice(0, unclosedFencePos);
-    }
-  }
-
-  // Track how many unclosed tags can be left for external closing
-  const externalBudget: Record<string, number> = {};
-  if (externalClosingTags) {
-    for (const [tag, count] of Object.entries(externalClosingTags)) {
-      if (count && count > 0) {
-        externalBudget[tag] = count;
+      const trimmedLen = maxLen - closeFence.length;
+      if (trimmedLen > unclosedFencePos) {
+        result = result.slice(0, trimmedLen) + closeFence;
+      } else {
+        result = result.slice(0, unclosedFencePos);
       }
     }
   }
 
   // Close unclosed HTML tags iteratively.
-  // Re-scan after each modification since trimming changes the stack.
+  // We calculate the total space needed for all closing tags, then
+  // trim the content once to make room, and append all closing tags.
   let stack = findAllUnclosedTags(result);
-
-  // Consume external budget from the outermost (first) entries
   while (stack.length > 0) {
-    const outermost = stack[0];
-    if ((externalBudget[outermost.tag] ?? 0) > 0) {
-      externalBudget[outermost.tag]--;
-      stack.shift();
-    } else {
-      break;
+    // Calculate total suffix needed for all unclosed tags (innermost first)
+    let suffix = '';
+    for (let i = stack.length - 1; i >= 0; i--) {
+      suffix += `\n</${stack[i].tag}>\n`;
     }
-  }
 
-  // Process remaining unclosed tags from innermost to outermost
-  while (stack.length > 0) {
-    const innermost = stack[stack.length - 1];
-    const closeTag = `\n</${innermost.tag}>\n`;
-    if (result.length + closeTag.length <= maxLen) {
-      result += closeTag;
-    } else {
-      result = result.slice(0, innermost.position);
+    if (result.length + suffix.length <= maxLen) {
+      // All closing tags fit, append them all
+      return result + suffix;
     }
-    // Re-scan and re-apply external budget since text changed
-    stack = findAllUnclosedTags(result);
-    // Re-consume external budget from outermost
-    const budgetCopy = { ...externalClosingTags };
-    while (stack.length > 0) {
-      const outer = stack[0];
-      const remaining = budgetCopy[outer.tag] ?? 0;
-      if (remaining > 0) {
-        budgetCopy[outer.tag] = remaining - 1;
-        stack.shift();
-      } else {
-        break;
-      }
+
+    // Trim content to make room for all closing tags
+    const availableForContent = maxLen - suffix.length;
+    if (availableForContent > 0) {
+      result = result.slice(0, availableForContent);
+      // Re-scan: trimming may have changed which tags are unclosed
+      stack = findAllUnclosedTags(result);
+    } else {
+      // Not enough room even for closing tags alone,
+      // remove the outermost unclosed tag entirely
+      result = result.slice(0, stack[0].position);
+      stack = findAllUnclosedTags(result);
     }
   }
 
@@ -188,7 +171,6 @@ export function smartTruncate(input: string, len: number): string {
     const truncatedNotes = closeUnclosedStructures(
       releaseNotes.slice(0, availableLength),
       availableLength,
-      { details: 1 },
     );
     return preNotes + truncatedNotes + divider + postNotes;
   }


### PR DESCRIPTION
## Changes

When `smartTruncate()` slices the Release Notes section to fit within the platform character limit (e.g., 58,000 chars on GitHub), the raw `slice()` can cut in the middle of a fenced code block (`` ``` ``) or an unclosed HTML tag (`<details>`, `<summary>`, `<table>`, `<div>`, `<blockquote>`). This leaves the markdown in a broken state — everything after the cut point, including the **rebase/retry checkbox**, renders inside the broken structure and becomes invisible to users in the GitHub PR view.

This PR adds a `closeUnclosedStructures(text, maxLen)` function that repairs broken markdown/HTML structure after slicing:

- **Case 1 (closing tag fits):** Append the closing tag if it stays within `maxLen`
- **Case 2 (closing tag exceeds limit):** Trim content inside the tag to make room for the closing tag; only remove the tag entirely as a last resort

The function is CommonMark-compliant for fenced code blocks (tracks backtick count, distinguishes opening/closing fences) and handles all relevant HTML tags (`<details>`, `<summary>`, `<table>`, `<div>`, `<blockquote>`).

The regex for splitting the PR body is also updated to include the outermost `<details>` in `preNotes`, so `closeUnclosedStructures` only processes inner tags from upstream release note content. The divider's `</details>` naturally pairs with that outermost `<details>`.

## Context

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

Related discussion: https://github.com/renovatebot/renovate/discussions/41912

## AI assistance disclosure

- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).

## Documentation (please check one with an [x])

- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Newly added/modified unit tests, or
- [ ] Both unit tests + ran on a real repository