### PR TITLE
feat(instrumentation): instrument cache lifecycle with OTEL 

### DIFF
--- a/docs/usage/opentelemetry.md
+++ b/docs/usage/opentelemetry.md
@@ -77,6 +77,7 @@ Renovate provides instrumentation through traces for (non-exhaustively):
 - Any Git operations
 - Per-manager traces when performing the `lookup` and `extract` splits
 - Per-branch traces when performing the `update` split
+- Cache lifecycle operations (repository cache load/save, package cache init/destroy)
 - Important functions (more instrumentation be added)
 
 As well as following [OpenTelemetry's semantic conventions](https://opentelemetry.io/docs/specs/semconv/) where possible, Renovate defines several Custom Attributes, which can be found in [`lib/instrumentation/types.ts`](https://github.com/renovatebot/renovate/blob/main/lib/instrumentation/types.ts).

--- a/lib/util/cache/package/backend.ts
+++ b/lib/util/cache/package/backend.ts
@@ -1,4 +1,5 @@
 import type { AllConfig } from '../../../config/types.ts';
+import { instrument } from '../../../instrumentation/index.ts';
 import { getEnv } from '../../env.ts';
 import type { PackageCacheBase } from './impl/base.ts';
 import { PackageCacheFile } from './impl/file.ts';
@@ -14,28 +15,30 @@ export function getCacheType(): typeof cacheType {
 }
 
 export async function init(config: AllConfig): Promise<void> {
-  await destroy();
+  await instrument('package-cache.init', async () => {
+    await destroy();
 
-  if (config.redisUrl) {
-    cacheProxy = await PackageCacheRedis.create(
-      config.redisUrl,
-      config.redisPrefix,
-    );
-    cacheType = 'redis';
-    return;
-  }
+    if (config.redisUrl) {
+      cacheProxy = await PackageCacheRedis.create(
+        config.redisUrl,
+        config.redisPrefix,
+      );
+      cacheType = 'redis';
+      return;
+    }
 
-  if (getEnv().RENOVATE_X_SQLITE_PACKAGE_CACHE && config.cacheDir) {
-    cacheProxy = await PackageCacheSqlite.create(config.cacheDir);
-    cacheType = 'sqlite';
-    return;
-  }
+    if (getEnv().RENOVATE_X_SQLITE_PACKAGE_CACHE && config.cacheDir) {
+      cacheProxy = await PackageCacheSqlite.create(config.cacheDir);
+      cacheType = 'sqlite';
+      return;
+    }
 
-  if (config.cacheDir) {
-    cacheProxy = PackageCacheFile.create(config.cacheDir);
-    cacheType = 'file';
-    return;
-  }
+    if (config.cacheDir) {
+      cacheProxy = PackageCacheFile.create(config.cacheDir);
+      cacheType = 'file';
+      return;
+    }
+  });
 }
 
 export async function get<T = unknown>(
@@ -55,10 +58,12 @@ export async function set(
 }
 
 export async function destroy(): Promise<void> {
-  cacheType = undefined;
-  try {
-    await cacheProxy?.destroy();
-  } finally {
-    cacheProxy = undefined;
-  }
+  await instrument('package-cache.destroy', async () => {
+    cacheType = undefined;
+    try {
+      await cacheProxy?.destroy();
+    } finally {
+      cacheProxy = undefined;
+    }
+  });
 }

--- a/lib/util/cache/package/backend.ts
+++ b/lib/util/cache/package/backend.ts
@@ -16,7 +16,7 @@ export function getCacheType(): typeof cacheType {
 
 export async function init(config: AllConfig): Promise<void> {
   await destroy();
-  await instrument('package-cache.init', async () => {
+  await instrument('init PackageCache', async () => {
     if (config.redisUrl) {
       cacheProxy = await PackageCacheRedis.create(
         config.redisUrl,
@@ -57,7 +57,7 @@ export async function set(
 }
 
 export async function destroy(): Promise<void> {
-  await instrument('package-cache.destroy', async () => {
+  await instrument('destroy PackageCache', async () => {
     cacheType = undefined;
     try {
       await cacheProxy?.destroy();

--- a/lib/util/cache/package/backend.ts
+++ b/lib/util/cache/package/backend.ts
@@ -15,9 +15,8 @@ export function getCacheType(): typeof cacheType {
 }
 
 export async function init(config: AllConfig): Promise<void> {
+  await destroy();
   await instrument('package-cache.init', async () => {
-    await destroy();
-
     if (config.redisUrl) {
       cacheProxy = await PackageCacheRedis.create(
         config.redisUrl,

--- a/lib/util/cache/repository/index.ts
+++ b/lib/util/cache/repository/index.ts
@@ -1,4 +1,5 @@
 import { GlobalConfig } from '../../../config/global.ts';
+import { instrument } from '../../../instrumentation/index.ts';
 import { logger } from '../../../logger/index.ts';
 import { RepoCacheNull } from './impl/null.ts';
 import type { RepoCache, RepoCacheData } from './types.ts';
@@ -23,7 +24,7 @@ export async function saveCache(): Promise<void> {
   if (GlobalConfig.get('dryRun')) {
     logger.info(`DRY-RUN: Would save repository cache.`);
   } else {
-    await repoCache.save();
+    await instrument('repository-cache.save', () => repoCache.save());
   }
 }
 

--- a/lib/util/cache/repository/index.ts
+++ b/lib/util/cache/repository/index.ts
@@ -24,7 +24,7 @@ export async function saveCache(): Promise<void> {
   if (GlobalConfig.get('dryRun')) {
     logger.info(`DRY-RUN: Would save repository cache.`);
   } else {
-    await instrument('repository-cache.save', () => repoCache.save());
+    await instrument('save RepoCache', () => repoCache.save());
   }
 }
 

--- a/lib/util/cache/repository/init.ts
+++ b/lib/util/cache/repository/init.ts
@@ -24,14 +24,14 @@ export async function initRepoCache(config: RepoCacheConfig): Promise<void> {
 
   if (repositoryCache === 'enabled') {
     const cache = CacheFactory.get(repository!, repoFingerprint, type);
-    await instrument('repository-cache.load', () => cache.load());
+    await instrument('load RepoCache', () => cache.load());
     setCache(cache);
     return;
   }
 
   if (repositoryCache === 'reset') {
     const cache = CacheFactory.get(repository!, repoFingerprint, type);
-    await instrument('repository-cache.save', () => cache.save());
+    await instrument('save RepoCache', () => cache.save());
     setCache(cache);
     return;
   }

--- a/lib/util/cache/repository/init.ts
+++ b/lib/util/cache/repository/init.ts
@@ -1,3 +1,4 @@
+import { instrument } from '../../../instrumentation/index.ts';
 import { CacheFactory } from './impl/cache-factory.ts';
 import { RepoCacheNull } from './impl/null.ts';
 import { resetCache, setCache } from './index.ts';
@@ -23,14 +24,14 @@ export async function initRepoCache(config: RepoCacheConfig): Promise<void> {
 
   if (repositoryCache === 'enabled') {
     const cache = CacheFactory.get(repository!, repoFingerprint, type);
-    await cache.load();
+    await instrument('repository-cache.load', () => cache.load());
     setCache(cache);
     return;
   }
 
   if (repositoryCache === 'reset') {
     const cache = CacheFactory.get(repository!, repoFingerprint, type);
-    await cache.save();
+    await instrument('repository-cache.save', () => cache.save());
     setCache(cache);
     return;
   }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds `instrument()` wrappers to cache lifecycle operations, creating OpenTelemetry spans for:

- Repository cache `load()` and `save()`
- Package cache `init()` and `destroy()`

This gives visibility into cache performance (especially useful with S3/Redis backends) without adding per-key spans that would be costly at scale (as described in https://github.com/renovatebot/renovate/issues/41760).

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [X] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [X] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [X] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [X] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->