### PR TITLE
fix(repository/finalize): avoid pruning crash when base branches are not resolved yet

### DIFF
--- a/lib/workers/repository/finalize/prune.spec.ts
+++ b/lib/workers/repository/finalize/prune.spec.ts
@@ -113,6 +113,33 @@ describe('workers/repository/finalize/prune', () => {
       );
     });
 
+    it('uses defaultBranch when baseBranchPatterns exist but baseBranches are not computed yet', async () => {
+      config.branchList = [];
+      config.baseBranchPatterns = ['/^release\\/.*/'];
+      config.defaultBranch = 'main';
+      git.getBranchList.mockReturnValueOnce([
+        'renovate/release/1.x-dependency',
+      ]);
+      platform.findPr.mockResolvedValueOnce(null);
+
+      await expect(
+        cleanup.pruneStaleBranches(config, config.branchList),
+      ).resolves.not.toThrow();
+
+      expect(platform.findPr).toHaveBeenCalledExactlyOnceWith({
+        branchName: 'renovate/release/1.x-dependency',
+        state: 'open',
+        targetBranch: 'main',
+      });
+      expect(scm.isBranchModified).toHaveBeenCalledExactlyOnceWith(
+        'renovate/release/1.x-dependency',
+        'main',
+      );
+      expect(scm.deleteBranch).toHaveBeenCalledExactlyOnceWith(
+        'renovate/release/1.x-dependency',
+      );
+    });
+
     it('does nothing on dryRun', async () => {
       config.branchList = ['renovate/a', 'renovate/b'];
       GlobalConfig.set({ dryRun: 'full' });

--- a/lib/workers/repository/finalize/prune.ts
+++ b/lib/workers/repository/finalize/prune.ts
@@ -120,7 +120,7 @@ async function cleanUpBranches(
  * @param config Renovate configuration
  */
 function calculateBaseBranchRegex(config: RenovateConfig): RegExp | null {
-  if (!config.baseBranchPatterns?.length) {
+  if (!config.baseBranchPatterns?.length || !config.baseBranches?.length) {
     return null;
   }
 
@@ -130,9 +130,7 @@ function calculateBaseBranchRegex(config: RenovateConfig): RegExp | null {
     .filter(uniqueStrings)
     .map(escapeRegExp);
 
-  // calculate possible base branches and escape for regex
-  // if baseBranchPatterns is configured, baseBranches will be defined too
-  const baseBranches = config.baseBranches!.map(escapeRegExp);
+  const baseBranches = config.baseBranches.map(escapeRegExp);
 
   // create regex to extract base branche from branch name
   const baseBranchRe = regEx(


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Avoids an error during repo finalization when pruning runs is done before `baseBranchPatterns` has been expanded to `baseBranches` in `unfoldBaseBranches(...)`. 

This can happen, e.g., when using `useBaseBranchConfig=merge`, `baseBranchPatterns` are defined, onboarding is disabled, and no renovate config exists on the default branch but a matching base branch does have one. The assumption from the former comment that `baseBranches` is always configured, when `baseBranchPatterns` is defined, was not always true.

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

- https://github.com/renovatebot/renovate/discussions/40677

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
