### PR TITLE
feat(package-rules): support template compilation for sourceUrl

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -3856,6 +3856,8 @@ Use this field to set the directory in which the package is present at the sourc
 Use this field to set the source URL for a package, including overriding an existing one.
 Source URLs are necessary to link to the source of the package and in order to look up changelogs.
 
+The `sourceUrl` field supports template compilation, allowing you to dynamically construct URLs based on package information.
+
 ```json title="Setting the source URL for the dummy package"
 {
   "packageRules": [
@@ -3866,6 +3868,20 @@ Source URLs are necessary to link to the source of the package and in order to l
   ]
 }
 ```
+
+```json title="Using templates to construct source URLs for OpenTofu providers"
+{
+  "packageRules": [
+    {
+      "matchDatasources": ["terraform-provider"],
+      "registryUrls": ["https://registry.opentofu.org"],
+      "sourceUrl": "https://github.com/{{replace '/' '/terraform-provider-' packageName}}"
+    }
+  ]
+}
+```
+
+In the example above, a package name like `hashicorp/aws` will be transformed to `https://github.com/hashicorp/terraform-provider-aws`.
 
 ## patch
 

--- a/lib/util/package-rules/index.spec.ts
+++ b/lib/util/package-rules/index.spec.ts
@@ -1282,4 +1282,39 @@ describe('util/package-rules/index', () => {
     expect(res.depName).toBe('node');
     expect(res.packageName).toBe('docker.io/library/node');
   });
+
+  it('compiles sourceUrl with template helper functions', async () => {
+    const config: TestConfig = {
+      datasource: 'terraform-provider',
+      depName: 'aws',
+      packageName: 'hashicorp/aws',
+      packageRules: [
+        {
+          matchDatasources: ['terraform-provider'],
+          sourceUrl:
+            'https://github.com/{{replace "/" "/terraform-provider-" packageName}}',
+        },
+      ],
+    };
+    const res = await applyPackageRules(config);
+    expect(res.sourceUrl).toBe(
+      'https://github.com/hashicorp/terraform-provider-aws',
+    );
+  });
+
+  it('compiles sourceUrl with template variables', async () => {
+    const config: TestConfig = {
+      datasource: 'terraform-provider',
+      depName: 'aws',
+      packageName: 'hashicorp/aws',
+      packageRules: [
+        {
+          matchDatasources: ['terraform-provider'],
+          sourceUrl: 'https://github.com/{{packageName}}',
+        },
+      ],
+    };
+    const res = await applyPackageRules(config);
+    expect(res.sourceUrl).toBe('https://github.com/hashicorp/aws');
+  });
 });

--- a/lib/util/package-rules/index.ts
+++ b/lib/util/package-rules/index.ts
@@ -90,6 +90,9 @@ export async function applyPackageRules<T extends PackageRuleInputConfig>(
         );
         config.packageName = compile(toApply.overridePackageName, config);
       }
+      if (isString(toApply.sourceUrl)) {
+        toApply.sourceUrl = compile(toApply.sourceUrl, config);
+      }
       delete toApply.overrideDatasource;
       delete toApply.overrideDepName;
       delete toApply.overridePackageName;


### PR DESCRIPTION
## Changes
- Added template compilation for `sourceUrl` in `applyPackageRules` function
- Added two test cases to verify template compilation works correctly
- Updated documentation with template support explanation and example

The implementation follows the same pattern as `overrideDepName` and `overridePackageName` template compilation, ensuring consistency with existing code.

## Context

- [x] This closes an existing Issue, Closes: #35974
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

> **Note:** This replaces #39816 which was accidentally closed when cleaning up forked repos.

## AI assistance disclosure

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

This PR was created with AI assistance (Claude/Cursor AI). The AI was responsible for:
- Implementing the template compilation feature in `lib/util/package-rules/index.ts`
- Writing the test cases in `lib/util/package-rules/index.spec.ts`
- Updating the documentation in `docs/usage/configuration-options.md`
- Researching the codebase to understand existing patterns and conventions
- Following the repository's development guidelines and best practices

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository