### PR TITLE
refactor(kubernetes): use zod schema to extract API versions

### DIFF
--- a/lib/modules/manager/kubernetes/__fixtures__/kubernetes.registry-alias.yaml
+++ b/lib/modules/manager/kubernetes/__fixtures__/kubernetes.registry-alias.yaml
@@ -7,6 +7,6 @@ metadata:
 spec:
   containers:
     - name: node
-    image: quay.io/node:0.0.1
-    ports:
-    - containerPort: 80
+      image: quay.io/node:0.0.1
+      ports:
+        - containerPort: 80

--- a/lib/modules/manager/kubernetes/extract.ts
+++ b/lib/modules/manager/kubernetes/extract.ts
@@ -1,7 +1,6 @@
-import { isNonEmptyStringAndNotWhitespace, isTruthy } from '@sindresorhus/is';
 import { logger } from '../../../logger/index.ts';
 import { newlineRegex, regEx } from '../../../util/regex.ts';
-import { parseYaml } from '../../../util/yaml.ts';
+import { withDebugMessage } from '../../../util/schema-utils/index.ts';
 import {
   KubernetesApiDatasource,
   supportedApis,
@@ -13,7 +12,7 @@ import type {
   PackageDependency,
   PackageFileContent,
 } from '../types.ts';
-import type { KubernetesConfiguration } from './types.ts';
+import { type KubernetesManifest, KubernetesManifests } from './schema.ts';
 
 export function extractPackageFile(
   content: string,
@@ -29,9 +28,13 @@ export function extractPackageFile(
     return null;
   }
 
+  const manifests = KubernetesManifests.catch(
+    withDebugMessage([], `${packageFile} does not match Kubernetes schema`),
+  ).parse(content);
+
   const deps: PackageDependency[] = [
     ...extractImages(content, config),
-    ...extractApis(content, packageFile),
+    ...extractApis(manifests),
   ];
 
   return deps.length ? { deps } : null;
@@ -71,29 +74,8 @@ function extractImages(
   return deps;
 }
 
-function extractApis(
-  content: string,
-  packageFile: string,
-): PackageDependency[] {
-  let doc: KubernetesConfiguration[];
-
-  try {
-    // TODO: use schema (#9610)
-    doc = parseYaml(content, {
-      removeTemplates: true,
-    });
-  } catch (err) {
-    logger.debug({ err, packageFile }, 'Failed to parse Kubernetes manifest.');
-    return [];
-  }
-
-  return doc
-    .filter(isTruthy)
-    .filter(
-      (m) =>
-        isNonEmptyStringAndNotWhitespace(m.kind) &&
-        isNonEmptyStringAndNotWhitespace(m.apiVersion),
-    )
+function extractApis(manifests: KubernetesManifest[]): PackageDependency[] {
+  return manifests
     .filter((m) => supportedApis.has(m.kind))
     .map((configuration) => ({
       depName: configuration.kind,

--- a/lib/modules/manager/kubernetes/schema.ts
+++ b/lib/modules/manager/kubernetes/schema.ts
@@ -1,10 +1,17 @@
 import { z } from 'zod/v3';
+import { LooseArray, multidocYaml } from '../../../util/schema-utils/index.ts';
 
 export const KubernetesResource = z.object({
-  apiVersion: z.string(),
-  kind: z.string(),
+  apiVersion: z.string().trim().min(1),
+  kind: z.string().trim().min(1),
   metadata: z.object({
     name: z.string(),
     namespace: z.string().optional(),
   }),
 });
+
+export type KubernetesManifest = z.infer<typeof KubernetesResource>;
+
+export const KubernetesManifests = multidocYaml({
+  removeTemplates: true,
+}).pipe(LooseArray(KubernetesResource));

--- a/lib/modules/manager/kubernetes/types.ts
+++ b/lib/modules/manager/kubernetes/types.ts
@@ -1,4 +1,0 @@
-export interface KubernetesConfiguration {
-  apiVersion: string;
-  kind: string;
-}


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Simple refactoring to Zod schema in preparation of adding support for `volume.image.reference` (https://github.com/renovatebot/renovate/discussions/41924). The manifests are intentionally parsed outside of `extractApis` to prepare for a follow-up PR.

Fixing the (not test-relevant) indentation of a fixture is unrelated but a prerequisite to also do image extraction via zod (later).

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

- Preparation for https://github.com/renovatebot/renovate/discussions/41924
- Related to https://github.com/renovatebot/renovate/issues/9610

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
