### PR TITLE
feat(bitbucket-server): reattempt platform automerge after PR updates

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -3896,7 +3896,7 @@ If enabled Renovate will pin Docker images or GitHub Actions by means of their S
 
 If you have enabled `automerge` and set `automergeType=pr` in the Renovate config, then leaving `platformAutomerge` as `true` speeds up merging via the platform's native automerge functionality.
 
-On GitHub and GitLab, Renovate re-enables the PR for platform-native automerge whenever it's rebased.
+On GitHub, GitLab, and Bitbucket Server, Renovate re-enables the PR for platform-native automerge whenever it's rebased.
 
 `platformAutomerge` will configure PRs to be merged after all (if any) branch policies have been met.
 This option is available for Azure, Bitbucket Server, Forgejo, Gitea, GitHub and GitLab.

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -3896,7 +3896,7 @@ If enabled Renovate will pin Docker images or GitHub Actions by means of their S
 
 If you have enabled `automerge` and set `automergeType=pr` in the Renovate config, then leaving `platformAutomerge` as `true` speeds up merging via the platform's native automerge functionality.
 
-On GitHub, GitLab, and Bitbucket Server, Renovate re-enables the PR for platform-native automerge whenever it's rebased.
+On Bitbucket Server, GitHub and GitLab, Renovate re-enables the PR for platform-native automerge whenever it's rebased.
 
 `platformAutomerge` will configure PRs to be merged after all (if any) branch policies have been met.
 This option is available for Azure, Bitbucket Server, Forgejo, Gitea, GitHub and GitLab.

--- a/lib/modules/platform/bitbucket-server/index.spec.ts
+++ b/lib/modules/platform/bitbucket-server/index.spec.ts
@@ -11,6 +11,7 @@ import {
 import * as repoCache from '../../../util/cache/repository/index.ts';
 import type { LongCommitSha } from '../../../util/git/types.ts';
 import { ensureTrailingSlash } from '../../../util/url.ts';
+import type { ReattemptPlatformAutomergeConfig } from '../types.ts';
 import * as bitbucket from './index.ts';
 
 vi.mock('timers/promises');
@@ -1935,6 +1936,37 @@ describe('modules/platform/bitbucket-server/index', () => {
         );
       });
 
+      it('platform-native automerge returns early if usePlatformAutomerge is false', async () => {
+        const scope = await initRepo();
+        scope
+          .post(
+            `${urlPath}/rest/api/1.0/projects/SOME/repos/repo/pull-requests`,
+          )
+          .reply(200, prMock(url, 'SOME', 'repo'))
+          .get(
+            `${urlPath}/rest/api/1.0/projects/SOME/repos/repo/pull-requests?state=ALL&limit=100&role.1=AUTHOR&username.1=abc`,
+          )
+          .reply(200, {
+            isLastPage: true,
+            values: [],
+          });
+
+        await bitbucket.createPr({
+          sourceBranch: 'branch',
+          targetBranch: 'master',
+          prTitle: 'title',
+          prBody: 'body',
+          platformPrOptions: {
+            usePlatformAutomerge: false,
+          },
+        });
+
+        expect(logger.logger.debug).not.toHaveBeenCalledWith(
+          expect.anything(),
+          expect.stringContaining('tryPrAutomerge'),
+        );
+      });
+
       it('platform-native automerge returns early if Bitbucket Server <= 8.15.0 is used', async () => {
         const scope = await initRepo();
         scope
@@ -2004,6 +2036,64 @@ describe('modules/platform/bitbucket-server/index', () => {
         expect(logger.logger.warn).toHaveBeenCalledWith(
           { err: expect.any(Error), prNumber: 5 },
           expect.stringContaining('automerge: fail'),
+        );
+      });
+    });
+
+    describe('reattemptPlatformAutomerge()', () => {
+      const pr: ReattemptPlatformAutomergeConfig = {
+        number: 123,
+        platformPrOptions: { usePlatformAutomerge: true },
+      };
+
+      it('should reattempt automerge', async () => {
+        const scope = await initRepo();
+        scope
+          .get(
+            `${urlPath}/rest/api/1.0/projects/SOME/repos/repo/pull-requests/123`,
+          )
+          .reply(200, prMock(url, 'SOME', 'repo'))
+          .post(
+            `${urlPath}/rest/api/1.0/projects/SOME/repos/repo/pull-requests/5/merge?version=1`,
+          )
+          .reply(200);
+
+        // Simulate version >= 8.15.0
+        vi.spyOn(semver, 'lt').mockReturnValue(false);
+
+        await bitbucket.reattemptPlatformAutomerge(pr);
+
+        expect(logger.logger.debug).toHaveBeenLastCalledWith(
+          'PR platform automerge re-attempted...prNo: 123',
+        );
+      });
+
+      it('handles unknown error', async () => {
+        const scope = await initRepo();
+        scope
+          .get(
+            `${urlPath}/rest/api/1.0/projects/SOME/repos/repo/pull-requests/123`,
+          )
+          .replyWithError('unknown error');
+
+        await bitbucket.reattemptPlatformAutomerge(pr);
+
+        expect(logger.logger.warn).toHaveBeenCalledWith(
+          { err: expect.any(Error) },
+          'Error re-attempting PR platform automerge',
+        );
+      });
+
+      it('handles missing prNo', async () => {
+        await initRepo();
+        await bitbucket.reattemptPlatformAutomerge({
+          ...pr,
+          number: null as any,
+        });
+
+        expect(logger.logger.warn).toHaveBeenCalledWith(
+          { err: expect.objectContaining({ message: REPOSITORY_NOT_FOUND }) },
+          'Error re-attempting PR platform automerge',
         );
       });
     });

--- a/lib/modules/platform/bitbucket-server/index.ts
+++ b/lib/modules/platform/bitbucket-server/index.ts
@@ -41,8 +41,10 @@ import type {
   Issue,
   MergePRConfig,
   PlatformParams,
+  PlatformPrOptions,
   PlatformResult,
   Pr,
+  ReattemptPlatformAutomergeConfig,
   RepoParams,
   RepoResult,
   UpdatePrConfig,
@@ -1089,11 +1091,28 @@ export async function createPr({
     pr,
   );
 
-  if (platformPrOptions?.usePlatformAutomerge) {
-    await tryPrAutomerge(pr.number, pr.version!);
-  }
+  await tryPrAutomerge(pr.number, pr.version!, platformPrOptions);
 
   return pr;
+}
+
+export async function reattemptPlatformAutomerge({
+  number,
+  platformPrOptions,
+}: ReattemptPlatformAutomergeConfig): Promise<void> {
+  logger.debug(`reattemptPlatformAutomerge(${number})`);
+
+  try {
+    const pr = await getPr(number, true);
+    if (!pr) {
+      throw new Error(REPOSITORY_NOT_FOUND);
+    }
+    await tryPrAutomerge(pr.number, pr.version!, platformPrOptions);
+
+    logger.debug(`PR platform automerge re-attempted...prNo: ${number}`);
+  } catch (err) {
+    logger.warn({ err }, 'Error re-attempting PR platform automerge');
+  }
 }
 
 export async function updatePr({
@@ -1242,8 +1261,13 @@ export async function mergePr({
 async function tryPrAutomerge(
   prNumber: number,
   prVersion: number,
+  platformPrOptions?: PlatformPrOptions,
 ): Promise<void> {
-  logger.debug(`automergePr(${prNumber})`);
+  if (!platformPrOptions?.usePlatformAutomerge) {
+    return;
+  }
+
+  logger.debug(`tryPrAutomerge(${prNumber})`);
 
   if (semver.lt(defaults.version, '8.15.0')) {
     logger.debug(


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This change re-attempts Bitbucket Server-native automerge for existing PRs after rebasing. Basically mimics what was already there for GitHub and Gitlab.

The `usePlatformAutomerge` early return now lives in `tryPrAutomerge()` too, matching the structure already used by the other platform managers (https://github.com/renovatebot/renovate/pull/26567).

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

Follow-up PR to:
- https://github.com/renovatebot/renovate/pull/39885

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

Tested with a real repo. How it looks like:
<img width="1092" height="521" alt="reattempt" src="https://github.com/user-attachments/assets/40a038b0-42fa-472e-980e-8c0ba6bffd5d" />


<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
