### PR TITLE
feat(presets/monorepos): Add Effect.ts v4 to monorepo.json

### DIFF
--- a/lib/data/monorepo.json
+++ b/lib/data/monorepo.json
@@ -344,6 +344,7 @@
     "dotnetcore-cap": "https://github.com/dotnetcore/CAP",
     "dropwizard": "https://github.com/dropwizard/dropwizard",
     "duende-identityserver": "https://github.com/DuendeSoftware/IdentityServer",
+    "effect": "https://github.com/Effect-TS/effect-smol",
     "elastic-apm-agent-rum-js": "https://github.com/elastic/apm-agent-rum-js",
     "elastic-ecs-dotnet": "https://github.com/elastic/ecs-dotnet",
     "electron-forge": [


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This PR groups packages from https://effect.website (v4 beta). Currently stable ecosystem packages come from https://github.com/Effect-TS/effect and do not have their versions synced. For example, latest [`effect@latest`](https://www.npmjs.com/package/effect) is `3.19.19` while [`@effect/platform-node@latest`](https://www.npmjs.com/package/@effect/platform-node) is `0.104.1`.

This changes in the new major - [see announcement of v4 beta](https://effect.website/blog/releases/effect/40-beta/) (2026-02-18)

- Repo URL is now https://github.com/Effect-TS/effect-smol
- All package versions are in sync going forward (e.g. `4.0.0-beta.32`)
  - Proof: [section in announcement](https://effect.website/blog/releases/effect/40-beta/#one-version-one-ecosystem)
  - Examples:
    - https://www.npmjs.com/package/effect?activeTab=versions
    - https://www.npmjs.com/package/@effect/platform-node?activeTab=versions

Not sure if https://github.com/Effect-TS/effect-smol will remain the 'home' of all package once v4 stable is out. But even if this changes, adding the repo would be useful for many until then. It is expected that Effect v4 stabilisation may take a while because of a pretty high bar that has been set by maintainers. 

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
- [x] Other: looked at own PRs accepted earlier, e.g.
   - https://github.com/renovatebot/renovate/pull/41115
   - https://github.com/renovatebot/renovate/pull/31011


<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
