### PR TITLE
fix(docker): support per-repo credentials in getAuthHeaders

### DIFF
--- a/lib/modules/datasource/docker/common.spec.ts
+++ b/lib/modules/datasource/docker/common.spec.ts
@@ -211,6 +211,111 @@ describe('modules/datasource/docker/common', () => {
       expect(headers).toBeNull();
     });
 
+    it('falls back to per-repo credentials when API URL does not match', async () => {
+      httpMock
+        .scope('https://quay.io')
+        .get('/v2/', undefined, { badheaders: ['authorization'] })
+        .reply(401, '', {
+          'www-authenticate':
+            'Bearer realm="https://quay.io/v2/auth",service="quay.io",scope="repository:myorg/myrepo:pull"',
+        })
+        .get(
+          '/v2/auth?scope=repository%3Amyorg%2Fmyrepo%3Apull&service=quay.io',
+        )
+        .reply(200, { token: 'some-token' });
+
+      // API URL doesn't match per-repo matchHost, but repo URL does
+      hostRules.find.mockImplementation((search) => {
+        if (search?.url === 'https://quay.io/myorg/myrepo') {
+          return {
+            username: 'repo-user',
+            password: 'repo-password',
+          };
+        }
+        return {};
+      });
+
+      const headers = await getAuthHeaders(
+        http,
+        'https://quay.io',
+        'myorg/myrepo',
+      );
+
+      expect(hostRules.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          hostType: 'docker',
+          url: 'https://quay.io/v2/',
+        }),
+      );
+      expect(hostRules.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          hostType: 'docker',
+          url: 'https://quay.io/myorg/myrepo',
+        }),
+      );
+      expect(headers).toMatchObject({
+        authorization: 'Bearer some-token',
+      });
+    });
+
+    it('does not fall back to per-repo credentials when API URL already matches', async () => {
+      httpMock
+        .scope('https://my.local.registry')
+        .get('/v2/', undefined, { badheaders: ['authorization'] })
+        .reply(401, '', { 'www-authenticate': 'Authenticate you must' });
+
+      hostRules.find.mockReturnValue({
+        username: 'registry-user',
+        password: 'registry-password',
+      });
+
+      const headers = await getAuthHeaders(
+        http,
+        'https://my.local.registry',
+        'org/repo',
+      );
+
+      // Should never call find with the repo URL — no fallback needed
+      expect(hostRules.find).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: 'https://my.local.registry/org/repo',
+        }),
+      );
+      expect(headers).toMatchObject({
+        authorization: expect.stringMatching(/^Basic /),
+      });
+    });
+
+    it('falls back to per-repo token credentials', async () => {
+      httpMock
+        .scope('https://quay.io')
+        .get('/v2/', undefined, { badheaders: ['authorization'] })
+        .reply(401, '', { 'www-authenticate': 'Authenticate you must' });
+
+      hostRules.find.mockImplementation((search) => {
+        if (search?.url === 'https://quay.io/myorg/myrepo') {
+          return { token: 'repo-token' };
+        }
+        return {};
+      });
+
+      const headers = await getAuthHeaders(
+        http,
+        'https://quay.io',
+        'myorg/myrepo',
+      );
+
+      expect(hostRules.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          hostType: 'docker',
+          url: 'https://quay.io/myorg/myrepo',
+        }),
+      );
+      expect(headers).toMatchObject({
+        authorization: 'Bearer repo-token',
+      });
+    });
+
     it('use resources URL and resolve scope in www-authenticate header', async () => {
       httpMock
         .scope('https://my.local.registry')

--- a/lib/modules/datasource/docker/common.ts
+++ b/lib/modules/datasource/docker/common.ts
@@ -87,10 +87,25 @@ export async function getAuthHeaders(
       return null;
     }
 
-    const rule = hostRules.find({
+    let rule = hostRules.find({
       hostType: dockerDatasourceId,
       url: apiCheckUrl,
     });
+
+    // If no credentials found with the API URL, try the repository path URL.
+    // This supports per-repo matchHost like "quay.io/org/repo" where the
+    // matchHost path doesn't match Docker v2 API URLs (e.g. /v2/...).
+    if (!rule.username && !rule.password && !rule.token) {
+      const repoUrl = `${registryHost}/${dockerRepository}`;
+      const repoRule = hostRules.find({
+        hostType: dockerDatasourceId,
+        url: repoUrl,
+      });
+      if (repoRule.username || repoRule.password || repoRule.token) {
+        rule = { ...rule, ...repoRule };
+      }
+    }
+
     const opts: HttpOptions = {};
 
     if (ecrRegex.test(registryHost)) {


### PR DESCRIPTION
When hostRules use a path-based matchHost (e.g. `quay.io/org/repo`), the credentials were never matched against Docker v2 API URLs because those use `/v2/` as a path prefix. Add a fallback lookup using the repository path URL when the initial API URL lookup finds no credentials.

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

When `hostRules` are configured with a path-based matchHost for Docker registries (e.g. `quay.io/org/repo`), the credentials are never matched against Docker v2 API URLs. This is because `matchesHost()` uses `startsWith()` to compare URLs, and Docker v2 API URLs always insert `/v2/` as a path prefix (e.g. `https://quay.io/v2/org/repo/manifests/tag`), which never starts with the configured `matchHost` path (`https://quay.io/org/repo`).

This results in `getAuthHeaders()` requesting an anonymous token from the registry, which lacks pull permissions for private repositories. The subsequent manifest requests fail with 401, causing `getDigest()` to return `null`. This means digest updates are never detected for the affected images, they are silently filtered out with no updates created.

This PR adds a fallback credential lookup in `getAuthHeaders()`: when no credentials are found using the API URL, it retries with the repository path URL (`${registryHost}/${dockerRepository}`), which matches the user-configured `matchHost` exactly. The fallback only triggers when the initial lookup returns no credentials, so existing behavior is unchanged.


## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: no public repo as this requires private container repos for testing.

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
