### PR TITLE
fix(bazel-module): use --lockfile_mode=update when updating lockfile

### DIFF
--- a/lib/modules/manager/bazel-module/lockfile.spec.ts
+++ b/lib/modules/manager/bazel-module/lockfile.spec.ts
@@ -49,7 +49,9 @@ describe('modules/manager/bazel-module/lockfile', () => {
         },
       },
     ]);
-    expect(execSnapshots).toMatchObject([{ cmd: 'bazel mod deps' }]);
+    expect(execSnapshots).toMatchObject([
+      { cmd: 'bazel mod deps --lockfile_mode=update' },
+    ]);
     expect(fs.deleteLocalFile).not.toHaveBeenCalled();
   });
 
@@ -79,7 +81,9 @@ describe('modules/manager/bazel-module/lockfile', () => {
         },
       },
     ]);
-    expect(execSnapshots).toMatchObject([{ cmd: 'bazel mod deps' }]);
+    expect(execSnapshots).toMatchObject([
+      { cmd: 'bazel mod deps --lockfile_mode=update' },
+    ]);
   });
 
   it('returns null when lockfile is not modified', async () => {
@@ -98,7 +102,9 @@ describe('modules/manager/bazel-module/lockfile', () => {
     );
 
     expect(result).toBeNull();
-    expect(execSnapshots).toMatchObject([{ cmd: 'bazel mod deps' }]);
+    expect(execSnapshots).toMatchObject([
+      { cmd: 'bazel mod deps --lockfile_mode=update' },
+    ]);
   });
 
   it('deletes lockfile during maintenance', async () => {
@@ -126,7 +132,9 @@ describe('modules/manager/bazel-module/lockfile', () => {
         },
       },
     ]);
-    expect(execSnapshots).toMatchObject([{ cmd: 'bazel mod deps' }]);
+    expect(execSnapshots).toMatchObject([
+      { cmd: 'bazel mod deps --lockfile_mode=update' },
+    ]);
     expect(fs.deleteLocalFile).toHaveBeenCalledWith('MODULE.bazel.lock');
   });
 

--- a/lib/modules/manager/bazel-module/lockfile.ts
+++ b/lib/modules/manager/bazel-module/lockfile.ts
@@ -24,7 +24,7 @@ export async function updateBazelLockfile(
         { toolName: 'bazelisk', constraint: bazeliskConstraint },
       ],
     };
-    await exec('bazel mod deps', execOptions);
+    await exec('bazel mod deps --lockfile_mode=update', execOptions);
 
     const status = await getRepoStatus();
     if (


### PR DESCRIPTION


## Changes

Explicitly set --lockfile_mode=update when running bazel mod deps to ensure the lockfile can be updated even when checksums are missing or mismatched. This prevents failures when --lockfile_mode=error is the default or active in the environment.

```
 "cmd": "bazel mod deps",
2026-03-17T12:17:22.9567264Z          "stderr": "ERROR: Missing checksum for registry file https://bcr.bazel.build/modules/platforms/1.0.0/MODULE.bazel not permitted with --lockfile_mode=error. Please run `bazel mod deps --lockfile_mode=update` to update your lockfile.\n",
2026-03-17T12:17:22.9568989Z          "stdout": "",
2026-03-17T12:17:22.9569368Z          "options": {
2026-03-17T12:17:22.9569944Z            "cwd": "/tmp/renovate/repos/github/angular/angular-cli",
2026-03-17T12:17:22.9570770Z            "env": ["CI", "HOME", "PATH", "LANG", "CONTAINERBASE_CACHE_DIR"],
2026-03-17T12:17:22.9571450Z            "maxBuffer": 10485760,
2026-03-17T12:17:22.9571937Z            "timeout": 900000,
2026-03-17T12:17:22.9572618Z            "stdin": "pipe",
2026-03-17T12:17:22.9573027Z            "stdout": "pipe",
2026-03-17T12:17:22.9573422Z            "stderr": "pipe"
2026-03-17T12:17:22.9573793Z          },
2026-03-17T12:17:22.9574115Z          "exitCode": 37,
2026-03-17T12:17:22.9574476Z          "name": "ExecError",
2026-03-17T12:17:22.9576502Z          "message": "Command failed: bazel mod deps\nERROR: Missing checksum for registry file https://bcr.bazel.build/modules/platforms/1.0.0/MODULE.bazel not permitted with --lockfile_mode=error. Please run `bazel mod deps --lockfile_mode=update` to update your lockfile.\n",
```
## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
