### PR TITLE
fix(repository/finalize): skip branch pruning when defaultBranch is unavailable

### DIFF
--- a/lib/workers/repository/finalize/prune.spec.ts
+++ b/lib/workers/repository/finalize/prune.spec.ts
@@ -9,6 +9,7 @@ let config: RenovateConfig;
 beforeEach(() => {
   config = partial<RenovateConfig>({
     repoIsOnboarded: true,
+    defaultBranch: 'main',
     branchPrefix: `renovate/`,
     pruneStaleBranches: true,
   });
@@ -28,6 +29,13 @@ describe('workers/repository/finalize/prune', () => {
 
     it('ignores reconfigure branch', async () => {
       delete config.branchList;
+      await cleanup.pruneStaleBranches(config, config.branchList);
+      expect(git.getBranchList).toHaveBeenCalledTimes(0);
+    });
+
+    it('returns if no defaultBranch', async () => {
+      delete config.defaultBranch;
+      config.branchList = [];
       await cleanup.pruneStaleBranches(config, config.branchList);
       expect(git.getBranchList).toHaveBeenCalledTimes(0);
     });

--- a/lib/workers/repository/finalize/prune.ts
+++ b/lib/workers/repository/finalize/prune.ts
@@ -29,7 +29,7 @@ async function cleanUpBranches(
     try {
       // get base branch from branch name if base branches are configured
       // use default branch if no base branches are configured
-      // use defaul branch name if no match (can happen when base branches are configured later)
+      // use default branch name if no match (can happen when base branches are configured later)
       const baseBranch =
         baseBranchRe?.exec(branchName)?.[1] ?? config.defaultBranch!;
       const pr = await platform.findPr({
@@ -150,6 +150,10 @@ export async function pruneStaleBranches(
   logger.debug(`config.repoIsOnboarded=${config.repoIsOnboarded!}`);
   if (!branchList) {
     logger.debug('No branchList');
+    return;
+  }
+  if (!config.defaultBranch) {
+    logger.debug('No defaultBranch set - skipping branch pruning');
     return;
   }
   // TODO: types (#22198)


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This PR skips branch pruning when `defaultBranch` is missing in `pruneStaleBranches()`.

When `initRepo()` fails early (e.g. with `REPOSITORY_NO_CONFIG` because `requireConfig=required`, `onboarding=false`, and there is no config file on the default branch), the error handler in `renovateRepository` ([here](https://github.com/renovatebot/renovate/blob/023b01848f1c3c0d9c75145d8ed672755ad4a98d/lib/workers/repository/index.ts#L93-L95)) calls `pruneStaleBranches()` with a config that has not yet been enriched with platform-derived fields like `defaultBranch`.

Without `defaultBranch`, prune cleanup can end up passing an `undefined` base branch into `findPr()`/`isBranchModified` checks that lead to invalid git revision warnings (but no crash). This change avoids that by skipping pruning when `defaultBranch` is unavailable.

**Detailed explanation**

If there are existing `renovate/*` branches in the repo, the prune logic would call `cleanUpBranches()` with `remainingBranches=["renovate/some-update"])`. Now execution arrives here:

https://github.com/renovatebot/renovate/blob/023b01848f1c3c0d9c75145d8ed672755ad4a98d/lib/workers/repository/finalize/prune.ts#L26-L34

If `initRepo()` didn't complete, `extractDependencies()` ([here](https://github.com/renovatebot/renovate/blob/023b01848f1c3c0d9c75145d8ed672755ad4a98d/lib/workers/repository/index.ts#L119)) never got called and base branches were also not extracted:

https://github.com/renovatebot/renovate/blob/023b01848f1c3c0d9c75145d8ed672755ad4a98d/lib/workers/repository/process/index.ts#L158-L161

This in turn means that in `cleanupBranches()` we fallback to `defaultBranch`:

https://github.com/renovatebot/renovate/blob/023b01848f1c3c0d9c75145d8ed672755ad4a98d/lib/workers/repository/finalize/prune.ts#L33-L34

When `undefined` is then used as the base branch for `findPr()` and `isBranchModified()` calls, it leads to `git log origin/undefined..origin/renovate/xxx` and the warning "_Error checking last author for isBranchModified_", see https://github.com/renovatebot/renovate/discussions/40677#discussioncomment-16173545.

```
DEBUG: Branch lists (repository=tgpfeiffer/renovate-discussion-40677)
       "branchList": [],
       "renovateBranches": ["renovate/some-update"]
DEBUG: remainingBranches=renovate/some-update (repository=tgpfeiffer/renovate-discussion-40677)
DEBUG: findPr(renovate/some-update, undefined, open) (repository=tgpfeiffer/renovate-discussion-40677)
DEBUG: branch.isModified(): using git to calculate against baseBranch "undefined" (repository=tgpfeiffer/renovate-discussion-40677)
 WARN: Error checking last author for isBranchModified (repository=tgpfeiffer/renovate-discussion-40677)
```

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

- Follow-up on https://github.com/renovatebot/renovate/pull/41928
  - The fix here was correct, it just didn't cover the follow-up issue
- https://github.com/renovatebot/renovate/discussions/40677

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/tgpfeiffer/renovate-discussion-40677

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
