### PR TITLE
ci: add module label sync tooling

### DIFF
--- a/docs/development/issue-labeling.md
+++ b/docs/development/issue-labeling.md
@@ -234,7 +234,7 @@ The Action runs each week.
 
 Run `pnpm labels:check` to check whether all datasource, manager, and platform modules have matching GitHub labels.
 
-If you have permission to create labels, run `pnpm labels:sync` to create any missing labels with the default color and description.
+Run `pnpm labels:dry-run` to print copy-pasteable `gh label create ...` commands for any missing labels.
 
 ### Apply the correct labels manually
 

--- a/docs/development/issue-labeling.md
+++ b/docs/development/issue-labeling.md
@@ -230,6 +230,12 @@ Any Issues with missing labels will be put in a list in a new "error" Issue.
 
 The Action runs each week.
 
+## Checking Module Label Coverage
+
+Run `pnpm labels:check` to check whether all datasource, manager, and platform modules have matching GitHub labels.
+
+If you have permission to create labels, run `pnpm labels:sync` to create any missing labels with the default color and description.
+
 ### Apply the correct labels manually
 
 The Action will _not_ fix any badly labeled issues.

--- a/docs/development/issue-labeling.md
+++ b/docs/development/issue-labeling.md
@@ -234,7 +234,7 @@ The Action runs each week.
 
 Run `pnpm labels:check` to check whether all datasource, manager, and platform modules have matching GitHub labels.
 
-Run `pnpm labels:dry-run` to print copy-pasteable `gh label create ...` commands for any missing labels.
+Run `pnpm labels:show-commands` to print copy-pasteable `gh label create ...` commands for any missing labels.
 
 ### Apply the correct labels manually
 

--- a/package.json
+++ b/package.json
@@ -50,6 +50,8 @@
     "pretest": "run-s 'generate:*'",
     "prettier": "PRETTIER_EXPERIMENTAL_CLI=1 prettier --cache --check '**/*.{ts,js,mjs,json,md,yml}'",
     "prettier-fix": "PRETTIER_EXPERIMENTAL_CLI=1 prettier --write --cache '**/*.{ts,js,mjs,json,md,yml}'",
+    "labels:check": "node tools/sync-module-labels.ts",
+    "labels:sync": "node tools/sync-module-labels.ts --write",
     "release:prepare": "node tools/prepare-release.ts",
     "release:publish": "node tools/publish-release.ts",
     "start": "node lib/renovate.ts",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "prettier": "PRETTIER_EXPERIMENTAL_CLI=1 prettier --cache --check '**/*.{ts,js,mjs,json,md,yml}'",
     "prettier-fix": "PRETTIER_EXPERIMENTAL_CLI=1 prettier --write --cache '**/*.{ts,js,mjs,json,md,yml}'",
     "labels:check": "node tools/sync-module-labels.ts",
-    "labels:dry-run": "node tools/sync-module-labels.ts --dry-run",
+    "labels:show-commands": "node tools/sync-module-labels.ts --show-commands",
     "release:prepare": "node tools/prepare-release.ts",
     "release:publish": "node tools/publish-release.ts",
     "start": "node lib/renovate.ts",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "prettier": "PRETTIER_EXPERIMENTAL_CLI=1 prettier --cache --check '**/*.{ts,js,mjs,json,md,yml}'",
     "prettier-fix": "PRETTIER_EXPERIMENTAL_CLI=1 prettier --write --cache '**/*.{ts,js,mjs,json,md,yml}'",
     "labels:check": "node tools/sync-module-labels.ts",
-    "labels:sync": "node tools/sync-module-labels.ts --write",
+    "labels:dry-run": "node tools/sync-module-labels.ts --dry-run",
     "release:prepare": "node tools/prepare-release.ts",
     "release:publish": "node tools/publish-release.ts",
     "start": "node lib/renovate.ts",

--- a/test/other/sync-module-labels.spec.ts
+++ b/test/other/sync-module-labels.spec.ts
@@ -33,7 +33,7 @@ describe('other/sync-module-labels', () => {
     expect(formatMissingLabels(missing)).toContain('manager:jsonata');
   });
 
-  it('renders stable dry-run commands for missing labels', () => {
+  it('renders stable label creation commands for missing labels', () => {
     const commands = formatCreateLabelCommands('renovatebot/renovate', [
       {
         color: 'C5DEF5',

--- a/test/other/sync-module-labels.spec.ts
+++ b/test/other/sync-module-labels.spec.ts
@@ -1,0 +1,43 @@
+import {
+  createModuleLabel,
+  formatMissingLabels,
+  getExpectedModuleLabels,
+  getMissingModuleLabels,
+} from '../../tools/sync-module-labels.ts';
+
+describe('other/sync-module-labels', () => {
+  it('creates module labels with the expected metadata', () => {
+    expect(createModuleLabel('manager', 'jsonata')).toEqual({
+      color: 'C5DEF5',
+      description: 'Related to the jsonata manager',
+      name: 'manager:jsonata',
+    });
+  });
+
+  it('reports missing labels without flagging existing ones', () => {
+    const missing = getMissingModuleLabels(
+      [
+        createModuleLabel('datasource', 'docker'),
+        createModuleLabel('manager', 'jsonata'),
+        createModuleLabel('platform', 'scm-manager'),
+      ],
+      [
+        createModuleLabel('datasource', 'docker'),
+        createModuleLabel('platform', 'scm-manager'),
+      ],
+    );
+
+    expect(missing).toEqual([createModuleLabel('manager', 'jsonata')]);
+    expect(formatMissingLabels(missing)).toContain('manager:jsonata');
+  });
+
+  it('includes labels for known runtime module ids', () => {
+    const labelNames = new Set(
+      getExpectedModuleLabels().map((label) => label.name),
+    );
+
+    expect(labelNames.has('datasource:github-digest')).toBe(true);
+    expect(labelNames.has('manager:jsonata')).toBe(true);
+    expect(labelNames.has('manager:helm-values')).toBe(true);
+  });
+});

--- a/test/other/sync-module-labels.spec.ts
+++ b/test/other/sync-module-labels.spec.ts
@@ -1,5 +1,7 @@
+import { quote } from 'shlex';
 import {
   createModuleLabel,
+  formatCreateLabelCommands,
   formatMissingLabels,
   getExpectedModuleLabels,
   getMissingModuleLabels,
@@ -29,6 +31,32 @@ describe('other/sync-module-labels', () => {
 
     expect(missing).toEqual([createModuleLabel('manager', 'jsonata')]);
     expect(formatMissingLabels(missing)).toContain('manager:jsonata');
+  });
+
+  it('renders stable dry-run commands for missing labels', () => {
+    const commands = formatCreateLabelCommands('renovatebot/renovate', [
+      {
+        color: 'C5DEF5',
+        description: "Bob's manager label",
+        name: 'manager:jsonata',
+      },
+      createModuleLabel('datasource', 'docker'),
+    ]);
+
+    expect(commands).toBe(
+      [
+        `gh label create ${quote('datasource:docker')} -R ${quote(
+          'renovatebot/renovate',
+        )} --color ${quote('C5DEF5')} --description ${quote(
+          'Related to the docker datasource',
+        )}`,
+        `gh label create ${quote('manager:jsonata')} -R ${quote(
+          'renovatebot/renovate',
+        )} --color ${quote('C5DEF5')} --description ${quote(
+          "Bob's manager label",
+        )}`,
+      ].join('\n'),
+    );
   });
 
   it('includes labels for known runtime module ids', () => {

--- a/tools/sync-module-labels.ts
+++ b/tools/sync-module-labels.ts
@@ -143,9 +143,7 @@ async function main(args = process.argv): Promise<void> {
   );
 
   const program = new Command('node tools/sync-module-labels.ts')
-    .description(
-      'Check that datasource/manager/platform GitHub labels exist.',
-    )
+    .description('Check that datasource/manager/platform GitHub labels exist.')
     .option(
       '--repo <owner/name>',
       `Repository to query (default: ${defaultRepo})`,
@@ -158,7 +156,7 @@ async function main(args = process.argv): Promise<void> {
 
   await program.parseAsync(normalizedArgs);
 
-  const options = program.opts<CliOptions>();
+  const options = program.opts() as CliOptions;
   const expectedLabels = getExpectedModuleLabels();
   const existingLabels = await getRepoLabels(options.repo);
   const missingLabels = getMissingModuleLabels(expectedLabels, existingLabels);

--- a/tools/sync-module-labels.ts
+++ b/tools/sync-module-labels.ts
@@ -17,7 +17,7 @@ export interface GitHubLabel {
 
 export interface CliOptions {
   repo: string;
-  showCommands: boolean;
+  showCommands?: boolean;
 }
 
 const defaultRepo = 'renovatebot/renovate';

--- a/tools/sync-module-labels.ts
+++ b/tools/sync-module-labels.ts
@@ -1,0 +1,215 @@
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+import { getDatasourceList } from '../lib/modules/datasource/index.ts';
+import { allManagersList } from '../lib/modules/manager/index.ts';
+import { getPlatformList } from '../lib/modules/platform/index.ts';
+import { exec } from './utils/exec.ts';
+
+export type ModuleLabelKind = 'datasource' | 'manager' | 'platform';
+
+export interface GitHubLabel {
+  color: string;
+  description: string;
+  name: string;
+}
+
+export interface CliOptions {
+  repo: string;
+  write: boolean;
+}
+
+const defaultRepo = 'renovatebot/renovate';
+const moduleLabelColor = 'C5DEF5';
+
+export function getLabelDescription(
+  kind: ModuleLabelKind,
+  moduleId: string,
+): string {
+  return `Related to the ${moduleId} ${kind}`;
+}
+
+export function createModuleLabel(
+  kind: ModuleLabelKind,
+  moduleId: string,
+): GitHubLabel {
+  return {
+    color: moduleLabelColor,
+    description: getLabelDescription(kind, moduleId),
+    name: `${kind}:${moduleId}`,
+  };
+}
+
+function getSortedUnique(values: string[]): string[] {
+  return [...new Set(values)].sort((left, right) => left.localeCompare(right));
+}
+
+export function getExpectedModuleLabels(): GitHubLabel[] {
+  const datasources = getSortedUnique(getDatasourceList()).map((datasource) =>
+    createModuleLabel('datasource', datasource),
+  );
+  const managers = getSortedUnique(allManagersList).map((manager) =>
+    createModuleLabel('manager', manager),
+  );
+  const platforms = getSortedUnique(getPlatformList()).map((platform) =>
+    createModuleLabel('platform', platform),
+  );
+
+  return [...datasources, ...managers, ...platforms].sort((left, right) =>
+    left.name.localeCompare(right.name),
+  );
+}
+
+export function getMissingModuleLabels(
+  expectedLabels: GitHubLabel[],
+  existingLabels: GitHubLabel[],
+): GitHubLabel[] {
+  const existingNames = new Set(existingLabels.map((label) => label.name));
+
+  return expectedLabels.filter((label) => !existingNames.has(label.name));
+}
+
+export function formatMissingLabels(labels: GitHubLabel[]): string {
+  const sections: Record<ModuleLabelKind, string[]> = {
+    datasource: [],
+    manager: [],
+    platform: [],
+  };
+
+  for (const label of labels) {
+    const kind = label.name.split(':')[0] as ModuleLabelKind;
+    sections[kind].push(label.name);
+  }
+
+  const lines: string[] = [];
+
+  for (const kind of ['datasource', 'manager', 'platform'] as const) {
+    const names = sections[kind];
+    if (names.length === 0) {
+      continue;
+    }
+    lines.push(`${kind}s (${names.length}):`);
+    for (const name of names) {
+      lines.push(`- ${name}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+export function parseArgs(args: string[]): CliOptions {
+  const options: CliOptions = {
+    repo: defaultRepo,
+    write: false,
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+
+    switch (arg) {
+      case '--repo':
+        index += 1;
+        if (!args[index]) {
+          throw new Error('Missing value for --repo');
+        }
+        options.repo = args[index];
+        break;
+      case '--write':
+        options.write = true;
+        break;
+      case '--help':
+      case '-h':
+        printHelp();
+        process.exit(0);
+        return options;
+      default:
+        throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+async function getRepoLabels(repo: string): Promise<GitHubLabel[]> {
+  const result = await exec('gh', [
+    'label',
+    'list',
+    '-R',
+    repo,
+    '--limit',
+    '1000',
+    '--json',
+    'name,color,description',
+  ]);
+
+  const labels = JSON.parse(result.stdout) as GitHubLabel[];
+  return labels.sort((left, right) => left.name.localeCompare(right.name));
+}
+
+async function createMissingLabels(
+  repo: string,
+  labels: GitHubLabel[],
+): Promise<void> {
+  for (const label of labels) {
+    await exec('gh', [
+      'label',
+      'create',
+      label.name,
+      '-R',
+      repo,
+      '--color',
+      label.color,
+      '--description',
+      label.description,
+    ]);
+  }
+}
+
+function printHelp(): void {
+  console.log(`Check that datasource/manager/platform GitHub labels exist.
+
+Usage:
+  node tools/sync-module-labels.ts [--repo owner/name] [--write]
+
+Options:
+  --repo   Repository to query and update (default: ${defaultRepo})
+  --write  Create any missing labels with the default color and description
+`);
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2));
+  const expectedLabels = getExpectedModuleLabels();
+  const existingLabels = await getRepoLabels(options.repo);
+  const missingLabels = getMissingModuleLabels(expectedLabels, existingLabels);
+
+  if (missingLabels.length === 0) {
+    console.log(
+      `All datasource/manager/platform labels exist in ${options.repo}.`,
+    );
+    return;
+  }
+
+  if (options.write) {
+    await createMissingLabels(options.repo, missingLabels);
+    console.log(
+      `Created ${missingLabels.length} missing datasource/manager/platform labels in ${options.repo}:`,
+    );
+  } else {
+    console.error(
+      `Missing ${missingLabels.length} datasource/manager/platform labels in ${options.repo}:`,
+    );
+  }
+
+  console.log(formatMissingLabels(missingLabels));
+
+  if (!options.write) {
+    process.exitCode = 1;
+  }
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  await main();
+}

--- a/tools/sync-module-labels.ts
+++ b/tools/sync-module-labels.ts
@@ -144,11 +144,7 @@ process.on('unhandledRejection', (err) => {
 
 const program = new Command('node tools/sync-module-labels.ts')
   .description('Check that datasource/manager/platform GitHub labels exist.')
-  .option(
-    '--repo <owner/name>',
-    `Repository to query`,
-    defaultRepo,
-  )
+  .option('--repo <owner/name>', `Repository to query`, defaultRepo)
   .option(
     '--show-commands',
     'Print gh label create commands for any missing labels',

--- a/tools/sync-module-labels.ts
+++ b/tools/sync-module-labels.ts
@@ -1,5 +1,8 @@
 import process from 'node:process';
 import { pathToFileURL } from 'node:url';
+import { Command } from 'commander';
+import { quote } from 'shlex';
+import { init, logger } from '../lib/logger/index.ts';
 import { getDatasourceList } from '../lib/modules/datasource/index.ts';
 import { allManagersList } from '../lib/modules/manager/index.ts';
 import { getPlatformList } from '../lib/modules/platform/index.ts';
@@ -14,8 +17,8 @@ export interface GitHubLabel {
 }
 
 export interface CliOptions {
+  dryRun: boolean;
   repo: string;
-  write: boolean;
 }
 
 const defaultRepo = 'renovatebot/renovate';
@@ -96,37 +99,25 @@ export function formatMissingLabels(labels: GitHubLabel[]): string {
   return lines.join('\n');
 }
 
-export function parseArgs(args: string[]): CliOptions {
-  const options: CliOptions = {
-    repo: defaultRepo,
-    write: false,
-  };
+export function getCreateLabelCommand(
+  repo: string,
+  label: GitHubLabel,
+): string {
+  return (
+    `gh label create ${quote(label.name)} -R ${quote(repo)}` +
+    ` --color ${quote(label.color)}` +
+    ` --description ${quote(label.description)}`
+  );
+}
 
-  for (let index = 0; index < args.length; index += 1) {
-    const arg = args[index];
-
-    switch (arg) {
-      case '--repo':
-        index += 1;
-        if (!args[index]) {
-          throw new Error('Missing value for --repo');
-        }
-        options.repo = args[index];
-        break;
-      case '--write':
-        options.write = true;
-        break;
-      case '--help':
-      case '-h':
-        printHelp();
-        process.exit(0);
-        return options;
-      default:
-        throw new Error(`Unknown argument: ${arg}`);
-    }
-  }
-
-  return options;
+export function formatCreateLabelCommands(
+  repo: string,
+  labels: GitHubLabel[],
+): string {
+  return [...labels]
+    .sort((left, right) => left.name.localeCompare(right.name))
+    .map((label) => getCreateLabelCommand(repo, label))
+    .join('\n');
 }
 
 async function getRepoLabels(repo: string): Promise<GitHubLabel[]> {
@@ -145,71 +136,70 @@ async function getRepoLabels(repo: string): Promise<GitHubLabel[]> {
   return labels.sort((left, right) => left.name.localeCompare(right.name));
 }
 
-async function createMissingLabels(
-  repo: string,
-  labels: GitHubLabel[],
-): Promise<void> {
-  for (const label of labels) {
-    await exec('gh', [
-      'label',
-      'create',
-      label.name,
-      '-R',
-      repo,
-      '--color',
-      label.color,
-      '--description',
-      label.description,
-    ]);
-  }
-}
+async function main(args = process.argv): Promise<void> {
+  await init();
+  const normalizedArgs = args.filter(
+    (arg, index) => !(index > 1 && arg === '--'),
+  );
 
-function printHelp(): void {
-  console.log(`Check that datasource/manager/platform GitHub labels exist.
+  const program = new Command('node tools/sync-module-labels.ts')
+    .description(
+      'Check that datasource/manager/platform GitHub labels exist.',
+    )
+    .option(
+      '--repo <owner/name>',
+      `Repository to query (default: ${defaultRepo})`,
+      defaultRepo,
+    )
+    .option(
+      '--dry-run',
+      'Print gh label create commands for any missing labels',
+    );
 
-Usage:
-  node tools/sync-module-labels.ts [--repo owner/name] [--write]
+  await program.parseAsync(normalizedArgs);
 
-Options:
-  --repo   Repository to query and update (default: ${defaultRepo})
-  --write  Create any missing labels with the default color and description
-`);
-}
-
-async function main(): Promise<void> {
-  const options = parseArgs(process.argv.slice(2));
+  const options = program.opts<CliOptions>();
   const expectedLabels = getExpectedModuleLabels();
   const existingLabels = await getRepoLabels(options.repo);
   const missingLabels = getMissingModuleLabels(expectedLabels, existingLabels);
 
   if (missingLabels.length === 0) {
-    console.log(
+    logger.info(
       `All datasource/manager/platform labels exist in ${options.repo}.`,
     );
     return;
   }
 
-  if (options.write) {
-    await createMissingLabels(options.repo, missingLabels);
-    console.log(
-      `Created ${missingLabels.length} missing datasource/manager/platform labels in ${options.repo}:`,
-    );
-  } else {
-    console.error(
-      `Missing ${missingLabels.length} datasource/manager/platform labels in ${options.repo}:`,
+  logger.error(
+    `Missing ${missingLabels.length} datasource/manager/platform labels in ${options.repo}:\n${formatMissingLabels(
+      missingLabels,
+    )}`,
+  );
+
+  if (options.dryRun) {
+    logger.info(
+      `Run the following commands to create the missing labels:\n${formatCreateLabelCommands(
+        options.repo,
+        missingLabels,
+      )}`,
     );
   }
 
-  console.log(formatMissingLabels(missingLabels));
-
-  if (!options.write) {
-    process.exitCode = 1;
-  }
+  process.exitCode = 1;
 }
 
 if (
   process.argv[1] &&
   import.meta.url === pathToFileURL(process.argv[1]).href
 ) {
-  await main();
+  process.on('unhandledRejection', (err) => {
+    // Will print "unhandledRejection err is not defined"
+    logger.error({ err }, 'unhandledRejection');
+    process.exit(-1);
+  });
+
+  void main().catch((err) => {
+    logger.error({ err }, 'Unexpected error');
+    process.exit(1);
+  });
 }

--- a/tools/sync-module-labels.ts
+++ b/tools/sync-module-labels.ts
@@ -1,5 +1,4 @@
 import process from 'node:process';
-import { pathToFileURL } from 'node:url';
 import { Command } from 'commander';
 import { quote } from 'shlex';
 import { init, logger } from '../lib/logger/index.ts';
@@ -17,8 +16,8 @@ export interface GitHubLabel {
 }
 
 export interface CliOptions {
-  dryRun: boolean;
   repo: string;
+  showCommands: boolean;
 }
 
 const defaultRepo = 'renovatebot/renovate';
@@ -136,68 +135,56 @@ async function getRepoLabels(repo: string): Promise<GitHubLabel[]> {
   return labels.sort((left, right) => left.name.localeCompare(right.name));
 }
 
-async function main(args = process.argv): Promise<void> {
-  await init();
-  const normalizedArgs = args.filter(
-    (arg, index) => !(index > 1 && arg === '--'),
-  );
+await init();
 
-  const program = new Command('node tools/sync-module-labels.ts')
-    .description('Check that datasource/manager/platform GitHub labels exist.')
-    .option(
-      '--repo <owner/name>',
-      `Repository to query (default: ${defaultRepo})`,
-      defaultRepo,
-    )
-    .option(
-      '--dry-run',
-      'Print gh label create commands for any missing labels',
+process.on('unhandledRejection', (err) => {
+  // Will print "unhandledRejection err is not defined"
+  logger.error({ err }, 'unhandledRejection');
+  process.exit(-1);
+});
+
+const program = new Command('node tools/sync-module-labels.ts')
+  .description('Check that datasource/manager/platform GitHub labels exist.')
+  .option(
+    '--repo <owner/name>',
+    `Repository to query (default: ${defaultRepo})`,
+    defaultRepo,
+  )
+  .option(
+    '--show-commands',
+    'Print gh label create commands for any missing labels',
+  )
+  .action(async (options: CliOptions) => {
+    const expectedLabels = getExpectedModuleLabels();
+    const existingLabels = await getRepoLabels(options.repo);
+    const missingLabels = getMissingModuleLabels(
+      expectedLabels,
+      existingLabels,
     );
 
-  await program.parseAsync(normalizedArgs);
+    if (missingLabels.length === 0) {
+      logger.info(
+        `All datasource/manager/platform labels exist in ${options.repo}.`,
+      );
+      return;
+    }
 
-  const options = program.opts() as CliOptions;
-  const expectedLabels = getExpectedModuleLabels();
-  const existingLabels = await getRepoLabels(options.repo);
-  const missingLabels = getMissingModuleLabels(expectedLabels, existingLabels);
-
-  if (missingLabels.length === 0) {
-    logger.info(
-      `All datasource/manager/platform labels exist in ${options.repo}.`,
-    );
-    return;
-  }
-
-  logger.error(
-    `Missing ${missingLabels.length} datasource/manager/platform labels in ${options.repo}:\n${formatMissingLabels(
-      missingLabels,
-    )}`,
-  );
-
-  if (options.dryRun) {
-    logger.info(
-      `Run the following commands to create the missing labels:\n${formatCreateLabelCommands(
-        options.repo,
+    logger.error(
+      `Missing ${missingLabels.length} datasource/manager/platform labels in ${options.repo}:\n${formatMissingLabels(
         missingLabels,
       )}`,
     );
-  }
 
-  process.exitCode = 1;
-}
+    if (options.showCommands) {
+      logger.info(
+        `Run the following commands to create the missing labels:\n${formatCreateLabelCommands(
+          options.repo,
+          missingLabels,
+        )}`,
+      );
+    }
 
-if (
-  process.argv[1] &&
-  import.meta.url === pathToFileURL(process.argv[1]).href
-) {
-  process.on('unhandledRejection', (err) => {
-    // Will print "unhandledRejection err is not defined"
-    logger.error({ err }, 'unhandledRejection');
-    process.exit(-1);
+    process.exitCode = 1;
   });
 
-  void main().catch((err) => {
-    logger.error({ err }, 'Unexpected error');
-    process.exit(1);
-  });
-}
+void program.parseAsync();

--- a/tools/sync-module-labels.ts
+++ b/tools/sync-module-labels.ts
@@ -1,4 +1,3 @@
-import process from 'node:process';
 import { Command } from 'commander';
 import { quote } from 'shlex';
 import { init, logger } from '../lib/logger/index.ts';
@@ -147,7 +146,7 @@ const program = new Command('node tools/sync-module-labels.ts')
   .description('Check that datasource/manager/platform GitHub labels exist.')
   .option(
     '--repo <owner/name>',
-    `Repository to query (default: ${defaultRepo})`,
+    `Repository to query`,
     defaultRepo,
   )
   .option(


### PR DESCRIPTION
## Changes

- add a `tools/sync-module-labels.ts` script that derives expected datasource, manager, and platform labels from Renovate's exported module ids
- add `pnpm labels:check` and `pnpm labels:sync` so maintainers can either audit coverage or create any missing labels
- document the new workflow in the issue labeling guide and add unit coverage for the label diffing helpers

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #41814
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/renovatebot/renovate

Validation details:

- `pnpm exec vitest run --coverage false test/other/sync-module-labels.spec.ts`
- `pnpm exec eslint tools/sync-module-labels.ts test/other/sync-module-labels.spec.ts`
- `pnpm labels:check` (expected to exit non-zero today because the repository still has missing module labels; the script successfully reported the current missing label set)
