### PR TITLE
fix(manager/flux): support Helm semver ranges for OCI HelmRepository sources

### DIFF
--- a/lib/modules/datasource/docker/index.ts
+++ b/lib/modules/datasource/docker/index.ts
@@ -56,7 +56,7 @@ import {
 const defaultConfig = {
   commitMessageTopic: '{{{depName}}} Docker tag',
   commitMessageExtra:
-    'to {{#if isPinDigest}}{{{newDigestShort}}}{{else}}{{#if isMajor}}{{{prettyNewMajor}}}{{else}}{{{prettyNewVersion}}}{{/if}}{{/if}}',
+    'to {{#if isPinDigest}}{{{newDigestShort}}}{{else}}{{#if isMajor}}{{{prettyNewMajor}}}{{else}}{{#if isSingleVersion}}{{{prettyNewVersion}}}{{else}}{{{newValue}}}{{/if}}{{/if}}{{/if}}',
   digest: {
     branchTopic: '{{{depNameSanitized}}}-{{{currentValue}}}',
     commitMessageExtra: 'to {{newDigestShort}}',

--- a/lib/modules/manager/flux/__fixtures__/helmOCIReleaseRange.yaml
+++ b/lib/modules/manager/flux/__fixtures__/helmOCIReleaseRange.yaml
@@ -1,0 +1,16 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: arc-assets
+  namespace: dev
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: actions-runner-controller-charts/gha-runner-scale-set
+      version: 0.4.x
+      sourceRef:
+        kind: HelmRepository
+        name: actions-runner-controller
+        namespace: flux-system
+      interval: 30m

--- a/lib/modules/manager/flux/extract.spec.ts
+++ b/lib/modules/manager/flux/extract.spec.ts
@@ -300,6 +300,48 @@ describe('modules/manager/flux/extract', () => {
       });
     });
 
+    // These patterns are exercised by Flux's own OCI chart repository tests,
+    // see https://github.com/fluxcd/source-controller/blob/5376a7ead3e636f6bef21dc7d06e9c2fe90808c6/internal/helm/repository/oci_chart_repository_test.go#L95-L184
+    it.each(['*', '0.9.x', '0.*'])(
+      'uses helm versioning for OCI HelmRelease range %p resolved through registryAliases',
+      (version) => {
+        const result = extractPackageFile(
+          codeBlock`
+            apiVersion: helm.toolkit.fluxcd.io/v2beta1
+            kind: HelmRelease
+            metadata:
+              name: sealed-secrets
+              namespace: kube-system
+            spec:
+              chart:
+                spec:
+                  chart: sealed-secrets
+                  sourceRef:
+                    kind: HelmRepository
+                    name: sealed-secrets
+                  version: "${version}"
+          `,
+          'helmRelease.yaml',
+          {
+            registryAliases: {
+              'sealed-secrets': 'oci://ghcr.io/charts',
+            },
+          },
+        );
+        expect(result).toEqual({
+          deps: [
+            {
+              currentValue: version,
+              datasource: DockerDatasource.id,
+              depName: 'sealed-secrets',
+              packageName: 'ghcr.io/charts/sealed-secrets',
+              versioning: 'helm',
+            },
+          ],
+        });
+      },
+    );
+
     it('ignores HelmRelease resources without an apiVersion', () => {
       const result = extractPackageFile('kind: HelmRelease', 'test.yaml');
       expect(result).toBeNull();
@@ -1819,6 +1861,54 @@ describe('modules/manager/flux/extract', () => {
         },
       ]);
     });
+
+    // These patterns are exercised by Flux's own OCI chart repository tests,
+    // see https://github.com/fluxcd/source-controller/blob/5376a7ead3e636f6bef21dc7d06e9c2fe90808c6/internal/helm/repository/oci_chart_repository_test.go#L95-L184
+    it.each(['*', '0.9.x', '0.*'])(
+      'uses helm versioning for OCI HelmRepository range %p',
+      (version) => {
+        const result = extractPackageFile(
+          codeBlock`
+            apiVersion: source.toolkit.fluxcd.io/v1beta2
+            kind: HelmRepository
+            metadata:
+              name: actions-runner-controller
+              namespace: flux-system
+            spec:
+              type: oci
+              url: oci://ghcr.io/actions
+            ---
+            apiVersion: helm.toolkit.fluxcd.io/v2beta1
+            kind: HelmRelease
+            metadata:
+              name: arc-assets
+              namespace: flux-system
+            spec:
+              chart:
+                spec:
+                  chart: actions-runner-controller-charts/gha-runner-scale-set
+                  version: "${version}"
+                  sourceRef:
+                    kind: HelmRepository
+                    name: actions-runner-controller
+                    namespace: flux-system
+          `,
+          'helmRelease.yaml',
+        );
+        expect(result).toEqual({
+          deps: [
+            {
+              currentValue: version,
+              datasource: DockerDatasource.id,
+              depName: 'actions-runner-controller-charts/gha-runner-scale-set',
+              packageName:
+                'ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set',
+              versioning: 'helm',
+            },
+          ],
+        });
+      },
+    );
 
     it('should handle HelmRepository w/o type oci and url starts with oci', async () => {
       const result = await extractAllPackageFiles(config, [

--- a/lib/modules/manager/flux/extract.spec.ts
+++ b/lib/modules/manager/flux/extract.spec.ts
@@ -263,6 +263,43 @@ describe('modules/manager/flux/extract', () => {
       });
     });
 
+    it('uses helm versioning for OCI HelmRelease ranges resolved through registryAliases', () => {
+      const result = extractPackageFile(
+        codeBlock`
+          apiVersion: helm.toolkit.fluxcd.io/v2beta1
+          kind: HelmRelease
+          metadata:
+            name: sealed-secrets
+            namespace: kube-system
+          spec:
+            chart:
+              spec:
+                chart: sealed-secrets
+                sourceRef:
+                  kind: HelmRepository
+                  name: sealed-secrets
+                version: "1.2.x"
+        `,
+        'helmRelease.yaml',
+        {
+          registryAliases: {
+            'sealed-secrets': 'oci://ghcr.io/charts',
+          },
+        },
+      );
+      expect(result).toEqual({
+        deps: [
+          {
+            currentValue: '1.2.x',
+            datasource: DockerDatasource.id,
+            depName: 'sealed-secrets',
+            packageName: 'ghcr.io/charts/sealed-secrets',
+            versioning: 'helm',
+          },
+        ],
+      });
+    });
+
     it('ignores HelmRelease resources without an apiVersion', () => {
       const result = extractPackageFile('kind: HelmRelease', 'test.yaml');
       expect(result).toBeNull();
@@ -1756,6 +1793,29 @@ describe('modules/manager/flux/extract', () => {
           ],
           packageFile:
             'lib/modules/manager/flux/__fixtures__/helmOCIRelease.yaml',
+        },
+      ]);
+    });
+
+    it('should use helm versioning for OCI HelmRepository range versions', async () => {
+      const result = await extractAllPackageFiles(config, [
+        'lib/modules/manager/flux/__fixtures__/helmOCISource.yaml',
+        'lib/modules/manager/flux/__fixtures__/helmOCIReleaseRange.yaml',
+      ]);
+      expect(result).toEqual([
+        {
+          deps: [
+            {
+              currentValue: '0.4.x',
+              datasource: DockerDatasource.id,
+              depName: 'actions-runner-controller-charts/gha-runner-scale-set',
+              packageName:
+                'ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set',
+              versioning: 'helm',
+            },
+          ],
+          packageFile:
+            'lib/modules/manager/flux/__fixtures__/helmOCIReleaseRange.yaml',
         },
       ]);
     });

--- a/lib/modules/manager/flux/extract.ts
+++ b/lib/modules/manager/flux/extract.ts
@@ -124,6 +124,31 @@ function resolveGitRepositoryPerSourceTag(
   }
 }
 
+/**
+ * Flux always treats `spec.chart.spec.version` as a Helm chart semver
+ * expression, including ranges, regardless of whether the chart is served
+ * from a classic Helm repository or an OCI registry:
+ * - https://github.com/fluxcd/source-controller/blob/main/internal/helm/repository/oci_chart_repository.go#L142-L144
+ * - https://github.com/fluxcd/source-controller/blob/main/internal/helm/repository/oci_chart_repository.go#L170-L171
+ * - https://github.com/fluxcd/source-controller/blob/main/internal/helm/repository/oci_chart_repository.go#L257-L277
+ *
+ * Renovate's Docker datasource defaults to `docker` versioning, which does
+ * not understand Helm/semver ranges such as `*`, `0.9.x` or `0.*` (all
+ * exercised in Flux's own test suite, see
+ * https://github.com/fluxcd/source-controller/blob/5376a7ead3e636f6bef21dc7d06e9c2fe90808c6/internal/helm/repository/oci_chart_repository_test.go#L95-L184).
+ * When the current value is a range rather than a concrete version, switch
+ * to `helm` versioning so Renovate resolves/bumps it the same way Flux does.
+ */
+function applyOCIHelmVersioning(dep: PackageDependency): void {
+  if (
+    dep.currentValue &&
+    !dockerVersioningApi.isVersion(dep.currentValue) &&
+    helmVersioningApi.isValid(dep.currentValue)
+  ) {
+    dep.versioning = helmVersioningId;
+  }
+}
+
 function resolveHelmRepository(
   dep: PackageDependency,
   matchingRepositories: HelmRepository[],
@@ -136,13 +161,7 @@ function resolveHelmRepository(
         if (repo.spec.type === 'oci' || isOCIRegistry(repo.spec.url)) {
           // Change datasource to Docker
           dep.datasource = DockerDatasource.id;
-          if (
-            dep.currentValue &&
-            !dockerVersioningApi.isVersion(dep.currentValue) &&
-            helmVersioningApi.isValid(dep.currentValue)
-          ) {
-            dep.versioning = helmVersioningId;
-          }
+          applyOCIHelmVersioning(dep);
           // Ensure the URL is a valid OCI path
           dep.packageName = getDep(
             `${removeOCIPrefix(repo.spec.url)}/${dep.depName}`,
@@ -169,13 +188,7 @@ function resolveHelmRepository(
       if (isOCIRegistry(aliasUrl)) {
         // Treat alias value as an OCI registry URL
         dep.datasource = DockerDatasource.id;
-        if (
-          dep.currentValue &&
-          !dockerVersioningApi.isVersion(dep.currentValue) &&
-          helmVersioningApi.isValid(dep.currentValue)
-        ) {
-          dep.versioning = helmVersioningId;
-        }
+        applyOCIHelmVersioning(dep);
         dep.packageName = getDep(
           `${removeOCIPrefix(aliasUrl)}/${dep.depName}`,
           false,

--- a/lib/modules/manager/flux/extract.ts
+++ b/lib/modules/manager/flux/extract.ts
@@ -22,6 +22,11 @@ import { GithubReleasesDatasource } from '../../datasource/github-releases/index
 import { GithubTagsDatasource } from '../../datasource/github-tags/index.ts';
 import { GitlabTagsDatasource } from '../../datasource/gitlab-tags/index.ts';
 import { HelmDatasource } from '../../datasource/helm/index.ts';
+import { api as dockerVersioningApi } from '../../versioning/docker/index.ts';
+import {
+  api as helmVersioningApi,
+  id as helmVersioningId,
+} from '../../versioning/helm/index.ts';
 import { getDep } from '../dockerfile/extract.ts';
 import { findDependencies } from '../helm-values/extract.ts';
 import { isOCIRegistry, removeOCIPrefix } from '../helmv3/oci.ts';
@@ -131,6 +136,13 @@ function resolveHelmRepository(
         if (repo.spec.type === 'oci' || isOCIRegistry(repo.spec.url)) {
           // Change datasource to Docker
           dep.datasource = DockerDatasource.id;
+          if (
+            dep.currentValue &&
+            !dockerVersioningApi.isVersion(dep.currentValue) &&
+            helmVersioningApi.isValid(dep.currentValue)
+          ) {
+            dep.versioning = helmVersioningId;
+          }
           // Ensure the URL is a valid OCI path
           dep.packageName = getDep(
             `${removeOCIPrefix(repo.spec.url)}/${dep.depName}`,
@@ -157,6 +169,13 @@ function resolveHelmRepository(
       if (isOCIRegistry(aliasUrl)) {
         // Treat alias value as an OCI registry URL
         dep.datasource = DockerDatasource.id;
+        if (
+          dep.currentValue &&
+          !dockerVersioningApi.isVersion(dep.currentValue) &&
+          helmVersioningApi.isValid(dep.currentValue)
+        ) {
+          dep.versioning = helmVersioningId;
+        }
         dep.packageName = getDep(
           `${removeOCIPrefix(aliasUrl)}/${dep.depName}`,
           false,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
## Changes
This PR fixes Flux `HelmRelease` extraction for OCI Helm repositories when `spec.chart.spec.version` uses a Helm range (e.g. `1.2.x`).
Previously, OCI sources were mapped to the Docker datasource, but range values like `1.2.x` were interpreted with Docker versioning and therefore not updated as expected.  
Now, for Flux OCI Helm sources, Renovate keeps `datasource=docker` but sets `versioning=helm` when the current value is a valid Helm range and not a plain Docker version.
Also added regression coverage:
- `extract.spec.ts`: OCI via `registryAliases` with `version: "1.2.x"`
- `extract.spec.ts` + new fixture `helmOCIReleaseRange.yaml`: OCI `HelmRepository` + `HelmRelease` with `version: 1.2.x`
## Context
Please select one of the following:
- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation
## AI assistance disclosure
<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
Did you use AI tools to create any part of this pull request?
Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.
- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):
Used AI assistance to analyze Renovate Flux extraction logic, implement code changes, and draft/add regression tests and fixture updates.
## Documentation (please check one with an [x])
- [ ] I have updated the documentation, or
- [x] No documentation update is required
## How I've tested my work (please select one)
I have verified these changes via:
- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository
The public repository: private Gerrit repository (yes, Gerrit...)
<img width="2556" height="1155" alt="image" src="https://github.com/user-attachments/assets/acdc2e2b-73a5-491d-bbcb-b65933a18c31" />
<!-- If you have any suggestions about this PR template, edit it here: 

https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->
<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->