### PR TITLE
feat(replacements): add `@wuchale/vite-plugin`

### DIFF
--- a/lib/data/replacements.json
+++ b/lib/data/replacements.json
@@ -1238,6 +1238,7 @@
     "description": "The `@wuchale/vite-plugin` package is now included in `wuchale` at `wuchale/vite`.",
     "packageRules": [
       {
+        "matchCurrentVersion": "^0.17.0",
         "matchDatasources": ["npm"],
         "matchPackageNames": ["@wuchale/vite-plugin"],
         "replacementName": "wuchale",

--- a/lib/data/replacements.json
+++ b/lib/data/replacements.json
@@ -1239,7 +1239,7 @@
     "packageRules": [
       {
         "matchDatasources": ["npm"],
-        "matchPacakgeNames": ["@wuchale/vite-plugin"],
+        "matchPackageNames": ["@wuchale/vite-plugin"],
         "replacementName": "wuchale",
         "replacementVersion": "0.22.0"
       }

--- a/lib/data/replacements.json
+++ b/lib/data/replacements.json
@@ -58,6 +58,7 @@
       "replacements:vitest-coverage-c8-to-coverage-v8",
       "replacements:vso-task-lib-to-azure-pipelines-task-lib",
       "replacements:vsts-task-lib-to-azure-pipelines-task-lib",
+      "replacements:wuchale-vite-plugin-to-wuchale",
       "replacements:xmldom-to-scoped",
       "replacements:zap"
     ],
@@ -1230,6 +1231,17 @@
         "matchPackageNames": ["vsts-task-lib"],
         "replacementName": "azure-pipelines-task-lib",
         "replacementVersion": "3.4.0"
+      }
+    ]
+  },
+  "wuchale-vite-plugin-to-wuchale": {
+    "description": "The `@wuchale/vite-plugin` package is now included in `wuchale` at `wuchale/vite`.",
+    "packageRules": [
+      {
+        "matchDatasources": ["npm"],
+        "matchPacakgeNames": ["@wuchale/vite-plugin"],
+        "replacementName": "wuchale",
+        "replacementVersion": "0.22.0"
       }
     ]
   },


### PR DESCRIPTION
See https://github.com/wuchalejs/wuchale/releases/tag/wuchale%400.22.0#:~:text=The%20vite%20plugin%20will%20no%20longer%20be%20a%20separate%20package%2E

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
