### PR TITLE
feat(manager/kubernetes): extract image volume references from manifests

### DIFF
--- a/lib/modules/manager/kubernetes/extract.spec.ts
+++ b/lib/modules/manager/kubernetes/extract.spec.ts
@@ -1,3 +1,4 @@
+import { codeBlock } from 'common-tags';
 import { Fixtures } from '~test/fixtures.ts';
 import { extractPackageFile } from './index.ts';
 
@@ -215,6 +216,145 @@ kind: ConfigMap
             replaceString: 'busybox',
           },
         ],
+      });
+    });
+
+    describe('image volume references', () => {
+      it.each`
+        kind                       | apiVersion
+        ${'DaemonSet'}             | ${'apps/v1'}
+        ${'Deployment'}            | ${'apps/v1'}
+        ${'Job'}                   | ${'batch/v1'}
+        ${'ReplicaSet'}            | ${'apps/v1'}
+        ${'ReplicationController'} | ${'v1'}
+        ${'StatefulSet'}           | ${'apps/v1'}
+      `(
+        'extracts image volumes from $kind',
+        ({ kind, apiVersion }: { kind: string; apiVersion: string }) => {
+          const res = extractPackageFile(
+            codeBlock`
+              apiVersion: ${apiVersion}
+              kind: ${kind}
+              metadata:
+                name: test
+              spec:
+                template:
+                  spec:
+                    volumes:
+                      - name: vol
+                        image:
+                          reference: quay.io/test/image:v1.0.0
+            `,
+            'file.yaml',
+            {},
+          );
+
+          expect(res?.deps).toContainEqual({
+            autoReplaceStringTemplate:
+              '{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}',
+            currentDigest: undefined,
+            currentValue: 'v1.0.0',
+            datasource: 'docker',
+            depName: 'quay.io/test/image',
+            packageName: 'quay.io/test/image',
+            replaceString: 'quay.io/test/image:v1.0.0',
+          });
+        },
+      );
+
+      it('extracts image volumes from Pod and CronJob', () => {
+        const res = extractPackageFile(
+          codeBlock`
+            apiVersion: v1
+            kind: Pod
+            metadata:
+              name: pod-test
+            spec:
+              volumes:
+                - name: vol
+                  image:
+                    reference: quay.io/test/pod-image:v1.0.0
+            ---
+            apiVersion: batch/v1
+            kind: CronJob
+            metadata:
+              name: cronjob-test
+            spec:
+              jobTemplate:
+                spec:
+                  template:
+                    spec:
+                      volumes:
+                        - name: vol
+                          image:
+                            reference: quay.io/test/cronjob-image:v2.0.0
+          `,
+          'file.yaml',
+          {},
+        );
+
+        expect(res?.deps).toStrictEqual([
+          {
+            autoReplaceStringTemplate:
+              '{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}',
+            currentDigest: undefined,
+            currentValue: 'v1.0.0',
+            datasource: 'docker',
+            depName: 'quay.io/test/pod-image',
+            packageName: 'quay.io/test/pod-image',
+            replaceString: 'quay.io/test/pod-image:v1.0.0',
+          },
+          {
+            autoReplaceStringTemplate:
+              '{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}',
+            currentDigest: undefined,
+            currentValue: 'v2.0.0',
+            datasource: 'docker',
+            depName: 'quay.io/test/cronjob-image',
+            packageName: 'quay.io/test/cronjob-image',
+            replaceString: 'quay.io/test/cronjob-image:v2.0.0',
+          },
+          {
+            currentValue: 'batch/v1',
+            datasource: 'kubernetes-api',
+            depName: 'CronJob',
+            versioning: 'kubernetes-api',
+          },
+        ]);
+      });
+
+      it('skips malformed volume entries and extracts valid ones', () => {
+        const res = extractPackageFile(
+          codeBlock`
+            apiVersion: v1
+            kind: Pod
+            metadata:
+              name: pod-test
+            spec:
+              volumes:
+                - name: bad-vol
+                  image:
+                    notReference: invalid
+                - name: good-vol
+                  image:
+                    reference: quay.io/test/image:v1.0.0
+          `,
+          'file.yaml',
+          {},
+        );
+
+        expect(res?.deps).toStrictEqual([
+          {
+            autoReplaceStringTemplate:
+              '{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}',
+            currentDigest: undefined,
+            currentValue: 'v1.0.0',
+            datasource: 'docker',
+            depName: 'quay.io/test/image',
+            packageName: 'quay.io/test/image',
+            replaceString: 'quay.io/test/image:v1.0.0',
+          },
+        ]);
       });
     });
   });

--- a/lib/modules/manager/kubernetes/extract.spec.ts
+++ b/lib/modules/manager/kubernetes/extract.spec.ts
@@ -323,6 +323,29 @@ kind: ConfigMap
         ]);
       });
 
+      it('does not extract image volumes for unsupported kind', () => {
+        const res = extractPackageFile(
+          codeBlock`
+            apiVersion: extensions/v1beta1
+            kind: NetworkPolicy
+            metadata:
+              name: test-network-policy
+            spec:
+              podSelector: {}
+          `,
+          'file.yaml',
+          {},
+        );
+        expect(res?.deps).toStrictEqual([
+          {
+            currentValue: 'extensions/v1beta1',
+            datasource: 'kubernetes-api',
+            depName: 'NetworkPolicy',
+            versioning: 'kubernetes-api',
+          },
+        ]);
+      });
+
       it('skips malformed volume entries and extracts valid ones', () => {
         const res = extractPackageFile(
           codeBlock`

--- a/lib/modules/manager/kubernetes/extract.ts
+++ b/lib/modules/manager/kubernetes/extract.ts
@@ -34,6 +34,7 @@ export function extractPackageFile(
 
   const deps: PackageDependency[] = [
     ...extractImages(content, config),
+    ...extractImageVolumes(manifests, config),
     ...extractApis(manifests),
   ];
 
@@ -66,6 +67,30 @@ function extractImages(
           currentDigest: dep.currentDigest,
         },
         'Kubernetes image',
+      );
+      deps.push(dep);
+    }
+  }
+
+  return deps;
+}
+
+function extractImageVolumes(
+  manifests: KubernetesManifest[],
+  config: ExtractConfig,
+): PackageDependency[] {
+  const deps: PackageDependency[] = [];
+
+  for (const manifest of manifests) {
+    for (const currentFrom of manifest.imageVolumeReferences) {
+      const dep = getDep(currentFrom, true, config.registryAliases);
+      logger.debug(
+        {
+          depName: dep.depName,
+          currentValue: dep.currentValue,
+          currentDigest: dep.currentDigest,
+        },
+        'Kubernetes image volume',
       );
       deps.push(dep);
     }

--- a/lib/modules/manager/kubernetes/schema.ts
+++ b/lib/modules/manager/kubernetes/schema.ts
@@ -11,29 +11,32 @@ const TemplateSpecVolumes = z.object({
   template: z.object({ spec: PodSpecVolumes }),
 });
 
-const ImageVolumeReferences = z.discriminatedUnion('kind', [
-  z.object({
-    kind: z.literal('Pod'),
-    spec: PodSpecVolumes.transform((s) => s.volumes),
-  }),
-  z.object({
-    kind: z.enum([
-      'DaemonSet',
-      'Deployment',
-      'Job',
-      'ReplicaSet',
-      'ReplicationController',
-      'StatefulSet',
-    ]),
-    spec: TemplateSpecVolumes.transform((s) => s.template.spec.volumes),
-  }),
-  z.object({
-    kind: z.literal('CronJob'),
-    spec: z
-      .object({ jobTemplate: z.object({ spec: TemplateSpecVolumes }) })
-      .transform((s) => s.jobTemplate.spec.template.spec.volumes),
-  }),
-]);
+const ImageVolumeReferences = z
+  .discriminatedUnion('kind', [
+    z.object({
+      kind: z.literal('Pod'),
+      spec: PodSpecVolumes.transform((s) => s.volumes),
+    }),
+    z.object({
+      kind: z.enum([
+        'DaemonSet',
+        'Deployment',
+        'Job',
+        'ReplicaSet',
+        'ReplicationController',
+        'StatefulSet',
+      ]),
+      spec: TemplateSpecVolumes.transform((s) => s.template.spec.volumes),
+    }),
+    z.object({
+      kind: z.literal('CronJob'),
+      spec: z
+        .object({ jobTemplate: z.object({ spec: TemplateSpecVolumes }) })
+        .transform((s) => s.jobTemplate.spec.template.spec.volumes),
+    }),
+  ])
+  .transform(({ spec }) => spec)
+  .catch([]);
 
 export const KubernetesResource = z.object({
   apiVersion: z.string().trim().min(1),
@@ -48,9 +51,10 @@ export const KubernetesManifest = KubernetesResource.extend({
   spec: z.unknown(),
 }).transform(({ spec, ...resource }) => ({
   ...resource,
-  imageVolumeReferences:
-    ImageVolumeReferences.safeParse({ kind: resource.kind, spec }).data?.spec ??
-    [],
+  imageVolumeReferences: ImageVolumeReferences.parse({
+    kind: resource.kind,
+    spec,
+  }),
 }));
 export type KubernetesManifest = z.infer<typeof KubernetesManifest>;
 

--- a/lib/modules/manager/kubernetes/schema.ts
+++ b/lib/modules/manager/kubernetes/schema.ts
@@ -11,26 +11,28 @@ const TemplateSpecVolumes = z.object({
   template: z.object({ spec: PodSpecVolumes }),
 });
 
-const templateSpecVolumeExtractor = TemplateSpecVolumes.transform(
-  (s) => s.template.spec.volumes,
-);
-
-const cronJobVolumeExtractor = z
-  .object({ jobTemplate: z.object({ spec: TemplateSpecVolumes }) })
-  .transform((s) => s.jobTemplate.spec.template.spec.volumes);
-
-const imageVolumeExtractors = new Map<
-  string,
-  z.ZodType<string[], z.ZodTypeDef, unknown>
->([
-  ['Pod', PodSpecVolumes.transform((s) => s.volumes)],
-  ['DaemonSet', templateSpecVolumeExtractor],
-  ['Deployment', templateSpecVolumeExtractor],
-  ['Job', templateSpecVolumeExtractor],
-  ['ReplicaSet', templateSpecVolumeExtractor],
-  ['ReplicationController', templateSpecVolumeExtractor],
-  ['StatefulSet', templateSpecVolumeExtractor],
-  ['CronJob', cronJobVolumeExtractor],
+const ImageVolumeReferences = z.discriminatedUnion('kind', [
+  z.object({
+    kind: z.literal('Pod'),
+    spec: PodSpecVolumes.transform((s) => s.volumes),
+  }),
+  z.object({
+    kind: z.enum([
+      'DaemonSet',
+      'Deployment',
+      'Job',
+      'ReplicaSet',
+      'ReplicationController',
+      'StatefulSet',
+    ]),
+    spec: TemplateSpecVolumes.transform((s) => s.template.spec.volumes),
+  }),
+  z.object({
+    kind: z.literal('CronJob'),
+    spec: z
+      .object({ jobTemplate: z.object({ spec: TemplateSpecVolumes }) })
+      .transform((s) => s.jobTemplate.spec.template.spec.volumes),
+  }),
 ]);
 
 export const KubernetesResource = z.object({
@@ -47,7 +49,8 @@ export const KubernetesManifest = KubernetesResource.extend({
 }).transform(({ spec, ...resource }) => ({
   ...resource,
   imageVolumeReferences:
-    imageVolumeExtractors.get(resource.kind)?.safeParse(spec).data ?? [],
+    ImageVolumeReferences.safeParse({ kind: resource.kind, spec }).data?.spec ??
+    [],
 }));
 export type KubernetesManifest = z.infer<typeof KubernetesManifest>;
 

--- a/lib/modules/manager/kubernetes/schema.ts
+++ b/lib/modules/manager/kubernetes/schema.ts
@@ -1,6 +1,38 @@
 import { z } from 'zod/v3';
 import { LooseArray, multidocYaml } from '../../../util/schema-utils/index.ts';
 
+const PodSpecVolumes = z.object({
+  volumes: LooseArray(z.object({ image: z.object({ reference: z.string() }) }))
+    .transform((volumes) => volumes.map((v) => v.image.reference))
+    .catch([]),
+});
+
+const TemplateSpecVolumes = z.object({
+  template: z.object({ spec: PodSpecVolumes }),
+});
+
+const templateSpecVolumeExtractor = TemplateSpecVolumes.transform(
+  (s) => s.template.spec.volumes,
+);
+
+const cronJobVolumeExtractor = z
+  .object({ jobTemplate: z.object({ spec: TemplateSpecVolumes }) })
+  .transform((s) => s.jobTemplate.spec.template.spec.volumes);
+
+const imageVolumeExtractors = new Map<
+  string,
+  z.ZodType<string[], z.ZodTypeDef, unknown>
+>([
+  ['Pod', PodSpecVolumes.transform((s) => s.volumes)],
+  ['DaemonSet', templateSpecVolumeExtractor],
+  ['Deployment', templateSpecVolumeExtractor],
+  ['Job', templateSpecVolumeExtractor],
+  ['ReplicaSet', templateSpecVolumeExtractor],
+  ['ReplicationController', templateSpecVolumeExtractor],
+  ['StatefulSet', templateSpecVolumeExtractor],
+  ['CronJob', cronJobVolumeExtractor],
+]);
+
 export const KubernetesResource = z.object({
   apiVersion: z.string().trim().min(1),
   kind: z.string().trim().min(1),
@@ -10,8 +42,15 @@ export const KubernetesResource = z.object({
   }),
 });
 
-export type KubernetesManifest = z.infer<typeof KubernetesResource>;
+export const KubernetesManifest = KubernetesResource.extend({
+  spec: z.unknown(),
+}).transform(({ spec, ...resource }) => ({
+  ...resource,
+  imageVolumeReferences:
+    imageVolumeExtractors.get(resource.kind)?.safeParse(spec).data ?? [],
+}));
+export type KubernetesManifest = z.infer<typeof KubernetesManifest>;
 
 export const KubernetesManifests = multidocYaml({
   removeTemplates: true,
-}).pipe(LooseArray(KubernetesResource));
+}).pipe(LooseArray(KubernetesManifest));


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds support for extracting OCI image volume references from Kubernetes manifests, so Renovate can update images used in `spec.volumes[].image.reference` fields.

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

- https://github.com/renovatebot/renovate/discussions/41924

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
