### PR TITLE
feat(manager/npm): pass --before to npm install when minimumReleaseAge is set

### DIFF
--- a/docs/usage/key-concepts/minimum-release-age.md
+++ b/docs/usage/key-concepts/minimum-release-age.md
@@ -44,6 +44,14 @@ To protect against this, it's recommended to ensure that your package manager co
 There is ongoing work to [integrate more closely with package manager checks](https://github.com/renovatebot/renovate/issues/41652) to make sure that Renovate's minimum release age configuration is specified when calling package managers that support it.
 If you have a package manager you'd like supported, please raise a [Suggest an Idea Discussion](https://github.com/renovatebot/renovate/discussions/new?category=suggest-an-idea).
 
+#### npm
+
+When `minimumReleaseAge` is configured, Renovate passes `--before=<date>` to npm commands during lock file generation.
+This ensures that npm only resolves package versions that were available before the cooldown threshold, protecting against newly published (and potentially malicious) transitive dependencies.
+
+The `--before` date is calculated as `now - minimumReleaseAge`.
+If a `before=<date>` or `min-release-age=<days>` setting already exists in the project's `.npmrc`, Renovate uses the stricter (older) of the two dates.
+
 ### What happens if the datasource and/or registry does not provide a release timestamp, when using `minimumReleaseAge`?
 
 <!-- prettier-ignore -->

--- a/lib/modules/manager/npm/post-update/index.ts
+++ b/lib/modules/manager/npm/post-update/index.ts
@@ -450,6 +450,7 @@ export async function getAdditionalFiles(
       fileName,
       config,
       upgrades,
+      npmrcContent,
     );
     if (res.error) {
       /* v8 ignore next -- needs test */

--- a/lib/modules/manager/npm/post-update/npm.spec.ts
+++ b/lib/modules/manager/npm/post-update/npm.spec.ts
@@ -954,4 +954,191 @@ describe('modules/manager/npm/post-update/npm', () => {
       ]);
     });
   });
+
+  describe('--before with minimumReleaseAge', () => {
+    let execSnapshots: ReturnType<typeof mockExecAll>;
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-06-15T12:00:00.000Z'));
+      execSnapshots = mockExecAll();
+      fs.readLocalFile.mockResolvedValueOnce('{}');
+      const packageLockContents = JSON.stringify({
+        packages: {},
+        lockfileVersion: 3,
+      });
+      fs.readLocalFile
+        .mockResolvedValueOnce(packageLockContents)
+        .mockResolvedValueOnce(packageLockContents);
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('sets --before from minimumReleaseAge', async () => {
+      await npmHelper.generateLockFile(
+        'some-dir',
+        {},
+        'package-lock.json',
+        { skipInstalls: true, minimumReleaseAge: '3 days' },
+        [
+          {
+            packageName: 'some-dep',
+            newVersion: '1.0.1',
+            isLockfileUpdate: false,
+          },
+        ],
+      );
+
+      expect(execSnapshots).toMatchObject([
+        {
+          cmd: 'npm install --package-lock-only --no-audit --ignore-scripts --before=2026-06-12T12:00:00.000Z',
+        },
+      ]);
+    });
+
+    it('skips --before on unparseable minimumReleaseAge', async () => {
+      await npmHelper.generateLockFile(
+        'some-dir',
+        {},
+        'package-lock.json',
+        { skipInstalls: true, minimumReleaseAge: 'invalid garbage' },
+        [
+          {
+            packageName: 'some-dep',
+            newVersion: '1.0.1',
+            isLockfileUpdate: false,
+          },
+        ],
+      );
+
+      expect(execSnapshots).toMatchObject([
+        {
+          cmd: 'npm install --package-lock-only --no-audit --ignore-scripts',
+        },
+      ]);
+    });
+
+    it('uses stricter npmrc before date when older than minimumReleaseAge', async () => {
+      // npmrc (June 1) is earlier than minimumReleaseAge (3 days = June 12)
+      await npmHelper.generateLockFile(
+        'some-dir',
+        {},
+        'package-lock.json',
+        { skipInstalls: true, minimumReleaseAge: '3 days' },
+        [
+          {
+            packageName: 'some-dep',
+            newVersion: '1.0.1',
+            isLockfileUpdate: false,
+          },
+        ],
+        'registry=https://registry.npmjs.org\nbefore=2026-06-01T00:00:00.000Z\n',
+      );
+
+      expect(execSnapshots).toMatchObject([
+        {
+          cmd: 'npm install --package-lock-only --no-audit --ignore-scripts --before=2026-06-01T00:00:00.000Z',
+        },
+      ]);
+    });
+
+    it('uses minimumReleaseAge date when stricter than npmrc before date', async () => {
+      // minimumReleaseAge (3 days = June 12) is earlier than npmrc (June 14)
+      await npmHelper.generateLockFile(
+        'some-dir',
+        {},
+        'package-lock.json',
+        { skipInstalls: true, minimumReleaseAge: '3 days' },
+        [
+          {
+            packageName: 'some-dep',
+            newVersion: '1.0.1',
+            isLockfileUpdate: false,
+          },
+        ],
+        'before=2026-06-14T00:00:00.000Z\n',
+      );
+
+      expect(execSnapshots).toMatchObject([
+        {
+          cmd: 'npm install --package-lock-only --no-audit --ignore-scripts --before=2026-06-12T12:00:00.000Z',
+        },
+      ]);
+    });
+
+    it('skips --before when minimumReleaseAge is absent even if npmrc has before', async () => {
+      await npmHelper.generateLockFile(
+        'some-dir',
+        {},
+        'package-lock.json',
+        { skipInstalls: true },
+        [
+          {
+            packageName: 'some-dep',
+            newVersion: '1.0.1',
+            isLockfileUpdate: false,
+          },
+        ],
+        'before=2026-06-01T00:00:00.000Z\n',
+      );
+
+      expect(execSnapshots).toMatchObject([
+        {
+          cmd: 'npm install --package-lock-only --no-audit --ignore-scripts',
+        },
+      ]);
+    });
+  });
+
+  describe('parseNpmrcCooldownDate', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-06-15T12:00:00.000Z'));
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    describe('returns null', () => {
+      it.each`
+        content
+        ${null}
+        ${'registry=https://registry.npmjs.org\n'}
+        ${'before=not-a-date\n'}
+        ${'before=2026-13-99T00:00:00.000Z\n'}
+      `('for: $content', ({ content }: { content: string | null }) => {
+        expect(npmHelper.parseNpmrcCooldownDate(content)).toBeNull();
+      });
+    });
+
+    describe('parses before= key', () => {
+      it.each`
+        input
+        ${'before=2026-06-01T00:00:00.000Z\n'}
+        ${'before="2026-06-01T00:00:00.000Z"\n'}
+        ${'registry=https://registry.npmjs.org\nbefore=2026-06-01T00:00:00.000Z # some comment\naudit=false\n'}
+      `('$input', ({ input }: { input: string }) => {
+        expect(npmHelper.parseNpmrcCooldownDate(input)?.toISO()).toBe(
+          '2026-06-01T00:00:00.000Z',
+        );
+      });
+    });
+
+    describe('parses min-release-age= key', () => {
+      it.each`
+        input
+        ${'min-release-age=30\n'}
+        ${'min-release-age="30"\n'}
+        ${'min-release-age=30 # 30 days\n'}
+        ${'registry=https://registry.npmjs.org\nmin-release-age=30 # 30 days\n'}
+      `('$input', ({ input }: { input: string }) => {
+        expect(npmHelper.parseNpmrcCooldownDate(input)?.toISO()).toBe(
+          '2026-05-16T12:00:00.000Z',
+        );
+      });
+    });
+  });
 });

--- a/lib/modules/manager/npm/post-update/npm.ts
+++ b/lib/modules/manager/npm/post-update/npm.ts
@@ -148,7 +148,10 @@ export async function generateLockFile(
       const ms = toMs(config.minimumReleaseAge);
       if (ms === null) {
         logger.debug(
-          `Invalid minimumReleaseAge value: ${config.minimumReleaseAge}, skipping --before for npm install`,
+          {
+            minimumReleaseAge: config.minimumReleaseAge,
+          },
+          'Invalid minimumReleaseAge, skipping --before for npm install',
         );
       } else {
         let beforeDate = DateTime.now().minus(ms).toUTC();
@@ -156,14 +159,22 @@ export async function generateLockFile(
         const npmrcDate = parseNpmrcCooldownDate(npmrcContent);
         if (npmrcDate && npmrcDate < beforeDate) {
           logger.debug(
-            `Using stricter .npmrc cooldown date ${npmrcDate.toISO()} over minimumReleaseAge date ${beforeDate.toISO()}`,
+            {
+              npmrcDate: npmrcDate.toISO(),
+              beforeDate: beforeDate.toISO(),
+            },
+            'Using stricter .npmrc cooldown date over minimumReleaseAge date',
           );
           beforeDate = npmrcDate;
         }
 
         const beforeISO = beforeDate.toISO();
         logger.debug(
-          `Setting npm --before=${beforeISO} based on minimumReleaseAge=${config.minimumReleaseAge}`,
+          {
+            beforeISO,
+            minimumReleaseAge: config.minimumReleaseAge,
+          },
+          'Setting npm --before based on minimumReleaseAge',
         );
         cmdOptions += ` --before=${beforeISO}`;
       }

--- a/lib/modules/manager/npm/post-update/npm.ts
+++ b/lib/modules/manager/npm/post-update/npm.ts
@@ -47,7 +47,7 @@ const npmrcMinReleaseAgeRegex = regEx(
 
 export function parseNpmrcCooldownDate(
   npmrcContent: string | null,
-): DateTime | null {
+): DateTime<true> | null {
   const dateStr = npmrcContent?.match(npmrcBeforeRegex)?.[1];
   if (dateStr) {
     const parsed = DateTime.fromISO(dateStr, { zone: 'utc' });

--- a/lib/modules/manager/npm/post-update/npm.ts
+++ b/lib/modules/manager/npm/post-update/npm.ts
@@ -1,5 +1,6 @@
 // TODO: types (#22198)
 import { isNonEmptyString, isString } from '@sindresorhus/is';
+import { DateTime } from 'luxon';
 import semver from 'semver';
 import { quote } from 'shlex';
 import upath from 'upath';
@@ -22,6 +23,8 @@ import {
   renameLocalFile,
 } from '../../../../util/fs/index.ts';
 import { minimatch } from '../../../../util/minimatch.ts';
+import { toMs } from '../../../../util/pretty-time.ts';
+import { regEx } from '../../../../util/regex.ts';
 import { Result } from '../../../../util/result.ts';
 import { trimSlashes } from '../../../../util/url.ts';
 import type { PostUpdateConfig, Upgrade } from '../../types.ts';
@@ -34,6 +37,35 @@ import {
   getPackageManagerVersion,
   lazyLoadPackageJson,
 } from './utils.ts';
+
+const npmrcBeforeRegex = regEx(
+  /^\s*before\s*=\s*"?(\d{4}-\d{2}-\d{2}(?:T[\d:.]+Z?)?)"?(?:\s+[;#].*)?\s*$/m,
+);
+const npmrcMinReleaseAgeRegex = regEx(
+  /^\s*min-release-age\s*=\s*"?(\d+)"?(?:\s+[;#].*)?\s*$/m,
+);
+
+export function parseNpmrcCooldownDate(
+  npmrcContent: string | null,
+): DateTime | null {
+  const dateStr = npmrcContent?.match(npmrcBeforeRegex)?.[1];
+  if (dateStr) {
+    const parsed = DateTime.fromISO(dateStr, { zone: 'utc' });
+    if (parsed.isValid) {
+      return parsed;
+    }
+    logger.debug(`Invalid before date in .npmrc: ${dateStr}, ignoring`);
+  }
+
+  const daysStr = npmrcContent?.match(npmrcMinReleaseAgeRegex)?.[1];
+  if (daysStr) {
+    return DateTime.now()
+      .minus({ days: parseInt(daysStr, 10) })
+      .toUTC();
+  }
+
+  return null;
+}
 
 async function getNpmConstraintFromPackageLock(
   lockFileDir: string,
@@ -67,6 +99,7 @@ export async function generateLockFile(
   filename: string,
   config: Partial<PostUpdateConfig> = {},
   upgrades: Upgrade[] = [],
+  npmrcContent: string | null = null,
 ): Promise<GenerateLockFileResult> {
   // TODO: don't assume package-lock.json is in the same directory
   const lockFileName = upath.join(lockFileDir, filename);
@@ -109,6 +142,31 @@ export async function generateLockFile(
 
     if (!GlobalConfig.get('allowScripts') || config.ignoreScripts) {
       cmdOptions += ' --ignore-scripts';
+    }
+
+    if (config.minimumReleaseAge) {
+      const ms = toMs(config.minimumReleaseAge);
+      if (ms === null) {
+        logger.debug(
+          `Invalid minimumReleaseAge value: ${config.minimumReleaseAge}, skipping --before for npm install`,
+        );
+      } else {
+        let beforeDate = DateTime.now().minus(ms).toUTC();
+
+        const npmrcDate = parseNpmrcCooldownDate(npmrcContent);
+        if (npmrcDate && npmrcDate < beforeDate) {
+          logger.debug(
+            `Using stricter .npmrc cooldown date ${npmrcDate.toISO()} over minimumReleaseAge date ${beforeDate.toISO()}`,
+          );
+          beforeDate = npmrcDate;
+        }
+
+        const beforeISO = beforeDate.toISO();
+        logger.debug(
+          `Setting npm --before=${beforeISO} based on minimumReleaseAge=${config.minimumReleaseAge}`,
+        );
+        cmdOptions += ` --before=${beforeISO}`;
+      }
     }
 
     const extraEnv: ExtraEnv = {

--- a/lib/modules/manager/types.ts
+++ b/lib/modules/manager/types.ts
@@ -9,6 +9,7 @@ import type { Category } from '../../constants/index.ts';
 import type {
   MaybePromise,
   ModuleApi,
+  Nullish,
   RangeStrategy,
   SkipReason,
   StageName,
@@ -350,5 +351,6 @@ export interface PostUpdateConfig<T = Record<string, any>>
   reuseExistingBranch?: boolean;
   toolSettings?: ToolSettingsOptions;
 
+  minimumReleaseAge?: Nullish<string>;
   isLockFileMaintenance?: boolean;
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

When `minimumReleaseAge` is configured, Renovate now passes `--before=<date>` to `npm install` during lock file generation. This prevents npm from resolving newly published transitive dependencies that haven't yet passed the cooldown threshold.

`--before` is used rather than `--min-release-age` because `--before` has been available since npm 6 (released in 2018), whereas `--min-release-age` was only introduced in npm 11. 

If the project's `.npmrc` already contains a `before=` or `min-release-age=` setting, Renovate uses the stricter (earlier) of the two dates so that existing project-level constraints are never weakened.

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #41657 <!-- NOTE that this should NOT be a Discussion -->
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/renovate-demo/41657-npm-lockfile-before
with `"minimumReleaseAge": "5 days"`

```
DEBUG: Generating package-lock.json for . (repository=renovate-demo/41657-npm-lockfile-before, branch=renovate/vite-8.x)
DEBUG: Spawning npm install to create ./package-lock.json (repository=renovate-demo/41657-npm-lockfile-before, branch=renovate/vite-8.x)
DEBUG: Updating lock file only (repository=renovate-demo/41657-npm-lockfile-before, branch=renovate/vite-8.x)
DEBUG: Setting npm --before=2026-03-17T14:14:08.740Z based on minimumReleaseAge=5 days (repository=renovate-demo/41657-npm-lockfile-before, branch=renovate/vite-8.x)
DEBUG: No node constraint found - using latest (repository=renovate-demo/41657-npm-lockfile-before, branch=renovate/vite-8.x)
DEBUG: Executing command (repository=renovate-demo/41657-npm-lockfile-before, branch=renovate/vite-8.x)
       "command": "npm install --package-lock-only --no-audit --ignore-scripts --before=2026-03-17T14:14:08.740Z"
DEBUG: exec completed (repository=renovate-demo/41657-npm-lockfile-before, branch=renovate/vite-8.x)
       "durationMs": 3499,
       "stdout": "\nup to date in 3s\n\n8 packages are looking for funding\n  run `npm fund` for details\n",
```

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
