### PR TITLE
fix(scm-manager): invalid base url, due to double slashes and a fixed context path

### DIFF
--- a/lib/modules/platform/scm-manager/index.spec.ts
+++ b/lib/modules/platform/scm-manager/index.spec.ts
@@ -12,8 +12,8 @@ import type { PrFilterByState } from './types.ts';
 vi.mock('../util');
 vi.mock('../../../util/git');
 
-const endpoint = 'https://localhost:8080';
-const baseUrl = `${endpoint}/scm/api/v2`;
+const endpoint = 'https://localhost:8080/scm/';
+const baseUrl = `${endpoint}api/v2`;
 const token = 'TEST_TOKEN';
 
 const user: User = {

--- a/lib/modules/platform/scm-manager/index.ts
+++ b/lib/modules/platform/scm-manager/index.ts
@@ -60,7 +60,7 @@ export async function initPlatform({
     throw new Error('Init: SCM-Manager API token not configured');
   }
 
-  const baseUrl = `${endpoint}scm/api/v2`;
+  const baseUrl = `${endpoint}api/v2`;
   setBaseUrl(baseUrl);
 
   try {

--- a/lib/modules/platform/scm-manager/index.ts
+++ b/lib/modules/platform/scm-manager/index.ts
@@ -4,6 +4,7 @@ import type { BranchStatus } from '../../../types/index.ts';
 import * as git from '../../../util/git/index.ts';
 import { getBaseUrl, setBaseUrl } from '../../../util/http/scm-manager.ts';
 import { sanitize } from '../../../util/sanitize.ts';
+import { ensureTrailingSlash } from '../../../util/url.ts';
 import type {
   BranchStatusConfig,
   CreatePRConfig,
@@ -60,7 +61,7 @@ export async function initPlatform({
     throw new Error('Init: SCM-Manager API token not configured');
   }
 
-  const baseUrl = `${endpoint}api/v2`;
+  const baseUrl = `${ensureTrailingSlash(endpoint)}api/v2`;
   setBaseUrl(baseUrl);
 
   try {

--- a/lib/modules/platform/scm-manager/index.ts
+++ b/lib/modules/platform/scm-manager/index.ts
@@ -60,7 +60,7 @@ export async function initPlatform({
     throw new Error('Init: SCM-Manager API token not configured');
   }
 
-  const baseUrl = `${endpoint}/scm/api/v2`;
+  const baseUrl = `${endpoint}scm/api/v2`;
   setBaseUrl(baseUrl);
 
   try {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
The Base URL for the SCM-Manager was constructed with this line:
`const baseUrl = `${endpoint}/scm/api/v2;`

There are two issues with this line of code.
First it falsely assumes that `endpoint` will not have a trailing slash, resulting in double slashes within the `baseUrl`.
Secondly the first segment of the path (`/scm`) is configurable and can be changed to any valid path, therefore this part can not be hardcoded and needs to be part of the `endpoint` configuration.

This PR fixes this two errors.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [X] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [X] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [X] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [X] Both unit tests + ran on a real repository


<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
