### PR TITLE
feat(manager/mise): add support for tart

### DIFF
--- a/lib/modules/manager/mise/extract.spec.ts
+++ b/lib/modules/manager/mise/extract.spec.ts
@@ -84,6 +84,7 @@ describe('modules/manager/mise/extract', () => {
       swiftformat = "0.58.0"
       swiftlint = "0.55.1"
       taplo = "0.10.0"
+      tart = "2.31.0"
       terragrunt = "0.72.6"
       tilt = "0.34.0"
       tusd = "2.8.0"
@@ -312,6 +313,12 @@ describe('modules/manager/mise/extract', () => {
             datasource: 'github-releases',
             depName: 'taplo',
             packageName: 'tamasfe/taplo',
+          },
+          {
+            currentValue: '2.31.0',
+            datasource: 'github-releases',
+            depName: 'tart',
+            packageName: 'cirruslabs/tart',
           },
           {
             currentValue: '0.72.6',

--- a/lib/modules/manager/mise/upgradeable-tooling.ts
+++ b/lib/modules/manager/mise/upgradeable-tooling.ts
@@ -465,6 +465,13 @@ const miseRegistryTooling: Record<string, ToolingDefinition> = {
       datasource: GithubReleasesDatasource.id,
     },
   },
+  tart: {
+    misePluginUrl: 'https://mise.jdx.dev/registry.html#tools',
+    config: {
+      packageName: 'cirruslabs/tart',
+      datasource: GithubReleasesDatasource.id,
+    },
+  },
   terragrunt: {
     misePluginUrl: 'https://mise.jdx.dev/registry.html#tools',
     config: {


### PR DESCRIPTION
## Changes

Adds `tart` (Cirrus Labs Tart) to the set of mise tools for renovate to manage. Tart provides macOS and Linux VMs on Apple Silicon using Apple's Virtualization.framework.

## Context

- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, and documentation).

## Documentation (please check one with an [x])

- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Newly added/modified unit tests