### PR TITLE
feat(mise): add lock file support

### DIFF
--- a/lib/modules/manager/mise/artifacts.spec.ts
+++ b/lib/modules/manager/mise/artifacts.spec.ts
@@ -9,11 +9,15 @@ import { TEMPORARY_ERROR } from '../../../constants/error-messages.ts';
 import * as docker from '../../../util/exec/docker/index.ts';
 import type { UpdateArtifactsConfig } from '../types.ts';
 import { updateArtifacts, updateLockedDependency } from './artifacts.ts';
+import * as lockfile from './lockfile.ts';
 
 vi.mock('../../../util/exec/env.ts');
 vi.mock('../../../util/fs/index.ts');
 vi.mock('../../../util/git/index.ts');
 vi.mock('../../../util/host-rules.ts', () => mockDeep());
+vi.mock('./lockfile.ts', async (importOriginal) => ({
+  ...(await importOriginal<typeof lockfile>()),
+}));
 
 const adminConfig: RepoGlobalConfig = {
   // `join` fixes Windows CI
@@ -285,6 +289,28 @@ describe('modules/manager/mise/artifacts', () => {
   // containerbase support may not be available in all test environments.
   // The functionality is tested through the regular tests which use mockExecAll.
 
+  it('prevents command injection', async () => {
+    fs.readLocalFile.mockResolvedValueOnce('existing content');
+    fs.writeLocalFile.mockResolvedValueOnce();
+    const execSnapshots = mockExecAll();
+    git.getRepoStatus.mockResolvedValue(
+      partial<StatusResult>({
+        modified: [],
+      }),
+    );
+
+    await updateArtifacts({
+      packageFileName: 'mise.toml',
+      updatedDeps: [{ depName: '|| date; echo ' }, { depName: 'node' }],
+      newPackageFileContent: 'content',
+      config,
+    });
+
+    expect(execSnapshots).toMatchObject([
+      { cmd: "mise lock '|| date; echo ' node" },
+    ]);
+  });
+
   it('handles subdirectory package files', async () => {
     fs.readLocalFile
       .mockResolvedValueOnce('existing content')
@@ -402,6 +428,36 @@ version = "3.10.17"
       });
 
       expect(res).toEqual({ status: 'unsupported' });
+    });
+
+    it('returns unsupported when depName is undefined', () => {
+      const res = updateLockedDependency({
+        packageFile: 'mise.toml',
+        lockFile: 'mise.lock',
+        lockFileContent,
+        depName: undefined as never,
+        currentVersion: '20.10.0',
+        newVersion: '20.11.0',
+      });
+
+      expect(res).toEqual({ status: 'unsupported' });
+    });
+
+    it('returns update-failed in case of errors', () => {
+      vi.spyOn(lockfile, 'getLockedVersion').mockImplementationOnce(() => {
+        throw new Error('unexpected error');
+      });
+
+      const res = updateLockedDependency({
+        packageFile: 'mise.toml',
+        lockFile: 'mise.lock',
+        lockFileContent,
+        depName: 'node',
+        currentVersion: '20.10.0',
+        newVersion: '20.11.0',
+      });
+
+      expect(res).toEqual({ status: 'update-failed' });
     });
   });
 });

--- a/lib/modules/manager/mise/artifacts.spec.ts
+++ b/lib/modules/manager/mise/artifacts.spec.ts
@@ -1,0 +1,407 @@
+import type { StatusResult } from 'simple-git';
+import upath from 'upath';
+import { mockDeep } from 'vitest-mock-extended';
+import { envMock, mockExecAll, mockExecSequence } from '~test/exec-util.ts';
+import { env, fs, git, hostRules, partial } from '~test/util.ts';
+import { GlobalConfig } from '../../../config/global.ts';
+import type { RepoGlobalConfig } from '../../../config/types.ts';
+import { TEMPORARY_ERROR } from '../../../constants/error-messages.ts';
+import * as docker from '../../../util/exec/docker/index.ts';
+import type { UpdateArtifactsConfig } from '../types.ts';
+import { updateArtifacts, updateLockedDependency } from './artifacts.ts';
+
+vi.mock('../../../util/exec/env.ts');
+vi.mock('../../../util/fs/index.ts');
+vi.mock('../../../util/git/index.ts');
+vi.mock('../../../util/host-rules.ts', () => mockDeep());
+
+const adminConfig: RepoGlobalConfig = {
+  // `join` fixes Windows CI
+  localDir: upath.join('/tmp/github/some/repo'),
+  cacheDir: upath.join('/tmp/renovate/cache'),
+  containerbaseDir: upath.join('/tmp/renovate/cache/containerbase'),
+};
+
+process.env.CONTAINERBASE = 'true';
+
+const config: UpdateArtifactsConfig = {};
+const lockMaintenanceConfig = { ...config, isLockFileMaintenance: true };
+const updateToolCmd = 'mise lock node';
+const updateMultipleToolsCmd = 'mise lock node python';
+const lockfileMaintenanceCmd = 'mise lock';
+
+describe('modules/manager/mise/artifacts', () => {
+  beforeEach(() => {
+    env.getChildProcessEnv.mockReturnValue({
+      ...envMock.basic,
+      LANG: 'en_US.UTF-8',
+      LC_ALL: 'en_US',
+    });
+    GlobalConfig.set(adminConfig);
+    docker.resetPrefetchedImages();
+    hostRules.find.mockReturnValue({ token: undefined });
+  });
+
+  it('returns null if lock file does not exist', async () => {
+    fs.readLocalFile.mockResolvedValueOnce(null);
+    const execSnapshots = mockExecAll();
+    const res = await updateArtifacts({
+      packageFileName: 'mise.toml',
+      updatedDeps: [],
+      newPackageFileContent: '',
+      config,
+    });
+
+    expect(res).toBeNull();
+    expect(execSnapshots).toEqual([]);
+  });
+
+  it('returns null if lock file unchanged after exec', async () => {
+    fs.readLocalFile.mockResolvedValueOnce('existing content');
+    fs.writeLocalFile.mockResolvedValueOnce();
+    const execSnapshots = mockExecAll();
+    git.getRepoStatus.mockResolvedValue(
+      partial<StatusResult>({
+        modified: [],
+      }),
+    );
+
+    const res = await updateArtifacts({
+      packageFileName: 'mise.toml',
+      updatedDeps: [{ depName: 'node' }],
+      newPackageFileContent: 'some new content',
+      config,
+    });
+
+    expect(res).toBeNull();
+    expect(execSnapshots).toMatchObject([{ cmd: updateToolCmd }]);
+  });
+
+  it('returns updated lock file on success', async () => {
+    fs.readLocalFile
+      .mockResolvedValueOnce('existing content')
+      .mockResolvedValueOnce('new content');
+    fs.writeLocalFile.mockResolvedValueOnce();
+    const execSnapshots = mockExecAll();
+    git.getRepoStatus.mockResolvedValue(
+      partial<StatusResult>({
+        modified: ['mise.lock'],
+      }),
+    );
+
+    const res = await updateArtifacts({
+      packageFileName: 'mise.toml',
+      updatedDeps: [{ depName: 'node' }],
+      newPackageFileContent: 'some new content',
+      config,
+    });
+
+    expect(res).toEqual([
+      {
+        file: {
+          contents: 'new content',
+          path: 'mise.lock',
+          type: 'addition',
+        },
+      },
+    ]);
+    expect(execSnapshots).toMatchObject([{ cmd: updateToolCmd }]);
+  });
+
+  it('returns artifactError on exec failure with combined output', async () => {
+    fs.readLocalFile.mockResolvedValueOnce('existing content');
+    fs.writeLocalFile.mockResolvedValueOnce();
+    const error = new Error('exec error');
+    (error as any).stdout = 'stdout output';
+    (error as any).stderr = 'stderr output';
+    const execSnapshots = mockExecSequence([error]);
+
+    const res = await updateArtifacts({
+      packageFileName: 'mise.toml',
+      updatedDeps: [{ depName: 'node' }],
+      newPackageFileContent: 'some new content',
+      config,
+    });
+
+    expect(res).toEqual([
+      {
+        artifactError: {
+          fileName: 'mise.lock',
+          stderr: 'stdout output\nstderr output\nexec error',
+        },
+      },
+    ]);
+    expect(execSnapshots).toMatchObject([{ cmd: updateToolCmd }]);
+  });
+
+  it('rethrows TEMPORARY_ERROR', async () => {
+    fs.readLocalFile.mockResolvedValueOnce('existing content');
+    fs.writeLocalFile.mockResolvedValueOnce();
+    mockExecSequence([new Error(TEMPORARY_ERROR)]);
+
+    await expect(
+      updateArtifacts({
+        packageFileName: 'mise.toml',
+        updatedDeps: [{ depName: 'node' }],
+        newPackageFileContent: 'some new content',
+        config,
+      }),
+    ).rejects.toThrow(TEMPORARY_ERROR);
+  });
+
+  it('runs mise lock for lockFileMaintenance', async () => {
+    fs.readLocalFile.mockResolvedValueOnce('existing content');
+    fs.writeLocalFile.mockResolvedValueOnce();
+    const execSnapshots = mockExecAll();
+    git.getRepoStatus.mockResolvedValue(
+      partial<StatusResult>({
+        modified: [],
+      }),
+    );
+
+    await updateArtifacts({
+      packageFileName: 'mise.toml',
+      updatedDeps: [{ depName: 'node' }],
+      newPackageFileContent: 'some content',
+      config: lockMaintenanceConfig,
+    });
+
+    expect(execSnapshots).toMatchObject([{ cmd: lockfileMaintenanceCmd }]);
+  });
+
+  it('runs mise lock <tools> for targeted updates', async () => {
+    fs.readLocalFile.mockResolvedValueOnce('existing content');
+    fs.writeLocalFile.mockResolvedValueOnce();
+    const execSnapshots = mockExecAll();
+    git.getRepoStatus.mockResolvedValue(
+      partial<StatusResult>({
+        modified: [],
+      }),
+    );
+
+    await updateArtifacts({
+      packageFileName: 'mise.toml',
+      updatedDeps: [{ depName: 'node' }, { depName: 'python' }],
+      newPackageFileContent: 'some content',
+      config,
+    });
+
+    expect(execSnapshots).toMatchObject([{ cmd: updateMultipleToolsCmd }]);
+  });
+
+  it('injects GITHUB_TOKEN when host rule found', async () => {
+    fs.readLocalFile
+      .mockResolvedValueOnce('existing content')
+      .mockResolvedValueOnce('new content');
+    fs.writeLocalFile.mockResolvedValueOnce();
+    const execSnapshots = mockExecAll();
+    git.getRepoStatus.mockResolvedValue(
+      partial<StatusResult>({
+        modified: ['mise.lock'],
+      }),
+    );
+    hostRules.find.mockReturnValueOnce({ token: 'github-token' });
+
+    const res = await updateArtifacts({
+      packageFileName: 'mise.toml',
+      updatedDeps: [{ depName: 'node' }],
+      newPackageFileContent: 'some new content',
+      config,
+    });
+
+    expect(res).toEqual([
+      {
+        file: {
+          contents: 'new content',
+          path: 'mise.lock',
+          type: 'addition',
+        },
+      },
+    ]);
+    expect(execSnapshots).toMatchObject([
+      {
+        cmd: updateToolCmd,
+        options: {
+          env: expect.objectContaining({
+            GITHUB_TOKEN: 'github-token',
+          }),
+        },
+      },
+    ]);
+  });
+
+  it('handles empty updatedDeps with fallback to full lock', async () => {
+    fs.readLocalFile.mockResolvedValueOnce('existing content');
+    fs.writeLocalFile.mockResolvedValueOnce();
+    const execSnapshots = mockExecAll();
+    git.getRepoStatus.mockResolvedValue(
+      partial<StatusResult>({
+        modified: [],
+      }),
+    );
+
+    await updateArtifacts({
+      packageFileName: 'mise.toml',
+      updatedDeps: [],
+      newPackageFileContent: 'some content',
+      config,
+    });
+
+    expect(execSnapshots).toMatchObject([{ cmd: lockfileMaintenanceCmd }]);
+  });
+
+  it('handles environment-specific lock files', async () => {
+    fs.readLocalFile
+      .mockResolvedValueOnce('existing content')
+      .mockResolvedValueOnce('new content');
+    fs.writeLocalFile.mockResolvedValueOnce();
+    const execSnapshots = mockExecAll();
+    git.getRepoStatus.mockResolvedValue(
+      partial<StatusResult>({
+        modified: ['mise.test.lock'],
+      }),
+    );
+
+    const res = await updateArtifacts({
+      packageFileName: 'mise.test.toml',
+      updatedDeps: [{ depName: 'node' }],
+      newPackageFileContent: 'some new content',
+      config,
+    });
+
+    expect(res).toEqual([
+      {
+        file: {
+          contents: 'new content',
+          path: 'mise.test.lock',
+          type: 'addition',
+        },
+      },
+    ]);
+    expect(execSnapshots).toMatchObject([{ cmd: updateToolCmd }]);
+  });
+
+  // Note: Docker and install mode tests are not included here because mise
+  // containerbase support may not be available in all test environments.
+  // The functionality is tested through the regular tests which use mockExecAll.
+
+  it('handles subdirectory package files', async () => {
+    fs.readLocalFile
+      .mockResolvedValueOnce('existing content')
+      .mockResolvedValueOnce('new content');
+    fs.writeLocalFile.mockResolvedValueOnce();
+    const execSnapshots = mockExecAll();
+    git.getRepoStatus.mockResolvedValue(
+      partial<StatusResult>({
+        modified: ['subdir/mise.lock'],
+      }),
+    );
+
+    const res = await updateArtifacts({
+      packageFileName: 'subdir/mise.toml',
+      updatedDeps: [{ depName: 'node' }],
+      newPackageFileContent: 'some new content',
+      config,
+    });
+
+    expect(res).toEqual([
+      {
+        file: {
+          contents: 'new content',
+          path: 'subdir/mise.lock',
+          type: 'addition',
+        },
+      },
+    ]);
+    expect(execSnapshots).toMatchObject([{ cmd: updateToolCmd }]);
+  });
+
+  describe('updateLockedDependency', () => {
+    const lockFileContent = `
+[[tools.node]]
+version = "20.11.0"
+backend = "core:node"
+
+[[tools.python]]
+version = "3.10.17"
+`;
+
+    it('returns already-updated when version matches', () => {
+      const res = updateLockedDependency({
+        packageFile: 'mise.toml',
+        lockFile: 'mise.lock',
+        lockFileContent,
+        depName: 'node',
+        currentVersion: '20.10.0',
+        newVersion: '20.11.0',
+      });
+
+      expect(res).toEqual({ status: 'already-updated' });
+    });
+
+    it('returns already-updated for tool with backend prefix', () => {
+      const res = updateLockedDependency({
+        packageFile: 'mise.toml',
+        lockFile: 'mise.lock',
+        lockFileContent,
+        depName: 'core:node',
+        currentVersion: '20.10.0',
+        newVersion: '20.11.0',
+      });
+
+      expect(res).toEqual({ status: 'already-updated' });
+    });
+
+    it('returns unsupported when version does not match', () => {
+      const res = updateLockedDependency({
+        packageFile: 'mise.toml',
+        lockFile: 'mise.lock',
+        lockFileContent,
+        depName: 'node',
+        currentVersion: '20.10.0',
+        newVersion: '22.0.0',
+      });
+
+      expect(res).toEqual({ status: 'unsupported' });
+    });
+
+    it('returns unsupported when tool not in lock file', () => {
+      const res = updateLockedDependency({
+        packageFile: 'mise.toml',
+        lockFile: 'mise.lock',
+        lockFileContent,
+        depName: 'ruby',
+        currentVersion: '3.2.0',
+        newVersion: '3.3.0',
+      });
+
+      expect(res).toEqual({ status: 'unsupported' });
+    });
+
+    it('returns unsupported when no lock file content', () => {
+      const res = updateLockedDependency({
+        packageFile: 'mise.toml',
+        lockFile: 'mise.lock',
+        lockFileContent: undefined,
+        depName: 'node',
+        currentVersion: '20.10.0',
+        newVersion: '20.11.0',
+      });
+
+      expect(res).toEqual({ status: 'unsupported' });
+    });
+
+    it('returns unsupported for invalid lock file content', () => {
+      const res = updateLockedDependency({
+        packageFile: 'mise.toml',
+        lockFile: 'mise.lock',
+        lockFileContent: 'invalid toml {{{',
+        depName: 'node',
+        currentVersion: '20.10.0',
+        newVersion: '20.11.0',
+      });
+
+      expect(res).toEqual({ status: 'unsupported' });
+    });
+  });
+});

--- a/lib/modules/manager/mise/artifacts.ts
+++ b/lib/modules/manager/mise/artifacts.ts
@@ -14,9 +14,13 @@ import type {
   UpdateLockedConfig,
   UpdateLockedResult,
 } from '../types.ts';
-import { getLockFileName } from './lockfile.ts';
+import { getLockFileName, getLockedVersion } from './lockfile.ts';
 import { MiseLockFile } from './schema.ts';
 
+/**
+ * Updates mise lock files when dependencies are updated.
+ * Runs `mise lock` for lock file maintenance or `mise lock <tools>` for targeted updates.
+ */
 export async function updateArtifacts({
   packageFileName,
   updatedDeps,
@@ -86,7 +90,7 @@ export async function updateArtifacts({
       },
     ];
   } catch (err) {
-    // Rethrow temporary errors to allow Renovate to retry
+    // istanbul ignore if: not worth testing
     if (err.message === TEMPORARY_ERROR) {
       throw err;
     }
@@ -120,6 +124,10 @@ export function updateLockedDependency(
     `mise.updateLockedDependency: ${depName} -> ${newVersion} [${lockFile}]`,
   );
 
+  if (!depName) {
+    return { status: 'unsupported' };
+  }
+
   if (!lockFileContent) {
     return { status: 'unsupported' };
   }
@@ -130,10 +138,9 @@ export function updateLockedDependency(
       return { status: 'unsupported' };
     }
 
-    const toolName = getToolNameForLockFile(depName);
-    const lockedTools = parsed.data.tools[toolName];
+    const lockedVersion = getLockedVersion(parsed.data, depName);
 
-    if (lockedTools?.some((tool) => tool.version === newVersion)) {
+    if (lockedVersion === newVersion) {
       return { status: 'already-updated' };
     }
 
@@ -142,16 +149,4 @@ export function updateLockedDependency(
     logger.debug({ err }, 'mise.updateLockedDependency() error');
     return { status: 'update-failed' };
   }
-}
-
-/**
- * Get the tool name used in the lock file from the dependency name.
- * Lock files use the tool name without backend prefix (e.g., "core:node" -> "node").
- */
-function getToolNameForLockFile(depName: string): string {
-  const delimiterIndex = depName.indexOf(':');
-  if (delimiterIndex === -1) {
-    return depName;
-  }
-  return depName.substring(delimiterIndex + 1);
 }

--- a/lib/modules/manager/mise/artifacts.ts
+++ b/lib/modules/manager/mise/artifacts.ts
@@ -1,0 +1,171 @@
+import { isNonEmptyStringAndNotWhitespace } from '@sindresorhus/is';
+import { quote } from 'shlex';
+import { TEMPORARY_ERROR } from '../../../constants/error-messages.ts';
+import { logger } from '../../../logger/index.ts';
+import { findGithubToken } from '../../../util/check-token.ts';
+import { exec } from '../../../util/exec/index.ts';
+import type { ExecOptions, ExtraEnv } from '../../../util/exec/types.ts';
+import { readLocalFile, writeLocalFile } from '../../../util/fs/index.ts';
+import { getRepoStatus } from '../../../util/git/index.ts';
+import * as hostRules from '../../../util/host-rules.ts';
+import type {
+  UpdateArtifact,
+  UpdateArtifactsResult,
+  UpdateLockedConfig,
+  UpdateLockedResult,
+} from '../types.ts';
+import { getLockFileName } from './lockfile.ts';
+import { MiseLockFile } from './schema.ts';
+
+export async function updateArtifacts({
+  packageFileName,
+  updatedDeps,
+  newPackageFileContent,
+  config,
+}: UpdateArtifact): Promise<UpdateArtifactsResult[] | null> {
+  // 1. Derive lock file name from package file
+  const lockFileName = getLockFileName(packageFileName);
+
+  // 2. Check if lock file exists
+  const existingLockFileContent = await readLocalFile(lockFileName, 'utf8');
+  if (!existingLockFileContent) {
+    logger.debug({ lockFileName }, 'No mise lock file found');
+    return null;
+  }
+
+  // 3. Write updated package file content
+  await writeLocalFile(packageFileName, newPackageFileContent);
+
+  // 4. Build command based on maintenance mode
+  let cmd: string;
+  if (config.isLockFileMaintenance) {
+    // Full lock file update
+    cmd = 'mise lock';
+  } else {
+    // Targeted update for specific tools
+    const tools = updatedDeps
+      .map(({ depName }) => depName)
+      .filter(isNonEmptyStringAndNotWhitespace)
+      .map((depName) => quote(depName))
+      .join(' ');
+    cmd = tools ? `mise lock ${tools}` : 'mise lock';
+  }
+
+  // 5. Set up environment with GitHub token if available
+  const extraEnv: ExtraEnv = {};
+  const token = findGithubToken(
+    hostRules.find({
+      hostType: 'github',
+      url: 'https://api.github.com/',
+    }),
+  );
+  if (token) {
+    extraEnv.GITHUB_TOKEN = token;
+  }
+
+  // 6. Execute with tool constraints
+  const execOptions: ExecOptions = {
+    cwdFile: packageFileName,
+    extraEnv,
+    toolConstraints: [
+      {
+        toolName: 'mise',
+        constraint: config.constraints?.mise,
+      },
+    ],
+    docker: {},
+  };
+
+  try {
+    await exec(cmd, execOptions);
+
+    // 7. Check if lock file was modified
+    const status = await getRepoStatus();
+    if (!status.modified.includes(lockFileName)) {
+      return null;
+    }
+
+    // 8. Return updated lock file
+    logger.debug({ lockFileName }, 'Returning updated mise lock file');
+    return [
+      {
+        file: {
+          type: 'addition',
+          path: lockFileName,
+          contents: await readLocalFile(lockFileName),
+        },
+      },
+    ];
+  } catch (err) {
+    // Rethrow temporary errors to allow Renovate to retry
+    if (err.message === TEMPORARY_ERROR) {
+      throw err;
+    }
+
+    // Combine stdout, stderr, and message for better error reporting
+    const errorOutput = [err.stdout, err.stderr, err.message]
+      .filter(Boolean)
+      .join('\n');
+
+    logger.warn({ err }, `Error updating ${lockFileName}`);
+    return [
+      {
+        artifactError: {
+          fileName: lockFileName,
+          stderr: errorOutput,
+        },
+      },
+    ];
+  }
+}
+
+/**
+ * Check if a dependency is already at the target version in the lock file.
+ * Returns 'already-updated' if the locked version matches newVersion,
+ * 'unsupported' otherwise (letting Renovate proceed with the update).
+ */
+export function updateLockedDependency(
+  config: UpdateLockedConfig,
+): UpdateLockedResult {
+  const { depName, newVersion, lockFile, lockFileContent } = config;
+  logger.debug(
+    `mise.updateLockedDependency: ${depName} -> ${newVersion} [${lockFile}]`,
+  );
+
+  if (!lockFileContent) {
+    return { status: 'unsupported' };
+  }
+
+  try {
+    const parsed = MiseLockFile.safeParse(lockFileContent);
+    if (!parsed.success) {
+      return { status: 'unsupported' };
+    }
+
+    // Extract tool name without backend prefix for lock file lookup
+    const toolName = getToolNameForLockFile(depName);
+    const lockedTools = parsed.data.tools[toolName];
+
+    if (lockedTools?.some((tool) => tool.version === newVersion)) {
+      return { status: 'already-updated' };
+    }
+
+    return { status: 'unsupported' };
+  } catch (err) {
+    logger.debug({ err }, 'mise.updateLockedDependency() error');
+    return { status: 'update-failed' };
+  }
+}
+
+/**
+ * Get the tool name used in the lock file from the dependency name.
+ * Lock files use the tool name without backend prefix.
+ */
+function getToolNameForLockFile(depName: string): string {
+  const delimiterIndex = depName.indexOf(':');
+  if (delimiterIndex === -1) {
+    return depName;
+  }
+  // Remove backend prefix (e.g., "core:node" -> "node")
+  return depName.substring(delimiterIndex + 1);
+}

--- a/lib/modules/manager/mise/artifacts.ts
+++ b/lib/modules/manager/mise/artifacts.ts
@@ -23,26 +23,19 @@ export async function updateArtifacts({
   newPackageFileContent,
   config,
 }: UpdateArtifact): Promise<UpdateArtifactsResult[] | null> {
-  // 1. Derive lock file name from package file
   const lockFileName = getLockFileName(packageFileName);
-
-  // 2. Check if lock file exists
   const existingLockFileContent = await readLocalFile(lockFileName, 'utf8');
   if (!existingLockFileContent) {
     logger.debug({ lockFileName }, 'No mise lock file found');
     return null;
   }
 
-  // 3. Write updated package file content
   await writeLocalFile(packageFileName, newPackageFileContent);
 
-  // 4. Build command based on maintenance mode
   let cmd: string;
   if (config.isLockFileMaintenance) {
-    // Full lock file update
     cmd = 'mise lock';
   } else {
-    // Targeted update for specific tools
     const tools = updatedDeps
       .map(({ depName }) => depName)
       .filter(isNonEmptyStringAndNotWhitespace)
@@ -51,7 +44,6 @@ export async function updateArtifacts({
     cmd = tools ? `mise lock ${tools}` : 'mise lock';
   }
 
-  // 5. Set up environment with GitHub token if available
   const extraEnv: ExtraEnv = {};
   const token = findGithubToken(
     hostRules.find({
@@ -63,7 +55,6 @@ export async function updateArtifacts({
     extraEnv.GITHUB_TOKEN = token;
   }
 
-  // 6. Execute with tool constraints
   const execOptions: ExecOptions = {
     cwdFile: packageFileName,
     extraEnv,
@@ -79,13 +70,11 @@ export async function updateArtifacts({
   try {
     await exec(cmd, execOptions);
 
-    // 7. Check if lock file was modified
     const status = await getRepoStatus();
     if (!status.modified.includes(lockFileName)) {
       return null;
     }
 
-    // 8. Return updated lock file
     logger.debug({ lockFileName }, 'Returning updated mise lock file');
     return [
       {
@@ -102,7 +91,6 @@ export async function updateArtifacts({
       throw err;
     }
 
-    // Combine stdout, stderr, and message for better error reporting
     const errorOutput = [err.stdout, err.stderr, err.message]
       .filter(Boolean)
       .join('\n');
@@ -142,7 +130,6 @@ export function updateLockedDependency(
       return { status: 'unsupported' };
     }
 
-    // Extract tool name without backend prefix for lock file lookup
     const toolName = getToolNameForLockFile(depName);
     const lockedTools = parsed.data.tools[toolName];
 
@@ -159,13 +146,12 @@ export function updateLockedDependency(
 
 /**
  * Get the tool name used in the lock file from the dependency name.
- * Lock files use the tool name without backend prefix.
+ * Lock files use the tool name without backend prefix (e.g., "core:node" -> "node").
  */
 function getToolNameForLockFile(depName: string): string {
   const delimiterIndex = depName.indexOf(':');
   if (delimiterIndex === -1) {
     return depName;
   }
-  // Remove backend prefix (e.g., "core:node" -> "node")
   return depName.substring(delimiterIndex + 1);
 }

--- a/lib/modules/manager/mise/extract.spec.ts
+++ b/lib/modules/manager/mise/extract.spec.ts
@@ -1,5 +1,6 @@
 import { codeBlock } from 'common-tags';
 import { Fixtures } from '~test/fixtures.ts';
+import { fs } from '~test/util.ts';
 import { extractPackageFile } from './index.ts';
 
 vi.mock('../../../util/fs/index.ts');
@@ -9,29 +10,34 @@ const miseFilename = 'mise.toml';
 const mise1toml = Fixtures.get('Mise.1.toml');
 
 describe('modules/manager/mise/extract', () => {
+  beforeEach(() => {
+    // By default, mock no lock file found
+    fs.readLocalFile.mockResolvedValue(null);
+  });
+
   describe('extractPackageFile()', () => {
-    it('returns null for empty', () => {
-      expect(extractPackageFile('', miseFilename)).toBeNull();
+    it('returns null for empty', async () => {
+      expect(await extractPackageFile('', miseFilename)).toBeNull();
     });
 
-    it('returns null for invalid TOML', () => {
-      expect(extractPackageFile('foo', miseFilename)).toBeNull();
+    it('returns null for invalid TOML', async () => {
+      expect(await extractPackageFile('foo', miseFilename)).toBeNull();
     });
 
-    it('returns null for empty tools section', () => {
+    it('returns null for empty tools section', async () => {
       const content = codeBlock`
       [tools]
     `;
-      expect(extractPackageFile(content, miseFilename)).toBeNull();
+      expect(await extractPackageFile(content, miseFilename)).toBeNull();
     });
 
-    it('extracts tools - mise core plugins', () => {
+    it('extracts tools - mise core plugins', async () => {
       const content = codeBlock`
       [tools]
       erlang = '23.3'
       node = '16'
     `;
-      const result = extractPackageFile(content, miseFilename);
+      const result = await extractPackageFile(content, miseFilename);
       expect(result).toMatchObject({
         deps: [
           {
@@ -48,7 +54,7 @@ describe('modules/manager/mise/extract', () => {
       });
     });
 
-    it('extracts tools - mise registry tools', () => {
+    it('extracts tools - mise registry tools', async () => {
       const content = codeBlock`
       [tools]
       actionlint = "1.7.7"
@@ -89,7 +95,7 @@ describe('modules/manager/mise/extract', () => {
       tusd = "2.8.0"
       usage = "2.1.1"
     `;
-      const result = extractPackageFile(content, miseFilename);
+      const result = await extractPackageFile(content, miseFilename);
       expect(result).toMatchObject({
         deps: [
           {
@@ -345,12 +351,12 @@ describe('modules/manager/mise/extract', () => {
       });
     });
 
-    it('extracts tools - asdf plugins', () => {
+    it('extracts tools - asdf plugins', async () => {
       const content = codeBlock`
       [tools]
       terraform = '1.8.0'
     `;
-      const result = extractPackageFile(content, miseFilename);
+      const result = await extractPackageFile(content, miseFilename);
       expect(result).toMatchObject({
         deps: [
           {
@@ -361,13 +367,13 @@ describe('modules/manager/mise/extract', () => {
       });
     });
 
-    it('extracts tools with multiple versions', () => {
+    it('extracts tools with multiple versions', async () => {
       const content = codeBlock`
       [tools]
       erlang = ['23.3', '24.0']
       node = ['16', 'prefix:20', 'ref:master', 'path:~/.nodes/14']
     `;
-      const result = extractPackageFile(content, miseFilename);
+      const result = await extractPackageFile(content, miseFilename);
       expect(result).toMatchObject({
         deps: [
           {
@@ -384,12 +390,12 @@ describe('modules/manager/mise/extract', () => {
       });
     });
 
-    it('extracts tools with plugin options', () => {
+    it('extracts tools with plugin options', async () => {
       const content = codeBlock`
       [tools]
       python = {version='3.11', virtualenv='.venv'}
     `;
-      const result = extractPackageFile(content, miseFilename);
+      const result = await extractPackageFile(content, miseFilename);
       expect(result).toMatchObject({
         deps: [
           {
@@ -400,7 +406,7 @@ describe('modules/manager/mise/extract', () => {
       });
     });
 
-    it('extracts tools in the default registry with backends', () => {
+    it('extracts tools in the default registry with backends', async () => {
       const content = codeBlock`
       [tools]
       "core:node" = "16"
@@ -408,7 +414,7 @@ describe('modules/manager/mise/extract', () => {
       "vfox:scala" = "3.5.2"
       "aqua:act" = "0.2.70"
     `;
-      const result = extractPackageFile(content, miseFilename);
+      const result = await extractPackageFile(content, miseFilename);
       expect(result).toMatchObject({
         deps: [
           {
@@ -439,13 +445,13 @@ describe('modules/manager/mise/extract', () => {
       });
     });
 
-    it('extracts aqua backend tool', () => {
+    it('extracts aqua backend tool', async () => {
       const content = codeBlock`
       [tools]
       "aqua:BurntSushi/ripgrep" = "14.1.0"
       "aqua:cli/cli" = "v2.64.0"
     `;
-      const result = extractPackageFile(content, miseFilename);
+      const result = await extractPackageFile(content, miseFilename);
       expect(result).toMatchObject({
         deps: [
           {
@@ -466,7 +472,7 @@ describe('modules/manager/mise/extract', () => {
       });
     });
 
-    it('extracts cargo backend tools', () => {
+    it('extracts cargo backend tools', async () => {
       const content = codeBlock`
       [tools]
       "cargo:eza" = "0.18.21"
@@ -474,7 +480,7 @@ describe('modules/manager/mise/extract', () => {
       "cargo:https://github.com/username/demo2" = "branch:main"
       "cargo:https://github.com/username/demo3" = "rev:abcdef"
     `;
-      const result = extractPackageFile(content, miseFilename);
+      const result = await extractPackageFile(content, miseFilename);
       expect(result).toMatchObject({
         deps: [
           {
@@ -505,12 +511,12 @@ describe('modules/manager/mise/extract', () => {
       });
     });
 
-    it('extracts dotnet backend tool', () => {
+    it('extracts dotnet backend tool', async () => {
       const content = codeBlock`
       [tools]
       "dotnet:GitVersion.Tool" = "5.12.0"
     `;
-      const result = extractPackageFile(content, miseFilename);
+      const result = await extractPackageFile(content, miseFilename);
       expect(result).toMatchObject({
         deps: [
           {
@@ -523,12 +529,12 @@ describe('modules/manager/mise/extract', () => {
       });
     });
 
-    it('extracts gem backend tool', () => {
+    it('extracts gem backend tool', async () => {
       const content = codeBlock`
       [tools]
       "gem:rubocop" = "1.69.2"
     `;
-      const result = extractPackageFile(content, miseFilename);
+      const result = await extractPackageFile(content, miseFilename);
       expect(result).toMatchObject({
         deps: [
           {
@@ -541,12 +547,12 @@ describe('modules/manager/mise/extract', () => {
       });
     });
 
-    it('extracts go backend tool', () => {
+    it('extracts go backend tool', async () => {
       const content = codeBlock`
       [tools]
       "go:github.com/DarthSim/hivemind" = "1.0.6"
     `;
-      const result = extractPackageFile(content, miseFilename);
+      const result = await extractPackageFile(content, miseFilename);
       expect(result).toMatchObject({
         deps: [
           {
@@ -559,12 +565,12 @@ describe('modules/manager/mise/extract', () => {
       });
     });
 
-    it('extracts npm backend tool', () => {
+    it('extracts npm backend tool', async () => {
       const content = codeBlock`
       [tools]
       "npm:prettier" = "3.3.2"
     `;
-      const result = extractPackageFile(content, miseFilename);
+      const result = await extractPackageFile(content, miseFilename);
       expect(result).toMatchObject({
         deps: [
           {
@@ -577,14 +583,14 @@ describe('modules/manager/mise/extract', () => {
       });
     });
 
-    it('extracts pipx backend tools', () => {
+    it('extracts pipx backend tools', async () => {
       const content = codeBlock`
       [tools]
       "pipx:yamllint" = "1.35.0"
       "pipx:psf/black" = "24.4.1"
       "pipx:git+https://github.com/psf/black.git" = "24.4.1"
     `;
-      const result = extractPackageFile(content, miseFilename);
+      const result = await extractPackageFile(content, miseFilename);
       expect(result).toMatchObject({
         deps: [
           {
@@ -609,13 +615,13 @@ describe('modules/manager/mise/extract', () => {
       });
     });
 
-    it('extracts spm backend tools', () => {
+    it('extracts spm backend tools', async () => {
       const content = codeBlock`
       [tools]
       "spm:tuist/tuist" = "4.15.0"
       "spm:https://github.com/tuist/tuist.git" = "4.13.0"
     `;
-      const result = extractPackageFile(content, miseFilename);
+      const result = await extractPackageFile(content, miseFilename);
       expect(result).toMatchObject({
         deps: [
           {
@@ -634,7 +640,7 @@ describe('modules/manager/mise/extract', () => {
       });
     });
 
-    it('extracts ubi backend tools', () => {
+    it('extracts ubi backend tools', async () => {
       const content = codeBlock`
       [tools]
       "ubi:nekto/act" = "v0.2.70"
@@ -644,7 +650,7 @@ describe('modules/manager/mise/extract', () => {
       "ubi:cargo-bins/cargo-binstall[tag_regex=^\\\\d+\\\\.]" = "1.0.0"
       'ubi:cargo-bins/cargo-binstall[tag_regex=^\\d+\\.\\d+\\.]' = { tag_regex = '^\\d+\\.', version = "1.0.0" }
     `;
-      const result = extractPackageFile(content, miseFilename);
+      const result = await extractPackageFile(content, miseFilename);
       expect(result).toMatchObject({
         deps: [
           {
@@ -692,7 +698,7 @@ describe('modules/manager/mise/extract', () => {
       });
     });
 
-    it('extracts github backend tools', () => {
+    it('extracts github backend tools', async () => {
       const content = codeBlock`
       [tools]
       "github:BurntSushi/ripgrep" = "14.1.1"
@@ -700,7 +706,7 @@ describe('modules/manager/mise/extract', () => {
       "github:some/repo" = { version_prefix = "release-", version = "1.0.0" }
       "github:other/repo[version_prefix=v]" = "2.0.0"
     `;
-      const result = extractPackageFile(content, miseFilename);
+      const result = await extractPackageFile(content, miseFilename);
       expect(result).toMatchObject({
         deps: [
           {
@@ -733,13 +739,13 @@ describe('modules/manager/mise/extract', () => {
       });
     });
 
-    it('provides skipReason for lines with unsupported tooling', () => {
+    it('provides skipReason for lines with unsupported tooling', async () => {
       const content = codeBlock`
       [tools]
       fake-tool = '1.0.0'
       'fake:tool' = '1.0.0'
     `;
-      const result = extractPackageFile(content, miseFilename);
+      const result = await extractPackageFile(content, miseFilename);
       expect(result).toMatchObject({
         deps: [
           {
@@ -754,12 +760,12 @@ describe('modules/manager/mise/extract', () => {
       });
     });
 
-    it('provides skipReason for missing version - empty string', () => {
+    it('provides skipReason for missing version - empty string', async () => {
       const content = codeBlock`
       [tools]
       python = ''
     `;
-      const result = extractPackageFile(content, miseFilename);
+      const result = await extractPackageFile(content, miseFilename);
       expect(result).toMatchObject({
         deps: [
           {
@@ -770,12 +776,12 @@ describe('modules/manager/mise/extract', () => {
       });
     });
 
-    it('provides skipReason for missing version - missing version in object', () => {
+    it('provides skipReason for missing version - missing version in object', async () => {
       const content = codeBlock`
       [tools]
       python = {virtualenv='.venv'}
     `;
-      const result = extractPackageFile(content, miseFilename);
+      const result = await extractPackageFile(content, miseFilename);
       expect(result).toMatchObject({
         deps: [
           {
@@ -786,13 +792,13 @@ describe('modules/manager/mise/extract', () => {
       });
     });
 
-    it('provides skipReason for missing version - empty array', () => {
+    it('provides skipReason for missing version - empty array', async () => {
       const content = codeBlock`
       [tools]
       java = '21.0.2'
       erlang = []
     `;
-      const result = extractPackageFile(content, miseFilename);
+      const result = await extractPackageFile(content, miseFilename);
       expect(result).toMatchObject({
         deps: [
           {
@@ -807,8 +813,8 @@ describe('modules/manager/mise/extract', () => {
       });
     });
 
-    it('complete mise.toml example', () => {
-      const result = extractPackageFile(mise1toml, miseFilename);
+    it('complete mise.toml example', async () => {
+      const result = await extractPackageFile(mise1toml, miseFilename);
       expect(result).toMatchObject({
         deps: [
           {
@@ -830,7 +836,7 @@ describe('modules/manager/mise/extract', () => {
       });
     });
 
-    it('complete example with skip', () => {
+    it('complete example with skip', async () => {
       const content = codeBlock`
       [tools]
       java = '21.0.2'
@@ -838,7 +844,7 @@ describe('modules/manager/mise/extract', () => {
       terraform = {version='1.8.0'}
       fake-tool = '1.6.2'
     `;
-      const result = extractPackageFile(content, miseFilename);
+      const result = await extractPackageFile(content, miseFilename);
       expect(result).toMatchObject({
         deps: [
           {
@@ -863,12 +869,12 @@ describe('modules/manager/mise/extract', () => {
       });
     });
 
-    it('core java plugin function', () => {
+    it('core java plugin function', async () => {
       const content = codeBlock`
       [tools]
       java = "21.0.2"
     `;
-      const result = extractPackageFile(content, miseFilename);
+      const result = await extractPackageFile(content, miseFilename);
       expect(result).toMatchObject({
         deps: [
           {
@@ -883,7 +889,7 @@ describe('modules/manager/mise/extract', () => {
       [tools]
       java = "openjdk-21.0.2"
     `;
-      const result2 = extractPackageFile(content2, miseFilename);
+      const result2 = await extractPackageFile(content2, miseFilename);
       expect(result2).toMatchObject({
         deps: [
           {
@@ -898,7 +904,7 @@ describe('modules/manager/mise/extract', () => {
       [tools]
       java = "temurin-21.0.2"
     `;
-      const result3 = extractPackageFile(content3, miseFilename);
+      const result3 = await extractPackageFile(content3, miseFilename);
       expect(result3).toMatchObject({
         deps: [
           {
@@ -913,7 +919,7 @@ describe('modules/manager/mise/extract', () => {
       [tools]
       java = "zulu-21.0.2"
     `;
-      const result4 = extractPackageFile(content4, miseFilename);
+      const result4 = await extractPackageFile(content4, miseFilename);
       expect(result4).toMatchObject({
         deps: [
           {
@@ -928,7 +934,7 @@ describe('modules/manager/mise/extract', () => {
       [tools]
       java = "corretto-21.0.2"
     `;
-      const result5 = extractPackageFile(content5, miseFilename);
+      const result5 = await extractPackageFile(content5, miseFilename);
       expect(result5).toMatchObject({
         deps: [
           {
@@ -943,7 +949,7 @@ describe('modules/manager/mise/extract', () => {
       [tools]
       java = "oracle-graalvm-21.0.2"
     `;
-      const result6 = extractPackageFile(content6, miseFilename);
+      const result6 = await extractPackageFile(content6, miseFilename);
       expect(result6).toMatchObject({
         deps: [
           {
@@ -958,7 +964,7 @@ describe('modules/manager/mise/extract', () => {
       [tools]
       java = "adoptopenjdk-21.0.2"
     `;
-      const result7 = extractPackageFile(content7, miseFilename);
+      const result7 = await extractPackageFile(content7, miseFilename);
       expect(result7).toMatchObject({
         deps: [
           {
@@ -974,7 +980,7 @@ describe('modules/manager/mise/extract', () => {
       [tools]
       java = "adoptopenjdk-jre-16.0.0+36"
     `;
-      const result8 = extractPackageFile(content8, miseFilename);
+      const result8 = await extractPackageFile(content8, miseFilename);
       expect(result8).toMatchObject({
         deps: [
           {
@@ -994,12 +1000,12 @@ describe('modules/manager/mise/extract', () => {
       ${'corretto-21.0'} | ${'21.0'}
     `(
       'uses semver-partial versioning for short java version $version',
-      ({ version, currentValue }) => {
+      async ({ version, currentValue }) => {
         const content = codeBlock`
         [tools]
         java = "${version}"
       `;
-        const result = extractPackageFile(content, miseFilename);
+        const result = await extractPackageFile(content, miseFilename);
         expect(result).toMatchObject({
           deps: [
             {
@@ -1019,12 +1025,12 @@ describe('modules/manager/mise/extract', () => {
       ${'temurin-21.0.2'} | ${'21.0.2'}
     `(
       'does not use semver-partial for full java version $version',
-      ({ version, currentValue }) => {
+      async ({ version, currentValue }) => {
         const content = codeBlock`
         [tools]
         java = "${version}"
       `;
-        const result = extractPackageFile(content, miseFilename);
+        const result = await extractPackageFile(content, miseFilename);
         expect(result).toMatchObject({
           deps: [
             {
@@ -1037,5 +1043,127 @@ describe('modules/manager/mise/extract', () => {
         expect(result?.deps[0]).not.toHaveProperty('versioning');
       },
     );
+  });
+
+  describe('extractPackageFile() with lock files', () => {
+    const lockFileContent = codeBlock`
+      [[tools.node]]
+      version = "20.11.0"
+      backend = "core:node"
+
+      [[tools.python]]
+      version = "3.10.17"
+    `;
+
+    it('extracts lockedVersion when lock file present', async () => {
+      fs.readLocalFile.mockResolvedValueOnce(lockFileContent);
+      const content = codeBlock`
+        [tools]
+        node = "20"
+        python = "3.10"
+      `;
+      const result = await extractPackageFile(content, 'mise.toml');
+      expect(result).toMatchObject({
+        deps: [
+          {
+            depName: 'node',
+            currentValue: '20',
+            lockedVersion: '20.11.0',
+          },
+          {
+            depName: 'python',
+            currentValue: '3.10',
+            lockedVersion: '3.10.17',
+          },
+        ],
+        lockFiles: ['mise.lock'],
+      });
+    });
+
+    it('sets lockFiles array when lock file present', async () => {
+      fs.readLocalFile.mockResolvedValueOnce(lockFileContent);
+      const content = codeBlock`
+        [tools]
+        node = "20"
+      `;
+      const result = await extractPackageFile(content, 'mise.toml');
+      expect(result?.lockFiles).toEqual(['mise.lock']);
+    });
+
+    it('handles missing lock file gracefully', async () => {
+      fs.readLocalFile.mockResolvedValueOnce(null);
+      const content = codeBlock`
+        [tools]
+        node = "20"
+      `;
+      const result = await extractPackageFile(content, 'mise.toml');
+      expect(result?.deps[0]).not.toHaveProperty('lockedVersion');
+      expect(result?.lockFiles).toBeUndefined();
+    });
+
+    it('handles malformed lock file gracefully', async () => {
+      fs.readLocalFile.mockResolvedValueOnce('invalid toml {{{{');
+      const content = codeBlock`
+        [tools]
+        node = "20"
+      `;
+      const result = await extractPackageFile(content, 'mise.toml');
+      expect(result?.deps[0]).not.toHaveProperty('lockedVersion');
+      expect(result?.lockFiles).toBeUndefined();
+    });
+
+    it('works with environment-specific lock files', async () => {
+      const testLockFileContent = codeBlock`
+        [[tools.node]]
+        version = "18.19.0"
+      `;
+      fs.readLocalFile.mockResolvedValueOnce(testLockFileContent);
+      const content = codeBlock`
+        [tools]
+        node = "18"
+      `;
+      const result = await extractPackageFile(content, 'mise.test.toml');
+      expect(result?.lockFiles).toEqual(['mise.test.lock']);
+      expect(result?.deps[0]).toMatchObject({
+        depName: 'node',
+        currentValue: '18',
+        lockedVersion: '18.19.0',
+      });
+    });
+
+    it('extracts lockedVersion for tools with backend prefix', async () => {
+      fs.readLocalFile.mockResolvedValueOnce(lockFileContent);
+      const content = codeBlock`
+        [tools]
+        "core:node" = "20"
+      `;
+      const result = await extractPackageFile(content, 'mise.toml');
+      expect(result?.deps[0]).toMatchObject({
+        depName: 'core:node',
+        currentValue: '20',
+        lockedVersion: '20.11.0',
+      });
+    });
+
+    it('extracts first lockedVersion when multiple versions exist', async () => {
+      const multiVersionLockFileContent = codeBlock`
+        [[tools.python]]
+        version = "3.10.17"
+
+        [[tools.python]]
+        version = "3.11.12"
+      `;
+      fs.readLocalFile.mockResolvedValueOnce(multiVersionLockFileContent);
+      const content = codeBlock`
+        [tools]
+        python = ["3.10", "3.11"]
+      `;
+      const result = await extractPackageFile(content, 'mise.toml');
+      expect(result?.deps[0]).toMatchObject({
+        depName: 'python',
+        currentValue: '3.10',
+        lockedVersion: '3.10.17',
+      });
+    });
   });
 });

--- a/lib/modules/manager/mise/extract.ts
+++ b/lib/modules/manager/mise/extract.ts
@@ -77,7 +77,6 @@ export async function extractPackageFile(
 
   const result: PackageFileContent = { deps };
 
-  // Try to read and parse lock file for locked versions
   const lockFileName = getLockFileName(packageFile);
   const lockFileContent = await readLocalFile(lockFileName, 'utf8');
 
@@ -87,7 +86,6 @@ export async function extractPackageFile(
       result.lockFiles = [lockFileName];
       for (const dep of deps) {
         if (dep.depName) {
-          // Extract the tool name without the backend prefix for lock file lookup
           const toolName = getToolNameForLockFile(dep.depName);
           const lockedTools = lockFileParsed.data.tools[toolName];
           if (lockedTools?.length) {
@@ -108,14 +106,13 @@ export async function extractPackageFile(
 
 /**
  * Get the tool name used in the lock file from the dependency name.
- * Lock files use the tool name without backend prefix.
+ * Lock files use the tool name without backend prefix (e.g., "core:node" -> "node").
  */
 function getToolNameForLockFile(depName: string): string {
   const delimiterIndex = depName.indexOf(':');
   if (delimiterIndex === -1) {
     return depName;
   }
-  // Remove backend prefix (e.g., "core:node" -> "node")
   return depName.substring(delimiterIndex + 1);
 }
 

--- a/lib/modules/manager/mise/extract.ts
+++ b/lib/modules/manager/mise/extract.ts
@@ -7,6 +7,7 @@ import {
   isString,
 } from '@sindresorhus/is';
 import { logger } from '../../../logger/index.ts';
+import { readLocalFile } from '../../../util/fs/index.ts';
 import { regEx } from '../../../util/regex.ts';
 import type { StaticTooling } from '../asdf/upgradeable-tooling.ts';
 import type { PackageDependency, PackageFileContent } from '../types.ts';
@@ -23,7 +24,9 @@ import {
   createSpmToolConfig,
   createUbiToolConfig,
 } from './backends.ts';
+import { getLockFileName } from './lockfile.ts';
 import type { MiseTool, MiseToolOptions } from './schema.ts';
+import { MiseLockFile } from './schema.ts';
 import type { ToolingDefinition } from './upgradeable-tooling.ts';
 import { asdfTooling, miseTooling } from './upgradeable-tooling.ts';
 import { parseTomlFile } from './utils.ts';
@@ -32,10 +35,10 @@ import { parseTomlFile } from './utils.ts';
 // e.g. ubi:tamasfe/taplo[matching=full,exe=taplo]
 const optionInToolNameRegex = regEx(/^(?<name>.+?)(?:\[(?<options>.+)\])?$/);
 
-export function extractPackageFile(
+export async function extractPackageFile(
   content: string,
   packageFile: string,
-): PackageFileContent | null {
+): Promise<PackageFileContent | null> {
   logger.trace(`mise.extractPackageFile(${packageFile})`);
 
   const misefile = parseTomlFile(content, packageFile);
@@ -68,7 +71,52 @@ export function extractPackageFile(
     }
   }
 
-  return deps.length ? { deps } : null;
+  if (!deps.length) {
+    return null;
+  }
+
+  const result: PackageFileContent = { deps };
+
+  // Try to read and parse lock file for locked versions
+  const lockFileName = getLockFileName(packageFile);
+  const lockFileContent = await readLocalFile(lockFileName, 'utf8');
+
+  if (lockFileContent) {
+    const lockFileParsed = MiseLockFile.safeParse(lockFileContent);
+    if (lockFileParsed.success) {
+      result.lockFiles = [lockFileName];
+      for (const dep of deps) {
+        if (dep.depName) {
+          // Extract the tool name without the backend prefix for lock file lookup
+          const toolName = getToolNameForLockFile(dep.depName);
+          const lockedTools = lockFileParsed.data.tools[toolName];
+          if (lockedTools?.length) {
+            dep.lockedVersion = lockedTools[0].version;
+          }
+        }
+      }
+    } else {
+      logger.debug(
+        { lockFileName, error: lockFileParsed.error },
+        'Failed to parse mise lock file',
+      );
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Get the tool name used in the lock file from the dependency name.
+ * Lock files use the tool name without backend prefix.
+ */
+function getToolNameForLockFile(depName: string): string {
+  const delimiterIndex = depName.indexOf(':');
+  if (delimiterIndex === -1) {
+    return depName;
+  }
+  // Remove backend prefix (e.g., "core:node" -> "node")
+  return depName.substring(delimiterIndex + 1);
 }
 
 function parseVersion(toolData: MiseTool): string | null {

--- a/lib/modules/manager/mise/extract.ts
+++ b/lib/modules/manager/mise/extract.ts
@@ -24,7 +24,7 @@ import {
   createSpmToolConfig,
   createUbiToolConfig,
 } from './backends.ts';
-import { getLockFileName } from './lockfile.ts';
+import { getLockFileName, getLockedVersion } from './lockfile.ts';
 import type { MiseTool, MiseToolOptions } from './schema.ts';
 import { MiseLockFile } from './schema.ts';
 import type { ToolingDefinition } from './upgradeable-tooling.ts';
@@ -35,6 +35,11 @@ import { parseTomlFile } from './utils.ts';
 // e.g. ubi:tamasfe/taplo[matching=full,exe=taplo]
 const optionInToolNameRegex = regEx(/^(?<name>.+?)(?:\[(?<options>.+)\])?$/);
 
+/**
+ * Extracts mise tool dependencies from a mise configuration file.
+ * Supports various backends (core, asdf, aqua, cargo, etc.) and
+ * extracts locked versions when a corresponding lock file exists.
+ */
 export async function extractPackageFile(
   content: string,
   packageFile: string,
@@ -86,10 +91,12 @@ export async function extractPackageFile(
       result.lockFiles = [lockFileName];
       for (const dep of deps) {
         if (dep.depName) {
-          const toolName = getToolNameForLockFile(dep.depName);
-          const lockedTools = lockFileParsed.data.tools[toolName];
-          if (lockedTools?.length) {
-            dep.lockedVersion = lockedTools[0].version;
+          const lockedVersion = getLockedVersion(
+            lockFileParsed.data,
+            dep.depName,
+          );
+          if (lockedVersion) {
+            dep.lockedVersion = lockedVersion;
           }
         }
       }
@@ -102,18 +109,6 @@ export async function extractPackageFile(
   }
 
   return result;
-}
-
-/**
- * Get the tool name used in the lock file from the dependency name.
- * Lock files use the tool name without backend prefix (e.g., "core:node" -> "node").
- */
-function getToolNameForLockFile(depName: string): string {
-  const delimiterIndex = depName.indexOf(':');
-  if (delimiterIndex === -1) {
-    return depName;
-  }
-  return depName.substring(delimiterIndex + 1);
 }
 
 function parseVersion(toolData: MiseTool): string | null {

--- a/lib/modules/manager/mise/index.ts
+++ b/lib/modules/manager/mise/index.ts
@@ -14,9 +14,12 @@ import { RubyVersionDatasource } from '../../datasource/ruby-version/index.ts';
 import { RubygemsDatasource } from '../../datasource/rubygems/index.ts';
 import { supportedDatasources as asdfSupportedDatasources } from '../asdf/index.ts';
 
+export { updateArtifacts, updateLockedDependency } from './artifacts.ts';
 export { extractPackageFile } from './extract.ts';
 
 export const displayName = 'mise-en-place';
+export const supportsLockFileMaintenance = true;
+export const lockFileNames = ['mise.lock'];
 export const url = 'https://mise.jdx.dev';
 
 export const defaultConfig = {

--- a/lib/modules/manager/mise/lockfile.spec.ts
+++ b/lib/modules/manager/mise/lockfile.spec.ts
@@ -1,0 +1,22 @@
+import { getLockFileName } from './lockfile.ts';
+
+describe('modules/manager/mise/lockfile', () => {
+  describe('getLockFileName()', () => {
+    it.each`
+      configPath                    | expected
+      ${'mise.toml'}                | ${'mise.lock'}
+      ${'.mise.toml'}               | ${'mise.lock'}
+      ${'config.toml'}              | ${'mise.lock'}
+      ${'mise.test.toml'}           | ${'mise.test.lock'}
+      ${'mise.staging.toml'}        | ${'mise.staging.lock'}
+      ${'mise.local.toml'}          | ${'mise.local.lock'}
+      ${'mise.test.local.toml'}     | ${'mise.test.local.lock'}
+      ${'subdir/mise.toml'}         | ${'subdir/mise.lock'}
+      ${'subdir/mise.prod.toml'}    | ${'subdir/mise.prod.lock'}
+      ${'conf.d/python.toml'}       | ${'mise.lock'}
+      ${'project/conf.d/node.toml'} | ${'project/mise.lock'}
+    `('returns $expected for $configPath', ({ configPath, expected }) => {
+      expect(getLockFileName(configPath)).toBe(expected);
+    });
+  });
+});

--- a/lib/modules/manager/mise/lockfile.spec.ts
+++ b/lib/modules/manager/mise/lockfile.spec.ts
@@ -1,4 +1,5 @@
-import { getLockFileName } from './lockfile.ts';
+import { getLockFileName, getLockedVersion } from './lockfile.ts';
+import type { MiseLockFile } from './schema.ts';
 
 describe('modules/manager/mise/lockfile', () => {
   describe('getLockFileName()', () => {
@@ -17,6 +18,44 @@ describe('modules/manager/mise/lockfile', () => {
       ${'project/conf.d/node.toml'} | ${'project/mise.lock'}
     `('returns $expected for $configPath', ({ configPath, expected }) => {
       expect(getLockFileName(configPath)).toBe(expected);
+    });
+  });
+
+  describe('getLockedVersion()', () => {
+    const lockFileData: MiseLockFile = {
+      tools: {
+        node: [{ version: '20.11.0' }],
+        python: [{ version: '3.10.17' }, { version: '3.11.12' }],
+        'aqua:cli/cli': [{ version: '2.64.0' }],
+        'ubi:cargo-bins/cargo-binstall': [{ version: '1.10.21' }],
+      },
+    };
+
+    it.each`
+      depName                            | expected
+      ${'node'}                          | ${'20.11.0'}
+      ${'core:node'}                     | ${'20.11.0'}
+      ${'asdf:node'}                     | ${'20.11.0'}
+      ${'python'}                        | ${'3.10.17'}
+      ${'core:python'}                   | ${'3.10.17'}
+      ${'aqua:cli/cli'}                  | ${'2.64.0'}
+      ${'ubi:cargo-bins/cargo-binstall'} | ${'1.10.21'}
+      ${'unknown'}                       | ${undefined}
+      ${'core:unknown'}                  | ${undefined}
+    `('returns $expected for $depName', ({ depName, expected }) => {
+      expect(getLockedVersion(lockFileData, depName)).toBe(expected);
+    });
+
+    it('returns first version when multiple versions exist', () => {
+      expect(getLockedVersion(lockFileData, 'python')).toBe('3.10.17');
+    });
+
+    it('handles tools with bracket options in name', () => {
+      // depName from extraction has brackets stripped by regex,
+      // so we test the full backend-qualified name
+      expect(
+        getLockedVersion(lockFileData, 'ubi:cargo-bins/cargo-binstall'),
+      ).toBe('1.10.21');
     });
   });
 });

--- a/lib/modules/manager/mise/lockfile.ts
+++ b/lib/modules/manager/mise/lockfile.ts
@@ -1,5 +1,6 @@
 import upath from 'upath';
 import { regEx } from '../../../util/regex.ts';
+import type { MiseLockFile } from './schema.ts';
 
 /**
  * Derives the lock file path from a mise config file path.
@@ -34,4 +35,52 @@ export function getLockFileName(configPath: string): string {
   }
 
   return upath.join(lockDir, lockFileName);
+}
+
+/**
+ * Get the locked version for a dependency from the parsed lock file.
+ *
+ * Mise lock files use different key formats depending on whether a tool is in
+ * the mise registry:
+ * - Registry tools (e.g., node, python): key is the short name ("node")
+ * - Non-registry tools (e.g., ubi:owner/repo): key is the full name ("ubi:owner/repo")
+ *
+ * When a user specifies "core:node" in their config, mise resolves it to the
+ * registry short name "node" in the lock file. But "aqua:cli/cli" (not in
+ * registry) stays as "aqua:cli/cli" in the lock file.
+ *
+ * We use a fallback approach (Option A) rather than checking the registry (Option B):
+ *
+ * Option A (implemented): Try full depName first, then try stripped short name.
+ *   Pros: Simple, no registry dependency, works even if Renovate's registry
+ *         is out of sync with mise's registry.
+ *   Cons: Theoretical collision risk if both "foo" and "backend:foo" exist
+ *         in the same lock file (practically impossible - mise wouldn't generate this).
+ *
+ * Option B (not implemented): Check miseTooling/asdfTooling to determine if
+ *   the tool is in the registry, then use short name or full name accordingly.
+ *   Pros: Matches mise's exact logic.
+ *   Cons: More complex, requires passing registry data, fails if Renovate's
+ *         registry doesn't include a tool that mise's registry does.
+ *
+ * Option A is preferred because it's simpler, has no practical downsides, and
+ * doesn't couple lock file parsing to Renovate's registry coverage.
+ */
+export function getLockedVersion(
+  lockFileData: MiseLockFile,
+  depName: string,
+): string | undefined {
+  // Try full name first (for non-registry tools like ubi:, aqua:)
+  let lockedTools = lockFileData.tools[depName];
+
+  // If not found and has backend prefix, try stripped name (for registry tools)
+  if (!lockedTools) {
+    const delimiterIndex = depName.indexOf(':');
+    if (delimiterIndex !== -1) {
+      const shortName = depName.substring(delimiterIndex + 1);
+      lockedTools = lockFileData.tools[shortName];
+    }
+  }
+
+  return lockedTools?.[0]?.version;
 }

--- a/lib/modules/manager/mise/lockfile.ts
+++ b/lib/modules/manager/mise/lockfile.ts
@@ -1,0 +1,39 @@
+import upath from 'upath';
+import { regEx } from '../../../util/regex.ts';
+
+/**
+ * Derives the lock file path from a mise config file path.
+ * Matches mise's lockfile_path_for_config() logic from src/lockfile.rs
+ */
+export function getLockFileName(configPath: string): string {
+  const filename = upath.basename(configPath);
+  const dirname = upath.dirname(configPath);
+  const parentDirname = upath.basename(dirname);
+
+  // For conf.d files, lock file goes in parent directory
+  const lockDir = parentDirname === 'conf.d' ? upath.dirname(dirname) : dirname;
+
+  // Check if this is a local config
+  const isLocal = filename.includes('.local.');
+
+  // Extract environment from filename
+  // Patterns: mise.{env}.toml, mise.{env}.local.toml, .mise.{env}.toml, config.{env}.toml
+  const envMatch = regEx(
+    /^(?:\.?mise|config)\.([^.]+)(?:\.local)?\.toml$/,
+  ).exec(filename);
+  const env = envMatch?.[1] === 'local' ? undefined : envMatch?.[1];
+
+  // Build lock file name
+  let lockFileName: string;
+  if (env && isLocal) {
+    lockFileName = `mise.${env}.local.lock`;
+  } else if (env) {
+    lockFileName = `mise.${env}.lock`;
+  } else if (isLocal) {
+    lockFileName = 'mise.local.lock';
+  } else {
+    lockFileName = 'mise.lock';
+  }
+
+  return upath.join(lockDir, lockFileName);
+}

--- a/lib/modules/manager/mise/lockfile.ts
+++ b/lib/modules/manager/mise/lockfile.ts
@@ -13,7 +13,6 @@ export function getLockFileName(configPath: string): string {
   // For conf.d files, lock file goes in parent directory
   const lockDir = parentDirname === 'conf.d' ? upath.dirname(dirname) : dirname;
 
-  // Check if this is a local config
   const isLocal = filename.includes('.local.');
 
   // Extract environment from filename
@@ -23,7 +22,6 @@ export function getLockFileName(configPath: string): string {
   ).exec(filename);
   const env = envMatch?.[1] === 'local' ? undefined : envMatch?.[1];
 
-  // Build lock file name
   let lockFileName: string;
   if (env && isLocal) {
     lockFileName = `mise.${env}.local.lock`;

--- a/lib/modules/manager/mise/readme.md
+++ b/lib/modules/manager/mise/readme.md
@@ -11,6 +11,24 @@ Renovate supports all standard mise configuration file patterns:
 - Environment-specific variants (e.g., `mise.production.toml`, `.mise.dev.toml`)
 - Local variants (e.g., `mise.local.toml`, `.mise.local.toml`)
 
+### Lock file support
+
+Renovate supports mise lock files (`mise.lock`).
+When a lock file is present:
+
+- Dependencies will have their `lockedVersion` extracted from the lock file
+- Renovate can update lock files when dependencies change
+- Lock file maintenance is supported via the `lockFileMaintenance` option
+
+Renovate recognizes environment-specific lock files:
+
+- `mise.lock` - default lock file
+- `mise.local.lock` - local configuration lock file
+- `mise.{env}.lock` - environment-specific lock files (e.g., `mise.production.lock`)
+- `mise.{env}.local.lock` - environment-specific local lock files
+
+For more information about mise lock files, see the [mise lock file documentation](https://mise.jdx.dev/dev-tools/mise-lock.html).
+
 ### Renovate only updates primary versions
 
 Renovate's `mise` manager is designed to automatically update the _first_ (primary) version listed for each tool in the `mise.toml` file.

--- a/lib/modules/manager/mise/schema.ts
+++ b/lib/modules/manager/mise/schema.ts
@@ -24,3 +24,25 @@ export const MiseFile = Toml.pipe(
   }),
 );
 export type MiseFile = z.infer<typeof MiseFile>;
+
+const MiseLockTool = z.object({
+  version: z.string(),
+  backend: z.string().optional(),
+  options: z.record(z.string()).optional(),
+  platforms: z
+    .record(
+      z.object({
+        checksum: z.string().optional(),
+        size: z.number().optional(),
+        url: z.string().optional(),
+      }),
+    )
+    .optional(),
+});
+
+export const MiseLockFile = Toml.pipe(
+  z.object({
+    tools: z.record(z.array(MiseLockTool)),
+  }),
+);
+export type MiseLockFile = z.infer<typeof MiseLockFile>;


### PR DESCRIPTION
## Summary

Adds lock file support to the mise package manager, enabling Renovate to:
- Extract locked versions from `mise.lock` files
- Update lock files when dependencies change
- Support lock file maintenance mode

Closes #40568

## Changes

### New Files
- **`lib/modules/manager/mise/lockfile.ts`** - `getLockFileName()` utility for deriving lock file paths
- **`lib/modules/manager/mise/lockfile.spec.ts`** - Tests for lock file path derivation
- **`lib/modules/manager/mise/artifacts.ts`** - `updateArtifacts()` and `updateLockedDependency()` functions
- **`lib/modules/manager/mise/artifacts.spec.ts`** - Tests for artifact updates

### Modified Files
- **`lib/modules/manager/mise/index.ts`** - Added exports for lock file support
- **`lib/modules/manager/mise/schema.ts`** - Added `MiseLockFile` Zod schema
- **`lib/modules/manager/mise/extract.ts`** - Made async, added `lockedVersion` extraction
- **`lib/modules/manager/mise/extract.spec.ts`** - Converted to async, added lock file tests

## Implementation Details

- Follows patterns from `nix` and `cargo` managers
- Handles TEMPORARY_ERROR for Renovate's retry mechanism
- Combines stdout/stderr/message in artifact errors for better debugging
- `updateLockedDependency()` returns `already-updated` when version matches