### PR TITLE
fix(preset): restore subdirectory and prefix matching for `gitlabPipelineVersions` preset

### DIFF
--- a/lib/config/presets/internal/custom-managers.preset.ts
+++ b/lib/config/presets/internal/custom-managers.preset.ts
@@ -80,7 +80,7 @@ export const presets: Record<string, Preset> = {
     customManagers: [
       {
         customType: 'regex',
-        managerFilePatterns: ['.gitlab-ci.{yml,yaml}'],
+        managerFilePatterns: ['**/*.gitlab-ci.{yml,yaml}'],
         matchStrings: [
           '# renovate: datasource=(?<datasource>[a-zA-Z0-9-._]+?) depName=(?<depName>[^\\s]+?)(?: (?:packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?(?: registryUrl=(?<registryUrl>[^\\s]+?))?\\s+[A-Za-z0-9_]+?_VERSION\\s*:\\s*["\']?(?<currentValue>.+?)["\']?\\s',
         ],

--- a/lib/config/presets/internal/custom-managers.spec.ts
+++ b/lib/config/presets/internal/custom-managers.spec.ts
@@ -606,13 +606,19 @@ describe('config/presets/internal/custom-managers', () => {
 
     describe('matches regexes patterns', () => {
       it.each`
-        path                        | expected
-        ${'.gitlab-ci.yaml'}        | ${true}
-        ${'.gitlab-ci.yml'}         | ${true}
-        ${'foo.yaml'}               | ${false}
-        ${'foo.yml'}                | ${false}
-        ${'.gitlab/ci.yml'}         | ${false}
-        ${'includes/gitlab-ci.yml'} | ${false}
+        path                             | expected
+        ${'.gitlab-ci.yaml'}             | ${true}
+        ${'.gitlab-ci.yml'}              | ${true}
+        ${'foo.gitlab-ci.yaml'}          | ${true}
+        ${'foo.gitlab-ci.yml'}           | ${true}
+        ${'includes/.gitlab-ci.yaml'}    | ${true}
+        ${'includes/.gitlab-ci.yml'}     | ${true}
+        ${'includes/foo.gitlab-ci.yaml'} | ${true}
+        ${'includes/foo.gitlab-ci.yml'}  | ${true}
+        ${'foo.yaml'}                    | ${false}
+        ${'foo.yml'}                     | ${false}
+        ${'.gitlab/ci.yml'}              | ${false}
+        ${'includes/gitlab-ci.yml'}      | ${false}
       `('$path', ({ path, expected }) => {
         expect(
           matchRegexOrGlobList(path, customManager!.managerFilePatterns),


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

I've fixed a regression introduced in #34615 in which the `gitlabPipelineVersions` custom manager preset only matches `.gitlab-ci.{yml,yaml}` files in the repository root, breaking support for prefixed filenames and nested directories:

```diff
     customManagers: [
       {
         customType: 'regex',
-        fileMatch: ['\\.gitlab-ci\\.ya?ml$'],
+        managerFilePatterns: ['/\\.gitlab-ci\\.ya?ml$/'],
         ...
       }
     ]
```

I've also extended the test table by cases covering subdirectory and prefixed filenames to guard against future regression.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required _(the [preset snippet](https://docs.renovatebot.com/presets-customManagers/#custommanagersgitlabpipelineversions) in the docs is generated AFAIK)_

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: n/a

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
