### PR TITLE
fix(platform/bitbucket): replace deprecated cross-workspace repos endpoint

### DIFF
--- a/lib/modules/platform/bitbucket/index.spec.ts
+++ b/lib/modules/platform/bitbucket/index.spec.ts
@@ -129,8 +129,8 @@ describe('modules/platform/bitbucket/index', () => {
         .get('/2.0/user/workspaces?pagelen=100')
         .reply(200, {
           values: [
-            { workspace: { slug: 'some' } },
             { workspace: { slug: 'foo' } },
+            { workspace: { slug: 'some' } },
           ],
         })
         .get('/2.0/repositories/foo?pagelen=100')
@@ -154,7 +154,7 @@ describe('modules/platform/bitbucket/index', () => {
           ],
         });
       const res = await bitbucket.getRepos({});
-      expect(res).toEqual(['some/repo', 'foo/bar']);
+      expect(res).toEqual(['foo/bar', 'some/repo']);
     });
 
     it('uses configured namespaces directly without fetching workspaces', async () => {
@@ -187,19 +187,19 @@ describe('modules/platform/bitbucket/index', () => {
             {
               mainbranch: { name: 'master' },
               uuid: '111',
-              full_name: 'foo/bar',
+              full_name: 'some/bar',
               project: { name: 'ignore' },
             },
             {
               mainbranch: { name: 'master' },
               uuid: '222',
-              full_name: 'foo/repo',
+              full_name: 'some/repo',
               project: { name: 'allow' },
             },
           ],
         });
       const res = await bitbucket.getRepos({ projects: ['allow'] });
-      expect(res).toEqual(['foo/repo']);
+      expect(res).toEqual(['some/repo']);
     });
 
     it('filters repos based on autodiscoverProjects patterns with negation', async () => {
@@ -215,19 +215,19 @@ describe('modules/platform/bitbucket/index', () => {
             {
               mainbranch: { name: 'master' },
               uuid: '111',
-              full_name: 'some/bar',
+              full_name: 'foo/bar',
               project: { name: 'ignore' },
             },
             {
               mainbranch: { name: 'master' },
               uuid: '222',
-              full_name: 'some/repo',
+              full_name: 'foo/repo',
               project: { name: 'allow' },
             },
           ],
         });
       const res = await bitbucket.getRepos({ projects: ['!ignore'] });
-      expect(res).toEqual(['some/repo']);
+      expect(res).toEqual(['foo/repo']);
     });
   });
 

--- a/lib/modules/platform/bitbucket/index.spec.ts
+++ b/lib/modules/platform/bitbucket/index.spec.ts
@@ -126,7 +126,14 @@ describe('modules/platform/bitbucket/index', () => {
     it('returns repos', async () => {
       httpMock
         .scope(baseUrl)
-        .get('/2.0/repositories?role=contributor&pagelen=100')
+        .get('/2.0/user/workspaces?pagelen=100')
+        .reply(200, {
+          values: [
+            { workspace: { slug: 'foo' } },
+            { workspace: { slug: 'some' } },
+          ],
+        })
+        .get('/2.0/repositories/foo?pagelen=100')
         .reply(200, {
           values: [
             {
@@ -134,6 +141,11 @@ describe('modules/platform/bitbucket/index', () => {
               uuid: '111',
               full_name: 'foo/bar',
             },
+          ],
+        })
+        .get('/2.0/repositories/some?pagelen=100')
+        .reply(200, {
+          values: [
             {
               mainbranch: { name: 'master' },
               uuid: '222',
@@ -145,10 +157,31 @@ describe('modules/platform/bitbucket/index', () => {
       expect(res).toEqual(['foo/bar', 'some/repo']);
     });
 
+    it('uses configured namespaces directly without fetching workspaces', async () => {
+      httpMock
+        .scope(baseUrl)
+        .get('/2.0/repositories/foo?pagelen=100')
+        .reply(200, {
+          values: [
+            {
+              mainbranch: { name: 'master' },
+              uuid: '111',
+              full_name: 'foo/bar',
+            },
+          ],
+        });
+      const res = await bitbucket.getRepos({ namespaces: ['foo'] });
+      expect(res).toEqual(['foo/bar']);
+    });
+
     it('filters repos based on autodiscoverProjects patterns', async () => {
       httpMock
         .scope(baseUrl)
-        .get('/2.0/repositories?role=contributor&pagelen=100')
+        .get('/2.0/user/workspaces?pagelen=100')
+        .reply(200, {
+          values: [{ workspace: { slug: 'foo' } }],
+        })
+        .get('/2.0/repositories/foo?pagelen=100')
         .reply(200, {
           values: [
             {
@@ -160,25 +193,29 @@ describe('modules/platform/bitbucket/index', () => {
             {
               mainbranch: { name: 'master' },
               uuid: '222',
-              full_name: 'some/repo',
+              full_name: 'foo/repo',
               project: { name: 'allow' },
             },
           ],
         });
       const res = await bitbucket.getRepos({ projects: ['allow'] });
-      expect(res).toEqual(['some/repo']);
+      expect(res).toEqual(['foo/repo']);
     });
 
     it('filters repos based on autodiscoverProjects patterns with negation', async () => {
       httpMock
         .scope(baseUrl)
-        .get('/2.0/repositories?role=contributor&pagelen=100')
+        .get('/2.0/user/workspaces?pagelen=100')
+        .reply(200, {
+          values: [{ workspace: { slug: 'some' } }],
+        })
+        .get('/2.0/repositories/some?pagelen=100')
         .reply(200, {
           values: [
             {
               mainbranch: { name: 'master' },
               uuid: '111',
-              full_name: 'foo/bar',
+              full_name: 'some/bar',
               project: { name: 'ignore' },
             },
             {

--- a/lib/modules/platform/bitbucket/index.spec.ts
+++ b/lib/modules/platform/bitbucket/index.spec.ts
@@ -221,13 +221,13 @@ describe('modules/platform/bitbucket/index', () => {
             {
               mainbranch: { name: 'master' },
               uuid: '222',
-              full_name: 'foo/repo',
+              full_name: 'some/repo',
               project: { name: 'allow' },
             },
           ],
         });
       const res = await bitbucket.getRepos({ projects: ['!ignore'] });
-      expect(res).toEqual(['foo/repo']);
+      expect(res).toEqual(['some/repo']);
     });
   });
 

--- a/lib/modules/platform/bitbucket/index.spec.ts
+++ b/lib/modules/platform/bitbucket/index.spec.ts
@@ -129,8 +129,8 @@ describe('modules/platform/bitbucket/index', () => {
         .get('/2.0/user/workspaces?pagelen=100')
         .reply(200, {
           values: [
-            { workspace: { slug: 'foo' } },
             { workspace: { slug: 'some' } },
+            { workspace: { slug: 'foo' } },
           ],
         })
         .get('/2.0/repositories/foo?pagelen=100')
@@ -154,7 +154,7 @@ describe('modules/platform/bitbucket/index', () => {
           ],
         });
       const res = await bitbucket.getRepos({});
-      expect(res).toEqual(['foo/bar', 'some/repo']);
+      expect(res).toEqual(['some/repo', 'foo/bar']);
     });
 
     it('uses configured namespaces directly without fetching workspaces', async () => {
@@ -179,9 +179,9 @@ describe('modules/platform/bitbucket/index', () => {
         .scope(baseUrl)
         .get('/2.0/user/workspaces?pagelen=100')
         .reply(200, {
-          values: [{ workspace: { slug: 'foo' } }],
+          values: [{ workspace: { slug: 'some' } }],
         })
-        .get('/2.0/repositories/foo?pagelen=100')
+        .get('/2.0/repositories/some?pagelen=100')
         .reply(200, {
           values: [
             {
@@ -207,9 +207,9 @@ describe('modules/platform/bitbucket/index', () => {
         .scope(baseUrl)
         .get('/2.0/user/workspaces?pagelen=100')
         .reply(200, {
-          values: [{ workspace: { slug: 'some' } }],
+          values: [{ workspace: { slug: 'foo' } }],
         })
-        .get('/2.0/repositories/some?pagelen=100')
+        .get('/2.0/repositories/foo?pagelen=100')
         .reply(200, {
           values: [
             {

--- a/lib/modules/platform/bitbucket/index.ts
+++ b/lib/modules/platform/bitbucket/index.ts
@@ -40,7 +40,12 @@ import { smartTruncate } from '../utils/pr-body.ts';
 import { readOnlyIssueBody } from '../utils/read-only-issue-body.ts';
 import * as comments from './comments.ts';
 import { BitbucketPrCache } from './pr-cache.ts';
-import { RepoInfo, Repositories, UnresolvedPrTasks } from './schema.ts';
+import {
+  RepoInfo,
+  Repositories,
+  UnresolvedPrTasks,
+  WorkspaceAccesses,
+} from './schema.ts';
 import type {
   Account,
   BitbucketStatus,
@@ -125,14 +130,49 @@ export async function initPlatform({
 export async function getRepos(config: AutodiscoverConfig): Promise<string[]> {
   logger.debug('Autodiscovering Bitbucket Cloud repositories');
   try {
-    let { body: repos } = await bitbucketHttp.getJson(
-      `/2.0/repositories/?role=contributor`,
-      { paginate: true },
-      Repositories,
+    // Determine which workspaces to query.
+    // If the caller supplied explicit namespaces use them directly;
+    // otherwise discover all workspaces the authenticated user belongs to.
+    // The old cross-workspace endpoint GET /2.0/repositories?role=contributor
+    // was removed by Bitbucket on 2026-03-31 (CHANGE-2770).
+    let workspaceSlugs: string[];
+    const autodiscoverNamespaces = config.namespaces;
+    if (isNonEmptyArray(autodiscoverNamespaces)) {
+      logger.debug(
+        { autodiscoverNamespaces },
+        'Using configured namespaces as Bitbucket workspaces',
+      );
+      workspaceSlugs = autodiscoverNamespaces;
+    } else {
+      logger.debug('Fetching Bitbucket workspaces for the current user');
+      const { body: slugs } = await bitbucketHttp.getJson(
+        '/2.0/user/workspaces',
+        { paginate: true },
+        WorkspaceAccesses,
+      );
+      workspaceSlugs = slugs;
+      logger.debug(
+        { workspaceSlugs },
+        `Found ${workspaceSlugs.length} Bitbucket workspace(s)`,
+      );
+    }
+
+    // Fetch repositories for every workspace in parallel.
+    const repoArrays = await Promise.all(
+      workspaceSlugs.map((workspace) =>
+        bitbucketHttp
+          .getJson(
+            `/2.0/repositories/${workspace}`,
+            { paginate: true },
+            Repositories,
+          )
+          .then(({ body }) => body),
+      ),
     );
 
-    // if autodiscoverProjects is configured
-    // filter the repos list
+    let repos = repoArrays.flat();
+
+    // if autodiscoverProjects is configured, filter the repos list
     const autodiscoverProjects = config.projects;
     if (isNonEmptyArray(autodiscoverProjects)) {
       logger.debug(

--- a/lib/modules/platform/bitbucket/index.ts
+++ b/lib/modules/platform/bitbucket/index.ts
@@ -14,6 +14,7 @@ import {
   repoCacheProvider,
 } from '../../../util/http/cache/repository-http-cache-provider.ts';
 import type { HttpOptions } from '../../../util/http/types.ts';
+import * as promises from '../../../util/promises.ts';
 import { regEx } from '../../../util/regex.ts';
 import { sanitize } from '../../../util/sanitize.ts';
 import { UUIDRegex, matchRegexOrGlobList } from '../../../util/string-match.ts';
@@ -157,17 +158,15 @@ export async function getRepos(config: AutodiscoverConfig): Promise<string[]> {
       );
     }
 
-    // Fetch repositories for every workspace in parallel.
-    const repoArrays = await Promise.all(
-      workspaceSlugs.map((workspace) =>
-        bitbucketHttp
-          .getJson(
-            `/2.0/repositories/${workspace}`,
-            { paginate: true },
-            Repositories,
-          )
-          .then(({ body }) => body),
-      ),
+    // Fetch repositories for every workspace in parallel (concurrency-limited).
+    const repoArrays = await promises.map(workspaceSlugs, (workspace) =>
+      bitbucketHttp
+        .getJson(
+          `/2.0/repositories/${workspace}`,
+          { paginate: true },
+          Repositories,
+        )
+        .then(({ body }) => body),
     );
 
     let repos = repoArrays.flat();

--- a/lib/modules/platform/bitbucket/schema.ts
+++ b/lib/modules/platform/bitbucket/schema.ts
@@ -93,3 +93,15 @@ export const UnresolvedPrTasks = z
   .transform((data) =>
     data.values.filter((task) => task.state === 'UNRESOLVED'),
   );
+
+const WorkspaceAccess = z.object({
+  workspace: z.object({
+    slug: z.string(),
+  }),
+});
+
+export const WorkspaceAccesses = z
+  .object({
+    values: LooseArray(WorkspaceAccess),
+  })
+  .transform((body) => body.values.map(({ workspace }) => workspace.slug));

--- a/lib/modules/platform/bitbucket/schema.ts
+++ b/lib/modules/platform/bitbucket/schema.ts
@@ -102,6 +102,6 @@ const WorkspaceAccess = z.object({
 
 export const WorkspaceAccesses = z
   .object({
-    values: LooseArray(WorkspaceAccess),
+    values: z.array(WorkspaceAccess),
   })
   .transform((body) => body.values.map(({ workspace }) => workspace.slug));


### PR DESCRIPTION


The GET /2.0/repositories?role=contributor endpoint is being removed by Bitbucket Cloud on 2026-03-31 (CHANGE-2770). Replace it with per-workspace calls to GET /2.0/repositories/{workspace}.

When autodiscoverNamespaces is set, those values are used directly as workspace slugs. Otherwise the current user's workspaces are first discovered via GET /2.0/user/workspaces (the non-deprecated replacement for GET /2.0/workspaces) and repositories are then fetched per workspace.

Fixes #42102

## Changes
Replace the deprecated `GET /2.0/repositories?role=contributor` endpoint (removed by Bitbucket) with a two-step approach: first discover workspaces via `GET /2.0/user/workspaces`, then fetch repos per workspace via `GET /2.0/repositories/{workspace}`. If `autodiscoverNamespaces` is configured, workspace slugs are used directly, skipping workspace discovery.

## Context
- [x] This closes an existing Issue, Closes: #42102

## AI assistance disclosure
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
This PR was written primarily by Claude (OpenCode/claude-sonnet-4.6), including the implementation in `index.ts`, the new Zod schema in `schema.ts`, and all updated/new tests in `index.spec.ts`.

## Documentation
- [x] No documentation update is required

## How I've tested my work
- [x] Newly added/modified unit tests

