### PR TITLE
fix(maven-wrapper): only delete old JAR if performing updates to the properties file

### DIFF
--- a/lib/modules/manager/maven-wrapper/artifacts.spec.ts
+++ b/lib/modules/manager/maven-wrapper/artifacts.spec.ts
@@ -631,6 +631,42 @@ describe('modules/manager/maven-wrapper/artifacts', () => {
       const finalWrittenContent = vi.mocked(fs.writeLocalFile).mock.calls[1][1];
       expect(finalWrittenContent).not.toContain('oldhash123');
       expect(finalWrittenContent).not.toContain('oldwrapperhash456');
+      expect(fs.deleteLocalFile).toHaveBeenCalledWith(
+        '.mvn/wrapper/maven-wrapper.jar',
+      );
+    });
+
+    it('should not attempt to delete old JAR file if doing a Maven Wrapper update', async () => {
+      const propertiesWithChecksums = codeBlock`
+        distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip
+        distributionSha256Sum=oldhash123
+        wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.2/maven-wrapper-3.3.2.jar
+        wrapperSha256Sum=oldwrapperhash456
+      `;
+
+      httpMock
+        .scope('https://repo.maven.apache.org')
+        .get(
+          '/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip',
+        )
+        .reply(200, Buffer.from('fake-maven-content'))
+        .get(
+          '/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.2/maven-wrapper-3.3.2.jar',
+        )
+        .reply(200, Buffer.from('fake-wrapper-content'));
+      mockMavenFileChangedInGit();
+      mockExecAll({ stdout: '', stderr: '' });
+      // Mock readLocalFile to return content after wrapper:wrapper runs
+      fs.readLocalFile.mockResolvedValueOnce(propertiesWithChecksums);
+
+      await updateArtifacts({
+        packageFileName: 'mvnw',
+        newPackageFileContent: propertiesWithChecksums,
+        updatedDeps: [{ depName: 'maven-wrapper', newValue: '3.3.2' }],
+        config: { currentValue: '3.3.1', newValue: '3.3.2' },
+      });
+
+      expect(fs.deleteLocalFile).not.toHaveBeenCalled();
     });
 
     it('should preserve old checksum when fetch fails', async () => {

--- a/lib/modules/manager/maven-wrapper/artifacts.ts
+++ b/lib/modules/manager/maven-wrapper/artifacts.ts
@@ -278,11 +278,13 @@ export async function updateArtifacts({
         'maven-wrapper.properties',
         'maven-wrapper.jar',
       );
-      try {
-        await deleteLocalFile(jarPath);
-        logger.debug({ jarPath }, 'Deleted old maven-wrapper.jar');
-      } catch {
-        // File may not exist, ignore
+      if (jarPath.endsWith('maven-wrapper.jar')) {
+        try {
+          await deleteLocalFile(jarPath);
+          logger.debug({ jarPath }, 'Deleted old maven-wrapper.jar');
+        } catch {
+          // File may not exist, ignore
+        }
       }
     }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
As reported in #41994, in #40481, we
assumed that `updateArtifacts` would only ever be called when updating
the `maven-wrapper.properties`.

As this isn't always the case, and we may be updating a `mvnw` file, we
should check what we're about to delete, before we do.

## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

(I did try and get Claude Code to build me a test case so I could then fix it, but it didn't do very well 😅)

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
