### PR TITLE
docs: explicitly document `depTypes` each manager supports

### DIFF
--- a/docs/development/adding-a-package-manager.md
+++ b/docs/development/adding-a-package-manager.md
@@ -22,6 +22,8 @@ The manager's `index.ts` file supports the following values or functions:
 | `extractAllPackageFiles`      | yes      | yes   |
 | `getRangeStrategy`            | yes      |       |
 | `categories`                  | yes      |       |
+| `knownDepTypes`               | yes      |       |
+| `supportsDynamicDepTypesNote` | yes      |       |
 | `supportsLockFileMaintenance` | yes      |       |
 | `updateArtifacts`             | yes      | yes   |
 | `updateDependency`            | yes      |       |
@@ -82,6 +84,24 @@ For example, pinning or _not_ pinning a dependency, depending on other values in
 The `npm` manager uses the `getRangeStrategy` function to pin `devDependencies` but not `dependencies`, unless the package file is detected as an app.
 
 If left undefined, then a default `getRangeStrategy` will be used that always returns "replace".
+
+### `knownDepTypes` (optional)
+
+Use this to document any dependency types (`depType`) that the manager can extract.
+
+Only set the `prettyDepType` if the Manager sets it on the `Upgrade`.
+
+Use `description` to provide a human-readable description which will be found in the documentation for the Manager.
+
+This should be placed in `dep-types.ts`.
+
+### `supportsDynamicDepTypesNote` (optional)
+
+Use this to provide a Markdown note about dynamically generated `depType` values that can't be listed in `knownDepTypes`.
+
+This note will be rendered after the `knownDepTypes` table (regardless of whether any known `depTypes` are present).
+
+This should be placed in `dep-types.ts`.
 
 ### `supportsLockFileMaintenance` (optional)
 

--- a/lib/modules/manager/ansible-galaxy/dep-types.ts
+++ b/lib/modules/manager/ansible-galaxy/dep-types.ts
@@ -1,0 +1,12 @@
+import type { DepTypeMetadata } from '../types.ts';
+
+export const knownDepTypes = [
+  {
+    depType: 'galaxy-collection',
+    description: 'Ansible Galaxy collection',
+  },
+  {
+    depType: 'role',
+    description: 'Ansible role',
+  },
+] as const satisfies readonly DepTypeMetadata[];

--- a/lib/modules/manager/ansible-galaxy/index.ts
+++ b/lib/modules/manager/ansible-galaxy/index.ts
@@ -18,3 +18,5 @@ export const supportedDatasources = [
   GitTagsDatasource.id,
   GithubTagsDatasource.id,
 ];
+
+export { knownDepTypes } from './dep-types.ts';

--- a/lib/modules/manager/ansible-galaxy/readme.md
+++ b/lib/modules/manager/ansible-galaxy/readme.md
@@ -1,6 +1,1 @@
 Extracts Ansible Galaxy dependencies from configuration files used by the `ansible-galaxy` CLI tool.
-
-This manager uses two `depType`s to allow a fine-grained control of which dependencies are upgraded:
-
-- collection
-- role

--- a/lib/modules/manager/azure-pipelines/dep-types.ts
+++ b/lib/modules/manager/azure-pipelines/dep-types.ts
@@ -1,0 +1,14 @@
+import type { DepTypeMetadata } from '../types.ts';
+
+export const knownDepTypes = [
+  {
+    depType: 'docker',
+    description:
+      'A Docker image reference in a `container:` field in Azure Pipelines',
+  },
+  {
+    depType: 'gitTags',
+    description:
+      'A Git repository resource referenced by tag (e.g. `refs/tags/v1.0.0`)',
+  },
+] as const satisfies readonly DepTypeMetadata[];

--- a/lib/modules/manager/azure-pipelines/index.ts
+++ b/lib/modules/manager/azure-pipelines/index.ts
@@ -2,6 +2,7 @@ import type { Category } from '../../../constants/index.ts';
 import { AzurePipelinesTasksDatasource } from '../../datasource/azure-pipelines-tasks/index.ts';
 import { GitTagsDatasource } from '../../datasource/git-tags/index.ts';
 
+export { knownDepTypes } from './dep-types.ts';
 export { extractPackageFile } from './extract.ts';
 
 export const url = 'https://learn.microsoft.com/azure/devops/pipelines';

--- a/lib/modules/manager/bazel-module/dep-types.ts
+++ b/lib/modules/manager/bazel-module/dep-types.ts
@@ -1,0 +1,57 @@
+import type { DepTypeMetadata } from '../types.ts';
+
+export const knownDepTypes = [
+  {
+    depType: 'bazel_dep',
+    description: 'A direct Bazel module dependency via `bazel_dep`',
+  },
+  {
+    depType: 'git_override',
+    description:
+      'A Git-based override for a Bazel module dependency via `git_override`',
+  },
+  {
+    depType: 'archive_override',
+    description:
+      'An archive-based override for a Bazel module dependency via `archive_override`',
+  },
+  {
+    depType: 'local_path_override',
+    description:
+      'A local path override for a Bazel module dependency via `local_path_override`',
+  },
+  {
+    depType: 'single_version_override',
+    description:
+      'A version or registry override for a Bazel module dependency via `single_version_override`',
+  },
+  {
+    depType: 'git_repository',
+    description:
+      'A Git repository dependency via `git_repository` in a module extension',
+  },
+  {
+    depType: 'new_git_repository',
+    description:
+      'A Git repository with a custom BUILD file via `new_git_repository` in a module extension',
+  },
+  {
+    depType: 'oci_pull',
+    description:
+      'An OCI container image pulled via the `oci.pull` module extension tag',
+  },
+  {
+    depType: 'maven_install',
+    description: 'A Maven artifact installed via the `maven` module extension',
+  },
+  {
+    depType: 'crate_spec',
+    description:
+      'A Rust crate dependency via the `crate.spec` module extension tag',
+  },
+  {
+    depType: 'rules_img_pull',
+    description:
+      'A container image pulled via a `rules_img` repo rule in a module extension',
+  },
+] as const satisfies readonly DepTypeMetadata[];

--- a/lib/modules/manager/bazel-module/index.ts
+++ b/lib/modules/manager/bazel-module/index.ts
@@ -6,6 +6,7 @@ import { GithubTagsDatasource } from '../../datasource/github-tags/index.ts';
 import { MavenDatasource } from '../../datasource/maven/index.ts';
 
 export { updateArtifacts } from './artifacts.ts';
+export { knownDepTypes } from './dep-types.ts';
 export { extractPackageFile } from './extract.ts';
 
 export const url = 'https://bazel.build/external/module';

--- a/lib/modules/manager/bazel/dep-types.ts
+++ b/lib/modules/manager/bazel/dep-types.ts
@@ -1,0 +1,76 @@
+import type { DepTypeMetadata } from '../types.ts';
+
+export const knownDepTypes = [
+  {
+    depType: 'container_pull',
+    description: 'A Docker container image pulled via `container_pull`',
+  },
+  {
+    depType: '_container_pull',
+    description:
+      'A Docker container image pulled via the private `_container_pull` rule',
+  },
+  {
+    depType: 'git_repository',
+    description: 'A Git repository dependency via `git_repository`',
+  },
+  {
+    depType: '_git_repository',
+    description:
+      'A Git repository dependency via the private `_git_repository` rule',
+  },
+  {
+    depType: 'new_git_repository',
+    description:
+      'A Git repository with a custom BUILD file via `new_git_repository`',
+  },
+  {
+    depType: '_new_git_repository',
+    description:
+      'A Git repository with a custom BUILD file via the private `_new_git_repository` rule',
+  },
+  {
+    depType: 'go_repository',
+    description: 'A Go module dependency via `go_repository`',
+  },
+  {
+    depType: '_go_repository',
+    description: 'A Go module dependency via the private `_go_repository` rule',
+  },
+  {
+    depType: 'http_archive',
+    description: 'An archive downloaded over HTTP via `http_archive`',
+  },
+  {
+    depType: '_http_archive',
+    description:
+      'An archive downloaded over HTTP via the private `_http_archive` rule',
+  },
+  {
+    depType: 'http_file',
+    description: 'A file downloaded over HTTP via `http_file`',
+  },
+  {
+    depType: '_http_file',
+    description:
+      'A file downloaded over HTTP via the private `_http_file` rule',
+  },
+  {
+    depType: 'oci_pull',
+    description: 'An OCI container image pulled via `oci_pull`',
+  },
+  {
+    depType: '_oci_pull',
+    description:
+      'An OCI container image pulled via the private `_oci_pull` rule',
+  },
+  {
+    depType: 'maven_install',
+    description: 'A Maven artifact installed via `maven_install`',
+  },
+  {
+    depType: '_maven_install',
+    description:
+      'A Maven artifact installed via the private `_maven_install` rule',
+  },
+] as const satisfies readonly DepTypeMetadata[];

--- a/lib/modules/manager/bazel/index.ts
+++ b/lib/modules/manager/bazel/index.ts
@@ -7,6 +7,7 @@ import { updateArtifacts } from './artifacts.ts';
 import { extractPackageFile } from './extract.ts';
 
 export { extractPackageFile, updateArtifacts };
+export { knownDepTypes } from './dep-types.ts';
 
 export const url = 'https://bazel.build/docs';
 export const categories: Category[] = ['bazel'];

--- a/lib/modules/manager/bitbucket-pipelines/dep-types.ts
+++ b/lib/modules/manager/bitbucket-pipelines/dep-types.ts
@@ -1,0 +1,13 @@
+import type { DepTypeMetadata } from '../types.ts';
+
+export const knownDepTypes = [
+  {
+    depType: 'bitbucket-tags',
+    description: 'A Bitbucket pipe reference resolved via Bitbucket tags',
+  },
+  {
+    depType: 'docker',
+    description:
+      'A Docker image used as the build image or in a service definition',
+  },
+] as const satisfies readonly DepTypeMetadata[];

--- a/lib/modules/manager/bitbucket-pipelines/index.ts
+++ b/lib/modules/manager/bitbucket-pipelines/index.ts
@@ -2,6 +2,7 @@ import type { Category } from '../../../constants/index.ts';
 import { DockerDatasource } from '../../datasource/docker/index.ts';
 import { extractPackageFile } from './extract.ts';
 
+export { knownDepTypes } from './dep-types.ts';
 export { extractPackageFile };
 
 export const url =

--- a/lib/modules/manager/circleci/dep-types.ts
+++ b/lib/modules/manager/circleci/dep-types.ts
@@ -1,0 +1,12 @@
+import type { DepTypeMetadata } from '../types.ts';
+
+export const knownDepTypes = [
+  {
+    depType: 'orb',
+    description: 'CircleCI orb reference',
+  },
+  {
+    depType: 'docker',
+    description: 'Docker image in executor/job configuration',
+  },
+] as const satisfies readonly DepTypeMetadata[];

--- a/lib/modules/manager/circleci/index.ts
+++ b/lib/modules/manager/circleci/index.ts
@@ -16,3 +16,5 @@ export const defaultConfig = {
 };
 
 export const supportedDatasources = [DockerDatasource.id, OrbDatasource.id];
+
+export { knownDepTypes } from './dep-types.ts';

--- a/lib/modules/manager/composer/dep-types.ts
+++ b/lib/modules/manager/composer/dep-types.ts
@@ -1,0 +1,12 @@
+import type { DepTypeMetadata } from '../types.ts';
+
+export const knownDepTypes = [
+  {
+    depType: 'require',
+    description: 'Production dependency from `require` section',
+  },
+  {
+    depType: 'require-dev',
+    description: 'Development dependency from `require-dev` section',
+  },
+] as const satisfies readonly DepTypeMetadata[];

--- a/lib/modules/manager/composer/index.ts
+++ b/lib/modules/manager/composer/index.ts
@@ -31,3 +31,5 @@ export const supportedDatasources = [
   GitTagsDatasource.id,
   PackagistDatasource.id,
 ];
+
+export { knownDepTypes } from './dep-types.ts';

--- a/lib/modules/manager/conan/dep-types.ts
+++ b/lib/modules/manager/conan/dep-types.ts
@@ -1,0 +1,19 @@
+import type { DepTypeMetadata } from '../types.ts';
+
+export const knownDepTypes = [
+  {
+    depType: 'build_requires',
+    description:
+      'A build-time dependency declared in `[build_requires]` or `build_requirements()`',
+  },
+  {
+    depType: 'python_requires',
+    description:
+      'A Python-based Conan recipe dependency declared via `python_requires`',
+  },
+  {
+    depType: 'requires',
+    description:
+      'A runtime dependency declared in `[requires]` or `requirements()`',
+  },
+] as const satisfies readonly DepTypeMetadata[];

--- a/lib/modules/manager/conan/index.ts
+++ b/lib/modules/manager/conan/index.ts
@@ -1,4 +1,5 @@
 export { updateArtifacts } from './artifacts.ts';
+export { knownDepTypes } from './dep-types.ts';
 export { extractPackageFile } from './extract.ts';
 
 import type { Category } from '../../../constants/index.ts';

--- a/lib/modules/manager/copier/dep-types.ts
+++ b/lib/modules/manager/copier/dep-types.ts
@@ -1,0 +1,8 @@
+import type { DepTypeMetadata } from '../types.ts';
+
+export const knownDepTypes = [
+  {
+    depType: 'template',
+    description: 'Copier project template source',
+  },
+] as const satisfies readonly DepTypeMetadata[];

--- a/lib/modules/manager/copier/index.ts
+++ b/lib/modules/manager/copier/index.ts
@@ -13,3 +13,5 @@ export const defaultConfig = {
 };
 
 export const supportedDatasources = [GitTagsDatasource.id];
+
+export { knownDepTypes } from './dep-types.ts';

--- a/lib/modules/manager/cpanfile/dep-types.ts
+++ b/lib/modules/manager/cpanfile/dep-types.ts
@@ -1,0 +1,24 @@
+import type { DepTypeMetadata } from '../types.ts';
+
+export const knownDepTypes = [
+  {
+    depType: 'configure',
+    description: 'Dependencies needed during the configure phase',
+  },
+  {
+    depType: 'build',
+    description: 'Dependencies needed during the build phase',
+  },
+  {
+    depType: 'test',
+    description: 'Dependencies needed during the test phase',
+  },
+  {
+    depType: 'runtime',
+    description: 'Dependencies needed at runtime',
+  },
+  {
+    depType: 'develop',
+    description: 'Dependencies needed during development (author_requires)',
+  },
+] as const satisfies readonly DepTypeMetadata[];

--- a/lib/modules/manager/cpanfile/index.ts
+++ b/lib/modules/manager/cpanfile/index.ts
@@ -2,6 +2,7 @@ import type { Category } from '../../../constants/index.ts';
 import { CpanDatasource } from '../../datasource/cpan/index.ts';
 import { GithubTagsDatasource } from '../../datasource/github-tags/index.ts';
 
+export { knownDepTypes } from './dep-types.ts';
 export { extractPackageFile } from './extract.ts';
 
 export const displayName = 'cpanfile';

--- a/lib/modules/manager/crossplane/dep-types.ts
+++ b/lib/modules/manager/crossplane/dep-types.ts
@@ -1,0 +1,16 @@
+import type { DepTypeMetadata } from '../types.ts';
+
+export const knownDepTypes = [
+  {
+    depType: 'provider',
+    description: 'A Crossplane Provider package',
+  },
+  {
+    depType: 'configuration',
+    description: 'A Crossplane Configuration package',
+  },
+  {
+    depType: 'function',
+    description: 'A Crossplane Function package',
+  },
+] as const satisfies readonly DepTypeMetadata[];

--- a/lib/modules/manager/crossplane/index.ts
+++ b/lib/modules/manager/crossplane/index.ts
@@ -1,6 +1,7 @@
 import type { Category } from '../../../constants/index.ts';
 import { DockerDatasource } from '../../datasource/docker/index.ts';
 
+export { knownDepTypes } from './dep-types.ts';
 export { extractPackageFile } from './extract.ts';
 
 export const url = 'https://docs.crossplane.io';

--- a/lib/modules/manager/devcontainer/dep-types.ts
+++ b/lib/modules/manager/devcontainer/dep-types.ts
@@ -1,0 +1,14 @@
+import type { DepTypeMetadata } from '../types.ts';
+
+export const knownDepTypes = [
+  {
+    depType: 'feature',
+    description:
+      'A Dev Container Feature reference (e.g. `ghcr.io/devcontainers/features/node:1`)',
+  },
+  {
+    depType: 'image',
+    description:
+      'The base Docker image specified in the `image` field of devcontainer.json',
+  },
+] as const satisfies readonly DepTypeMetadata[];

--- a/lib/modules/manager/devcontainer/index.ts
+++ b/lib/modules/manager/devcontainer/index.ts
@@ -5,6 +5,7 @@ import { NodeVersionDatasource } from '../../datasource/node-version/index.ts';
 import { PythonVersionDatasource } from '../../datasource/python-version/index.ts';
 import { RubyVersionDatasource } from '../../datasource/ruby-version/index.ts';
 
+export { knownDepTypes } from './dep-types.ts';
 export { extractPackageFile } from './extract.ts';
 
 export const name = 'Dev Container';

--- a/lib/modules/manager/dockerfile/dep-types.ts
+++ b/lib/modules/manager/dockerfile/dep-types.ts
@@ -1,0 +1,18 @@
+import type { DepTypeMetadata } from '../types.ts';
+
+export const knownDepTypes = [
+  {
+    depType: 'syntax',
+    description:
+      'The `# syntax=` parser directive at the top of the Dockerfile',
+  },
+  {
+    depType: 'stage',
+    description: 'An intermediate `FROM` instruction in a multi-stage build',
+  },
+  {
+    depType: 'final',
+    description:
+      'The last `FROM` instruction in the Dockerfile (the final build stage)',
+  },
+] as const satisfies readonly DepTypeMetadata[];

--- a/lib/modules/manager/dockerfile/index.ts
+++ b/lib/modules/manager/dockerfile/index.ts
@@ -3,6 +3,7 @@ import { DockerDatasource } from '../../datasource/docker/index.ts';
 import { extractPackageFile } from './extract.ts';
 
 export { extractPackageFile };
+export { knownDepTypes } from './dep-types.ts';
 
 export const url = 'https://docs.docker.com/build/concepts/dockerfile';
 export const categories: Category[] = ['docker'];

--- a/lib/modules/manager/droneci/dep-types.ts
+++ b/lib/modules/manager/droneci/dep-types.ts
@@ -1,0 +1,8 @@
+import type { DepTypeMetadata } from '../types.ts';
+
+export const knownDepTypes = [
+  {
+    depType: 'docker',
+    description: 'A Docker image used in a Drone CI pipeline step or service',
+  },
+] as const satisfies readonly DepTypeMetadata[];

--- a/lib/modules/manager/droneci/index.ts
+++ b/lib/modules/manager/droneci/index.ts
@@ -2,6 +2,7 @@ import type { Category } from '../../../constants/index.ts';
 import { DockerDatasource } from '../../datasource/docker/index.ts';
 import { extractPackageFile } from './extract.ts';
 
+export { knownDepTypes } from './dep-types.ts';
 export { extractPackageFile };
 
 export const url = 'https://docs.drone.io';

--- a/lib/modules/manager/fleet/dep-types.ts
+++ b/lib/modules/manager/fleet/dep-types.ts
@@ -1,0 +1,12 @@
+import type { DepTypeMetadata } from '../types.ts';
+
+export const knownDepTypes = [
+  {
+    depType: 'git_repo',
+    description: 'Git repository reference in a Fleet GitRepo manifest',
+  },
+  {
+    depType: 'fleet',
+    description: 'Helm chart reference in a Fleet deployment',
+  },
+] as const satisfies readonly DepTypeMetadata[];

--- a/lib/modules/manager/fleet/index.ts
+++ b/lib/modules/manager/fleet/index.ts
@@ -18,3 +18,5 @@ export const supportedDatasources = [
   HelmDatasource.id,
   DockerDatasource.id,
 ];
+
+export { knownDepTypes } from './dep-types.ts';

--- a/lib/modules/manager/github-actions/dep-types.ts
+++ b/lib/modules/manager/github-actions/dep-types.ts
@@ -1,0 +1,32 @@
+import type { DepTypeMetadata } from '../types.ts';
+
+export const knownDepTypes = [
+  {
+    depType: 'action',
+    description:
+      'A repository-based action reference in a `uses:` field (e.g. `actions/checkout@v4`)',
+  },
+  {
+    depType: 'docker',
+    description:
+      'A Docker image reference in a `uses:` field (e.g. `uses: docker://alpine:3`)',
+  },
+  {
+    depType: 'container',
+    description: "A Docker image specified in a job's `container:` field",
+  },
+  {
+    depType: 'service',
+    description: "A Docker image specified in a job's `services:` field",
+  },
+  {
+    depType: 'github-runner',
+    description:
+      'A GitHub-hosted runner version in a `runs-on:` field (e.g. `ubuntu-24.04`)',
+  },
+  {
+    depType: 'uses-with',
+    description:
+      'A language/runtime version passed as an input to a versioned action (e.g. `node-version` for `actions/setup-node`)',
+  },
+] as const satisfies readonly DepTypeMetadata[];

--- a/lib/modules/manager/github-actions/index.ts
+++ b/lib/modules/manager/github-actions/index.ts
@@ -4,6 +4,7 @@ import { GithubDigestDatasource } from '../../datasource/github-digest/index.ts'
 import { GithubRunnersDatasource } from '../../datasource/github-runners/index.ts';
 import { GithubTagsDatasource } from '../../datasource/github-tags/index.ts';
 
+export { knownDepTypes } from './dep-types.ts';
 export { extractPackageFile } from './extract.ts';
 
 export const displayName = 'GitHub Actions';

--- a/lib/modules/manager/gitlabci-include/dep-types.ts
+++ b/lib/modules/manager/gitlabci-include/dep-types.ts
@@ -1,0 +1,9 @@
+import type { DepTypeMetadata } from '../types.ts';
+
+export const knownDepTypes = [
+  {
+    depType: 'repository',
+    description:
+      'GitLab project repository reference in a CI/CD `include` statement',
+  },
+] as const satisfies readonly DepTypeMetadata[];

--- a/lib/modules/manager/gitlabci-include/index.ts
+++ b/lib/modules/manager/gitlabci-include/index.ts
@@ -13,3 +13,5 @@ export const defaultConfig = {
 };
 
 export const supportedDatasources = [GitlabTagsDatasource.id];
+
+export { knownDepTypes } from './dep-types.ts';

--- a/lib/modules/manager/gitlabci/dep-types.ts
+++ b/lib/modules/manager/gitlabci/dep-types.ts
@@ -1,0 +1,20 @@
+import type { DepTypeMetadata } from '../types.ts';
+
+export const knownDepTypes = [
+  {
+    depType: 'image',
+    description: 'Docker image specified as a string',
+  },
+  {
+    depType: 'image-name',
+    description: 'Docker image specified via the `name` property',
+  },
+  {
+    depType: 'service-image',
+    description: 'Docker image used as a service',
+  },
+  {
+    depType: 'repository',
+    description: 'A GitLab CI/CD component reference',
+  },
+] as const satisfies readonly DepTypeMetadata[];

--- a/lib/modules/manager/gitlabci/index.ts
+++ b/lib/modules/manager/gitlabci/index.ts
@@ -4,6 +4,7 @@ import { GitlabTagsDatasource } from '../../datasource/gitlab-tags/index.ts';
 import { extractAllPackageFiles, extractPackageFile } from './extract.ts';
 
 export { extractAllPackageFiles, extractPackageFile };
+export { knownDepTypes } from './dep-types.ts';
 
 export const displayName = 'GitLab CI/CD';
 export const url = 'https://docs.gitlab.com/ee/ci';

--- a/lib/modules/manager/gleam/dep-types.ts
+++ b/lib/modules/manager/gleam/dep-types.ts
@@ -1,0 +1,12 @@
+import type { DepTypeMetadata } from '../types.ts';
+
+export const knownDepTypes = [
+  {
+    depType: 'dependencies',
+    description: 'Listed under `dependencies`',
+  },
+  {
+    depType: 'devDependencies',
+    description: 'Listed under `dev-dependencies`',
+  },
+] as const satisfies readonly DepTypeMetadata[];

--- a/lib/modules/manager/gleam/index.ts
+++ b/lib/modules/manager/gleam/index.ts
@@ -2,6 +2,7 @@ import { HexDatasource } from '../../datasource/hex/index.ts';
 import * as hexVersioning from '../../versioning/hex/index.ts';
 
 export { updateArtifacts } from './artifacts.ts';
+export { knownDepTypes } from './dep-types.ts';
 export { extractPackageFile } from './extract.ts';
 export { getRangeStrategy } from './range.ts';
 

--- a/lib/modules/manager/gleam/readme.md
+++ b/lib/modules/manager/gleam/readme.md
@@ -1,10 +1,5 @@
 Renovate can update `gleam.toml` and/or `manifest.toml` files.
 
-The `gleam` manager can update these `depTypes`:
-
-- `dependencies`
-- `dev-dependencies`
-
 ### How Renovate updates `gleam.toml` files
 
 The `gleam` manager extracts dependencies for the `hex` datasource, and uses Renovate's implementation of Hex SemVer to evaluate `gleam.toml` updates.

--- a/lib/modules/manager/gomod/dep-types.ts
+++ b/lib/modules/manager/gomod/dep-types.ts
@@ -1,0 +1,30 @@
+import type { DepTypeMetadata } from '../types.ts';
+
+export const knownDepTypes = [
+  {
+    depType: 'golang',
+    description:
+      'The `go` directive specifying the minimum version of Go that the code is source compatible with',
+  },
+  {
+    depType: 'toolchain',
+    description:
+      'The `toolchain` directive specifying the Go toolchain version',
+  },
+  {
+    depType: 'require',
+    description: 'A direct module dependency',
+  },
+  {
+    depType: 'indirect',
+    description: 'An indirect (transitive) module dependency',
+  },
+  {
+    depType: 'replace',
+    description: 'A module replacement directive',
+  },
+  {
+    depType: 'tool',
+    description: `A tool dependency using Go 1.24+'s \`tool\` directive`,
+  },
+] as const satisfies readonly DepTypeMetadata[];

--- a/lib/modules/manager/gomod/index.ts
+++ b/lib/modules/manager/gomod/index.ts
@@ -6,6 +6,7 @@ import { extractPackageFile } from './extract.ts';
 import { updateDependency } from './update.ts';
 
 export { extractPackageFile, updateDependency, updateArtifacts };
+export { knownDepTypes } from './dep-types.ts';
 
 export const displayName = 'Go Modules';
 export const url = 'https://go.dev/ref/mod';

--- a/lib/modules/manager/gradle/dep-types.ts
+++ b/lib/modules/manager/gradle/dep-types.ts
@@ -1,0 +1,21 @@
+import type { DepTypeMetadata } from '../types.ts';
+
+export const knownDepTypes = [
+  {
+    depType: 'plugin',
+    description: 'A Gradle plugin dependency',
+  },
+  {
+    depType: 'dependencies',
+    description: 'A standard Gradle dependency',
+  },
+  {
+    depType: 'devDependencies',
+    description: 'A dependency from a `buildSrc` project',
+  },
+  {
+    depType: 'test',
+    description:
+      'A test dependency from the `gradle-consistent-versions` plugin lock file',
+  },
+] as const satisfies readonly DepTypeMetadata[];

--- a/lib/modules/manager/gradle/index.ts
+++ b/lib/modules/manager/gradle/index.ts
@@ -3,6 +3,7 @@ import { MavenDatasource } from '../../datasource/maven/index.ts';
 import * as gradleVersioning from '../../versioning/gradle/index.ts';
 
 export { updateArtifacts } from './artifacts.ts';
+export { knownDepTypes } from './dep-types.ts';
 export { extractAllPackageFiles } from './extract.ts';
 export { updateDependency } from './update.ts';
 

--- a/lib/modules/manager/index.spec.ts
+++ b/lib/modules/manager/index.spec.ts
@@ -260,4 +260,26 @@ describe('modules/manager/index', () => {
       expect(manager.isKnownManager('custom.unknown')).toBeFalse();
     });
   });
+
+  describe('getPrettyDepType', () => {
+    it('when no manager found, returns undefined', () => {
+      expect(
+        manager.getPrettyDepType('invalid-manager', 'unused'),
+      ).toBeUndefined();
+    });
+
+    it('when manager found, but no prettyDepType found, returns undefined', () => {
+      expect(manager.getPrettyDepType('npm', 'foo-bar-baz')).toBeUndefined();
+    });
+
+    it('when manager found, but no prettyDepType found, returns undefined', () => {
+      expect(manager.getPrettyDepType('regex', 'foo-bar-baz')).toBeUndefined();
+    });
+
+    it('when manager found, and a prettyDepType found in knownDepTypes, returns the defined prettyDepType', () => {
+      expect(manager.getPrettyDepType('npm', 'dependencies')).toEqual(
+        'dependency',
+      );
+    });
+  });
 });

--- a/lib/modules/manager/index.ts
+++ b/lib/modules/manager/index.ts
@@ -104,6 +104,15 @@ export function getRangeStrategy(config: RangeConfig): RangeStrategy | null {
   return config.rangeStrategy!;
 }
 
+export function getPrettyDepType(
+  manager: string,
+  depType: string,
+): string | undefined {
+  const m = managers.get(manager) ?? customManagers.get(manager);
+  return m?.knownDepTypes?.find((meta) => meta.depType === depType)
+    ?.prettyDepType;
+}
+
 export function isKnownManager(mgr: string): boolean {
   return allManagersList.includes(mgr.replace('custom.', ''));
 }

--- a/lib/modules/manager/kustomize/dep-types.ts
+++ b/lib/modules/manager/kustomize/dep-types.ts
@@ -1,0 +1,17 @@
+import type { DepTypeMetadata } from '../types.ts';
+
+export const knownDepTypes = [
+  {
+    depType: 'Kustomization',
+    description: 'Kustomization resource referencing remote bases or images',
+  },
+  {
+    depType: 'Component',
+    description:
+      'Kustomize Component resource referencing remote bases or images',
+  },
+  {
+    depType: 'HelmChart',
+    description: 'Helm chart embedded in a kustomization file via `helmCharts`',
+  },
+] as const satisfies readonly DepTypeMetadata[];

--- a/lib/modules/manager/kustomize/index.ts
+++ b/lib/modules/manager/kustomize/index.ts
@@ -21,3 +21,5 @@ export const supportedDatasources = [
   GithubTagsDatasource.id,
   HelmDatasource.id,
 ];
+
+export { knownDepTypes } from './dep-types.ts';

--- a/lib/modules/manager/leiningen/dep-types.ts
+++ b/lib/modules/manager/leiningen/dep-types.ts
@@ -1,0 +1,24 @@
+import type { DepTypeMetadata } from '../types.ts';
+
+export const knownDepTypes = [
+  {
+    depType: 'dependencies',
+    description: 'Listed under `:dependencies`',
+  },
+  {
+    depType: 'managed-dependencies',
+    description: 'Listed under `:managed-dependencies`',
+  },
+  {
+    depType: 'plugins',
+    description: 'Listed under `:plugins`',
+  },
+  {
+    depType: 'pom-plugins',
+    description: 'Listed under `:pom-plugins`',
+  },
+  {
+    depType: 'parent-project',
+    description: 'Listed under `:parent-project` (via lein-parent `:coords`)',
+  },
+] as const satisfies readonly DepTypeMetadata[];

--- a/lib/modules/manager/leiningen/index.ts
+++ b/lib/modules/manager/leiningen/index.ts
@@ -2,6 +2,7 @@ import type { Category } from '../../../constants/index.ts';
 import { ClojureDatasource } from '../../datasource/clojure/index.ts';
 import * as mavenVersioning from '../../versioning/maven/index.ts';
 
+export { knownDepTypes } from './dep-types.ts';
 export { extractPackageFile } from './extract.ts';
 
 export const url = 'https://leiningen.org';

--- a/lib/modules/manager/maven/dep-types.ts
+++ b/lib/modules/manager/maven/dep-types.ts
@@ -1,0 +1,53 @@
+import type { DepTypeMetadata } from '../types.ts';
+
+export const knownDepTypes = [
+  {
+    depType: 'compile',
+    description:
+      'Dependency with `compile` scope (default); available on all classpaths',
+  },
+  {
+    depType: 'provided',
+    description:
+      'Dependency with `provided` scope; expected to be supplied by the JDK or container at runtime',
+  },
+  {
+    depType: 'runtime',
+    description:
+      'Dependency with `runtime` scope; required at runtime but not for compilation',
+  },
+  {
+    depType: 'test',
+    description:
+      'Dependency with `test` scope; only used for test compilation and execution',
+  },
+  {
+    depType: 'system',
+    description:
+      'Dependency with `system` scope; similar to `provided` but the JAR is specified explicitly',
+  },
+  {
+    depType: 'import',
+    description:
+      'Dependency with `import` scope; used to import dependency management from another POM (BOM)',
+  },
+  {
+    depType: 'optional',
+    description:
+      'Optional dependency (declared with `<optional>true</optional>`)',
+  },
+  {
+    depType: 'build',
+    description:
+      'A build plugin or extension (`<plugin>` or `<extension>` element)',
+  },
+  {
+    depType: 'parent',
+    description: 'The parent POM (`<parent>` element)',
+  },
+  {
+    depType: 'parent-root',
+    description:
+      'A parent POM that is itself a root POM or has an external parent; promoted from `parent` during multi-module resolution',
+  },
+] as const satisfies readonly DepTypeMetadata[];

--- a/lib/modules/manager/maven/index.ts
+++ b/lib/modules/manager/maven/index.ts
@@ -17,3 +17,5 @@ export const defaultConfig = {
 };
 
 export const supportedDatasources = [MavenDatasource.id, DockerDatasource.id];
+
+export { knownDepTypes } from './dep-types.ts';

--- a/lib/modules/manager/mix/dep-types.ts
+++ b/lib/modules/manager/mix/dep-types.ts
@@ -1,0 +1,12 @@
+import type { DepTypeMetadata } from '../types.ts';
+
+export const knownDepTypes = [
+  {
+    depType: 'prod',
+    description: 'A production dependency',
+  },
+  {
+    depType: 'dev',
+    description: 'A development-only dependency (restricted via `only:`)',
+  },
+] as const satisfies readonly DepTypeMetadata[];

--- a/lib/modules/manager/mix/index.ts
+++ b/lib/modules/manager/mix/index.ts
@@ -4,6 +4,7 @@ import { GithubTagsDatasource } from '../../datasource/github-tags/index.ts';
 import { HexDatasource } from '../../datasource/hex/index.ts';
 
 export { updateArtifacts } from './artifacts.ts';
+export { knownDepTypes } from './dep-types.ts';
 export { extractPackageFile } from './extract.ts';
 export { getRangeStrategy } from './range.ts';
 

--- a/lib/modules/manager/npm/dep-types.ts
+++ b/lib/modules/manager/npm/dep-types.ts
@@ -1,0 +1,62 @@
+import type { DepTypeMetadata } from '../types.ts';
+
+export const knownDepTypes = [
+  {
+    depType: 'dependencies',
+    prettyDepType: 'dependency',
+    description: 'Listed under `dependencies`',
+  },
+  {
+    depType: 'devDependencies',
+    prettyDepType: 'devDependency',
+    description: 'Listed under `devDependencies`',
+  },
+  {
+    depType: 'optionalDependencies',
+    prettyDepType: 'optionalDependency',
+    description: 'Listed under `optionalDependencies`',
+  },
+  {
+    depType: 'peerDependencies',
+    prettyDepType: 'peerDependency',
+    description: 'Listed under `peerDependencies`',
+  },
+  {
+    depType: 'engines',
+    prettyDepType: 'engine',
+    description: 'Listed under `engines`',
+  },
+  {
+    depType: 'volta',
+    prettyDepType: 'volta',
+    description: 'Listed under `volta`',
+  },
+  {
+    depType: 'resolutions',
+    prettyDepType: 'resolutions',
+    description: 'Listed under `resolutions` (Yarn)',
+  },
+  {
+    depType: 'packageManager',
+    prettyDepType: 'packageManager',
+    description: 'Listed under `packageManager`',
+  },
+  {
+    depType: 'overrides',
+    prettyDepType: 'overrides',
+    description: 'Listed under `overrides`',
+  },
+  {
+    depType: 'pnpm',
+    prettyDepType: 'pnpm',
+    description: 'Listed under the top-level `pnpm` field',
+  },
+  {
+    depType: 'pnpm.overrides',
+    prettyDepType: 'overrides',
+    description: 'Listed under `pnpm.overrides`',
+  },
+] as const satisfies readonly DepTypeMetadata[];
+
+export const supportsDynamicDepTypesNote =
+  'Additionally, catalog dependencies produce dynamic `depType` values: `pnpm.catalog.<name>` for [pnpm catalogs](https://pnpm.io/catalogs#defining-catalogs) and `yarn.catalog.<name>` for [yarn catalogs](https://yarnpkg.com/features/catalogs).';

--- a/lib/modules/manager/npm/index.ts
+++ b/lib/modules/manager/npm/index.ts
@@ -47,3 +47,5 @@ export const supportedDatasources = [
   NpmDatasource.id,
   NodeVersionDatasource.id,
 ];
+
+export { knownDepTypes, supportsDynamicDepTypesNote } from './dep-types.ts';

--- a/lib/modules/manager/npm/readme.md
+++ b/lib/modules/manager/npm/readme.md
@@ -1,18 +1,3 @@
-The following `depTypes` are currently supported by the npm manager :
-
-- `dependencies`
-- `devDependencies`
-- `optionalDependencies`
-- `peerDependencies`
-- `engines` : Renovate will update any `node`, `npm` and `yarn` version specified under `engines`.
-- `volta` : Renovate will update any `node`, `npm`, `pnpm` and `yarn` version specified under `volta`.
-- `packageManager`
-- `overrides`
-- `resolutions`
-- `pnpm.overrides`
-- `pnpm.catalog` or `pnpm.catalog.<name>`. [Matches any default and named pnpm catalogs](https://pnpm.io/catalogs#defining-catalogs).
-- `yarn.catalog` or `yarn.catalogs.<name>`. [Matches any default and named yarn catalogs](https://yarnpkg.com/features/catalogs).
-
 ### npm problems and workarounds
 
 #### Invalid lock file (npm ci fails)

--- a/lib/modules/manager/nuget/dep-types.ts
+++ b/lib/modules/manager/nuget/dep-types.ts
@@ -1,0 +1,22 @@
+import type { DepTypeMetadata } from '../types.ts';
+
+export const knownDepTypes = [
+  {
+    depType: 'docker',
+    description: 'Container base image from `ContainerBaseImage`',
+  },
+  {
+    depType: 'nuget',
+    description:
+      'NuGet package reference from `PackageReference`, `PackageVersion`, or similar elements',
+  },
+  {
+    depType: 'msbuild-sdk',
+    description:
+      'MSBuild SDK reference from `Sdk` elements, `Import` elements, or `Project Sdk` attribute',
+  },
+  {
+    depType: 'dotnet-sdk',
+    description: '.NET SDK version from `global.json`',
+  },
+] as const satisfies readonly DepTypeMetadata[];

--- a/lib/modules/manager/nuget/index.ts
+++ b/lib/modules/manager/nuget/index.ts
@@ -28,3 +28,5 @@ export const supportedDatasources = [
   DotnetVersionDatasource.id,
   NugetDatasource.id,
 ];
+
+export { knownDepTypes } from './dep-types.ts';

--- a/lib/modules/manager/ocb/dep-types.ts
+++ b/lib/modules/manager/ocb/dep-types.ts
@@ -1,0 +1,32 @@
+import type { DepTypeMetadata } from '../types.ts';
+
+export const knownDepTypes = [
+  {
+    depType: 'collector',
+    description: 'The OpenTelemetry Collector version itself',
+  },
+  {
+    depType: 'connectors',
+    description: 'Connector component module',
+  },
+  {
+    depType: 'exports',
+    description: 'Exporter component module',
+  },
+  {
+    depType: 'extensions',
+    description: 'Extension component module',
+  },
+  {
+    depType: 'processors',
+    description: 'Processor component module',
+  },
+  {
+    depType: 'providers',
+    description: 'Provider component module',
+  },
+  {
+    depType: 'receivers',
+    description: 'Receiver component module',
+  },
+] as const satisfies readonly DepTypeMetadata[];

--- a/lib/modules/manager/ocb/index.ts
+++ b/lib/modules/manager/ocb/index.ts
@@ -14,3 +14,5 @@ export const defaultConfig = {
 };
 
 export const supportedDatasources = [GoDatasource.id];
+
+export { knownDepTypes } from './dep-types.ts';

--- a/lib/modules/manager/pep621/dep-types.ts
+++ b/lib/modules/manager/pep621/dep-types.ts
@@ -1,0 +1,44 @@
+import type { DepTypeMetadata } from '../types.ts';
+
+/**
+ * pep621 depTypes are partially dynamic: Hatch environment names
+ * produce `tool.hatch.envs.${envName}` depTypes at runtime.
+ * The values below cover all known/common depTypes.
+ */
+export const knownDepTypes = [
+  {
+    depType: 'requires-python',
+    description: 'The `requires-python` constraint from `[project]`',
+  },
+  {
+    depType: 'project.dependencies',
+    description: 'Listed under `[project.dependencies]`',
+  },
+  {
+    depType: 'project.optional-dependencies',
+    description: 'Listed under `[project.optional-dependencies]`',
+  },
+  {
+    depType: 'dependency-groups',
+    description: 'Listed under `[dependency-groups]` (PEP 735)',
+  },
+  {
+    depType: 'build-system.requires',
+    description: 'Listed under `[build-system.requires]`',
+  },
+  {
+    depType: 'tool.pdm.dev-dependencies',
+    description: 'Listed under `[tool.pdm.dev-dependencies]`',
+  },
+  {
+    depType: 'tool.uv.dev-dependencies',
+    description: 'Listed under `[tool.uv.dev-dependencies]`',
+  },
+  {
+    depType: 'tool.uv.sources',
+    description: 'Listed under `[tool.uv.sources]`',
+  },
+] as const satisfies readonly DepTypeMetadata[];
+
+export const supportsDynamicDepTypesNote =
+  'Hatch environments produce dynamic `depType` values in the form `tool.hatch.envs.<env-name>`.';

--- a/lib/modules/manager/pep621/dep-types.ts
+++ b/lib/modules/manager/pep621/dep-types.ts
@@ -1,10 +1,5 @@
 import type { DepTypeMetadata } from '../types.ts';
 
-/**
- * pep621 depTypes are partially dynamic: Hatch environment names
- * produce `tool.hatch.envs.${envName}` depTypes at runtime.
- * The values below cover all known/common depTypes.
- */
 export const knownDepTypes = [
   {
     depType: 'requires-python',

--- a/lib/modules/manager/pep621/index.ts
+++ b/lib/modules/manager/pep621/index.ts
@@ -17,3 +17,5 @@ export const defaultConfig = {
 };
 
 export const supportedDatasources = [PypiDatasource.id];
+
+export { knownDepTypes, supportsDynamicDepTypesNote } from './dep-types.ts';

--- a/lib/modules/manager/pep621/readme.md
+++ b/lib/modules/manager/pep621/readme.md
@@ -6,17 +6,6 @@ In addition to standard dependencies, these toolsets are also supported:
 - `uv` (including `uv.lock` files and `uv` workspaces)
 - `hatch`
 
-Available `depType`s:
-
-- `project.dependencies`
-- `project.optional-dependencies`
-- `dependency-groups`
-- `build-system.requires`
-- `tool.pdm.dev-dependencies`
-- `tool.uv.dev-dependencies`
-- `tool.uv.sources`
-- `tool.hatch.envs.<env-name>`
-
 ### Private Modules Authentication
 
 Before running the `pdm` or `uv` commands to update the `pdm.lock` or `uv.lock` respectively, Renovate exports `git` [`insteadOf`](https://git-scm.com/docs/git-config#Documentation/git-config.txt-urlltbasegtinsteadOf) directives in environment variables.

--- a/lib/modules/manager/pep723/dep-types.ts
+++ b/lib/modules/manager/pep723/dep-types.ts
@@ -1,0 +1,9 @@
+import type { DepTypeMetadata } from '../types.ts';
+
+export const knownDepTypes = [
+  {
+    depType: 'project.dependencies',
+    description:
+      'A dependency from the inline `[script.dependencies]` metadata (parsed as PEP 508)',
+  },
+] as const satisfies readonly DepTypeMetadata[];

--- a/lib/modules/manager/pep723/index.ts
+++ b/lib/modules/manager/pep723/index.ts
@@ -13,3 +13,5 @@ export const defaultConfig = {
 };
 
 export const supportedDatasources = [PypiDatasource.id];
+
+export { knownDepTypes } from './dep-types.ts';

--- a/lib/modules/manager/pip-compile/dep-types.ts
+++ b/lib/modules/manager/pip-compile/dep-types.ts
@@ -1,0 +1,9 @@
+import type { DepTypeMetadata } from '../types.ts';
+
+export const knownDepTypes = [
+  {
+    depType: 'indirect',
+    description:
+      'Indirect/transitive dependency locked in the compiled requirements file, but not directly specified in source',
+  },
+] as const satisfies readonly DepTypeMetadata[];

--- a/lib/modules/manager/pip-compile/index.ts
+++ b/lib/modules/manager/pip-compile/index.ts
@@ -22,3 +22,5 @@ export const defaultConfig = {
 };
 
 export const supportedDatasources = [PypiDatasource.id, GitTagsDatasource.id];
+
+export { knownDepTypes } from './dep-types.ts';

--- a/lib/modules/manager/pipenv/dep-types.ts
+++ b/lib/modules/manager/pipenv/dep-types.ts
@@ -1,11 +1,5 @@
 import type { DepTypeMetadata } from '../types.ts';
 
-/**
- * pipenv depTypes are dynamic: they come from the TOML section names
- * in the Pipfile. Any section that is not `source` or `requires` is
- * treated as a dependency section. The values below cover the standard
- * section names.
- */
 export const knownDepTypes = [
   {
     depType: 'packages',

--- a/lib/modules/manager/pipenv/dep-types.ts
+++ b/lib/modules/manager/pipenv/dep-types.ts
@@ -1,0 +1,21 @@
+import type { DepTypeMetadata } from '../types.ts';
+
+/**
+ * pipenv depTypes are dynamic: they come from the TOML section names
+ * in the Pipfile. Any section that is not `source` or `requires` is
+ * treated as a dependency section. The values below cover the standard
+ * section names.
+ */
+export const knownDepTypes = [
+  {
+    depType: 'packages',
+    description: 'Listed under `[packages]`',
+  },
+  {
+    depType: 'dev-packages',
+    description: 'Listed under `[dev-packages]`',
+  },
+] as const satisfies readonly DepTypeMetadata[];
+
+export const supportsDynamicDepTypesNote =
+  'Dependencies from other package category groups in the Pipfile use the group name as the `depType`.';

--- a/lib/modules/manager/pipenv/index.ts
+++ b/lib/modules/manager/pipenv/index.ts
@@ -15,3 +15,5 @@ export const defaultConfig = {
 };
 
 export const supportedDatasources = [PypiDatasource.id];
+
+export { knownDepTypes, supportsDynamicDepTypesNote } from './dep-types.ts';

--- a/lib/modules/manager/pipenv/readme.md
+++ b/lib/modules/manager/pipenv/readme.md
@@ -1,8 +1,1 @@
 `Pipenv.lock` updating is supported.
-
-The Pipenv manager supports the default `depTypes`:
-
-- `packages`
-- `dev-packages`
-
-and also extracts dependencies from other package category groups, using the group name as the `depType`.

--- a/lib/modules/manager/pixi/dep-types.ts
+++ b/lib/modules/manager/pixi/dep-types.ts
@@ -1,0 +1,16 @@
+import type { DepTypeMetadata } from '../types.ts';
+
+/**
+ * pixi depTypes are fully dynamic: feature dependencies produce
+ * `feature-${name}` depTypes at runtime, where `name` is the
+ * feature name defined in the pixi configuration.
+ *
+ * Top-level dependencies (under `[dependencies]` or `[pypi-dependencies]`)
+ * do not have a depType set.
+ *
+ * There are no fixed/enumerable depType values for this manager.
+ */
+export const knownDepTypes = [] as const satisfies readonly DepTypeMetadata[];
+
+export const supportsDynamicDepTypesNote =
+  'Feature dependencies produce dynamic `depType` values in the form `feature-<name>`, where `<name>` is the feature name defined in the pixi configuration. Top-level dependencies (under `[dependencies]` or `[pypi-dependencies]`) do not have a `depType` set.';

--- a/lib/modules/manager/pixi/dep-types.ts
+++ b/lib/modules/manager/pixi/dep-types.ts
@@ -1,15 +1,5 @@
 import type { DepTypeMetadata } from '../types.ts';
 
-/**
- * pixi depTypes are fully dynamic: feature dependencies produce
- * `feature-${name}` depTypes at runtime, where `name` is the
- * feature name defined in the pixi configuration.
- *
- * Top-level dependencies (under `[dependencies]` or `[pypi-dependencies]`)
- * do not have a depType set.
- *
- * There are no fixed/enumerable depType values for this manager.
- */
 export const knownDepTypes = [] as const satisfies readonly DepTypeMetadata[];
 
 export const supportsDynamicDepTypesNote =

--- a/lib/modules/manager/pixi/index.ts
+++ b/lib/modules/manager/pixi/index.ts
@@ -19,3 +19,5 @@ export const defaultConfig = {
 };
 
 export const supportedDatasources = [PypiDatasource.id, CondaDatasource.id];
+
+export { knownDepTypes, supportsDynamicDepTypesNote } from './dep-types.ts';

--- a/lib/modules/manager/poetry/dep-types.ts
+++ b/lib/modules/manager/poetry/dep-types.ts
@@ -1,10 +1,5 @@
 import type { DepTypeMetadata } from '../types.ts';
 
-/**
- * poetry depTypes are partially dynamic: group names from
- * `[tool.poetry.group.<name>.dependencies]` become depTypes at runtime.
- * The values below cover all known/common depTypes.
- */
 export const knownDepTypes = [
   {
     depType: 'dependencies',

--- a/lib/modules/manager/poetry/dep-types.ts
+++ b/lib/modules/manager/poetry/dep-types.ts
@@ -1,0 +1,41 @@
+import type { DepTypeMetadata } from '../types.ts';
+
+/**
+ * poetry depTypes are partially dynamic: group names from
+ * `[tool.poetry.group.<name>.dependencies]` become depTypes at runtime.
+ * The values below cover all known/common depTypes.
+ */
+export const knownDepTypes = [
+  {
+    depType: 'dependencies',
+    description: 'Listed under `[tool.poetry.dependencies]`',
+  },
+  {
+    depType: 'dev-dependencies',
+    description: 'Listed under `[tool.poetry.dev-dependencies]`',
+  },
+  {
+    depType: 'extras',
+    description: 'An optional dependency marked with `optional = true`',
+  },
+  {
+    depType: 'build-system.requires',
+    description: 'Listed under `[build-system.requires]`',
+  },
+  {
+    depType: 'project.dependencies',
+    description: 'Listed under `[project.dependencies]` (PEP 621 style)',
+  },
+  {
+    depType: 'project.optional-dependencies',
+    description:
+      'Listed under `[project.optional-dependencies]` (PEP 621 style)',
+  },
+  {
+    depType: 'dependency-groups',
+    description: 'Listed under `[dependency-groups]` (PEP 735)',
+  },
+] as const satisfies readonly DepTypeMetadata[];
+
+export const supportsDynamicDepTypesNote =
+  'Dependency group names from `[tool.poetry.group.<name>.dependencies]` are also used as `depType` values.';

--- a/lib/modules/manager/poetry/index.ts
+++ b/lib/modules/manager/poetry/index.ts
@@ -30,3 +30,5 @@ export const supportedDatasources = [
   GitRefsDatasource.id,
   GitTagsDatasource.id,
 ];
+
+export { knownDepTypes, supportsDynamicDepTypesNote } from './dep-types.ts';

--- a/lib/modules/manager/poetry/readme.md
+++ b/lib/modules/manager/poetry/readme.md
@@ -2,15 +2,6 @@ Poetry 0.x, 1.x and 2.x versions are supported.
 
 Whenever the `pyproject.toml` file is updated, the Poetry lock file will be checked for updates as well.
 
-The following `depTypes` are supported by the Poetry manager:
-
-- `build-system.requires`
-- `dependencies`
-- `dev-dependencies`
-- `dependency-groups`
-- `extras`
-- `<group-name>` (dynamic, based on the group name, per [dependency groups documentation](https://python-poetry.org/docs/managing-dependencies/#dependency-groups))
-
 <!-- prettier-ignore -->
 !!! warning
     Updating locked versions of Poetry dependencies is at times unreliable.

--- a/lib/modules/manager/pre-commit/dep-types.ts
+++ b/lib/modules/manager/pre-commit/dep-types.ts
@@ -1,0 +1,20 @@
+import type { DepTypeMetadata } from '../types.ts';
+
+export const knownDepTypes = [
+  {
+    depType: 'repository',
+    description: 'Pre-commit hook repository reference',
+  },
+  {
+    depType: 'pre-commit-node',
+    description: 'Node.js additional dependency for a pre-commit hook',
+  },
+  {
+    depType: 'pre-commit-python',
+    description: 'Python additional dependency for a pre-commit hook',
+  },
+  {
+    depType: 'pre-commit-golang',
+    description: 'Go additional dependency for a pre-commit hook',
+  },
+] as const satisfies readonly DepTypeMetadata[];

--- a/lib/modules/manager/pre-commit/index.ts
+++ b/lib/modules/manager/pre-commit/index.ts
@@ -23,3 +23,5 @@ export const supportedDatasources = [
   GithubTagsDatasource.id,
   GitlabTagsDatasource.id,
 ];
+
+export { knownDepTypes } from './dep-types.ts';

--- a/lib/modules/manager/pub/dep-types.ts
+++ b/lib/modules/manager/pub/dep-types.ts
@@ -1,0 +1,12 @@
+import type { DepTypeMetadata } from '../types.ts';
+
+export const knownDepTypes = [
+  {
+    depType: 'dependencies',
+    description: 'Listed under `dependencies`',
+  },
+  {
+    depType: 'dev_dependencies',
+    description: 'Listed under `dev_dependencies`',
+  },
+] as const satisfies readonly DepTypeMetadata[];

--- a/lib/modules/manager/pub/index.ts
+++ b/lib/modules/manager/pub/index.ts
@@ -22,3 +22,5 @@ export const supportedDatasources = [
   DartVersionDatasource.id,
   FlutterVersionDatasource.id,
 ];
+
+export { knownDepTypes } from './dep-types.ts';

--- a/lib/modules/manager/quadlet/dep-types.ts
+++ b/lib/modules/manager/quadlet/dep-types.ts
@@ -1,0 +1,8 @@
+import type { DepTypeMetadata } from '../types.ts';
+
+export const knownDepTypes = [
+  {
+    depType: 'image',
+    description: 'Container image referenced in a Quadlet unit file',
+  },
+] as const satisfies readonly DepTypeMetadata[];

--- a/lib/modules/manager/quadlet/index.ts
+++ b/lib/modules/manager/quadlet/index.ts
@@ -1,6 +1,7 @@
 import type { Category } from '../../../constants/index.ts';
 import { DockerDatasource } from '../../datasource/docker/index.ts';
 
+export { knownDepTypes } from './dep-types.ts';
 export { extractPackageFile } from './extract.ts';
 
 export const url =

--- a/lib/modules/manager/sbt/dep-types.ts
+++ b/lib/modules/manager/sbt/dep-types.ts
@@ -1,0 +1,18 @@
+import type { DepTypeMetadata } from '../types.ts';
+
+/**
+ * sbt depType values are dynamic: the `plugin` value is hardcoded for
+ * `addSbtPlugin`/`addCompilerPlugin`, but other values come from the
+ * classifier or configuration string in the build file (e.g. `% "test"`).
+ * This list enumerates common known values for documentation purposes.
+ */
+export const knownDepTypes = [
+  {
+    depType: 'plugin',
+    description:
+      'An sbt plugin added via `addSbtPlugin` or `addCompilerPlugin`',
+  },
+] as const satisfies readonly DepTypeMetadata[];
+
+export const supportsDynamicDepTypesNote =
+  'Other `depType` values are extracted dynamically from the classifier or configuration string in the build file (e.g. `% "test"`, `% Provided`, `classifier "sources"`).';

--- a/lib/modules/manager/sbt/dep-types.ts
+++ b/lib/modules/manager/sbt/dep-types.ts
@@ -1,11 +1,5 @@
 import type { DepTypeMetadata } from '../types.ts';
 
-/**
- * sbt depType values are dynamic: the `plugin` value is hardcoded for
- * `addSbtPlugin`/`addCompilerPlugin`, but other values come from the
- * classifier or configuration string in the build file (e.g. `% "test"`).
- * This list enumerates common known values for documentation purposes.
- */
 export const knownDepTypes = [
   {
     depType: 'plugin',

--- a/lib/modules/manager/sbt/index.ts
+++ b/lib/modules/manager/sbt/index.ts
@@ -28,3 +28,5 @@ export const supportedDatasources = [
   SbtPluginDatasource.id,
   GithubReleasesDatasource.id, // For sbt itself
 ];
+
+export { knownDepTypes, supportsDynamicDepTypesNote } from './dep-types.ts';

--- a/lib/modules/manager/setup-cfg/dep-types.ts
+++ b/lib/modules/manager/setup-cfg/dep-types.ts
@@ -1,0 +1,20 @@
+import type { DepTypeMetadata } from '../types.ts';
+
+export const knownDepTypes = [
+  {
+    depType: 'install',
+    description: 'Listed under `install_requires` in the `[options]` section',
+  },
+  {
+    depType: 'setup',
+    description: 'Listed under `setup_requires` in the `[options]` section',
+  },
+  {
+    depType: 'test',
+    description: 'Listed under `tests_require` in the `[options]` section',
+  },
+  {
+    depType: 'extra',
+    description: 'Listed under the `[options.extras_require]` section',
+  },
+] as const satisfies readonly DepTypeMetadata[];

--- a/lib/modules/manager/setup-cfg/index.ts
+++ b/lib/modules/manager/setup-cfg/index.ts
@@ -15,3 +15,5 @@ export const defaultConfig = {
 };
 
 export const supportedDatasources = [PypiDatasource.id];
+
+export { knownDepTypes } from './dep-types.ts';

--- a/lib/modules/manager/sveltos/dep-types.ts
+++ b/lib/modules/manager/sveltos/dep-types.ts
@@ -1,0 +1,16 @@
+import type { DepTypeMetadata } from '../types.ts';
+
+export const knownDepTypes = [
+  {
+    depType: 'ClusterProfile',
+    description: 'A Sveltos `ClusterProfile` resource',
+  },
+  {
+    depType: 'Profile',
+    description: 'A Sveltos `Profile` resource',
+  },
+  {
+    depType: 'EventTrigger',
+    description: 'A Sveltos `EventTrigger` resource',
+  },
+] as const satisfies readonly DepTypeMetadata[];

--- a/lib/modules/manager/sveltos/index.ts
+++ b/lib/modules/manager/sveltos/index.ts
@@ -12,3 +12,5 @@ export const defaultConfig = {
 };
 
 export const supportedDatasources = [DockerDatasource.id, HelmDatasource.id];
+
+export { knownDepTypes } from './dep-types.ts';

--- a/lib/modules/manager/tekton/dep-types.ts
+++ b/lib/modules/manager/tekton/dep-types.ts
@@ -1,0 +1,18 @@
+import type { DepTypeMetadata } from '../types.ts';
+
+export const knownDepTypes = [
+  {
+    depType: 'tekton-annotation',
+    description:
+      'Tekton resource referenced via an annotation (e.g. GitHub release or git tag URL)',
+  },
+  {
+    depType: 'tekton-bundle',
+    description: 'Tekton Bundle OCI image reference',
+  },
+  {
+    depType: 'tekton-step-image',
+    description:
+      'Container image used in a Tekton step, sidecar, or step template',
+  },
+] as const satisfies readonly DepTypeMetadata[];

--- a/lib/modules/manager/tekton/index.ts
+++ b/lib/modules/manager/tekton/index.ts
@@ -4,6 +4,7 @@ import { GitTagsDatasource } from '../../datasource/git-tags/index.ts';
 import { extractPackageFile } from './extract.ts';
 
 export { extractPackageFile };
+export { knownDepTypes } from './dep-types.ts';
 
 export const url = 'https://tekton.dev/docs';
 export const categories: Category[] = ['ci', 'cd'];

--- a/lib/modules/manager/terraform/dep-types.ts
+++ b/lib/modules/manager/terraform/dep-types.ts
@@ -1,0 +1,104 @@
+import type { DepTypeMetadata } from '../types.ts';
+
+export const knownDepTypes = [
+  {
+    depType: 'module',
+    description: 'A Terraform module source reference',
+  },
+  {
+    depType: 'provider',
+    description: 'A Terraform provider declared in a `provider` block',
+  },
+  {
+    depType: 'required_provider',
+    description:
+      'A Terraform provider declared in a `required_providers` block',
+  },
+  {
+    depType: 'required_version',
+    description:
+      'The Terraform version constraint in a `required_version` field',
+  },
+  {
+    depType: 'helm_release',
+    description: 'A Helm chart deployed via a `helm_release` resource',
+  },
+  {
+    depType: 'tfe_workspace',
+    description: 'A Terraform version pinned in a `tfe_workspace` resource',
+  },
+  {
+    depType: 'docker_image',
+    description: 'A Docker image in a `docker_image` resource',
+  },
+  {
+    depType: 'docker_container',
+    description: 'A Docker image in a `docker_container` resource',
+  },
+  {
+    depType: 'docker_service',
+    description: 'A Docker image in a `docker_service` resource',
+  },
+  {
+    depType: 'docker_registry_image',
+    description: 'A Docker image in a `docker_registry_image` data source',
+  },
+  {
+    depType: 'kubernetes_pod',
+    description: 'A container image in a `kubernetes_pod` resource',
+  },
+  {
+    depType: 'kubernetes_pod_v1',
+    description: 'A container image in a `kubernetes_pod_v1` resource',
+  },
+  {
+    depType: 'kubernetes_cron_job',
+    description: 'A container image in a `kubernetes_cron_job` resource',
+  },
+  {
+    depType: 'kubernetes_cron_job_v1',
+    description: 'A container image in a `kubernetes_cron_job_v1` resource',
+  },
+  {
+    depType: 'kubernetes_daemonset',
+    description: 'A container image in a `kubernetes_daemonset` resource',
+  },
+  {
+    depType: 'kubernetes_daemon_set_v1',
+    description: 'A container image in a `kubernetes_daemon_set_v1` resource',
+  },
+  {
+    depType: 'kubernetes_deployment',
+    description: 'A container image in a `kubernetes_deployment` resource',
+  },
+  {
+    depType: 'kubernetes_deployment_v1',
+    description: 'A container image in a `kubernetes_deployment_v1` resource',
+  },
+  {
+    depType: 'kubernetes_job',
+    description: 'A container image in a `kubernetes_job` resource',
+  },
+  {
+    depType: 'kubernetes_job_v1',
+    description: 'A container image in a `kubernetes_job_v1` resource',
+  },
+  {
+    depType: 'kubernetes_replication_controller',
+    description:
+      'A container image in a `kubernetes_replication_controller` resource',
+  },
+  {
+    depType: 'kubernetes_replication_controller_v1',
+    description:
+      'A container image in a `kubernetes_replication_controller_v1` resource',
+  },
+  {
+    depType: 'kubernetes_stateful_set',
+    description: 'A container image in a `kubernetes_stateful_set` resource',
+  },
+  {
+    depType: 'kubernetes_stateful_set_v1',
+    description: 'A container image in a `kubernetes_stateful_set_v1` resource',
+  },
+] as const satisfies readonly DepTypeMetadata[];

--- a/lib/modules/manager/terraform/index.ts
+++ b/lib/modules/manager/terraform/index.ts
@@ -34,3 +34,5 @@ export const supportedDatasources = [
   TerraformModuleDatasource.id,
   TerraformProviderDatasource.id,
 ];
+
+export { knownDepTypes } from './dep-types.ts';

--- a/lib/modules/manager/terragrunt/dep-types.ts
+++ b/lib/modules/manager/terragrunt/dep-types.ts
@@ -1,0 +1,16 @@
+import type { DepTypeMetadata } from '../types.ts';
+
+export const knownDepTypes = [
+  {
+    depType: 'github',
+    description: 'Terragrunt module sourced from a GitHub repository',
+  },
+  {
+    depType: 'gitTags',
+    description: 'Terragrunt module sourced from a generic Git repository',
+  },
+  {
+    depType: 'terragrunt',
+    description: 'Terragrunt module sourced from a Terraform Module registry',
+  },
+] as const satisfies readonly DepTypeMetadata[];

--- a/lib/modules/manager/terragrunt/index.ts
+++ b/lib/modules/manager/terragrunt/index.ts
@@ -7,6 +7,7 @@ import { GitlabTagsDatasource } from '../../datasource/gitlab-tags/index.ts';
 import { TerraformModuleDatasource } from '../../datasource/terraform-module/index.ts';
 
 export { updateArtifacts } from './artifacts.ts';
+export { knownDepTypes } from './dep-types.ts';
 export { extractPackageFile } from './extract.ts';
 
 export const supportsLockFileMaintenance = true;

--- a/lib/modules/manager/tflint-plugin/dep-types.ts
+++ b/lib/modules/manager/tflint-plugin/dep-types.ts
@@ -1,0 +1,8 @@
+import type { DepTypeMetadata } from '../types.ts';
+
+export const knownDepTypes = [
+  {
+    depType: 'plugin',
+    description: 'TFLint plugin sourced from GitHub Releases',
+  },
+] as const satisfies readonly DepTypeMetadata[];

--- a/lib/modules/manager/tflint-plugin/index.ts
+++ b/lib/modules/manager/tflint-plugin/index.ts
@@ -1,6 +1,7 @@
 import type { Category } from '../../../constants/index.ts';
 import { GithubReleasesDatasource } from '../../datasource/github-releases/index.ts';
 
+export { knownDepTypes } from './dep-types.ts';
 export { extractPackageFile } from './extract.ts';
 
 export const displayName = 'TFLint Plugins';

--- a/lib/modules/manager/types.ts
+++ b/lib/modules/manager/types.ts
@@ -133,11 +133,12 @@ export interface LookupUpdate {
  */
 export interface PackageDependency<
   T = Record<string, any>,
+  DepType extends string = string,
 > extends ManagerData<T> {
   currentValue?: string | null;
   currentDigest?: string;
   depName?: string;
-  depType?: string;
+  depType?: DepType;
   fileReplacePosition?: number;
   sharedVariableName?: string;
   lineNumber?: number;
@@ -192,7 +193,10 @@ export interface PackageDependency<
   isAbandoned?: boolean;
 }
 
-export interface Upgrade<T = Record<string, any>> extends PackageDependency<T> {
+export interface Upgrade<
+  T = Record<string, any>,
+  DepType extends string = string,
+> extends PackageDependency<T, DepType> {
   workspace?: string;
   isLockfileUpdate?: boolean;
   currentRawValue?: any;
@@ -281,10 +285,32 @@ export interface GlobalManagerConfig {
   npmrcMerge?: boolean;
 }
 
+export interface DepTypeMetadata {
+  /**
+   * The raw depType set on a given PackageDependency
+   *
+   * @see PackageDependency
+   */
+  depType: string;
+  /**
+   * An alternate name for the `depType`, derived from the Manager's `prettyDepType` used.
+   *
+   * For instance, `optionalDependencies` may have a `prettyDepType` of `optionalDependency`
+   *
+   * Not supported by all Managers.
+   * */
+  prettyDepType?: string;
+  /** Human-readable description of what this depType represents */
+  description: string;
+}
+
 interface ManagerApiBase extends ModuleApi {
   defaultConfig: Record<string, unknown>;
 
   categories?: Category[];
+  knownDepTypes?: readonly DepTypeMetadata[];
+  /** Markdown note about dynamically generated depTypes not covered by `knownDepTypes` */
+  supportsDynamicDepTypesNote?: string;
   supportsLockFileMaintenance?: boolean;
   lockFileNames?: string[];
   supersedesManagers?: string[];

--- a/lib/modules/manager/vendir/dep-types.ts
+++ b/lib/modules/manager/vendir/dep-types.ts
@@ -1,0 +1,20 @@
+import type { DepTypeMetadata } from '../types.ts';
+
+export const knownDepTypes = [
+  {
+    depType: 'HelmChart',
+    description: 'Helm chart dependency in vendir configuration',
+  },
+  {
+    depType: 'GitSource',
+    description: 'Git reference-based source',
+  },
+  {
+    depType: 'GithubRelease',
+    description: 'GitHub release-based source',
+  },
+  {
+    depType: 'HttpSource',
+    description: 'HTTP-based source',
+  },
+] as const satisfies readonly DepTypeMetadata[];

--- a/lib/modules/manager/vendir/index.ts
+++ b/lib/modules/manager/vendir/index.ts
@@ -16,3 +16,5 @@ export const defaultConfig = {
 };
 
 export const supportedDatasources = [HelmDatasource.id, DockerDatasource.id];
+
+export { knownDepTypes } from './dep-types.ts';

--- a/tools/docs/manager.ts
+++ b/tools/docs/manager.ts
@@ -146,6 +146,39 @@ export async function generateManagers(
         .join(', ');
       md += `This manager supports extracting the following datasources: ${escapedDatasources}.\n\n`;
       md += formatUrls(urls);
+      if (
+        definition.knownDepTypes?.length ||
+        definition.supportsDynamicDepTypesNote
+      ) {
+        md += '## Dependency types\n\n';
+        if (definition.knownDepTypes?.length) {
+          const hasPrettyDepType = definition.knownDepTypes.some(
+            (m) => m.prettyDepType,
+          );
+          md += 'This manager extracts the following `depType` values:\n\n';
+          if (hasPrettyDepType) {
+            md += '| `depType` | `prettyDepType` | Description |\n';
+            md += '|-----------|-----------------|-------------|\n';
+            for (const {
+              depType,
+              prettyDepType,
+              description,
+            } of definition.knownDepTypes) {
+              md += `| \`${depType}\` | ${prettyDepType ? `\`${prettyDepType}\`` : ''} | ${description} |\n`;
+            }
+          } else {
+            md += '| `depType` | Description |\n';
+            md += '|-----------|-------------|\n';
+            for (const { depType, description } of definition.knownDepTypes) {
+              md += `| \`${depType}\` | ${description} |\n`;
+            }
+          }
+          md += '\n';
+        }
+        if (definition.supportsDynamicDepTypesNote) {
+          md += definition.supportsDynamicDepTypesNote + '\n\n';
+        }
+      }
       md += '## Default config\n\n';
       md += '```json\n';
       md += JSON.stringify(definition.defaultConfig, null, 2) + '\n';

--- a/tools/docs/manager.ts
+++ b/tools/docs/manager.ts
@@ -146,38 +146,39 @@ export async function generateManagers(
         .join(', ');
       md += `This manager supports extracting the following datasources: ${escapedDatasources}.\n\n`;
       md += formatUrls(urls);
-      if (
-        definition.knownDepTypes?.length ||
-        definition.supportsDynamicDepTypesNote
-      ) {
-        md += '## Dependency types\n\n';
-        if (definition.knownDepTypes?.length) {
-          const hasPrettyDepType = definition.knownDepTypes.some(
-            (m) => m.prettyDepType,
-          );
-          md += 'This manager extracts the following `depType` values:\n\n';
-          if (hasPrettyDepType) {
-            md += '| `depType` | `prettyDepType` | Description |\n';
-            md += '|-----------|-----------------|-------------|\n';
-            for (const {
-              depType,
-              prettyDepType,
-              description,
-            } of definition.knownDepTypes) {
-              md += `| \`${depType}\` | ${prettyDepType ? `\`${prettyDepType}\`` : ''} | ${description} |\n`;
-            }
-          } else {
-            md += '| `depType` | Description |\n';
-            md += '|-----------|-------------|\n';
-            for (const { depType, description } of definition.knownDepTypes) {
-              md += `| \`${depType}\` | ${description} |\n`;
-            }
+      md += '## Dependency types\n\n';
+      if (definition.knownDepTypes?.length) {
+        const hasPrettyDepType = definition.knownDepTypes.some(
+          (m) => m.prettyDepType,
+        );
+        md += 'This manager extracts the following `depType` values:\n\n';
+        if (hasPrettyDepType) {
+          md += '| `depType` | `prettyDepType` | Description |\n';
+          md += '|-----------|-----------------|-------------|\n';
+          for (const {
+            depType,
+            prettyDepType,
+            description,
+          } of definition.knownDepTypes) {
+            md += `| \`${depType}\` | ${prettyDepType ? `\`${prettyDepType}\`` : ''} | ${description} |\n`;
           }
-          md += '\n';
+        } else {
+          md += '| `depType` | Description |\n';
+          md += '|-----------|-------------|\n';
+          for (const { depType, description } of definition.knownDepTypes) {
+            md += `| \`${depType}\` | ${description} |\n`;
+          }
         }
-        if (definition.supportsDynamicDepTypesNote) {
-          md += definition.supportsDynamicDepTypesNote + '\n\n';
-        }
+        md += '\n';
+      }
+      if (definition.supportsDynamicDepTypesNote) {
+        md += definition.supportsDynamicDepTypesNote + '\n\n';
+      }
+      if (
+        (!definition.knownDepTypes || definition.knownDepTypes.length === 0) &&
+        definition.supportsDynamicDepTypesNote === undefined
+      ) {
+        md += 'This manager has no documented `depType` values.\n';
       }
       md += '## Default config\n\n';
       md += '```json\n';


### PR DESCRIPTION

## Changes

A long-standing question we receive is "what `depTypes` can I match
against in my project".

Although the best recommendation we usually have is "check the
`packageFiles with updates" log line (as a very key log line for users),
we can go one step further and try and create a stronger contract.


To do this, I've used Claude Sonnet 4.6 to work through the codebase,
determine areas that a `depType` is set in a manager (statically or
dynamically) and generate a structured, typed, means to document how
they're used.

Through a few iterations of the process, and attempts at human-written
documentation, we've settled on:

- prioritising autogenerated documentation (for humans to read) to note
  what `depTypes` are known, and what they are
- `knownDepTypes`, to describe any known, static, `depType`s and their
  human-readable meaning
  - with the `prettyDepType`, if used
- `supportsDynamicDepTypesNote`, to add a Markdown note to the generated
  documentation

While here, we also:

- make sure to note this in the "adding a new package manager"
  documentation
- remove any hand-written references to `depTypes` in each manager's
  documentation page
- correct the Gleam `depTypes`
- make sure to use the `knownDepTypes`'s `prettyDepType` definition if
  we know it, for a given `depType`

The descriptions have been generated by Claude Sonnet, with some
human-written tweaks where appropriate.

[0]: https://github.com/renovatebot/renovate/discussions/15176



## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe): Claude Sonnet 4.6

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
