### PR TITLE
feat(pnpm): pass minimumReleaseAge to pnpm during lock file generation

### DIFF
--- a/docs/usage/key-concepts/minimum-release-age.md
+++ b/docs/usage/key-concepts/minimum-release-age.md
@@ -52,6 +52,14 @@ This ensures that npm only resolves package versions that were available before 
 The `--before` date is calculated as `now - minimumReleaseAge`.
 If a `before=<date>` or `min-release-age=<days>` setting already exists in the project's `.npmrc`, Renovate uses the stricter (older) of the two dates.
 
+#### pnpm
+
+When `minimumReleaseAge` is configured, Renovate temporarily injects a `minimumReleaseAge` setting (in minutes) into `pnpm-workspace.yaml` before running `pnpm install`.
+This uses pnpm's native [`minimumReleaseAge`](https://pnpm.io/settings#minimumreleaseage) setting to prevent resolving packages published more recently than the threshold.
+
+The original `pnpm-workspace.yaml` is restored after the lock file is generated.
+If `pnpm-workspace.yaml` already contains a `minimumReleaseAge` setting, Renovate does not override it.
+
 ### What happens if the datasource and/or registry does not provide a release timestamp, when using `minimumReleaseAge`?
 
 <!-- prettier-ignore -->
@@ -116,19 +124,19 @@ Depending on your manager, datasource and the given package(s), it may be that s
 
 <!-- markdownlint-disable MD060 -->
 
-| Update Type           | Supports `minimumReleaseAge`? | Notes                                                                                                     |
-| --------------------- | ----------------------------- | --------------------------------------------------------------------------------------------------------- |
-| `major`               | ✅                            | Depends on the Manager, Datasource, and package(s)                                                        |
-| `minor`               | ✅                            | Depends on the Manager, Datasource, and package(s)                                                        |
-| `patch`               | ✅                            | Depends on the Manager, Datasource, and package(s)                                                        |
-| `pin`                 | ❌                            | [Not yet supported](https://github.com/renovatebot/renovate/issues/40288)                                 |
-| `digest`              | 🟡                            | Generally not supported. Depends on the Manager, Datasource, and package(s)                               |
-| `pinDigest`           | ❌                            | [Not yet supported](https://github.com/renovatebot/renovate/issues/40288)                                 |
-| `lockFileMaintenance` | ❌                            | Not possible, as we delegate to the package manager to perform the required changes to update package(s). |
-| `lockFileUpdate`      | ❌                            |                                                                                                           |
-| `rollback`            | ❌                            |                                                                                                           |
-| `bump`                | ❌                            |                                                                                                           |
-| `replacement`         | ❌                            | [Not yet supported](https://github.com/renovatebot/renovate/issues/39400)                                 |
+| Update Type           | Supports `minimumReleaseAge`? | Notes                                                                                                                                 |
+| --------------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `major`               | ✅                            | Depends on the Manager, Datasource, and package(s)                                                                                    |
+| `minor`               | ✅                            | Depends on the Manager, Datasource, and package(s)                                                                                    |
+| `patch`               | ✅                            | Depends on the Manager, Datasource, and package(s)                                                                                    |
+| `pin`                 | ❌                            | [Not yet supported](https://github.com/renovatebot/renovate/issues/40288)                                                             |
+| `digest`              | 🟡                            | Generally not supported. Depends on the Manager, Datasource, and package(s)                                                           |
+| `pinDigest`           | ❌                            | [Not yet supported](https://github.com/renovatebot/renovate/issues/40288)                                                             |
+| `lockFileMaintenance` | 🟡                            | Supported for npm (via `--before`) and pnpm (via `minimumReleaseAge` in `pnpm-workspace.yaml`). Not yet supported for other managers. |
+| `lockFileUpdate`      | ❌                            |                                                                                                                                       |
+| `rollback`            | ❌                            |                                                                                                                                       |
+| `bump`                | ❌                            |                                                                                                                                       |
+| `replacement`         | ❌                            | [Not yet supported](https://github.com/renovatebot/renovate/issues/39400)                                                             |
 
 You can validate which update types may have release timestamps by following something similar to how [verify if the registry you're using](#which-registries-support-release-timestamps).
 

--- a/docs/usage/key-concepts/minimum-release-age.md
+++ b/docs/usage/key-concepts/minimum-release-age.md
@@ -44,6 +44,14 @@ To protect against this, it's recommended to ensure that your package manager co
 There is ongoing work to [integrate more closely with package manager checks](https://github.com/renovatebot/renovate/issues/41652) to make sure that Renovate's minimum release age configuration is specified when calling package managers that support it.
 If you have a package manager you'd like supported, please raise a [Suggest an Idea Discussion](https://github.com/renovatebot/renovate/discussions/new?category=suggest-an-idea).
 
+#### npm
+
+When `minimumReleaseAge` is configured, Renovate passes `--before=<date>` to npm commands during lock file generation.
+This ensures that npm only resolves package versions that were available before the cooldown threshold, protecting against newly published (and potentially malicious) transitive dependencies.
+
+The `--before` date is calculated as `now - minimumReleaseAge`.
+If a `before=<date>` or `min-release-age=<days>` setting already exists in the project's `.npmrc`, Renovate uses the stricter (older) of the two dates.
+
 ### What happens if the datasource and/or registry does not provide a release timestamp, when using `minimumReleaseAge`?
 
 <!-- prettier-ignore -->

--- a/lib/modules/manager/npm/post-update/index.ts
+++ b/lib/modules/manager/npm/post-update/index.ts
@@ -450,6 +450,7 @@ export async function getAdditionalFiles(
       fileName,
       config,
       upgrades,
+      npmrcContent,
     );
     if (res.error) {
       /* v8 ignore next -- needs test */

--- a/lib/modules/manager/npm/post-update/npm.spec.ts
+++ b/lib/modules/manager/npm/post-update/npm.spec.ts
@@ -954,4 +954,191 @@ describe('modules/manager/npm/post-update/npm', () => {
       ]);
     });
   });
+
+  describe('--before with minimumReleaseAge', () => {
+    let execSnapshots: ReturnType<typeof mockExecAll>;
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-06-15T12:00:00.000Z'));
+      execSnapshots = mockExecAll();
+      fs.readLocalFile.mockResolvedValueOnce('{}');
+      const packageLockContents = JSON.stringify({
+        packages: {},
+        lockfileVersion: 3,
+      });
+      fs.readLocalFile
+        .mockResolvedValueOnce(packageLockContents)
+        .mockResolvedValueOnce(packageLockContents);
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('sets --before from minimumReleaseAge', async () => {
+      await npmHelper.generateLockFile(
+        'some-dir',
+        {},
+        'package-lock.json',
+        { skipInstalls: true, minimumReleaseAge: '3 days' },
+        [
+          {
+            packageName: 'some-dep',
+            newVersion: '1.0.1',
+            isLockfileUpdate: false,
+          },
+        ],
+      );
+
+      expect(execSnapshots).toMatchObject([
+        {
+          cmd: 'npm install --package-lock-only --no-audit --ignore-scripts --before=2026-06-12T12:00:00.000Z',
+        },
+      ]);
+    });
+
+    it('skips --before on unparseable minimumReleaseAge', async () => {
+      await npmHelper.generateLockFile(
+        'some-dir',
+        {},
+        'package-lock.json',
+        { skipInstalls: true, minimumReleaseAge: 'invalid garbage' },
+        [
+          {
+            packageName: 'some-dep',
+            newVersion: '1.0.1',
+            isLockfileUpdate: false,
+          },
+        ],
+      );
+
+      expect(execSnapshots).toMatchObject([
+        {
+          cmd: 'npm install --package-lock-only --no-audit --ignore-scripts',
+        },
+      ]);
+    });
+
+    it('uses stricter npmrc before date when older than minimumReleaseAge', async () => {
+      // npmrc (June 1) is earlier than minimumReleaseAge (3 days = June 12)
+      await npmHelper.generateLockFile(
+        'some-dir',
+        {},
+        'package-lock.json',
+        { skipInstalls: true, minimumReleaseAge: '3 days' },
+        [
+          {
+            packageName: 'some-dep',
+            newVersion: '1.0.1',
+            isLockfileUpdate: false,
+          },
+        ],
+        'registry=https://registry.npmjs.org\nbefore=2026-06-01T00:00:00.000Z\n',
+      );
+
+      expect(execSnapshots).toMatchObject([
+        {
+          cmd: 'npm install --package-lock-only --no-audit --ignore-scripts --before=2026-06-01T00:00:00.000Z',
+        },
+      ]);
+    });
+
+    it('uses minimumReleaseAge date when stricter than npmrc before date', async () => {
+      // minimumReleaseAge (3 days = June 12) is earlier than npmrc (June 14)
+      await npmHelper.generateLockFile(
+        'some-dir',
+        {},
+        'package-lock.json',
+        { skipInstalls: true, minimumReleaseAge: '3 days' },
+        [
+          {
+            packageName: 'some-dep',
+            newVersion: '1.0.1',
+            isLockfileUpdate: false,
+          },
+        ],
+        'before=2026-06-14T00:00:00.000Z\n',
+      );
+
+      expect(execSnapshots).toMatchObject([
+        {
+          cmd: 'npm install --package-lock-only --no-audit --ignore-scripts --before=2026-06-12T12:00:00.000Z',
+        },
+      ]);
+    });
+
+    it('skips --before when minimumReleaseAge is absent even if npmrc has before', async () => {
+      await npmHelper.generateLockFile(
+        'some-dir',
+        {},
+        'package-lock.json',
+        { skipInstalls: true },
+        [
+          {
+            packageName: 'some-dep',
+            newVersion: '1.0.1',
+            isLockfileUpdate: false,
+          },
+        ],
+        'before=2026-06-01T00:00:00.000Z\n',
+      );
+
+      expect(execSnapshots).toMatchObject([
+        {
+          cmd: 'npm install --package-lock-only --no-audit --ignore-scripts',
+        },
+      ]);
+    });
+  });
+
+  describe('parseNpmrcCooldownDate', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-06-15T12:00:00.000Z'));
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    describe('returns null', () => {
+      it.each`
+        content
+        ${null}
+        ${'registry=https://registry.npmjs.org\n'}
+        ${'before=not-a-date\n'}
+        ${'before=2026-13-99T00:00:00.000Z\n'}
+      `('for: $content', ({ content }: { content: string | null }) => {
+        expect(npmHelper.parseNpmrcCooldownDate(content)).toBeNull();
+      });
+    });
+
+    describe('parses before= key', () => {
+      it.each`
+        input
+        ${'before=2026-06-01T00:00:00.000Z\n'}
+        ${'before="2026-06-01T00:00:00.000Z"\n'}
+        ${'registry=https://registry.npmjs.org\nbefore=2026-06-01T00:00:00.000Z # some comment\naudit=false\n'}
+      `('$input', ({ input }: { input: string }) => {
+        expect(npmHelper.parseNpmrcCooldownDate(input)?.toISO()).toBe(
+          '2026-06-01T00:00:00.000Z',
+        );
+      });
+    });
+
+    describe('parses min-release-age= key', () => {
+      it.each`
+        input
+        ${'min-release-age=30\n'}
+        ${'min-release-age="30"\n'}
+        ${'min-release-age=30 # 30 days\n'}
+        ${'registry=https://registry.npmjs.org\nmin-release-age=30 # 30 days\n'}
+      `('$input', ({ input }: { input: string }) => {
+        expect(npmHelper.parseNpmrcCooldownDate(input)?.toISO()).toBe(
+          '2026-05-16T12:00:00.000Z',
+        );
+      });
+    });
+  });
 });

--- a/lib/modules/manager/npm/post-update/npm.ts
+++ b/lib/modules/manager/npm/post-update/npm.ts
@@ -148,7 +148,10 @@ export async function generateLockFile(
       const ms = toMs(config.minimumReleaseAge);
       if (ms === null) {
         logger.debug(
-          `Invalid minimumReleaseAge value: ${config.minimumReleaseAge}, skipping --before for npm install`,
+          {
+            minimumReleaseAge: config.minimumReleaseAge,
+          },
+          'Invalid minimumReleaseAge, skipping --before for npm install',
         );
       } else {
         let beforeDate = DateTime.now().minus(ms).toUTC();
@@ -156,14 +159,22 @@ export async function generateLockFile(
         const npmrcDate = parseNpmrcCooldownDate(npmrcContent);
         if (npmrcDate && npmrcDate < beforeDate) {
           logger.debug(
-            `Using stricter .npmrc cooldown date ${npmrcDate.toISO()} over minimumReleaseAge date ${beforeDate.toISO()}`,
+            {
+              npmrcDate: npmrcDate.toISO(),
+              beforeDate: beforeDate.toISO(),
+            },
+            'Using stricter .npmrc cooldown date over minimumReleaseAge date',
           );
           beforeDate = npmrcDate;
         }
 
         const beforeISO = beforeDate.toISO();
         logger.debug(
-          `Setting npm --before=${beforeISO} based on minimumReleaseAge=${config.minimumReleaseAge}`,
+          {
+            beforeISO,
+            minimumReleaseAge: config.minimumReleaseAge,
+          },
+          'Setting npm --before based on minimumReleaseAge',
         );
         cmdOptions += ` --before=${beforeISO}`;
       }

--- a/lib/modules/manager/npm/post-update/npm.ts
+++ b/lib/modules/manager/npm/post-update/npm.ts
@@ -47,7 +47,7 @@ const npmrcMinReleaseAgeRegex = regEx(
 
 export function parseNpmrcCooldownDate(
   npmrcContent: string | null,
-): DateTime | null {
+): DateTime<true> | null {
   const dateStr = npmrcContent?.match(npmrcBeforeRegex)?.[1];
   if (dateStr) {
     const parsed = DateTime.fromISO(dateStr, { zone: 'utc' });

--- a/lib/modules/manager/npm/post-update/npm.ts
+++ b/lib/modules/manager/npm/post-update/npm.ts
@@ -1,5 +1,6 @@
 // TODO: types (#22198)
 import { isNonEmptyString, isString } from '@sindresorhus/is';
+import { DateTime } from 'luxon';
 import semver from 'semver';
 import { quote } from 'shlex';
 import upath from 'upath';
@@ -22,6 +23,8 @@ import {
   renameLocalFile,
 } from '../../../../util/fs/index.ts';
 import { minimatch } from '../../../../util/minimatch.ts';
+import { toMs } from '../../../../util/pretty-time.ts';
+import { regEx } from '../../../../util/regex.ts';
 import { Result } from '../../../../util/result.ts';
 import { trimSlashes } from '../../../../util/url.ts';
 import type { PostUpdateConfig, Upgrade } from '../../types.ts';
@@ -34,6 +37,35 @@ import {
   getPackageManagerVersion,
   lazyLoadPackageJson,
 } from './utils.ts';
+
+const npmrcBeforeRegex = regEx(
+  /^\s*before\s*=\s*"?(\d{4}-\d{2}-\d{2}(?:T[\d:.]+Z?)?)"?(?:\s+[;#].*)?\s*$/m,
+);
+const npmrcMinReleaseAgeRegex = regEx(
+  /^\s*min-release-age\s*=\s*"?(\d+)"?(?:\s+[;#].*)?\s*$/m,
+);
+
+export function parseNpmrcCooldownDate(
+  npmrcContent: string | null,
+): DateTime | null {
+  const dateStr = npmrcContent?.match(npmrcBeforeRegex)?.[1];
+  if (dateStr) {
+    const parsed = DateTime.fromISO(dateStr, { zone: 'utc' });
+    if (parsed.isValid) {
+      return parsed;
+    }
+    logger.debug(`Invalid before date in .npmrc: ${dateStr}, ignoring`);
+  }
+
+  const daysStr = npmrcContent?.match(npmrcMinReleaseAgeRegex)?.[1];
+  if (daysStr) {
+    return DateTime.now()
+      .minus({ days: parseInt(daysStr, 10) })
+      .toUTC();
+  }
+
+  return null;
+}
 
 async function getNpmConstraintFromPackageLock(
   lockFileDir: string,
@@ -67,6 +99,7 @@ export async function generateLockFile(
   filename: string,
   config: Partial<PostUpdateConfig> = {},
   upgrades: Upgrade[] = [],
+  npmrcContent: string | null = null,
 ): Promise<GenerateLockFileResult> {
   // TODO: don't assume package-lock.json is in the same directory
   const lockFileName = upath.join(lockFileDir, filename);
@@ -109,6 +142,31 @@ export async function generateLockFile(
 
     if (!GlobalConfig.get('allowScripts') || config.ignoreScripts) {
       cmdOptions += ' --ignore-scripts';
+    }
+
+    if (config.minimumReleaseAge) {
+      const ms = toMs(config.minimumReleaseAge);
+      if (ms === null) {
+        logger.debug(
+          `Invalid minimumReleaseAge value: ${config.minimumReleaseAge}, skipping --before for npm install`,
+        );
+      } else {
+        let beforeDate = DateTime.now().minus(ms).toUTC();
+
+        const npmrcDate = parseNpmrcCooldownDate(npmrcContent);
+        if (npmrcDate && npmrcDate < beforeDate) {
+          logger.debug(
+            `Using stricter .npmrc cooldown date ${npmrcDate.toISO()} over minimumReleaseAge date ${beforeDate.toISO()}`,
+          );
+          beforeDate = npmrcDate;
+        }
+
+        const beforeISO = beforeDate.toISO();
+        logger.debug(
+          `Setting npm --before=${beforeISO} based on minimumReleaseAge=${config.minimumReleaseAge}`,
+        );
+        cmdOptions += ` --before=${beforeISO}`;
+      }
     }
 
     const extraEnv: ExtraEnv = {

--- a/lib/modules/manager/npm/post-update/pnpm.spec.ts
+++ b/lib/modules/manager/npm/post-update/pnpm.spec.ts
@@ -695,4 +695,124 @@ describe('modules/manager/npm/post-update/pnpm', () => {
       expect(res).toBe('>=9');
     });
   });
+
+  describe('minimumReleaseAge with pnpm-workspace.yaml', () => {
+    it('injects minimumReleaseAge into pnpm-workspace.yaml when configured', async () => {
+      const execSnapshots = mockExecAll();
+      const workspaceContent = 'packages:\n  - packages/*\n';
+      fs.getSiblingFileName.mockReturnValue('some-dir/pnpm-workspace.yaml');
+      fs.localPathExists.mockResolvedValueOnce(true);
+      fs.readLocalFile.mockImplementation((fileName: string) => {
+        if (fileName === 'some-dir/pnpm-workspace.yaml') {
+          return Promise.resolve(workspaceContent);
+        }
+        if (fileName === 'some-dir/pnpm-lock.yaml') {
+          return Promise.resolve('package-lock-contents');
+        }
+        return Promise.resolve('{}');
+      });
+      const res = await pnpmHelper.generateLockFile(
+        'some-dir',
+        {},
+        { ...config, minimumReleaseAge: '3 days' },
+        [{ isLockFileMaintenance: true }],
+      );
+      expect(res.lockFile).toBe('package-lock-contents');
+      expect(fs.writeLocalFile).toHaveBeenCalledWith(
+        'some-dir/pnpm-workspace.yaml',
+        expect.stringContaining('minimumReleaseAge: 4320'),
+      );
+      // Should restore original content after exec
+      expect(fs.writeLocalFile).toHaveBeenLastCalledWith(
+        'some-dir/pnpm-workspace.yaml',
+        workspaceContent,
+      );
+      expect(execSnapshots).toHaveLength(1);
+    });
+
+    it('skips injection when minimumReleaseAge is invalid', async () => {
+      const execSnapshots = mockExecAll();
+      fs.getSiblingFileName.mockReturnValue('some-dir/pnpm-workspace.yaml');
+      fs.localPathExists.mockResolvedValueOnce(true);
+      fs.readLocalFile.mockImplementation((fileName: string) => {
+        if (fileName === 'some-dir/pnpm-lock.yaml') {
+          return Promise.resolve('package-lock-contents');
+        }
+        return Promise.resolve('{}');
+      });
+      await pnpmHelper.generateLockFile(
+        'some-dir',
+        {},
+        { ...config, minimumReleaseAge: 'invalid garbage' },
+        [{ isLockFileMaintenance: true }],
+      );
+      expect(fs.writeLocalFile).not.toHaveBeenCalled();
+      expect(execSnapshots).toHaveLength(1);
+    });
+
+    it('skips injection when workspace file is unreadable', async () => {
+      const execSnapshots = mockExecAll();
+      let workspaceReadCount = 0;
+      fs.getSiblingFileName.mockReturnValue('some-dir/pnpm-workspace.yaml');
+      fs.localPathExists.mockResolvedValueOnce(true);
+      fs.readLocalFile.mockImplementation((fileName: string) => {
+        if (fileName === 'some-dir/pnpm-workspace.yaml') {
+          workspaceReadCount++;
+          // First read (workspace packages check) returns valid content;
+          // second read (minimumReleaseAge injection) returns null
+          if (workspaceReadCount === 1) {
+            return Promise.resolve('packages:\n  - packages/*\n');
+          }
+          return Promise.resolve(null);
+        }
+        if (fileName === 'some-dir/pnpm-lock.yaml') {
+          return Promise.resolve('package-lock-contents');
+        }
+        return Promise.resolve('{}');
+      });
+      await pnpmHelper.generateLockFile(
+        'some-dir',
+        {},
+        { ...config, minimumReleaseAge: '3 days' },
+        [{ isLockFileMaintenance: true }],
+      );
+      expect(fs.writeLocalFile).not.toHaveBeenCalled();
+      expect(execSnapshots).toHaveLength(1);
+    });
+
+    it('does not inject when workspace already has minimumReleaseAge', async () => {
+      const execSnapshots = mockExecAll();
+      const workspaceContent =
+        'packages:\n  - packages/*\nminimumReleaseAge: 1440\n';
+      fs.getSiblingFileName.mockReturnValue('some-dir/pnpm-workspace.yaml');
+      fs.localPathExists.mockResolvedValueOnce(true);
+      fs.readLocalFile.mockImplementation((fileName: string) => {
+        if (fileName === 'some-dir/pnpm-workspace.yaml') {
+          return Promise.resolve(workspaceContent);
+        }
+        if (fileName === 'some-dir/pnpm-lock.yaml') {
+          return Promise.resolve('package-lock-contents');
+        }
+        return Promise.resolve('{}');
+      });
+      await pnpmHelper.generateLockFile(
+        'some-dir',
+        {},
+        { ...config, minimumReleaseAge: '3 days' },
+        [{ isLockFileMaintenance: true }],
+      );
+      expect(fs.writeLocalFile).not.toHaveBeenCalled();
+      expect(execSnapshots).toHaveLength(1);
+    });
+
+    it('does not inject when minimumReleaseAge is not configured', async () => {
+      const execSnapshots = mockExecAll();
+      fs.readLocalFile.mockResolvedValue('package-lock-contents');
+      await pnpmHelper.generateLockFile('some-dir', {}, config, [
+        { isLockFileMaintenance: true },
+      ]);
+      expect(fs.writeLocalFile).not.toHaveBeenCalled();
+      expect(execSnapshots).toHaveLength(1);
+    });
+  });
 });

--- a/lib/modules/manager/npm/post-update/pnpm.ts
+++ b/lib/modules/manager/npm/post-update/pnpm.ts
@@ -1,4 +1,4 @@
-import { isNumber, isNumericString } from '@sindresorhus/is';
+import { isNonEmptyString, isNumber, isNumericString } from '@sindresorhus/is';
 import { quote } from 'shlex';
 import upath from 'upath';
 import { GlobalConfig } from '../../../../config/global.ts';
@@ -16,7 +16,9 @@ import {
   getSiblingFileName,
   localPathExists,
   readLocalFile,
+  writeLocalFile,
 } from '../../../../util/fs/index.ts';
+import { toMs } from '../../../../util/pretty-time.ts';
 import { uniqueStrings } from '../../../../util/string.ts';
 import { parseSingleYaml } from '../../../../util/yaml.ts';
 import type { PostUpdateConfig, Upgrade } from '../../types.ts';
@@ -167,7 +169,49 @@ export async function generateLockFile(
       }
     }
 
-    await exec(commands, execOptions);
+    // Temporarily inject minimumReleaseAge into pnpm-workspace.yaml if configured
+    let originalWorkspaceContent: string | null = null;
+    if (isNonEmptyString(config.minimumReleaseAge)) {
+      const ms = toMs(config.minimumReleaseAge);
+      if (ms === null) {
+        logger.debug(
+          { minimumReleaseAge: config.minimumReleaseAge },
+          'Invalid minimumReleaseAge, skipping injection into pnpm-workspace.yaml',
+        );
+      } else {
+        const minimumReleaseAgeMinutes = Math.ceil(ms / 60000);
+        const existingContent = await readLocalFile(
+          pnpmWorkspaceFilePath,
+          'utf8',
+        );
+        if (existingContent) {
+          const parsed = parseSingleYaml<PnpmWorkspaceFile>(existingContent);
+          if (!parsed.minimumReleaseAge) {
+            originalWorkspaceContent = existingContent;
+            const injectedContent =
+              existingContent.trimEnd() +
+              `\nminimumReleaseAge: ${minimumReleaseAgeMinutes}\n`;
+            await writeLocalFile(pnpmWorkspaceFilePath, injectedContent);
+            logger.debug(
+              {
+                minimumReleaseAge: config.minimumReleaseAge,
+                minimumReleaseAgeMinutes,
+              },
+              'Injected minimumReleaseAge into pnpm-workspace.yaml',
+            );
+          }
+        }
+      }
+    }
+
+    try {
+      await exec(commands, execOptions);
+    } finally {
+      if (originalWorkspaceContent !== null) {
+        await writeLocalFile(pnpmWorkspaceFilePath, originalWorkspaceContent);
+        logger.debug('Restored original pnpm-workspace.yaml');
+      }
+    }
     lockFile = await readLocalFile(lockFileName, 'utf8');
     /* v8 ignore next -- needs test */
   } catch (err) {

--- a/lib/modules/manager/types.ts
+++ b/lib/modules/manager/types.ts
@@ -9,6 +9,7 @@ import type { Category } from '../../constants/index.ts';
 import type {
   MaybePromise,
   ModuleApi,
+  Nullish,
   RangeStrategy,
   SkipReason,
   StageName,
@@ -350,5 +351,6 @@ export interface PostUpdateConfig<T = Record<string, any>>
   reuseExistingBranch?: boolean;
   toolSettings?: ToolSettingsOptions;
 
+  minimumReleaseAge?: Nullish<string>;
   isLockFileMaintenance?: boolean;
 }


### PR DESCRIPTION
## Changes

Extends the `minimumReleaseAge` package manager integration (started in #42051 for npm) to pnpm.

When `minimumReleaseAge` is configured, Renovate temporarily injects a `minimumReleaseAge` setting (in minutes) into `pnpm-workspace.yaml` before running `pnpm install`, then restores the original file afterward. This uses pnpm's native [`minimumReleaseAge`](https://pnpm.io/settings#minimumreleaseage) setting (available since pnpm 10.16) to prevent resolving packages published more recently than the threshold.

If `pnpm-workspace.yaml` already contains a `minimumReleaseAge` setting, Renovate does not override it.

This branch includes the commits from #42051 as a base. The pnpm-specific changes are in the final commit.

### Why `pnpm-workspace.yaml` injection?

pnpm has no CLI flag equivalent to npm's `--before`. The `minimumReleaseAge` setting can only be configured via `pnpm-workspace.yaml` or the global config. Temporary file injection with restore-on-completion is the only viable approach.

### Related issues

- Closes #40475 -- Specify `minimumReleaseAge` for pnpm if set in Renovate config
- #42051 -- npm `--before` support (base for this PR)
- #41652 -- Integrate more closely with package manager checks

## Context

- [x] This closes an existing Issue, Closes: #40475
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

- [ ] No -- I did not use AI for this contribution.
- [ ] Yes -- minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes -- substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).
- [ ] Yes -- other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository