### PR TITLE
chore(logger): sanitize boxed `String` objects

### DIFF
--- a/lib/logger/utils.spec.ts
+++ b/lib/logger/utils.spec.ts
@@ -23,6 +23,19 @@ describe('logger/utils', () => {
     expect(sanitizeValue(input)).toBe(output);
   });
 
+  it('sanitizes boxed String objects as strings', () => {
+    const input = {
+      commands: [
+        'clone',
+        new String('https://token@domain.com/repo.git'),
+        new String('.'),
+      ],
+    };
+    expect(sanitizeValue(input)).toEqual({
+      commands: ['clone', 'https://**redacted**@domain.com/repo.git', '.'],
+    });
+  });
+
   it('preserves secret template strings in redacted fields', () => {
     const input = {
       normal: 'value',

--- a/lib/logger/utils.ts
+++ b/lib/logger/utils.ts
@@ -167,6 +167,13 @@ export function sanitizeValue(
     return sanitize(sanitizeUrls(value));
   }
 
+  // Handle boxed String objects (e.g. from `new String()`), which `isString`
+  // rejects but `isObject` would iterate character-by-character producing
+  // `{"0":"h","1":"e",...}` in log output.
+  if (value instanceof String) {
+    return sanitize(sanitizeUrls(value.toString()));
+  }
+
   if (isDate(value)) {
     return value;
   }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Noticed when attempting to run Renovate against an empty repository (on
`platform=bitbucket`) we previously saw:

    WARN: Host error (repository=jamie-tanna-mend-1/test-any-updates)
           "hostType": "git",
           "packageName": undefined,
           "err": {
             "task": {
               "commands": [
                 "clone",
                 "-b",
                 "main",
                 "--filter=blob:none",
                 {
                   "0": "h",
                   "1": "t",
                   "2": "t",
                   "3": "p",
                   ...

                   "281": "i",
                   "282": "t"
                 },
                 {"0": "."}
               ],
               "format": "utf-8",
               "parser": "[function]"
             },
             "message": "Cloning into '.'...\nfatal: Remote branch main not found in upstream origin\n",
               "stack": "..."

We can instead match against the case where it's a `String` object, and
forcibly return the `sanitized`'d value.


## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe): Claude Sonnet 4.6

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
