### PR TITLE
fix(npm): use packageName for pnpm overrides with range selectors in minimumReleaseAgeExclude

### DIFF
--- a/lib/modules/manager/npm/artifacts.spec.ts
+++ b/lib/modules/manager/npm/artifacts.spec.ts
@@ -703,6 +703,41 @@ minimumReleaseAgeExclude:
       expect(res).toBeNull();
     });
 
+    it('uses packageName (bare package name) for pnpm overrides with range selectors', async () => {
+      fs.getSiblingFileName.mockReturnValueOnce('pnpm-workspace.yaml');
+      fs.localPathExists.mockResolvedValueOnce(true);
+      fs.readLocalFile.mockResolvedValueOnce(
+        codeBlock`minimumReleaseAge: 4320`,
+      ); // for pnpm-workspace.yaml
+      const res = await updateArtifacts({
+        packageFileName: 'package.json',
+        updatedDeps: [
+          {
+            ...validDepUpdate,
+            depName: 'fast-xml-parser@<=5.3.5',
+            packageName: 'fast-xml-parser',
+            depType: 'pnpm.overrides',
+            currentValue: '5.3.5',
+            newVersion: '5.5.7',
+            managerData: { pnpmShrinkwrap: 'pnpm-lock.yaml' },
+            isVulnerabilityAlert: true,
+          },
+        ],
+        newPackageFileContent: 'some new content',
+        config,
+      });
+      expect(res).toStrictEqual([
+        {
+          file: {
+            type: 'addition',
+            path: 'pnpm-workspace.yaml',
+            contents:
+              'minimumReleaseAge: 4320\nminimumReleaseAgeExclude:\n  # Renovate security update: fast-xml-parser@5.5.7\n  - fast-xml-parser@5.5.7\n',
+          },
+        },
+      ]);
+    });
+
     it('handles multiple security upgrades correctly (bug fix test)', async () => {
       fs.getSiblingFileName.mockReturnValueOnce('pnpm-workspace.yaml');
       fs.localPathExists.mockResolvedValueOnce(true);

--- a/lib/modules/manager/npm/artifacts.ts
+++ b/lib/modules/manager/npm/artifacts.ts
@@ -186,6 +186,10 @@ async function updatePnpmWorkspace(
   for (const upgrade of upgrades) {
     let excludeNode = doc.getIn(['minimumReleaseAgeExclude']) as YAMLSeq | null;
     const newVersion = upgrade.newVersion ?? upgrade.newValue;
+    // For pnpm overrides with range selectors (e.g. "pkg@<=1.0.0"), depName contains
+    // the full key including the selector. Use packageName (bare package name) for
+    // minimumReleaseAgeExclude entries which require exact versions only.
+    const excludeDepName = upgrade.packageName ?? upgrade.depName;
 
     /* v8 ignore if -- should not happen, adding for type narrowing*/
     if (excludeNode && !isSeq(excludeNode)) {
@@ -195,8 +199,8 @@ async function updatePnpmWorkspace(
     if (!excludeNode) {
       logger.debug('Adding new exclude block');
       excludeNode = doc.createNode([]) as YAMLSeq;
-      const newItem = doc.createNode(`${upgrade.depName}@${newVersion}`);
-      newItem.commentBefore = ` Renovate security update: ${upgrade.depName}@${newVersion}`;
+      const newItem = doc.createNode(`${excludeDepName}@${newVersion}`);
+      newItem.commentBefore = ` Renovate security update: ${excludeDepName}@${newVersion}`;
       excludeNode.items.push(newItem);
       doc.set('minimumReleaseAgeExclude', excludeNode);
       updated = true;
@@ -204,7 +208,7 @@ async function updatePnpmWorkspace(
     }
 
     const { item: matchedItem, allExcluded } = getMatchedItem(
-      upgrade.depName!,
+      excludeDepName!,
       excludeNode.items,
     );
 
@@ -214,12 +218,12 @@ async function updatePnpmWorkspace(
 
     if (isScalar<string>(matchedItem)) {
       // if we have a comment before the list, which includes the dependency
-      if (excludeNode?.commentBefore?.includes(`${upgrade.depName}@`)) {
+      if (excludeNode?.commentBefore?.includes(`${excludeDepName}@`)) {
         // and it doesn't already have the version included in it
         if (
           !minimumReleaseAgeExcludeIncludesDepNameAndVersion(
             excludeNode.commentBefore,
-            upgrade.depName,
+            excludeDepName,
             newVersion,
           )
         ) {
@@ -237,7 +241,7 @@ async function updatePnpmWorkspace(
         if (
           !minimumReleaseAgeExcludeIncludesDepNameAndVersion(
             matchedItem.commentBefore,
-            upgrade.depName,
+            excludeDepName,
             newVersion,
           )
         ) {
@@ -247,14 +251,14 @@ async function updatePnpmWorkspace(
           updated = true;
         }
       } else {
-        matchedItem.commentBefore = ` Renovate security update: ${upgrade.depName}@${newVersion}`;
+        matchedItem.commentBefore = ` Renovate security update: ${excludeDepName}@${newVersion}`;
         updated = true;
       }
 
       if (
         !minimumReleaseAgeExcludeIncludesDepNameAndVersion(
           matchedItem.value,
-          upgrade.depName,
+          excludeDepName,
           newVersion,
         )
       ) {
@@ -263,8 +267,8 @@ async function updatePnpmWorkspace(
       }
     } else {
       // add new entry
-      const newItem = doc.createNode(`${upgrade.depName}@${newVersion}`);
-      newItem.commentBefore = ` Renovate security update: ${upgrade.depName}@${newVersion}`;
+      const newItem = doc.createNode(`${excludeDepName}@${newVersion}`);
+      newItem.commentBefore = ` Renovate security update: ${excludeDepName}@${newVersion}`;
 
       excludeNode.items.push(newItem);
       updated = true;


### PR DESCRIPTION
## Changes

When a `pnpm.overrides` entry uses a version range selector (e.g. `"fast-xml-parser@<=5.3.5": "5.5.7"`), Renovate was generating an invalid `minimumReleaseAgeExclude` entry like `fast-xml-parser@<=5.3.5@5.5.7` instead of `fast-xml-parser@5.5.7`, causing `pnpm install` to fail with `ERR_PNPM_INVALID_MINIMUM_RELEASE_AGE_EXCLUDE`.

The root cause: `depName` for pnpm overrides with range selectors contains the full override key (needed for correctly updating `package.json`), but `minimumReleaseAgeExclude` requires exact package name + version pairs.

Fix by using `upgrade.packageName ?? upgrade.depName` when constructing `minimumReleaseAgeExclude` entries. `packageName` holds the bare npm package name (`fast-xml-parser`) as parsed by `@pnpm/parse-overrides`, while `depName` retains the full key. Falls back to `depName` for all other dependency types where `packageName` is not set, preserving existing behaviour.

## Context

- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).

Made with Cursor (claude-4.6-sonnet). AI was used for root cause analysis, implementation, tests, and documentation.

## Documentation (please check one with an [x])

- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Newly added/modified unit tests