### PR TITLE
fix(github): pass gitAuthor to platform commit API to prevent false "Edited/Blocked"

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -1864,7 +1864,8 @@ When this field is unset (default), Renovate will use its platform credentials (
 
 <!-- prettier-ignore -->
 !!! note
-    If running as a GitHub App and using `platformCommit`, GitHub itself sets the git author in commits so you should not configure this field.
+    If running as a GitHub App and using `platformCommit`, Renovate passes `gitAuthor` to the GitHub commits API so the author field on remote commits matches the configured identity.
+    Configure `gitAuthor` to match the GitHub App's commit author (e.g. `App Name <app-id+app-slug[bot]@users.noreply.github.com>`) to ensure Renovate correctly recognizes its own commits.
 
 The `gitAuthor` option accepts a [RFC5322](https://datatracker.ietf.org/doc/html/rfc5322)-compliant string.
 It's recommended to include a name followed by an email address, e.g.
@@ -3957,7 +3958,16 @@ This way Renovate can use GitHub's [Commit signing support for bots and other Gi
 
 <!-- prettier-ignore -->
 !!! note
-    When using platform commits, GitHub determines the git author string to use and Renovate's own gitAuthor is ignored.
+    When using platform commits, Renovate passes its configured `gitAuthor` to the GitHub API so the commit author matches the configured identity.
+    GitHub signs the commit as the committer (using its own GPG key), but the author field will reflect `gitAuthor`.
+    This ensures Renovate can correctly recognize its own commits when checking for branch modifications.
+
+<!-- prettier-ignore -->
+!!! warning
+    If `gitAuthor` is set to an identity that differs from the GitHub App's actual account (for example, an email address that does not correspond to the authenticated App), the commit's author will show as unverified in GitHub's UI when [vigilant mode](https://docs.github.com/en/authentication/managing-commit-signature-verification/displaying-verification-statuses-for-all-of-your-commits) is enabled for that identity.
+    The commit itself will still carry GitHub's committer signature (web-flow) and be marked as verified via that signature.
+    This is the same behavior as regular `git`-based commits, where Renovate also writes whatever `gitAuthor` is configured without GitHub being able to verify the author.
+    To avoid this, configure `gitAuthor` to match the GitHub App's commit identity exactly (e.g. `App Name <APP_ID+app-slug[bot]@users.noreply.github.com>`).
 
 ## postUpdateOptions
 

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -1210,6 +1210,11 @@ const options: Readonly<RenovateOptions>[] = [
     allowedValues: ['merge', 'none'],
     default: 'none',
   },
+  // TODO: set globalOnly: true to prevent repo-level config from overriding
+  // the commit author identity. A repository owner can currently set an
+  // arbitrary gitAuthor in renovate.json, which Renovate will use for both
+  // local git commits and platform API commits (when platformCommit is
+  // enabled). Compare with gitPrivateKey which is already globalOnly.
   {
     name: 'gitAuthor',
     description:

--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -5266,5 +5266,80 @@ describe('modules/platform/github/index', () => {
 
       expect(res).toBeNull();
     });
+
+    it('includes configured git author in commit API call', async () => {
+      git.pushCommitToRenovateRef.mockResolvedValueOnce();
+      git.listCommitTree.mockResolvedValueOnce([]);
+      git.getGitAuthor.mockReturnValueOnce({
+        name: 'Renovate Bot',
+        email: 'renovate@example.com',
+      });
+
+      const scope = httpMock.scope(githubApiHost);
+
+      initRepoMock(scope, 'some/repo');
+      await github.initRepo({ repository: 'some/repo' });
+
+      scope
+        .post('/repos/some/repo/git/trees')
+        .reply(200, { sha: '111' })
+        .post('/repos/some/repo/git/commits')
+        .reply(200, { sha: '222' })
+        .head('/repos/some/repo/git/commits/222')
+        .reply(200)
+        .post('/repos/some/repo/git/refs')
+        .reply(200);
+      vi.spyOn(branch, 'remoteBranchExists').mockResolvedValueOnce(false);
+
+      await github.commitFiles({
+        branchName: 'foo/bar',
+        files: [{ type: 'addition', path: 'foo.bar', contents: 'foobar' }],
+        message: 'Foobar',
+      });
+
+      const commitApiCall = httpMock
+        .getTrace()
+        .find(
+          (req) => req.url?.endsWith('/git/commits') && req.method === 'POST',
+        );
+      expect(commitApiCall?.body).toMatchObject({
+        author: { name: 'Renovate Bot', email: 'renovate@example.com' },
+      });
+    });
+
+    it('omits author field in commit API call when git author is not configured', async () => {
+      git.pushCommitToRenovateRef.mockResolvedValueOnce();
+      git.listCommitTree.mockResolvedValueOnce([]);
+      git.getGitAuthor.mockReturnValueOnce(null);
+
+      const scope = httpMock.scope(githubApiHost);
+
+      initRepoMock(scope, 'some/repo');
+      await github.initRepo({ repository: 'some/repo' });
+
+      scope
+        .post('/repos/some/repo/git/trees')
+        .reply(200, { sha: '111' })
+        .post('/repos/some/repo/git/commits')
+        .reply(200, { sha: '222' })
+        .head('/repos/some/repo/git/commits/222')
+        .reply(200)
+        .post('/repos/some/repo/git/refs')
+        .reply(200);
+      vi.spyOn(branch, 'remoteBranchExists').mockResolvedValueOnce(false);
+
+      await github.commitFiles({
+        branchName: 'foo/bar',
+        files: [{ type: 'addition', path: 'foo.bar', contents: 'foobar' }],
+        message: 'Foobar',
+      });
+
+      const commitApiCall = httpMock
+        .getTrace()
+        .find(
+          (req) => req.url?.endsWith('/git/commits') && req.method === 'POST',
+        );
+      expect(commitApiCall?.body).not.toHaveProperty('author');
+    });
   });
 });

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -2176,9 +2176,17 @@ async function pushFiles(
     const treeSha = treeRes.body.sha;
 
     // Now we recreate the commit using the tree we recreated the step before
+    const gitAuthor = git.getGitAuthor();
     const commitRes = await githubApi.postJson<{ sha: string }>(
       `/repos/${config.repository}/git/commits`,
-      { body: { message, tree: treeSha, parents: [parentCommitSha] } },
+      {
+        body: {
+          message,
+          tree: treeSha,
+          parents: [parentCommitSha],
+          ...(gitAuthor && { author: gitAuthor }),
+        },
+      },
     );
     incLimitedValue('Commits');
     const remoteCommitSha = commitRes.body.sha as LongCommitSha;

--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -1051,6 +1051,30 @@ describe('util/git/index', { timeout: 10000 }, () => {
     });
   });
 
+  describe('getGitAuthor()', () => {
+    it('returns the configured author name and email', () => {
+      // beforeEach sets author to 'Jest <Jest@example.com>'
+      expect(git.getGitAuthor()).toEqual({
+        name: 'Jest',
+        email: 'Jest@example.com',
+      });
+    });
+
+    it('returns updated author after setGitAuthor', () => {
+      git.setGitAuthor('Renovate Bot <renovate@example.com>');
+      expect(git.getGitAuthor()).toEqual({
+        name: 'Renovate Bot',
+        email: 'renovate@example.com',
+      });
+    });
+
+    it('returns null when author is not configured', async () => {
+      await git.initRepo({ url: origin.path });
+      // initRepo resets config, clearing gitAuthorName and gitAuthorEmail
+      expect(git.getGitAuthor()).toBeNull();
+    });
+  });
+
   describe('isBranchConflicted', () => {
     beforeAll(async () => {
       const repo = simpleGit(base.path);

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -305,6 +305,14 @@ export function setGitAuthor(gitAuthor: string | undefined): void {
   config.gitAuthorEmail = gitAuthorParsed.address;
 }
 
+export function getGitAuthor(): { name: string; email: string } | null {
+  const { gitAuthorName, gitAuthorEmail } = config;
+  if (gitAuthorName && gitAuthorEmail) {
+    return { name: gitAuthorName, email: gitAuthorEmail };
+  }
+  return null;
+}
+
 export async function writeGitAuthor(): Promise<void> {
   const { gitAuthorName, gitAuthorEmail, writeGitDone } = config;
   /* v8 ignore if -- TODO: add test #40625 */


### PR DESCRIPTION
## Changes

When `platformCommit` is enabled, Renovate creates commits via GitHub's REST API without specifying an `author` field, so GitHub assigns the App's own identity as the commit author. On the next run, `isBranchModified` compares commit author emails from `git log` against `gitAuthorEmail`; if they differ, the branch is incorrectly flagged as externally modified, triggering the "Edited/Blocked" notification and blocking autoclose of failed-artifact PRs.

Fix: pass the configured `gitAuthor` (name + email) as the `author` field in the `POST /repos/{repo}/git/commits` request so the remote commit's author email matches what `isBranchModified` expects.

Also adds a `TODO` comment on the `gitAuthor` option noting it should be `globalOnly: true` to prevent repo-level author spoofing, and updates the `platformCommit` and `gitAuthor` documentation to reflect the new behavior.

## Context

- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).

Made with Cursor (claude-4.6-sonnet). AI was used for root cause analysis, implementation, tests, and documentation.

## Documentation (please check one with an [x])

- [x] I have updated the documentation

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Newly added/modified unit tests