### PR TITLE
fix(manager/npm): scope version check in minimumReleaseAgeExclude to …

### DIFF
--- a/lib/modules/manager/npm/artifacts.spec.ts
+++ b/lib/modules/manager/npm/artifacts.spec.ts
@@ -744,5 +744,48 @@ minimumReleaseAgeExclude:
         },
       ]);
     });
+
+    it('does not skip version append when a different dep shares the same version string', async () => {
+      fs.getSiblingFileName.mockReturnValueOnce('pnpm-workspace.yaml');
+      fs.localPathExists.mockResolvedValueOnce(true);
+      fs.readLocalFile.mockResolvedValueOnce(
+        codeBlock`minimumReleaseAge: 10080
+minimumReleaseAgeExclude:
+  # Renovate security update: lodash@4.17.21
+  - lodash@4.17.21`,
+      ); // for pnpm-workspace.yaml
+      const res = await updateArtifacts({
+        packageFileName: 'package.json',
+        updatedDeps: [
+          {
+            ...validDepUpdate,
+            depName: 'underscore',
+            currentValue: '1.13.5',
+            newVersion: '4.17.21',
+            managerData: { pnpmShrinkwrap: 'pnpm-lock.yaml' },
+            isVulnerabilityAlert: true,
+          },
+        ],
+        newPackageFileContent: 'some new content',
+        config,
+      });
+      expect(res).toStrictEqual([
+        {
+          file: {
+            type: 'addition',
+            path: 'pnpm-workspace.yaml',
+            contents:
+              codeBlock`
+                minimumReleaseAge: 10080
+                minimumReleaseAgeExclude:
+                  # Renovate security update: lodash@4.17.21
+                  - lodash@4.17.21
+                  # Renovate security update: underscore@4.17.21
+                  - underscore@4.17.21
+              ` + '\n',
+          },
+        },
+      ]);
+    });
   });
 });

--- a/lib/modules/manager/npm/artifacts.ts
+++ b/lib/modules/manager/npm/artifacts.ts
@@ -327,13 +327,18 @@ function minimumReleaseAgeExcludeIncludesDepNameAndVersion(
   depName: string | undefined,
   newVersion: string | undefined,
 ): boolean {
-  if (line.includes(`${depName}@${newVersion}`)) {
-    return true;
+  /* v8 ignore if -- should not happen, adding for type narrowing */
+  if (!depName || !newVersion) {
+    return false;
   }
 
-  if (line.includes(`|| ${newVersion}`)) {
-    return true;
+  const depIndex = line.indexOf(`${depName}@`);
+  if (depIndex === -1) {
+    return false;
   }
 
-  return false;
+  // Only search for the version within the substring that starts at this dep's entry,
+  // preventing false positives from other deps that share the same version string.
+  const fromDep = line.slice(depIndex);
+  return fromDep.includes(newVersion);
 }


### PR DESCRIPTION
## Changes

The `minimumReleaseAgeExcludeIncludesDepNameAndVersion` function used a loose `line.includes(|| ${newVersion})` substring check that could match a version string belonging to a completely different dependency entry in the same line/comment. This caused a false positive where the function would incorrectly report the version as already present, skipping the append.

The fix scopes the version search to the substring starting from the matching `depName@` prefix, so only the correct dependency's version chain is inspected.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, and PR description). Tool: Cursor.
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository