### PR TITLE
feat(manager/ant): add `<import>` file traversal

### DIFF
--- a/lib/modules/manager/ant/extract.spec.ts
+++ b/lib/modules/manager/ant/extract.spec.ts
@@ -723,4 +723,134 @@ describe('modules/manager/ant/extract', () => {
       },
     ]);
   });
+
+  it('follows import file references', async () => {
+    fs.readLocalFile.mockImplementation((fileName: string) => {
+      const files: Record<string, string> = {
+        'build.xml': codeBlock`
+          <project>
+            <import file="deps.xml" />
+          </project>
+        `,
+        'deps.xml': codeBlock`
+          <project>
+            <artifact:dependencies>
+              <dependency groupId="junit" artifactId="junit" version="4.13.2" />
+            </artifact:dependencies>
+          </project>
+        `,
+      };
+      return Promise.resolve(files[fileName] ?? null);
+    });
+
+    const result = await extractAllPackageFiles({}, ['build.xml']);
+
+    expect(result).toEqual([
+      {
+        packageFile: 'deps.xml',
+        deps: [
+          expect.objectContaining({
+            depName: 'junit:junit',
+            currentValue: '4.13.2',
+          }),
+        ],
+      },
+    ]);
+  });
+
+  it('skips missing import files', async () => {
+    fs.readLocalFile.mockImplementation((fileName: string) => {
+      const files: Record<string, string> = {
+        'build.xml': codeBlock`
+          <project>
+            <import file="missing.xml" />
+            <artifact:dependencies>
+              <dependency groupId="junit" artifactId="junit" version="4.13.2" />
+            </artifact:dependencies>
+          </project>
+        `,
+      };
+      return Promise.resolve(files[fileName] ?? null);
+    });
+
+    const result = await extractAllPackageFiles({}, ['build.xml']);
+
+    expect(result).toEqual([
+      {
+        packageFile: 'build.xml',
+        deps: [
+          expect.objectContaining({
+            depName: 'junit:junit',
+            currentValue: '4.13.2',
+          }),
+        ],
+      },
+    ]);
+  });
+
+  it('does not loop on self-importing files', async () => {
+    fs.readLocalFile.mockImplementation((fileName: string) => {
+      const files: Record<string, string> = {
+        'build.xml': codeBlock`
+          <project>
+            <import file="build.xml" />
+            <artifact:dependencies>
+              <dependency groupId="junit" artifactId="junit" version="4.13.2" />
+            </artifact:dependencies>
+          </project>
+        `,
+      };
+      return Promise.resolve(files[fileName] ?? null);
+    });
+
+    const result = await extractAllPackageFiles({}, ['build.xml']);
+
+    expect(result).toEqual([
+      {
+        packageFile: 'build.xml',
+        deps: [
+          expect.objectContaining({
+            depName: 'junit:junit',
+            currentValue: '4.13.2',
+          }),
+        ],
+      },
+    ]);
+  });
+
+  it('shares properties across imported files', async () => {
+    fs.readLocalFile.mockImplementation((fileName: string) => {
+      const files: Record<string, string> = {
+        'build.xml': codeBlock`
+          <project>
+            <property name="junit.version" value="4.13.2" />
+            <import file="deps.xml" />
+          </project>
+        `,
+        'deps.xml': codeBlock`
+          <project>
+            <artifact:dependencies>
+              <dependency groupId="junit" artifactId="junit" version="\${junit.version}" />
+            </artifact:dependencies>
+          </project>
+        `,
+      };
+      return Promise.resolve(files[fileName] ?? null);
+    });
+
+    const result = await extractAllPackageFiles({}, ['build.xml']);
+
+    expect(result).toEqual([
+      {
+        packageFile: 'build.xml',
+        deps: [
+          expect.objectContaining({
+            depName: 'junit:junit',
+            currentValue: '4.13.2',
+            sharedVariableName: 'junit.version',
+          }),
+        ],
+      },
+    ]);
+  });
 });

--- a/lib/modules/manager/ant/extract.spec.ts
+++ b/lib/modules/manager/ant/extract.spec.ts
@@ -1,0 +1,173 @@
+import { codeBlock } from 'common-tags';
+import { fs } from '~test/util.ts';
+import { extractAllPackageFiles } from './extract.ts';
+
+vi.mock('../../../util/fs/index.ts');
+
+describe('modules/manager/ant/extract', () => {
+  it('extracts inline version dependencies from build.xml', async () => {
+    fs.readLocalFile.mockImplementation((fileName: string) => {
+      const files: Record<string, string> = {
+        'build.xml': codeBlock`
+          <project>
+            <artifact:dependencies>
+              <dependency groupId="junit" artifactId="junit" version="4.13.2" scope="test" />
+            </artifact:dependencies>
+          </project>
+        `,
+      };
+      return Promise.resolve(files[fileName] ?? null);
+    });
+
+    await expect(extractAllPackageFiles({}, ['build.xml'])).resolves.toEqual([
+      {
+        packageFile: 'build.xml',
+        deps: [
+          expect.objectContaining({
+            datasource: 'maven',
+            depName: 'junit:junit',
+            currentValue: '4.13.2',
+            depType: 'test',
+            registryUrls: [],
+          }),
+        ],
+      },
+    ]);
+  });
+
+  it('extracts multiple dependencies', async () => {
+    fs.readLocalFile.mockImplementation((fileName: string) => {
+      const files: Record<string, string> = {
+        'build.xml': codeBlock`
+          <project>
+            <artifact:dependencies>
+              <dependency groupId="junit" artifactId="junit" version="4.13.2" scope="test" />
+              <dependency groupId="org.slf4j" artifactId="slf4j-api" version="1.7.36" scope="compile" />
+              <dependency groupId="org.apache.commons" artifactId="commons-lang3" version="3.12.0" scope="runtime" />
+            </artifact:dependencies>
+          </project>
+        `,
+      };
+      return Promise.resolve(files[fileName] ?? null);
+    });
+
+    const result = await extractAllPackageFiles({}, ['build.xml']);
+
+    expect(result).toHaveLength(1);
+    expect(result![0].deps).toHaveLength(3);
+    expect(result![0].deps).toContainEqual(
+      expect.objectContaining({
+        depName: 'junit:junit',
+        currentValue: '4.13.2',
+        depType: 'test',
+      }),
+    );
+    expect(result![0].deps).toContainEqual(
+      expect.objectContaining({
+        depName: 'org.slf4j:slf4j-api',
+        currentValue: '1.7.36',
+        depType: 'compile',
+      }),
+    );
+    expect(result![0].deps).toContainEqual(
+      expect.objectContaining({
+        depName: 'org.apache.commons:commons-lang3',
+        currentValue: '3.12.0',
+        depType: 'runtime',
+      }),
+    );
+  });
+
+  it('defaults depType to compile when no scope is set', async () => {
+    fs.readLocalFile.mockImplementation((fileName: string) => {
+      const files: Record<string, string> = {
+        'build.xml': codeBlock`
+          <project>
+            <artifact:dependencies>
+              <dependency groupId="junit" artifactId="junit" version="4.13.2" />
+            </artifact:dependencies>
+          </project>
+        `,
+      };
+      return Promise.resolve(files[fileName] ?? null);
+    });
+
+    const result = await extractAllPackageFiles({}, ['build.xml']);
+
+    expect(result).toEqual([
+      {
+        packageFile: 'build.xml',
+        deps: [
+          expect.objectContaining({
+            depName: 'junit:junit',
+            depType: 'compile',
+          }),
+        ],
+      },
+    ]);
+  });
+
+  it('returns null for unreadable build.xml', async () => {
+    fs.readLocalFile.mockResolvedValue(null);
+
+    await expect(extractAllPackageFiles({}, ['build.xml'])).resolves.toBeNull();
+  });
+
+  it('returns null for invalid XML', async () => {
+    fs.readLocalFile.mockResolvedValue('<<< not xml >>>');
+
+    await expect(extractAllPackageFiles({}, ['build.xml'])).resolves.toBeNull();
+  });
+
+  it('returns null for build.xml with no dependencies', async () => {
+    fs.readLocalFile.mockImplementation((fileName: string) => {
+      const files: Record<string, string> = {
+        'build.xml': '<project><target name="build" /></project>',
+      };
+      return Promise.resolve(files[fileName] ?? null);
+    });
+
+    await expect(extractAllPackageFiles({}, ['build.xml'])).resolves.toBeNull();
+  });
+
+  it('ignores dependency nodes without version', async () => {
+    fs.readLocalFile.mockImplementation((fileName: string) => {
+      const files: Record<string, string> = {
+        'build.xml': codeBlock`
+          <project>
+            <artifact:dependencies>
+              <dependency groupId="org.example" artifactId="lib" />
+            </artifact:dependencies>
+          </project>
+        `,
+      };
+      return Promise.resolve(files[fileName] ?? null);
+    });
+
+    await expect(extractAllPackageFiles({}, ['build.xml'])).resolves.toBeNull();
+  });
+
+  it('does not revisit the same file', async () => {
+    let readCount = 0;
+    fs.readLocalFile.mockImplementation((fileName: string) => {
+      if (fileName === 'build.xml') {
+        readCount++;
+      }
+      const files: Record<string, string> = {
+        'build.xml': codeBlock`
+          <project>
+            <artifact:dependencies>
+              <dependency groupId="junit" artifactId="junit" version="4.13.2" />
+            </artifact:dependencies>
+          </project>
+        `,
+      };
+      return Promise.resolve(files[fileName] ?? null);
+    });
+
+    const result = await extractAllPackageFiles({}, ['build.xml', 'build.xml']);
+
+    expect(result).toHaveLength(1);
+    expect(readCount).toBe(1);
+  });
+});

--- a/lib/modules/manager/ant/extract.spec.ts
+++ b/lib/modules/manager/ant/extract.spec.ts
@@ -537,4 +537,190 @@ describe('modules/manager/ant/extract', () => {
     expect(result).toHaveLength(1);
     expect(readCount).toBe(1);
   });
+
+  it('extracts dependency from 3-part coords attribute', async () => {
+    fs.readLocalFile.mockImplementation((fileName: string) => {
+      const files: Record<string, string> = {
+        'build.xml': codeBlock`
+          <project>
+            <artifact:dependencies>
+              <dependency coords="junit:junit:4.13.2" />
+            </artifact:dependencies>
+          </project>
+        `,
+      };
+      return Promise.resolve(files[fileName] ?? null);
+    });
+
+    const result = await extractAllPackageFiles({}, ['build.xml']);
+
+    expect(result).toEqual([
+      {
+        packageFile: 'build.xml',
+        deps: [
+          expect.objectContaining({
+            datasource: 'maven',
+            depName: 'junit:junit',
+            currentValue: '4.13.2',
+            depType: 'compile',
+            registryUrls: [],
+          }),
+        ],
+      },
+    ]);
+  });
+
+  it('extracts scope from 4-part coords attribute', async () => {
+    fs.readLocalFile.mockImplementation((fileName: string) => {
+      const files: Record<string, string> = {
+        'build.xml': codeBlock`
+          <project>
+            <artifact:dependencies>
+              <dependency coords="junit:junit:4.13.2:test" />
+            </artifact:dependencies>
+          </project>
+        `,
+      };
+      return Promise.resolve(files[fileName] ?? null);
+    });
+
+    const result = await extractAllPackageFiles({}, ['build.xml']);
+
+    expect(result).toEqual([
+      {
+        packageFile: 'build.xml',
+        deps: [
+          expect.objectContaining({
+            depName: 'junit:junit',
+            currentValue: '4.13.2',
+            depType: 'test',
+          }),
+        ],
+      },
+    ]);
+  });
+
+  it('ignores coords with fewer than 3 parts', async () => {
+    fs.readLocalFile.mockImplementation((fileName: string) => {
+      const files: Record<string, string> = {
+        'build.xml': codeBlock`
+          <project>
+            <artifact:dependencies>
+              <dependency coords="junit:junit" />
+            </artifact:dependencies>
+          </project>
+        `,
+      };
+      return Promise.resolve(files[fileName] ?? null);
+    });
+
+    await expect(extractAllPackageFiles({}, ['build.xml'])).resolves.toBeNull();
+  });
+
+  it('ignores coords with empty groupId', async () => {
+    fs.readLocalFile.mockImplementation((fileName: string) => {
+      const files: Record<string, string> = {
+        'build.xml': codeBlock`
+          <project>
+            <artifact:dependencies>
+              <dependency coords=":junit:4.13.2" />
+            </artifact:dependencies>
+          </project>
+        `,
+      };
+      return Promise.resolve(files[fileName] ?? null);
+    });
+
+    await expect(extractAllPackageFiles({}, ['build.xml'])).resolves.toBeNull();
+  });
+
+  it('resolves property references in coords version', async () => {
+    fs.readLocalFile.mockImplementation((fileName: string) => {
+      const files: Record<string, string> = {
+        'build.xml': codeBlock`
+          <project>
+            <property name="junit.version" value="4.13.2" />
+            <artifact:dependencies>
+              <dependency coords="junit:junit:\${junit.version}" />
+            </artifact:dependencies>
+          </project>
+        `,
+      };
+      return Promise.resolve(files[fileName] ?? null);
+    });
+
+    const result = await extractAllPackageFiles({}, ['build.xml']);
+
+    expect(result).toEqual([
+      {
+        packageFile: 'build.xml',
+        deps: [
+          expect.objectContaining({
+            depName: 'junit:junit',
+            currentValue: '4.13.2',
+            sharedVariableName: 'junit.version',
+          }),
+        ],
+      },
+    ]);
+  });
+
+  it('marks coords dependency as contains-variable for unresolvable property', async () => {
+    fs.readLocalFile.mockImplementation((fileName: string) => {
+      const files: Record<string, string> = {
+        'build.xml': codeBlock`
+          <project>
+            <artifact:dependencies>
+              <dependency coords="junit:junit:\${missing}" />
+            </artifact:dependencies>
+          </project>
+        `,
+      };
+      return Promise.resolve(files[fileName] ?? null);
+    });
+
+    const result = await extractAllPackageFiles({}, ['build.xml']);
+
+    expect(result).toEqual([
+      {
+        packageFile: 'build.xml',
+        deps: [
+          expect.objectContaining({
+            depName: 'junit:junit',
+            skipReason: 'contains-variable',
+          }),
+        ],
+      },
+    ]);
+  });
+
+  it('treats last part as version when it is not a known scope', async () => {
+    fs.readLocalFile.mockImplementation((fileName: string) => {
+      const files: Record<string, string> = {
+        'build.xml': codeBlock`
+          <project>
+            <artifact:dependencies>
+              <dependency coords="org.example:lib:jar:1.0.0" />
+            </artifact:dependencies>
+          </project>
+        `,
+      };
+      return Promise.resolve(files[fileName] ?? null);
+    });
+
+    const result = await extractAllPackageFiles({}, ['build.xml']);
+
+    expect(result).toEqual([
+      {
+        packageFile: 'build.xml',
+        deps: [
+          expect.objectContaining({
+            depName: 'org.example:lib',
+            currentValue: '1.0.0',
+            depType: 'compile',
+          }),
+        ],
+      },
+    ]);
+  });
 });

--- a/lib/modules/manager/ant/extract.spec.ts
+++ b/lib/modules/manager/ant/extract.spec.ts
@@ -147,6 +147,373 @@ describe('modules/manager/ant/extract', () => {
     await expect(extractAllPackageFiles({}, ['build.xml'])).resolves.toBeNull();
   });
 
+  it('resolves same-file property references', async () => {
+    fs.readLocalFile.mockImplementation((fileName: string) => {
+      const files: Record<string, string> = {
+        'build.xml': codeBlock`
+          <project>
+            <property name="slf4j.version" value="1.7.36" />
+            <artifact:dependencies>
+              <dependency groupId="org.slf4j" artifactId="slf4j-api" version="\${slf4j.version}" scope="compile" />
+            </artifact:dependencies>
+          </project>
+        `,
+      };
+      return Promise.resolve(files[fileName] ?? null);
+    });
+
+    await expect(extractAllPackageFiles({}, ['build.xml'])).resolves.toEqual([
+      {
+        packageFile: 'build.xml',
+        deps: [
+          expect.objectContaining({
+            depName: 'org.slf4j:slf4j-api',
+            currentValue: '1.7.36',
+            depType: 'compile',
+            sharedVariableName: 'slf4j.version',
+          }),
+        ],
+      },
+    ]);
+  });
+
+  it('resolves chained property references', async () => {
+    fs.readLocalFile.mockImplementation((fileName: string) => {
+      const files: Record<string, string> = {
+        'build.xml': codeBlock`
+          <project>
+            <property name="base.version" value="1.7.36" />
+            <property name="slf4j.version" value="\${base.version}" />
+            <artifact:dependencies>
+              <dependency groupId="org.slf4j" artifactId="slf4j-api" version="\${slf4j.version}" scope="compile" />
+            </artifact:dependencies>
+          </project>
+        `,
+      };
+      return Promise.resolve(files[fileName] ?? null);
+    });
+
+    await expect(extractAllPackageFiles({}, ['build.xml'])).resolves.toEqual([
+      {
+        packageFile: 'build.xml',
+        deps: [
+          expect.objectContaining({
+            depName: 'org.slf4j:slf4j-api',
+            currentValue: '1.7.36',
+            sharedVariableName: 'slf4j.version',
+          }),
+        ],
+      },
+    ]);
+  });
+
+  it('marks as contains-variable when chained property partially resolves', async () => {
+    fs.readLocalFile.mockImplementation((fileName: string) => {
+      const files: Record<string, string> = {
+        'build.xml': codeBlock`
+          <project>
+            <property name="a" value="\${known}-\${unknown}" />
+            <property name="known" value="1.0" />
+            <artifact:dependencies>
+              <dependency groupId="org.example" artifactId="lib" version="\${a}" />
+            </artifact:dependencies>
+          </project>
+        `,
+      };
+      return Promise.resolve(files[fileName] ?? null);
+    });
+
+    const result = await extractAllPackageFiles({}, ['build.xml']);
+
+    expect(result).toEqual([
+      {
+        packageFile: 'build.xml',
+        deps: [
+          expect.objectContaining({
+            depName: 'org.example:lib',
+            skipReason: 'contains-variable',
+          }),
+        ],
+      },
+    ]);
+  });
+
+  it('resolves properties from external .properties files', async () => {
+    fs.readLocalFile.mockImplementation((fileName: string) => {
+      const files: Record<string, string> = {
+        'build.xml': codeBlock`
+          <project>
+            <property file="versions.properties" />
+            <artifact:dependencies>
+              <dependency groupId="junit" artifactId="junit" version="\${junit.version}" />
+            </artifact:dependencies>
+          </project>
+        `,
+        'versions.properties': 'junit.version=4.13.2\n',
+      };
+      return Promise.resolve(files[fileName] ?? null);
+    });
+
+    await expect(extractAllPackageFiles({}, ['build.xml'])).resolves.toEqual([
+      {
+        packageFile: 'versions.properties',
+        deps: [
+          expect.objectContaining({
+            depName: 'junit:junit',
+            currentValue: '4.13.2',
+            sharedVariableName: 'junit.version',
+          }),
+        ],
+      },
+    ]);
+  });
+
+  it('keeps the first property definition and ignores later overrides', async () => {
+    fs.readLocalFile.mockImplementation((fileName: string) => {
+      const files: Record<string, string> = {
+        'build.xml': codeBlock`
+          <project>
+            <property file="versions-a.properties" />
+            <property file="versions-b.properties" />
+            <artifact:dependencies>
+              <dependency groupId="junit" artifactId="junit" version="\${junit.version}" />
+            </artifact:dependencies>
+          </project>
+        `,
+        'versions-a.properties': 'junit.version=4.13.2\n',
+        'versions-b.properties': 'junit.version=4.13.3\n',
+      };
+      return Promise.resolve(files[fileName] ?? null);
+    });
+
+    await expect(extractAllPackageFiles({}, ['build.xml'])).resolves.toEqual([
+      {
+        packageFile: 'versions-a.properties',
+        deps: [
+          expect.objectContaining({
+            depName: 'junit:junit',
+            currentValue: '4.13.2',
+            sharedVariableName: 'junit.version',
+          }),
+        ],
+      },
+    ]);
+  });
+
+  it('skips dependencies with unresolvable property references', async () => {
+    fs.readLocalFile.mockImplementation((fileName: string) => {
+      const files: Record<string, string> = {
+        'build.xml': codeBlock`
+          <project>
+            <artifact:dependencies>
+              <dependency groupId="org.example" artifactId="lib" version="\${undefined.prop}" />
+            </artifact:dependencies>
+          </project>
+        `,
+      };
+      return Promise.resolve(files[fileName] ?? null);
+    });
+
+    const result = await extractAllPackageFiles({}, ['build.xml']);
+
+    expect(result).toEqual([
+      {
+        packageFile: 'build.xml',
+        deps: [
+          expect.objectContaining({
+            depName: 'org.example:lib',
+            skipReason: 'contains-variable',
+          }),
+        ],
+      },
+    ]);
+  });
+
+  it('marks dependency as contains-variable for circular property references', async () => {
+    fs.readLocalFile.mockImplementation((fileName: string) => {
+      const files: Record<string, string> = {
+        'build.xml': codeBlock`
+          <project>
+            <property name="a" value="\${b}" />
+            <property name="b" value="\${a}" />
+            <artifact:dependencies>
+              <dependency groupId="org.example" artifactId="lib" version="\${a}" />
+            </artifact:dependencies>
+          </project>
+        `,
+      };
+      return Promise.resolve(files[fileName] ?? null);
+    });
+
+    const result = await extractAllPackageFiles({}, ['build.xml']);
+
+    expect(result).toEqual([
+      {
+        packageFile: 'build.xml',
+        deps: [
+          expect.objectContaining({
+            depName: 'org.example:lib',
+            skipReason: 'contains-variable',
+          }),
+        ],
+      },
+    ]);
+  });
+
+  it('marks dependency as contains-variable when nested property is unresolvable', async () => {
+    fs.readLocalFile.mockImplementation((fileName: string) => {
+      const files: Record<string, string> = {
+        'build.xml': codeBlock`
+          <project>
+            <property name="a" value="\${missing}" />
+            <artifact:dependencies>
+              <dependency groupId="org.example" artifactId="lib" version="\${a}" />
+            </artifact:dependencies>
+          </project>
+        `,
+      };
+      return Promise.resolve(files[fileName] ?? null);
+    });
+
+    const result = await extractAllPackageFiles({}, ['build.xml']);
+
+    expect(result).toEqual([
+      {
+        packageFile: 'build.xml',
+        deps: [
+          expect.objectContaining({
+            depName: 'org.example:lib',
+            skipReason: 'contains-variable',
+          }),
+        ],
+      },
+    ]);
+  });
+
+  it('marks inline version as contains-variable when value has partial unresolvable reference', async () => {
+    fs.readLocalFile.mockImplementation((fileName: string) => {
+      const files: Record<string, string> = {
+        'build.xml': codeBlock`
+          <project>
+            <artifact:dependencies>
+              <dependency groupId="org.example" artifactId="lib" version="prefix-\${unknown}" />
+            </artifact:dependencies>
+          </project>
+        `,
+      };
+      return Promise.resolve(files[fileName] ?? null);
+    });
+
+    const result = await extractAllPackageFiles({}, ['build.xml']);
+
+    expect(result).toEqual([
+      {
+        packageFile: 'build.xml',
+        deps: [
+          expect.objectContaining({
+            depName: 'org.example:lib',
+            skipReason: 'contains-variable',
+          }),
+        ],
+      },
+    ]);
+  });
+
+  it('skips unreadable properties files', async () => {
+    fs.readLocalFile.mockImplementation((fileName: string) => {
+      const files: Record<string, string> = {
+        'build.xml': codeBlock`
+          <project>
+            <property file="missing.properties" />
+            <artifact:dependencies>
+              <dependency groupId="junit" artifactId="junit" version="4.13.2" />
+            </artifact:dependencies>
+          </project>
+        `,
+      };
+      return Promise.resolve(files[fileName] ?? null);
+    });
+
+    const result = await extractAllPackageFiles({}, ['build.xml']);
+
+    expect(result).toEqual([
+      {
+        packageFile: 'build.xml',
+        deps: [
+          expect.objectContaining({
+            depName: 'junit:junit',
+            currentValue: '4.13.2',
+          }),
+        ],
+      },
+    ]);
+  });
+
+  it('skips properties lines without separator or with empty values', async () => {
+    fs.readLocalFile.mockImplementation((fileName: string) => {
+      const files: Record<string, string> = {
+        'build.xml': codeBlock`
+          <project>
+            <property file="versions.properties" />
+            <artifact:dependencies>
+              <dependency groupId="junit" artifactId="junit" version="\${junit.version}" />
+            </artifact:dependencies>
+          </project>
+        `,
+        'versions.properties':
+          '# comment line\njust-a-key-no-separator\nempty.value=\njunit.version=4.13.2\n',
+      };
+      return Promise.resolve(files[fileName] ?? null);
+    });
+
+    const result = await extractAllPackageFiles({}, ['build.xml']);
+
+    expect(result).toEqual([
+      {
+        packageFile: 'versions.properties',
+        deps: [
+          expect.objectContaining({
+            depName: 'junit:junit',
+            currentValue: '4.13.2',
+            sharedVariableName: 'junit.version',
+          }),
+        ],
+      },
+    ]);
+  });
+
+  it('does not revisit the same properties file twice', async () => {
+    fs.readLocalFile.mockImplementation((fileName: string) => {
+      const files: Record<string, string> = {
+        'build.xml': codeBlock`
+          <project>
+            <property file="v.properties" />
+            <property file="v.properties" />
+            <artifact:dependencies>
+              <dependency groupId="junit" artifactId="junit" version="\${v}" />
+            </artifact:dependencies>
+          </project>
+        `,
+        'v.properties': 'v=1.0\n',
+      };
+      return Promise.resolve(files[fileName] ?? null);
+    });
+
+    const result = await extractAllPackageFiles({}, ['build.xml']);
+
+    expect(result).toEqual([
+      {
+        packageFile: 'v.properties',
+        deps: [
+          expect.objectContaining({
+            depName: 'junit:junit',
+            currentValue: '1.0',
+          }),
+        ],
+      },
+    ]);
+  });
+
   it('does not revisit the same file', async () => {
     let readCount = 0;
     fs.readLocalFile.mockImplementation((fileName: string) => {

--- a/lib/modules/manager/ant/extract.ts
+++ b/lib/modules/manager/ant/extract.ts
@@ -1,3 +1,4 @@
+import upath from 'upath';
 import { XmlDocument } from 'xmldoc';
 import { logger } from '../../../logger/index.ts';
 import { readLocalFile } from '../../../util/fs/index.ts';
@@ -16,6 +17,19 @@ const scopeNames = new Set([
   'provided',
   'system',
 ]);
+
+interface AntProperty {
+  value: string;
+  fileReplacePosition: number;
+  packageFile: string;
+}
+
+interface WalkContext {
+  propertyMap: Map<string, AntProperty>;
+  visitedXmlFiles: Set<string>;
+  visitedPropertiesFiles: Set<string>;
+  results: Map<string, PackageFileContent>;
+}
 
 function isXmlElement(node: unknown): node is XmlDocument {
   const n = node as { type?: string };
@@ -59,6 +73,154 @@ function readAttributeRange(
   return { valuePosition, valueLength: match.groups.value.length };
 }
 
+function addProperty(
+  ctx: WalkContext,
+  name: string,
+  value: string,
+  fileReplacePosition: number,
+  packageFile: string,
+): void {
+  if (!ctx.propertyMap.has(name)) {
+    ctx.propertyMap.set(name, { value, fileReplacePosition, packageFile });
+  }
+}
+
+function parsePropertiesFile(
+  content: string,
+  packageFile: string,
+  ctx: WalkContext,
+): void {
+  const isCrlf = content.includes('\r\n');
+  const lineBreakLength = isCrlf ? 2 : 1;
+  const lines = content.split(regEx(/\r?\n/));
+
+  let offset = 0;
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#') || trimmed.startsWith('!')) {
+      offset += line.length + lineBreakLength;
+      continue;
+    }
+
+    const separatorMatch = regEx(/[:=]/).exec(trimmed);
+    if (!separatorMatch?.index) {
+      offset += line.length + lineBreakLength;
+      continue;
+    }
+
+    const separatorIndex = separatorMatch.index;
+    const key = trimmed.slice(0, separatorIndex).trim();
+    const rawValue = trimmed.slice(separatorIndex + 1);
+    const leftPartLength = separatorIndex + 1 + rawValue.search(regEx(/\S|$/));
+    const value = rawValue.trim();
+
+    if (!key || !value) {
+      offset += line.length + lineBreakLength;
+      continue;
+    }
+
+    const leadingWhitespace = line.length - line.trimStart().length;
+    const valuePosition = offset + leadingWhitespace + leftPartLength;
+
+    addProperty(ctx, key, value, valuePosition, packageFile);
+    offset += line.length + lineBreakLength;
+  }
+}
+
+function resolvePropertyString(
+  input: string,
+  propertyMap: Map<string, AntProperty>,
+  visited: Set<string> = new Set(),
+): string | null {
+  if (!input.includes('${')) {
+    return input;
+  }
+
+  const propRegex = regEx(/\$\{([^}]+)}/g);
+  let changed = false;
+  const result = input.replace(propRegex, (match, propName: string) => {
+    if (visited.has(propName)) {
+      return match;
+    }
+
+    const prop = propertyMap.get(propName);
+    if (!prop) {
+      return match;
+    }
+
+    visited.add(propName);
+    const resolved = resolvePropertyString(prop.value, propertyMap, visited);
+    visited.delete(propName);
+
+    if (!resolved) {
+      return match;
+    }
+
+    /* v8 ignore next 3 -- v8 does not track replace callback coverage reliably */
+    changed = true;
+    return resolved;
+  });
+
+  if (changed && result.includes('${')) {
+    return null;
+  }
+
+  if (!changed) {
+    return null;
+  }
+
+  return result;
+}
+
+function resolveVersionReference(
+  rawVersion: string,
+  propertyMap: Map<string, AntProperty>,
+): {
+  currentValue: string | null;
+  sharedVariableName: string | undefined;
+  property: AntProperty | undefined;
+} {
+  const singlePropMatch = regEx(/^\$\{([^}]+)}$/).exec(rawVersion);
+
+  if (singlePropMatch) {
+    const propName = singlePropMatch[1];
+    const prop = propertyMap.get(propName);
+    if (!prop) {
+      return {
+        currentValue: null,
+        sharedVariableName: propName,
+        property: undefined,
+      };
+    }
+
+    const resolved = resolvePropertyString(
+      prop.value,
+      propertyMap,
+      new Set([propName]),
+    );
+    return {
+      currentValue: resolved,
+      sharedVariableName: propName,
+      property: prop,
+    };
+  }
+
+  if (rawVersion.includes('${')) {
+    const resolved = resolvePropertyString(rawVersion, propertyMap);
+    return {
+      currentValue: resolved,
+      sharedVariableName: undefined,
+      property: undefined,
+    };
+  }
+
+  return {
+    currentValue: rawVersion,
+    sharedVariableName: undefined,
+    property: undefined,
+  };
+}
+
 function getDependencyType(scope: string | undefined): string {
   if (scope && scopeNames.has(scope)) {
     return scope;
@@ -69,63 +231,126 @@ function getDependencyType(scope: string | undefined): string {
 function collectDependency(
   content: string,
   node: XmlDocument,
-): PackageDependency | null {
+  packageFile: string,
+  ctx: WalkContext,
+): void {
   const { groupId, artifactId, version, scope } = node.attr;
 
   if (!version || !groupId || !artifactId) {
-    return null;
+    return;
   }
 
   const range = readAttributeRange(content, node, 'version', version);
   /* v8 ignore next 3 -- readAttributeRange only fails if xmldoc misreports attributes */
   if (!range) {
-    return null;
+    return;
   }
 
-  return {
+  const { currentValue, sharedVariableName, property } =
+    resolveVersionReference(version, ctx.propertyMap);
+
+  const dep: PackageDependency = {
     datasource: MavenDatasource.id,
     depName: `${groupId}:${artifactId}`,
-    currentValue: version,
     depType: getDependencyType(scope),
-    fileReplacePosition: range.valuePosition,
     registryUrls: [],
   };
+
+  if (currentValue) {
+    dep.currentValue = currentValue;
+  } else {
+    dep.currentValue = version;
+    dep.skipReason = 'contains-variable';
+  }
+
+  if (sharedVariableName) {
+    dep.sharedVariableName = sharedVariableName;
+  }
+
+  const targetFile = property?.packageFile ?? packageFile;
+  const targetPosition = property?.fileReplacePosition ?? range.valuePosition;
+  dep.fileReplacePosition = targetPosition;
+
+  if (!ctx.results.has(targetFile)) {
+    ctx.results.set(targetFile, { packageFile: targetFile, deps: [] });
+  }
+  ctx.results.get(targetFile)!.deps.push(dep);
 }
 
-function walkNode(
+async function walkNode(
   content: string,
   node: XmlDocument,
-  deps: PackageDependency[],
-): void {
+  packageFile: string,
+  ctx: WalkContext,
+): Promise<void> {
   for (const child of node.children) {
     if (!isXmlElement(child)) {
       continue;
     }
 
-    if (child.name === 'dependency') {
-      const dep = collectDependency(content, child);
-      if (dep) {
-        deps.push(dep);
+    if (child.name === 'property') {
+      if (child.attr.name && child.attr.value) {
+        const propRange = readAttributeRange(
+          content,
+          child,
+          'value',
+          child.attr.value,
+        );
+        if (propRange) {
+          addProperty(
+            ctx,
+            child.attr.name,
+            child.attr.value,
+            propRange.valuePosition,
+            packageFile,
+          );
+        }
+      } else if (child.attr.file) {
+        const propFilePath = upath.join(
+          upath.dirname(packageFile),
+          child.attr.file,
+        );
+        await walkPropertiesFile(propFilePath, ctx);
       }
+    } else if (child.name === 'dependency') {
+      collectDependency(content, child, packageFile, ctx);
     } else {
-      walkNode(content, child, deps);
+      await walkNode(content, child, packageFile, ctx);
     }
   }
 }
 
+async function walkPropertiesFile(
+  filePath: string,
+  ctx: WalkContext,
+): Promise<void> {
+  if (ctx.visitedPropertiesFiles.has(filePath)) {
+    return;
+  }
+  ctx.visitedPropertiesFiles.add(filePath);
+
+  const content = await readLocalFile(filePath, 'utf8');
+  if (!content) {
+    logger.debug(`ant manager: could not read properties file ${filePath}`);
+    return;
+  }
+
+  parsePropertiesFile(content, filePath, ctx);
+}
+
 async function walkXmlFile(
   packageFile: string,
-  visitedFiles: Set<string>,
-): Promise<PackageFileContent | null> {
-  if (visitedFiles.has(packageFile)) {
-    return null;
+  ctx: WalkContext,
+): Promise<void> {
+  if (ctx.visitedXmlFiles.has(packageFile)) {
+    return;
   }
-  visitedFiles.add(packageFile);
+  ctx.visitedXmlFiles.add(packageFile);
 
   const content = await readLocalFile(packageFile, 'utf8');
   if (!content) {
     logger.debug(`ant manager: could not read ${packageFile}`);
-    return null;
+    return;
   }
 
   let doc: XmlDocument;
@@ -133,32 +358,27 @@ async function walkXmlFile(
     doc = new XmlDocument(content);
   } catch {
     logger.debug(`ant manager: could not parse XML ${packageFile}`);
-    return null;
+    return;
   }
 
-  const deps: PackageDependency[] = [];
-  walkNode(content, doc, deps);
-
-  if (deps.length === 0) {
-    return null;
-  }
-
-  return { packageFile, deps };
+  await walkNode(content, doc, packageFile, ctx);
 }
 
 export async function extractAllPackageFiles(
   _config: ExtractConfig,
   packageFiles: string[],
 ): Promise<PackageFileContent[] | null> {
-  const results: PackageFileContent[] = [];
-  const visitedFiles = new Set<string>();
+  const ctx: WalkContext = {
+    propertyMap: new Map(),
+    visitedXmlFiles: new Set(),
+    visitedPropertiesFiles: new Set(),
+    results: new Map(),
+  };
 
   for (const packageFile of packageFiles) {
-    const result = await walkXmlFile(packageFile, visitedFiles);
-    if (result) {
-      results.push(result);
-    }
+    await walkXmlFile(packageFile, ctx);
   }
 
+  const results = [...ctx.results.values()].filter((r) => r.deps.length > 0);
   return results.length > 0 ? results : null;
 }

--- a/lib/modules/manager/ant/extract.ts
+++ b/lib/modules/manager/ant/extract.ts
@@ -1,0 +1,164 @@
+import { XmlDocument } from 'xmldoc';
+import { logger } from '../../../logger/index.ts';
+import { readLocalFile } from '../../../util/fs/index.ts';
+import { regEx } from '../../../util/regex.ts';
+import { MavenDatasource } from '../../datasource/maven/index.ts';
+import type {
+  ExtractConfig,
+  PackageDependency,
+  PackageFileContent,
+} from '../types.ts';
+
+const scopeNames = new Set([
+  'compile',
+  'runtime',
+  'test',
+  'provided',
+  'system',
+]);
+
+function isXmlElement(node: unknown): node is XmlDocument {
+  const n = node as { type?: string };
+  return n?.type === 'element';
+}
+
+function escapeRegex(input: string): string {
+  return input.replace(regEx(/[.*+?^${}()|[\]\\]/g), '\\$&');
+}
+
+function readAttributeRange(
+  content: string,
+  node: XmlDocument,
+  attrName: string,
+  attrValue: string,
+): { valuePosition: number; valueLength: number } | null {
+  const startTagPosition = node.startTagPosition ?? node.position;
+  /* v8 ignore next 3 -- xmldoc always sets startTagPosition */
+  if (startTagPosition === undefined || startTagPosition === null) {
+    return null;
+  }
+
+  const tagEnd = content.indexOf('>', startTagPosition);
+  /* v8 ignore next 3 -- parsed XML always contains closing > */
+  if (tagEnd === -1) {
+    return null;
+  }
+
+  const tagContent = content.slice(startTagPosition, tagEnd + 1);
+  const attrRegex = regEx(
+    `\\b${attrName}\\s*=\\s*(?<quote>["'])(?<value>${escapeRegex(attrValue)})\\k<quote>`,
+  );
+  const match = attrRegex.exec(tagContent);
+  /* v8 ignore next 3 -- only called with attributes already parsed by xmldoc */
+  if (!match?.groups?.quote || !match.groups.value) {
+    return null;
+  }
+
+  const valuePosition =
+    startTagPosition + match.index + match[0].indexOf(match.groups.value);
+  return { valuePosition, valueLength: match.groups.value.length };
+}
+
+function getDependencyType(scope: string | undefined): string {
+  if (scope && scopeNames.has(scope)) {
+    return scope;
+  }
+  return 'compile';
+}
+
+function collectDependency(
+  content: string,
+  node: XmlDocument,
+): PackageDependency | null {
+  const { groupId, artifactId, version, scope } = node.attr;
+
+  if (!version || !groupId || !artifactId) {
+    return null;
+  }
+
+  const range = readAttributeRange(content, node, 'version', version);
+  /* v8 ignore next 3 -- readAttributeRange only fails if xmldoc misreports attributes */
+  if (!range) {
+    return null;
+  }
+
+  return {
+    datasource: MavenDatasource.id,
+    depName: `${groupId}:${artifactId}`,
+    currentValue: version,
+    depType: getDependencyType(scope),
+    fileReplacePosition: range.valuePosition,
+    registryUrls: [],
+  };
+}
+
+function walkNode(
+  content: string,
+  node: XmlDocument,
+  deps: PackageDependency[],
+): void {
+  for (const child of node.children) {
+    if (!isXmlElement(child)) {
+      continue;
+    }
+
+    if (child.name === 'dependency') {
+      const dep = collectDependency(content, child);
+      if (dep) {
+        deps.push(dep);
+      }
+    } else {
+      walkNode(content, child, deps);
+    }
+  }
+}
+
+async function walkXmlFile(
+  packageFile: string,
+  visitedFiles: Set<string>,
+): Promise<PackageFileContent | null> {
+  if (visitedFiles.has(packageFile)) {
+    return null;
+  }
+  visitedFiles.add(packageFile);
+
+  const content = await readLocalFile(packageFile, 'utf8');
+  if (!content) {
+    logger.debug(`ant manager: could not read ${packageFile}`);
+    return null;
+  }
+
+  let doc: XmlDocument;
+  try {
+    doc = new XmlDocument(content);
+  } catch {
+    logger.debug(`ant manager: could not parse XML ${packageFile}`);
+    return null;
+  }
+
+  const deps: PackageDependency[] = [];
+  walkNode(content, doc, deps);
+
+  if (deps.length === 0) {
+    return null;
+  }
+
+  return { packageFile, deps };
+}
+
+export async function extractAllPackageFiles(
+  _config: ExtractConfig,
+  packageFiles: string[],
+): Promise<PackageFileContent[] | null> {
+  const results: PackageFileContent[] = [];
+  const visitedFiles = new Set<string>();
+
+  for (const packageFile of packageFiles) {
+    const result = await walkXmlFile(packageFile, visitedFiles);
+    if (result) {
+      results.push(result);
+    }
+  }
+
+  return results.length > 0 ? results : null;
+}

--- a/lib/modules/manager/ant/extract.ts
+++ b/lib/modules/manager/ant/extract.ts
@@ -421,6 +421,11 @@ async function walkNode(
         );
         await walkPropertiesFile(propFilePath, ctx);
       }
+    } else if (child.name === 'import' && child.attr.file) {
+      const importedFile = upath.normalize(
+        upath.join(upath.dirname(packageFile), child.attr.file),
+      );
+      await walkXmlFile(importedFile, ctx);
     } else if (child.name === 'dependency') {
       collectDependency(content, child, packageFile, ctx);
     } else {

--- a/lib/modules/manager/ant/extract.ts
+++ b/lib/modules/manager/ant/extract.ts
@@ -221,11 +221,60 @@ function resolveVersionReference(
   };
 }
 
-function getDependencyType(scope: string | undefined): string {
+function parseCoords(coords: string): {
+  depName: string;
+  depType?: string;
+  rawVersion: string;
+} | null {
+  const parts = coords.split(':');
+  if (parts.length < 3) {
+    return null;
+  }
+
+  const [groupId, artifactId] = parts;
+  if (!groupId || !artifactId) {
+    return null;
+  }
+
+  let depType: string | undefined;
+  let rawVersion: string;
+
+  if (parts.length >= 4 && scopeNames.has(parts.at(-1)!)) {
+    depType = parts.at(-1);
+    rawVersion = parts.at(-2)!;
+  } else {
+    rawVersion = parts.at(-1)!;
+  }
+
+  return {
+    depName: `${groupId}:${artifactId}`,
+    rawVersion,
+    depType,
+  };
+}
+
+function getDependencyType(
+  scope: string | undefined,
+  coordsDepType?: string,
+): string {
+  if (coordsDepType) {
+    return coordsDepType;
+  }
   if (scope && scopeNames.has(scope)) {
     return scope;
   }
   return 'compile';
+}
+
+function addDependencyResult(
+  dep: PackageDependency,
+  targetFile: string,
+  ctx: WalkContext,
+): void {
+  if (!ctx.results.has(targetFile)) {
+    ctx.results.set(targetFile, { packageFile: targetFile, deps: [] });
+  }
+  ctx.results.get(targetFile)!.deps.push(dep);
 }
 
 function collectDependency(
@@ -234,11 +283,20 @@ function collectDependency(
   packageFile: string,
   ctx: WalkContext,
 ): void {
-  const { groupId, artifactId, version, scope } = node.attr;
-
-  if (!version || !groupId || !artifactId) {
-    return;
+  if (node.attr.groupId && node.attr.artifactId && node.attr.version) {
+    collectInlineDependency(content, node, packageFile, ctx);
+  } else if (node.attr.coords) {
+    collectCoordsDependency(content, node, packageFile, ctx);
   }
+}
+
+function collectInlineDependency(
+  content: string,
+  node: XmlDocument,
+  packageFile: string,
+  ctx: WalkContext,
+): void {
+  const { groupId, artifactId, version, scope } = node.attr;
 
   const range = readAttributeRange(content, node, 'version', version);
   /* v8 ignore next 3 -- readAttributeRange only fails if xmldoc misreports attributes */
@@ -268,13 +326,64 @@ function collectDependency(
   }
 
   const targetFile = property?.packageFile ?? packageFile;
-  const targetPosition = property?.fileReplacePosition ?? range.valuePosition;
-  dep.fileReplacePosition = targetPosition;
+  dep.fileReplacePosition =
+    property?.fileReplacePosition ?? range.valuePosition;
 
-  if (!ctx.results.has(targetFile)) {
-    ctx.results.set(targetFile, { packageFile: targetFile, deps: [] });
+  addDependencyResult(dep, targetFile, ctx);
+}
+
+function collectCoordsDependency(
+  content: string,
+  node: XmlDocument,
+  packageFile: string,
+  ctx: WalkContext,
+): void {
+  const coords = parseCoords(node.attr.coords);
+  if (!coords) {
+    return;
   }
-  ctx.results.get(targetFile)!.deps.push(dep);
+
+  const { currentValue, sharedVariableName, property } =
+    resolveVersionReference(coords.rawVersion, ctx.propertyMap);
+
+  const range = readAttributeRange(content, node, 'coords', node.attr.coords);
+  /* v8 ignore next 3 -- readAttributeRange only fails if xmldoc misreports attributes */
+  if (!range) {
+    return;
+  }
+
+  const versionPositionInCoords = node.attr.coords.lastIndexOf(
+    coords.rawVersion,
+  );
+  /* v8 ignore next 3 -- rawVersion was extracted from coords so it always exists */
+  if (versionPositionInCoords === -1) {
+    return;
+  }
+
+  const dep: PackageDependency = {
+    datasource: MavenDatasource.id,
+    depName: coords.depName,
+    depType: getDependencyType(node.attr.scope, coords.depType),
+    registryUrls: [],
+  };
+
+  if (currentValue) {
+    dep.currentValue = currentValue;
+  } else {
+    dep.currentValue = coords.rawVersion;
+    dep.skipReason = 'contains-variable';
+  }
+
+  if (sharedVariableName) {
+    dep.sharedVariableName = sharedVariableName;
+  }
+
+  const targetFile = property?.packageFile ?? packageFile;
+  dep.fileReplacePosition =
+    property?.fileReplacePosition ??
+    range.valuePosition + versionPositionInCoords;
+
+  addDependencyResult(dep, targetFile, ctx);
 }
 
 async function walkNode(

--- a/lib/modules/manager/ant/index.ts
+++ b/lib/modules/manager/ant/index.ts
@@ -1,0 +1,15 @@
+import type { Category } from '../../../constants/index.ts';
+import { MavenDatasource } from '../../datasource/maven/index.ts';
+
+export { extractAllPackageFiles } from './extract.ts';
+export { updateDependency } from './update.ts';
+
+export const displayName = 'Apache Ant';
+export const url = 'https://ant.apache.org/';
+export const categories: Category[] = ['java'];
+
+export const defaultConfig = {
+  managerFilePatterns: ['/(^|/)build\\.xml$/'],
+};
+
+export const supportedDatasources = [MavenDatasource.id];

--- a/lib/modules/manager/ant/readme.md
+++ b/lib/modules/manager/ant/readme.md
@@ -1,0 +1,2 @@
+Extracts Apache Ant dependencies from `build.xml` files that use the `maven-resolver-ant-tasks` library.
+Dependencies are looked up using the Maven datasource.

--- a/lib/modules/manager/ant/update.spec.ts
+++ b/lib/modules/manager/ant/update.spec.ts
@@ -203,4 +203,21 @@ describe('modules/manager/ant/update', () => {
 
     expect(result).toBeNull();
   });
+
+  it('updates version within coords attribute', () => {
+    const fileContent =
+      '<project><dependency coords="junit:junit:4.13.2" /></project>';
+
+    const result = updateDependency({
+      fileContent,
+      upgrade: {
+        depName: 'junit:junit',
+        currentValue: '4.13.2',
+        newValue: '4.13.3',
+        fileReplacePosition: fileContent.indexOf('4.13.2'),
+      },
+    });
+
+    expect(result).toContain('coords="junit:junit:4.13.3"');
+  });
 });

--- a/lib/modules/manager/ant/update.spec.ts
+++ b/lib/modules/manager/ant/update.spec.ts
@@ -107,6 +107,89 @@ describe('modules/manager/ant/update', () => {
     expect(result).toContain("version='4.13.3'");
   });
 
+  it('updates properties file values', () => {
+    const fileContent = 'slf4j.version=1.7.36\nother=value\n';
+
+    const result = updateDependency({
+      fileContent,
+      upgrade: {
+        depName: 'org.slf4j:slf4j-api',
+        currentValue: '1.7.36',
+        newValue: '2.0.17',
+        fileReplacePosition: fileContent.indexOf('1.7.36'),
+        sharedVariableName: 'slf4j.version',
+      },
+    });
+
+    expect(result).toContain('slf4j.version=2.0.17');
+  });
+
+  it('returns null when properties value does not match and no sharedVariableName', () => {
+    const fileContent = 'some.version=9.9.9\n';
+
+    const result = updateDependency({
+      fileContent,
+      upgrade: {
+        depName: 'org.example:lib',
+        currentValue: '1.0.0',
+        newValue: '2.0.0',
+        fileReplacePosition: fileContent.indexOf('9.9.9'),
+      },
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('updates properties value when sharedVariableName is set even if mismatch', () => {
+    const fileContent = 'my.version=999\n';
+
+    const result = updateDependency({
+      fileContent,
+      upgrade: {
+        depName: 'org.example:lib',
+        currentValue: '1.0.0',
+        newValue: '2.0.0',
+        fileReplacePosition: fileContent.indexOf('999'),
+        sharedVariableName: 'my.version',
+      },
+    });
+
+    expect(result).toContain('my.version=2.0.0');
+  });
+
+  it('returns fileContent unchanged when properties value already matches newValue', () => {
+    const fileContent = 'slf4j.version=2.0.17\nother=value\n';
+
+    const result = updateDependency({
+      fileContent,
+      upgrade: {
+        depName: 'org.slf4j:slf4j-api',
+        currentValue: '1.7.36',
+        newValue: '2.0.17',
+        fileReplacePosition: fileContent.indexOf('2.0.17'),
+        sharedVariableName: 'slf4j.version',
+      },
+    });
+
+    expect(result).toBe(fileContent);
+  });
+
+  it('returns null when properties line is empty at offset', () => {
+    const fileContent = 'some.version=\n';
+
+    const result = updateDependency({
+      fileContent,
+      upgrade: {
+        depName: 'org.example:lib',
+        currentValue: '1.0.0',
+        newValue: '2.0.0',
+        fileReplacePosition: fileContent.indexOf('\n'),
+      },
+    });
+
+    expect(result).toBeNull();
+  });
+
   it('returns null when no quote is found before position', () => {
     const result = updateDependency({
       fileContent: 'no-quotes-here',

--- a/lib/modules/manager/ant/update.spec.ts
+++ b/lib/modules/manager/ant/update.spec.ts
@@ -1,0 +1,123 @@
+import { codeBlock } from 'common-tags';
+import { updateDependency } from './update.ts';
+
+describe('modules/manager/ant/update', () => {
+  it('updates XML version attributes', () => {
+    const fileContent = codeBlock`
+      <project>
+        <artifact:dependencies>
+          <dependency groupId="junit" artifactId="junit" version="4.13.2" />
+        </artifact:dependencies>
+      </project>
+    `;
+
+    const result = updateDependency({
+      fileContent,
+      upgrade: {
+        depName: 'junit:junit',
+        currentValue: '4.13.2',
+        newValue: '4.13.3',
+        fileReplacePosition: fileContent.indexOf('4.13.2'),
+      },
+    });
+
+    expect(result).toContain('version="4.13.3"');
+  });
+
+  it('returns null when fileReplacePosition is missing', () => {
+    const result = updateDependency({
+      fileContent: '<project />',
+      upgrade: {
+        depName: 'junit:junit',
+        currentValue: '1.0',
+        newValue: '2.0',
+      },
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when newValue is missing', () => {
+    const result = updateDependency({
+      fileContent: '<project />',
+      upgrade: {
+        depName: 'junit:junit',
+        currentValue: '1.0',
+        fileReplacePosition: 0,
+      },
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('returns fileContent unchanged when already updated', () => {
+    const fileContent = codeBlock`
+      <project>
+        <dependency groupId="junit" artifactId="junit" version="4.13.3" />
+      </project>
+    `;
+
+    const result = updateDependency({
+      fileContent,
+      upgrade: {
+        depName: 'junit:junit',
+        currentValue: '4.13.3',
+        newValue: '4.13.3',
+        fileReplacePosition: fileContent.indexOf('4.13.3'),
+      },
+    });
+
+    expect(result).toBe(fileContent);
+  });
+
+  it('returns null when version at position does not match', () => {
+    const fileContent = codeBlock`
+      <project>
+        <dependency groupId="junit" artifactId="junit" version="9.9.9" />
+      </project>
+    `;
+
+    const result = updateDependency({
+      fileContent,
+      upgrade: {
+        depName: 'junit:junit',
+        currentValue: '4.13.2',
+        newValue: '4.13.3',
+        fileReplacePosition: fileContent.indexOf('9.9.9'),
+      },
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('handles single-quoted XML attributes', () => {
+    const fileContent =
+      "<project><dependency groupId='junit' artifactId='junit' version='4.13.2' /></project>";
+
+    const result = updateDependency({
+      fileContent,
+      upgrade: {
+        depName: 'junit:junit',
+        currentValue: '4.13.2',
+        newValue: '4.13.3',
+        fileReplacePosition: fileContent.indexOf('4.13.2'),
+      },
+    });
+
+    expect(result).toContain("version='4.13.3'");
+  });
+
+  it('returns null when no quote is found before position', () => {
+    const result = updateDependency({
+      fileContent: 'no-quotes-here',
+      upgrade: {
+        depName: 'org.example:lib',
+        currentValue: '1.0.0',
+        newValue: '2.0.0',
+        fileReplacePosition: 5,
+      },
+    });
+
+    expect(result).toBeNull();
+  });
+});

--- a/lib/modules/manager/ant/update.ts
+++ b/lib/modules/manager/ant/update.ts
@@ -64,22 +64,37 @@ export function updateDependency({
     fileReplacePosition,
   );
   if (quotedAttribute) {
-    if (quotedAttribute.value === newValue) {
-      return fileContent;
-    }
-
-    if (quotedAttribute.value !== currentValue) {
-      logger.debug(
-        `ant manager: version mismatch at position ${fileReplacePosition}`,
+    if (quotedAttribute.value === currentValue) {
+      if (currentValue === newValue) {
+        return fileContent;
+      }
+      return (
+        fileContent.slice(0, quotedAttribute.start) +
+        newValue +
+        fileContent.slice(quotedAttribute.end)
       );
-      return null;
     }
 
-    return (
-      fileContent.slice(0, quotedAttribute.start) +
-      newValue +
-      fileContent.slice(quotedAttribute.end)
+    if (currentValue && quotedAttribute.value.includes(currentValue)) {
+      /* v8 ignore next 3 -- coords value already contains newValue */
+      if (quotedAttribute.value.includes(newValue)) {
+        return fileContent;
+      }
+      const replacedValue = quotedAttribute.value.replace(
+        currentValue,
+        newValue,
+      );
+      return (
+        fileContent.slice(0, quotedAttribute.start) +
+        replacedValue +
+        fileContent.slice(quotedAttribute.end)
+      );
+    }
+
+    logger.debug(
+      `ant manager: version mismatch at position ${fileReplacePosition}`,
     );
+    return null;
   }
 
   const propertiesValue = versionFromPropertiesContent(

--- a/lib/modules/manager/ant/update.ts
+++ b/lib/modules/manager/ant/update.ts
@@ -1,0 +1,72 @@
+import { logger } from '../../../logger/index.ts';
+import type { UpdateDependencyConfig } from '../types.ts';
+
+function versionFromQuotedAttribute(
+  content: string,
+  offset: number,
+): { value: string; start: number; end: number } | null {
+  const doubleQuoteStart = content.lastIndexOf('"', offset - 1);
+  const singleQuoteStart = content.lastIndexOf("'", offset - 1);
+  const quoteStart = Math.max(doubleQuoteStart, singleQuoteStart);
+  if (quoteStart === -1) {
+    return null;
+  }
+
+  const quote = content[quoteStart];
+  /* v8 ignore next 3 -- quoteStart always points to a quote character */
+  if (quote !== '"' && quote !== "'") {
+    return null;
+  }
+
+  const end = content.indexOf(quote, offset);
+  /* v8 ignore next 3 -- well-formed XML always has matching closing quote */
+  if (end === -1) {
+    return null;
+  }
+
+  const value = content.slice(quoteStart + 1, end);
+  return { value, start: quoteStart + 1, end };
+}
+
+export function updateDependency({
+  fileContent,
+  upgrade,
+}: UpdateDependencyConfig): string | null {
+  const { currentValue, newValue, fileReplacePosition } = upgrade;
+
+  if (fileReplacePosition === undefined || fileReplacePosition === null) {
+    logger.debug('ant manager: missing fileReplacePosition');
+    return null;
+  }
+
+  if (!newValue) {
+    logger.debug('ant manager: missing newValue');
+    return null;
+  }
+
+  const quotedAttribute = versionFromQuotedAttribute(
+    fileContent,
+    fileReplacePosition,
+  );
+  if (quotedAttribute) {
+    if (quotedAttribute.value === newValue) {
+      return fileContent;
+    }
+
+    if (quotedAttribute.value !== currentValue) {
+      logger.debug(
+        `ant manager: version mismatch at position ${fileReplacePosition}`,
+      );
+      return null;
+    }
+
+    return (
+      fileContent.slice(0, quotedAttribute.start) +
+      newValue +
+      fileContent.slice(quotedAttribute.end)
+    );
+  }
+
+  logger.debug('ant manager: could not detect version value');
+  return null;
+}

--- a/lib/modules/manager/ant/update.ts
+++ b/lib/modules/manager/ant/update.ts
@@ -28,6 +28,21 @@ function versionFromQuotedAttribute(
   return { value, start: quoteStart + 1, end };
 }
 
+function versionFromPropertiesContent(
+  content: string,
+  offset: number,
+): { value: string; start: number; end: number } | null {
+  let end = content.indexOf('\n', offset);
+  if (end === -1) {
+    end = content.length;
+  }
+  const value = content.slice(offset, end).trim();
+  if (!value) {
+    return null;
+  }
+  return { value, start: offset, end: offset + value.length };
+}
+
 export function updateDependency({
   fileContent,
   upgrade,
@@ -64,6 +79,29 @@ export function updateDependency({
       fileContent.slice(0, quotedAttribute.start) +
       newValue +
       fileContent.slice(quotedAttribute.end)
+    );
+  }
+
+  const propertiesValue = versionFromPropertiesContent(
+    fileContent,
+    fileReplacePosition,
+  );
+  if (propertiesValue) {
+    if (propertiesValue.value === newValue) {
+      return fileContent;
+    }
+
+    if (propertiesValue.value !== currentValue && !upgrade.sharedVariableName) {
+      logger.debug(
+        `ant manager: properties value mismatch at position ${fileReplacePosition}`,
+      );
+      return null;
+    }
+
+    return (
+      fileContent.slice(0, propertiesValue.start) +
+      newValue +
+      fileContent.slice(propertiesValue.end)
     );
   }
 

--- a/lib/modules/manager/api.ts
+++ b/lib/modules/manager/api.ts
@@ -1,5 +1,6 @@
 import * as ansible from './ansible/index.ts';
 import * as ansibleGalaxy from './ansible-galaxy/index.ts';
+import * as ant from './ant/index.ts';
 import * as argoCD from './argocd/index.ts';
 import * as asdf from './asdf/index.ts';
 import * as azurePipelines from './azure-pipelines/index.ts';
@@ -113,6 +114,7 @@ import * as woodpecker from './woodpecker/index.ts';
 const api = new Map<string, ManagerApi>();
 export default api;
 
+api.set('ant', ant);
 api.set('ansible', ansible);
 api.set('ansible-galaxy', ansibleGalaxy);
 api.set('argocd', argoCD);


### PR DESCRIPTION
  ## Changes
  - Follow ⁠ <import file="..." /> ⁠ elements to extract dependencies from imported Ant build files
  - Share property context across imported files (properties defined before ⁠ <import> ⁠ are available in the imported file)
  - Prevent infinite loops via visited-file cycle detection
  - Skip gracefully when imported files are missing or unreadable

  ## Context

  Please select one of the following:

  - [x] This closes an existing Issue, Closes: #42181 
  - [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or
   implementation

  > *Stacked PR 4/5* — depends on #42176 

  ## AI assistance disclosure

  Did you use AI tools to create any part of this pull request?

  Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

  - [ ] No — I did not use AI for this contribution.
  - [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
  - [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, and documentation).
  - [ ] Yes — other (please describe):

  ## Documentation (please check one with an [x])

  - [ ] I have updated the documentation, or
  - [x] No documentation update is required

  ## How I've tested my work (please select one)

  I have verified these changes via:

  - [ ] Code inspection only, or
  - [x] Newly added/modified unit tests, or
  - [ ] No unit tests, but ran on a real repository, or
  - [ ] Both unit tests + ran on a real repository