### PR TITLE
fix(cli): avoid printing logs on `--version`/`--help`

### DIFF
--- a/lib/renovate.spec.ts
+++ b/lib/renovate.spec.ts
@@ -4,6 +4,7 @@ import * as renovateWorker from './workers/global/index.ts';
 vi.mock('./instrumentation/index.ts');
 vi.mock('./proxy.ts');
 vi.mock('./workers/global/index.ts');
+vi.mock('./workers/global/config/parse/cli.ts');
 
 describe('renovate', () => {
   it('starts', async () => {

--- a/lib/renovate.ts
+++ b/lib/renovate.ts
@@ -4,6 +4,11 @@ import 'source-map-support/register.js';
 import './punycode.cjs';
 
 void (async (): Promise<void> => {
+  // prints and exits the process if --version or --help is passed
+  const { parseEarlyFlags } =
+    await import('./workers/global/config/parse/cli.ts');
+  parseEarlyFlags();
+
   // has to be imported before logger and other libraries which are instrumentalised
   const otel = await import('./instrumentation/index.ts');
   otel.init();

--- a/lib/workers/global/config/parse/cli.spec.ts
+++ b/lib/workers/global/config/parse/cli.spec.ts
@@ -1,3 +1,4 @@
+import { pkg } from '../../../../expose.ts';
 import { DockerDatasource } from '../../../../modules/datasource/docker/index.ts';
 import getArgv from './__fixtures__/argv.ts';
 import * as cli from './cli.ts';
@@ -204,6 +205,25 @@ describe('workers/global/config/parse/cli', () => {
     it('requireConfig boolean false', () => {
       argv.push('--require-config=false');
       expect(cli.getConfig(argv)).toEqual({ requireConfig: 'optional' });
+    });
+  });
+
+  describe('.parseEarlyFlags(argv)', () => {
+    it('prints version and exits when --version is passed', () => {
+      const exitSpy = vi
+        .spyOn(process, 'exit')
+        .mockImplementation((() => undefined) as never);
+      const stdoutSpy = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
+
+      cli.parseEarlyFlags([...argv, '--version']);
+
+      expect(stdoutSpy).toHaveBeenCalledExactlyOnceWith(
+        expect.stringContaining(pkg.version),
+      );
+      expect(exitSpy).toHaveBeenCalledExactlyOnceWith(0);
+
+      stdoutSpy.mockRestore();
+      exitSpy.mockRestore();
     });
   });
 });

--- a/lib/workers/global/config/parse/cli.ts
+++ b/lib/workers/global/config/parse/cli.ts
@@ -15,6 +15,48 @@ export function getCliName(option: ParseConfigOptions): string {
   return `--${nameWithHyphens.toLowerCase()}`;
 }
 
+function createProgram(): Command<[string[]]> {
+  const options = getOptions();
+
+  let program = new Command().arguments('[repositories...]');
+
+  options.forEach((option) => {
+    if (option.cli !== false) {
+      const param = `<${option.type}>`.replace('<boolean>', '[boolean]');
+      const optionString = `${getCliName(option)} ${param}`;
+      program = program.option(
+        optionString,
+        option.description,
+        coersions[option.type],
+      );
+    }
+  });
+
+  /* oxlint-disable no-console -- intentional: CLI help output */
+  /* istanbul ignore next */
+  function helpConsole(): void {
+    console.log('  Examples:');
+    console.log('');
+    console.log('    $ renovate --token 123test singapore/lint-condo');
+    console.log(
+      '    $ LOG_LEVEL=debug renovate --labels=renovate,dependency --ignore-unstable=false singapore/lint-condo',
+    );
+    console.log('    $ renovate singapore/lint-condo singapore/package-test');
+    console.log(
+      `    $ renovate singapore/lint-condo --onboarding-config='{"extends":["config:recommended"]}'`,
+    );
+    /* oxlint-enable no-console */
+  }
+
+  return program
+    .version(pkg.version, '-v, --version')
+    .on('--help', helpConsole);
+}
+
+export function parseEarlyFlags(input: string[] = process.argv): void {
+  createProgram().allowUnknownOption().allowExcessArguments().parse(input);
+}
+
 export function getConfig(input: string[]): AllConfig {
   // massage migrated configuration keys
   const argv = input
@@ -48,39 +90,7 @@ export function getConfig(input: string[]): AllConfig {
 
   const config: Record<string, any> = {};
 
-  let program = new Command().arguments('[repositories...]');
-
-  options.forEach((option) => {
-    if (option.cli !== false) {
-      const param = `<${option.type}>`.replace('<boolean>', '[boolean]');
-      const optionString = `${getCliName(option)} ${param}`;
-      program = program.option(
-        optionString,
-        option.description,
-        coersions[option.type],
-      );
-    }
-  });
-
-  /* oxlint-disable no-console -- intentional: CLI help output */
-  /* istanbul ignore next */
-  function helpConsole(): void {
-    console.log('  Examples:');
-    console.log('');
-    console.log('    $ renovate --token 123test singapore/lint-condo');
-    console.log(
-      '    $ LOG_LEVEL=debug renovate --labels=renovate,dependency --ignore-unstable=false singapore/lint-condo',
-    );
-    console.log('    $ renovate singapore/lint-condo singapore/package-test');
-    console.log(
-      `    $ renovate singapore/lint-condo --onboarding-config='{"extends":["config:recommended"]}'`,
-    );
-    /* oxlint-enable no-console */
-  }
-
-  program = program
-    .version(pkg.version, '-v, --version')
-    .on('--help', helpConsole)
+  createProgram()
     .action((repositories: string[], opts: Record<string, unknown>) => {
       if (repositories?.length) {
         config.repositories = repositories;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

This PR fixes a bug in the Renovate CLI where it was printing logs to stdout before handling the `--version` and `--help` flags, which caused the output to be unparsable by tools that expect only the version or help text.

```console
## BEFORE ##
$ renovate --version
 INFO: Renovate started
       "renovateVersion": "0.0.0-semantic-release"
 WARN: Config validation errors found
       "configType": "config.js",
       "errors": [
         {
           "topic": "Configuration Error",
           "message": "Invalid configuration option: reportFormatting"
         }
       ]
0.0.0-semantic-release

## AFTER ##
$ renovatte --version
0.0.0-semantic-release
```

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
