### PR TITLE
chore(tools): handle additional errors

### DIFF
--- a/tools/mkdocs.ts
+++ b/tools/mkdocs.ts
@@ -79,6 +79,15 @@ function checkResult(res: ExecaSyncReturnValue<string>): void {
   } else if (res.exitCode) {
     logger.error(`Error occured:\n${res.stderr || res.stdout}`);
     process.exit(res.exitCode);
+  } else if (res.timedOut) {
+    logger.error({ res }, 'Process timed out');
+    process.exit(-1);
+  } else if (res.killed) {
+    logger.error({ res }, 'Process was killed');
+    process.exit(-1);
+  } else if (res.failed) {
+    logger.error({ res }, 'Process call failed');
+    process.exit(-1);
   } else {
     logger.debug(`Build completed:\n${res.stdout || res.stderr}`);
   }

--- a/tools/prepare-release.ts
+++ b/tools/prepare-release.ts
@@ -50,6 +50,15 @@ async function build(): Promise<void> {
   } else if (res.exitCode) {
     logger.error(`Error occured:\n${res.stderr || res.stdout}`);
     process.exit(res.exitCode);
+  } else if (res.timedOut) {
+    logger.error({ res }, 'Process timed out');
+    process.exit(-1);
+  } else if (res.killed) {
+    logger.error({ res }, 'Process was killed');
+    process.exit(-1);
+  } else if (res.failed) {
+    logger.error({ res }, 'Process call failed');
+    process.exit(-1);
   } else {
     logger.debug(`Build succeeded:\n${res.stdout || res.stderr}`);
   }


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
In the case that `pdm` can't be executed, for instance if it's only
installed in a Virtualenv that's not currently active, this previously
would silently pass, even though the command had failed.

We can now make it more resilient by warning/erroring in the cases that:

- there is a timeout
- the process was killed
- the process failed to execute

Originally raised as #40987, which was closed due to the migration to
`execa` and errors being flagged as an `unhandledRejection`.

However, after #41712, we would no
longer reject, leading to an incomplete error handling case.

## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

When `pdm` can't be found:

```
ERROR: Process call failed
       "res": {
         "errno": -2,
         "code": "ENOENT",
         "syscall": "spawn pdm",
         "path": "pdm",
         "spawnargs": ["run", "mkdocs", "build", "--strict"],
         "originalMessage": "spawn pdm ENOENT",
         "shortMessage": "Command failed with ENOENT: pdm run mkdocs build --strict\nspawn pdm ENOENT",
         "command": "pdm run mkdocs build --strict",
         "escapedCommand": "pdm run mkdocs build --strict",
         "cwd": "tools/mkdocs",
         "failed": true,
         "timedOut": false,
         "isCanceled": false,
         "killed": false,
         "message": "Command failed with ENOENT: pdm run mkdocs build --strict\nspawn pdm ENOENT",
         "stack": "Error: Command failed with ENOENT: pdm run mkdocs build --strict\nspawn pdm ENOENT\n    at ChildProcess._handle.onexit (node:internal/child_process:286:19)\n    at onErrorNT (node:internal/child_process:507:16)\n    at process.processTicksAndRejections (node:internal/process/task_queues:90:21)"
       }
```

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
