### PR TITLE
feat(gradle): use Java 25 with gradle >= 9.1

### DIFF
--- a/lib/modules/manager/gradle-wrapper/util.spec.ts
+++ b/lib/modules/manager/gradle-wrapper/util.spec.ts
@@ -28,6 +28,8 @@ describe('modules/manager/gradle-wrapper/util', () => {
         ${'8.0.1'}    | ${'^17.0.0'}
         ${'8.5.0'}    | ${'^21.0.0'}
         ${'9.0.1'}    | ${'^21.0.0'}
+        ${'9.1.0'}    | ${'^25.0.0'}
+        ${'10.0.1'}   | ${'^25.0.0'}
       `(
         '$gradleVersion | $javaConstraint',
         async ({ gradleVersion, javaConstraint }) => {

--- a/lib/modules/manager/gradle-wrapper/utils.ts
+++ b/lib/modules/manager/gradle-wrapper/utils.ts
@@ -73,6 +73,9 @@ export async function getJavaConstraint(
         return `^${languageVersion}.0.0`;
       }
     }
+    if (major > 9 || (major === 9 && minor && minor >= 1)) {
+      return '^25.0.0';
+    }
     if (major > 8 || (major === 8 && minor && minor >= 5)) {
       return '^21.0.0';
     }


### PR DESCRIPTION

## Changes

Gradle 9.1 introduced full compatibility with Java 25 (see [here](https://docs.gradle.org/current/userguide/compatibility.html)). Similar to what was done for previous LTS releases, this PR extends the lists of Java constraints. It causes renovate to select Java 25 for artifact and gradle-wrapper updates if gradle >= 9.1 is in use.

As always, this selection can be customized in the renovate config (see [here](https://docs.renovatebot.com/language-constraints-and-upgrading/#applying-constraints-through-config)) or via the the gradle JVM discovery functionality (see [here](https://docs.gradle.org/current/userguide/gradle_daemon.html#sec:daemon_jvm_criteria)).

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

