### PR TITLE
refactor(lint): remove ESLint rules already covered by oxlint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -71,16 +71,6 @@ export default tseslint.config(
   {
     ...jsFiles,
     rules: {
-      'consistent-return': 0,
-      eqeqeq: 'error',
-      'no-console': 'error',
-      'no-negated-condition': 'error',
-      'no-param-reassign': 'error',
-      'no-template-curly-in-string': 'error',
-      radix: ['error', 'as-needed'], // on ES5+ the radix defaults to 10
-
-      'sort-imports': 0,
-
       'no-restricted-imports': [
         2,
         {
@@ -93,13 +83,6 @@ export default tseslint.config(
         {
           assertionStyle: 'as',
           objectLiteralTypeAssertions: 'allow',
-        },
-      ],
-
-      '@typescript-eslint/consistent-type-imports': [
-        'error',
-        {
-          disallowTypeAnnotations: false,
         },
       ],
 
@@ -123,18 +106,12 @@ export default tseslint.config(
         },
       ],
 
-      curly: [2, 'all'],
-
       '@typescript-eslint/no-empty-object-type': [
         2,
         {
           allowInterfaces: 'with-single-extends',
         },
       ],
-
-      // TODO: not compatible with recent versions of typescript-eslint
-      // 'typescript-enum/no-const-enum': 2,
-      // 'typescript-enum/no-enum': 2,
 
       'object-shorthand': [
         'error',
@@ -155,7 +132,6 @@ export default tseslint.config(
     },
 
     rules: {
-      'no-template-curly-in-string': 0,
       'prefer-destructuring': 0,
       'prefer-promise-reject-errors': 0,
       'global-require': 0,
@@ -185,10 +161,6 @@ export default tseslint.config(
       globals: {
         ...globals.node,
       },
-    },
-
-    rules: {
-      'no-console': 'off',
     },
   },
   {


### PR DESCRIPTION
These rules are already configured in `.oxlintrc.json` with matching behavior, making the ESLint copies pure duplication:

- `eqeqeq`, `no-console`, `no-negated-condition`, `no-param-reassign`
- `no-template-curly-in-string`, `curly`, `radix`
- `@typescript-eslint/consistent-type-imports`

Also removes redundant overrides (`no-template-curly-in-string` off in tests, `no-console` off in config/tools) and no-op disables (`consistent-return`, `sort-imports`).

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
