### PR TITLE
refactor(lint): move option-dependent rules from ESLint to oxlint

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -31,7 +31,20 @@
         "disallowTypeAnnotations": false
       }
     ],
-    "no-unused-vars": "error",
+    "no-restricted-imports": [
+      "error",
+      {
+        "paths": ["nock", "parse-link-header", "path"]
+      }
+    ],
+    "no-unused-vars": [
+      "error",
+      {
+        "vars": "all",
+        "args": "none",
+        "ignoreRestSiblings": true
+      }
+    ],
     "no-unassigned-vars": "error",
 
     "renovate/no-tools-import": "error",
@@ -58,6 +71,20 @@
     ],
     "typescript/unbound-method": ["error", { "ignoreStatic": true }],
     "typescript/require-await": "error",
+
+    "typescript/explicit-function-return-type": [
+      "error",
+      {
+        "allowExpressions": true,
+        "allowTypedFunctionExpressions": true
+      }
+    ],
+    "typescript/no-empty-object-type": [
+      "error",
+      {
+        "allowInterfaces": "with-single-extends"
+      }
+    ],
 
     "typescript/dot-notation": "error",
     "typescript/non-nullable-type-assertion-style": "error",
@@ -102,7 +129,8 @@
         "no-template-curly-in-string": "off",
         "jest/valid-title": "error",
         "typescript/unbound-method": "off",
-        "renovate/test-root-describe": "error"
+        "renovate/test-root-describe": "error",
+        "typescript/explicit-function-return-type": "off"
       }
     },
     {
@@ -143,7 +171,8 @@
     {
       "files": ["**/*.js", "**/*.mjs", "**/*.cjs"],
       "rules": {
-        "typescript/restrict-template-expressions": "off"
+        "typescript/restrict-template-expressions": "off",
+        "typescript/explicit-function-return-type": "off"
       }
     }
   ],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -63,39 +63,8 @@ export default tseslint.config(
   {
     ...jsFiles,
     rules: {
-      'no-restricted-imports': [
-        2,
-        {
-          paths: ['nock', 'parse-link-header', 'path'],
-        },
-      ],
-
-      '@typescript-eslint/explicit-function-return-type': [
-        'error',
-        {
-          allowExpressions: true,
-          allowTypedFunctionExpressions: true,
-        },
-      ],
-
       '@typescript-eslint/no-explicit-any': 0,
       '@typescript-eslint/no-non-null-assertion': 0,
-
-      '@typescript-eslint/no-unused-vars': [
-        2,
-        {
-          vars: 'all',
-          args: 'none',
-          ignoreRestSiblings: true,
-        },
-      ],
-
-      '@typescript-eslint/no-empty-object-type': [
-        2,
-        {
-          allowInterfaces: 'with-single-extends',
-        },
-      ],
 
       'object-shorthand': [
         'error',
@@ -134,7 +103,6 @@ export default tseslint.config(
       'global-require': 0,
       '@typescript-eslint/no-var-requires': 0,
       '@typescript-eslint/no-object-literal-type-assertion': 0,
-      '@typescript-eslint/explicit-function-return-type': 0,
       'max-classes-per-file': 0,
       'class-methods-use-this': 0,
     },
@@ -143,7 +111,6 @@ export default tseslint.config(
     files: ['**/*.{js,mjs,cjs}'],
 
     rules: {
-      '@typescript-eslint/explicit-function-return-type': 0,
       '@typescript-eslint/explicit-module-boundary-types': 0,
     },
   },

--- a/lib/util/url.ts
+++ b/lib/util/url.ts
@@ -4,7 +4,7 @@ import {
   isString,
   isUrlInstance,
 } from '@sindresorhus/is';
-// eslint-disable-next-line no-restricted-imports
+// oxlint-disable-next-line no-restricted-imports
 import _parseLinkHeader from 'parse-link-header';
 import urlJoin from 'url-join';
 import { logger } from '../logger/index.ts';

--- a/test/http-mock.ts
+++ b/test/http-mock.ts
@@ -2,11 +2,11 @@ import fs from 'node:fs';
 import type { Url } from 'node:url';
 import is from '@sindresorhus/is';
 import { codeBlock } from 'common-tags';
-// eslint-disable-next-line no-restricted-imports
+// oxlint-disable-next-line no-restricted-imports
 import nock from 'nock';
 import { makeGraphqlSnapshot } from './graphql-snapshot.ts';
 
-// eslint-disable-next-line no-restricted-imports
+// oxlint-disable-next-line no-restricted-imports
 export type { Body, ReplyHeaders, Scope } from 'nock';
 
 interface RequestLog {


### PR DESCRIPTION
Migrate rules that previously stayed in ESLint due to option parity concerns. oxlint now supports all needed options:

- `no-restricted-imports` (paths: nock, parse-link-header, path)
- `consistent-type-assertions` (objectLiteralTypeAssertions: allow)
- `explicit-function-return-type` (allowExpressions, allowTypedFunctionExpressions)
- `no-unused-vars` (args: none, ignoreRestSiblings)
- `no-empty-object-type` (allowInterfaces: with-single-extends)

Convert eslint-disable comments to oxlint-disable for the allowed import sites (url.ts wrapper, http-mock.ts test helper).

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
