### PR TITLE
fix(swift): Parse pins without version key in Package.resolved

### DIFF
--- a/lib/modules/manager/swift/artifacts.spec.ts
+++ b/lib/modules/manager/swift/artifacts.spec.ts
@@ -20,6 +20,14 @@ const v2Fixture = JSON.stringify(
   {
     pins: [
       {
+        identity: 'by-commit',
+        kind: 'remoteSourceControl',
+        location: 'https://github.com/example/by-commit',
+        state: {
+          revision: 'decaf',
+        },
+      },
+      {
         identity: 'alamofire',
         kind: 'remoteSourceControl',
         location: 'https://github.com/Alamofire/Alamofire',

--- a/lib/modules/manager/swift/schema.ts
+++ b/lib/modules/manager/swift/schema.ts
@@ -7,7 +7,7 @@ const PackageResolvedPin = z.object({
   location: z.string(),
   state: z.object({
     revision: z.string(),
-    version: z.string().nullable(),
+    version: z.string().nullable().optional(),
     branch: z.string().nullable().optional(),
   }),
 });


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Allows parsing `Package.resolved` files that contain pins without a `version` field, which can be created by Xcode when pinning a package to a specific commit. 

Without this change, the presence of a single pin of this type prevents all updates to a `Package.resolved` file due to an parse error:

```
"issues": {"pins": {"5": {"state": {"version": "Required"}}}}
```

This parse error was replicated with the modified fixture and resolved by marking the `version` field as optional.


## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

VS Code Copilot in-line autocomplete

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
