### PR TITLE
refactor(tools/sync-module-labels): move shared code into a shared helper

### DIFF
--- a/test/other/sync-module-labels.spec.ts
+++ b/test/other/sync-module-labels.spec.ts
@@ -5,7 +5,7 @@ import {
   formatMissingLabels,
   getExpectedModuleLabels,
   getMissingModuleLabels,
-} from '../../tools/sync-module-labels.ts';
+} from '../../tools/utils/sync-module-labels.ts';
 
 describe('other/sync-module-labels', () => {
   it('creates module labels with the expected metadata', () => {

--- a/tools/sync-module-labels.ts
+++ b/tools/sync-module-labels.ts
@@ -1,122 +1,15 @@
 import { Command } from 'commander';
-import { quote } from 'shlex';
 import { init, logger } from '../lib/logger/index.ts';
-import { getDatasourceList } from '../lib/modules/datasource/index.ts';
-import { allManagersList } from '../lib/modules/manager/index.ts';
-import { getPlatformList } from '../lib/modules/platform/index.ts';
 import { exec } from './utils/exec.ts';
-
-export type ModuleLabelKind = 'datasource' | 'manager' | 'platform';
-
-export interface GitHubLabel {
-  color: string;
-  description: string;
-  name: string;
-}
-
-export interface CliOptions {
-  repo: string;
-  showCommands?: boolean;
-}
+import type { CliOptions, GitHubLabel } from './utils/sync-module-labels.ts';
+import {
+  formatCreateLabelCommands,
+  formatMissingLabels,
+  getExpectedModuleLabels,
+  getMissingModuleLabels,
+} from './utils/sync-module-labels.ts';
 
 const defaultRepo = 'renovatebot/renovate';
-const moduleLabelColor = 'C5DEF5';
-
-export function getLabelDescription(
-  kind: ModuleLabelKind,
-  moduleId: string,
-): string {
-  return `Related to the ${moduleId} ${kind}`;
-}
-
-export function createModuleLabel(
-  kind: ModuleLabelKind,
-  moduleId: string,
-): GitHubLabel {
-  return {
-    color: moduleLabelColor,
-    description: getLabelDescription(kind, moduleId),
-    name: `${kind}:${moduleId}`,
-  };
-}
-
-function getSortedUnique(values: string[]): string[] {
-  return [...new Set(values)].sort((left, right) => left.localeCompare(right));
-}
-
-export function getExpectedModuleLabels(): GitHubLabel[] {
-  const datasources = getSortedUnique(getDatasourceList()).map((datasource) =>
-    createModuleLabel('datasource', datasource),
-  );
-  const managers = getSortedUnique(allManagersList).map((manager) =>
-    createModuleLabel('manager', manager),
-  );
-  const platforms = getSortedUnique(getPlatformList()).map((platform) =>
-    createModuleLabel('platform', platform),
-  );
-
-  return [...datasources, ...managers, ...platforms].sort((left, right) =>
-    left.name.localeCompare(right.name),
-  );
-}
-
-export function getMissingModuleLabels(
-  expectedLabels: GitHubLabel[],
-  existingLabels: GitHubLabel[],
-): GitHubLabel[] {
-  const existingNames = new Set(existingLabels.map((label) => label.name));
-
-  return expectedLabels.filter((label) => !existingNames.has(label.name));
-}
-
-export function formatMissingLabels(labels: GitHubLabel[]): string {
-  const sections: Record<ModuleLabelKind, string[]> = {
-    datasource: [],
-    manager: [],
-    platform: [],
-  };
-
-  for (const label of labels) {
-    const kind = label.name.split(':')[0] as ModuleLabelKind;
-    sections[kind].push(label.name);
-  }
-
-  const lines: string[] = [];
-
-  for (const kind of ['datasource', 'manager', 'platform'] as const) {
-    const names = sections[kind];
-    if (names.length === 0) {
-      continue;
-    }
-    lines.push(`${kind}s (${names.length}):`);
-    for (const name of names) {
-      lines.push(`- ${name}`);
-    }
-  }
-
-  return lines.join('\n');
-}
-
-export function getCreateLabelCommand(
-  repo: string,
-  label: GitHubLabel,
-): string {
-  return (
-    `gh label create ${quote(label.name)} -R ${quote(repo)}` +
-    ` --color ${quote(label.color)}` +
-    ` --description ${quote(label.description)}`
-  );
-}
-
-export function formatCreateLabelCommands(
-  repo: string,
-  labels: GitHubLabel[],
-): string {
-  return [...labels]
-    .sort((left, right) => left.name.localeCompare(right.name))
-    .map((label) => getCreateLabelCommand(repo, label))
-    .join('\n');
-}
 
 async function getRepoLabels(repo: string): Promise<GitHubLabel[]> {
   const result = await exec('gh', [

--- a/tools/utils/sync-module-labels.ts
+++ b/tools/utils/sync-module-labels.ts
@@ -1,0 +1,115 @@
+import { quote } from 'shlex';
+import { getDatasourceList } from '../../lib/modules/datasource/index.ts';
+import { allManagersList } from '../../lib/modules/manager/index.ts';
+import { getPlatformList } from '../../lib/modules/platform/index.ts';
+
+export type ModuleLabelKind = 'datasource' | 'manager' | 'platform';
+
+export interface GitHubLabel {
+  color: string;
+  description: string;
+  name: string;
+}
+
+export interface CliOptions {
+  repo: string;
+  showCommands?: boolean;
+}
+
+const moduleLabelColor = 'C5DEF5';
+
+export function getLabelDescription(
+  kind: ModuleLabelKind,
+  moduleId: string,
+): string {
+  return `Related to the ${moduleId} ${kind}`;
+}
+
+export function createModuleLabel(
+  kind: ModuleLabelKind,
+  moduleId: string,
+): GitHubLabel {
+  return {
+    color: moduleLabelColor,
+    description: getLabelDescription(kind, moduleId),
+    name: `${kind}:${moduleId}`,
+  };
+}
+
+function getSortedUnique(values: string[]): string[] {
+  return [...new Set(values)].sort((left, right) => left.localeCompare(right));
+}
+
+export function getExpectedModuleLabels(): GitHubLabel[] {
+  const datasources = getSortedUnique(getDatasourceList()).map((datasource) =>
+    createModuleLabel('datasource', datasource),
+  );
+  const managers = getSortedUnique(allManagersList).map((manager) =>
+    createModuleLabel('manager', manager),
+  );
+  const platforms = getSortedUnique(getPlatformList()).map((platform) =>
+    createModuleLabel('platform', platform),
+  );
+
+  return [...datasources, ...managers, ...platforms].sort((left, right) =>
+    left.name.localeCompare(right.name),
+  );
+}
+
+export function getMissingModuleLabels(
+  expectedLabels: GitHubLabel[],
+  existingLabels: GitHubLabel[],
+): GitHubLabel[] {
+  const existingNames = new Set(existingLabels.map((label) => label.name));
+
+  return expectedLabels.filter((label) => !existingNames.has(label.name));
+}
+
+export function formatMissingLabels(labels: GitHubLabel[]): string {
+  const sections: Record<ModuleLabelKind, string[]> = {
+    datasource: [],
+    manager: [],
+    platform: [],
+  };
+
+  for (const label of labels) {
+    const kind = label.name.split(':')[0] as ModuleLabelKind;
+    sections[kind].push(label.name);
+  }
+
+  const lines: string[] = [];
+
+  for (const kind of ['datasource', 'manager', 'platform'] as const) {
+    const names = sections[kind];
+    if (names.length === 0) {
+      continue;
+    }
+    lines.push(`${kind}s (${names.length}):`);
+    for (const name of names) {
+      lines.push(`- ${name}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+export function getCreateLabelCommand(
+  repo: string,
+  label: GitHubLabel,
+): string {
+  return (
+    `gh label create ${quote(label.name)} -R ${quote(repo)}` +
+    ` --color ${quote(label.color)}` +
+    ` --description ${quote(label.description)}`
+  );
+}
+
+export function formatCreateLabelCommands(
+  repo: string,
+  labels: GitHubLabel[],
+): string {
+  return [...labels]
+    .sort((left, right) => left.name.localeCompare(right.name))
+    .map((label) => getCreateLabelCommand(repo, label))
+    .join('\n');
+}


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
As otherwise this leads to us importing the tool itself, which has a
top-level function that runs the tool.

As noted on a comment on #42012, this means that the tests are now
executing `gh` which isn't intended.

## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe): Claude Sonnet 4.6

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
