### PR TITLE
docs: inter-link presets' `extends`

### DIFF
--- a/tools/docs/presets.ts
+++ b/tools/docs/presets.ts
@@ -6,6 +6,127 @@ function jsUcfirst(string: string): string {
   return string.charAt(0).toUpperCase() + string.slice(1);
 }
 
+function presetRefToLink(presetRef: string): string | null {
+  // Separate base name from arguments: ":followTag(typescript, next)" -> base=":followTag", argCount=2
+  let baseName = presetRef;
+  let argCount = 0;
+  const parenMatch = /^([^(]+)\((.+)\)$/.exec(presetRef);
+  if (parenMatch) {
+    baseName = parenMatch[1];
+    argCount = parenMatch[2].split(/,\s*/).length;
+  }
+
+  let group: string;
+  const colonIdx = baseName.indexOf(':');
+  if (colonIdx === 0) {
+    group = 'default';
+  } else if (colonIdx > 0) {
+    group = baseName.slice(0, colonIdx);
+  } else {
+    return null;
+  }
+
+  // Reconstruct the heading text as it appears on the target page,
+  // where concrete args are replaced with <arg0>, <arg1>, etc.
+  let headingText = baseName;
+  if (argCount > 0) {
+    const argList = Array.from({ length: argCount }, (_, i) => `<arg${i}>`);
+    headingText += `(${argList.join(', ')})`;
+  }
+
+  // Slugify matching python-markdown's toc extension default behavior
+  const slug = headingText
+    .replace(/[^\w\s-]/g, '')
+    .trim()
+    .toLowerCase()
+    .replace(/[-\s]+/g, '-');
+
+  return `./presets-${group}.md#${slug}`;
+}
+
+function getPresetDescription(
+  presetRef: string,
+  descriptions: Map<string, string>,
+): string | undefined {
+  // Try exact match first
+  let desc = descriptions.get(presetRef);
+  if (desc) {
+    return desc;
+  }
+
+  // Parameterized preset references like ":semanticCommitType(chore)" will be looked up as `:semanticCommitType` (which is the preset name)
+  const [prefix] = presetRef.split('(');
+  if (prefix) {
+    logger.info({ prefix });
+    desc = descriptions.get(prefix);
+    if (desc) {
+      return desc;
+    }
+  }
+
+  return undefined;
+}
+
+function generateCodeBlock(
+  value: Record<string, unknown>,
+  descriptions: Map<string, string>,
+): string {
+  const json = JSON.stringify(value, null, 2);
+  const lines = json.split('\n');
+  let inExtends = false;
+  let counter = 0;
+  const annotations: {
+    num: number;
+    ref: string;
+    link: string;
+    description: string | undefined;
+  }[] = [];
+
+  const annotatedLines = lines.map((line) => {
+    if (/^\s+"extends":\s*\[/.test(line)) {
+      inExtends = true;
+      return line;
+    }
+    if (inExtends) {
+      if (/^\s+\]/.test(line)) {
+        inExtends = false;
+        return line;
+      }
+      const match = /^(\s+"([^"]+)")(,?)$/.exec(line);
+      if (match) {
+        const presetRef = match[2];
+        const link = presetRefToLink(presetRef);
+        if (link) {
+          counter++;
+          const description = getPresetDescription(presetRef, descriptions);
+          annotations.push({ num: counter, ref: presetRef, link, description });
+          // note that we use a trailing `!` to strip the comment from the resulting code block
+          return `${match[1]}${match[3]} // (${counter})!`;
+        }
+      }
+    }
+    return line;
+  });
+
+  if (annotations.length === 0) {
+    return `\n\`\`\`json\n${json}\n\`\`\`\n`;
+  }
+
+  let result = '\n``` { .json .annotate }\n';
+  result += annotatedLines.join('\n');
+  result += '\n```\n\n';
+
+  for (const ann of annotations) {
+    if (ann.description) {
+      result += `${ann.num}. [\`${ann.ref}\`](${ann.link}): ${ann.description}\n`;
+    } else {
+      result += `${ann.num}. [\`${ann.ref}\`](${ann.link})\n`;
+    }
+  }
+
+  return result;
+}
+
 function getEditUrl(name: string): string {
   const url =
     'https://github.com/renovatebot/renovate/edit/main/lib/config/presets/internal/';
@@ -47,6 +168,26 @@ edit_url: ${getEditUrl(presetName)}
 }
 
 export async function generatePresets(dist: string): Promise<void> {
+  // Calculate the descriptions for each preset ahead-of-time, as we remove them during generation
+  const descriptions = new Map<string, string>();
+  for (const [groupName, presetConfig] of Object.entries(presetGroups)) {
+    for (const [presetName, value] of Object.entries(presetConfig)) {
+      const ref =
+        groupName === 'default'
+          ? `:${presetName}`
+          : `${groupName}:${presetName}`;
+      if (ref.includes('follow')) {
+        logger.info({ ref });
+      }
+      const desc =
+        (value.description as string | undefined) ??
+        (value.packageRules?.[0]?.description as string | undefined);
+      if (desc) {
+        descriptions.set(ref, desc);
+      }
+    }
+  }
+
   let index = 0;
   for (const [name, presetConfig] of Object.entries(presetGroups)) {
     index += 1;
@@ -75,9 +216,7 @@ export async function generatePresets(dist: string): Promise<void> {
           'Preset has no description',
         );
       }
-      body += '\n```json\n';
-      body += JSON.stringify(value, null, 2);
-      body += '\n```\n';
+      body += generateCodeBlock(value, descriptions);
       body += '\n----\n';
       if (body.includes('{{arg0}}')) {
         header += '(`<arg0>`';


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

When trying to work out how Renovate's internal presets work, it can be
a little awkward trying to jump between the different `extends`, as it
requires copy-pasting and searching.

We can utilise the annotations functionality in Material for MkDocs[0]
and generate the relevant annotations for each of the `extends` that
appears.

In the case that a preset has a description (which is most of them) we
can add that for a more interesting annotation.

This requires we:

- look up the presets' `description` ahead-of-time, as the generation
  process removes descriptions
- traverse the preset's `extends` and link it through to the destination
  preset
- create an ordered list after the code block to note the annotations
- handle parameterised presets

[0]: https://squidfunk.github.io/mkdocs-material/reference/code-blocks/#adding-annotations

Co-authored-by: Claude Sonnet 4.6 <jamie.tanna+claude-code@mend.io>



## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe): Claude Sonnet 4.6

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->


<img width="819" height="494" alt="Screenshot 2026-03-31 at 10 33 24" src="https://github.com/user-attachments/assets/6236459f-2b92-4e0d-af5f-9424703bdfea" />
<img width="793" height="478" alt="Screenshot 2026-03-31 at 10 33 31" src="https://github.com/user-attachments/assets/28ca83d4-9501-4bbe-9635-3e8bbb0005ca" />
<img width="814" height="291" alt="Screenshot 2026-03-31 at 10 33 52" src="https://github.com/user-attachments/assets/52379d69-4e3b-4fa8-aa1e-bec9fb10007b" />
