### PR TITLE
test(presets): ensure that a `description` is always set

### DIFF
--- a/lib/config/presets/internal/index.spec.ts
+++ b/lib/config/presets/internal/index.spec.ts
@@ -1,3 +1,4 @@
+import { test } from 'vitest'
 import { CONFIG_VALIDATION } from '../../../constants/error-messages.ts';
 import { regEx } from '../../../util/regex.ts';
 import { massageConfig } from '../../massage.ts';
@@ -25,6 +26,33 @@ describe('config/presets/internal/index', () => {
       CONFIG_VALIDATION,
     );
   });
+
+
+  for (const [groupName, groupPresets] of Object.entries(internal.groups)) {
+    for (const [presetName, presetConfig] of Object.entries(
+      groupPresets,
+    )) {
+      // these presets don't always have the description as they're a mix of human-generated and auto-generated
+      if (groupName === 'monorepo' || groupName === 'group') {
+        if (presetConfig.description) {
+          it(`${`${groupName}:${presetName}`} has a description`, () => {
+            expect(presetConfig.description).toBeDefined()
+            expect(presetConfig.description).not.toBeEmptyString()
+          })
+        } else {
+          test.todo(`${`${groupName}:${presetName}`} has a description`, () => {
+            expect(presetConfig.description).toBeDefined()
+            expect(presetConfig.description).not.toBeEmptyString()
+          })
+        }
+      } else {
+        it(`${`${groupName}:${presetName}`} has a description`, () => {
+          expect(presetConfig.description).toBeDefined()
+          expect(presetConfig.description).not.toBeEmptyString()
+        })
+      }
+    }
+  }
 
   for (const [groupName, groupPresets] of Object.entries(internal.groups)) {
     for (const [presetName, presetConfig] of Object.entries(


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

As we should always be using a `description` for all of our presets.


## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
