### PR TITLE
fix(datasource/github-digest): add github-digest to GITHUB_API_USING_HOST_TYPES

### DIFF
--- a/lib/constants/platform.spec.ts
+++ b/lib/constants/platform.spec.ts
@@ -1,6 +1,7 @@
 import { BitbucketServerTagsDatasource } from '../modules/datasource/bitbucket-server-tags/index.ts';
 import { BitbucketTagsDatasource } from '../modules/datasource/bitbucket-tags/index.ts';
 import { GiteaTagsDatasource } from '../modules/datasource/gitea-tags/index.ts';
+import { GithubDigestDatasource } from '../modules/datasource/github-digest/index.ts';
 import { GithubReleasesDatasource } from '../modules/datasource/github-releases/index.ts';
 import { GithubTagsDatasource } from '../modules/datasource/github-tags/index.ts';
 import { GitlabPackagesDatasource } from '../modules/datasource/gitlab-packages/index.ts';
@@ -62,6 +63,9 @@ describe('constants/platform', () => {
   it('should be part of the GITHUB_API_USING_HOST_TYPES', () => {
     expect(
       GITHUB_API_USING_HOST_TYPES.includes(GithubTagsDatasource.id),
+    ).toBeTrue();
+    expect(
+      GITHUB_API_USING_HOST_TYPES.includes(GithubDigestDatasource.id),
     ).toBeTrue();
     expect(
       GITHUB_API_USING_HOST_TYPES.includes(GithubReleasesDatasource.id),

--- a/lib/constants/platforms.ts
+++ b/lib/constants/platforms.ts
@@ -35,6 +35,7 @@ export const GITHUB_API_USING_HOST_TYPES = [
   'github-releases',
   'github-release-attachments',
   'github-tags',
+  'github-digest',
   'pod',
   'hermit',
   'github-changelog',


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

We noticed when consuming GitHub Actions from a GitHub Enterprise Server, the new GitHub digest lookups (#40225 & #40226) don't work out of the box as the platform credentials are not used for lookup.
Resulting in such warnings (and failed lookups) for packages on our internal GitHub Enterprise Server:

<img width="804" height="450" alt="grafik" src="https://github.com/user-attachments/assets/6e36fc70-46c0-46f0-a1c8-7506e801a597" />



```json
{
  "warnings": [
    "Failed to look up github-digest package $ORG/$REPO: no-result"
  ],
  "files": [
    ".github/workflows/build.yaml"
  ]
}
```


This PR adds the datasource `github-digest` to the `GITHUB_API_USING_HOST_TYPES` to align with how other (github) datasources are handled. While new datasources, which consume `api.github.com`, should not be added there, I think it is reasonable to add datasources using custom GitHub Enterprise Servers endpoints (like `github-digest`). 

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation



## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

Tested on an internal repository on our GitHub Enterprise Server: 
<img width="833" height="488" alt="grafik" src="https://github.com/user-attachments/assets/d5dc5fd8-e1e8-4897-99fa-27b93ce2d2cf" />


The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
