### PR TITLE
feat: S3-backed persistence for `persistRepoData`

### DIFF
--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -1170,7 +1170,7 @@ Use an `s3://` URL to archive the `.git/` directory to S3 after each run and res
 ```ts title="Set persistRepoDataType to an S3 URI to enable S3 backed git data persistence"
 {
   persistRepoData: true,
-  persistRepoDataType: 's3://bucket-name/renovate-git/';
+  persistRepoDataType: 's3://bucket-name/renovate-git/',
 }
 ```
 

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -1155,6 +1155,42 @@ Set this to `true` if you want Renovate to persist repo data between runs.
 The intention is that this allows Renovate to do a faster `git fetch` between runs rather than `git clone`.
 It also may mean that ignored directories like `node_modules` can be preserved and save time on operations like `npm install`.
 
+## persistRepoDataType
+
+<!-- prettier-ignore -->
+!!! warning "This feature is flagged as experimental"
+    Experimental features might be changed or removed at any time.
+
+Set the storage backend for persisted repository git data when [`persistRepoData`](#persistrepodata) is `true`.
+
+By default, Renovate keeps repository data on the local filesystem (`local`).
+On ephemeral infrastructure (e.g., AWS Fargate, Kubernetes Jobs), local data is lost between runs.
+Use an `s3://` URL to archive the `.git/` directory to S3 after each run and restore it before the next run, enabling fast `git fetch` instead of full `git clone`.
+
+```ts title="Set persistRepoDataType to an S3 URI to enable S3 backed git data persistence"
+{
+  persistRepoData: true,
+  persistRepoDataType: 's3://bucket-name/renovate-git/';
+}
+```
+
+Renovate uses the [AWS SDK for JavaScript V3](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/welcome.html) to connect to the S3 instance.
+Therefore, Renovate supports all the authentication methods supported by the AWS SDK.
+Read more about [the default credential provider chain for AWS SDK for JavaScript V3](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/Package/-aws-sdk-credential-providers/#fromnodeproviderchain).
+
+The S3 object key follows the pattern `{prefix}{platform}/{repository}/git-data.tar.gz`.
+
+This option reuses [`s3Endpoint`](#s3endpoint) and [`s3PathStyle`](#s3pathstyle) for S3-compatible storage.
+
+<!-- prettier-ignore -->
+!!! tip
+    You may set a folder hierarchy as part of `persistRepoDataType`.
+    For example, `persistRepoDataType: 's3://bucket-name/dir1/.../dirN/'`.
+
+<!-- prettier-ignore -->
+!!! note
+    This option persists git repository data (the `.git/` directory) to enable fast fetches, and is separate from the repository cache ([`repositoryCacheType`](#repositorycachetype)) and the lookup cache ([`redisUrl`](#redisurl)). If the S3 archive is missing (first run) or corrupted, Renovate falls back to a full `git clone` automatically.
+
 ## platform
 
 ## prCacheSyncMaxPages

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -1003,6 +1003,15 @@ const options: Readonly<RenovateOptions>[] = [
     globalOnly: true,
   },
   {
+    name: 'persistRepoDataType',
+    description:
+      'Set the storage backend for persisted repository git data when `persistRepoData` is `true`. Use an `s3://` URL to persist to S3.',
+    type: 'string',
+    default: 'local',
+    globalOnly: true,
+    experimental: true,
+  },
+  {
     name: 'exposeAllEnv',
     description:
       'Set this to `true` to allow passing of all environment variables to package managers.',

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -32,6 +32,7 @@ export type RenovateSplit =
 
 export type RepositoryCacheConfig = 'disabled' | 'enabled' | 'reset';
 export type RepositoryCacheType = 'local' | (string & {});
+export type PersistRepoDataType = 'local' | (string & {});
 export type DryRunConfig = 'extract' | 'lookup' | 'full';
 export type RequiredConfig = 'required' | 'optional' | 'ignored';
 
@@ -287,6 +288,7 @@ export interface LegacyAdminConfig {
   optimizeForDisabled?: boolean;
 
   persistRepoData?: boolean;
+  persistRepoDataType?: PersistRepoDataType;
 
   prCommitsPerRunLimit?: number;
 

--- a/lib/util/git/s3-persist.spec.ts
+++ b/lib/util/git/s3-persist.spec.ts
@@ -72,6 +72,12 @@ describe('util/git/s3-persist', () => {
   }
 
   describe('restoreGitDataFromS3', () => {
+    it('throws on invalid S3 URL', async () => {
+      await expect(
+        restoreGitDataFromS3(tmpDir, 'not-an-s3-url', platform, repository),
+      ).rejects.toThrow('Invalid S3 URL: not-an-s3-url');
+    });
+
     it('restores git data successfully', async () => {
       const archiveDir = await fs.mkdtemp('/tmp/s3-persist-archive-');
       const archive = await createValidArchive(archiveDir);

--- a/lib/util/git/s3-persist.spec.ts
+++ b/lib/util/git/s3-persist.spec.ts
@@ -1,0 +1,347 @@
+import { Readable } from 'node:stream';
+import type { GetObjectCommandInput } from '@aws-sdk/client-s3';
+import {
+  GetObjectCommand,
+  PutObjectCommand,
+  S3Client,
+} from '@aws-sdk/client-s3';
+import { mockClient } from 'aws-sdk-client-mock';
+import fs from 'fs-extra';
+import * as tar from 'tar';
+import { logger } from '../../logger/index.ts';
+import { archiveGitDataToS3, restoreGitDataFromS3 } from './s3-persist.ts';
+
+describe('util/git/s3-persist', () => {
+  const s3Mock = mockClient(S3Client);
+  const platform = 'github';
+  const repository = 'org/repo';
+  const s3Url = 's3://my-bucket/renovate-git/';
+
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    s3Mock.reset();
+    tmpDir = await fs.mkdtemp('/tmp/s3-persist-test-');
+  });
+
+  afterEach(async () => {
+    await fs.remove(tmpDir);
+  });
+
+  function expectedGetParams(): GetObjectCommandInput {
+    return {
+      Bucket: 'my-bucket',
+      Key: 'renovate-git/github/org/repo/git-data.tar.gz',
+    };
+  }
+
+  async function createValidArchive(sourceDir: string): Promise<Buffer> {
+    const gitDir = `${sourceDir}/.git`;
+    await fs.ensureDir(gitDir);
+    await fs.writeFile(`${gitDir}/HEAD`, 'ref: refs/heads/main\n');
+    await fs.writeFile(`${gitDir}/config`, '[core]\n');
+
+    const pack = tar.create({ gzip: true, cwd: sourceDir }, ['.git']);
+    const chunks: Buffer[] = [];
+    for await (const chunk of pack) {
+      chunks.push(Buffer.from(chunk as Uint8Array));
+    }
+    return Buffer.concat(chunks);
+  }
+
+  async function createCorruptArchive(sourceDir: string): Promise<Buffer> {
+    await fs.ensureDir(`${sourceDir}/not-git`);
+    await fs.writeFile(`${sourceDir}/not-git/file.txt`, 'data');
+
+    const pack = tar.create({ gzip: true, cwd: sourceDir }, ['not-git']);
+    const chunks: Buffer[] = [];
+    for await (const chunk of pack) {
+      chunks.push(Buffer.from(chunk as Uint8Array));
+    }
+    return Buffer.concat(chunks);
+  }
+
+  async function streamToBuffer(
+    stream: NodeJS.ReadableStream,
+  ): Promise<Buffer> {
+    const chunks: Buffer[] = [];
+    for await (const chunk of stream) {
+      chunks.push(Buffer.from(chunk as Uint8Array));
+    }
+    return Buffer.concat(chunks);
+  }
+
+  describe('restoreGitDataFromS3', () => {
+    it('restores git data successfully', async () => {
+      const archiveDir = await fs.mkdtemp('/tmp/s3-persist-archive-');
+      const archive = await createValidArchive(archiveDir);
+      await fs.remove(archiveDir);
+
+      s3Mock
+        .on(GetObjectCommand, expectedGetParams())
+        .resolvesOnce({ Body: Readable.from([archive]) as never });
+
+      const result = await restoreGitDataFromS3(
+        tmpDir,
+        s3Url,
+        platform,
+        repository,
+      );
+
+      expect(result).toBeTrue();
+      expect(await fs.pathExists(`${tmpDir}/.git/HEAD`)).toBeTrue();
+      expect(logger.debug).toHaveBeenCalledWith(
+        { key: 'renovate-git/github/org/repo/git-data.tar.gz' },
+        'restoreGitDataFromS3() - success',
+      );
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    it('returns false on first run (NoSuchKey)', async () => {
+      const err = new Error('NoSuchKey');
+      err.name = 'NoSuchKey';
+      s3Mock.on(GetObjectCommand, expectedGetParams()).rejectsOnce(err);
+
+      const result = await restoreGitDataFromS3(
+        tmpDir,
+        s3Url,
+        platform,
+        repository,
+      );
+
+      expect(result).toBeFalse();
+      expect(logger.debug).toHaveBeenCalledWith(
+        'restoreGitDataFromS3() - no archive found in S3',
+      );
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    it('returns false on S3 error', async () => {
+      const err = new Error('AccessDenied');
+      s3Mock.on(GetObjectCommand, expectedGetParams()).rejectsOnce(err);
+
+      const result = await restoreGitDataFromS3(
+        tmpDir,
+        s3Url,
+        platform,
+        repository,
+      );
+
+      expect(result).toBeFalse();
+      expect(logger.warn).toHaveBeenCalledWith(
+        { err },
+        'restoreGitDataFromS3() - failure',
+      );
+    });
+
+    it('returns false and cleans up on corrupted archive', async () => {
+      const archiveDir = await fs.mkdtemp('/tmp/s3-persist-archive-');
+      const archive = await createCorruptArchive(archiveDir);
+      await fs.remove(archiveDir);
+
+      s3Mock
+        .on(GetObjectCommand, expectedGetParams())
+        .resolvesOnce({ Body: Readable.from([archive]) as never });
+
+      const result = await restoreGitDataFromS3(
+        tmpDir,
+        s3Url,
+        platform,
+        repository,
+      );
+
+      expect(result).toBeFalse();
+      expect(await fs.pathExists(`${tmpDir}/.git`)).toBeFalse();
+      expect(logger.warn).toHaveBeenCalledWith(
+        { key: 'renovate-git/github/org/repo/git-data.tar.gz' },
+        'restoreGitDataFromS3() - archive extracted but .git/HEAD not found, cleaning up',
+      );
+    });
+
+    it('returns false on unexpected response type', async () => {
+      s3Mock
+        .on(GetObjectCommand, expectedGetParams())
+        .resolvesOnce({ Body: undefined as never });
+
+      const result = await restoreGitDataFromS3(
+        tmpDir,
+        s3Url,
+        platform,
+        repository,
+      );
+
+      expect(result).toBeFalse();
+      expect(logger.warn).toHaveBeenCalledWith(
+        { returnType: 'undefined' },
+        'restoreGitDataFromS3() - unexpected response type from S3',
+      );
+    });
+
+    it('handles S3 URL without trailing slash', async () => {
+      const archiveDir = await fs.mkdtemp('/tmp/s3-persist-archive-');
+      const archive = await createValidArchive(archiveDir);
+      await fs.remove(archiveDir);
+
+      s3Mock.on(GetObjectCommand).resolvesOnce({
+        Body: Readable.from([archive]) as never,
+      });
+
+      const result = await restoreGitDataFromS3(
+        tmpDir,
+        's3://my-bucket/renovate-git',
+        platform,
+        repository,
+      );
+
+      expect(result).toBeTrue();
+      expect(logger.warn).toHaveBeenCalledWith(
+        { pathname: 'renovate-git' },
+        'getS3Key() - appending missing trailing slash to pathname',
+      );
+      const call = s3Mock.commandCalls(GetObjectCommand)[0];
+      expect(call.args[0].input).toEqual({
+        Bucket: 'my-bucket',
+        Key: 'renovate-git/github/org/repo/git-data.tar.gz',
+      });
+    });
+
+    it('handles S3 URL with no prefix path', async () => {
+      const archiveDir = await fs.mkdtemp('/tmp/s3-persist-archive-');
+      const archive = await createValidArchive(archiveDir);
+      await fs.remove(archiveDir);
+
+      s3Mock.on(GetObjectCommand).resolvesOnce({
+        Body: Readable.from([archive]) as never,
+      });
+
+      const result = await restoreGitDataFromS3(
+        tmpDir,
+        's3://my-bucket',
+        platform,
+        repository,
+      );
+
+      expect(result).toBeTrue();
+      const call = s3Mock.commandCalls(GetObjectCommand)[0];
+      expect(call.args[0].input).toEqual({
+        Bucket: 'my-bucket',
+        Key: 'github/org/repo/git-data.tar.gz',
+      });
+    });
+
+    it('handles nested repository paths', async () => {
+      const archiveDir = await fs.mkdtemp('/tmp/s3-persist-archive-');
+      const archive = await createValidArchive(archiveDir);
+      await fs.remove(archiveDir);
+
+      s3Mock.on(GetObjectCommand).resolvesOnce({
+        Body: Readable.from([archive]) as never,
+      });
+
+      const result = await restoreGitDataFromS3(
+        tmpDir,
+        s3Url,
+        'gitlab',
+        'group/subgroup/repo',
+      );
+
+      expect(result).toBeTrue();
+      const call = s3Mock.commandCalls(GetObjectCommand)[0];
+      expect(call.args[0].input).toEqual({
+        Bucket: 'my-bucket',
+        Key: 'renovate-git/gitlab/group/subgroup/repo/git-data.tar.gz',
+      });
+    });
+  });
+
+  describe('archiveGitDataToS3', () => {
+    it('archives git data successfully', async () => {
+      await fs.ensureDir(`${tmpDir}/.git`);
+      await fs.writeFile(`${tmpDir}/.git/HEAD`, 'ref: refs/heads/main\n');
+
+      s3Mock.on(PutObjectCommand).resolvesOnce({
+        $metadata: { httpStatusCode: 200 },
+      });
+
+      await archiveGitDataToS3(tmpDir, s3Url, platform, repository);
+
+      const calls = s3Mock.commandCalls(PutObjectCommand);
+      expect(calls).toHaveLength(1);
+      expect(calls[0].args[0].input.Bucket).toBe('my-bucket');
+      expect(calls[0].args[0].input.Key).toBe(
+        'renovate-git/github/org/repo/git-data.tar.gz',
+      );
+      expect(calls[0].args[0].input.ContentType).toBe('application/gzip');
+      expect(calls[0].args[0].input.Body).toBeInstanceOf(Readable);
+      expect(logger.debug).toHaveBeenCalledWith(
+        { key: 'renovate-git/github/org/repo/git-data.tar.gz' },
+        'archiveGitDataToS3() - success',
+      );
+    });
+
+    it('skips archive when .git does not exist', async () => {
+      await archiveGitDataToS3(tmpDir, s3Url, platform, repository);
+
+      expect(s3Mock.commandCalls(PutObjectCommand)).toHaveLength(0);
+      expect(logger.debug).toHaveBeenCalledWith(
+        'archiveGitDataToS3() - no .git directory found, skipping',
+      );
+    });
+
+    it('logs warning on S3 upload failure', async () => {
+      await fs.ensureDir(`${tmpDir}/.git`);
+      await fs.writeFile(`${tmpDir}/.git/HEAD`, 'ref: refs/heads/main\n');
+
+      const err = new Error('Upload failed');
+      s3Mock.on(PutObjectCommand).rejectsOnce(err);
+
+      await archiveGitDataToS3(tmpDir, s3Url, platform, repository);
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        { err },
+        'archiveGitDataToS3() - failure',
+      );
+    });
+
+    it('produces a valid archive that can be restored', async () => {
+      await fs.ensureDir(`${tmpDir}/.git/refs`);
+      await fs.writeFile(`${tmpDir}/.git/HEAD`, 'ref: refs/heads/main\n');
+      await fs.writeFile(`${tmpDir}/.git/config`, '[core]\n');
+
+      let uploadedBody: Buffer | undefined;
+      s3Mock.on(PutObjectCommand).callsFake(async (input) => {
+        uploadedBody = await streamToBuffer(
+          input.Body as NodeJS.ReadableStream,
+        );
+        return { $metadata: { httpStatusCode: 200 } };
+      });
+
+      await archiveGitDataToS3(tmpDir, s3Url, platform, repository);
+      expect(uploadedBody).toBeDefined();
+
+      // Restore to a different directory
+      const restoreDir = await fs.mkdtemp('/tmp/s3-persist-restore-');
+      s3Mock.reset();
+      s3Mock.on(GetObjectCommand).resolvesOnce({
+        Body: Readable.from([uploadedBody!]) as never,
+      });
+
+      const result = await restoreGitDataFromS3(
+        restoreDir,
+        s3Url,
+        platform,
+        repository,
+      );
+
+      expect(result).toBeTrue();
+      expect(await fs.readFile(`${restoreDir}/.git/HEAD`, 'utf8')).toBe(
+        'ref: refs/heads/main\n',
+      );
+      expect(await fs.readFile(`${restoreDir}/.git/config`, 'utf8')).toBe(
+        '[core]\n',
+      );
+
+      await fs.remove(restoreDir);
+    });
+  });
+});

--- a/lib/util/git/s3-persist.spec.ts
+++ b/lib/util/git/s3-persist.spec.ts
@@ -1,4 +1,6 @@
-import { Readable } from 'node:stream';
+import { PassThrough, Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+import { createZstdCompress } from 'node:zlib';
 import type { GetObjectCommandInput } from '@aws-sdk/client-s3';
 import {
   GetObjectCommand,
@@ -28,11 +30,25 @@ describe('util/git/s3-persist', () => {
     await fs.remove(tmpDir);
   });
 
-  function expectedGetParams(): GetObjectCommandInput {
+  function expectedGetParams(
+    fileName = 'git-data.tar.zst',
+  ): GetObjectCommandInput {
     return {
       Bucket: 'my-bucket',
-      Key: 'renovate-git/github/org/repo/git-data.tar.gz',
+      Key: `renovate-git/github/org/repo/${fileName}`,
     };
+  }
+
+  async function createArchive(
+    sourceDir: string,
+    entries: string[],
+  ): Promise<Buffer> {
+    const pack = tar.create({ cwd: sourceDir }, entries);
+    const compressionStream = createZstdCompress();
+    const body = new PassThrough();
+    const bodyPromise = streamToBuffer(body);
+    await pipeline(pack, compressionStream, body);
+    return await bodyPromise;
   }
 
   async function createValidArchive(sourceDir: string): Promise<Buffer> {
@@ -41,24 +57,14 @@ describe('util/git/s3-persist', () => {
     await fs.writeFile(`${gitDir}/HEAD`, 'ref: refs/heads/main\n');
     await fs.writeFile(`${gitDir}/config`, '[core]\n');
 
-    const pack = tar.create({ gzip: true, cwd: sourceDir }, ['.git']);
-    const chunks: Buffer[] = [];
-    for await (const chunk of pack) {
-      chunks.push(Buffer.from(chunk as Uint8Array));
-    }
-    return Buffer.concat(chunks);
+    return await createArchive(sourceDir, ['.git']);
   }
 
   async function createCorruptArchive(sourceDir: string): Promise<Buffer> {
     await fs.ensureDir(`${sourceDir}/not-git`);
     await fs.writeFile(`${sourceDir}/not-git/file.txt`, 'data');
 
-    const pack = tar.create({ gzip: true, cwd: sourceDir }, ['not-git']);
-    const chunks: Buffer[] = [];
-    for await (const chunk of pack) {
-      chunks.push(Buffer.from(chunk as Uint8Array));
-    }
-    return Buffer.concat(chunks);
+    return await createArchive(sourceDir, ['not-git']);
   }
 
   async function streamToBuffer(
@@ -97,7 +103,7 @@ describe('util/git/s3-persist', () => {
       expect(result).toBeTrue();
       expect(await fs.pathExists(`${tmpDir}/.git/HEAD`)).toBeTrue();
       expect(logger.debug).toHaveBeenCalledWith(
-        { key: 'renovate-git/github/org/repo/git-data.tar.gz' },
+        { key: 'renovate-git/github/org/repo/git-data.tar.zst' },
         'restoreGitDataFromS3() - success',
       );
       expect(logger.warn).not.toHaveBeenCalled();
@@ -159,7 +165,7 @@ describe('util/git/s3-persist', () => {
       expect(result).toBeFalse();
       expect(await fs.pathExists(`${tmpDir}/.git`)).toBeFalse();
       expect(logger.warn).toHaveBeenCalledWith(
-        { key: 'renovate-git/github/org/repo/git-data.tar.gz' },
+        { key: 'renovate-git/github/org/repo/git-data.tar.zst' },
         'restoreGitDataFromS3() - archive extracted but .git/HEAD not found, cleaning up',
       );
     });
@@ -207,7 +213,7 @@ describe('util/git/s3-persist', () => {
       const call = s3Mock.commandCalls(GetObjectCommand)[0];
       expect(call.args[0].input).toEqual({
         Bucket: 'my-bucket',
-        Key: 'renovate-git/github/org/repo/git-data.tar.gz',
+        Key: 'renovate-git/github/org/repo/git-data.tar.zst',
       });
     });
 
@@ -231,7 +237,7 @@ describe('util/git/s3-persist', () => {
       const call = s3Mock.commandCalls(GetObjectCommand)[0];
       expect(call.args[0].input).toEqual({
         Bucket: 'my-bucket',
-        Key: 'github/org/repo/git-data.tar.gz',
+        Key: 'github/org/repo/git-data.tar.zst',
       });
     });
 
@@ -255,7 +261,7 @@ describe('util/git/s3-persist', () => {
       const call = s3Mock.commandCalls(GetObjectCommand)[0];
       expect(call.args[0].input).toEqual({
         Bucket: 'my-bucket',
-        Key: 'renovate-git/gitlab/group/subgroup/repo/git-data.tar.gz',
+        Key: 'renovate-git/gitlab/group/subgroup/repo/git-data.tar.zst',
       });
     });
   });
@@ -275,12 +281,12 @@ describe('util/git/s3-persist', () => {
       expect(calls).toHaveLength(1);
       expect(calls[0].args[0].input.Bucket).toBe('my-bucket');
       expect(calls[0].args[0].input.Key).toBe(
-        'renovate-git/github/org/repo/git-data.tar.gz',
+        'renovate-git/github/org/repo/git-data.tar.zst',
       );
-      expect(calls[0].args[0].input.ContentType).toBe('application/gzip');
+      expect(calls[0].args[0].input.ContentType).toBe('application/zstd');
       expect(calls[0].args[0].input.Body).toBeInstanceOf(Readable);
       expect(logger.debug).toHaveBeenCalledWith(
-        { key: 'renovate-git/github/org/repo/git-data.tar.gz' },
+        { key: 'renovate-git/github/org/repo/git-data.tar.zst' },
         'archiveGitDataToS3() - success',
       );
     });

--- a/lib/util/git/s3-persist.ts
+++ b/lib/util/git/s3-persist.ts
@@ -1,0 +1,127 @@
+import { PassThrough, Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+import type {
+  GetObjectCommandInput,
+  PutObjectCommandInput,
+} from '@aws-sdk/client-s3';
+import { GetObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3';
+import fs from 'fs-extra';
+import * as tar from 'tar';
+import upath from 'upath';
+import { instrument } from '../../instrumentation/index.ts';
+import { logger } from '../../logger/index.ts';
+import { getS3Client, parseS3Url } from '../s3.ts';
+
+function getS3Key(
+  s3Url: string,
+  platform: string,
+  repository: string,
+): { bucket: string; key: string } {
+  const parsed = parseS3Url(s3Url);
+  if (!parsed) {
+    throw new Error(`Invalid S3 URL: ${s3Url}`);
+  }
+  let prefix = parsed.Key;
+  if (prefix && !prefix.endsWith('/')) {
+    logger.warn(
+      { pathname: prefix },
+      'getS3Key() - appending missing trailing slash to pathname',
+    );
+    prefix += '/';
+  }
+  return {
+    bucket: parsed.Bucket,
+    key: `${prefix}${platform}/${repository}/git-data.tar.gz`,
+  };
+}
+
+export async function restoreGitDataFromS3(
+  localDir: string,
+  s3Url: string,
+  platform: string,
+  repository: string,
+): Promise<boolean> {
+  return await instrument('restoreGitFromS3', async () => {
+    const { bucket, key } = getS3Key(s3Url, platform, repository);
+    const s3Params: GetObjectCommandInput = {
+      Bucket: bucket,
+      Key: key,
+    };
+
+    try {
+      const { Body: body } = await getS3Client().send(
+        new GetObjectCommand(s3Params),
+      );
+      if (!(body instanceof Readable)) {
+        logger.warn(
+          { returnType: typeof body },
+          'restoreGitDataFromS3() - unexpected response type from S3',
+        );
+        return false;
+      }
+
+      await pipeline(body, tar.extract({ cwd: localDir }));
+
+      const gitHead = upath.join(localDir, '.git/HEAD');
+      if (await fs.pathExists(gitHead)) {
+        logger.debug({ key }, 'restoreGitDataFromS3() - success');
+        return true;
+      }
+
+      logger.warn(
+        { key },
+        'restoreGitDataFromS3() - archive extracted but .git/HEAD not found, cleaning up',
+      );
+      await fs.remove(upath.join(localDir, '.git'));
+      return false;
+    } catch (err) {
+      // https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html
+      if (err.name === 'NoSuchKey') {
+        logger.debug('restoreGitDataFromS3() - no archive found in S3');
+        return false;
+      }
+      logger.warn({ err }, 'restoreGitDataFromS3() - failure');
+      return false;
+    }
+  });
+}
+
+export async function archiveGitDataToS3(
+  localDir: string,
+  s3Url: string,
+  platform: string,
+  repository: string,
+): Promise<void> {
+  await instrument('archiveGitToS3', async () => {
+    const gitDir = upath.join(localDir, '.git');
+    if (!(await fs.pathExists(gitDir))) {
+      logger.debug('archiveGitDataToS3() - no .git directory found, skipping');
+      return;
+    }
+
+    const { bucket, key } = getS3Key(s3Url, platform, repository);
+
+    try {
+      const archiveStream = tar.create(
+        { gzip: true, cwd: localDir, portable: true },
+        ['.git'],
+      );
+      const body = new PassThrough();
+
+      const s3Params: PutObjectCommandInput = {
+        Bucket: bucket,
+        Key: key,
+        Body: body,
+        ContentType: 'application/gzip',
+      };
+
+      await Promise.all([
+        getS3Client().send(new PutObjectCommand(s3Params)),
+        pipeline(archiveStream, body),
+      ]);
+      logger.debug({ key }, 'archiveGitDataToS3() - success');
+    } catch (err) {
+      logger.warn({ err }, 'archiveGitDataToS3() - failure');
+    }
+  });
+}

--- a/lib/util/git/s3-persist.ts
+++ b/lib/util/git/s3-persist.ts
@@ -1,5 +1,6 @@
 import { PassThrough, Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
+import { createZstdCompress, createZstdDecompress } from 'node:zlib';
 import type {
   GetObjectCommandInput,
   PutObjectCommandInput,
@@ -12,10 +13,25 @@ import { instrument } from '../../instrumentation/index.ts';
 import { logger } from '../../logger/index.ts';
 import { getS3Client, parseS3Url } from '../s3.ts';
 
+interface GitArchiveFormat {
+  contentType: string;
+  fileName: string;
+  getCompressStream: () => NodeJS.ReadWriteStream;
+  getDecompressStream: () => NodeJS.ReadWriteStream;
+}
+
+const gitArchiveFormat: GitArchiveFormat = {
+  contentType: 'application/zstd',
+  fileName: 'git-data.tar.zst',
+  getCompressStream: () => createZstdCompress(),
+  getDecompressStream: () => createZstdDecompress(),
+};
+
 function getS3Key(
   s3Url: string,
   platform: string,
   repository: string,
+  fileName = gitArchiveFormat.fileName,
 ): { bucket: string; key: string } {
   const parsed = parseS3Url(s3Url);
   if (!parsed) {
@@ -31,7 +47,7 @@ function getS3Key(
   }
   return {
     bucket: parsed.Bucket,
-    key: `${prefix}${platform}/${repository}/git-data.tar.gz`,
+    key: `${prefix}${platform}/${repository}/${fileName}`,
   };
 }
 
@@ -60,7 +76,11 @@ export async function restoreGitDataFromS3(
         return false;
       }
 
-      await pipeline(body, tar.extract({ cwd: localDir }));
+      await pipeline(
+        body,
+        gitArchiveFormat.getDecompressStream(),
+        tar.extract({ cwd: localDir }),
+      );
 
       const gitHead = upath.join(localDir, '.git/HEAD');
       if (await fs.pathExists(gitHead)) {
@@ -102,22 +122,22 @@ export async function archiveGitDataToS3(
     const { bucket, key } = getS3Key(s3Url, platform, repository);
 
     try {
-      const archiveStream = tar.create(
-        { gzip: true, cwd: localDir, portable: true },
-        ['.git'],
-      );
+      const archiveStream = tar.create({ cwd: localDir, portable: true }, [
+        '.git',
+      ]);
+      const compressionStream = gitArchiveFormat.getCompressStream();
       const body = new PassThrough();
 
       const s3Params: PutObjectCommandInput = {
         Bucket: bucket,
         Key: key,
         Body: body,
-        ContentType: 'application/gzip',
+        ContentType: gitArchiveFormat.contentType,
       };
 
       await Promise.all([
         getS3Client().send(new PutObjectCommand(s3Params)),
-        pipeline(archiveStream, body),
+        pipeline(archiveStream, compressionStream, body),
       ]);
       logger.debug({ key }, 'archiveGitDataToS3() - success');
     } catch (err) {

--- a/lib/util/s3.spec.ts
+++ b/lib/util/s3.spec.ts
@@ -44,6 +44,9 @@ describe('util/s3', () => {
       query: undefined,
     });
     expect(client1.config.forcePathStyle).toBeTrue();
+    expect(await client1.config.requestChecksumCalculation()).toBe(
+      'WHEN_REQUIRED',
+    );
   });
 
   it('uses s3 values from globalConfig instead of GlobalConfig class', async () => {
@@ -59,5 +62,8 @@ describe('util/s3', () => {
       query: undefined,
     });
     expect(client1.config.forcePathStyle).toBeTrue();
+    expect(await client1.config.requestChecksumCalculation()).toBe(
+      'WHEN_REQUIRED',
+    );
   });
 });

--- a/lib/util/s3.ts
+++ b/lib/util/s3.ts
@@ -18,6 +18,9 @@ export function getS3Client(
     s3Instance = new S3Client({
       ...(endpoint && { endpoint }),
       ...(forcePathStyle && { forcePathStyle: true }),
+      ...(endpoint && {
+        requestChecksumCalculation: 'WHEN_REQUIRED',
+      }),
     });
   }
   return s3Instance;

--- a/lib/workers/repository/index.spec.ts
+++ b/lib/workers/repository/index.spec.ts
@@ -1,4 +1,5 @@
-import fs from 'fs-extra';
+import type { DirectoryResult } from 'tmp-promise';
+import tmp from 'tmp-promise';
 import { mock } from 'vitest-mock-extended';
 import type { RenovateConfig } from '~test/util.ts';
 import { getConfig } from '../../config/defaults.ts';
@@ -24,10 +25,12 @@ describe('workers/repository/index', () => {
   describe('renovateRepository()', () => {
     let config: RenovateConfig;
     let localDir: string;
+    let localDirResult: DirectoryResult;
 
     beforeEach(async () => {
       GlobalConfig.reset();
-      localDir = await fs.mkdtemp('/tmp/renovate-repository-');
+      localDirResult = await tmp.dir({ unsafeCleanup: true });
+      localDir = localDirResult.path;
       config = {
         ...getConfig(),
         localDir,
@@ -45,7 +48,7 @@ describe('workers/repository/index', () => {
     });
 
     afterEach(async () => {
-      await fs.remove(localDir);
+      await localDirResult?.cleanup();
       GlobalConfig.reset();
     });
 

--- a/lib/workers/repository/index.spec.ts
+++ b/lib/workers/repository/index.spec.ts
@@ -1,32 +1,85 @@
+import fs from 'fs-extra';
 import { mock } from 'vitest-mock-extended';
 import type { RenovateConfig } from '~test/util.ts';
 import { getConfig } from '../../config/defaults.ts';
+import { GlobalConfig } from '../../config/global.ts';
+import { logger } from '../../logger/index.ts';
+import * as _s3Persist from '../../util/git/s3-persist.ts';
 import { renovateRepository } from './index.ts';
+import * as _init from './init/index.ts';
 import type { ExtractResult } from './process/extract-update.ts';
 import * as _process from './process/index.ts';
 
 const process = vi.mocked(_process);
+const initRepo = vi.mocked(_init.initRepo);
+const s3Persist = vi.mocked(_s3Persist);
 
 vi.mock('./init/index.ts');
 vi.mock('./process/index.ts');
 vi.mock('./result.ts');
 vi.mock('./error.ts');
+vi.mock('../../util/git/s3-persist.ts');
 
 describe('workers/repository/index', () => {
   describe('renovateRepository()', () => {
     let config: RenovateConfig;
+    let localDir: string;
 
-    beforeEach(() => {
-      config = getConfig();
-      config.localDir = '';
+    beforeEach(async () => {
+      GlobalConfig.reset();
+      localDir = await fs.mkdtemp('/tmp/renovate-repository-');
+      config = {
+        ...getConfig(),
+        localDir,
+        platform: 'github',
+        repository: 'org/repo',
+        dryRun: 'lookup',
+      } as RenovateConfig;
+
+      initRepo.mockImplementation((input) => Promise.resolve(input));
+      process.extractDependencies.mockResolvedValue({
+        branches: [],
+        branchList: [],
+        packageFiles: {},
+      });
+    });
+
+    afterEach(async () => {
+      await fs.remove(localDir);
+      GlobalConfig.reset();
     });
 
     it('does not process a repository, but also does not error', async () => {
       process.extractDependencies.mockResolvedValue(mock<ExtractResult>());
+      config.localDir = '';
       const res = await renovateRepository(config);
       // this returns `undefined`, as we do not actually process a repository, so no `ProcessResult` is returned
       // but importantly, no errors are thrown, either
       expect(res).toBeUndefined();
+    });
+
+    it('restores and archives git data for s3-backed persistRepoData', async () => {
+      config.persistRepoData = true;
+      config.persistRepoDataType = 's3://my-bucket/renovate-git/';
+      s3Persist.restoreGitDataFromS3.mockResolvedValue(true);
+
+      await renovateRepository(config);
+
+      expect(s3Persist.restoreGitDataFromS3).toHaveBeenCalledWith(
+        localDir,
+        's3://my-bucket/renovate-git/',
+        'github',
+        'org/repo',
+      );
+      expect(logger.info).toHaveBeenCalledWith(
+        'Restored git data from S3 - will use fast fetch',
+      );
+      expect(s3Persist.archiveGitDataToS3).toHaveBeenCalledWith(
+        localDir,
+        's3://my-bucket/renovate-git/',
+        'github',
+        'org/repo',
+      );
     });
   });
 });

--- a/lib/workers/repository/index.ts
+++ b/lib/workers/repository/index.ts
@@ -17,6 +17,10 @@ import { getInheritedOrGlobal } from '../../util/common.ts';
 import { removeDanglingContainers } from '../../util/exec/docker/index.ts';
 import { deleteLocalFile, privateCacheDir } from '../../util/fs/index.ts';
 import { isCloned } from '../../util/git/index.ts';
+import {
+  archiveGitDataToS3,
+  restoreGitDataFromS3,
+} from '../../util/git/s3-persist.ts';
 import { detectSemanticCommits } from '../../util/git/semantic.ts';
 import * as queue from '../../util/http/queue.ts';
 import * as throttle from '../../util/http/throttle.ts';
@@ -84,8 +88,6 @@ export async function renovateRepository(
           repoConfig.persistRepoData &&
           repoConfig.persistRepoDataType?.startsWith('s3://')
         ) {
-          const { restoreGitDataFromS3 } =
-            await import('../../util/git/s3-persist.ts');
           const platform = GlobalConfig.get('platform')!;
           const restored = await restoreGitDataFromS3(
             localDir,
@@ -210,7 +212,6 @@ export async function renovateRepository(
     repoConfig.persistRepoData &&
     repoConfig.persistRepoDataType?.startsWith('s3://')
   ) {
-    const { archiveGitDataToS3 } = await import('../../util/git/s3-persist.ts');
     const platform = GlobalConfig.get('platform')!;
     await archiveGitDataToS3(
       localDir,

--- a/lib/workers/repository/index.ts
+++ b/lib/workers/repository/index.ts
@@ -80,6 +80,23 @@ export async function renovateRepository(
       try {
         await fs.ensureDir(localDir);
         logger.debug('Using localDir: ' + localDir);
+        if (
+          repoConfig.persistRepoData &&
+          repoConfig.persistRepoDataType?.startsWith('s3://')
+        ) {
+          const { restoreGitDataFromS3 } =
+            await import('../../util/git/s3-persist.ts');
+          const platform = GlobalConfig.get('platform')!;
+          const restored = await restoreGitDataFromS3(
+            localDir,
+            repoConfig.persistRepoDataType,
+            platform,
+            repoConfig.repository!,
+          );
+          if (restored) {
+            logger.info('Restored git data from S3 - will use fast fetch');
+          }
+        }
         config = await initRepo(config);
         addSplit('init');
       } catch (err) /* istanbul ignore next */ {
@@ -187,6 +204,20 @@ export async function renovateRepository(
       await pruneStaleBranches(config, []);
     }
     repoResult = processResult(config, errorRes);
+  }
+  if (
+    localDir &&
+    repoConfig.persistRepoData &&
+    repoConfig.persistRepoDataType?.startsWith('s3://')
+  ) {
+    const { archiveGitDataToS3 } = await import('../../util/git/s3-persist.ts');
+    const platform = GlobalConfig.get('platform')!;
+    await archiveGitDataToS3(
+      localDir,
+      repoConfig.persistRepoDataType,
+      platform,
+      repoConfig.repository!,
+    );
   }
   if (localDir && !repoConfig.persistRepoData) {
     try {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Adds S3-backed persistence for `persistRepoData` so Renovate can reuse `.git/` data across runs on ephemeral workers.

Example config:

```json
{
  "persistRepoData": true,
  "persistRepoDataType": "s3://my-bucket/renovate-git/",
  "s3Endpoint": "https://s3.us-east-1.amazonaws.com"
}
```

### Why S3 vs blobless cloning

The S3 implementation proposed here should be an additional option rather than a replacement for blobless cloning because it solves a different problem. 

Blobless clone makes a cold clone cheaper by skipping most blobs up front, but each run still starts from the remote Git host and has to renegotiate objects again. S3-backed repo persistence is meant for environments where runners are stateless or short-lived, such as containers or Fargate tasks, and therefore cannot keep a local .git directory between runs. In those cases, storing the repository metadata in S3 allows a later run to restore the previous Git state and perform an incremental fetch instead of paying the cost of a fresh clone every time. 

That can reduce repeated network transfer and repeated load on the source platform for repositories that Renovate processes often. At the same time, S3 adds operational complexity and storage overhead, so it is not universally better than blobless cloning. Blobless remains the simpler choice for one-off or infrequent runs, while S3 persistence is useful as an opt-in remote cache for ephemeral runners that need cross-run reuse of Git state.

### Implementation details

- Added `persistRepoDataType` as a new global config option.
- Added S3 restore before repository init so an existing `.git/` archive can be reused and `git fetch` can run against restored repository state instead of starting from a fresh clone.
- Added S3 archive after repository processing to persist `.git/` back to S3 for later runs.
- The upload path streams the generated archive directly to S3 instead of buffering it fully in memory, which is important for large repositories.
- The persisted archive is now a zstd-compressed tarball rather than gzip.
- Reused the existing shared S3 utilities in `lib/util/s3.ts`.
- Kept local cleanup behavior unchanged; S3 persistence is additive and does not decide whether the worktree is deleted.
- The repository worker imports the S3 persistence helpers directly, avoiding any ambiguity about emitted import extensions during compilation.

### Patterns followed

- S3 key layout mirrors `RepoCacheS3`: `{prefix}{platform}/{repository}/git-data.tar.zst`.
- Missing trailing slashes on the configured S3 prefix are normalized with a warning, matching existing S3 cache behavior.
- Restore error handling follows the existing S3 cache patterns: `NoSuchKey` falls back quietly, while other errors warn and fall back.
- Restore validates the extracted archive by checking for `.git/HEAD`; if extraction succeeds but the result is not a usable Git directory, the partial `.git/` directory is cleaned up.
- The upload path streams the generated tar archive through zstd compression into S3 instead of buffering the full archive in memory first; buffering the whole `.git` archive would not be viable for the large repositories this feature is meant to help.
- The shared S3 client configuration is reused so uploads and downloads also work with S3-compatible endpoints.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [X] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [X] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [X] Both unit tests + ran on a real repository

Verified with a local direct dry run against an S3-compatible endpoint

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
