### PR TITLE
fix(http): fallback to github hostType for GHE platform endpoint

### DIFF
--- a/lib/util/http/host-rules.spec.ts
+++ b/lib/util/http/host-rules.spec.ts
@@ -570,6 +570,57 @@ describe('util/http/host-rules', () => {
     });
   });
 
+  describe('GHE platform endpoint fallback', () => {
+    beforeEach(() => {
+      GlobalConfig.set({
+        platform: 'github',
+        endpoint: 'https://ghe.example.com/',
+      });
+      hostRules.clear();
+      hostRules.add({
+        hostType: 'github',
+        matchHost: 'ghe.example.com',
+        token: 'ghe-token',
+      });
+    });
+
+    afterEach(() => {
+      GlobalConfig.reset();
+    });
+
+    it('fallback to github for non-listed hostType targeting GHE endpoint', () => {
+      // github-digest is NOT in GITHUB_API_USING_HOST_TYPES,
+      // but should still get credentials when targeting the GHE endpoint
+      const opts = { hostType: 'github-digest' };
+      const hostRule = findMatchingRule(
+        'https://ghe.example.com/api/v3/',
+        opts,
+      );
+      expect(hostRule).toEqual({
+        token: 'ghe-token',
+      });
+      expect(
+        applyHostRule('https://ghe.example.com/api/v3/', opts, hostRule),
+      ).toEqual({
+        context: {
+          authType: undefined,
+        },
+        hostType: 'github-digest',
+        token: 'ghe-token',
+      });
+    });
+
+    it('no fallback when request targets a different host', () => {
+      // Request targets a different host than the platform endpoint — no fallback
+      const opts = { hostType: 'github-digest' };
+      const hostRule = findMatchingRule(
+        'https://other-ghe.example.com/api/v3/',
+        opts,
+      );
+      expect(hostRule).toEqual({});
+    });
+  });
+
   it('no fallback to gitlab', () => {
     hostRules.add({
       hostType: 'gitlab-packages',

--- a/lib/util/http/host-rules.spec.ts
+++ b/lib/util/http/host-rules.spec.ts
@@ -584,10 +584,6 @@ describe('util/http/host-rules', () => {
       });
     });
 
-    afterEach(() => {
-      GlobalConfig.reset();
-    });
-
     it('fallback to github for non-listed hostType targeting GHE endpoint', () => {
       // github-digest is NOT in GITHUB_API_USING_HOST_TYPES,
       // but should still get credentials when targeting the GHE endpoint

--- a/lib/util/http/host-rules.ts
+++ b/lib/util/http/host-rules.ts
@@ -78,6 +78,23 @@ export function findMatchingRule<GotOptions extends HostRulesGotOptions>(
       }),
       ...res,
     };
+  } else if (GlobalConfig.get('platform') === 'github') {
+    // Fallback to `github` hostType when the request URL targets the same host as the configured GitHub platform endpoint.
+    // This covers GitHub Enterprise Server without hardcoding URLs.
+    const platformEndpoint = GlobalConfig.get('endpoint');
+    if (platformEndpoint) {
+      const requestHost = parseUrl(url)?.hostname;
+      const endpointHost = parseUrl(platformEndpoint)?.hostname;
+      if (requestHost && endpointHost && requestHost === endpointHost) {
+        res = {
+          ...hostRules.find({
+            hostType: 'github',
+            url,
+          }),
+          ...res,
+        };
+      }
+    }
   }
 
   // Fallback to `gitlab` hostType

--- a/lib/util/http/host-rules.ts
+++ b/lib/util/http/host-rules.ts
@@ -69,6 +69,9 @@ export function findMatchingRule<GotOptions extends HostRulesGotOptions>(
     };
   }
 
+  const platform = GlobalConfig.get('platform');
+  const platformEndpoint = GlobalConfig.get('endpoint');
+
   // in the case that an API URL is used for GitHub.com, fallback to `github` hostType, and use the `url`'s host to find a `matchHost: api.github.com` (or `matchHost: github.com`)
   if (url.startsWith('https://api.github.com/')) {
     res = {
@@ -78,22 +81,18 @@ export function findMatchingRule<GotOptions extends HostRulesGotOptions>(
       }),
       ...res,
     };
-  } else if (GlobalConfig.get('platform') === 'github') {
-    // Fallback to `github` hostType when the request URL targets the same host as the configured GitHub platform endpoint.
+  } else if (platform === 'github' && platformEndpoint) {
+    // Fallback to `github` hostType when the request URL targets the same host
+    // as the configured GitHub platform endpoint.
+    //
     // This covers GitHub Enterprise Server without hardcoding URLs.
-    const platformEndpoint = GlobalConfig.get('endpoint');
-    if (platformEndpoint) {
-      const requestHost = parseUrl(url)?.hostname;
-      const endpointHost = parseUrl(platformEndpoint)?.hostname;
-      if (requestHost && endpointHost && requestHost === endpointHost) {
-        res = {
-          ...hostRules.find({
-            hostType: 'github',
-            url,
-          }),
-          ...res,
-        };
-      }
+    const requestHost = parseUrl(url)?.hostname;
+    const endpointHost = parseUrl(platformEndpoint)?.hostname;
+    if (requestHost && endpointHost && requestHost === endpointHost) {
+      res = {
+        ...hostRules.find({ hostType: 'github', url }),
+        ...res,
+      };
     }
   }
 


### PR DESCRIPTION
## Changes

When running against GitHub Enterprise Server, datasources not listed in `GITHUB_API_USING_HOST_TYPES` (e.g. `github-digest`) fail to authenticate because the existing fallback only covers `api.github.com` URLs.

This adds a host-matching fallback: when the active platform is `github` and the request URL targets the same host as the configured endpoint, credentials from the `github` hostType rule are applied.

This makes the existing `api.github.com` workaround unnecessary for GHE — the fallback is now derived from the platform configuration rather than hardcoded URLs.

## Context

- Closes: #42283

The issue in #42283 added `github-digest` to `GITHUB_API_USING_HOST_TYPES` as a workaround, but this violates the deprecation guidance in that constant. This fix addresses the root cause: the host-rule fallback logic didn't account for GHE platform endpoints.

## AI assistance disclosure

- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Newly added/modified unit tests