### PR TITLE
fix(swift): don't write `from:` range to `Package.resolved`

### DIFF
--- a/lib/modules/manager/swift/artifacts.spec.ts
+++ b/lib/modules/manager/swift/artifacts.spec.ts
@@ -199,6 +199,31 @@ describe('modules/manager/swift/artifacts', () => {
     );
   });
 
+  it('does not write `from:` range to Package.resolved', async () => {
+    scm.getFileList.mockResolvedValue(['Package.resolved']);
+    fs.readLocalFile.mockResolvedValue(v2Fixture);
+    vi.mocked(datasource.getDigest).mockResolvedValue('newrevisionsha123');
+
+    const result = await updateArtifacts({
+      packageFileName: 'Package.swift',
+      updatedDeps: [
+        {
+          depName: 'Alamofire/Alamofire',
+          datasource: GithubTagsDatasource.id,
+          newVersion: '5.10.0',
+          newValue: 'from: "5.10.0"',
+        },
+      ],
+      newPackageFileContent: '',
+      config: {},
+    });
+
+    expect(result).toHaveLength(1);
+    const { contents } = result![0].file as { contents: string };
+    expect(contents).toContain('"version": "5.10.0"');
+    expect(contents).not.toContain('from:');
+  });
+
   it('updates multiple pins in one call', async () => {
     scm.getFileList.mockResolvedValue(['Package.resolved']);
     fs.readLocalFile.mockResolvedValue(v2Fixture);

--- a/lib/modules/manager/swift/artifacts.ts
+++ b/lib/modules/manager/swift/artifacts.ts
@@ -208,17 +208,19 @@ export async function updateArtifacts({
         continue;
       }
 
+      const resolvedVersion = dep.newVersion.replace(/^v/, '');
+
       // Skip if already up-to-date
-      if (pin.state.version === newValue) {
+      if (pin.state.version === resolvedVersion) {
         logger.debug(
-          { depName: dep.depName, newValue },
+          { depName: dep.depName, resolvedVersion },
           'swift: pin already at target version',
         );
         continue;
       }
 
       const newRevision = await resolveCommitSha(dep, dep.newVersion);
-      updated = updatePinInJson(updated, pin, newValue, newRevision);
+      updated = updatePinInJson(updated, pin, resolvedVersion, newRevision);
     }
 
     if (updated !== content) {

--- a/lib/modules/manager/swift/artifacts.ts
+++ b/lib/modules/manager/swift/artifacts.ts
@@ -208,7 +208,7 @@ export async function updateArtifacts({
         continue;
       }
 
-      const resolvedVersion = dep.newVersion.replace(/^v/, '');
+      const resolvedVersion = dep.newVersion.replace(regEx(/^v/), '');
 
       // Skip if already up-to-date
       if (pin.state.version === resolvedVersion) {


### PR DESCRIPTION
## Changes

When a dependency uses a range specifier like `from: "1.0.0"` in Package.swift, the `newValue` produced by the versioning module contains the range expression (e.g. `from: "603.0.0"`) rather than a plain version string. Using `newValue` directly to update `Package.resolved` results in the lock file containing the range expression instead of a resolved version, which corrupts it.

Fix by using `dep.newVersion` with the `v` prefix stripped, which is the actual resolved version and the correct value for `Package.resolved`.

This is a regression introduced by #41782, which fixed the `v` prefix issue by switching from `newVersion` to `newValue` — but `newValue` can contain range expressions for `from:`-style dependencies.

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #42188
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

This PR was written with Claude Code (claude-sonnet-4-6).

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

A failing test was written first to reproduce the bug, then the fix was applied to make it pass. All existing tests (including those added in #41782) continue to pass.