### PR TITLE
fix(swift): strip range prefix from newVersion in Package.resolved updates

### DIFF
--- a/lib/modules/manager/swift/artifacts.spec.ts
+++ b/lib/modules/manager/swift/artifacts.spec.ts
@@ -3,7 +3,7 @@ import { GitTagsDatasource } from '../../datasource/git-tags/index.ts';
 import { GithubTagsDatasource } from '../../datasource/github-tags/index.ts';
 import { GitlabTagsDatasource } from '../../datasource/gitlab-tags/index.ts';
 import * as datasource from '../../datasource/index.ts';
-import { updateArtifacts } from './artifacts.ts';
+import { extractPlainVersion, updateArtifacts } from './artifacts.ts';
 
 vi.mock('../../../util/fs/index.ts');
 vi.mock('../../datasource/index.ts', async () => {
@@ -71,6 +71,20 @@ const v3Fixture = JSON.stringify(
   null,
   2,
 );
+
+describe('modules/manager/swift/artifacts', () => {
+  it.each([
+    ['v5.10.0', '5.10.0'],
+    ['5.10.0', '5.10.0'],
+    ['from: "37.0.0"', '37.0.0'],
+    ['exact: "1.2.3"', '1.2.3'],
+    ['upToNextMajor: "2.0.0"', '2.0.0'],
+    ['upToNextMinor: "3.1.0"', '3.1.0'],
+    ['v1.0.0-beta.1', '1.0.0-beta.1'],
+  ])('extractPlainVersion(%j) => %j', (input, expected) => {
+    expect(extractPlainVersion(input)).toBe(expected);
+  });
+});
 
 describe('modules/manager/swift/artifacts', () => {
   it('returns null when no Package.resolved files exist', async () => {
@@ -199,7 +213,7 @@ describe('modules/manager/swift/artifacts', () => {
     );
   });
 
-  it('does not write `from:` range to Package.resolved', async () => {
+  it('does not write `from:` range to Package.resolved when newValue has range syntax', async () => {
     scm.getFileList.mockResolvedValue(['Package.resolved']);
     fs.readLocalFile.mockResolvedValue(v2Fixture);
     vi.mocked(datasource.getDigest).mockResolvedValue('newrevisionsha123');
@@ -222,6 +236,36 @@ describe('modules/manager/swift/artifacts', () => {
     const { contents } = result![0].file as { contents: string };
     expect(contents).toContain('"version": "5.10.0"');
     expect(contents).not.toContain('from:');
+  });
+
+  it('strips `from:` range prefix from newVersion before writing to Package.resolved', async () => {
+    scm.getFileList.mockResolvedValue(['Package.resolved']);
+    fs.readLocalFile.mockResolvedValue(v2Fixture);
+    vi.mocked(datasource.getDigest).mockResolvedValue('newrevisionsha123');
+
+    // Simulate the scenario where newVersion arrives with the range prefix
+    // that belongs in Package.swift — this produced corrupted JSON like
+    // "version" : "from: "37.0.0"" in production (see #41534)
+    const result = await updateArtifacts({
+      packageFileName: 'Package.swift',
+      updatedDeps: [
+        {
+          depName: 'Alamofire/Alamofire',
+          datasource: GithubTagsDatasource.id,
+          newVersion: 'from: "5.10.0"',
+          newValue: 'from: "5.10.0"',
+        },
+      ],
+      newPackageFileContent: '',
+      config: {},
+    });
+
+    expect(result).toHaveLength(1);
+    const { contents } = result![0].file as { contents: string };
+    expect(contents).toContain('"version": "5.10.0"');
+    expect(contents).not.toContain('"from:');
+    // Verify the output is valid JSON
+    expect(() => JSON.parse(contents)).not.toThrow();
   });
 
   it('updates multiple pins in one call', async () => {

--- a/lib/modules/manager/swift/artifacts.ts
+++ b/lib/modules/manager/swift/artifacts.ts
@@ -13,6 +13,26 @@ import type {
 import type { PackageResolvedPin } from './schema.ts';
 import { PackageResolvedJson } from './schema.ts';
 
+/**
+ * Extract a plain semver version from a value that may contain
+ * Swift Package Manager range syntax (e.g. `from: "1.0.0"`).
+ *
+ * Package.resolved stores bare versions like `"1.0.0"`, but
+ * `dep.newVersion` may arrive with a `v` prefix or, in some
+ * edge cases, wrapped in a range operator copied from
+ * Package.swift (`from: "1.0.0"`, `exact: "1.0.0"`, etc.).
+ * Writing the range syntax verbatim produces invalid JSON.
+ */
+export function extractPlainVersion(version: string): string {
+  const rangeMatch = regEx(
+    /^(?:from|exact|upToNextMajor|upToNextMinor)\s*:\s*"([^"]+)"$/,
+  ).exec(version);
+  if (rangeMatch) {
+    return rangeMatch[1];
+  }
+  return version.replace(regEx(/^v/), '');
+}
+
 async function findPackageResolvedFiles(): Promise<string[]> {
   const fileList = await scm.getFileList();
   return fileList.filter((f) => f.endsWith('Package.resolved'));
@@ -208,7 +228,7 @@ export async function updateArtifacts({
         continue;
       }
 
-      const resolvedVersion = dep.newVersion.replace(regEx(/^v/), '');
+      const resolvedVersion = extractPlainVersion(dep.newVersion);
 
       // Skip if already up-to-date
       if (pin.state.version === resolvedVersion) {


### PR DESCRIPTION
## Changes

Fix a bug in the Swift `updateArtifacts` function where `dep.newVersion` may contain a Swift Package Manager range prefix (e.g. `from: "37.0.0"` instead of `37.0.0`), producing corrupted JSON in `Package.resolved`:

```json
"version" : "from: "37.0.0""
```

This is a follow-up to #41534, which added `Package.resolved` lockfile support to the Swift manager.

### Root cause

`dep.newVersion` can arrive wrapped in a range operator from `Package.swift` syntax. The existing code only strips the `v` prefix but not range operators like `from:`, `exact:`, `upToNextMajor:`, or `upToNextMinor:`. When the range-prefixed value is written directly into the `"version"` field, the resulting JSON is invalid (embedded unescaped quotes).

### Fix

Add an `extractPlainVersion()` helper that strips Swift range prefixes before writing to `Package.resolved`. The function handles:
- `from: "1.0.0"` → `1.0.0`
- `exact: "1.0.0"` → `1.0.0`
- `upToNextMajor: "1.0.0"` → `1.0.0`
- `upToNextMinor: "1.0.0"` → `1.0.0`
- `v1.0.0` → `1.0.0` (existing behavior preserved)

## Context

- Follow-up to #41534 (feat: update Package.resolved when updating Package.swift)
- [x] I have read the [Renovate Docs](https://docs.renovatebot.com/)

## AI assistance disclosure

- [x] Yes - substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).

## Documentation (please check one with an [x])

- [x] No documentation update is required

## How I've tested my work (please select one)

- [x] Newly added/modified unit tests

7 new parametrized test cases for `extractPlainVersion()` plus an integration test that reproduces the exact corruption scenario. All 35 tests pass.

```
 ✓ lib/modules/manager/swift/artifacts.spec.ts (35 tests) 11ms
```