### PR TITLE
fix: correctly warn when an attestation is missing

### DIFF
--- a/lib/modules/manager/types.ts
+++ b/lib/modules/manager/types.ts
@@ -125,6 +125,12 @@ export interface LookupUpdate {
   libYears?: number;
 
   version?: string;
+  /**
+   * Whether the package registry has attestation information for the given update.
+   *
+   * Renovate does NOT validate the attestation, only determine whether the field is present and set to a value.
+   */
+  hasAttestation?: boolean;
 }
 
 /**
@@ -191,6 +197,12 @@ export interface PackageDependency<
 
   mostRecentTimestamp?: Timestamp;
   isAbandoned?: boolean;
+  /**
+   * Whether the package registry has attestation information for the given update.
+   *
+   * Renovate does NOT validate the attestation, only determine whether the field is present and set to a value.
+   */
+  hasAttestation?: boolean;
 }
 
 export interface Upgrade<

--- a/lib/workers/repository/process/lookup/generate.ts
+++ b/lib/workers/repository/process/lookup/generate.ts
@@ -23,6 +23,7 @@ export async function generateUpdate(
     bucket,
     newVersion,
     newValue: null!,
+    hasAttestation: release.attestation,
   };
 
   // istanbul ignore if

--- a/lib/workers/repository/process/lookup/index.spec.ts
+++ b/lib/workers/repository/process/lookup/index.spec.ts
@@ -161,6 +161,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: '2015-05-17T04:25:07.299Z' as Timestamp,
           updateType: 'major',
+          hasAttestation: false,
         },
       ]);
     });
@@ -219,6 +220,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: '2013-09-04T17:07:22.948Z' as Timestamp,
           updateType: 'minor',
+          hasAttestation: false,
         },
         {
           bucket: 'major',
@@ -232,6 +234,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: '2015-05-17T04:25:07.299Z' as Timestamp,
           updateType: 'major',
+          hasAttestation: false,
         },
       ]);
     });
@@ -263,6 +266,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: '2011-06-10T17:20:04.719Z' as Timestamp,
           updateType: 'patch',
+          hasAttestation: false,
         },
         {
           bucket: 'minor',
@@ -276,6 +280,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: '2013-09-04T17:07:22.948Z' as Timestamp,
           updateType: 'minor',
+          hasAttestation: false,
         },
         {
           bucket: 'major',
@@ -289,6 +294,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: '2015-05-17T04:25:07.299Z' as Timestamp,
           updateType: 'major',
+          hasAttestation: false,
         },
       ]);
     });
@@ -317,6 +323,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: expect.any(String),
           updateType: 'minor',
+          hasAttestation: false,
         },
         {
           bucket: 'major',
@@ -329,6 +336,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: expect.any(String),
           updateType: 'major',
+          hasAttestation: false,
         },
       ]);
     });
@@ -358,6 +366,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: expect.any(String),
           updateType: 'patch',
+          hasAttestation: false,
         },
         {
           bucket: 'minor',
@@ -370,6 +379,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: expect.any(String),
           updateType: 'minor',
+          hasAttestation: false,
         },
         {
           bucket: 'major',
@@ -382,6 +392,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: expect.any(String),
           updateType: 'major',
+          hasAttestation: false,
         },
       ]);
     });
@@ -411,6 +422,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: expect.any(String),
           updateType: 'major',
+          hasAttestation: false,
         },
       ]);
     });
@@ -447,6 +459,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: '2013-09-04T17:07:22.948Z' as Timestamp,
           updateType: 'minor',
+          hasAttestation: false,
         },
         {
           bucket: 'major',
@@ -460,6 +473,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: '2015-05-17T04:25:07.299Z' as Timestamp,
           updateType: 'major',
+          hasAttestation: false,
         },
       ]);
     });
@@ -487,6 +501,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: expect.any(String),
           updateType: 'minor',
+          hasAttestation: false,
         },
       ]);
     });
@@ -514,6 +529,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: '2013-09-04T17:07:22.948Z' as Timestamp,
           updateType: 'minor',
+          hasAttestation: false,
         },
       ]);
     });
@@ -541,6 +557,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: '2013-09-04T17:07:22.948Z' as Timestamp,
           updateType: 'minor',
+          hasAttestation: false,
         },
       ]);
     });
@@ -569,6 +586,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: '2013-09-04T17:07:22.948Z' as Timestamp,
           updateType: 'minor',
+          hasAttestation: false,
         },
       ]);
     });
@@ -597,6 +615,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: '2013-05-22T20:26:50.888Z' as Timestamp,
           updateType: 'minor',
+          hasAttestation: false,
         },
       ]);
     });
@@ -636,6 +655,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: expect.any(String),
           updateType: 'patch',
+          hasAttestation: false,
         },
         {
           bucket: 'major',
@@ -648,6 +668,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: expect.any(String),
           updateType: 'major',
+          hasAttestation: false,
         },
       ]);
     });
@@ -681,6 +702,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: expect.any(String),
           updateType: 'patch',
+          hasAttestation: false,
         },
         {
           bucket: 'major',
@@ -693,6 +715,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: expect.any(String),
           updateType: 'major',
+          hasAttestation: false,
         },
       ]);
     });
@@ -721,6 +744,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: '2013-09-04T17:07:22.948Z' as Timestamp,
           updateType: 'patch',
+          hasAttestation: false,
         },
         {
           bucket: 'major',
@@ -733,6 +757,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: '2015-05-17T04:25:07.299Z' as Timestamp,
           updateType: 'major',
+          hasAttestation: false,
         },
       ]);
     });
@@ -761,6 +786,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: expect.any(String),
           updateType: 'patch',
+          hasAttestation: false,
         },
         {
           bucket: 'minor',
@@ -773,6 +799,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: expect.any(String),
           updateType: 'minor',
+          hasAttestation: false,
         },
         {
           bucket: 'major',
@@ -785,6 +812,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: expect.any(String),
           updateType: 'major',
+          hasAttestation: false,
         },
       ]);
     });
@@ -821,6 +849,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: '2015-05-17T04:25:07.299Z' as Timestamp,
           updateType: 'major',
+          hasAttestation: false,
         },
       ]);
     });
@@ -849,6 +878,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: '2015-05-17T04:25:07.299Z' as Timestamp,
           updateType: 'minor',
+          hasAttestation: false,
         },
       ]);
     });
@@ -876,6 +906,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: expect.any(String),
           updateType: 'patch',
+          hasAttestation: false,
         },
       ]);
     });
@@ -904,6 +935,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: expect.any(String),
           updateType: 'minor',
+          hasAttestation: false,
         },
       ]);
     });
@@ -932,6 +964,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: expect.any(String),
           updateType: 'minor',
+          hasAttestation: false,
         },
       ]);
     });
@@ -960,6 +993,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: expect.any(String),
           updateType: 'minor',
+          hasAttestation: false,
         },
       ]);
     });
@@ -988,6 +1022,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: expect.any(String),
           updateType: 'minor',
+          hasAttestation: false,
         },
       ]);
     });
@@ -1017,6 +1052,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: expect.any(String),
           updateType: 'minor',
+          hasAttestation: false,
         },
       ]);
     });
@@ -1045,6 +1081,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: expect.any(String),
           updateType: 'patch',
+          hasAttestation: false,
         },
       ]);
     });
@@ -1095,6 +1132,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: '2013-09-04T17:07:22.948Z' as Timestamp,
           updateType: 'minor',
+          hasAttestation: false,
         },
         {
           bucket: 'major',
@@ -1108,6 +1146,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: '2015-05-17T04:25:07.299Z' as Timestamp,
           updateType: 'major',
+          hasAttestation: false,
         },
       ]);
     });
@@ -1244,6 +1283,7 @@ describe('workers/repository/process/lookup/index', () => {
         },
         {
           bucket: 'major',
+          hasAttestation: false,
           isBreaking: true,
           isRange: true,
           newMajor: 1,
@@ -1289,6 +1329,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: '2015-05-17T04:25:07.299Z' as Timestamp,
           updateType: 'minor',
+          hasAttestation: false,
         },
       ]);
     });
@@ -1319,6 +1360,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: expect.any(String),
           updateType: 'minor',
+          hasAttestation: false,
         },
       ]);
     });
@@ -1349,6 +1391,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: expect.any(String),
           updateType: 'minor',
+          hasAttestation: false,
         },
       ]);
     });
@@ -1379,6 +1422,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: expect.any(String),
           updateType: 'patch',
+          hasAttestation: false,
         },
       ]);
     });
@@ -1408,6 +1452,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: expect.any(String),
           updateType: 'minor',
+          hasAttestation: false,
         },
       ]);
     });
@@ -1435,6 +1480,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersion: '1.3.0',
           releaseTimestamp: '2015-04-26T16:42:11.311Z' as Timestamp,
           updateType: 'minor',
+          hasAttestation: false,
         },
       ]);
       expect(updates[0].newValue).toBeUndefined();
@@ -1465,6 +1511,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: '2015-05-17T04:25:07.299Z' as Timestamp,
           updateType: 'minor',
+          hasAttestation: false,
         },
       ]);
     });
@@ -1493,6 +1540,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: '2015-05-17T04:25:07.299Z' as Timestamp,
           updateType: 'minor',
+          hasAttestation: false,
         },
       ]);
     });
@@ -1524,6 +1572,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: '2017-10-17T15:22:36.646Z' as Timestamp,
           updateType: 'major',
+          hasAttestation: false,
         },
       ]);
     });
@@ -1555,6 +1604,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: '2017-10-17T15:22:36.646Z' as Timestamp,
           updateType: 'major',
+          hasAttestation: false,
         },
       ]);
     });
@@ -1664,6 +1714,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: '2015-05-17T04:25:07.299Z' as Timestamp,
           updateType: 'minor',
+          hasAttestation: false,
         },
       ]);
     });
@@ -1699,6 +1750,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: '2015-05-17T04:25:07.299Z' as Timestamp,
           updateType: 'minor',
+          hasAttestation: false,
         },
       ]);
     });
@@ -1727,6 +1779,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: '2015-05-17T04:25:07.299Z' as Timestamp,
           updateType: 'minor',
+          hasAttestation: false,
         },
       ]);
     });
@@ -1755,6 +1808,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: '2015-05-17T04:25:07.299Z' as Timestamp,
           updateType: 'major',
+          hasAttestation: false,
         },
       ]);
     });
@@ -1783,6 +1837,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: '2015-05-17T04:25:07.299Z' as Timestamp,
           updateType: 'minor',
+          hasAttestation: false,
         },
       ]);
     });
@@ -1811,6 +1866,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: '2015-05-17T04:25:07.299Z' as Timestamp,
           updateType: 'minor',
+          hasAttestation: false,
         },
       ]);
     });
@@ -1839,6 +1895,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: '2015-05-17T04:25:07.299Z' as Timestamp,
           updateType: 'major',
+          hasAttestation: false,
         },
       ]);
     });
@@ -1867,6 +1924,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: '2015-05-17T04:25:07.299Z' as Timestamp,
           updateType: 'minor',
+          hasAttestation: false,
         },
       ]);
     });
@@ -1895,6 +1953,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: '2013-09-04T17:07:22.948Z' as Timestamp,
           updateType: 'minor',
+          hasAttestation: false,
         },
         {
           bucket: 'major',
@@ -1908,6 +1967,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: '2015-05-17T04:25:07.299Z' as Timestamp,
           updateType: 'major',
+          hasAttestation: false,
         },
       ]);
     });
@@ -1936,6 +1996,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: '2013-09-04T17:07:22.948Z' as Timestamp,
           updateType: 'minor',
+          hasAttestation: false,
         },
         {
           bucket: 'major',
@@ -1949,6 +2010,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: '2015-05-17T04:25:07.299Z' as Timestamp,
           updateType: 'major',
+          hasAttestation: false,
         },
       ]);
     });
@@ -1977,6 +2039,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: expect.any(String),
           updateType: 'minor',
+          hasAttestation: false,
         },
         {
           bucket: 'major',
@@ -1990,6 +2053,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: expect.any(String),
           updateType: 'major',
+          hasAttestation: false,
         },
       ]);
     });
@@ -2021,6 +2085,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: '2017-10-17T15:22:36.646Z' as Timestamp,
           updateType: 'major',
+          hasAttestation: false,
         },
       ]);
     });
@@ -2052,6 +2117,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: '2017-10-17T15:22:36.646Z' as Timestamp,
           updateType: 'major',
+          hasAttestation: false,
         },
       ]);
     });
@@ -2083,6 +2149,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: '2017-10-17T15:22:36.646Z' as Timestamp,
           updateType: 'major',
+          hasAttestation: false,
         },
       ]);
     });
@@ -2114,6 +2181,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: '2017-10-17T15:22:36.646Z' as Timestamp,
           updateType: 'major',
+          hasAttestation: false,
         },
       ]);
     });
@@ -2142,6 +2210,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: '2015-05-17T04:25:07.299Z' as Timestamp,
           updateType: 'minor',
+          hasAttestation: false,
         },
       ]);
     });
@@ -2184,6 +2253,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: '2013-09-04T17:07:22.948Z' as Timestamp,
           updateType: 'minor',
+          hasAttestation: false,
         },
         {
           bucket: 'major',
@@ -2197,6 +2267,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: '2015-05-17T04:25:07.299Z' as Timestamp,
           updateType: 'major',
+          hasAttestation: false,
         },
       ]);
     });
@@ -2225,6 +2296,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: '2013-09-04T17:07:22.948Z' as Timestamp,
           updateType: 'minor',
+          hasAttestation: false,
         },
         {
           bucket: 'major',
@@ -2238,6 +2310,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: '2015-05-17T04:25:07.299Z' as Timestamp,
           updateType: 'major',
+          hasAttestation: false,
         },
       ]);
     });
@@ -2266,6 +2339,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: '2015-05-17T04:25:07.299Z' as Timestamp,
           updateType: 'major',
+          hasAttestation: false,
         },
       ]);
     });
@@ -2294,6 +2368,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: '2015-05-17T04:25:07.299Z' as Timestamp,
           updateType: 'minor',
+          hasAttestation: false,
         },
       ]);
     });
@@ -2322,6 +2397,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: '2015-05-17T04:25:07.299Z' as Timestamp,
           updateType: 'minor',
+          hasAttestation: false,
         },
       ]);
     });
@@ -2351,6 +2427,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: '2015-01-31T08:11:47.852Z' as Timestamp,
           updateType: 'major',
+          hasAttestation: false,
         },
       ]);
     });
@@ -2379,6 +2456,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: expect.any(String),
           updateType: 'minor',
+          hasAttestation: false,
         },
       ]);
     });
@@ -2407,6 +2485,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: expect.any(String),
           updateType: 'major',
+          hasAttestation: false,
         },
       ]);
     });
@@ -2435,6 +2514,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: expect.any(String),
           updateType: 'major',
+          hasAttestation: false,
         },
       ]);
     });
@@ -2463,6 +2543,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: expect.any(String),
           updateType: 'minor',
+          hasAttestation: false,
         },
         {
           bucket: 'major',
@@ -2476,6 +2557,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: expect.any(String),
           updateType: 'major',
+          hasAttestation: false,
         },
       ]);
     });
@@ -2504,6 +2586,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: expect.any(String),
           updateType: 'minor',
+          hasAttestation: false,
         },
         {
           bucket: 'major',
@@ -2517,6 +2600,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: expect.any(String),
           updateType: 'major',
+          hasAttestation: false,
         },
       ]);
     });
@@ -2558,6 +2642,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: '2015-01-31T08:11:47.852Z' as Timestamp,
           updateType: 'major',
+          hasAttestation: false,
         },
       ]);
     });
@@ -2604,6 +2689,7 @@ describe('workers/repository/process/lookup/index', () => {
           newValue: '2.0.0',
           newVersion: '2.0.0',
           updateType: 'major',
+          hasAttestation: undefined,
         },
       ]);
     });
@@ -2635,6 +2721,7 @@ describe('workers/repository/process/lookup/index', () => {
           newValue: '20.3.1',
           newVersion: '20.3.1',
           updateType: 'patch',
+          hasAttestation: undefined,
         },
       ]);
     });
@@ -2680,6 +2767,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: expect.any(String),
           updateType: 'patch',
+          hasAttestation: undefined,
         },
       ]);
     });
@@ -2725,6 +2813,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: expect.any(String),
           updateType: 'patch',
+          hasAttestation: undefined,
         },
       ]);
     });
@@ -2756,6 +2845,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: expect.any(String),
           updateType: 'patch',
+          hasAttestation: false,
         },
       ]);
     });
@@ -2785,6 +2875,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: expect.any(String),
           updateType: 'patch',
+          hasAttestation: false,
         },
       ]);
     });
@@ -2814,6 +2905,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: expect.any(String),
           updateType: 'patch',
+          hasAttestation: false,
         },
       ]);
     });
@@ -2844,6 +2936,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: expect.any(String),
           updateType: 'patch',
+          hasAttestation: false,
         },
       ]);
     });
@@ -2891,6 +2984,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: expect.any(String),
           updateType: 'patch',
+          hasAttestation: false,
         },
       ]);
     });
@@ -2948,6 +3042,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: expect.any(String),
           updateType: 'patch',
+          hasAttestation: false,
         },
       ]);
     });
@@ -3145,6 +3240,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: '2017-04-27T16:59:06.479Z' as Timestamp,
           updateType: 'patch',
+          hasAttestation: false,
         },
       ]);
     });
@@ -3200,6 +3296,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: expect.any(String),
           updateType: 'minor',
+          hasAttestation: false,
         },
         {
           bucket: 'major',
@@ -3212,6 +3309,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: expect.any(String),
           updateType: 'major',
+          hasAttestation: false,
         },
       ]);
     });
@@ -3242,6 +3340,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: expect.any(String),
           updateType: 'minor',
+          hasAttestation: false,
         },
         {
           bucket: 'v2',
@@ -3254,6 +3353,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: expect.any(String),
           updateType: 'major',
+          hasAttestation: false,
         },
         {
           bucket: 'v3',
@@ -3267,6 +3367,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: expect.any(String),
           updateType: 'major',
+          hasAttestation: false,
         },
       ]);
     });
@@ -3328,6 +3429,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: '2015-05-17T04:25:07.299Z' as Timestamp,
           updateType: 'minor',
+          hasAttestation: false,
         },
       ]);
     });
@@ -3358,6 +3460,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: '2014-03-11T18:47:17.560Z' as Timestamp,
           updateType: 'patch',
+          hasAttestation: false,
         },
         {
           bucket: 'minor',
@@ -3371,6 +3474,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: '2015-05-17T04:25:07.299Z' as Timestamp,
           updateType: 'minor',
+          hasAttestation: false,
         },
       ]);
     });
@@ -3390,6 +3494,7 @@ describe('workers/repository/process/lookup/index', () => {
       expect(updates).toEqual([
         {
           bucket: 'patch',
+          hasAttestation: false,
           isBreaking: false,
           isBump: true,
           isRange: true,
@@ -3404,6 +3509,7 @@ describe('workers/repository/process/lookup/index', () => {
         },
         {
           bucket: 'minor',
+          hasAttestation: false,
           isBreaking: false,
           isRange: true,
           newMajor: 1,
@@ -3432,6 +3538,7 @@ describe('workers/repository/process/lookup/index', () => {
       expect(updates).toEqual([
         {
           bucket: 'non-major',
+          hasAttestation: false,
           isBreaking: false,
           isBump: true,
           isRange: true,
@@ -3462,6 +3569,7 @@ describe('workers/repository/process/lookup/index', () => {
       expect(updates).toEqual([
         {
           bucket: 'latest',
+          hasAttestation: false,
           isBreaking: true,
           isBump: true,
           isRange: true,
@@ -3534,6 +3642,7 @@ describe('workers/repository/process/lookup/index', () => {
       expect(updates).toEqual([
         {
           bucket: 'non-major',
+          hasAttestation: false,
           isBreaking: false,
           newMajor: 1,
           newMinor: 4,
@@ -3638,6 +3747,7 @@ describe('workers/repository/process/lookup/index', () => {
         },
         {
           bucket: 'major',
+          hasAttestation: false,
           isBreaking: true,
           isRange: true,
           newMajor: 1,
@@ -4529,6 +4639,7 @@ describe('workers/repository/process/lookup/index', () => {
         updates: [
           {
             bucket: 'major',
+            hasAttestation: false,
             isBreaking: true,
             newMajor: 1,
             newMinor: 3,
@@ -5450,6 +5561,7 @@ describe('workers/repository/process/lookup/index', () => {
             newVersionAgeInDays: expect.any(Number),
             releaseTimestamp: '2017-10-17T15:22:36.646Z' as Timestamp,
             updateType: 'minor',
+            hasAttestation: false,
           },
         ]);
       });
@@ -5480,6 +5592,7 @@ describe('workers/repository/process/lookup/index', () => {
             newVersionAgeInDays: expect.any(Number),
             releaseTimestamp: '2017-10-17T15:22:36.646Z' as Timestamp,
             updateType: 'minor',
+            hasAttestation: false,
           },
         ]);
       });
@@ -5541,6 +5654,7 @@ describe('workers/repository/process/lookup/index', () => {
           newVersionAgeInDays: expect.any(Number),
           releaseTimestamp: '2024-05-09T18:34:42.000Z' as Timestamp,
           updateType: 'digest',
+          hasAttestation: undefined,
         },
       ]);
     });
@@ -5584,6 +5698,7 @@ describe('workers/repository/process/lookup/index', () => {
             newValue: '8.1.0',
             newVersion: '8.1.0',
             updateType: 'minor',
+            hasAttestation: undefined,
           },
         ],
         versioning: 'npm',

--- a/lib/workers/repository/update/pr/index.spec.ts
+++ b/lib/workers/repository/update/pr/index.spec.ts
@@ -1009,10 +1009,7 @@ describe('workers/repository/update/pr/index', () => {
                 manager: 'npm',
                 currentVersion: '1.2.3',
                 newVersion: '2.3.4',
-                releases: [
-                  { version: '1.2.3', attestation: currentAttestation },
-                  { version: '2.3.4', attestation: newAttestation },
-                ],
+                releases: [{ version: '2.3.4', attestation: newAttestation }],
               });
 
               it('does not warn the user', async () => {
@@ -1020,6 +1017,7 @@ describe('workers/repository/update/pr/index', () => {
 
                 const res = await ensurePr({
                   ...config,
+                  hasAttestation: currentAttestation,
                   upgrades: [dummyUpgrade],
                 });
 
@@ -1039,7 +1037,7 @@ describe('workers/repository/update/pr/index', () => {
             currentVersion: '1.2.3',
             newVersion: '2.3.4',
             releases: [
-              { version: '1.2.3', attestation: true },
+              // but the update we're updating to does not
               { version: '2.3.4', attestation: false },
             ],
           });
@@ -1049,6 +1047,8 @@ describe('workers/repository/update/pr/index', () => {
 
             const res = await ensurePr({
               ...config,
+              // the current release has an attestation
+              hasAttestation: true,
               upgrades: [dummyUpgrade],
             });
 

--- a/lib/workers/repository/update/pr/index.spec.ts
+++ b/lib/workers/repository/update/pr/index.spec.ts
@@ -998,6 +998,7 @@ describe('workers/repository/update/pr/index', () => {
             [true, true],
             [false, true],
             [false, false],
+            [undefined, undefined],
           ])(
             'current attestation %s, new attestation %s',
             (currentAttestation, newAttestation) => {

--- a/lib/workers/repository/update/pr/index.spec.ts
+++ b/lib/workers/repository/update/pr/index.spec.ts
@@ -1070,6 +1070,41 @@ describe('workers/repository/update/pr/index', () => {
             });
           });
         });
+        // TODO #42312
+        describe('when attestation is removed in an intermediate version', () => {
+          const dummyUpgrade = partial<BranchUpgradeConfig>({
+            branchName: sourceBranch,
+            depType: 'foo',
+            depName: 'bar',
+            manager: 'npm',
+            currentVersion: '1.2.3',
+            newVersion: '2.3.4',
+            releases: [
+              // previous versions between our currentVersion and newVersion have gaps in attestations
+              { version: '1.2.4', attestation: false },
+              { version: '1.3.0', attestation: false },
+              { version: '2.0.0', attestation: false },
+
+              // but the update we're updating to has attestation information
+              { version: '2.3.4', attestation: true },
+            ],
+          });
+
+          it('does not warn the user', async () => {
+            platform.createPr.mockResolvedValueOnce(pr);
+
+            const res = await ensurePr({
+              ...config,
+              // the current release has an attestation
+              hasAttestation: true,
+              upgrades: [dummyUpgrade],
+            });
+
+            expect(res).toEqual({ type: 'with-pr', pr });
+            const [[bodyConfig]] = prBody.getPrBody.mock.calls;
+            expect(bodyConfig.upgrades[0].prBodyNotes).toBeUndefined();
+          });
+        });
       });
     });
 

--- a/lib/workers/repository/update/pr/index.ts
+++ b/lib/workers/repository/update/pr/index.ts
@@ -123,21 +123,18 @@ function hasNotIgnoredReviewers(pr: Pr, config: BranchConfig): boolean {
 
 function addPullRequestNoteIfAttestationHasBeenLost(
   upgrade: BranchUpgradeConfig,
+  currentReleaseHasAttestation: boolean | undefined,
 ): void {
   const { packageName, depName, currentVersion, newVersion } = upgrade;
   const name = packageName ?? depName;
 
-  const currentRelease = upgrade.releases?.find(
-    (release) => release.version === currentVersion,
-  );
   const newRelease = upgrade.releases?.find(
     (release) => release.version === newVersion,
   );
 
   if (
-    currentRelease &&
     newRelease &&
-    currentRelease.attestation === true &&
+    currentReleaseHasAttestation === true &&
     newRelease.attestation !== true
   ) {
     upgrade.prBodyNotes ??= [];
@@ -168,6 +165,7 @@ export async function ensurePr(
     internalChecksAsSuccess,
     prTitle = '',
     upgrades,
+    hasAttestation: currentReleaseHasAttestation,
   } = config;
   const getBranchStatus = memoize(() =>
     resolveBranchStatus(branchName, !!internalChecksAsSuccess, ignoreTests),
@@ -338,7 +336,10 @@ export async function ensurePr(
       }
     }
 
-    addPullRequestNoteIfAttestationHasBeenLost(upgrade);
+    addPullRequestNoteIfAttestationHasBeenLost(
+      upgrade,
+      currentReleaseHasAttestation,
+    );
 
     config.upgrades.push(upgrade);
   }

--- a/lib/workers/repository/updates/flatten.spec.ts
+++ b/lib/workers/repository/updates/flatten.spec.ts
@@ -1,6 +1,7 @@
 import { isNumber } from '@sindresorhus/is';
 import type { RenovateConfig } from '~test/util.ts';
 import { getConfig } from '../../../config/defaults.ts';
+import type { PackageFile } from '../../../modules/manager/types.ts';
 import { flattenUpdates, sanitizeDepName } from './flatten.ts';
 
 vi.mock('../../../util/git/semantic.ts');
@@ -276,6 +277,39 @@ describe('workers/repository/updates/flatten', () => {
       expect(lockFileUpdate!.branchName).toContain('lock-file-maintenance');
       expect(regularUpdate!.branchName).not.toContain('lock-file-maintenance');
       expect(lockFileUpdate!.branchName).not.toBe(regularUpdate!.branchName);
+    });
+
+    describe('hasAttestation is taken from the current value', () => {
+      it.each([[true], [false], [undefined]])(
+        'current attestation %s, new attestation %s',
+        async (currentAttestation) => {
+          config = getConfig(); // HACK
+          const packageFiles: Record<string, PackageFile[]> = {
+            npm: [
+              {
+                packageFile: 'package.json',
+                deps: [
+                  {
+                    depName: 'foo',
+                    currentValue: '1.0.0',
+                    hasAttestation: currentAttestation,
+                    updates: [
+                      {
+                        newValue: '2.0.0',
+                        // but the new update may have a different value
+                        hasAttestation: false,
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          };
+          const res = await flattenUpdates(config, packageFiles);
+          expect(res).toHaveLength(1);
+          expect(res[0].hasAttestation).toEqual(currentAttestation);
+        },
+      );
     });
   });
 });

--- a/lib/workers/repository/updates/flatten.ts
+++ b/lib/workers/repository/updates/flatten.ts
@@ -150,6 +150,10 @@ export async function flattenUpdates(
             updateConfig = applyUpdateConfig(updateConfig);
             updateConfig.baseDeps = packageFile.deps;
             update.branchName = updateConfig.branchName;
+
+            // make sure that we use the dependency's current state of attestation, rather than using the new updae's value
+            updateConfig.hasAttestation = depConfig.hasAttestation;
+
             updates.push(updateConfig);
           }
         }

--- a/lib/workers/repository/updates/flatten.ts
+++ b/lib/workers/repository/updates/flatten.ts
@@ -151,7 +151,7 @@ export async function flattenUpdates(
             updateConfig.baseDeps = packageFile.deps;
             update.branchName = updateConfig.branchName;
 
-            // make sure that we use the dependency's current state of attestation, rather than using the new updae's value
+            // make sure that we use the dependency's current state of attestation, rather than using the new update's value
             updateConfig.hasAttestation = depConfig.hasAttestation;
 
             updates.push(updateConfig);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

As noted in #37258, when a package registry had previously seen an
attestation for authenticity of a given package release, Renovate should
warn if future updates then lose authenticity.

Our previous attempt at this (https://github.com/renovatebot/renovate/pull/37268) didn't quite pass around the current
package's attestation, which results in no warnings.

Given recent supply chain attacks where an attestation was removed (such
as Axios in MSC-2026-3522), we should make sure that this logic does
work correctly, and flags to our users.

In the future, we'll add more checks and a failing status check.

By introducing `hasAttestation` in the `LookupUpdate`, this can now be
matched on with `matchJsonata`, as well as providing visibility in the
`packageFiles with updates` log line.



## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #37258
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/JamieTanna-Mend-testing/renovate-attestation-testing/pull/5

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
 
