### PR TITLE
feat(pr): break `Schedule` definition over multiple lines + show cron syntax in code blocks

### DIFF
--- a/lib/workers/repository/update/pr/body/config-description.spec.ts
+++ b/lib/workers/repository/update/pr/body/config-description.spec.ts
@@ -1,3 +1,4 @@
+import { codeBlock } from 'common-tags';
 import type { BranchConfig } from '../../../../types.ts';
 import { getPrConfigDescription } from './config-description.ts';
 
@@ -47,7 +48,7 @@ describe('workers/repository/update/pr/body/config-description', () => {
         schedule: ['* 1 * * * *'],
         timezone: 'Europe/Istanbul',
       });
-      expect(res).toContain(`in timezone Europe/Istanbul`);
+      expect(res).toContain(`(in timezone Europe/Istanbul)`);
     });
 
     it('renders UTC as the default timezone', () => {
@@ -55,9 +56,7 @@ describe('workers/repository/update/pr/body/config-description', () => {
         ...config,
         schedule: ['* 1 * * *'],
       });
-      expect(res).toContain(
-        'Between 01:00 AM and 01:59 AM ( * 1 * * * ) (UTC)',
-      );
+      expect(res).toContain('Between 01:00 AM and 01:59 AM ( * 1 * * * )');
     });
 
     it('summarizes cron schedules', () => {
@@ -65,8 +64,9 @@ describe('workers/repository/update/pr/body/config-description', () => {
         ...config,
         schedule: ['* 1 * * *', '* * 2 * 1'],
       });
+      expect(res).toContain('- Between 01:00 AM and 01:59 AM ( * 1 * * * )');
       expect(res).toContain(
-        'Between 01:00 AM and 01:59 AM ( * 1 * * * ), On day 2 of the month, and on Monday ( * * 2 * 1 ) (UTC)',
+        '- On day 2 of the month, and on Monday ( * * 2 * 1 )',
       );
     });
 
@@ -75,14 +75,12 @@ describe('workers/repository/update/pr/body/config-description', () => {
         ...config,
         schedule: ['before 6am on Monday', 'after 3pm on Tuesday'],
       });
-      expect(res).toContain(
-        '"before 6am on Monday,after 3pm on Tuesday" (UTC)',
-      );
+      expect(res).toContain('"before 6am on Monday,after 3pm on Tuesday"');
     });
 
     it('renders undefined schedule', () => {
       const res = getPrConfigDescription(config);
-      expect(res).toContain(`At any time (no schedule defined).`);
+      expect(res).toContain(`At any time (no schedule defined)`);
     });
 
     it('summarizes cron schedules (for automergeSchedule)', () => {
@@ -90,8 +88,9 @@ describe('workers/repository/update/pr/body/config-description', () => {
         ...config,
         automergeSchedule: ['* 1 * * *', '* * 2 * 1'],
       });
+      expect(res).toContain('- Between 01:00 AM and 01:59 AM ( * 1 * * * )');
       expect(res).toContain(
-        'Between 01:00 AM and 01:59 AM ( * 1 * * * ), On day 2 of the month, and on Monday ( * * 2 * 1 ) (UTC)',
+        '- On day 2 of the month, and on Monday ( * * 2 * 1 )',
       );
     });
 
@@ -101,9 +100,16 @@ describe('workers/repository/update/pr/body/config-description', () => {
         schedule: ['* 1 * * *', '* * 2 * 1'],
         automergeSchedule: ['before 6am on Monday', 'after 3pm on Tuesday'],
       });
-      expect(res).toContain(
-        '**Schedule**: Branch creation - Between 01:00 AM and 01:59 AM ( * 1 * * * ), On day 2 of the month, and on Monday ( * * 2 * 1 ) (UTC), Automerge - "before 6am on Monday,after 3pm on Tuesday" (UTC).',
-      );
+      const expected = codeBlock`
+        **Schedule**: (UTC)
+        - Branch creation
+          - Between 01:00 AM and 01:59 AM ( * 1 * * * )
+          - On day 2 of the month, and on Monday ( * * 2 * 1 )
+        - Automerge
+          - "before 6am on Monday,after 3pm on Tuesday"
+      `;
+
+      expect(res).toContain(expected);
     });
 
     it('renders recreateClosed=true', () => {

--- a/lib/workers/repository/update/pr/body/config-description.spec.ts
+++ b/lib/workers/repository/update/pr/body/config-description.spec.ts
@@ -85,6 +85,16 @@ describe('workers/repository/update/pr/body/config-description', () => {
       expect(res).toContain(`At any time (no schedule defined).`);
     });
 
+    it('summarizes cron schedules (for automergeSchedule)', () => {
+      const res = getPrConfigDescription({
+        ...config,
+        automergeSchedule: ['* 1 * * *', '* * 2 * 1'],
+      });
+      expect(res).toContain(
+        'Between 01:00 AM and 01:59 AM ( * 1 * * * ), On day 2 of the month, and on Monday ( * * 2 * 1 ) (UTC)',
+      );
+    });
+
     it('renders recreateClosed=true', () => {
       const res = getPrConfigDescription({
         ...config,

--- a/lib/workers/repository/update/pr/body/config-description.spec.ts
+++ b/lib/workers/repository/update/pr/body/config-description.spec.ts
@@ -95,6 +95,17 @@ describe('workers/repository/update/pr/body/config-description', () => {
       );
     });
 
+    it('summarizes both branch creation and automerge schedules', () => {
+      const res = getPrConfigDescription({
+        ...config,
+        schedule: ['* 1 * * *', '* * 2 * 1'],
+        automergeSchedule: ['before 6am on Monday', 'after 3pm on Tuesday'],
+      });
+      expect(res).toContain(
+        '**Schedule**: Branch creation - Between 01:00 AM and 01:59 AM ( * 1 * * * ), On day 2 of the month, and on Monday ( * * 2 * 1 ) (UTC), Automerge - "before 6am on Monday,after 3pm on Tuesday" (UTC).',
+      );
+    });
+
     it('renders recreateClosed=true', () => {
       const res = getPrConfigDescription({
         ...config,

--- a/lib/workers/repository/update/pr/body/config-description.spec.ts
+++ b/lib/workers/repository/update/pr/body/config-description.spec.ts
@@ -56,7 +56,7 @@ describe('workers/repository/update/pr/body/config-description', () => {
         ...config,
         schedule: ['* 1 * * *'],
       });
-      expect(res).toContain('Between 01:00 AM and 01:59 AM ( * 1 * * * )');
+      expect(res).toContain('Between 01:00 AM and 01:59 AM (`* 1 * * *`)');
     });
 
     it('summarizes cron schedules', () => {
@@ -64,9 +64,9 @@ describe('workers/repository/update/pr/body/config-description', () => {
         ...config,
         schedule: ['* 1 * * *', '* * 2 * 1'],
       });
-      expect(res).toContain('- Between 01:00 AM and 01:59 AM ( * 1 * * * )');
+      expect(res).toContain('- Between 01:00 AM and 01:59 AM (`* 1 * * *`)');
       expect(res).toContain(
-        '- On day 2 of the month, and on Monday ( * * 2 * 1 )',
+        '- On day 2 of the month, and on Monday (`* * 2 * 1`)',
       );
     });
 
@@ -88,9 +88,9 @@ describe('workers/repository/update/pr/body/config-description', () => {
         ...config,
         automergeSchedule: ['* 1 * * *', '* * 2 * 1'],
       });
-      expect(res).toContain('- Between 01:00 AM and 01:59 AM ( * 1 * * * )');
+      expect(res).toContain('- Between 01:00 AM and 01:59 AM (`* 1 * * *`)');
       expect(res).toContain(
-        '- On day 2 of the month, and on Monday ( * * 2 * 1 )',
+        '- On day 2 of the month, and on Monday (`* * 2 * 1`)',
       );
     });
 
@@ -103,8 +103,8 @@ describe('workers/repository/update/pr/body/config-description', () => {
       const expected = codeBlock`
         **Schedule**: (UTC)
         - Branch creation
-          - Between 01:00 AM and 01:59 AM ( * 1 * * * )
-          - On day 2 of the month, and on Monday ( * * 2 * 1 )
+          - Between 01:00 AM and 01:59 AM (\`* 1 * * *\`)
+          - On day 2 of the month, and on Monday (\`* * 2 * 1\`)
         - Automerge
           - "before 6am on Monday,after 3pm on Tuesday"
       `;

--- a/lib/workers/repository/update/pr/body/config-description.spec.ts
+++ b/lib/workers/repository/update/pr/body/config-description.spec.ts
@@ -102,6 +102,7 @@ describe('workers/repository/update/pr/body/config-description', () => {
       });
       const expected = codeBlock`
         **Schedule**: (UTC)
+
         - Branch creation
           - Between 01:00 AM and 01:59 AM (\`* 1 * * *\`)
           - On day 2 of the month, and on Monday (\`* * 2 * 1\`)

--- a/lib/workers/repository/update/pr/body/config-description.ts
+++ b/lib/workers/repository/update/pr/body/config-description.ts
@@ -92,7 +92,7 @@ function getReadableCronSchedule(scheduleText: string[]): string[] | null {
               throwExceptionOnParseError: false,
             })
             .replace('Every minute, ', ''),
-        ) + ` ( ${cron} )`,
+        ) + ` (\`${cron}\`)`,
     );
   } catch {
     return null;

--- a/lib/workers/repository/update/pr/body/config-description.ts
+++ b/lib/workers/repository/update/pr/body/config-description.ts
@@ -7,12 +7,22 @@ import type { BranchConfig } from '../../../../types.ts';
 export function getPrConfigDescription(config: BranchConfig): string {
   let prBody = `\n\n---\n\n### Configuration\n\n`;
   prBody += emojify(`:date: **Schedule**: `);
+
+  if (config.timezone) {
+    prBody += `(in timezone ${config.timezone})`;
+  } else {
+    prBody += `(UTC)`;
+  }
+  prBody += '\n';
+
   prBody +=
-    'Branch creation - ' + scheduleToString(config.schedule, config.timezone);
+    '- Branch creation\n' +
+    scheduleToString(config.schedule, config.timezone) +
+    '\n';
   prBody +=
-    ', Automerge - ' +
+    '- Automerge\n' +
     scheduleToString(config.automergeSchedule, config.timezone) +
-    '.';
+    '\n';
 
   prBody += '\n\n';
   prBody += emojify(':vertical_traffic_light: **Automerge**: ');
@@ -52,41 +62,38 @@ function scheduleToString(
   schedule: string[] | undefined,
   timezone: string | undefined,
 ): string {
-  let scheduleString = '';
+  const scheduleLines = [];
   if (schedule && schedule[0] !== 'at any time') {
-    scheduleString =
-      getReadableCronSchedule(schedule) ?? `"${String(schedule)}"`;
-    if (timezone) {
-      scheduleString += ` in timezone ${timezone}`;
+    const r = getReadableCronSchedule(schedule);
+    if (r) {
+      scheduleLines.push(...r);
     } else {
-      scheduleString += ` (UTC)`;
+      scheduleLines.push(`"${String(schedule)}"`);
     }
   } else {
-    scheduleString += 'At any time (no schedule defined)';
+    scheduleLines.push('At any time (no schedule defined)');
   }
-  return scheduleString;
+  return '  - ' + scheduleLines.join('\n  - ');
 }
 
 /**
  * Return human-readable cron schedule summary if the schedule is a valid cron
  * else return null
  */
-function getReadableCronSchedule(scheduleText: string[]): string | null {
+function getReadableCronSchedule(scheduleText: string[]): string[] | null {
   // assuming if one schedule is cron the others in the array will be cron too
   try {
     new CronPattern(scheduleText[0]); // validate cron
-    return scheduleText
-      .map(
-        (cron) =>
-          capitalize(
-            cronstrue
-              .toString(cron, {
-                throwExceptionOnParseError: false,
-              })
-              .replace('Every minute, ', ''),
-          ) + ` ( ${cron} )`,
-      )
-      .join(', ');
+    return scheduleText.map(
+      (cron) =>
+        capitalize(
+          cronstrue
+            .toString(cron, {
+              throwExceptionOnParseError: false,
+            })
+            .replace('Every minute, ', ''),
+        ) + ` ( ${cron} )`,
+    );
   } catch {
     return null;
   }

--- a/lib/workers/repository/update/pr/body/config-description.ts
+++ b/lib/workers/repository/update/pr/body/config-description.ts
@@ -13,7 +13,7 @@ export function getPrConfigDescription(config: BranchConfig): string {
   } else {
     prBody += `(UTC)`;
   }
-  prBody += '\n';
+  prBody += '\n\n'; // to ensure that Markdown renderers will note that the Schedule is a different element to the list
 
   prBody +=
     '- Branch creation\n' +


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

feat(pr): break `Schedule` definition over multiple lines

To provide a more readable set of `schedule` and `automergeSchedule`
configuration options, we can break these over multiple lines, which
makes it clearer where there are multiple schedules that may apply at
a given time, as well as making it clearer between branch creation vs
automerge, which isn't necessarily clear.

feat(pr): show cron syntax in code blocks

As it can make it clearer, as well as avoiding potential interpretation
as Markdown.


---

For instance:

Before (via https://redirect.github.com/SettRaziel/renovate-demo-app/pull/12):

📅 **Schedule**: Branch creation - Between 03:00 PM and 07:59 PM ( * 15-19 * * * ) in timezone Europe/Berlin, Automerge - At any time (no schedule defined).

After:

📅 **Schedule**: (in timezone Europe/Berlin)
- Branch creation
  - Between 03:00 PM and 07:59 PM (`* 15-19 * * *`)
- Automerge
  - At any time (no schedule defined)



## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
