### PR TITLE
feat(onboarding): make `Add your custom config to ...` more prominent

### DIFF
--- a/lib/workers/repository/onboarding/pr/__snapshots__/config-description.spec.ts.snap
+++ b/lib/workers/repository/onboarding/pr/__snapshots__/config-description.spec.ts.snap
@@ -1,50 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`workers/repository/onboarding/pr/config-description > getConfigDesc() > contains the onboardingConfigFileName if set 1`] = `
-"
-### Configuration Summary
-
-Based on the default config's presets, Renovate will:
-
-  - Start dependency updates only once this onboarding PR is merged
-  - Run Renovate on following schedule: before 5am
-
-🔡 Do you want to change how Renovate upgrades your dependencies? Add your custom config to \`.github/renovate.json\` in this branch. Renovate will update the Pull Request description the next time it runs.
-
----
-"
-`;
-
-exports[`workers/repository/onboarding/pr/config-description > getConfigDesc() > falls back to "renovate.json" if onboardingConfigFileName is not set 1`] = `
-"
-### Configuration Summary
-
-Based on the default config's presets, Renovate will:
-
-  - Start dependency updates only once this onboarding PR is merged
-  - Run Renovate on following schedule: before 5am
-
-🔡 Do you want to change how Renovate upgrades your dependencies? Add your custom config to \`renovate.json\` in this branch. Renovate will update the Pull Request description the next time it runs.
-
----
-"
-`;
-
-exports[`workers/repository/onboarding/pr/config-description > getConfigDesc() > falls back to "renovate.json" if onboardingConfigFileName is not valid 1`] = `
-"
-### Configuration Summary
-
-Based on the default config's presets, Renovate will:
-
-  - Start dependency updates only once this onboarding PR is merged
-  - Run Renovate on following schedule: before 5am
-
-🔡 Do you want to change how Renovate upgrades your dependencies? Add your custom config to \`renovate.json\` in this branch. Renovate will update the Pull Request description the next time it runs.
-
----
-"
-`;
-
 exports[`workers/repository/onboarding/pr/config-description > getConfigDesc() > include retry/refresh checkbox message only if onboardingRebaseCheckbox is true 1`] = `
 "
 ### Configuration Summary
@@ -53,8 +8,6 @@ Based on the default config's presets, Renovate will:
 
   - Start dependency updates only once this onboarding PR is merged
   - Run Renovate on following schedule: before 5am
-
-🔡 Do you want to change how Renovate upgrades your dependencies? Add your custom config to \`.github/renovate.json\` in this branch and select the Retry/Rebase checkbox below. Renovate will update the Pull Request description the next time it runs.
 
 ---
 "
@@ -71,8 +24,6 @@ Based on the default config's presets, Renovate will:
   - description two
   - something else
   - this is Docker-only
-
-🔡 Do you want to change how Renovate upgrades your dependencies? Add your custom config to \`renovate.json\` in this branch. Renovate will update the Pull Request description the next time it runs.
 
 ---
 "

--- a/lib/workers/repository/onboarding/pr/__snapshots__/index.spec.ts.snap
+++ b/lib/workers/repository/onboarding/pr/__snapshots__/index.spec.ts.snap
@@ -7,6 +7,8 @@ Welcome to [Renovate](https://github.com/renovatebot/renovate)! This is an onboa
 
 🚦 To activate Renovate, merge this Pull Request. To disable Renovate, simply close this Pull Request unmerged.
 
+🔡 Do you want to change how Renovate upgrades your dependencies? Add your custom config to \`renovate.json\` in this branch. Renovate will update the Pull Request description the next time it runs.
+
 
 
 ---
@@ -38,6 +40,8 @@ exports[`workers/repository/onboarding/pr/index > ensureOnboardingPr() > creates
 Welcome to [Renovate](https://github.com/renovatebot/renovate)! This is an onboarding PR to help you understand and configure settings before regular Pull Requests begin.
 
 🚦 To activate Renovate, merge this Pull Request. To disable Renovate, simply close this Pull Request unmerged.
+
+🔡 Do you want to change how Renovate upgrades your dependencies? Add your custom config to \`renovate.json\` in this branch and select the Retry/Rebase checkbox below. Renovate will update the Pull Request description the next time it runs.
 
 
 
@@ -76,6 +80,8 @@ Welcome to [Renovate](https://github.com/renovatebot/renovate)! This is an onboa
 
 🚦 To activate Renovate, merge this Pull Request. To disable Renovate, simply close this Pull Request unmerged.
 
+🔡 Do you want to change how Renovate upgrades your dependencies? Add your custom config to \`renovate.json\` in this branch. Renovate will update the Pull Request description the next time it runs.
+
 
 
 ---
@@ -107,6 +113,8 @@ exports[`workers/repository/onboarding/pr/index > ensureOnboardingPr() > creates
 Welcome to [Renovate](https://github.com/renovatebot/renovate)! This is an onboarding PR to help you understand and configure settings before regular Pull Requests begin.
 
 🚦 To activate Renovate, merge this Pull Request. To disable Renovate, simply close this Pull Request unmerged.
+
+🔡 Do you want to change how Renovate upgrades your dependencies? Add your custom config to \`renovate.json\` in this branch and select the Retry/Rebase checkbox below. Renovate will update the Pull Request description the next time it runs.
 
 
 
@@ -147,6 +155,8 @@ Welcome to [Renovate](https://github.com/renovatebot/renovate)! This is an onboa
 
 🚦 To activate Renovate, merge this Pull Request. To disable Renovate, simply close this Pull Request unmerged.
 
+🔡 Do you want to change how Renovate upgrades your dependencies? Add your custom config to \`renovate.json\` in this branch. Renovate will update the Pull Request description the next time it runs.
+
 
 
 ---
@@ -183,6 +193,8 @@ This should not be the first line of the PR
 Welcome to [Renovate](https://github.com/renovatebot/renovate)! This is an onboarding PR to help you understand and configure settings before regular Pull Requests begin.
 
 🚦 To activate Renovate, merge this Pull Request. To disable Renovate, simply close this Pull Request unmerged.
+
+🔡 Do you want to change how Renovate upgrades your dependencies? Add your custom config to \`renovate.json\` in this branch and select the Retry/Rebase checkbox below. Renovate will update the Pull Request description the next time it runs.
 
 
 

--- a/lib/workers/repository/onboarding/pr/config-description.spec.ts
+++ b/lib/workers/repository/onboarding/pr/config-description.spec.ts
@@ -50,38 +50,9 @@ describe('workers/repository/onboarding/pr/config-description', () => {
           - Start dependency updates only once this onboarding PR is merged
           - Run Renovate on following schedule: before 5am
 
-        🔡 Do you want to change how Renovate upgrades your dependencies? Add your custom config to \`renovate.json\` in this branch. Renovate will update the Pull Request description the next time it runs.
-
         ---
         "
       `);
-    });
-
-    it('contains the onboardingConfigFileName if set', () => {
-      delete config.description;
-      config.schedule = ['before 5am'];
-      GlobalConfig.set({ onboardingConfigFileName: '.github/renovate.json' });
-      const res = getConfigDesc(config);
-      expect(res).toMatchSnapshot();
-      expect(res.indexOf('`.github/renovate.json`')).not.toBe(-1);
-      expect(res.indexOf('`renovate.json`')).toBe(-1);
-    });
-
-    it('falls back to "renovate.json" if onboardingConfigFileName is not set', () => {
-      delete config.description;
-      config.schedule = ['before 5am'];
-      const res = getConfigDesc(config);
-      expect(res).toMatchSnapshot();
-      expect(res.indexOf('`renovate.json`')).not.toBe(-1);
-    });
-
-    it('falls back to "renovate.json" if onboardingConfigFileName is not valid', () => {
-      delete config.description;
-      config.schedule = ['before 5am'];
-      GlobalConfig.set({ onboardingConfigFileName: 'foo.bar' });
-      const res = getConfigDesc(config);
-      expect(res).toMatchSnapshot();
-      expect(res.indexOf('`renovate.json`')).not.toBe(-1);
     });
 
     it('include retry/refresh checkbox message only if onboardingRebaseCheckbox is true', () => {

--- a/lib/workers/repository/onboarding/pr/config-description.ts
+++ b/lib/workers/repository/onboarding/pr/config-description.ts
@@ -2,8 +2,6 @@ import { isArray, isString } from '@sindresorhus/is';
 import type { RenovateConfig } from '../../../../config/types.ts';
 import { logger } from '../../../../logger/index.ts';
 import type { PackageFile } from '../../../../modules/manager/types.ts';
-import { emojify } from '../../../../util/emoji.ts';
-import { getDefaultConfigFileName } from '../common.ts';
 
 export function getScheduleDesc(config: RenovateConfig): string[] {
   logger.debug('getScheduleDesc()');
@@ -33,7 +31,6 @@ export function getConfigDesc(
   _packageFiles?: Record<string, PackageFile[]>,
 ): string {
   // TODO: type (#22198)
-  const configFile = getDefaultConfigFileName();
   logger.debug('getConfigDesc()');
   logger.trace({ config });
   const descriptionArr = getDescriptionArray(config);
@@ -47,15 +44,6 @@ export function getConfigDesc(
   descriptionArr.forEach((d) => {
     desc += `  - ${d}\n`;
   });
-  desc += '\n';
-  desc += emojify(
-    `:abcd: Do you want to change how Renovate upgrades your dependencies?`,
-  );
-  desc += ` Add your custom config to \`${configFile}\` in this branch${
-    config.onboardingRebaseCheckbox
-      ? ' and select the Retry/Rebase checkbox below'
-      : ''
-  }. Renovate will update the Pull Request description the next time it runs.`;
-  desc += '\n\n---\n';
+  desc += '\n---\n';
   return desc;
 }

--- a/lib/workers/repository/onboarding/pr/config-description.ts
+++ b/lib/workers/repository/onboarding/pr/config-description.ts
@@ -30,7 +30,6 @@ export function getConfigDesc(
   // TODO: remove unused parameter
   _packageFiles?: Record<string, PackageFile[]>,
 ): string {
-  // TODO: type (#22198)
   logger.debug('getConfigDesc()');
   logger.trace({ config });
   const descriptionArr = getDescriptionArray(config);

--- a/lib/workers/repository/onboarding/pr/index.spec.ts
+++ b/lib/workers/repository/onboarding/pr/index.spec.ts
@@ -212,25 +212,6 @@ describe('workers/repository/onboarding/pr/index', () => {
       'returns if PR does not need updating' +
         '(onboardingRebaseCheckbox="$onboardingRebaseCheckbox")',
       async ({ onboardingRebaseCheckbox }) => {
-        /*
-TODO before
-
-
-stdout | lib/workers/repository/onboarding/pr/index.spec.ts > workers/repository/onboarding/pr/index > ensureOnboardingPr() > returns if PR does not need updating(onboardingRebaseCheckbox="false")
-{
-e: '30029ee05ed80b34d2f743afda6e78fe20247a1eedaa9ce6a8070045c229ebfa',
-prBodyHash: '30029ee05ed80b34d2f743afda6e78fe20247a1eedaa9ce6a8070045c229ebfa'
-}
-
-stdout | lib/workers/repository/onboarding/pr/index.spec.ts > workers/repository/onboarding/pr/index > ensureOnboardingPr() > returns if PR does not need updating(onboardingRebaseCheckbox="true")
-{
-e: '6aa71f8cb7b1503b883485c8f5bd564b31923b9c7fa765abe2a7338af40e03b1',
-prBodyHash: '6aa71f8cb7b1503b883485c8f5bd564b31923b9c7fa765abe2a7338af40e03b1'
-}
-        const hash =
-          '30029ee05ed80b34d2f743afda6e78fe20247a1eedaa9ce6a8070045c229ebfa'; // no rebase checkbox PR hash
-
-*/
         const hash =
           '4b0e83aaa5acee225d5b8af756a1f55eb1d3fe70aa5759d03cf708187ebec4df'; // no rebase checkbox PR hash
         config.onboardingRebaseCheckbox = onboardingRebaseCheckbox;

--- a/lib/workers/repository/onboarding/pr/index.spec.ts
+++ b/lib/workers/repository/onboarding/pr/index.spec.ts
@@ -21,7 +21,7 @@ describe('workers/repository/onboarding/pr/index', () => {
     let branches: BranchConfig[];
 
     const bodyStruct = {
-      hash: '6aa71f8cb7b1503b883485c8f5bd564b31923b9c7fa765abe2a7338af40e03b1',
+      hash: '137701e91134550a73cea4f6e6f2269897d4802122126657a2ff890459f07c72',
     };
 
     beforeEach(() => {
@@ -212,8 +212,27 @@ describe('workers/repository/onboarding/pr/index', () => {
       'returns if PR does not need updating' +
         '(onboardingRebaseCheckbox="$onboardingRebaseCheckbox")',
       async ({ onboardingRebaseCheckbox }) => {
+        /*
+TODO before
+
+
+stdout | lib/workers/repository/onboarding/pr/index.spec.ts > workers/repository/onboarding/pr/index > ensureOnboardingPr() > returns if PR does not need updating(onboardingRebaseCheckbox="false")
+{
+e: '30029ee05ed80b34d2f743afda6e78fe20247a1eedaa9ce6a8070045c229ebfa',
+prBodyHash: '30029ee05ed80b34d2f743afda6e78fe20247a1eedaa9ce6a8070045c229ebfa'
+}
+
+stdout | lib/workers/repository/onboarding/pr/index.spec.ts > workers/repository/onboarding/pr/index > ensureOnboardingPr() > returns if PR does not need updating(onboardingRebaseCheckbox="true")
+{
+e: '6aa71f8cb7b1503b883485c8f5bd564b31923b9c7fa765abe2a7338af40e03b1',
+prBodyHash: '6aa71f8cb7b1503b883485c8f5bd564b31923b9c7fa765abe2a7338af40e03b1'
+}
         const hash =
           '30029ee05ed80b34d2f743afda6e78fe20247a1eedaa9ce6a8070045c229ebfa'; // no rebase checkbox PR hash
+
+*/
+        const hash =
+          '4b0e83aaa5acee225d5b8af756a1f55eb1d3fe70aa5759d03cf708187ebec4df'; // no rebase checkbox PR hash
         config.onboardingRebaseCheckbox = onboardingRebaseCheckbox;
         OnboardingState.prUpdateRequested = true; // case 'false' is tested in "breaks early when onboarding"
         platform.getBranchPr.mockResolvedValue(
@@ -473,6 +492,35 @@ describe('workers/repository/onboarding/pr/index', () => {
       config.requireConfig = 'required';
       await ensureOnboardingPr(config, packageFiles, branches);
       expect(platform.createPr).toHaveBeenCalledTimes(1);
+    });
+
+    describe('the created PR references onboardingConfigFileName', () => {
+      it('when set', async () => {
+        GlobalConfig.set({ onboardingConfigFileName: '.github/renovate.json' });
+        await ensureOnboardingPr(config, packageFiles, branches);
+        expect(platform.createPr.mock.calls[0][0].prBody).toContain(
+          `Add your custom config to \`.github/renovate.json\` in this branch`,
+        );
+        expect(platform.createPr.mock.calls[0][0].prBody).not.toContain(
+          '`renovate.json`',
+        );
+      });
+
+      it('when not set, falls back to "renovate.json"', async () => {
+        GlobalConfig.set({ onboardingConfigFileName: undefined });
+        await ensureOnboardingPr(config, packageFiles, branches);
+        expect(platform.createPr.mock.calls[0][0].prBody).toContain(
+          `Add your custom config to \`renovate.json\` in this branch`,
+        );
+      });
+
+      it('when set, but not a valid filename, falls back to "renovate.json"', async () => {
+        GlobalConfig.set({ onboardingConfigFileName: 'foo.bar' });
+        await ensureOnboardingPr(config, packageFiles, branches);
+        expect(platform.createPr.mock.calls[0][0].prBody).toContain(
+          `Add your custom config to \`renovate.json\` in this branch`,
+        );
+      });
     });
 
     it('dryrun of creates PR', async () => {

--- a/lib/workers/repository/onboarding/pr/index.ts
+++ b/lib/workers/repository/onboarding/pr/index.ts
@@ -148,6 +148,17 @@ export async function ensureOnboardingPr(
       : emojify(
           `:vertical_traffic_light: Renovate will begin keeping your dependencies up-to-date only once you merge or close this Pull Request.\n\n`,
         );
+
+  const configFile = getDefaultConfigFileName();
+  prTemplate += emojify(
+    `:abcd: Do you want to change how Renovate upgrades your dependencies?`,
+  );
+  prTemplate += ` Add your custom config to \`${configFile}\` in this branch${
+    config.onboardingRebaseCheckbox
+      ? ' and select the Retry/Rebase checkbox below'
+      : ''
+  }. Renovate will update the Pull Request description the next time it runs.`;
+  prTemplate += '\n\n';
   // TODO #22198
   prTemplate += emojify(
     `


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
As part of work to improve the Onboarding flow as part of larger repos,
we noticed that the `Add your custom config to ...` comment may be
missed.

We can make this more prominent by moving it up to the top of the PR.

## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/JamieTanna-Mend-testing/damoun-docker-omada-controller/pull/1

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->

### 

[Before](https://redirect.github.com/damoun/docker-omada-controller/pull/180):

<img width="918" height="1586" alt="Screenshot 2026-04-02 at 12 08 16" src="https://github.com/user-attachments/assets/f18c2933-b651-4473-9233-481168dbf93f" />


[After](https://redirect.github.com/JamieTanna-Mend-testing/damoun-docker-omada-controller/pull/1):

<img width="923" height="494" alt="Screenshot 2026-04-02 at 12 13 43" src="https://github.com/user-attachments/assets/4aa86121-ac9e-4955-acd3-b22d6fda0466" />
