### PR TITLE
fix(replacements): don't use current releases for new digest when new name differs

### DIFF
--- a/lib/modules/datasource/types.ts
+++ b/lib/modules/datasource/types.ts
@@ -66,7 +66,7 @@ export interface Release {
   version: string;
   /** The original value to which `extractVersion` was applied */
   versionOrig?: string;
-  newDigest?: string | undefined;
+  newDigest?: string | null;
   constraints?: Record<string, string[]>;
   dependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;

--- a/lib/modules/manager/types.ts
+++ b/lib/modules/manager/types.ts
@@ -97,7 +97,7 @@ export interface LookupUpdate {
   isReplacement?: boolean;
   isSingleVersion?: boolean;
   isVulnerabilityAlert?: boolean;
-  newDigest?: string;
+  newDigest?: string | null;
   newMajor?: number;
   newMinor?: number;
   newPatch?: number;

--- a/lib/modules/manager/types.ts
+++ b/lib/modules/manager/types.ts
@@ -30,7 +30,7 @@ export interface ExtractConfig extends CustomExtractConfig {
   skipInstalls?: boolean | null;
   repository?: string;
   currentDigest?: string;
-  newDigest?: string;
+  newDigest?: string | null;
 }
 
 export interface UpdateArtifactsConfig {
@@ -216,7 +216,7 @@ export interface Upgrade<
   lockFiles?: string[];
   manager?: string;
   name?: string;
-  newDigest?: string;
+  newDigest?: string | null;
   newFrom?: string;
   newMajor?: number;
   newName?: string;

--- a/lib/util/cache/repository/types.ts
+++ b/lib/util/cache/repository/types.ts
@@ -26,7 +26,7 @@ export interface BranchUpgradeCache {
   fixedVersion?: string;
   currentVersion?: string;
   packageName?: string;
-  newDigest?: string;
+  newDigest?: string | null;
   newValue?: string;
   newVersion?: string;
   sourceUrl?: string;

--- a/lib/workers/repository/process/fingerprint-fields.ts
+++ b/lib/workers/repository/process/fingerprint-fields.ts
@@ -2,7 +2,7 @@ import type { UpgradeFingerprintConfig } from '../../types.ts';
 
 type CommitFingerprintFields = keyof UpgradeFingerprintConfig;
 
-export const upgradeFingerprintFields: CommitFingerprintFields[] = [
+export const upgradeFingerprintFields = [
   'autoReplaceStringTemplate',
   'currentDigest',
   'currentValue',
@@ -18,4 +18,4 @@ export const upgradeFingerprintFields: CommitFingerprintFields[] = [
   'newVersion',
   'packageFile',
   'replaceString',
-];
+] as const satisfies CommitFingerprintFields[];

--- a/lib/workers/repository/process/lookup/filter-checks.ts
+++ b/lib/workers/repository/process/lookup/filter-checks.ts
@@ -92,6 +92,7 @@ export async function filterInternalChecks(
           releaseConfig.minimumReleaseAgeBehaviour;
 
         // if there is a releaseTimestamp, regardless of `minimumReleaseAgeBehaviour`, we should process it
+        // v8 ignore else -- TODO: add test #40625
         if (candidateRelease.releaseTimestamp) {
           // we should skip this if we have a timestamp that isn't passing checks:
           if (
@@ -181,6 +182,7 @@ export async function filterInternalChecks(
     }
 
     if (!release) {
+      // v8 ignore else -- TODO: add test #40625
       if (pendingReleases.length) {
         // If all releases were pending then just take the highest
         logger.trace(

--- a/lib/workers/repository/process/lookup/filter.ts
+++ b/lib/workers/repository/process/lookup/filter.ts
@@ -139,9 +139,10 @@ export function filterVersions(
         semver.satisfies(
           semver.valid(r.version)
             ? r.version
-            : /* istanbul ignore next: not reachable, but it's safer to preserve it */ semver.coerce(
+            : /* v8 ignore start: not reachable, but it's safer to preserve it */ semver.coerce(
                 r.version,
               )!,
+          /* v8 ignore stop */
           allowedVersions,
         ),
       );

--- a/lib/workers/repository/process/lookup/index.spec.ts
+++ b/lib/workers/repository/process/lookup/index.spec.ts
@@ -4942,20 +4942,19 @@ describe('workers/repository/process/lookup/index', () => {
       config.datasource = DockerDatasource.id;
       config.versioning = dockerVersioningId;
       config.replacementName = 'eclipse-temurin';
-      config.replacementVersion = '19.0.0';
       getDockerReleases.mockResolvedValueOnce({
         releases: [
           {
             version: '17.0.0',
+            newDigest: 'sha256:fedcba0987654321',
           },
           {
             version: '17.0.1',
+            newDigest: 'sha256:abcdef1234567890',
           },
         ],
         lookupName: 'openjdk',
       });
-      getDockerDigest.mockResolvedValueOnce('sha256:abcdef1234567890');
-      getDockerDigest.mockResolvedValueOnce('sha256:fedcba0987654321');
       getDockerDigest.mockResolvedValueOnce('sha256:pin0987654321');
 
       const { updates } = await Result.wrap(
@@ -4975,49 +4974,21 @@ describe('workers/repository/process/lookup/index', () => {
           updateType: 'patch',
         },
         {
-          newDigest: 'sha256:fedcba0987654321',
-          newName: 'eclipse-temurin',
-          newValue: '19.0.0',
-          newVersion: undefined,
-          updateType: 'replacement',
-        },
-        {
           newDigest: 'sha256:pin0987654321',
+          newName: 'eclipse-temurin',
           newValue: '17.0.0',
           newVersion: undefined,
-          updateType: 'digest',
+          updateType: 'replacement',
         },
       ]);
 
       expect(getDockerDigest).toHaveBeenNthCalledWith(
         1,
         {
-          currentDigest: 'sha256:fedcba0987654321',
-          currentValue: '17.0.0',
-          lookupName: 'openjdk',
-          packageName: 'openjdk',
-          registryUrl: 'https://index.docker.io',
-        },
-        '17.0.1',
-      );
-      expect(getDockerDigest).toHaveBeenNthCalledWith(
-        2,
-        {
           currentDigest: undefined,
           currentValue: '17.0.0',
           lookupName: undefined,
           packageName: 'eclipse-temurin',
-          registryUrl: 'https://index.docker.io',
-        },
-        '19.0.0',
-      );
-      expect(getDockerDigest).toHaveBeenNthCalledWith(
-        3,
-        {
-          currentDigest: 'sha256:fedcba0987654321',
-          currentValue: '17.0.0',
-          lookupName: 'openjdk',
-          packageName: 'openjdk',
           registryUrl: 'https://index.docker.io',
         },
         '17.0.0',

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -93,6 +93,7 @@ export async function lookupUpdates(
     );
     if (config.currentValue && !isString(config.currentValue)) {
       // If currentValue is not a string, then it's invalid
+      // v8 ignore else -- TODO: add test #40625
       if (config.currentValue) {
         logger.debug(
           `Invalid currentValue for ${config.packageName}: ${JSON.stringify(config.currentValue)} (${typeof config.currentValue})`,
@@ -326,6 +327,7 @@ export async function lookupUpdates(
         )!;
 
       if (!currentVersion) {
+        // v8 ignore else -- TODO: add test #40625
         if (!config.lockedVersion) {
           logger.debug(
             `No currentVersion or lockedVersion found for ${config.packageName}`,
@@ -470,6 +472,7 @@ export async function lookupUpdates(
           release.version,
           versioningApi,
         );
+        // v8 ignore else -- TODO: add test #40625
         if (isString(bucket)) {
           if (buckets[bucket]) {
             buckets[bucket].push(release);
@@ -616,6 +619,7 @@ export async function lookupUpdates(
     ) {
       for (const update of res.updates) {
         logger.debug({ update });
+        // v8 ignore else -- TODO: add test #40625
         if (isString(config.currentValue) && isString(update.newValue)) {
           update.newValue = config.currentValue.replace(
             compareValue,
@@ -637,6 +641,7 @@ export async function lookupUpdates(
         }
       } else if (config.pinDigests) {
         // Create a pin only if one doesn't already exists
+        // v8 ignore else -- TODO: add test #40625
         if (!res.updates.some((update) => update.updateType === 'pin')) {
           // pin digest
           res.updates.push({
@@ -649,7 +654,7 @@ export async function lookupUpdates(
       if (versioningApi.valueToVersion) {
         // TODO #22198
         res.currentVersion = versioningApi.valueToVersion(res.currentVersion!);
-        for (const update of res.updates || /* istanbul ignore next*/ []) {
+        for (const update of res.updates) {
           // TODO #22198
           update.newVersion = versioningApi.valueToVersion(update.newVersion!);
         }
@@ -682,11 +687,22 @@ export async function lookupUpdates(
             getDigestConfig.replacementName = update.newName;
           }
 
-          // TODO #22198
-          update.newDigest ??=
-            dependency?.releases.find((r) => r.version === update.newValue)
-              ?.newDigest ??
-            (await getDigest(getDigestConfig, update.newValue))!;
+          // Don't use current releases if replacement changes name, otherwise we use the wrong new digest.
+          // This happens on datasources which return the digest in release info like `github-tags`.
+          // We can still use it when only version is changing.
+          if (
+            update.updateType !== 'replacement' ||
+            update.newName === config.packageName
+          ) {
+            update.newDigest ??= dependency?.releases.find(
+              (r) => r.version === update.newValue,
+            )?.newDigest;
+          }
+
+          update.newDigest ??= await getDigest(
+            getDigestConfig,
+            update.newValue,
+          );
 
           // If the digest could not be determined, report this as otherwise the
           // update will be omitted later on without notice.
@@ -754,8 +770,7 @@ export async function lookupUpdates(
     if (config.rollbackPrs && config.followTag) {
       res.updates = res.updates.filter(
         (update) =>
-          res.updates.length === 1 ||
-          /* istanbul ignore next */ update.updateType !== 'rollback',
+          update.updateType !== 'rollback' || res.updates.length === 1,
       );
     }
 

--- a/lib/workers/repository/process/write.ts
+++ b/lib/workers/repository/process/write.ts
@@ -36,7 +36,8 @@ export function generateCommitFingerprintConfig(
   const res = branch.upgrades.map((upgrade) => {
     const filteredUpgrade = {} as UpgradeFingerprintConfig;
     for (const field of upgradeFingerprintFields) {
-      filteredUpgrade[field] = upgrade[field];
+      // TS cannot narrow the type here
+      filteredUpgrade[field] = upgrade[field]!;
     }
     return filteredUpgrade;
   });

--- a/lib/workers/repository/update/branch/auto-replace.ts
+++ b/lib/workers/repository/update/branch/auto-replace.ts
@@ -209,8 +209,8 @@ async function checkExistingBranch(
  * @returns 1 if `current !== newString` and 0 if they are equal or at least one is undefined.
  */
 function updatedToInt(
-  current: string | undefined,
-  newString: string | undefined,
+  current: string | undefined | null,
+  newString: string | undefined | null,
 ): number {
   if (current && newString && newString !== current) {
     return 1;

--- a/lib/workers/types.ts
+++ b/lib/workers/types.ts
@@ -251,7 +251,7 @@ export interface UpgradeFingerprintConfig {
   lockedVersion?: string;
   manager?: string | null;
   newName?: string;
-  newDigest?: string;
+  newDigest?: string | null;
   newValue?: string;
   newVersion?: string;
   packageFile?: string;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Missing piece in #29164.

We can't use our current release list for new digest when the replacement changes the name.
<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: [<URL>](https://github.com/renovate-reproductions/action-replacments

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
