### PR TITLE
fix: migrate cli params before calling `parseEarlyFlags`

### DIFF
--- a/lib/workers/global/config/parse/cli.spec.ts
+++ b/lib/workers/global/config/parse/cli.spec.ts
@@ -225,5 +225,11 @@ describe('workers/global/config/parse/cli', () => {
       stdoutSpy.mockRestore();
       exitSpy.mockRestore();
     });
+
+    it('does not error when --dry-run is the last argument', () => {
+      expect(() =>
+        cli.parseEarlyFlags([...argv, 'myrepo', '--dry-run']),
+      ).not.toThrow();
+    });
   });
 });

--- a/lib/workers/global/config/parse/cli.ts
+++ b/lib/workers/global/config/parse/cli.ts
@@ -53,13 +53,14 @@ function createProgram(): Command<[string[]]> {
     .on('--help', helpConsole);
 }
 
-export function parseEarlyFlags(input: string[] = process.argv): void {
-  createProgram().allowUnknownOption().allowExcessArguments().parse(input);
-}
-
-export function getConfig(input: string[]): AllConfig {
-  // massage migrated configuration keys
-  const argv = input
+/**
+ * Massage migrated configuration keys.
+ * This must run before any Commander parse call so that
+ * deprecated/bare flags like `--dry-run` (no value) are rewritten
+ * before Commander tries to consume them.
+ */
+function migrateArgs(input: string[]): string[] {
+  return input
     .map((a) =>
       a
         .replace(
@@ -86,6 +87,17 @@ export function getConfig(input: string[]): AllConfig {
         .replace('--recreate-closed', '--recreate-when=always'),
     )
     .filter((a) => !a.startsWith('--git-fs'));
+}
+
+export function parseEarlyFlags(input: string[] = process.argv): void {
+  createProgram()
+    .allowUnknownOption()
+    .allowExcessArguments()
+    .parse(migrateArgs(input));
+}
+
+export function getConfig(input: string[]): AllConfig {
+  const argv = migrateArgs(input);
   const options = getOptions();
 
   const config: Record<string, any> = {};


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- migrate cli params before calling `parseEarlyFlags`
<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #42336 
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
