### PR TITLE
feat(manager/docker-compose): add ability to ignore package based on comment

### DIFF
--- a/lib/modules/manager/docker-compose/extract.spec.ts
+++ b/lib/modules/manager/docker-compose/extract.spec.ts
@@ -229,5 +229,66 @@ describe('modules/manager/docker-compose/extract', () => {
         ],
       });
     });
+
+    it('ignores dependency when skip comment is present', () => {
+      const compose = codeBlock`
+      version: "3"
+      services:
+        nginx:
+          image: quay.io/nginx:0.0.1 #renovate: ignore
+    `;
+      const res = extractPackageFile(compose, '', {});
+      expect(res).toEqual({
+        deps: [
+          {
+            autoReplaceStringTemplate:
+              '{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}',
+            currentDigest: undefined,
+            currentValue: '0.0.1',
+            datasource: 'docker',
+            depName: 'quay.io/nginx',
+            packageName: 'quay.io/nginx',
+            replaceString: 'quay.io/nginx:0.0.1',
+            skipReason: 'ignored',
+          },
+        ],
+      });
+    });
+
+    it('ignores dependency when skip comment is present in fragment', () => {
+      const compose = codeBlock`
+        ---
+        x-shared_setting: &shared_settings
+          image: debian:11 #renovate: ignore
+          # Other shared properties here
+
+        services:
+          service-a:
+            <<: *shared_settings
+            environment:
+              - SERVICE=a
+          service-b:
+            <<: *shared_settings
+            environment:
+              - SERVICE=b
+      `;
+      const res = extractPackageFile(compose, '', {});
+      expect(res).toEqual({
+        deps: [
+          {
+            autoReplaceStringTemplate:
+              '{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}',
+            currentDigest: undefined,
+            currentValue: '11',
+            datasource: 'docker',
+            depName: 'debian',
+            packageName: 'debian',
+            replaceString: 'debian:11',
+            skipReason: 'ignored',
+            versioning: 'debian',
+          },
+        ],
+      });
+    });
   });
 });

--- a/lib/modules/manager/docker-compose/extract.ts
+++ b/lib/modules/manager/docker-compose/extract.ts
@@ -1,7 +1,12 @@
 import { isString, isTruthy } from '@sindresorhus/is';
+import { type Document, type Node, isNode } from 'yaml';
 import { logger } from '../../../logger/index.ts';
+import { isSkipComment } from '../../../util/ignore.ts';
 import { newlineRegex, regEx } from '../../../util/regex.ts';
-import { parseSingleYaml } from '../../../util/yaml.ts';
+import {
+  parseSingleYaml,
+  parseSingleYamlDocument,
+} from '../../../util/yaml.ts';
 import { getDep } from '../dockerfile/extract.ts';
 import type { ExtractConfig, PackageFileContent } from '../types.ts';
 import { DockerComposeFile } from './schema.ts';
@@ -35,11 +40,13 @@ export function extractPackageFile(
 ): PackageFileContent | null {
   logger.debug(`docker-compose.extractPackageFile(${packageFile})`);
   let config: DockerComposeFile;
+  let rawConfig: Document;
   try {
     config = parseSingleYaml(content, {
       customSchema: DockerComposeFile,
       removeTemplates: true,
     });
+    rawConfig = parseSingleYamlDocument(content, { removeTemplates: true });
   } catch (err) {
     logger.debug(
       { err, packageFile },
@@ -60,17 +67,40 @@ export function extractPackageFile(
 
     // Image name/tags for services are only eligible for update if they don't
     // use variables and if the image is not built locally
-    const deps = Object.values(
+    const deps = Object.entries(
       services || /* istanbul ignore next: can never happen */ {},
     )
-      .concat(Object.values(extensions))
-      .filter((service) => isString(service?.image) && !service?.build)
-      .map((service) => {
+      .concat(Object.entries(extensions))
+      .filter(([_, service]) => isString(service?.image) && !service?.build)
+      .map(([serviceName, service]) => {
         const dep = getDep(service.image, true, extractConfig.registryAliases);
         const lineNumber = lineMapper.pluckLineNumber(service.image);
         // istanbul ignore if
         if (!lineNumber) {
           return null;
+        }
+        let comment: string | null | undefined;
+        // covers use cases for...
+        for (const paths of [
+          // fragments and compose v1
+          [serviceName, 'image'],
+          // compose v3
+          ['services', serviceName, 'image'],
+          // compose with extensions
+          ['extensions', serviceName, 'image'],
+        ]) {
+          if (isNode(rawConfig.getIn(paths, true))) {
+            comment = (rawConfig.getIn(paths, true) as Node).comment;
+            break;
+          }
+        }
+
+        if (
+          comment !== undefined &&
+          comment !== null &&
+          isSkipComment(comment.trim())
+        ) {
+          dep.skipReason = 'ignored';
         }
         return dep;
       })


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

This change adds some logic to the [docker-compose](https://docs.renovatebot.com/modules/manager/docker-compose/) manager so that individual service/packages can be skipped using a trailing comment on a service's `image` line.

After a docker-compose file has been successfully parsed, during package extract, it checks for a comment on the raw yaml document associated with the `image` line and sets `skipReason` if it matches the existing `renovate: ignore` format. Example:

```yaml
version: "3"
services:
  nginx:
    image: quay.io/nginx:0.0.1 #renovate: ignore
```

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

It's unclear if this should be documented as the other uses of `renovate: ignore` in [pip_requirements](https://github.com/renovatebot/renovate/blob/main/lib/modules/manager/pip_requirements/extract.ts#L41) and [jenkins](https://github.com/renovatebot/renovate/blob/main/lib/modules/manager/jenkins/extract.ts#L92) do not appear to be documented either.

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
