### PR TITLE
fix(manager/fleet): prevent setting replaceString for OCI chart extraction with registry aliases

### DIFF
--- a/lib/modules/manager/fleet/extract.spec.ts
+++ b/lib/modules/manager/fleet/extract.spec.ts
@@ -1,7 +1,9 @@
 import { codeBlock } from 'common-tags';
 import { Fixtures } from '~test/fixtures.ts';
 import { partial } from '~test/util.ts';
+import { DockerDatasource } from '../../datasource/docker/index.ts';
 import type { ExtractConfig } from '../types.ts';
+import { extractFleetHelmBlock } from './extract.ts';
 import { extractPackageFile } from './index.ts';
 
 const validFleetYaml = Fixtures.get('valid_fleet.yaml');
@@ -129,6 +131,29 @@ kind: Fleet
           },
         ]);
       });
+
+      it('should correctly extract an OCI chart with registryAliases', () => {
+        const sample = {
+          depName: 'registry.example.com/bitnamicharts/redis',
+          packageName: 'registry-1.docker.io/bitnamicharts/redis',
+          currentValue: '18.12.1',
+          depType: 'fleet',
+          datasource: DockerDatasource.id,
+          pinDigests: false,
+          currentDigest: undefined,
+        };
+        const pkg = extractFleetHelmBlock(
+          {
+            version: sample.currentValue,
+            chart: 'oci://registry.example.com/bitnamicharts/redis',
+          },
+          {
+            registryAliases: { 'registry.example.com': 'registry-1.docker.io' },
+          },
+        );
+        expect(pkg).toEqual(sample);
+      });
+
       it('should parse valid configuration with target customization', () => {
         const result = extractPackageFile(
           validFleetYamlWithCustom,

--- a/lib/modules/manager/fleet/extract.ts
+++ b/lib/modules/manager/fleet/extract.ts
@@ -43,7 +43,7 @@ function extractGitRepo(doc: GitRepo): PackageDependency {
   };
 }
 
-function extractFleetHelmBlock(
+export function extractFleetHelmBlock(
   doc: FleetHelmBlock,
   config: ExtractConfig,
 ): PackageDependency {
@@ -65,7 +65,7 @@ function extractFleetHelmBlock(
       false,
       config.registryAliases,
     );
-
+    delete dockerDep.replaceString;
     return {
       ...dockerDep,
       depType: 'fleet',


### PR DESCRIPTION


- https://github.com/renovatebot/renovate/discussions/42479

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

While using getDep from docker library if registryAlias is used replaceString is injected. Which breaks PR creation.
After dependency resolved remove replaceString

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
