### PR TITLE
docs: add Renovate Operator as Kubernetes-native option

### DIFF
--- a/docs/usage/.pages
+++ b/docs/usage/.pages
@@ -51,6 +51,7 @@ nav:
       - 'Security Presets': 'presets-security.md'
       - 'Workaround Presets': 'presets-workarounds.md'
   - All Other:
+      - 'Community Tools': 'community-tools.md'
       - ... | user-stories
       - 'Security and Permissions': 'security-and-permissions.md'
       - 'Merge Confidence': 'merge-confidence.md'

--- a/docs/usage/community-tools.md
+++ b/docs/usage/community-tools.md
@@ -1,0 +1,20 @@
+# Community Tools
+
+This page lists community-maintained tools that extend or complement Renovate.
+These tools are not officially supported by the Renovate team, but may be useful for your workflow.
+
+<!-- prettier-ignore -->
+!!! note
+    If you have a community tool you'd like to add to this page, please open a pull request.
+
+## Renovate Operator (Kubernetes)
+
+The [Renovate Operator](https://github.com/mogenius/renovate-operator) lets you run Renovate on Kubernetes in a native way.
+It wraps the Renovate CLI in a Kubernetes operator and adds features like:
+
+- CRD-based scheduling with declarative cron syntax
+- Parallel execution with configurable concurrency control
+- Auto-discovery of repositories
+- Built-in web dashboard for monitoring and management
+- Webhook API for on-demand runs
+- Prometheus metrics and health checks

--- a/docs/usage/getting-started/running.md
+++ b/docs/usage/getting-started/running.md
@@ -234,3 +234,7 @@ It's also OK to configure the same as a host rule instead, if you prefer that.
 ### Self-hosting examples
 
 For more examples on running Renovate self-hosted, read our [Self-hosted examples](../examples/self-hosting.md) page.
+
+### Community tools
+
+There are also some [community-maintained tools](../community-tools.md) which may help running Renovate.

--- a/readme.md
+++ b/readme.md
@@ -80,6 +80,8 @@ See docs: [Running Renovate](https://docs.renovatebot.com/getting-started/runnin
 
 **Supports: all platforms**
 
+For additional community-maintained options, see the [Community Tools](https://docs.renovatebot.com/community-tools/) page.
+
 ## Docs
 
 ### More about Renovate


### PR DESCRIPTION
## Changes

Add the [Renovate Operator](https://github.com/mogenius/renovate-operator) to the "Other ways to run Renovate" section in the README. This gives users a pointer to a Kubernetes-native approach for self-hosting Renovate.

@viceice you already contributed to the project :-) Thx for that again.

## Context

Please select one of the following:

- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Claude Code (Claude Opus) was used to draft the README addition and create this PR.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository