### PR TITLE
feat(osv): mark malicious packages with `skipReason`s

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2923,7 +2923,7 @@ The entire database is downloaded locally by [renovate-offline](https://github.c
 
 <!-- markdownlint-disable MD001 -->
 
-### Malicious package detection and protection
+#### Malicious package detection and protection
 
 <!-- prettier-ignore -->
 !!! note

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2921,6 +2921,20 @@ Renovate only queries the OSV database for dependencies that use one of these da
 
 The entire database is downloaded locally by [renovate-offline](https://github.com/renovatebot/osv-offline) and queried offline.
 
+<!-- markdownlint-disable MD001 -->
+
+### Malicious package detection and protection
+
+<!-- prettier-ignore -->
+!!! note
+    This functionality is currently experimental, being actively worked on, and will soon be available for usage outside of `osvVulnerabilityAlerts`.
+
+If Renovate detects a malicious dependency using data from OSV, it will surface this in log warnings, and prevent PRs from being created.
+
+If you currently have a dependency that is using a malicious version, Renovate will report this via a warning log.
+
+If Renovate finds a dependency update available, and that dependency update is found to be malicious, Renovate will skip **any updates to the dependency**, marking it with `skipReason: malicious-update-proposed`, and report this via a warning log.
+
 ## packageRules
 
 `packageRules` is a powerful feature that lets you apply rules to individual packages or to groups of packages using regex pattern matching.

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2935,6 +2935,8 @@ If you currently have a dependency that is using a malicious version, Renovate w
 
 If Renovate finds a dependency update available, and that dependency update is found to be malicious, Renovate will skip **any updates to the dependency**, marking it with `skipReason: malicious-update-proposed`, and report this via a warning log.
 
+<!-- markdownlint-enable MD001 -->
+
 ## packageRules
 
 `packageRules` is a powerful feature that lets you apply rules to individual packages or to groups of packages using regex pattern matching.

--- a/lib/workers/repository/process/extract-update.spec.ts
+++ b/lib/workers/repository/process/extract-update.spec.ts
@@ -6,7 +6,6 @@ import { fingerprint } from '../../../util/fingerprint.ts';
 import type { LongCommitSha } from '../../../util/git/types.ts';
 import { generateFingerprintConfig } from '../extract/extract-fingerprint-config.ts';
 import * as _branchify from '../updates/branchify.ts';
-import * as _fetch from './fetch.ts';
 import {
   EXTRACT_CACHE_REVISION,
   extract,
@@ -36,7 +35,6 @@ vi.mock('../../../util/cache/repository/index.ts');
 
 const branchify = vi.mocked(_branchify);
 const repositoryCache = vi.mocked(_repositoryCache);
-const fetch = vi.mocked(_fetch);
 
 describe('workers/repository/process/extract-update', () => {
   beforeEach(() => {
@@ -119,16 +117,14 @@ describe('workers/repository/process/extract-update', () => {
       expect(res).toEqual(packageFiles);
     });
 
-    it('fetches vulnerabilities and flags malicious packages', async () => {
+    it('fetches vulnerabilities', async () => {
       const config = {
         repoIsOnboarded: true,
         osvVulnerabilityAlerts: true,
       };
       const appendVulnerabilityPackageRulesMock = vi.fn();
-      const flagMaliciousPackagesMock = vi.fn();
-      createVulnerabilitiesMock.mockResolvedValue({
+      createVulnerabilitiesMock.mockResolvedValueOnce({
         appendVulnerabilityPackageRules: appendVulnerabilityPackageRulesMock,
-        flagMaliciousPackages: flagMaliciousPackagesMock,
       });
       repositoryCache.getCache.mockReturnValueOnce({ scan: {} });
       scm.checkoutBranch.mockResolvedValueOnce('123test' as LongCommitSha);
@@ -136,17 +132,10 @@ describe('workers/repository/process/extract-update', () => {
       const packageFiles = await extract(config);
       await lookup(config, packageFiles);
 
-      expect(createVulnerabilitiesMock).toHaveBeenCalledTimes(2);
+      expect(createVulnerabilitiesMock).toHaveBeenCalledExactlyOnceWith();
       expect(
         appendVulnerabilityPackageRulesMock,
       ).toHaveBeenCalledExactlyOnceWith(
-        {
-          repoIsOnboarded: true,
-          osvVulnerabilityAlerts: true,
-        },
-        undefined,
-      );
-      expect(flagMaliciousPackagesMock).toHaveBeenCalledExactlyOnceWith(
         {
           repoIsOnboarded: true,
           osvVulnerabilityAlerts: true,
@@ -160,14 +149,14 @@ describe('workers/repository/process/extract-update', () => {
         repoIsOnboarded: true,
         osvVulnerabilityAlerts: true,
       };
-      createVulnerabilitiesMock.mockRejectedValue(new Error());
+      createVulnerabilitiesMock.mockRejectedValueOnce(new Error());
       repositoryCache.getCache.mockReturnValueOnce({ scan: {} });
       scm.checkoutBranch.mockResolvedValueOnce('123test' as LongCommitSha);
 
       const packageFiles = await extract(config);
       await lookup(config, packageFiles);
 
-      expect(createVulnerabilitiesMock).toHaveBeenCalledTimes(2);
+      expect(createVulnerabilitiesMock).toHaveBeenCalledExactlyOnceWith();
     });
 
     describe('when skipReason=malicious-version-in-use', () => {
@@ -273,7 +262,7 @@ describe('workers/repository/process/extract-update', () => {
       });
     });
 
-    it('when skipReason=malicious-update-proposed, it logs a warning for each skipReason', async () => {
+    it('when skipReason=malicious-version-in-use, it logs a warning for each skipReason', async () => {
       const packageFiles: Record<string, PackageFile[]> = {
         npm: [
           {
@@ -343,65 +332,6 @@ describe('workers/repository/process/extract-update', () => {
         },
         'Dependency axios has update(s) proposed which would update you to a malicious version - skipping',
       );
-    });
-
-    it('flags malicious packages after updates have been fetched, so that proposed malicious updates can be detected', async () => {
-      const packageFiles: Record<string, PackageFile[]> = {
-        npm: [
-          {
-            deps: [
-              {
-                depType: 'devDependencies',
-                depName: 'axios',
-                currentValue: '1.14.0',
-                datasource: 'npm',
-                prettyDepType: 'devDependency',
-                lockedVersion: '1.14.0',
-                packageName: 'axios',
-              },
-            ],
-            packageFile: 'package.json',
-          },
-        ],
-      };
-
-      const config = {
-        repoIsOnboarded: true,
-        baseBranch: 'main',
-        osvVulnerabilityAlerts: true,
-      };
-
-      // Simulate fetchUpdates populating `updates` on each dep,
-      // the way the real implementation does.
-      fetch.fetchUpdates.mockImplementation(async (_config, pkgs) => {
-        for (const files of Object.values(pkgs!)) {
-          for (const file of files) {
-            for (const dep of file.deps) {
-              dep.updates = [{ newVersion: '1.14.1' }];
-            }
-          }
-        }
-      });
-
-      // Capture what the malicious-package flagging step sees when it runs.
-      let depsSeenByFlagMalicious: any;
-      const appendVulnerabilityPackageRulesMock = vi.fn();
-      const flagMaliciousPackagesMock = vi.fn(
-        async (_config: any, pkgs: any) => {
-          depsSeenByFlagMalicious = structuredClone(pkgs.npm[0].deps);
-        },
-      );
-      createVulnerabilitiesMock.mockResolvedValue({
-        appendVulnerabilityPackageRules: appendVulnerabilityPackageRulesMock,
-        flagMaliciousPackages: flagMaliciousPackagesMock,
-      });
-
-      await lookup(config, packageFiles);
-
-      expect(flagMaliciousPackagesMock).toHaveBeenCalled();
-      expect(depsSeenByFlagMalicious[0].updates).toEqual([
-        { newVersion: '1.14.1' },
-      ]);
     });
   });
 

--- a/lib/workers/repository/process/extract-update.spec.ts
+++ b/lib/workers/repository/process/extract-update.spec.ts
@@ -212,7 +212,7 @@ describe('workers/repository/process/extract-update', () => {
 
           // the first time, we're checking what updates are available, so don't modify anything
           appendVulnerabilityPackageRulesMock.mockImplementationOnce(
-            (
+            async (
               config: any,
               packageFiles: Record<string, PackageFile[]>,
             ): Promise<void> => {
@@ -221,7 +221,7 @@ describe('workers/repository/process/extract-update', () => {
           );
 
           fetch.fetchUpdates.mockImplementation(
-            (
+            async (
               config: any,
               packageFiles: Record<string, PackageFile[]>,
             ): Promise<void> => {
@@ -234,12 +234,12 @@ describe('workers/repository/process/extract-update', () => {
 
           // the next itme we
           appendVulnerabilityPackageRulesMock.mockImplementationOnce(
-            (
+            async (
               config: any,
               packageFiles: Record<string, PackageFile[]>,
             ): Promise<void> => {
               if (
-                packageFiles.npm[0].deps[0].updates[0].newVersion === '1.14.1'
+                packageFiles.npm[0].deps[0].updates[0]?.newVersion === '1.14.1'
               ) {
                 packageFiles.npm[0].deps[0].skipReason =
                   'malicious-update-proposed';

--- a/lib/workers/repository/process/extract-update.spec.ts
+++ b/lib/workers/repository/process/extract-update.spec.ts
@@ -13,6 +13,7 @@ import {
   lookup,
   update,
 } from './extract-update.ts';
+import * as _fetch from './fetch.ts';
 
 const createVulnerabilitiesMock = vi.fn();
 
@@ -35,6 +36,7 @@ vi.mock('../../../util/cache/repository/index.ts');
 
 const branchify = vi.mocked(_branchify);
 const repositoryCache = vi.mocked(_repositoryCache);
+const fetch = vi.mocked(_fetch);
 
 describe('workers/repository/process/extract-update', () => {
   beforeEach(() => {
@@ -159,179 +161,282 @@ describe('workers/repository/process/extract-update', () => {
       expect(createVulnerabilitiesMock).toHaveBeenCalledExactlyOnceWith();
     });
 
-    describe('when skipReason=malicious-version-in-use', () => {
-      it('logs a warning', async () => {
-        const packageFiles: Record<string, PackageFile[]> = {
-          npm: [
-            {
-              deps: [
-                {
-                  depType: 'devDependencies',
-                  depName: 'axios',
-                  currentValue: '1.14.1',
-                  datasource: 'npm',
-                  prettyDepType: 'devDependency',
-                  lockedVersion: '1.14.1',
-                  updates: [],
-                  packageName: 'axios',
-
-                  // most importantly
-                  skipReason: 'malicious-version-in-use',
-                },
-                // not malicious
-                {
-                  depType: 'devDependencies',
-                  depName: 'axios',
-                  currentValue: '1.14.0',
-                  datasource: 'npm',
-                  prettyDepType: 'devDependency',
-                  lockedVersion: '1.14.0',
-                  updates: [],
-                  packageName: 'axios',
-                },
-              ],
-              packageFile: 'package.json',
-            },
-          ],
-        };
-
-        const config = {
-          repoIsOnboarded: true,
-          baseBranch: 'main',
-        };
-
-        await lookup(config, packageFiles);
-
-        expect(logger.logger.warn).toHaveBeenCalledWith(
-          {
-            packageFile: 'package.json',
-            depName: 'axios',
-            packageName: 'axios',
-            manager: 'npm',
-            datasource: 'npm',
-          },
-          'Dependency axios is currently using a malicious version',
-        );
-      });
-
-      it('deletes the skipReason and skipStage, to allow the update phase to continue updating', async () => {
-        const packageFiles: Record<string, PackageFile[]> = {
-          npm: [
-            {
-              deps: [
-                {
-                  depType: 'devDependencies',
-                  depName: 'axios',
-                  currentValue: '1.14.1',
-                  datasource: 'npm',
-                  prettyDepType: 'devDependency',
-                  lockedVersion: '1.14.1',
-                  updates: [],
-                  packageName: 'axios',
-
-                  // most importantly
-                  skipReason: 'malicious-version-in-use',
-                  skipStage: 'lookup',
-                },
-                // not malicious
-                {
-                  depType: 'devDependencies',
-                  depName: 'axios',
-                  currentValue: '1.14.0',
-                  datasource: 'npm',
-                  prettyDepType: 'devDependency',
-                  lockedVersion: '1.14.0',
-                  updates: [],
-                  packageName: 'axios',
-                },
-              ],
-              packageFile: 'package.json',
-            },
-          ],
-        };
-
-        const config = {
-          repoIsOnboarded: true,
-          baseBranch: 'main',
-        };
-
-        await lookup(config, packageFiles);
-
-        expect(packageFiles.npm[0].deps[0].skipReason).toBeUndefined();
-        expect(packageFiles.npm[0].deps[0].skipStage).toBeUndefined();
-      });
-    });
-
-    it('when skipReason=malicious-version-in-use, it logs a warning for each skipReason', async () => {
-      const packageFiles: Record<string, PackageFile[]> = {
-        npm: [
-          {
-            deps: [
+    describe('malicious package detection', () => {
+      // this follows how the calls should actually work, but as it's heavily mocked, this may end up changing from actual behaviour
+      describe('when using mocks', () => {
+        it('skips malicious package updates', async () => {
+          const packageFiles: Record<string, PackageFile[]> = {
+            npm: [
               {
-                depType: 'devDependencies',
-                depName: 'axios',
-                currentValue: '1.14.0',
-                datasource: 'npm',
-                prettyDepType: 'devDependency',
-                lockedVersion: '1.14.0',
-                updates: [
+                deps: [
+                  // has a malicious update
                   {
-                    newVersion: '1.14.1',
+                    depType: 'devDependencies',
+                    depName: 'axios',
+                    currentValue: '1.14.0',
+                    datasource: 'npm',
+                    prettyDepType: 'devDependency',
+                    lockedVersion: '1.14.0',
+                    updates: [
+                      // will be populated by our mock
+                    ],
+                    packageName: 'axios',
                   },
+                  // not malicious
                   {
-                    // unrelated, using newValue
-                    newValue: '1.14.2',
-                  },
-                  {
-                    // unrelated
-                    newVersion: '2.0.0',
-                  },
-                  {
-                    // doesn't have a newVersion or newValue
-                    updateType: 'digest',
-                    newDigest: '1234',
+                    depType: 'devDependencies',
+                    depName: 'axios',
+                    currentValue: '1.14.0',
+                    datasource: 'npm',
+                    prettyDepType: 'devDependency',
+                    lockedVersion: '1.14.0',
+                    updates: [],
+                    packageName: 'axios',
                   },
                 ],
-                packageName: 'axios',
-
-                // most importantly
-                skipReason: 'malicious-update-proposed',
-              },
-              // not malicious
-              {
-                depType: 'devDependencies',
-                depName: 'axios',
-                currentValue: '1.14.0',
-                datasource: 'npm',
-                prettyDepType: 'devDependency',
-                lockedVersion: '1.14.0',
-                updates: [],
-                packageName: 'axios',
+                packageFile: 'package.json',
               },
             ],
-            packageFile: 'package.json',
-          },
-        ],
-      };
+          };
 
-      const config = {
-        repoIsOnboarded: true,
-        baseBranch: 'main',
-      };
+          const config = {
+            repoIsOnboarded: true,
+            baseBranch: 'main',
+            osvVulnerabilityAlerts: true,
+          };
+          const appendVulnerabilityPackageRulesMock = vi.fn();
+          createVulnerabilitiesMock.mockResolvedValue({
+            appendVulnerabilityPackageRules:
+              appendVulnerabilityPackageRulesMock,
+          });
 
-      await lookup(config, packageFiles);
+          // the first time, we're checking what updates are available, so don't modify anything
+          appendVulnerabilityPackageRulesMock.mockImplementationOnce(
+            (
+              config: any,
+              packageFiles: Record<string, PackageFile[]>,
+            ): Promise<void> => {
+              // no-op
+            },
+          );
 
-      expect(logger.logger.warn).toHaveBeenCalledWith(
-        {
-          packageFile: 'package.json',
-          depName: 'axios',
-          packageName: 'axios',
-          manager: 'npm',
-          datasource: 'npm',
-          newVersions: ['1.14.1', '1.14.2', '2.0.0'],
-        },
-        'Dependency axios has update(s) proposed which would update you to a malicious version - skipping',
-      );
+          fetch.fetchUpdates.mockImplementation(
+            (
+              config: any,
+              packageFiles: Record<string, PackageFile[]>,
+            ): Promise<void> => {
+              packageFiles.npm[0].deps[0].updates = [
+                // MAL-2026-2307
+                { newVersion: '1.14.1' },
+              ];
+            },
+          );
+
+          // the next itme we
+          appendVulnerabilityPackageRulesMock.mockImplementationOnce(
+            (
+              config: any,
+              packageFiles: Record<string, PackageFile[]>,
+            ): Promise<void> => {
+              if (
+                packageFiles.npm[0].deps[0].updates[0].newVersion === '1.14.1'
+              ) {
+                packageFiles.npm[0].deps[0].skipReason =
+                  'malicious-update-proposed';
+              }
+            },
+          );
+
+          await lookup(config, packageFiles);
+
+          expect(fetch.fetchUpdates).toHaveBeenCalled();
+          expect(appendVulnerabilityPackageRulesMock).toHaveBeenCalledTimes(2);
+
+          expect(packageFiles.npm).toHaveLength(1);
+          expect(packageFiles.npm[0].deps).toHaveLength(2);
+          expect(packageFiles.npm[0].deps[0].skipReason).toEqual(
+            'malicious-update-proposed',
+          );
+        });
+      });
+
+      // this
+      describe('when manually specifying the `skipReason`s', () => {
+        describe('when skipReason=malicious-version-in-use', () => {
+          it('logs a warning', async () => {
+            const packageFiles: Record<string, PackageFile[]> = {
+              npm: [
+                {
+                  deps: [
+                    {
+                      depType: 'devDependencies',
+                      depName: 'axios',
+                      currentValue: '1.14.1',
+                      datasource: 'npm',
+                      prettyDepType: 'devDependency',
+                      lockedVersion: '1.14.1',
+                      updates: [],
+                      packageName: 'axios',
+
+                      // most importantly
+                      skipReason: 'malicious-version-in-use',
+                    },
+                    // not malicious
+                    {
+                      depType: 'devDependencies',
+                      depName: 'axios',
+                      currentValue: '1.14.0',
+                      datasource: 'npm',
+                      prettyDepType: 'devDependency',
+                      lockedVersion: '1.14.0',
+                      updates: [],
+                      packageName: 'axios',
+                    },
+                  ],
+                  packageFile: 'package.json',
+                },
+              ],
+            };
+
+            const config = {
+              repoIsOnboarded: true,
+              baseBranch: 'main',
+            };
+
+            await lookup(config, packageFiles);
+
+            expect(logger.logger.warn).toHaveBeenCalledWith(
+              {
+                packageFile: 'package.json',
+                depName: 'axios',
+                packageName: 'axios',
+                manager: 'npm',
+                datasource: 'npm',
+              },
+              'Dependency axios is currently using a malicious version',
+            );
+          });
+
+          it('deletes the skipReason and skipStage, to allow the update phase to continue updating', async () => {
+            const packageFiles: Record<string, PackageFile[]> = {
+              npm: [
+                {
+                  deps: [
+                    {
+                      depType: 'devDependencies',
+                      depName: 'axios',
+                      currentValue: '1.14.1',
+                      datasource: 'npm',
+                      prettyDepType: 'devDependency',
+                      lockedVersion: '1.14.1',
+                      updates: [],
+                      packageName: 'axios',
+
+                      // most importantly
+                      skipReason: 'malicious-version-in-use',
+                      skipStage: 'lookup',
+                    },
+                    // not malicious
+                    {
+                      depType: 'devDependencies',
+                      depName: 'axios',
+                      currentValue: '1.14.0',
+                      datasource: 'npm',
+                      prettyDepType: 'devDependency',
+                      lockedVersion: '1.14.0',
+                      updates: [],
+                      packageName: 'axios',
+                    },
+                  ],
+                  packageFile: 'package.json',
+                },
+              ],
+            };
+
+            const config = {
+              repoIsOnboarded: true,
+              baseBranch: 'main',
+            };
+
+            await lookup(config, packageFiles);
+
+            expect(packageFiles.npm[0].deps[0].skipReason).toBeUndefined();
+            expect(packageFiles.npm[0].deps[0].skipStage).toBeUndefined();
+          });
+        });
+
+        it('when skipReason=malicious-version-in-use, it logs a warning for each skipReason', async () => {
+          const packageFiles: Record<string, PackageFile[]> = {
+            npm: [
+              {
+                deps: [
+                  {
+                    depType: 'devDependencies',
+                    depName: 'axios',
+                    currentValue: '1.14.0',
+                    datasource: 'npm',
+                    prettyDepType: 'devDependency',
+                    lockedVersion: '1.14.0',
+                    updates: [
+                      {
+                        newVersion: '1.14.1',
+                      },
+                      {
+                        // unrelated, using newValue
+                        newValue: '1.14.2',
+                      },
+                      {
+                        // unrelated
+                        newVersion: '2.0.0',
+                      },
+                      {
+                        // doesn't have a newVersion or newValue
+                        updateType: 'digest',
+                        newDigest: '1234',
+                      },
+                    ],
+                    packageName: 'axios',
+
+                    // most importantly
+                    skipReason: 'malicious-update-proposed',
+                  },
+                  // not malicious
+                  {
+                    depType: 'devDependencies',
+                    depName: 'axios',
+                    currentValue: '1.14.0',
+                    datasource: 'npm',
+                    prettyDepType: 'devDependency',
+                    lockedVersion: '1.14.0',
+                    updates: [],
+                    packageName: 'axios',
+                  },
+                ],
+                packageFile: 'package.json',
+              },
+            ],
+          };
+
+          const config = {
+            repoIsOnboarded: true,
+            baseBranch: 'main',
+          };
+
+          await lookup(config, packageFiles);
+
+          expect(logger.logger.warn).toHaveBeenCalledWith(
+            {
+              packageFile: 'package.json',
+              depName: 'axios',
+              packageName: 'axios',
+              manager: 'npm',
+              datasource: 'npm',
+              newVersions: ['1.14.1', '1.14.2', '2.0.0'],
+            },
+            'Dependency axios has update(s) proposed which would update you to a malicious version - skipping',
+          );
+        });
+      });
     });
   });
 

--- a/lib/workers/repository/process/extract-update.spec.ts
+++ b/lib/workers/repository/process/extract-update.spec.ts
@@ -6,6 +6,7 @@ import { fingerprint } from '../../../util/fingerprint.ts';
 import type { LongCommitSha } from '../../../util/git/types.ts';
 import { generateFingerprintConfig } from '../extract/extract-fingerprint-config.ts';
 import * as _branchify from '../updates/branchify.ts';
+import * as _fetch from './fetch.ts';
 import {
   EXTRACT_CACHE_REVISION,
   extract,
@@ -35,6 +36,7 @@ vi.mock('../../../util/cache/repository/index.ts');
 
 const branchify = vi.mocked(_branchify);
 const repositoryCache = vi.mocked(_repositoryCache);
+const fetch = vi.mocked(_fetch);
 
 describe('workers/repository/process/extract-update', () => {
   beforeEach(() => {
@@ -117,14 +119,16 @@ describe('workers/repository/process/extract-update', () => {
       expect(res).toEqual(packageFiles);
     });
 
-    it('fetches vulnerabilities', async () => {
+    it('fetches vulnerabilities and flags malicious packages', async () => {
       const config = {
         repoIsOnboarded: true,
         osvVulnerabilityAlerts: true,
       };
       const appendVulnerabilityPackageRulesMock = vi.fn();
-      createVulnerabilitiesMock.mockResolvedValueOnce({
+      const flagMaliciousPackagesMock = vi.fn();
+      createVulnerabilitiesMock.mockResolvedValue({
         appendVulnerabilityPackageRules: appendVulnerabilityPackageRulesMock,
+        flagMaliciousPackages: flagMaliciousPackagesMock,
       });
       repositoryCache.getCache.mockReturnValueOnce({ scan: {} });
       scm.checkoutBranch.mockResolvedValueOnce('123test' as LongCommitSha);
@@ -132,10 +136,17 @@ describe('workers/repository/process/extract-update', () => {
       const packageFiles = await extract(config);
       await lookup(config, packageFiles);
 
-      expect(createVulnerabilitiesMock).toHaveBeenCalledExactlyOnceWith();
+      expect(createVulnerabilitiesMock).toHaveBeenCalledTimes(2);
       expect(
         appendVulnerabilityPackageRulesMock,
       ).toHaveBeenCalledExactlyOnceWith(
+        {
+          repoIsOnboarded: true,
+          osvVulnerabilityAlerts: true,
+        },
+        undefined,
+      );
+      expect(flagMaliciousPackagesMock).toHaveBeenCalledExactlyOnceWith(
         {
           repoIsOnboarded: true,
           osvVulnerabilityAlerts: true,
@@ -149,14 +160,14 @@ describe('workers/repository/process/extract-update', () => {
         repoIsOnboarded: true,
         osvVulnerabilityAlerts: true,
       };
-      createVulnerabilitiesMock.mockRejectedValueOnce(new Error());
+      createVulnerabilitiesMock.mockRejectedValue(new Error());
       repositoryCache.getCache.mockReturnValueOnce({ scan: {} });
       scm.checkoutBranch.mockResolvedValueOnce('123test' as LongCommitSha);
 
       const packageFiles = await extract(config);
       await lookup(config, packageFiles);
 
-      expect(createVulnerabilitiesMock).toHaveBeenCalledExactlyOnceWith();
+      expect(createVulnerabilitiesMock).toHaveBeenCalledTimes(2);
     });
 
     describe('when skipReason=malicious-version-in-use', () => {
@@ -262,7 +273,7 @@ describe('workers/repository/process/extract-update', () => {
       });
     });
 
-    it('when skipReason=malicious-version-in-use, it logs a warning for each skipReason', async () => {
+    it('when skipReason=malicious-update-proposed, it logs a warning for each skipReason', async () => {
       const packageFiles: Record<string, PackageFile[]> = {
         npm: [
           {
@@ -332,6 +343,65 @@ describe('workers/repository/process/extract-update', () => {
         },
         'Dependency axios has update(s) proposed which would update you to a malicious version - skipping',
       );
+    });
+
+    it('flags malicious packages after updates have been fetched, so that proposed malicious updates can be detected', async () => {
+      const packageFiles: Record<string, PackageFile[]> = {
+        npm: [
+          {
+            deps: [
+              {
+                depType: 'devDependencies',
+                depName: 'axios',
+                currentValue: '1.14.0',
+                datasource: 'npm',
+                prettyDepType: 'devDependency',
+                lockedVersion: '1.14.0',
+                packageName: 'axios',
+              },
+            ],
+            packageFile: 'package.json',
+          },
+        ],
+      };
+
+      const config = {
+        repoIsOnboarded: true,
+        baseBranch: 'main',
+        osvVulnerabilityAlerts: true,
+      };
+
+      // Simulate fetchUpdates populating `updates` on each dep,
+      // the way the real implementation does.
+      fetch.fetchUpdates.mockImplementation(async (_config, pkgs) => {
+        for (const files of Object.values(pkgs!)) {
+          for (const file of files) {
+            for (const dep of file.deps) {
+              dep.updates = [{ newVersion: '1.14.1' }];
+            }
+          }
+        }
+      });
+
+      // Capture what the malicious-package flagging step sees when it runs.
+      let depsSeenByFlagMalicious: any;
+      const appendVulnerabilityPackageRulesMock = vi.fn();
+      const flagMaliciousPackagesMock = vi.fn(
+        async (_config: any, pkgs: any) => {
+          depsSeenByFlagMalicious = structuredClone(pkgs.npm[0].deps);
+        },
+      );
+      createVulnerabilitiesMock.mockResolvedValue({
+        appendVulnerabilityPackageRules: appendVulnerabilityPackageRulesMock,
+        flagMaliciousPackages: flagMaliciousPackagesMock,
+      });
+
+      await lookup(config, packageFiles);
+
+      expect(flagMaliciousPackagesMock).toHaveBeenCalled();
+      expect(depsSeenByFlagMalicious[0].updates).toEqual([
+        { newVersion: '1.14.1' },
+      ]);
     });
   });
 

--- a/lib/workers/repository/process/extract-update.spec.ts
+++ b/lib/workers/repository/process/extract-update.spec.ts
@@ -238,8 +238,9 @@ describe('workers/repository/process/extract-update', () => {
               config: any,
               packageFiles: Record<string, PackageFile[]>,
             ): Promise<void> => {
-              if (
-                packageFiles.npm[0].deps[0].updates[0]?.newVersion === '1.14.1'
+              const updates = packageFiles?.npm[0]?.deps[0]?.updates
+
+              if (updates && updates[0]?.newVersion === '1.14.1'
               ) {
                 packageFiles.npm[0].deps[0].skipReason =
                   'malicious-update-proposed';

--- a/lib/workers/repository/process/extract-update.spec.ts
+++ b/lib/workers/repository/process/extract-update.spec.ts
@@ -125,7 +125,7 @@ describe('workers/repository/process/extract-update', () => {
         osvVulnerabilityAlerts: true,
       };
       const appendVulnerabilityPackageRulesMock = vi.fn();
-      createVulnerabilitiesMock.mockResolvedValueOnce({
+      createVulnerabilitiesMock.mockResolvedValue({
         appendVulnerabilityPackageRules: appendVulnerabilityPackageRulesMock,
       });
       repositoryCache.getCache.mockReturnValueOnce({ scan: {} });
@@ -134,16 +134,8 @@ describe('workers/repository/process/extract-update', () => {
       const packageFiles = await extract(config);
       await lookup(config, packageFiles);
 
-      expect(createVulnerabilitiesMock).toHaveBeenCalledExactlyOnceWith();
-      expect(
-        appendVulnerabilityPackageRulesMock,
-      ).toHaveBeenCalledExactlyOnceWith(
-        {
-          repoIsOnboarded: true,
-          osvVulnerabilityAlerts: true,
-        },
-        undefined,
-      );
+      expect(createVulnerabilitiesMock).toHaveBeenCalledTimes(2);
+      expect(appendVulnerabilityPackageRulesMock).toHaveBeenCalledTimes(2);
     });
 
     it('handles exception when fetching vulnerabilities', async () => {
@@ -158,7 +150,7 @@ describe('workers/repository/process/extract-update', () => {
       const packageFiles = await extract(config);
       await lookup(config, packageFiles);
 
-      expect(createVulnerabilitiesMock).toHaveBeenCalledExactlyOnceWith();
+      expect(createVulnerabilitiesMock).toHaveBeenCalledTimes(2);
     });
 
     describe('malicious package detection', () => {
@@ -213,38 +205,38 @@ describe('workers/repository/process/extract-update', () => {
           // the first time, we're checking what updates are available, so don't modify anything
           appendVulnerabilityPackageRulesMock.mockImplementationOnce(
             async (
-              config: any,
-              packageFiles: Record<string, PackageFile[]>,
+              _config: any,
+              _packageFiles: Record<string, PackageFile[]>,
             ): Promise<void> => {
               // no-op
             },
           );
 
           fetch.fetchUpdates.mockImplementation(
-            async (
-              config: any,
+            (
+              _config: any,
               packageFiles: Record<string, PackageFile[]>,
             ): Promise<void> => {
               packageFiles.npm[0].deps[0].updates = [
                 // MAL-2026-2307
                 { newVersion: '1.14.1' },
               ];
+              return Promise.resolve();
             },
           );
 
-          // the next itme we
           appendVulnerabilityPackageRulesMock.mockImplementationOnce(
-            async (
-              config: any,
+            (
+              _config: any,
               packageFiles: Record<string, PackageFile[]>,
             ): Promise<void> => {
-              const updates = packageFiles?.npm[0]?.deps[0]?.updates
+              const updates = packageFiles?.npm[0]?.deps[0]?.updates;
 
-              if (updates && updates[0]?.newVersion === '1.14.1'
-              ) {
+              if (updates && updates[0]?.newVersion === '1.14.1') {
                 packageFiles.npm[0].deps[0].skipReason =
                   'malicious-update-proposed';
               }
+              return Promise.resolve();
             },
           );
 

--- a/lib/workers/repository/process/extract-update.ts
+++ b/lib/workers/repository/process/extract-update.ts
@@ -225,19 +225,35 @@ async function fetchVulnerabilities(
   }
 }
 
+async function flagMaliciousPackages(
+  config: RenovateConfig,
+  packageFiles: Record<string, PackageFile[]>,
+): Promise<void> {
+  if (config.osvVulnerabilityAlerts) {
+    logger.debug('flagMaliciousPackages() - osvVulnerabilityAlerts=true');
+    try {
+      const vulnerabilities = await Vulnerabilities.create();
+      await vulnerabilities.flagMaliciousPackages(config, packageFiles);
+    } catch (err) {
+      logger.warn({ err }, 'Unable to flag malicious packages');
+    }
+  }
+}
+
 export async function lookup(
   config: RenovateConfig,
   packageFiles: Record<string, PackageFile[]>,
 ): Promise<ExtractResult> {
   await fetchVulnerabilities(config, packageFiles);
   await fetchUpdates(config, packageFiles);
+  await flagMaliciousPackages(config, packageFiles);
+  reportMaliciousSkippedDependencies(packageFiles);
   memCache.cleanDatasourceKeys();
   calculateLibYears(config, packageFiles);
   const { branches, branchList } = await branchifyUpgrades(
     config,
     packageFiles,
   );
-  reportMaliciousSkippedDependencies(packageFiles);
   logger.debug(
     { baseBranch: config.baseBranch, config: packageFiles },
     'packageFiles with updates',

--- a/lib/workers/repository/process/extract-update.ts
+++ b/lib/workers/repository/process/extract-update.ts
@@ -225,35 +225,19 @@ async function fetchVulnerabilities(
   }
 }
 
-async function flagMaliciousPackages(
-  config: RenovateConfig,
-  packageFiles: Record<string, PackageFile[]>,
-): Promise<void> {
-  if (config.osvVulnerabilityAlerts) {
-    logger.debug('flagMaliciousPackages() - osvVulnerabilityAlerts=true');
-    try {
-      const vulnerabilities = await Vulnerabilities.create();
-      await vulnerabilities.flagMaliciousPackages(config, packageFiles);
-    } catch (err) {
-      logger.warn({ err }, 'Unable to flag malicious packages');
-    }
-  }
-}
-
 export async function lookup(
   config: RenovateConfig,
   packageFiles: Record<string, PackageFile[]>,
 ): Promise<ExtractResult> {
   await fetchVulnerabilities(config, packageFiles);
   await fetchUpdates(config, packageFiles);
-  await flagMaliciousPackages(config, packageFiles);
-  reportMaliciousSkippedDependencies(packageFiles);
   memCache.cleanDatasourceKeys();
   calculateLibYears(config, packageFiles);
   const { branches, branchList } = await branchifyUpgrades(
     config,
     packageFiles,
   );
+  reportMaliciousSkippedDependencies(packageFiles);
   logger.debug(
     { baseBranch: config.baseBranch, config: packageFiles },
     'packageFiles with updates',

--- a/lib/workers/repository/process/extract-update.ts
+++ b/lib/workers/repository/process/extract-update.ts
@@ -231,6 +231,9 @@ export async function lookup(
 ): Promise<ExtractResult> {
   await fetchVulnerabilities(config, packageFiles);
   await fetchUpdates(config, packageFiles);
+  // call this twice, as the second time, the updates will be availalbe for malicious package checks
+  // TODO: this will be refactored as part of #42423
+  await fetchVulnerabilities(config, packageFiles);
   memCache.cleanDatasourceKeys();
   calculateLibYears(config, packageFiles);
   const { branches, branchList } = await branchifyUpgrades(

--- a/lib/workers/repository/process/vulnerabilities.spec.ts
+++ b/lib/workers/repository/process/vulnerabilities.spec.ts
@@ -226,10 +226,7 @@ describe('workers/repository/process/vulnerabilities', () => {
           },
         ]);
 
-        await vulnerabilities.appendVulnerabilityPackageRules(
-          config,
-          packageFiles,
-        );
+        await vulnerabilities.flagMaliciousPackages(config, packageFiles);
 
         expect(packageFiles.npm[0].deps[0].skipReason).toEqual(
           'malicious-version-in-use',
@@ -238,14 +235,6 @@ describe('workers/repository/process/vulnerabilities', () => {
         // and it does not apply to the dependency that doesn't match
         expect(packageFiles.pip[0].deps[0].skipReason).toBeUndefined();
         expect(packageFiles.pip[0].deps[0].skipStage).toBeUndefined();
-
-        // validation to make sure that these were both valid advisories
-        expect(logger.logger.debug).toHaveBeenCalledWith(
-          'Vulnerability MAL-2026-2307 affects axios 1.14.1',
-        );
-        expect(logger.logger.debug).toHaveBeenCalledWith(
-          'Vulnerability GHSA-jxr6-qrxx-2ph2 affects num2words 0.5.15',
-        );
       });
 
       it('are logged', async () => {
@@ -348,10 +337,7 @@ describe('workers/repository/process/vulnerabilities', () => {
           },
         ]);
 
-        await vulnerabilities.appendVulnerabilityPackageRules(
-          config,
-          packageFiles,
-        );
+        await vulnerabilities.flagMaliciousPackages(config, packageFiles);
 
         expect(logger.logger.debug).toHaveBeenCalledWith(
           {
@@ -415,10 +401,7 @@ describe('workers/repository/process/vulnerabilities', () => {
           },
         ]);
 
-        await vulnerabilities.appendVulnerabilityPackageRules(
-          config,
-          packageFiles,
-        );
+        await vulnerabilities.flagMaliciousPackages(config, packageFiles);
 
         expect(packageFiles.npm[0].deps[0].skipReason).toBeUndefined();
       });
@@ -470,7 +453,7 @@ describe('workers/repository/process/vulnerabilities', () => {
         ]);
 
         await expect(
-          vulnerabilities.appendVulnerabilityPackageRules(config, packageFiles),
+          vulnerabilities.flagMaliciousPackages(config, packageFiles),
         ).resolves.not.toThrow();
       });
 
@@ -512,10 +495,7 @@ describe('workers/repository/process/vulnerabilities', () => {
           },
         ]);
 
-        await vulnerabilities.appendVulnerabilityPackageRules(
-          config,
-          packageFiles,
-        );
+        await vulnerabilities.flagMaliciousPackages(config, packageFiles);
 
         expect(packageFiles.npm[0].deps[0].skipReason).toEqual(
           'malicious-version-in-use',
@@ -576,10 +556,7 @@ describe('workers/repository/process/vulnerabilities', () => {
             },
           ]);
 
-          await vulnerabilities.appendVulnerabilityPackageRules(
-            config,
-            packageFiles,
-          );
+          await vulnerabilities.flagMaliciousPackages(config, packageFiles);
 
           expect(packageFiles.npm[0].deps[0].skipReason).toEqual(
             'malicious-update-proposed',
@@ -640,10 +617,7 @@ describe('workers/repository/process/vulnerabilities', () => {
             },
           ]);
 
-          await vulnerabilities.appendVulnerabilityPackageRules(
-            config,
-            packageFiles,
-          );
+          await vulnerabilities.flagMaliciousPackages(config, packageFiles);
 
           expect(logger.logger.debug).toHaveBeenCalledWith(
             {
@@ -705,10 +679,7 @@ describe('workers/repository/process/vulnerabilities', () => {
             },
           ]);
 
-          await vulnerabilities.appendVulnerabilityPackageRules(
-            config,
-            packageFiles,
-          );
+          await vulnerabilities.flagMaliciousPackages(config, packageFiles);
 
           expect(packageFiles.npm[0].deps[0].skipReason).toEqual(
             'malicious-update-proposed',

--- a/lib/workers/repository/process/vulnerabilities.spec.ts
+++ b/lib/workers/repository/process/vulnerabilities.spec.ts
@@ -423,6 +423,105 @@ describe('workers/repository/process/vulnerabilities', () => {
         expect(packageFiles.npm[0].deps[0].skipReason).toBeUndefined();
       });
 
+      it('handles a MAL- advisory with no affected field', async () => {
+        const packageFiles: Record<string, PackageFile[]> = {
+          npm: [
+            {
+              deps: [
+                {
+                  depType: 'devDependencies',
+                  depName: 'axios',
+                  currentValue: '1.14.1',
+                  datasource: 'npm',
+                  prettyDepType: 'devDependency',
+                  lockedVersion: '1.14.1',
+                  updates: [],
+                  packageName: 'axios',
+                },
+              ],
+              packageFile: 'package.json',
+            },
+          ],
+        };
+        getVulnerabilitiesMock.mockResolvedValueOnce([
+          {
+            modified: '2026-04-07T14:41:20Z',
+            published: '2026-03-31T03:15:49Z',
+            schema_version: '1.7.4',
+            id: 'MAL-2026-2307',
+            aliases: ['GHSA-fw8c-xr5c-95f9'],
+            affected: [
+              {
+                package: {
+                  ecosystem: 'npm',
+                  name: 'axios',
+                },
+                versions: ['1.14.1'],
+              },
+            ],
+          },
+          {
+            modified: '2026-04-07T14:41:20Z',
+            published: '2026-03-31T03:15:49Z',
+            schema_version: '1.7.4',
+            id: 'MAL-2026-9999',
+            aliases: [],
+          },
+        ]);
+
+        await expect(
+          vulnerabilities.appendVulnerabilityPackageRules(config, packageFiles),
+        ).resolves.not.toThrow();
+      });
+
+      it('handles a malicious dependency where updates is undefined', async () => {
+        const packageFiles: Record<string, PackageFile[]> = {
+          npm: [
+            {
+              deps: [
+                {
+                  depType: 'devDependencies',
+                  depName: 'axios',
+                  currentValue: '1.14.1',
+                  datasource: 'npm',
+                  prettyDepType: 'devDependency',
+                  lockedVersion: '1.14.1',
+                  packageName: 'axios',
+                },
+              ],
+              packageFile: 'package.json',
+            },
+          ],
+        };
+        getVulnerabilitiesMock.mockResolvedValueOnce([
+          {
+            modified: '2026-04-07T14:41:20Z',
+            published: '2026-03-31T03:15:49Z',
+            schema_version: '1.7.4',
+            id: 'MAL-2026-2307',
+            aliases: ['GHSA-fw8c-xr5c-95f9'],
+            affected: [
+              {
+                package: {
+                  ecosystem: 'npm',
+                  name: 'axios',
+                },
+                versions: ['1.14.1'],
+              },
+            ],
+          },
+        ]);
+
+        await vulnerabilities.appendVulnerabilityPackageRules(
+          config,
+          packageFiles,
+        );
+
+        expect(packageFiles.npm[0].deps[0].skipReason).toEqual(
+          'malicious-version-in-use',
+        );
+      });
+
       describe('when a malicious dependency update is proposed', () => {
         it('applies to dependency updates, and sets malicious-update-proposed', async () => {
           const packageFiles: Record<string, PackageFile[]> = {
@@ -558,6 +657,63 @@ describe('workers/repository/process/vulnerabilities', () => {
             },
             "Marking axios's update to 1.14.1 as skipReason=malicious-update-proposed, as it is affected by MAL-2026-2307",
           );
+        });
+
+        it('falls back to update.newValue when newVersion is missing, and skips updates that are not malicious', async () => {
+          const packageFiles: Record<string, PackageFile[]> = {
+            npm: [
+              {
+                deps: [
+                  {
+                    depType: 'devDependencies',
+                    depName: 'axios',
+                    currentValue: '1.14.0',
+                    datasource: 'npm',
+                    prettyDepType: 'devDependency',
+                    lockedVersion: '1.14.0',
+                    updates: [
+                      {
+                        newValue: '1.14.2',
+                      },
+                      {
+                        newValue: '1.14.1',
+                      },
+                    ],
+                    packageName: 'axios',
+                  },
+                ],
+                packageFile: 'package.json',
+              },
+            ],
+          };
+          getVulnerabilitiesMock.mockResolvedValueOnce([
+            {
+              modified: '2026-04-07T14:41:20Z',
+              published: '2026-03-31T03:15:49Z',
+              schema_version: '1.7.4',
+              id: 'MAL-2026-2307',
+              aliases: ['GHSA-fw8c-xr5c-95f9'],
+              affected: [
+                {
+                  package: {
+                    ecosystem: 'npm',
+                    name: 'axios',
+                  },
+                  versions: ['1.14.1'],
+                },
+              ],
+            },
+          ]);
+
+          await vulnerabilities.appendVulnerabilityPackageRules(
+            config,
+            packageFiles,
+          );
+
+          expect(packageFiles.npm[0].deps[0].skipReason).toEqual(
+            'malicious-update-proposed',
+          );
+          expect(packageFiles.npm[0].deps[0].skipStage).toEqual('lookup');
         });
       });
     });

--- a/lib/workers/repository/process/vulnerabilities.spec.ts
+++ b/lib/workers/repository/process/vulnerabilities.spec.ts
@@ -226,7 +226,10 @@ describe('workers/repository/process/vulnerabilities', () => {
           },
         ]);
 
-        await vulnerabilities.flagMaliciousPackages(config, packageFiles);
+        await vulnerabilities.appendVulnerabilityPackageRules(
+          config,
+          packageFiles,
+        );
 
         expect(packageFiles.npm[0].deps[0].skipReason).toEqual(
           'malicious-version-in-use',
@@ -235,6 +238,14 @@ describe('workers/repository/process/vulnerabilities', () => {
         // and it does not apply to the dependency that doesn't match
         expect(packageFiles.pip[0].deps[0].skipReason).toBeUndefined();
         expect(packageFiles.pip[0].deps[0].skipStage).toBeUndefined();
+
+        // validation to make sure that these were both valid advisories
+        expect(logger.logger.debug).toHaveBeenCalledWith(
+          'Vulnerability MAL-2026-2307 affects axios 1.14.1',
+        );
+        expect(logger.logger.debug).toHaveBeenCalledWith(
+          'Vulnerability GHSA-jxr6-qrxx-2ph2 affects num2words 0.5.15',
+        );
       });
 
       it('are logged', async () => {
@@ -337,7 +348,10 @@ describe('workers/repository/process/vulnerabilities', () => {
           },
         ]);
 
-        await vulnerabilities.flagMaliciousPackages(config, packageFiles);
+        await vulnerabilities.appendVulnerabilityPackageRules(
+          config,
+          packageFiles,
+        );
 
         expect(logger.logger.debug).toHaveBeenCalledWith(
           {
@@ -401,7 +415,10 @@ describe('workers/repository/process/vulnerabilities', () => {
           },
         ]);
 
-        await vulnerabilities.flagMaliciousPackages(config, packageFiles);
+        await vulnerabilities.appendVulnerabilityPackageRules(
+          config,
+          packageFiles,
+        );
 
         expect(packageFiles.npm[0].deps[0].skipReason).toBeUndefined();
       });
@@ -453,7 +470,7 @@ describe('workers/repository/process/vulnerabilities', () => {
         ]);
 
         await expect(
-          vulnerabilities.flagMaliciousPackages(config, packageFiles),
+          vulnerabilities.appendVulnerabilityPackageRules(config, packageFiles),
         ).resolves.not.toThrow();
       });
 
@@ -495,7 +512,10 @@ describe('workers/repository/process/vulnerabilities', () => {
           },
         ]);
 
-        await vulnerabilities.flagMaliciousPackages(config, packageFiles);
+        await vulnerabilities.appendVulnerabilityPackageRules(
+          config,
+          packageFiles,
+        );
 
         expect(packageFiles.npm[0].deps[0].skipReason).toEqual(
           'malicious-version-in-use',
@@ -556,7 +576,10 @@ describe('workers/repository/process/vulnerabilities', () => {
             },
           ]);
 
-          await vulnerabilities.flagMaliciousPackages(config, packageFiles);
+          await vulnerabilities.appendVulnerabilityPackageRules(
+            config,
+            packageFiles,
+          );
 
           expect(packageFiles.npm[0].deps[0].skipReason).toEqual(
             'malicious-update-proposed',
@@ -617,7 +640,10 @@ describe('workers/repository/process/vulnerabilities', () => {
             },
           ]);
 
-          await vulnerabilities.flagMaliciousPackages(config, packageFiles);
+          await vulnerabilities.appendVulnerabilityPackageRules(
+            config,
+            packageFiles,
+          );
 
           expect(logger.logger.debug).toHaveBeenCalledWith(
             {
@@ -679,7 +705,10 @@ describe('workers/repository/process/vulnerabilities', () => {
             },
           ]);
 
-          await vulnerabilities.flagMaliciousPackages(config, packageFiles);
+          await vulnerabilities.appendVulnerabilityPackageRules(
+            config,
+            packageFiles,
+          );
 
           expect(packageFiles.npm[0].deps[0].skipReason).toEqual(
             'malicious-update-proposed',

--- a/lib/workers/repository/process/vulnerabilities.spec.ts
+++ b/lib/workers/repository/process/vulnerabilities.spec.ts
@@ -124,6 +124,443 @@ describe('workers/repository/process/vulnerabilities', () => {
         },
       ]);
     });
+
+    describe('malicious packages', () => {
+      it('are marked for dependencies with a MAL- advisory ID against their current version with malicious-version-in-use', async () => {
+        const packageFiles: Record<string, PackageFile[]> = {
+          npm: [
+            {
+              deps: [
+                {
+                  depType: 'devDependencies',
+                  depName: 'axios',
+                  currentValue: '1.14.1',
+                  datasource: 'npm',
+                  prettyDepType: 'devDependency',
+                  lockedVersion: '1.14.1',
+                  updates: [],
+                  packageName: 'axios',
+                },
+              ],
+              packageFile: 'package.json',
+            },
+          ],
+          pip: [
+            {
+              deps: [
+                {
+                  depName: 'num2words',
+                  currentValue: '0.5.15',
+                  datasource: 'pypi',
+                  updates: [],
+                  packageName: 'num2words',
+                },
+              ],
+              packageFile: 'go.mod',
+            },
+          ],
+        };
+
+        getVulnerabilitiesMock.mockResolvedValueOnce([
+          {
+            modified: '2026-04-07T14:41:20Z',
+            published: '2026-03-31T03:15:49Z',
+            schema_version: '1.7.4',
+            id: 'MAL-2026-2307',
+            aliases: ['GHSA-fw8c-xr5c-95f9'],
+            affected: [
+              {
+                package: {
+                  ecosystem: 'npm',
+                  name: 'axios',
+                },
+                versions: ['0.30.4', '1.14.1'],
+                database_specific: {
+                  cwes: [
+                    {
+                      cweId: 'CWE-506',
+                      description:
+                        'The product contains code that appears to be malicious in nature.',
+                      name: 'Embedded Malicious Code',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        ]);
+
+        // GHSA-jxr6-qrxx-2ph2 has a corresponding MAL-2025-6794, but because this isn't literally MAL-2025-6794, we don't apply it
+        getVulnerabilitiesMock.mockResolvedValueOnce([
+          {
+            affected: [
+              {
+                database_specific: {
+                  source:
+                    'https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2025/07/GHSA-jxr6-qrxx-2ph2/GHSA-jxr6-qrxx-2ph2.json',
+                },
+                package: {
+                  ecosystem: 'PyPI',
+                  name: 'num2words',
+                  purl: 'pkg:pypi/num2words',
+                },
+                ranges: [
+                  {
+                    events: [
+                      {
+                        introduced: '0.5.15',
+                      },
+                      {
+                        last_affected: '0.5.16',
+                      },
+                    ],
+                    type: 'ECOSYSTEM',
+                  },
+                ],
+              },
+            ],
+            aliases: ['MAL-2025-6794', 'PYSEC-2025-72'],
+            id: 'GHSA-jxr6-qrxx-2ph2',
+            modified: '2025-08-06T04:27:26.046626Z',
+            published: '2025-07-31T19:33:29Z',
+          },
+        ]);
+
+        await vulnerabilities.appendVulnerabilityPackageRules(
+          config,
+          packageFiles,
+        );
+
+        expect(packageFiles.npm[0].deps[0].skipReason).toEqual(
+          'malicious-version-in-use',
+        );
+        expect(packageFiles.npm[0].deps[0].skipStage).toEqual('lookup');
+        // and it does not apply to the dependency that doesn't match
+        expect(packageFiles.pip[0].deps[0].skipReason).toBeUndefined();
+        expect(packageFiles.pip[0].deps[0].skipStage).toBeUndefined();
+
+        // validation to make sure that these were both valid advisories
+        expect(logger.logger.debug).toHaveBeenCalledWith(
+          'Vulnerability MAL-2026-2307 affects axios 1.14.1',
+        );
+        expect(logger.logger.debug).toHaveBeenCalledWith(
+          'Vulnerability GHSA-jxr6-qrxx-2ph2 affects num2words 0.5.15',
+        );
+      });
+
+      it('are logged', async () => {
+        const packageFiles: Record<string, PackageFile[]> = {
+          npm: [
+            {
+              deps: [
+                {
+                  depType: 'devDependencies',
+                  depName: 'axios',
+                  currentValue: '1.14.1',
+                  datasource: 'npm',
+                  prettyDepType: 'devDependency',
+                  lockedVersion: '1.14.1',
+                  updates: [],
+                  packageName: 'axios',
+                },
+              ],
+              packageFile: 'package.json',
+            },
+          ],
+          pip: [
+            {
+              deps: [
+                {
+                  depName: 'num2words',
+                  currentValue: '0.5.15',
+                  datasource: 'pypi',
+                  updates: [],
+                  packageName: 'num2words',
+                },
+              ],
+              packageFile: 'go.mod',
+            },
+          ],
+        };
+
+        getVulnerabilitiesMock.mockResolvedValueOnce([
+          {
+            modified: '2026-04-07T14:41:20Z',
+            published: '2026-03-31T03:15:49Z',
+            schema_version: '1.7.4',
+            id: 'MAL-2026-2307',
+            aliases: ['GHSA-fw8c-xr5c-95f9'],
+            affected: [
+              {
+                package: {
+                  ecosystem: 'npm',
+                  name: 'axios',
+                },
+                versions: ['0.30.4', '1.14.1'],
+                database_specific: {
+                  cwes: [
+                    {
+                      cweId: 'CWE-506',
+                      description:
+                        'The product contains code that appears to be malicious in nature.',
+                      name: 'Embedded Malicious Code',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        ]);
+
+        // GHSA-jxr6-qrxx-2ph2 has a corresponding MAL-2025-6794, but because this isn't literally MAL-2025-6794, we don't apply it
+        getVulnerabilitiesMock.mockResolvedValueOnce([
+          {
+            affected: [
+              {
+                database_specific: {
+                  source:
+                    'https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2025/07/GHSA-jxr6-qrxx-2ph2/GHSA-jxr6-qrxx-2ph2.json',
+                },
+                package: {
+                  ecosystem: 'PyPI',
+                  name: 'num2words',
+                  purl: 'pkg:pypi/num2words',
+                },
+                ranges: [
+                  {
+                    events: [
+                      {
+                        introduced: '0.5.15',
+                      },
+                      {
+                        last_affected: '0.5.16',
+                      },
+                    ],
+                    type: 'ECOSYSTEM',
+                  },
+                ],
+              },
+            ],
+            aliases: ['MAL-2025-6794', 'PYSEC-2025-72'],
+            id: 'GHSA-jxr6-qrxx-2ph2',
+            modified: '2025-08-06T04:27:26.046626Z',
+            published: '2025-07-31T19:33:29Z',
+          },
+        ]);
+
+        await vulnerabilities.appendVulnerabilityPackageRules(
+          config,
+          packageFiles,
+        );
+
+        expect(logger.logger.debug).toHaveBeenCalledWith(
+          {
+            packageFile: 'package.json',
+            depName: 'axios',
+            packageName: 'axios',
+            manager: 'npm',
+            datasource: 'npm',
+            currentVersion: '1.14.1',
+          },
+          'Marking axios as skipReason=malicious-version-in-use, as it is affected by MAL-2026-2307',
+        );
+      });
+
+      it('are not counted if the affected versions do not match', async () => {
+        const packageFiles: Record<string, PackageFile[]> = {
+          npm: [
+            {
+              deps: [
+                {
+                  depType: 'devDependencies',
+                  depName: 'axios',
+                  currentValue: '1.14.0',
+                  datasource: 'npm',
+                  prettyDepType: 'devDependency',
+                  lockedVersion: '1.14.0',
+                  updates: [],
+                  packageName: 'axios',
+                },
+              ],
+              packageFile: 'package.json',
+            },
+          ],
+        };
+        getVulnerabilitiesMock.mockResolvedValueOnce([
+          {
+            modified: '2026-04-07T14:41:20Z',
+            published: '2026-03-31T03:15:49Z',
+            schema_version: '1.7.4',
+            id: 'MAL-2026-2307',
+            aliases: ['GHSA-fw8c-xr5c-95f9'],
+            affected: [
+              {
+                package: {
+                  ecosystem: 'npm',
+                  name: 'axios',
+                },
+                versions: ['0.30.4', '1.14.1'],
+                database_specific: {
+                  cwes: [
+                    {
+                      cweId: 'CWE-506',
+                      description:
+                        'The product contains code that appears to be malicious in nature.',
+                      name: 'Embedded Malicious Code',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        ]);
+
+        await vulnerabilities.appendVulnerabilityPackageRules(
+          config,
+          packageFiles,
+        );
+
+        expect(packageFiles.npm[0].deps[0].skipReason).toBeUndefined();
+      });
+
+      describe('when a malicious dependency update is proposed', () => {
+        it('applies to dependency updates, and sets malicious-update-proposed', async () => {
+          const packageFiles: Record<string, PackageFile[]> = {
+            npm: [
+              {
+                deps: [
+                  {
+                    depType: 'devDependencies',
+                    depName: 'axios',
+                    currentValue: '1.14.0',
+                    datasource: 'npm',
+                    prettyDepType: 'devDependency',
+                    lockedVersion: '1.14.0',
+                    updates: [
+                      {
+                        newVersion: '1.14.1',
+                      },
+                    ],
+                    packageName: 'axios',
+                  },
+                ],
+                packageFile: 'package.json',
+              },
+            ],
+          };
+          getVulnerabilitiesMock.mockResolvedValueOnce([
+            {
+              modified: '2026-04-07T14:41:20Z',
+              published: '2026-03-31T03:15:49Z',
+              schema_version: '1.7.4',
+              id: 'MAL-2026-2307',
+              aliases: ['GHSA-fw8c-xr5c-95f9'],
+              affected: [
+                {
+                  package: {
+                    ecosystem: 'npm',
+                    name: 'axios',
+                  },
+                  versions: ['0.30.4', '1.14.1'],
+                  database_specific: {
+                    cwes: [
+                      {
+                        cweId: 'CWE-506',
+                        description:
+                          'The product contains code that appears to be malicious in nature.',
+                        name: 'Embedded Malicious Code',
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          ]);
+
+          await vulnerabilities.appendVulnerabilityPackageRules(
+            config,
+            packageFiles,
+          );
+
+          expect(packageFiles.npm[0].deps[0].skipReason).toEqual(
+            'malicious-update-proposed',
+          );
+          expect(packageFiles.npm[0].deps[0].skipStage).toEqual('lookup');
+        });
+
+        it('logs', async () => {
+          const packageFiles: Record<string, PackageFile[]> = {
+            npm: [
+              {
+                deps: [
+                  {
+                    depType: 'devDependencies',
+                    depName: 'axios',
+                    currentValue: '1.14.0',
+                    datasource: 'npm',
+                    prettyDepType: 'devDependency',
+                    lockedVersion: '1.14.0',
+                    updates: [
+                      {
+                        newVersion: '1.14.1',
+                      },
+                    ],
+                    packageName: 'axios',
+                  },
+                ],
+                packageFile: 'package.json',
+              },
+            ],
+          };
+          getVulnerabilitiesMock.mockResolvedValueOnce([
+            {
+              modified: '2026-04-07T14:41:20Z',
+              published: '2026-03-31T03:15:49Z',
+              schema_version: '1.7.4',
+              id: 'MAL-2026-2307',
+              aliases: ['GHSA-fw8c-xr5c-95f9'],
+              affected: [
+                {
+                  package: {
+                    ecosystem: 'npm',
+                    name: 'axios',
+                  },
+                  versions: ['0.30.4', '1.14.1'],
+                  database_specific: {
+                    cwes: [
+                      {
+                        cweId: 'CWE-506',
+                        description:
+                          'The product contains code that appears to be malicious in nature.',
+                        name: 'Embedded Malicious Code',
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          ]);
+
+          await vulnerabilities.appendVulnerabilityPackageRules(
+            config,
+            packageFiles,
+          );
+
+          expect(logger.logger.debug).toHaveBeenCalledWith(
+            {
+              packageFile: 'package.json',
+              depName: 'axios',
+              packageName: 'axios',
+              manager: 'npm',
+              datasource: 'npm',
+              currentVersion: '1.14.0',
+              newVersion: '1.14.1',
+            },
+            "Marking axios's update to 1.14.1 as skipReason=malicious-update-proposed, as it is affected by MAL-2026-2307",
+          );
+        });
+      });
+    });
   });
 
   describe('appendVulnerabilityPackageRules()', () => {

--- a/lib/workers/repository/process/vulnerabilities.ts
+++ b/lib/workers/repository/process/vulnerabilities.ts
@@ -217,6 +217,17 @@ export class Vulnerabilities {
           continue;
         }
 
+        this.skipMaliciousPackages(
+          ecosystem,
+          packageName,
+          depVersion,
+          versioningApi,
+          dep,
+          packageFileConfig.manager,
+          packageFileConfig.packageFile,
+          osvVulnerability,
+        );
+
         for (const affected of osvVulnerability.affected ?? []) {
           const isVulnerable = this.isPackageVulnerable(
             ecosystem,
@@ -258,6 +269,78 @@ export class Vulnerabilities {
         'Error fetching vulnerability information for package',
       );
       return null;
+    }
+  }
+
+  private skipMaliciousPackages(
+    ecosystem: Ecosystem,
+    packageName: string,
+    depVersion: string,
+    versioningApi: VersioningApi,
+    dep: PackageDependency<Record<string, any>, string>,
+    manager: string | undefined,
+    packageFile: string,
+    osvVulnerability: Osv.Vulnerability,
+  ): void {
+    // the OpenSSF's Malicious Packages (https://github.com/ossf/malicious-packages) is a source of advisories through osv.dev, which takes various sources of advisories, and will re-publish them with more specific information about their malicious usage
+    if (osvVulnerability.id.startsWith('MAL-')) {
+      // is the current dependency vulnerable?
+      for (const affected of osvVulnerability.affected ?? []) {
+        // is the current dependency vulnerable?
+        const isVulnerable = this.isPackageVulnerable(
+          ecosystem,
+          packageName,
+          depVersion,
+          affected,
+          versioningApi,
+        );
+
+        if (isVulnerable) {
+          logger.debug(
+            {
+              packageFile: packageFile,
+              depName: dep.depName,
+              packageName: dep.packageName,
+              manager: manager,
+              datasource: dep.datasource,
+              currentVersion: depVersion,
+            },
+            `Marking ${dep.depName} as skipReason=malicious-version-in-use, as it is affected by ${osvVulnerability.id}`,
+          );
+          dep.skipReason = 'malicious-version-in-use';
+          dep.skipStage = 'lookup';
+        }
+
+        // or are any of the updates vulnerable?
+        for (const update of dep.updates ?? []) {
+          const newVersion = update.newVersion ?? update.newValue!;
+
+          const isUpdateVulnerable = this.isPackageVulnerable(
+            ecosystem,
+            packageName,
+            newVersion,
+            affected,
+            versioningApi,
+          );
+
+          if (isUpdateVulnerable) {
+            logger.debug(
+              {
+                packageFile: packageFile,
+                depName: dep.depName,
+                packageName: dep.packageName,
+                manager: manager,
+                datasource: dep.datasource,
+                currentVersion: depVersion,
+                newVersion,
+              },
+              `Marking ${dep.depName}'s update to ${newVersion} as skipReason=malicious-update-proposed, as it is affected by ${osvVulnerability.id}`,
+            );
+            dep.skipReason = 'malicious-update-proposed';
+            dep.skipStage = 'lookup';
+          }
+        }
+      }
     }
   }
 

--- a/lib/workers/repository/process/vulnerabilities.ts
+++ b/lib/workers/repository/process/vulnerabilities.ts
@@ -277,7 +277,7 @@ export class Vulnerabilities {
     packageName: string,
     depVersion: string,
     versioningApi: VersioningApi,
-    dep: PackageDependency<Record<string, any>, string>,
+    dep: PackageDependency,
     manager: string | undefined,
     packageFile: string,
     osvVulnerability: Osv.Vulnerability,

--- a/lib/workers/repository/process/vulnerabilities.ts
+++ b/lib/workers/repository/process/vulnerabilities.ts
@@ -92,102 +92,6 @@ export class Vulnerabilities {
     }
   }
 
-  async flagMaliciousPackages(
-    config: RenovateConfig,
-    packageFiles: Record<string, PackageFile[]>,
-  ): Promise<void> {
-    const managers = Object.keys(packageFiles);
-    await Promise.all(
-      managers.map((manager) =>
-        this.flagManagerMaliciousPackages(config, packageFiles, manager),
-      ),
-    );
-  }
-
-  private async flagManagerMaliciousPackages(
-    config: RenovateConfig,
-    packageFiles: Record<string, PackageFile[]>,
-    manager: string,
-  ): Promise<void> {
-    const managerConfig = getManagerConfig(config, manager);
-    const queue = packageFiles[manager].map(
-      (pFile) => (): Promise<void> =>
-        this.flagPackageFileMaliciousPackages(managerConfig, pFile),
-    );
-    await p.all(queue);
-  }
-
-  private async flagPackageFileMaliciousPackages(
-    managerConfig: RenovateConfig,
-    pFile: PackageFile,
-  ): Promise<void> {
-    const packageFileConfig = mergeChildConfig(managerConfig, pFile);
-    const queue = pFile.deps.map(
-      (dep) => (): Promise<void> =>
-        this.flagDependencyMaliciousPackage(packageFileConfig, dep),
-    );
-    await p.all(queue);
-  }
-
-  private async flagDependencyMaliciousPackage(
-    packageFileConfig: RenovateConfig & PackageFile,
-    dep: PackageDependency,
-  ): Promise<void> {
-    const ecosystem = Vulnerabilities.datasourceEcosystemMap[dep.datasource!];
-    if (!ecosystem) {
-      return;
-    }
-
-    let packageName = dep.packageName ?? dep.depName!;
-    if (ecosystem === 'PyPI') {
-      packageName = packageName.toLowerCase().replace(regEx(/[_.-]+/g), '-');
-    }
-
-    try {
-      const osvVulnerabilities = await this.osvOffline.getVulnerabilities(
-        ecosystem,
-        packageName,
-      );
-      if (
-        isNullOrUndefined(osvVulnerabilities) ||
-        isEmptyArray(osvVulnerabilities)
-      ) {
-        return;
-      }
-
-      const depVersion =
-        dep.lockedVersion ?? dep.currentVersion ?? dep.currentValue!;
-      const versioning = dep.versioning ?? getDefaultVersioning(dep.datasource);
-      const versioningApi = getVersioning(versioning);
-
-      if (!versioningApi.isVersion(depVersion)) {
-        return;
-      }
-
-      for (const osvVulnerability of osvVulnerabilities) {
-        if (osvVulnerability.withdrawn) {
-          continue;
-        }
-
-        this.skipMaliciousPackages(
-          ecosystem,
-          packageName,
-          depVersion,
-          versioningApi,
-          dep,
-          packageFileConfig.manager,
-          packageFileConfig.packageFile,
-          osvVulnerability,
-        );
-      }
-    } catch (err) {
-      logger.warn(
-        { err, packageName },
-        'Error flagging malicious package information for package',
-      );
-    }
-  }
-
   async fetchVulnerabilities(
     config: RenovateConfig,
     packageFiles: Record<string, PackageFile[]>,
@@ -312,6 +216,17 @@ export class Vulnerabilities {
           );
           continue;
         }
+
+        this.skipMaliciousPackages(
+          ecosystem,
+          packageName,
+          depVersion,
+          versioningApi,
+          dep,
+          packageFileConfig.manager,
+          packageFileConfig.packageFile,
+          osvVulnerability,
+        );
 
         for (const affected of osvVulnerability.affected ?? []) {
           const isVulnerable = this.isPackageVulnerable(

--- a/lib/workers/repository/process/vulnerabilities.ts
+++ b/lib/workers/repository/process/vulnerabilities.ts
@@ -92,6 +92,102 @@ export class Vulnerabilities {
     }
   }
 
+  async flagMaliciousPackages(
+    config: RenovateConfig,
+    packageFiles: Record<string, PackageFile[]>,
+  ): Promise<void> {
+    const managers = Object.keys(packageFiles);
+    await Promise.all(
+      managers.map((manager) =>
+        this.flagManagerMaliciousPackages(config, packageFiles, manager),
+      ),
+    );
+  }
+
+  private async flagManagerMaliciousPackages(
+    config: RenovateConfig,
+    packageFiles: Record<string, PackageFile[]>,
+    manager: string,
+  ): Promise<void> {
+    const managerConfig = getManagerConfig(config, manager);
+    const queue = packageFiles[manager].map(
+      (pFile) => (): Promise<void> =>
+        this.flagPackageFileMaliciousPackages(managerConfig, pFile),
+    );
+    await p.all(queue);
+  }
+
+  private async flagPackageFileMaliciousPackages(
+    managerConfig: RenovateConfig,
+    pFile: PackageFile,
+  ): Promise<void> {
+    const packageFileConfig = mergeChildConfig(managerConfig, pFile);
+    const queue = pFile.deps.map(
+      (dep) => (): Promise<void> =>
+        this.flagDependencyMaliciousPackage(packageFileConfig, dep),
+    );
+    await p.all(queue);
+  }
+
+  private async flagDependencyMaliciousPackage(
+    packageFileConfig: RenovateConfig & PackageFile,
+    dep: PackageDependency,
+  ): Promise<void> {
+    const ecosystem = Vulnerabilities.datasourceEcosystemMap[dep.datasource!];
+    if (!ecosystem) {
+      return;
+    }
+
+    let packageName = dep.packageName ?? dep.depName!;
+    if (ecosystem === 'PyPI') {
+      packageName = packageName.toLowerCase().replace(regEx(/[_.-]+/g), '-');
+    }
+
+    try {
+      const osvVulnerabilities = await this.osvOffline.getVulnerabilities(
+        ecosystem,
+        packageName,
+      );
+      if (
+        isNullOrUndefined(osvVulnerabilities) ||
+        isEmptyArray(osvVulnerabilities)
+      ) {
+        return;
+      }
+
+      const depVersion =
+        dep.lockedVersion ?? dep.currentVersion ?? dep.currentValue!;
+      const versioning = dep.versioning ?? getDefaultVersioning(dep.datasource);
+      const versioningApi = getVersioning(versioning);
+
+      if (!versioningApi.isVersion(depVersion)) {
+        return;
+      }
+
+      for (const osvVulnerability of osvVulnerabilities) {
+        if (osvVulnerability.withdrawn) {
+          continue;
+        }
+
+        this.skipMaliciousPackages(
+          ecosystem,
+          packageName,
+          depVersion,
+          versioningApi,
+          dep,
+          packageFileConfig.manager,
+          packageFileConfig.packageFile,
+          osvVulnerability,
+        );
+      }
+    } catch (err) {
+      logger.warn(
+        { err, packageName },
+        'Error flagging malicious package information for package',
+      );
+    }
+  }
+
   async fetchVulnerabilities(
     config: RenovateConfig,
     packageFiles: Record<string, PackageFile[]>,
@@ -216,17 +312,6 @@ export class Vulnerabilities {
           );
           continue;
         }
-
-        this.skipMaliciousPackages(
-          ecosystem,
-          packageName,
-          depVersion,
-          versioningApi,
-          dep,
-          packageFileConfig.manager,
-          packageFileConfig.packageFile,
-          osvVulnerability,
-        );
 
         for (const affected of osvVulnerability.affected ?? []) {
           const isVulnerable = this.isPackageVulnerable(

--- a/lib/workers/repository/updates/flatten.spec.ts
+++ b/lib/workers/repository/updates/flatten.spec.ts
@@ -2,6 +2,7 @@ import { isNumber } from '@sindresorhus/is';
 import type { RenovateConfig } from '~test/util.ts';
 import { getConfig } from '../../../config/defaults.ts';
 import type { PackageFile } from '../../../modules/manager/types.ts';
+import type { SkipReason } from '../../../types/skip-reason.ts';
 import { flattenUpdates, sanitizeDepName } from './flatten.ts';
 
 vi.mock('../../../util/git/semantic.ts');
@@ -235,6 +236,84 @@ describe('workers/repository/updates/flatten', () => {
         ),
       ).toHaveLength(2);
       expect(res.filter((r) => r.isVulnerabilityAlert)).toHaveLength(1);
+    });
+
+    it('when a dependency is enabled=false, it is filtered', async () => {
+      const packageFiles = {
+        npm: [
+          {
+            packageFile: 'package.json',
+            lockFiles: ['package-lock.json'],
+            deps: [
+              {
+                depName: '@org/a',
+                updates: [
+                  {
+                    newValue: '1.0.0',
+                    sourceUrl: 'https://github.com/org/repo',
+                  },
+                ],
+                enabled: false,
+              },
+              {
+                depName: 'foo',
+                updates: [
+                  {
+                    newValue: '2.0.0',
+                    sourceUrl: 'https://github.com/org/repo',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      const res = await flattenUpdates(config, packageFiles);
+      expect(res).toHaveLength(1);
+      expect(
+        res.find((update) => update.depName === '@org/a'),
+      ).not.toBeDefined();
+      expect(res.find((update) => update.depName === 'foo')).toBeDefined();
+    });
+
+    it('when a skipReason is found on a dependency, it is filtered', async () => {
+      const packageFiles = {
+        npm: [
+          {
+            packageFile: 'package.json',
+            lockFiles: ['package-lock.json'],
+            deps: [
+              {
+                depName: '@org/a',
+                updates: [
+                  {
+                    newValue: '1.0.0',
+                    sourceUrl: 'https://github.com/org/repo',
+                  },
+                ],
+                skipReason: 'disabled' as SkipReason,
+              },
+              {
+                depName: 'foo',
+                updates: [
+                  {
+                    newValue: '2.0.0',
+                    sourceUrl: 'https://github.com/org/repo',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      const res = await flattenUpdates(config, packageFiles);
+      expect(res).toHaveLength(1);
+      expect(
+        res.find((update) => update.depName === '@org/a'),
+      ).not.toBeDefined();
+      expect(res.find((update) => update.depName === 'foo')).toBeDefined();
     });
 
     it('separates lockfile maintenance updates from other update types if grouping is applied', async () => {

--- a/lib/workers/repository/updates/flatten.ts
+++ b/lib/workers/repository/updates/flatten.ts
@@ -1,3 +1,4 @@
+import { isUndefined } from '@sindresorhus/is';
 import {
   filterConfig,
   getManagerConfig,
@@ -234,6 +235,7 @@ export async function flattenUpdates(
   }
   const filteredUpdates = updates
     .filter((update) => update.enabled !== false)
+    .filter((update) => isUndefined(update.skipReason))
     .map(({ vulnerabilityAlerts: _, ...update }) => update)
     .map((update) => filterConfig(update, 'branch'));
   if (filteredUpdates.length < updates.length) {


### PR DESCRIPTION


<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->



As part of current ongoing supply chain attacks, there have been cases
where Renovate updates packages to a malicious version.

We'll be introducing a more in-depth means to surface these, including
from different API sources, as part of the Enrichment functionality,
but in the short-term we can utilise osv.dev's ingestion of OpenSSF's
Malicious Packages data.

To do this, we need to:

- look for any `MAL-` advisories
- match it against the current dependency's version, and if affected, mark it
  as `skipReason: malicious-version-in-use` (which will be unset in
  the `lookup()` function, so we still perform updates
- match it against the dependency's available updates, and if any are
  affected, mark the dependency
  as `skipReason: malicious-update-proposed`



## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/JamieTanna-Mend-testing/react-dom-VULNERABLE-CODE-DO-NOT-USE

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->


```
DEBUG: fetchVulnerabilities() - osvVulnerabilityAlerts=true (repository=local)
(node:71346) MetadataLookupWarning: received unexpected error = All promises were rejected code = UNKNOWN
    at Object.isAvailable (/Users/jamietanna/workspaces/renovatebot/renovate/node_modules/.pnpm/gcp-metadata@8.1.2/node_modules/gcp-metadata/src/index.ts:402:17)
    at processTicksAndRejections (node:internal/process/task_queues:104:5)
    at runNextTicks (node:internal/process/task_queues:69:3)
    at listOnTimeout (node:internal/timers:567:9)
    at processTimers (node:internal/timers:541:7)
    at detect (/Users/jamietanna/workspaces/renovatebot/renovate/node_modules/.pnpm/@opentelemetry+resource-detector-gcp@0.49.0_@opentelemetry+api@1.9.1/node_modules/@opentelemetry/resource-detector-gcp/src/detectors/GcpDetector.ts:78:9)
    at GcpDetector._asyncAttributes (/Users/jamietanna/workspaces/renovatebot/renovate/node_modules/.pnpm/@opentelemetry+resource-detector-gcp@0.49.0_@opentelemetry+api@1.9.1/node_modules/@opentelemetry/resource-detector-gcp/src/detectors/GcpDetector.ts:212:22)
DEBUG: Marking axios as skipReason=malicious-version-in-use, as it is affected by MAL-2026-2307 (repository=local, packageFile=package.json)
       "depName": "axios",
       "packageName": undefined,
       "manager": "npm",
       "datasource": "npm",
       "currentVersion": "1.14.1"
DEBUG: Vulnerability MAL-2026-2307 affects axios 1.14.1 (repository=local)
DEBUG: No fixed version available for vulnerability MAL-2026-2307 in axios 1.14.1 (repository=local)
...
DEBUG: config.repoIsOnboarded=true (repository=local)
 WARN: Dependency axios is currently using a malicious version (repository=local, packageFile=package.json)
       "depName": "axios",
       "packageName": "axios",
       "manager": "npm",
       "datasource": "npm"
DEBUG: packageFiles with updates (repository=local)
       "config": {
         "npm": [
           {
             "deps": [
               {
                 "depType": "devDependencies",
                 "depName": "axios",
                 "currentValue": "1.14.1",
                 "datasource": "npm",
                 "prettyDepType": "devDependency",
                 "lockedVersion": "1.14.1",
                 "updates": [],
                 "packageName": "axios"
               }
             ],
             "extractedConstraints": {},
             "packageFileVersion": "17.0.2-fix.0",
             "managerData": {
               "packageJsonName": "@esm-bundle/react-dom",
               "hasPackageManager": false,
               "pnpmShrinkwrap": "pnpm-lock.yaml",
               "yarnZeroInstall": false,
               "npmrcFileName": null
             },
             "skipInstalls": true,
             "packageFile": "package.json",
             "lockFiles": ["pnpm-lock.yaml"]
           }
         ]
       }
```
