### PR TITLE
feat(packageRules): bumpVersions.type sync

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -613,6 +613,7 @@ Supported values are:
 - `patch`
 - `minor`
 - `major`
+- `match`
 
 This field supports templates for conditional logic.
 For example:
@@ -624,6 +625,32 @@ For example:
 ```
 
 In this example, the bump type is set to `patch` for patch updates and `minor` for all other cases.
+
+**Using `match` to sync with dependency updates**
+
+The `match` type is special: it uses the same version as the dependency manager update that triggered the branch.
+This is useful when you want to keep version files in sync with actual dependency updates.
+
+For example, if you have a `.release-version` file that should always match the version of a specific dependency:
+
+```json
+{
+  "bumpVersions": [
+    {
+      "filePatterns": [".release-version"],
+      "bumpType": "match",
+      "matchStrings": ["^(?<version>.+)$"]
+    }
+  ]
+}
+```
+
+When Renovate updates a dependency to version `2.5.3`, it will also update the `.release-version` file to `2.5.3`.
+
+<!-- prettier-ignore -->
+!!! note
+    When using `bumpType: "match"`, Renovate uses the `newVersion` from the first upgrade in the branch.
+    If no upgrades are found in the branch, the version bump will be skipped and a debug message will be logged.
 
 ### bumpVersions.filePatterns
 

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -613,7 +613,7 @@ Supported values are:
 - `patch`
 - `minor`
 - `major`
-- `match`
+- `sync`
 
 This field supports templates for conditional logic.
 For example:
@@ -626,9 +626,9 @@ For example:
 
 In this example, the bump type is set to `patch` for patch updates and `minor` for all other cases.
 
-**Using `match` to sync with dependency updates**
+**Using `sync` to sync with dependency updates**
 
-The `match` type is special: it uses the same version as the dependency manager update that triggered the branch.
+The `sync` type is special: it uses the same version as the dependency manager update that triggered the branch.
 This is useful when you want to keep version files in sync with actual dependency updates.
 
 For example, if you have a `.release-version` file that should always match the version of a specific dependency:
@@ -638,7 +638,7 @@ For example, if you have a `.release-version` file that should always match the 
   "bumpVersions": [
     {
       "filePatterns": [".release-version"],
-      "bumpType": "match",
+      "bumpType": "sync",
       "matchStrings": ["^(?<version>.+)$"]
     }
   ]
@@ -649,7 +649,7 @@ When Renovate updates a dependency to version `2.5.3`, it will also update the `
 
 <!-- prettier-ignore -->
 !!! note
-    When using `bumpType: "match"`, Renovate uses the `newVersion` from the first upgrade in the branch.
+    When using `bumpType: "sync"`, Renovate uses the `newVersion` from the first upgrade in the branch.
     If no upgrades are found in the branch, the version bump will be skipped and a debug message will be logged.
 
 ### bumpVersions.filePatterns

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -141,7 +141,7 @@ const options: Readonly<RenovateOptions>[] = [
   {
     name: 'bumpType',
     description:
-      'The semver level to use when bumping versions. This is used by the `bumpVersions` feature. Use "sync" to use the same version as the dependency update.',
+      'The semver level to use when bumping versions. This is used by the `bumpVersions` feature. Use `sync` to use the same version as the dependency update.',
     type: 'string',
     parents: ['bumpVersions'],
     allowedValues: ['major', 'minor', 'patch', 'sync'],

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -141,9 +141,10 @@ const options: Readonly<RenovateOptions>[] = [
   {
     name: 'bumpType',
     description:
-      'The semver level to use when bumping versions. This is used by the `bumpVersions` feature.',
+      'The semver level to use when bumping versions. This is used by the `bumpVersions` feature. Use "match" to use the same version as the dependency update.',
     type: 'string',
     parents: ['bumpVersions'],
+    allowedValues: ['major', 'minor', 'patch', 'match'],
   },
   {
     name: 'filePatterns',

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -141,7 +141,7 @@ const options: Readonly<RenovateOptions>[] = [
   {
     name: 'bumpType',
     description:
-      'The semver level to use when bumping versions. This is used by the `bumpVersions` feature. Use `sync` to use the same version as the dependency update.',
+      'The semver level to use when bumping versions. This is used by the `bumpVersions` feature.',
     type: 'string',
     parents: ['bumpVersions'],
     allowedValues: ['major', 'minor', 'patch', 'sync'],

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -141,10 +141,10 @@ const options: Readonly<RenovateOptions>[] = [
   {
     name: 'bumpType',
     description:
-      'The semver level to use when bumping versions. This is used by the `bumpVersions` feature. Use "match" to use the same version as the dependency update.',
+      'The semver level to use when bumping versions. This is used by the `bumpVersions` feature. Use "sync" to use the same version as the dependency update.',
     type: 'string',
     parents: ['bumpVersions'],
-    allowedValues: ['major', 'minor', 'patch', 'match'],
+    allowedValues: ['major', 'minor', 'patch', 'sync'],
   },
   {
     name: 'filePatterns',

--- a/lib/workers/repository/update/branch/bump-versions.spec.ts
+++ b/lib/workers/repository/update/branch/bump-versions.spec.ts
@@ -692,5 +692,73 @@ describe('workers/repository/update/branch/bump-versions', () => {
         ],
       });
     });
+
+    it('should use matched version when bumpType is match', async () => {
+      const config = partial<BranchConfig>({
+        bumpVersions: [
+          {
+            filePatterns: ['\\.release-version'],
+            bumpType: 'match',
+            matchStrings: ['^(?<version>.+)$'],
+          },
+        ],
+        upgrades: [
+          {
+            newVersion: '2.5.3',
+          },
+        ],
+        updatedPackageFiles: [
+          {
+            type: 'addition',
+            path: 'foo',
+            contents: 'bar',
+          },
+        ],
+      });
+      scm.getFileList.mockResolvedValueOnce(['foo', '.release-version']);
+      fs.readLocalFile.mockResolvedValueOnce('1.0.0');
+
+      await bumpVersions(config);
+
+      expect(config).toMatchObject({
+        updatedArtifacts: [
+          {
+            type: 'addition',
+            path: '.release-version',
+            contents: '2.5.3',
+          },
+        ],
+      });
+    });
+
+    it('should log debug when no upgrades found for match type', async () => {
+      const config = partial<BranchConfig>({
+        bumpVersions: [
+          {
+            name: 'test',
+            filePatterns: ['\\.release-version'],
+            bumpType: 'match',
+            matchStrings: ['^(?<version>.+)$'],
+          },
+        ],
+        upgrades: [],
+        updatedPackageFiles: [
+          {
+            type: 'addition',
+            path: 'foo',
+            contents: 'bar',
+          },
+        ],
+      });
+      scm.getFileList.mockResolvedValueOnce(['foo', '.release-version']);
+      fs.readLocalFile.mockResolvedValueOnce('1.0.0');
+
+      await bumpVersions(config);
+
+      expect(logger.logger.debug).toHaveBeenCalledWith(
+        { file: '.release-version' },
+        'bumpVersions(test): No upgrades found in branch config for match type',
+      );
+    });
   });
 });

--- a/lib/workers/repository/update/branch/bump-versions.spec.ts
+++ b/lib/workers/repository/update/branch/bump-versions.spec.ts
@@ -704,6 +704,8 @@ describe('workers/repository/update/branch/bump-versions', () => {
         ],
         upgrades: [
           {
+            branchName: 'test-branch',
+            manager: 'npm',
             newVersion: '2.5.3',
           },
         ],
@@ -758,6 +760,41 @@ describe('workers/repository/update/branch/bump-versions', () => {
       expect(logger.logger.debug).toHaveBeenCalledWith(
         { file: '.release-version' },
         'bumpVersions(test): No upgrades found in branch config for match type',
+      );
+    });
+
+    it('should log debug when newVersion is not found in upgrades for match type', async () => {
+      const config = partial<BranchConfig>({
+        bumpVersions: [
+          {
+            name: 'test',
+            filePatterns: ['\\.release-version'],
+            bumpType: 'match',
+            matchStrings: ['^(?<version>.+)$'],
+          },
+        ],
+        upgrades: [
+          {
+            branchName: 'test-branch',
+            manager: 'npm',
+          },
+        ],
+        updatedPackageFiles: [
+          {
+            type: 'addition',
+            path: 'foo',
+            contents: 'bar',
+          },
+        ],
+      });
+      scm.getFileList.mockResolvedValueOnce(['foo', '.release-version']);
+      fs.readLocalFile.mockResolvedValueOnce('1.0.0');
+
+      await bumpVersions(config);
+
+      expect(logger.logger.debug).toHaveBeenCalledWith(
+        { file: '.release-version' },
+        'bumpVersions(test): No newVersion found in branch upgrades for match type',
       );
     });
   });

--- a/lib/workers/repository/update/branch/bump-versions.spec.ts
+++ b/lib/workers/repository/update/branch/bump-versions.spec.ts
@@ -693,12 +693,12 @@ describe('workers/repository/update/branch/bump-versions', () => {
       });
     });
 
-    it('should use matched version when bumpType is match', async () => {
+    it('should use matched version when bumpType is sync', async () => {
       const config = partial<BranchConfig>({
         bumpVersions: [
           {
             filePatterns: ['\\.release-version'],
-            bumpType: 'match',
+            bumpType: 'sync',
             matchStrings: ['^(?<version>.+)$'],
           },
         ],
@@ -733,13 +733,13 @@ describe('workers/repository/update/branch/bump-versions', () => {
       });
     });
 
-    it('should log debug when no upgrades found for match type', async () => {
+    it('should log debug when no upgrades found for sync type', async () => {
       const config = partial<BranchConfig>({
         bumpVersions: [
           {
             name: 'test',
             filePatterns: ['\\.release-version'],
-            bumpType: 'match',
+            bumpType: 'sync',
             matchStrings: ['^(?<version>.+)$'],
           },
         ],
@@ -759,17 +759,17 @@ describe('workers/repository/update/branch/bump-versions', () => {
 
       expect(logger.logger.debug).toHaveBeenCalledWith(
         { file: '.release-version' },
-        'bumpVersions(test): No upgrades found in branch config for match type',
+        'bumpVersions(test): No upgrades found in branch config for sync type',
       );
     });
 
-    it('should log debug when newVersion is not found in upgrades for match type', async () => {
+    it('should log debug when newVersion is not found in upgrades for sync type', async () => {
       const config = partial<BranchConfig>({
         bumpVersions: [
           {
             name: 'test',
             filePatterns: ['\\.release-version'],
-            bumpType: 'match',
+            bumpType: 'sync',
             matchStrings: ['^(?<version>.+)$'],
           },
         ],
@@ -794,7 +794,7 @@ describe('workers/repository/update/branch/bump-versions', () => {
 
       expect(logger.logger.debug).toHaveBeenCalledWith(
         { file: '.release-version' },
-        'bumpVersions(test): No newVersion found in branch upgrades for match type',
+        'bumpVersions(test): No newVersion found in branch upgrades for sync type',
       );
     });
   });

--- a/lib/workers/repository/update/branch/bump-versions.ts
+++ b/lib/workers/repository/update/branch/bump-versions.ts
@@ -143,22 +143,45 @@ async function bumpVersion(
       let newVersion: string | null = null;
       try {
         const bumpType = compile(rawBumpType, branchConfig);
-        const parts = regEx('^(?<major>\\d+)(?:\\.(?<minor>\\d+))?$').exec(
-          version,
-        );
-        if (parts?.groups) {
-          const { major, minor } = parts.groups;
-          if (bumpType === 'major') {
-            newVersion = `${parseInt(major, 10) + 1}${minor ? `.0` : ''}`;
-          } else if (bumpType === 'minor') {
-            newVersion = `${major}.${parseInt(minor, 10) + 1}`;
+
+        // Handle 'match' type - use version from branch upgrades
+        if (bumpType === 'match') {
+          if (branchConfig.upgrades?.length) {
+            // Use the newVersion from the first upgrade
+            newVersion = branchConfig.upgrades[0].newVersion ?? null;
+            if (!newVersion) {
+              logger.debug(
+                { file: filePath },
+                `${bumpVersionsDescr}: No newVersion found in branch upgrades for match type`,
+              );
+              continue;
+            }
           } else {
-            throw new Error(
-              `Unsupported bump type for {major}.{minor} version: ${bumpType}`,
+            logger.debug(
+              { file: filePath },
+              `${bumpVersionsDescr}: No upgrades found in branch config for match type`,
             );
+            continue;
           }
         } else {
-          newVersion = inc(version, bumpType as ReleaseType);
+          // Existing logic for major/minor/patch
+          const parts = regEx('^(?<major>\\d+)(?:\\.(?<minor>\\d+))?$').exec(
+            version,
+          );
+          if (parts?.groups) {
+            const { major, minor } = parts.groups;
+            if (bumpType === 'major') {
+              newVersion = `${parseInt(major, 10) + 1}${minor ? `.0` : ''}`;
+            } else if (bumpType === 'minor') {
+              newVersion = `${major}.${parseInt(minor, 10) + 1}`;
+            } else {
+              throw new Error(
+                `Unsupported bump type for {major}.{minor} version: ${bumpType}`,
+              );
+            }
+          } else {
+            newVersion = inc(version, bumpType as ReleaseType);
+          }
         }
       } catch (e) {
         addArtifactError(

--- a/lib/workers/repository/update/branch/bump-versions.ts
+++ b/lib/workers/repository/update/branch/bump-versions.ts
@@ -144,22 +144,22 @@ async function bumpVersion(
       try {
         const bumpType = compile(rawBumpType, branchConfig);
 
-        // Handle 'match' type - use version from branch upgrades
-        if (bumpType === 'match') {
+        // Handle 'sync' type - use version from branch upgrades
+        if (bumpType === 'sync') {
           if (branchConfig.upgrades?.length) {
             // Use the newVersion from the first upgrade
             newVersion = branchConfig.upgrades[0].newVersion ?? null;
             if (!newVersion) {
               logger.debug(
                 { file: filePath },
-                `${bumpVersionsDescr}: No newVersion found in branch upgrades for match type`,
+                `${bumpVersionsDescr}: No newVersion found in branch upgrades for sync type`,
               );
               continue;
             }
           } else {
             logger.debug(
               { file: filePath },
-              `${bumpVersionsDescr}: No upgrades found in branch config for match type`,
+              `${bumpVersionsDescr}: No upgrades found in branch config for sync type`,
             );
             continue;
           }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

allow bumpVersions.type to accept `sync`. Will re-use the version template used by the manager instead of a bump strategy

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
