### PR TITLE
fix(homebrew): allow subdirectories for Homebrew Formulas

### DIFF
--- a/lib/modules/manager/homebrew/index.ts
+++ b/lib/modules/manager/homebrew/index.ts
@@ -9,7 +9,7 @@ export const url = 'https://brew.sh';
 
 export const defaultConfig = {
   commitMessageTopic: 'Homebrew Formula {{depName}}',
-  managerFilePatterns: ['/^Formula/[^/]+[.]rb$/'],
+  managerFilePatterns: ['/^Formula/\w*/*[^/]+[.]rb$/'],
 };
 
 export const supportedDatasources = [

--- a/lib/modules/manager/homebrew/index.ts
+++ b/lib/modules/manager/homebrew/index.ts
@@ -9,7 +9,7 @@ export const url = 'https://brew.sh';
 
 export const defaultConfig = {
   commitMessageTopic: 'Homebrew Formula {{depName}}',
-  managerFilePatterns: ['/^Formula/\w*/?[^/]+[.]rb$/'],
+  managerFilePatterns: ['/^Formula/\\w*/?[^/]+[.]rb$/'],
 };
 
 export const supportedDatasources = [

--- a/lib/modules/manager/homebrew/index.ts
+++ b/lib/modules/manager/homebrew/index.ts
@@ -9,7 +9,7 @@ export const url = 'https://brew.sh';
 
 export const defaultConfig = {
   commitMessageTopic: 'Homebrew Formula {{depName}}',
-  managerFilePatterns: ['/^Formula/\w*/*[^/]+[.]rb$/'],
+  managerFilePatterns: ['/^Formula/\w*/?[^/]+[.]rb$/'],
 };
 
 export const supportedDatasources = [


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
This PR allows homebrew formulas to exist in subdirectories, such as they do in the official homebrew core repo and many individual tap repos. See https://github.com/Homebrew/homebrew-core/tree/main/Formula

I tested this only in regex101, see https://regex101.com/?regex=%5EFormula%5C%2F%5Cw*%5C%2F%3F%5B%5E%5C%2F%5D%2B%5B.%5Drb%24&testString=Formula%2Ftest.rb%0AFormula%2Ft%2Ftest.rb%0AFormula%2Flib%2Fmy-lib.rb%0AFormula%2Ftest%2Ftest%2Ftest.rb%0AFormula%2Ft%2Ft%2Ftest.rb%0ANotFormula%2Ftest.rb%0AFormula%2Ftest.log%0A&flags=gm&flavor=javascript&delimiter=%2F (Note: the `\` in the regex before a `/` need to be removed to work with renovate, which is confusing)

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
