### PR TITLE
feat(cache): Optimize package cache `file` backend

### DIFF
--- a/lib/util/cache/package/impl/file.spec.ts
+++ b/lib/util/cache/package/impl/file.spec.ts
@@ -2,14 +2,33 @@ import cacache from 'cacache';
 import { DateTime } from 'luxon';
 import { type DirectoryResult, dir } from 'tmp-promise';
 import upath from 'upath';
-import { compressToBase64, decompressFromBuffer } from '../../../compress.ts';
+import {
+  compressToBase64,
+  compressToBuffer,
+  decompressFromBuffer,
+} from '../../../compress.ts';
 import { PackageCacheFile } from './file.ts';
+
+declare module 'luxon' {
+  interface TSSettings {
+    throwOnInvalid: true;
+  }
+}
 
 describe('util/cache/package/impl/file', () => {
   let tmpDir: DirectoryResult;
   let cacheDir: string;
   let cacheFileName: string;
   let cache: PackageCacheFile;
+  const namespace = '_test-namespace';
+  const cacheVersion = 2;
+  const cacheKey = (key: string): string => `${namespace}-${key}`;
+
+  const expectNoCacheEntry = async (key: string): Promise<void> => {
+    await expect(cacache.get(cacheFileName, key)).rejects.toThrow(
+      'No cache entry',
+    );
+  };
 
   function getExpiry(minutes: number): string {
     const expiry = DateTime.local().plus({ minutes }).toISO();
@@ -25,7 +44,7 @@ describe('util/cache/package/impl/file', () => {
   }
 
   async function putLegacyEntry(
-    cacheKey: string,
+    cacheEntryKey: string,
     value: unknown,
     ttlMinutes: number,
   ): Promise<{ expiry: string; payload: string }> {
@@ -36,7 +55,7 @@ describe('util/cache/package/impl/file', () => {
       value: compressedValue,
       expiry,
     });
-    await cacache.put(cacheFileName, cacheKey, payload);
+    await cacache.put(cacheFileName, cacheEntryKey, payload);
     return { expiry, payload };
   }
 
@@ -53,9 +72,9 @@ describe('util/cache/package/impl/file', () => {
 
   describe('basic operations', () => {
     it('sets and gets', async () => {
-      await cache.set('_test-namespace', 'key', 1234, 5);
+      await cache.set(namespace, 'key', 1234, 5);
 
-      const res = await cache.get('_test-namespace', 'key');
+      const res = await cache.get(namespace, 'key');
 
       expect(res).toBe(1234);
     });
@@ -63,64 +82,71 @@ describe('util/cache/package/impl/file', () => {
 
   describe('set', () => {
     it('stores expiry in index metadata', async () => {
-      await cache.set('_test-namespace', 'key', 1234, 5);
+      await cache.set(namespace, 'key', 1234, 5);
 
-      const info = await cacache.get.info(cacheFileName, '_test-namespace-key');
-      const cacheEntry = await cacache.get(
-        cacheFileName,
-        '_test-namespace-key',
-      );
+      const info = await cacache.get.info(cacheFileName, cacheKey('key'));
+      const cacheEntry = await cacache.get(cacheFileName, cacheKey('key'));
       const cachedValue = await decompressFromBuffer(cacheEntry.data);
 
       expect(info?.metadata).toEqual({
         expiry: expect.any(String),
-        version: 2,
+        version: cacheVersion,
       });
       expect(cachedValue).toBe('1234');
+    });
+
+    it('throws for invalid computed expiry', async () => {
+      const localSpy = vi
+        .spyOn(DateTime, 'local')
+        .mockReturnValue(DateTime.fromISO('invalid'));
+
+      await expect(cache.set(namespace, 'key', 1234, 5)).rejects.toThrow(
+        'Invalid package cache expiry',
+      );
+
+      localSpy.mockRestore();
     });
   });
 
   describe('get', () => {
     it('returns undefined on cache miss', async () => {
-      const res = await cache.get('_test-namespace', 'missing-key');
+      const res = await cache.get(namespace, 'missing-key');
 
       expect(res).toBeUndefined();
     });
 
     it('expires cached entries', async () => {
-      await cache.set('_test-namespace', 'key', 1234, -5);
+      await cache.set(namespace, 'key', 1234, -5);
 
-      const res = await cache.get('_test-namespace', 'key');
+      const res = await cache.get(namespace, 'key');
 
       expect(res).toBeUndefined();
 
-      await expect(
-        cacache.get(cacheFileName, '_test-namespace-key'),
-      ).rejects.toThrow('No cache entry');
+      await expectNoCacheEntry(cacheKey('key'));
     });
 
     it('expires metadata-backed entries without blob reads', async () => {
-      await cache.set('_test-namespace', 'key', 1234, -5);
+      await cache.set(namespace, 'key', 1234, -5);
       const cacacheGet = vi.spyOn(cacache, 'get');
 
-      const res = await cache.get('_test-namespace', 'key');
+      const res = await cache.get(namespace, 'key');
 
       expect(res).toBeUndefined();
       expect(cacacheGet).not.toHaveBeenCalled();
     });
 
     it('returns undefined for null cached value', async () => {
-      await cacache.put(cacheFileName, '_test-namespace-key', 'null');
+      await cacache.put(cacheFileName, cacheKey('key'), 'null');
 
-      const res = await cache.get('_test-namespace', 'key');
+      const res = await cache.get(namespace, 'key');
 
       expect(res).toBeUndefined();
     });
 
     it('returns undefined for invalid JSON', async () => {
-      await cacache.put(cacheFileName, '_test-namespace-key', 'invalid-json');
+      await cacache.put(cacheFileName, cacheKey('key'), 'invalid-json');
 
-      const res = await cache.get('_test-namespace', 'key');
+      const res = await cache.get(namespace, 'key');
 
       expect(res).toBeUndefined();
     });
@@ -129,11 +155,39 @@ describe('util/cache/package/impl/file', () => {
       const payload = JSON.stringify({
         compress: true,
         value: 'not-base64-encoded-gzip',
-        expiry: DateTime.local().plus({ minutes: 5 }),
+        expiry: getExpiry(5),
       });
-      await cacache.put(cacheFileName, '_test-namespace-key', payload);
+      await cacache.put(cacheFileName, cacheKey('key'), payload);
 
-      const res = await cache.get('_test-namespace', 'key');
+      const res = await cache.get(namespace, 'key');
+
+      expect(res).toBeUndefined();
+    });
+
+    it('returns undefined for malformed decompressed cache data', async () => {
+      const cacheEntryValue = await compressToBuffer('not-json');
+      await cacache.put(cacheFileName, cacheKey('key'), cacheEntryValue, {
+        metadata: {
+          version: cacheVersion,
+          expiry: getExpiry(5),
+        },
+      });
+
+      const res = await cache.get(namespace, 'key');
+
+      expect(res).toBeUndefined();
+    });
+
+    it('returns undefined for legacy entry with malformed decompressed payload', async () => {
+      const compressedValue = await compressToBase64('not-json');
+      const payload = JSON.stringify({
+        compress: true,
+        value: compressedValue,
+        expiry: getExpiry(5),
+      });
+      await cacache.put(cacheFileName, cacheKey('key'), payload);
+
+      const res = await cache.get(namespace, 'key');
 
       expect(res).toBeUndefined();
     });
@@ -144,15 +198,13 @@ describe('util/cache/package/impl/file', () => {
         compress: true,
         value: compressedValue,
       });
-      await cacache.put(cacheFileName, '_test-namespace-key', payload);
+      await cacache.put(cacheFileName, cacheKey('key'), payload);
 
-      const res = await cache.get('_test-namespace', 'key');
+      const res = await cache.get(namespace, 'key');
 
       expect(res).toBeUndefined();
 
-      await expect(
-        cacache.get(cacheFileName, '_test-namespace-key'),
-      ).rejects.toThrow('No cache entry');
+      await expectNoCacheEntry(cacheKey('key'));
     });
 
     it('returns undefined for invalid expiry', async () => {
@@ -162,17 +214,17 @@ describe('util/cache/package/impl/file', () => {
         value: compressedValue,
         expiry: 'not-a-date',
       });
-      await cacache.put(cacheFileName, '_test-namespace-key', payload);
+      await cacache.put(cacheFileName, cacheKey('key'), payload);
 
-      const res = await cache.get('_test-namespace', 'key');
+      const res = await cache.get(namespace, 'key');
 
       expect(res).toBeUndefined();
     });
 
     it('retrieves legacy compressed values', async () => {
-      await putLegacyEntry('_test-namespace-key', 1234, 5);
+      await putLegacyEntry(cacheKey('key'), 1234, 5);
 
-      const res = await cache.get('_test-namespace', 'key');
+      const res = await cache.get(namespace, 'key');
 
       expect(res).toBe(1234);
     });
@@ -180,8 +232,8 @@ describe('util/cache/package/impl/file', () => {
 
   describe('destroy', () => {
     it('uses metadata to clean up new-format entries', async () => {
-      await cache.set('_test-namespace', 'valid', 1234, 5);
-      await cache.set('_test-namespace', 'expired', 1234, -5);
+      await cache.set(namespace, 'valid', 1234, 5);
+      await cache.set(namespace, 'expired', 1234, -5);
 
       const cacacheGet = vi.spyOn(cacache, 'get');
 
@@ -189,7 +241,7 @@ describe('util/cache/package/impl/file', () => {
 
       const cacheKeys = await getCacheKeys();
 
-      expect(cacheKeys).toEqual(['_test-namespace-valid']);
+      expect(cacheKeys).toEqual([cacheKey('valid')]);
       expect(cacacheGet).not.toHaveBeenCalled();
     });
 
@@ -213,7 +265,7 @@ describe('util/cache/package/impl/file', () => {
       expect(cacheKeys).toEqual(['legacy-valid-key']);
       expect(validInfo?.metadata).toEqual({
         expiry,
-        version: 2,
+        version: cacheVersion,
       });
       expect(validValue).toBe('1234');
       expect(validEntry.data.toString()).not.toBe(payload);
@@ -236,26 +288,24 @@ describe('util/cache/package/impl/file', () => {
     });
 
     it('does not delete shared content used by surviving entries', async () => {
-      await cache.set('_test-namespace', 'expired-shared-key', 1234, -5);
-      await cache.set('_test-namespace', 'valid-shared-key', 1234, 5);
+      await cache.set(namespace, 'expired-shared-key', 1234, -5);
+      await cache.set(namespace, 'valid-shared-key', 1234, 5);
 
       await cache.destroy();
 
       const cacheKeys = await getCacheKeys();
-      const validEntry = await cache.get('_test-namespace', 'valid-shared-key');
+      const validEntry = await cache.get(namespace, 'valid-shared-key');
 
-      expect(cacheKeys).toEqual(['_test-namespace-valid-shared-key']);
+      expect(cacheKeys).toEqual([cacheKey('valid-shared-key')]);
       expect(validEntry).toBe(1234);
 
-      await expect(
-        cacache.get(cacheFileName, '_test-namespace-expired-shared-key'),
-      ).rejects.toThrow('No cache entry');
+      await expectNoCacheEntry(cacheKey('expired-shared-key'));
     });
 
     it('removes expired legacy and invalid entries', async () => {
-      await cache.set('_test-namespace', 'valid', 1234, 5);
+      await cache.set(namespace, 'valid', 1234, 5);
       const { payload: expiredPayload } = await putLegacyEntry(
-        '_test-namespace-expired',
+        cacheKey('expired'),
         1234,
         -5,
       );
@@ -265,14 +315,10 @@ describe('util/cache/package/impl/file', () => {
 
       const cacheKeys = await getCacheKeys();
 
-      expect(cacheKeys).toEqual(['_test-namespace-valid']);
+      expect(cacheKeys).toEqual([cacheKey('valid')]);
 
-      await expect(
-        cacache.get(cacheFileName, '_test-namespace-expired'),
-      ).rejects.toThrow('No cache entry');
-      await expect(cacache.get(cacheFileName, 'invalid')).rejects.toThrow(
-        'No cache entry',
-      );
+      await expectNoCacheEntry(cacheKey('expired'));
+      await expectNoCacheEntry('invalid');
 
       expect(expiredPayload).toContain('"compress":true');
     });
@@ -312,8 +358,36 @@ describe('util/cache/package/impl/file', () => {
       expect(cacheKeys).not.toContain('bad-expiry-key');
     });
 
+    it('removes entries with invalid metadata', async () => {
+      await cacache.put(cacheFileName, 'invalid-metadata', '1234', {
+        metadata: 'invalid' as unknown as { expiry: string; version: number },
+      });
+
+      await cache.destroy();
+
+      const cacheKeys = await getCacheKeys();
+
+      expect(cacheKeys).not.toContain('invalid-metadata');
+    });
+
+    it('removes entries with unsupported metadata version', async () => {
+      const payload = await compressToBuffer('1234');
+      await cacache.put(cacheFileName, 'unsupported-version', payload, {
+        metadata: {
+          version: 1,
+          expiry: getExpiry(5),
+        },
+      });
+
+      await cache.destroy();
+
+      const cacheKeys = await getCacheKeys();
+
+      expect(cacheKeys).not.toContain('unsupported-version');
+    });
+
     it('continues on cleanup errors', async () => {
-      await putLegacyEntry('valid', 1234, 5);
+      await putLegacyEntry(cacheKey('valid'), 1234, 5);
       const cacacheGet = vi
         .spyOn(cacache, 'get')
         .mockRejectedValue(new Error('error'));

--- a/lib/util/cache/package/impl/file.spec.ts
+++ b/lib/util/cache/package/impl/file.spec.ts
@@ -74,7 +74,6 @@ describe('util/cache/package/impl/file', () => {
 
       expect(info?.metadata).toEqual({
         expiry: expect.any(String),
-        format: 'br-json',
         version: 2,
       });
       expect(cachedValue).toBe('1234');
@@ -214,7 +213,6 @@ describe('util/cache/package/impl/file', () => {
       expect(cacheKeys).toEqual(['legacy-valid-key']);
       expect(validInfo?.metadata).toEqual({
         expiry,
-        format: 'br-json',
         version: 2,
       });
       expect(validValue).toBe('1234');

--- a/lib/util/cache/package/impl/file.spec.ts
+++ b/lib/util/cache/package/impl/file.spec.ts
@@ -9,12 +9,6 @@ import {
 } from '../../../compress.ts';
 import { PackageCacheFile } from './file.ts';
 
-declare module 'luxon' {
-  interface TSSettings {
-    throwOnInvalid: true;
-  }
-}
-
 describe('util/cache/package/impl/file', () => {
   let tmpDir: DirectoryResult;
   let cacheDir: string;
@@ -93,18 +87,6 @@ describe('util/cache/package/impl/file', () => {
         version: cacheVersion,
       });
       expect(cachedValue).toBe('1234');
-    });
-
-    it('throws for invalid computed expiry', async () => {
-      const localSpy = vi
-        .spyOn(DateTime, 'local')
-        .mockReturnValue(DateTime.fromISO('invalid'));
-
-      await expect(cache.set(namespace, 'key', 1234, 5)).rejects.toThrow(
-        'Invalid package cache expiry',
-      );
-
-      localSpy.mockRestore();
     });
   });
 

--- a/lib/util/cache/package/impl/file.spec.ts
+++ b/lib/util/cache/package/impl/file.spec.ts
@@ -24,6 +24,12 @@ describe('util/cache/package/impl/file', () => {
     );
   };
 
+  const expectNoContent = async (digest: string): Promise<void> => {
+    await expect(cacache.get.hasContent(cacheFileName, digest)).resolves.toBe(
+      false,
+    );
+  };
+
   function getExpiry(minutes: number): string {
     const expiry = DateTime.local().plus({ minutes }).toISO();
     if (!expiry) {
@@ -243,6 +249,11 @@ describe('util/cache/package/impl/file', () => {
         1234,
         5,
       );
+      const legacyInfo = await cacache.get.info(
+        cacheFileName,
+        'legacy-valid-key',
+      );
+      const legacyDigest = legacyInfo!.integrity;
 
       await cache.destroy();
 
@@ -263,6 +274,8 @@ describe('util/cache/package/impl/file', () => {
       expect(validEntry.data.equals(migratedBuffer)).toBe(true);
       expect(validValue).toBe('1234');
       expect(validEntry.data.toString()).not.toBe(payload);
+
+      await expectNoContent(legacyDigest);
     });
 
     it('uses migrated metadata for subsequent cleanup passes', async () => {
@@ -284,6 +297,16 @@ describe('util/cache/package/impl/file', () => {
     it('does not delete shared content used by surviving entries', async () => {
       await cache.set(namespace, 'expired-shared-key', 1234, -5);
       await cache.set(namespace, 'valid-shared-key', 1234, 5);
+      const expiredInfo = await cacache.get.info(
+        cacheFileName,
+        cacheKey('expired-shared-key'),
+      );
+      const expiredDigest = expiredInfo!.integrity;
+      const validInfo = await cacache.get.info(
+        cacheFileName,
+        cacheKey('valid-shared-key'),
+      );
+      const validDigest = validInfo!.integrity;
 
       await cache.destroy();
 
@@ -292,8 +315,31 @@ describe('util/cache/package/impl/file', () => {
 
       expect(cacheKeys).toEqual([cacheKey('valid-shared-key')]);
       expect(validEntry).toBe(1234);
+      expect(expiredDigest).toBe(validDigest);
+      expect(
+        await cacache.get.hasContent(cacheFileName, validDigest),
+      ).toBeTruthy();
 
       await expectNoCacheEntry(cacheKey('expired-shared-key'));
+    });
+
+    it('removes content for expired entries that are no longer referenced', async () => {
+      await cache.set(
+        namespace,
+        'expired-only-key',
+        { value: 'expired-only' },
+        -5,
+      );
+      const expiredInfo = await cacache.get.info(
+        cacheFileName,
+        cacheKey('expired-only-key'),
+      );
+      const expiredDigest = expiredInfo!.integrity;
+
+      await cache.destroy();
+
+      await expectNoCacheEntry(cacheKey('expired-only-key'));
+      await expectNoContent(expiredDigest);
     });
 
     it('removes expired legacy and invalid entries', async () => {

--- a/lib/util/cache/package/impl/file.spec.ts
+++ b/lib/util/cache/package/impl/file.spec.ts
@@ -97,6 +97,16 @@ describe('util/cache/package/impl/file', () => {
       expect(res).toBeUndefined();
     });
 
+    it('returns undefined when cache info lookup fails', async () => {
+      const cacheInfoSpy = vi
+        .spyOn(cacache.get, 'info')
+        .mockRejectedValue(new Error('error'));
+
+      await expect(cache.get(namespace, 'key')).resolves.toBeUndefined();
+
+      cacheInfoSpy.mockRestore();
+    });
+
     it('expires cached entries', async () => {
       await cache.set(namespace, 'key', 1234, -5);
 
@@ -303,6 +313,22 @@ describe('util/cache/package/impl/file', () => {
       await expectNoCacheEntry('invalid');
 
       expect(expiredPayload).toContain('"compress":true');
+    });
+
+    it('removes legacy entries with malformed decompressed payloads', async () => {
+      const compressedValue = await compressToBase64('not-json');
+      const payload = JSON.stringify({
+        compress: true,
+        value: compressedValue,
+        expiry: getExpiry(5),
+      });
+      await cacache.put(cacheFileName, 'invalid-legacy-payload', payload);
+
+      await cache.destroy();
+
+      const cacheKeys = await getCacheKeys();
+
+      expect(cacheKeys).not.toContain('invalid-legacy-payload');
     });
 
     it('removes invalid legacy entries without expiry', async () => {

--- a/lib/util/cache/package/impl/file.spec.ts
+++ b/lib/util/cache/package/impl/file.spec.ts
@@ -2,6 +2,7 @@ import cacache from 'cacache';
 import { DateTime } from 'luxon';
 import { type DirectoryResult, dir } from 'tmp-promise';
 import upath from 'upath';
+import { compressToBase64, decompressFromBuffer } from '../../../compress.ts';
 import { PackageCacheFile } from './file.ts';
 
 describe('util/cache/package/impl/file', () => {
@@ -9,6 +10,35 @@ describe('util/cache/package/impl/file', () => {
   let cacheDir: string;
   let cacheFileName: string;
   let cache: PackageCacheFile;
+
+  function getExpiry(minutes: number): string {
+    const expiry = DateTime.local().plus({ minutes }).toISO();
+    if (!expiry) {
+      throw new Error('Expected valid cache expiry');
+    }
+    return expiry;
+  }
+
+  async function getCacheKeys(): Promise<string[]> {
+    const cacheEntries = await cacache.ls(cacheFileName);
+    return Object.keys(cacheEntries);
+  }
+
+  async function putLegacyEntry(
+    cacheKey: string,
+    value: unknown,
+    ttlMinutes: number,
+  ): Promise<{ expiry: string; payload: string }> {
+    const expiry = getExpiry(ttlMinutes);
+    const compressedValue = await compressToBase64(JSON.stringify(value));
+    const payload = JSON.stringify({
+      compress: true,
+      value: compressedValue,
+      expiry,
+    });
+    await cacache.put(cacheFileName, cacheKey, payload);
+    return { expiry, payload };
+  }
 
   beforeEach(async () => {
     tmpDir = await dir({ unsafeCleanup: true });
@@ -31,6 +61,26 @@ describe('util/cache/package/impl/file', () => {
     });
   });
 
+  describe('set', () => {
+    it('stores expiry in index metadata', async () => {
+      await cache.set('_test-namespace', 'key', 1234, 5);
+
+      const info = await cacache.get.info(cacheFileName, '_test-namespace-key');
+      const cacheEntry = await cacache.get(
+        cacheFileName,
+        '_test-namespace-key',
+      );
+      const cachedValue = await decompressFromBuffer(cacheEntry.data);
+
+      expect(info?.metadata).toEqual({
+        expiry: expect.any(String),
+        format: 'br-json',
+        version: 2,
+      });
+      expect(cachedValue).toBe('1234');
+    });
+  });
+
   describe('get', () => {
     it('returns undefined on cache miss', async () => {
       const res = await cache.get('_test-namespace', 'missing-key');
@@ -48,6 +98,16 @@ describe('util/cache/package/impl/file', () => {
       await expect(
         cacache.get(cacheFileName, '_test-namespace-key'),
       ).rejects.toThrow('No cache entry');
+    });
+
+    it('expires metadata-backed entries without blob reads', async () => {
+      await cache.set('_test-namespace', 'key', 1234, -5);
+      const cacacheGet = vi.spyOn(cacache, 'get');
+
+      const res = await cache.get('_test-namespace', 'key');
+
+      expect(res).toBeUndefined();
+      expect(cacacheGet).not.toHaveBeenCalled();
     });
 
     it('returns undefined for null cached value', async () => {
@@ -80,18 +140,27 @@ describe('util/cache/package/impl/file', () => {
     });
 
     it('returns undefined for missing expiry', async () => {
-      const payload = JSON.stringify({ compress: false, value: 1234 });
+      const compressedValue = await compressToBase64(JSON.stringify(1234));
+      const payload = JSON.stringify({
+        compress: true,
+        value: compressedValue,
+      });
       await cacache.put(cacheFileName, '_test-namespace-key', payload);
 
       const res = await cache.get('_test-namespace', 'key');
 
       expect(res).toBeUndefined();
+
+      await expect(
+        cacache.get(cacheFileName, '_test-namespace-key'),
+      ).rejects.toThrow('No cache entry');
     });
 
     it('returns undefined for invalid expiry', async () => {
+      const compressedValue = await compressToBase64(JSON.stringify(1234));
       const payload = JSON.stringify({
-        compress: false,
-        value: 1234,
+        compress: true,
+        value: compressedValue,
         expiry: 'not-a-date',
       });
       await cacache.put(cacheFileName, '_test-namespace-key', payload);
@@ -101,13 +170,8 @@ describe('util/cache/package/impl/file', () => {
       expect(res).toBeUndefined();
     });
 
-    it('retrieves non-compressed value', async () => {
-      const payload = JSON.stringify({
-        compress: false,
-        value: 1234,
-        expiry: DateTime.local().plus({ minutes: 5 }),
-      });
-      await cacache.put(cacheFileName, '_test-namespace-key', payload);
+    it('retrieves legacy compressed values', async () => {
+      await putLegacyEntry('_test-namespace-key', 1234, 5);
 
       const res = await cache.get('_test-namespace', 'key');
 
@@ -116,52 +180,142 @@ describe('util/cache/package/impl/file', () => {
   });
 
   describe('destroy', () => {
-    it('removes expired and invalid entries', async () => {
+    it('uses metadata to clean up new-format entries', async () => {
       await cache.set('_test-namespace', 'valid', 1234, 5);
       await cache.set('_test-namespace', 'expired', 1234, -5);
-      await cacache.put(cacheFileName, 'invalid', 'not json');
 
-      const cacheObject = await cacache.get(
-        cacheFileName,
-        '_test-namespace-expired',
-      );
-      const expiredDigest = cacheObject.integrity;
+      const cacacheGet = vi.spyOn(cacache, 'get');
 
       await cache.destroy();
 
-      const entries = await cacache.ls(cacheFileName);
-      expect(Object.keys(entries)).toEqual(['_test-namespace-valid']);
+      const cacheKeys = await getCacheKeys();
 
-      await expect(
-        cacache.get.byDigest(cacheFileName, expiredDigest),
-      ).rejects.toThrow('ENOENT');
+      expect(cacheKeys).toEqual(['_test-namespace-valid']);
+      expect(cacacheGet).not.toHaveBeenCalled();
     });
 
-    it('keeps entries without expiry field', async () => {
-      const payload = JSON.stringify({ value: 'no-expiry' });
+    it('lazily migrates valid legacy entries without deleting them', async () => {
+      const { expiry, payload } = await putLegacyEntry(
+        'legacy-valid-key',
+        1234,
+        5,
+      );
+
+      await cache.destroy();
+
+      const cacheKeys = await getCacheKeys();
+      const validInfo = await cacache.get.info(
+        cacheFileName,
+        'legacy-valid-key',
+      );
+      const validEntry = await cacache.get(cacheFileName, 'legacy-valid-key');
+      const validValue = await decompressFromBuffer(validEntry.data);
+
+      expect(cacheKeys).toEqual(['legacy-valid-key']);
+      expect(validInfo?.metadata).toEqual({
+        expiry,
+        format: 'br-json',
+        version: 2,
+      });
+      expect(validValue).toBe('1234');
+      expect(validEntry.data.toString()).not.toBe(payload);
+    });
+
+    it('uses migrated metadata for subsequent cleanup passes', async () => {
+      await putLegacyEntry('legacy-valid-key', 1234, 5);
+
+      const cacacheGet = vi.spyOn(cacache, 'get');
+
+      await cache.destroy();
+      cacacheGet.mockClear();
+
+      await cache.destroy();
+
+      const cacheKeys = await getCacheKeys();
+
+      expect(cacheKeys).toEqual(['legacy-valid-key']);
+      expect(cacacheGet).not.toHaveBeenCalled();
+    });
+
+    it('does not delete shared content used by surviving entries', async () => {
+      await cache.set('_test-namespace', 'expired-shared-key', 1234, -5);
+      await cache.set('_test-namespace', 'valid-shared-key', 1234, 5);
+
+      await cache.destroy();
+
+      const cacheKeys = await getCacheKeys();
+      const validEntry = await cache.get('_test-namespace', 'valid-shared-key');
+
+      expect(cacheKeys).toEqual(['_test-namespace-valid-shared-key']);
+      expect(validEntry).toBe(1234);
+
+      await expect(
+        cacache.get(cacheFileName, '_test-namespace-expired-shared-key'),
+      ).rejects.toThrow('No cache entry');
+    });
+
+    it('removes expired legacy and invalid entries', async () => {
+      await cache.set('_test-namespace', 'valid', 1234, 5);
+      const { payload: expiredPayload } = await putLegacyEntry(
+        '_test-namespace-expired',
+        1234,
+        -5,
+      );
+      await cacache.put(cacheFileName, 'invalid', 'not json');
+
+      await cache.destroy();
+
+      const cacheKeys = await getCacheKeys();
+
+      expect(cacheKeys).toEqual(['_test-namespace-valid']);
+
+      await expect(
+        cacache.get(cacheFileName, '_test-namespace-expired'),
+      ).rejects.toThrow('No cache entry');
+      await expect(cacache.get(cacheFileName, 'invalid')).rejects.toThrow(
+        'No cache entry',
+      );
+
+      expect(expiredPayload).toContain('"compress":true');
+    });
+
+    it('removes invalid legacy entries without expiry', async () => {
+      const compressedValue = await compressToBase64(
+        JSON.stringify('no-expiry'),
+      );
+      const payload = JSON.stringify({
+        compress: true,
+        value: compressedValue,
+      });
       await cacache.put(cacheFileName, 'no-expiry-key', payload);
 
       await cache.destroy();
 
-      const entries = await cacache.ls(cacheFileName);
-      expect(Object.keys(entries)).toContain('no-expiry-key');
+      const cacheKeys = await getCacheKeys();
+
+      expect(cacheKeys).not.toContain('no-expiry-key');
     });
 
     it('removes entries with invalid expiry', async () => {
+      const compressedValue = await compressToBase64(
+        JSON.stringify('bad-expiry'),
+      );
       const payload = JSON.stringify({
-        value: 'bad-expiry',
+        compress: true,
+        value: compressedValue,
         expiry: 'not-a-date',
       });
       await cacache.put(cacheFileName, 'bad-expiry-key', payload);
 
       await cache.destroy();
 
-      const entries = await cacache.ls(cacheFileName);
-      expect(Object.keys(entries)).not.toContain('bad-expiry-key');
+      const cacheKeys = await getCacheKeys();
+
+      expect(cacheKeys).not.toContain('bad-expiry-key');
     });
 
     it('continues on cleanup errors', async () => {
-      await cache.set('_test-namespace', 'valid', 1234, 5);
+      await putLegacyEntry('valid', 1234, 5);
       const cacacheGet = vi
         .spyOn(cacache, 'get')
         .mockRejectedValue(new Error('error'));

--- a/lib/util/cache/package/impl/file.spec.ts
+++ b/lib/util/cache/package/impl/file.spec.ts
@@ -41,7 +41,7 @@ describe('util/cache/package/impl/file', () => {
     cacheEntryKey: string,
     value: unknown,
     ttlMinutes: number,
-  ): Promise<{ expiry: string; payload: string }> {
+  ): Promise<{ expiry: string; payload: string; compressedValue: string }> {
     const expiry = getExpiry(ttlMinutes);
     const compressedValue = await compressToBase64(JSON.stringify(value));
     const payload = JSON.stringify({
@@ -50,7 +50,7 @@ describe('util/cache/package/impl/file', () => {
       expiry,
     });
     await cacache.put(cacheFileName, cacheEntryKey, payload);
-    return { expiry, payload };
+    return { expiry, payload, compressedValue };
   }
 
   beforeEach(async () => {
@@ -237,8 +237,8 @@ describe('util/cache/package/impl/file', () => {
       expect(cacacheGet).not.toHaveBeenCalled();
     });
 
-    it('lazily migrates valid legacy entries without deleting them', async () => {
-      const { expiry, payload } = await putLegacyEntry(
+    it('lazily migrates valid legacy entries without recompressing them', async () => {
+      const { expiry, payload, compressedValue } = await putLegacyEntry(
         'legacy-valid-key',
         1234,
         5,
@@ -253,12 +253,14 @@ describe('util/cache/package/impl/file', () => {
       );
       const validEntry = await cacache.get(cacheFileName, 'legacy-valid-key');
       const validValue = await decompressFromBuffer(validEntry.data);
+      const migratedBuffer = Buffer.from(compressedValue, 'base64');
 
       expect(cacheKeys).toEqual(['legacy-valid-key']);
       expect(validInfo?.metadata).toEqual({
         expiry,
         version: cacheVersion,
       });
+      expect(validEntry.data.equals(migratedBuffer)).toBe(true);
       expect(validValue).toBe('1234');
       expect(validEntry.data.toString()).not.toBe(payload);
     });

--- a/lib/util/cache/package/impl/file.spec.ts
+++ b/lib/util/cache/package/impl/file.spec.ts
@@ -243,6 +243,29 @@ describe('util/cache/package/impl/file', () => {
       expect(cacacheGet).not.toHaveBeenCalled();
     });
 
+    it('skips invalid cache index stream payloads during cleanup', async () => {
+      await cache.set(namespace, 'valid', 1234, 5);
+      const validEntry = await cacache.get.info(
+        cacheFileName,
+        cacheKey('valid'),
+      );
+      const lsStreamSpy = vi.spyOn(cacache.ls, 'stream').mockImplementation(
+        () =>
+          (function* () {
+            yield 'invalid-cache-index-entry';
+            yield validEntry!;
+          })() as unknown as ReturnType<typeof cacache.ls.stream>,
+      );
+
+      await cache.destroy();
+
+      const cacheKeys = await getCacheKeys();
+
+      expect(cacheKeys).toEqual([cacheKey('valid')]);
+
+      lsStreamSpy.mockRestore();
+    });
+
     it('lazily migrates valid legacy entries without recompressing them', async () => {
       const { expiry, payload, compressedValue } = await putLegacyEntry(
         'legacy-valid-key',
@@ -379,6 +402,21 @@ describe('util/cache/package/impl/file', () => {
       expect(cacheKeys).not.toContain('invalid-legacy-payload');
     });
 
+    it('removes legacy entries with invalid compressed content during migration', async () => {
+      const payload = JSON.stringify({
+        compress: true,
+        value: Buffer.from('not-compressed').toString('base64'),
+        expiry: getExpiry(5),
+      });
+      await cacache.put(cacheFileName, 'invalid-legacy-content', payload);
+
+      await cache.destroy();
+
+      const cacheKeys = await getCacheKeys();
+
+      expect(cacheKeys).not.toContain('invalid-legacy-content');
+    });
+
     it('removes invalid legacy entries without expiry', async () => {
       const compressedValue = await compressToBase64(
         JSON.stringify('no-expiry'),
@@ -440,6 +478,32 @@ describe('util/cache/package/impl/file', () => {
       const cacheKeys = await getCacheKeys();
 
       expect(cacheKeys).not.toContain('unsupported-version');
+    });
+
+    it('continues when content cleanup fails', async () => {
+      await cache.set(namespace, 'valid', 1234, 5);
+      await cache.set(
+        namespace,
+        'expired-only-key',
+        { value: 'expired-only' },
+        -5,
+      );
+      const expiredInfo = await cacache.get.info(
+        cacheFileName,
+        cacheKey('expired-only-key'),
+      );
+      const expiredDigest = expiredInfo!.integrity;
+      const rmContentSpy = vi
+        .spyOn(cacache.rm, 'content')
+        .mockRejectedValueOnce(new Error('error'));
+
+      await expect(cache.destroy()).resolves.toBeUndefined();
+
+      expect(rmContentSpy).toHaveBeenCalledWith(cacheFileName, expiredDigest);
+      await expectNoCacheEntry(cacheKey('expired-only-key'));
+      await expect(cache.get(namespace, 'valid')).resolves.toBe(1234);
+
+      rmContentSpy.mockRestore();
     });
 
     it('continues on cleanup errors', async () => {

--- a/lib/util/cache/package/impl/file.ts
+++ b/lib/util/cache/package/impl/file.ts
@@ -143,31 +143,41 @@ export class PackageCacheFile extends PackageCacheBase {
     key: string,
     cacheKey: string,
   ): Promise<T | undefined> {
-    const cacheEntry = await cacache.get(this.cacheFileName, cacheKey);
-    const legacyEntry = parseLegacyCachePayload(cacheEntry.data);
+    try {
+      const cacheEntry = await cacache.get(this.cacheFileName, cacheKey);
+      const legacyEntry = parseLegacyCachePayload(cacheEntry.data);
 
-    if (!legacyEntry) {
-      await this.rm(namespace, key);
+      if (!legacyEntry) {
+        await this.rm(namespace, key);
+        return undefined;
+      }
+
+      if (isExpiredAt(legacyEntry.expiry, DateTime.local())) {
+        await this.rm(namespace, key);
+        return undefined;
+      }
+
+      logger.trace({ namespace, key }, 'Returning cached value');
+      return await decodeLegacyValue<T>(legacyEntry);
+    } catch (err) {
+      logger.trace({ err, namespace, key }, 'Cache miss');
       return undefined;
     }
-
-    if (isExpiredAt(legacyEntry.expiry, DateTime.local())) {
-      await this.rm(namespace, key);
-      return undefined;
-    }
-
-    logger.trace({ namespace, key }, 'Returning cached value');
-    return await decodeLegacyValue<T>(legacyEntry);
   }
 
   private async getValue<T>(
     namespace: PackageCacheNamespace,
     key: string,
     cacheKey: string,
-  ): Promise<T> {
-    const cacheEntry = await cacache.get(this.cacheFileName, cacheKey);
-    logger.trace({ namespace, key }, 'Returning cached value');
-    return await decodeValue<T>(cacheEntry.data);
+  ): Promise<T | undefined> {
+    try {
+      const cacheEntry = await cacache.get(this.cacheFileName, cacheKey);
+      logger.trace({ namespace, key }, 'Returning cached value');
+      return await decodeValue<T>(cacheEntry.data);
+    } catch (err) {
+      logger.trace({ err, namespace, key }, 'Cache miss');
+      return undefined;
+    }
   }
 
   private async migrateLegacyCacheEntry(
@@ -225,30 +235,25 @@ export class PackageCacheFile extends PackageCacheBase {
     namespace: PackageCacheNamespace,
     key: string,
   ): Promise<T | undefined> {
-    try {
-      const cacheKey = this.getKey(namespace, key);
-      const cacheInfo = await cacache.get.info(this.cacheFileName, cacheKey);
-      const now = DateTime.local();
+    const cacheKey = this.getKey(namespace, key);
+    const cacheInfo = await cacache.get.info(this.cacheFileName, cacheKey);
+    const now = DateTime.local();
 
-      if (!cacheInfo) {
+    if (!cacheInfo) {
+      return undefined;
+    }
+
+    if (cacheInfo.metadata !== undefined) {
+      const metadata = parseCacheMetadata(cacheInfo.metadata);
+      if (metadata === undefined || isExpiredAt(metadata.expiry, now)) {
+        await this.rm(namespace, key);
         return undefined;
       }
 
-      if (cacheInfo.metadata !== undefined) {
-        const metadata = parseCacheMetadata(cacheInfo.metadata);
-        if (metadata === undefined || isExpiredAt(metadata.expiry, now)) {
-          await this.rm(namespace, key);
-          return undefined;
-        }
-
-        return await this.getValue<T>(namespace, key, cacheKey);
-      }
-
-      return await this.getLegacy<T>(namespace, key, cacheKey);
-    } catch {
-      logger.trace({ namespace, key }, 'Cache miss');
+      return await this.getValue<T>(namespace, key, cacheKey);
     }
-    return undefined;
+
+    return await this.getLegacy<T>(namespace, key, cacheKey);
   }
 
   override async set(
@@ -260,9 +265,6 @@ export class PackageCacheFile extends PackageCacheBase {
     logger.trace({ namespace, key, hardTtlMinutes }, 'Saving cached value');
     const serialized = JSON.stringify(value);
     const expiry = DateTime.local().plus({ minutes: hardTtlMinutes }).toISO();
-    if (!expiry) {
-      throw new Error('Invalid package cache expiry');
-    }
 
     const cacheKey = this.getKey(namespace, key);
     await this.putCacheEntry(cacheKey, serialized, expiry);

--- a/lib/util/cache/package/impl/file.ts
+++ b/lib/util/cache/package/impl/file.ts
@@ -35,7 +35,7 @@ function parseJsonSafe<T>(text: string): T | undefined {
   }
 }
 
-function isExpiredAt(expiry: string, now: DateTime): boolean {
+function isExpired(expiry: string, now: DateTime = DateTime.local()): boolean {
   const expiryDateTime = DateTime.fromISO(expiry);
   if (!expiryDateTime.isValid) {
     return true;
@@ -126,6 +126,19 @@ export class PackageCacheFile extends PackageCacheBase {
     return `${namespace}-${key}`;
   }
 
+  private async getCacheInfo(
+    cacheKey: string,
+    namespace: PackageCacheNamespace,
+    key: string,
+  ): Promise<cacache.CacheObject | null> {
+    try {
+      return await cacache.get.info(this.cacheFileName, cacheKey);
+    } catch (err) {
+      logger.trace({ err, namespace, key }, 'Cache miss');
+      return null;
+    }
+  }
+
   private async putCacheEntry(
     cacheKey: string,
     serializedValue: string,
@@ -152,7 +165,7 @@ export class PackageCacheFile extends PackageCacheBase {
         return undefined;
       }
 
-      if (isExpiredAt(legacyEntry.expiry, DateTime.local())) {
+      if (isExpired(legacyEntry.expiry)) {
         await this.rm(namespace, key);
         return undefined;
       }
@@ -191,12 +204,24 @@ export class PackageCacheFile extends PackageCacheBase {
       return 'deleted';
     }
 
-    if (isExpiredAt(cachedValue.expiry, DateTime.local())) {
+    if (isExpired(cachedValue.expiry)) {
       await this.rmEntry(cacheKey);
       return 'deleted';
     }
 
-    const serializedValue = await decompressFromBase64(cachedValue.value);
+    let serializedValue: string;
+    try {
+      serializedValue = await decompressFromBase64(cachedValue.value);
+    } catch {
+      await this.rmEntry(cacheKey);
+      return 'deleted';
+    }
+
+    if (parseJsonSafe<unknown>(serializedValue) === undefined) {
+      await this.rmEntry(cacheKey);
+      return 'deleted';
+    }
+
     await this.putCacheEntry(cacheKey, serializedValue, cachedValue.expiry);
     return 'migrated';
   }
@@ -223,7 +248,7 @@ export class PackageCacheFile extends PackageCacheBase {
       return 'deleted';
     }
 
-    if (isExpiredAt(metadata.expiry, now)) {
+    if (isExpired(metadata.expiry, now)) {
       await this.rmEntry(cacheKey);
       return 'deleted';
     }
@@ -236,8 +261,7 @@ export class PackageCacheFile extends PackageCacheBase {
     key: string,
   ): Promise<T | undefined> {
     const cacheKey = this.getKey(namespace, key);
-    const cacheInfo = await cacache.get.info(this.cacheFileName, cacheKey);
-    const now = DateTime.local();
+    const cacheInfo = await this.getCacheInfo(cacheKey, namespace, key);
 
     if (!cacheInfo) {
       return undefined;
@@ -245,7 +269,7 @@ export class PackageCacheFile extends PackageCacheBase {
 
     if (cacheInfo.metadata !== undefined) {
       const metadata = parseCacheMetadata(cacheInfo.metadata);
-      if (metadata === undefined || isExpiredAt(metadata.expiry, now)) {
+      if (metadata === undefined || isExpired(metadata.expiry)) {
         await this.rm(namespace, key);
         return undefined;
       }

--- a/lib/util/cache/package/impl/file.ts
+++ b/lib/util/cache/package/impl/file.ts
@@ -24,10 +24,16 @@ interface CacheMetadata {
   version: number;
 }
 
-type LegacyMigrationStatus = 'deleted' | 'migrated';
-type CacheCleanupStatus = 'deleted' | 'kept';
+type CacheCleanupResult =
+  | { digest: string; status: 'deleted' }
+  | { digest: string; status: 'kept' }
+  | {
+      liveDigest: string;
+      replacedDigest: string;
+      status: 'migrated';
+    };
 
-function parseJsonSafe<T>(text: string): T | undefined {
+function parseJsonSafe<T = unknown>(text: string): T | undefined {
   try {
     return JSON.parse(text) as T;
   } catch {
@@ -35,13 +41,13 @@ function parseJsonSafe<T>(text: string): T | undefined {
   }
 }
 
-function isExpired(expiry: string, now: DateTime = DateTime.local()): boolean {
+function isExpired(expiry: string): boolean {
   const expiryDateTime = DateTime.fromISO(expiry);
   if (!expiryDateTime.isValid) {
     return true;
   }
 
-  return now >= expiryDateTime;
+  return DateTime.local() >= expiryDateTime;
 }
 
 function parseCacheMetadata(value: unknown): CacheMetadata | undefined {
@@ -61,7 +67,7 @@ function parseCacheMetadata(value: unknown): CacheMetadata | undefined {
 function parseLegacyCachePayload(
   data: Buffer,
 ): PackageCacheLegacyEntry | undefined {
-  const parsed = parseJsonSafe<unknown>(data.toString());
+  const parsed = parseJsonSafe(data.toString());
   if (parsed === undefined) {
     logger.debug('Error parsing cached value - deleting');
     return undefined;
@@ -143,9 +149,9 @@ export class PackageCacheFile extends PackageCacheBase {
     cacheKey: string,
     compressedValue: Buffer,
     expiry: string,
-  ): Promise<void> {
+  ): Promise<string> {
     const metadata = { version: CACHE_VERSION, expiry };
-    await cacache.put(this.cacheFileName, cacheKey, compressedValue, {
+    return await cacache.put(this.cacheFileName, cacheKey, compressedValue, {
       metadata,
     });
   }
@@ -203,18 +209,19 @@ export class PackageCacheFile extends PackageCacheBase {
 
   private async migrateLegacyCacheEntry(
     cacheKey: string,
-  ): Promise<LegacyMigrationStatus> {
+    digest: string,
+  ): Promise<CacheCleanupResult> {
     const legacyEntry = await cacache.get(this.cacheFileName, cacheKey);
     const cachedValue = parseLegacyCachePayload(legacyEntry.data);
 
     if (!cachedValue) {
       await this.rmEntry(cacheKey);
-      return 'deleted';
+      return { digest, status: 'deleted' };
     }
 
     if (isExpired(cachedValue.expiry)) {
       await this.rmEntry(cacheKey);
-      return 'deleted';
+      return { digest, status: 'deleted' };
     }
 
     const compressedValue = Buffer.from(cachedValue.value, 'base64');
@@ -224,46 +231,78 @@ export class PackageCacheFile extends PackageCacheBase {
       serializedValue = await decompressFromBuffer(compressedValue);
     } catch {
       await this.rmEntry(cacheKey);
-      return 'deleted';
+      return { digest, status: 'deleted' };
     }
 
-    if (parseJsonSafe<unknown>(serializedValue) === undefined) {
+    if (parseJsonSafe(serializedValue) === undefined) {
       await this.rmEntry(cacheKey);
-      return 'deleted';
+      return { digest, status: 'deleted' };
     }
 
-    await this.putCacheEntry(cacheKey, compressedValue, cachedValue.expiry);
-    return 'migrated';
-  }
+    const migratedDigest = await this.putCacheEntry(
+      cacheKey,
+      compressedValue,
+      cachedValue.expiry,
+    );
 
-  private async cleanupLegacyCacheEntry(
-    cacheKey: string,
-  ): Promise<CacheCleanupStatus> {
-    const migrationResult = await this.migrateLegacyCacheEntry(cacheKey);
-    if (migrationResult === 'deleted') {
-      return 'deleted';
-    }
-
-    return 'kept';
+    return {
+      liveDigest: migratedDigest,
+      replacedDigest: digest,
+      status: 'migrated',
+    };
   }
 
   private async cleanupEntry(
     cacheKey: string,
     rawMetadata: unknown,
-    now: DateTime,
-  ): Promise<CacheCleanupStatus> {
+    digest: string,
+  ): Promise<CacheCleanupResult> {
     const metadata = parseCacheMetadata(rawMetadata);
     if (!metadata) {
       await this.rmEntry(cacheKey);
-      return 'deleted';
+      return { digest, status: 'deleted' };
     }
 
-    if (isExpired(metadata.expiry, now)) {
+    if (isExpired(metadata.expiry)) {
       await this.rmEntry(cacheKey);
-      return 'deleted';
+      return { digest, status: 'deleted' };
     }
 
-    return 'kept';
+    return { digest, status: 'kept' };
+  }
+
+  private async getCleanupResult(
+    cacheEntry: cacache.CacheObject,
+  ): Promise<CacheCleanupResult> {
+    const { integrity: digest } = cacheEntry;
+
+    if (cacheEntry.metadata === undefined) {
+      return this.migrateLegacyCacheEntry(cacheEntry.key, digest);
+    }
+
+    return this.cleanupEntry(cacheEntry.key, cacheEntry.metadata, digest);
+  }
+
+  private async cleanupContent(
+    candidateDigests: ReadonlySet<string>,
+    liveDigests: ReadonlySet<string>,
+  ): Promise<number> {
+    let errorCount = 0;
+
+    for (const digest of candidateDigests) {
+      if (liveDigests.has(digest)) {
+        continue;
+      }
+
+      try {
+        await cacache.rm.content(this.cacheFileName, digest);
+      } catch (err) {
+        logger.trace({ err, digest }, 'Error cleaning up cache content');
+        errorCount += 1;
+      }
+    }
+
+    return errorCount;
   }
 
   override async get<T = unknown>(
@@ -306,29 +345,43 @@ export class PackageCacheFile extends PackageCacheBase {
 
   override async destroy(): Promise<void> {
     logger.debug('Checking file package cache for expired items');
+
     let totalCount = 0;
     let deletedCount = 0;
     let errorCount = 0;
+
     const startTime = Date.now();
-    const now = DateTime.local();
+    const candidateDigests = new Set<string>();
+    const liveDigests = new Set<string>();
+
     for await (const item of cacache.ls.stream(this.cacheFileName)) {
       try {
         totalCount += 1;
         const cacheEntry = item as unknown as cacache.CacheObject;
 
-        const cleanupResult =
-          cacheEntry.metadata === undefined
-            ? await this.cleanupLegacyCacheEntry(cacheEntry.key)
-            : await this.cleanupEntry(cacheEntry.key, cacheEntry.metadata, now);
+        const cleanupResult = await this.getCleanupResult(cacheEntry);
 
-        if (cleanupResult === 'deleted') {
-          deletedCount += 1;
+        switch (cleanupResult.status) {
+          case 'deleted':
+            deletedCount += 1;
+            candidateDigests.add(cleanupResult.digest);
+            break;
+          case 'kept':
+            liveDigests.add(cleanupResult.digest);
+            break;
+          case 'migrated':
+            candidateDigests.add(cleanupResult.replacedDigest);
+            liveDigests.add(cleanupResult.liveDigest);
+            break;
         }
       } catch (err) {
         logger.trace({ err }, 'Error cleaning up cache entry');
         errorCount += 1;
       }
     }
+
+    errorCount += await this.cleanupContent(candidateDigests, liveDigests);
+
     if (errorCount > 0) {
       logger.debug(`Error count cleaning up cache: ${errorCount}`);
     }

--- a/lib/util/cache/package/impl/file.ts
+++ b/lib/util/cache/package/impl/file.ts
@@ -1,10 +1,85 @@
+import { isPlainObject } from '@sindresorhus/is';
 import cacache from 'cacache';
 import { DateTime } from 'luxon';
 import upath from 'upath';
 import { logger } from '../../../../logger/index.ts';
-import { compressToBase64, decompressFromBase64 } from '../../../compress.ts';
+import {
+  compressToBuffer,
+  decompressFromBase64,
+  decompressFromBuffer,
+} from '../../../compress.ts';
 import type { PackageCacheNamespace } from '../types.ts';
 import { PackageCacheBase } from './base.ts';
+
+const currentCacheFormat = 'br-json';
+const currentCacheVersion = 2;
+
+interface PackageCacheLegacyEntry {
+  compress: true;
+  expiry: string;
+  value: string;
+}
+
+interface PackageCacheMetadata {
+  expiry: string;
+  format: typeof currentCacheFormat;
+  version: typeof currentCacheVersion;
+}
+
+function parseCacheMetadata(value: unknown): PackageCacheMetadata | undefined {
+  if (!isPlainObject(value)) {
+    return undefined;
+  }
+
+  const { expiry, format, version } = value;
+
+  if (
+    typeof expiry !== 'string' ||
+    format !== currentCacheFormat ||
+    version !== currentCacheVersion
+  ) {
+    return undefined;
+  }
+
+  return { expiry, format, version };
+}
+
+function parseLegacyCacheEntry(
+  data: Buffer,
+): PackageCacheLegacyEntry | undefined {
+  const parsed: unknown = JSON.parse(data.toString());
+  if (!isPlainObject(parsed)) {
+    return undefined;
+  }
+
+  const { compress, expiry, value } = parsed;
+
+  if (
+    compress !== true ||
+    typeof expiry !== 'string' ||
+    typeof value !== 'string'
+  ) {
+    return undefined;
+  }
+
+  return {
+    compress,
+    expiry,
+    value,
+  };
+}
+
+async function deserializeCurrentValue<T>(data: Buffer): Promise<T> {
+  const json = await decompressFromBuffer(data);
+  return JSON.parse(json) as T;
+}
+
+async function deserializeLegacyValue<T>(
+  entry: PackageCacheLegacyEntry,
+): Promise<T> {
+  const json = await decompressFromBase64(entry.value);
+  return JSON.parse(json) as T;
+}
 
 export class PackageCacheFile extends PackageCacheBase {
   static create(cacheDir: string): PackageCacheFile {
@@ -24,36 +99,101 @@ export class PackageCacheFile extends PackageCacheBase {
     return `${namespace}-${key}`;
   }
 
+  private async putCurrentEntry(
+    cacheKey: string,
+    serializedValue: string,
+    expiry: string,
+  ): Promise<void> {
+    const compressedValue = await compressToBuffer(serializedValue);
+    await cacache.put(this.cacheFileName, cacheKey, compressedValue, {
+      metadata: {
+        expiry,
+        format: currentCacheFormat,
+        version: currentCacheVersion,
+      },
+    });
+  }
+
+  private async getLegacy<T>(
+    namespace: PackageCacheNamespace,
+    key: string,
+    cacheKey: string,
+  ): Promise<T | undefined> {
+    const cacheEntry = await cacache.get(this.cacheFileName, cacheKey);
+    const legacyEntry = parseLegacyCacheEntry(cacheEntry.data);
+
+    if (!legacyEntry) {
+      await this.rm(namespace, key);
+      return undefined;
+    }
+
+    const expiry = DateTime.fromISO(legacyEntry.expiry);
+    if (!expiry.isValid || DateTime.local() >= expiry) {
+      await this.rm(namespace, key);
+      return undefined;
+    }
+
+    logger.trace({ namespace, key }, 'Returning cached value');
+    return await deserializeLegacyValue<T>(legacyEntry);
+  }
+
+  private async migrateLegacyEntry(cacheKey: string): Promise<boolean> {
+    const legacyEntry = await cacache.get(this.cacheFileName, cacheKey);
+    let cachedValue: PackageCacheLegacyEntry | undefined;
+
+    try {
+      cachedValue = parseLegacyCacheEntry(legacyEntry.data);
+    } catch {
+      logger.debug('Error parsing cached value - deleting');
+    }
+
+    if (!cachedValue) {
+      await this.rmEntry(cacheKey);
+      return true;
+    }
+
+    const expiry = DateTime.fromISO(cachedValue.expiry);
+    if (!expiry.isValid || DateTime.local() >= expiry) {
+      await this.rmEntry(cacheKey);
+      return true;
+    }
+
+    const serializedValue = await decompressFromBase64(cachedValue.value);
+    await this.putCurrentEntry(cacheKey, serializedValue, cachedValue.expiry);
+    return false;
+  }
+
   override async get<T = unknown>(
     namespace: PackageCacheNamespace,
     key: string,
   ): Promise<T | undefined> {
     try {
-      const entry = await cacache.get(
-        this.cacheFileName,
-        this.getKey(namespace, key),
-      );
-      const raw = entry.data.toString();
-      const cached = JSON.parse(raw);
+      const cacheKey = this.getKey(namespace, key);
+      const cacheInfo = await cacache.get.info(this.cacheFileName, cacheKey);
 
-      if (!cached) {
+      if (!cacheInfo) {
         return undefined;
       }
 
-      const expiry = DateTime.fromISO(cached.expiry);
-      if (!expiry.isValid || DateTime.local() >= expiry) {
-        await this.rm(namespace, key);
-        return undefined;
+      if (cacheInfo.metadata !== undefined) {
+        const metadata = parseCacheMetadata(cacheInfo.metadata);
+        if (!metadata) {
+          await this.rm(namespace, key);
+          return undefined;
+        }
+
+        const expiry = DateTime.fromISO(metadata.expiry);
+        if (!expiry.isValid || DateTime.local() >= expiry) {
+          await this.rm(namespace, key);
+          return undefined;
+        }
+
+        const cacheEntry = await cacache.get(this.cacheFileName, cacheKey);
+        logger.trace({ namespace, key }, 'Returning cached value');
+        return await deserializeCurrentValue<T>(cacheEntry.data);
       }
 
-      logger.trace({ namespace, key }, 'Returning cached value');
-
-      if (!cached.compress) {
-        return cached.value;
-      }
-
-      const json = await decompressFromBase64(cached.value);
-      return JSON.parse(json);
+      return await this.getLegacy<T>(namespace, key, cacheKey);
     } catch {
       logger.trace({ namespace, key }, 'Cache miss');
     }
@@ -68,14 +208,12 @@ export class PackageCacheFile extends PackageCacheBase {
   ): Promise<void> {
     logger.trace({ namespace, key, hardTtlMinutes }, 'Saving cached value');
     const serialized = JSON.stringify(value);
-    const compressedValue = await compressToBase64(serialized);
-    const expiry = DateTime.local().plus({ minutes: hardTtlMinutes });
-    const payload = JSON.stringify({
-      compress: true,
-      value: compressedValue,
-      expiry,
-    });
-    await cacache.put(this.cacheFileName, this.getKey(namespace, key), payload);
+    const expiry = DateTime.local().plus({ minutes: hardTtlMinutes }).toISO();
+    if (!expiry) {
+      throw new Error('Invalid package cache expiry');
+    }
+
+    await this.putCurrentEntry(this.getKey(namespace, key), serialized, expiry);
   }
 
   override async destroy(): Promise<void> {
@@ -88,28 +226,26 @@ export class PackageCacheFile extends PackageCacheBase {
       try {
         totalCount += 1;
         const cacheEntry = item as unknown as cacache.CacheObject;
-        const entry = await cacache.get(this.cacheFileName, cacheEntry.key);
-        let cached: { expiry?: string } | undefined;
-        try {
-          const raw = entry.data.toString();
-          cached = JSON.parse(raw);
-        } catch {
-          logger.debug('Error parsing cached value - deleting');
-        }
 
-        if (cached) {
-          if (!cached.expiry) {
+        if (cacheEntry.metadata !== undefined) {
+          const metadata = parseCacheMetadata(cacheEntry.metadata);
+          if (!metadata) {
+            await this.rmEntry(cacheEntry.key);
+            deletedCount += 1;
             continue;
           }
-          const expiry = DateTime.fromISO(cached.expiry);
+
+          const expiry = DateTime.fromISO(metadata.expiry);
           if (expiry.isValid && DateTime.local() <= expiry) {
             continue;
           }
+
+          await this.rmEntry(cacheEntry.key);
+          deletedCount += 1;
+          continue;
         }
 
-        await cacache.rm.entry(this.cacheFileName, cacheEntry.key);
-        await cacache.rm.content(this.cacheFileName, cacheEntry.integrity);
-        deletedCount += 1;
+        deletedCount += (await this.migrateLegacyEntry(cacheEntry.key)) ? 1 : 0;
       } catch (err) {
         logger.trace({ err }, 'Error cleaning up cache entry');
         errorCount += 1;
@@ -129,6 +265,10 @@ export class PackageCacheFile extends PackageCacheBase {
     key: string,
   ): Promise<void> {
     logger.trace({ namespace, key }, 'Removing cache entry');
-    await cacache.rm.entry(this.cacheFileName, this.getKey(namespace, key));
+    await this.rmEntry(this.getKey(namespace, key));
+  }
+
+  private async rmEntry(cacheKey: string): Promise<void> {
+    await cacache.rm.entry(this.cacheFileName, cacheKey);
   }
 }

--- a/lib/util/cache/package/impl/file.ts
+++ b/lib/util/cache/package/impl/file.ts
@@ -18,21 +18,25 @@ interface LegacyPayload {
   value: string;
 }
 
-interface CacheMetadata {
+interface CacheIndexMetadata {
   expiry: string;
   version: number;
 }
 
-interface CacheEntry {
+interface CacheIndexEntry {
   key: string;
   integrity: string;
   metadata?: unknown;
 }
 
-type CacheSweepResult =
-  | { status: 'deleted'; digest: string }
-  | { status: 'kept'; digest: string }
-  | { status: 'migrated'; liveDigest: string; replacedDigest: string };
+type CacheIndexSweepResult =
+  | { status: 'deleted'; contentDigest: string }
+  | { status: 'kept'; contentDigest: string }
+  | {
+      status: 'migrated';
+      liveContentDigest: string;
+      replacedContentDigest: string;
+    };
 
 function parseJsonSafe<T = unknown>(text: string): T | undefined {
   try {
@@ -51,7 +55,9 @@ function isExpired(expiry: string): boolean {
   return DateTime.local() >= expiryDateTime;
 }
 
-function parseCacheMetadata(value: unknown): CacheMetadata | undefined {
+function parseCacheIndexMetadata(
+  value: unknown,
+): CacheIndexMetadata | undefined {
   if (!isPlainObject(value) || !isString(value.expiry)) {
     return undefined;
   }
@@ -83,7 +89,7 @@ function parseLegacyPayload(data: Buffer): LegacyPayload | undefined {
   return { expiry, value };
 }
 
-function isCacheEntry(value: unknown): value is CacheEntry {
+function isCacheIndexEntry(value: unknown): value is CacheIndexEntry {
   if (!isPlainObject(value)) {
     return false;
   }
@@ -91,7 +97,7 @@ function isCacheEntry(value: unknown): value is CacheEntry {
   return isNonEmptyString(value.key) && isNonEmptyString(value.integrity);
 }
 
-async function decodeStoredValue<T>(data: Buffer): Promise<T> {
+async function decodeCurrentStoredValue<T>(data: Buffer): Promise<T> {
   const json = await decompressFromBuffer(data);
   const parsed = parseJsonSafe<T>(json);
 
@@ -102,7 +108,7 @@ async function decodeStoredValue<T>(data: Buffer): Promise<T> {
   return parsed;
 }
 
-async function decodeLegacyPayloadValue<T>(payload: LegacyPayload): Promise<T> {
+async function decodeLegacyStoredValue<T>(payload: LegacyPayload): Promise<T> {
   const json = await decompressFromBase64(payload.value);
   const parsed = parseJsonSafe<T>(json);
 
@@ -131,9 +137,9 @@ export class PackageCacheFile extends PackageCacheBase {
     namespace: PackageCacheNamespace,
     key: string,
   ): Promise<T | undefined> {
-    const cacheKey = this.getCacheKey(namespace, key);
+    const cacheIndexKey = this.getCacheIndexKey(namespace, key);
     const cacheIndexEntry = await this.getCacheIndexEntry(
-      cacheKey,
+      cacheIndexKey,
       namespace,
       key,
     );
@@ -143,17 +149,21 @@ export class PackageCacheFile extends PackageCacheBase {
     }
 
     if (cacheIndexEntry.metadata !== undefined) {
-      const metadata = parseCacheMetadata(cacheIndexEntry.metadata);
+      const metadata = parseCacheIndexMetadata(cacheIndexEntry.metadata);
 
       if (metadata === undefined || isExpired(metadata.expiry)) {
-        await this.removeCacheEntry(namespace, key);
+        await this.removeLogicalCacheEntry(namespace, key);
         return undefined;
       }
 
-      return await this.getCurrentValue<T>(namespace, key, cacheKey);
+      return await this.readCurrentCachedValue<T>(
+        namespace,
+        key,
+        cacheIndexKey,
+      );
     }
 
-    return await this.getLegacyValue<T>(namespace, key, cacheKey);
+    return await this.readLegacyCachedValue<T>(namespace, key, cacheIndexKey);
   }
 
   override async set(
@@ -166,8 +176,12 @@ export class PackageCacheFile extends PackageCacheBase {
     const serialized = JSON.stringify(value);
     const expiry = DateTime.local().plus({ minutes: hardTtlMinutes }).toISO();
 
-    const cacheKey = this.getCacheKey(namespace, key);
-    await this.writeSerializedCacheEntry(cacheKey, serialized, expiry);
+    const cacheIndexKey = this.getCacheIndexKey(namespace, key);
+    await this.writeSerializedCacheIndexEntry(
+      cacheIndexKey,
+      serialized,
+      expiry,
+    );
   }
 
   override async destroy(): Promise<void> {
@@ -178,41 +192,41 @@ export class PackageCacheFile extends PackageCacheBase {
     let errorCount = 0;
 
     const startTime = Date.now();
-    const candidateDigests = new Set<string>();
-    const liveDigests = new Set<string>();
+    const candidateContentDigests = new Set<string>();
+    const liveContentDigests = new Set<string>();
 
     for await (const item of cacache.ls.stream(this.cachePath)) {
       totalCount += 1;
-      if (!isCacheEntry(item)) {
+      if (!isCacheIndexEntry(item)) {
         logger.trace('Invalid cache index entry stream payload');
         errorCount += 1;
         continue;
       }
 
-      const cacheSweepResult = await this.safeClassifyCacheIndexEntry(item);
-      if (cacheSweepResult === undefined) {
+      const sweepResult = await this.trySweepCacheIndexEntry(item);
+      if (sweepResult === undefined) {
         errorCount += 1;
         continue;
       }
 
-      if (cacheSweepResult.status === 'deleted') {
+      if (sweepResult.status === 'deleted') {
         deletedCount += 1;
-        candidateDigests.add(cacheSweepResult.digest);
+        candidateContentDigests.add(sweepResult.contentDigest);
         continue;
       }
 
-      if (cacheSweepResult.status === 'kept') {
-        liveDigests.add(cacheSweepResult.digest);
+      if (sweepResult.status === 'kept') {
+        liveContentDigests.add(sweepResult.contentDigest);
         continue;
       }
 
-      candidateDigests.add(cacheSweepResult.replacedDigest);
-      liveDigests.add(cacheSweepResult.liveDigest);
+      candidateContentDigests.add(sweepResult.replacedContentDigest);
+      liveContentDigests.add(sweepResult.liveContentDigest);
     }
 
-    errorCount += await this.cleanupUnreferencedContent(
-      candidateDigests,
-      liveDigests,
+    errorCount += await this.removeUnreferencedContent(
+      candidateContentDigests,
+      liveContentDigests,
     );
 
     if (errorCount > 0) {
@@ -224,100 +238,103 @@ export class PackageCacheFile extends PackageCacheBase {
     );
   }
 
-  private getCacheKey(namespace: PackageCacheNamespace, key: string): string {
+  private getCacheIndexKey(
+    namespace: PackageCacheNamespace,
+    key: string,
+  ): string {
     return `${namespace}-${key}`;
   }
 
   private async getCacheIndexEntry(
-    cacheKey: string,
+    cacheIndexKey: string,
     namespace: PackageCacheNamespace,
     key: string,
-  ): Promise<CacheEntry | null> {
+  ): Promise<CacheIndexEntry | null> {
     try {
-      return await cacache.get.info(this.cachePath, cacheKey);
+      return await cacache.get.info(this.cachePath, cacheIndexKey);
     } catch (err) {
       logger.trace({ err, namespace, key }, 'Cache miss');
       return null;
     }
   }
 
-  private async writeCacheEntry(
-    cacheKey: string,
+  private async writeCacheIndexEntry(
+    cacheIndexKey: string,
     compressedValue: Buffer,
     expiry: string,
   ): Promise<string> {
     const metadata = { version: CACHE_VERSION, expiry };
-    return await cacache.put(this.cachePath, cacheKey, compressedValue, {
+    return await cacache.put(this.cachePath, cacheIndexKey, compressedValue, {
       metadata,
     });
   }
 
-  private async writeSerializedCacheEntry(
-    cacheKey: string,
+  private async writeSerializedCacheIndexEntry(
+    cacheIndexKey: string,
     serializedValue: string,
     expiry: string,
   ): Promise<void> {
     const compressedValue = await compressToBuffer(serializedValue);
-    await this.writeCacheEntry(cacheKey, compressedValue, expiry);
+    await this.writeCacheIndexEntry(cacheIndexKey, compressedValue, expiry);
   }
 
-  private async getLegacyValue<T>(
+  private async readLegacyCachedValue<T>(
     namespace: PackageCacheNamespace,
     key: string,
-    cacheKey: string,
+    cacheIndexKey: string,
   ): Promise<T | undefined> {
     try {
-      const cacheEntry = await cacache.get(this.cachePath, cacheKey);
-      const legacyPayload = parseLegacyPayload(cacheEntry.data);
+      const storedEntry = await cacache.get(this.cachePath, cacheIndexKey);
+      const legacyPayload = parseLegacyPayload(storedEntry.data);
 
       if (!legacyPayload) {
-        await this.removeCacheEntry(namespace, key);
+        await this.removeLogicalCacheEntry(namespace, key);
         return undefined;
       }
 
       if (isExpired(legacyPayload.expiry)) {
-        await this.removeCacheEntry(namespace, key);
+        await this.removeLogicalCacheEntry(namespace, key);
         return undefined;
       }
 
       logger.trace({ namespace, key }, 'Returning cached value');
-      return await decodeLegacyPayloadValue<T>(legacyPayload);
+      return await decodeLegacyStoredValue<T>(legacyPayload);
     } catch (err) {
       logger.trace({ err, namespace, key }, 'Cache miss');
       return undefined;
     }
   }
 
-  private async getCurrentValue<T>(
+  private async readCurrentCachedValue<T>(
     namespace: PackageCacheNamespace,
     key: string,
-    cacheKey: string,
+    cacheIndexKey: string,
   ): Promise<T | undefined> {
     try {
-      const cacheEntry = await cacache.get(this.cachePath, cacheKey);
+      const storedEntry = await cacache.get(this.cachePath, cacheIndexKey);
       logger.trace({ namespace, key }, 'Returning cached value');
-      return await decodeStoredValue<T>(cacheEntry.data);
+      return await decodeCurrentStoredValue<T>(storedEntry.data);
     } catch (err) {
       logger.trace({ err, namespace, key }, 'Cache miss');
       return undefined;
     }
   }
 
-  private async migrateLegacyCacheEntry(
-    cacheKey: string,
-    digest: string,
-  ): Promise<CacheSweepResult> {
-    const legacyEntry = await cacache.get(this.cachePath, cacheKey);
+  private async migrateLegacyCacheIndexEntry(
+    cacheIndexKey: string,
+    contentDigest: string,
+  ): Promise<CacheIndexSweepResult> {
+    const legacyEntry = await cacache.get(this.cachePath, cacheIndexKey);
     const legacyPayload = parseLegacyPayload(legacyEntry.data);
 
     if (!legacyPayload) {
-      await this.removeCacheIndexEntry(cacheKey);
-      return { digest, status: 'deleted' };
+      await this.removeCacheIndexEntry(cacheIndexKey);
+      return { status: 'deleted', contentDigest };
     }
 
     if (isExpired(legacyPayload.expiry)) {
-      await this.removeCacheIndexEntry(cacheKey);
-      return { digest, status: 'deleted' };
+      await this.removeCacheIndexEntry(cacheIndexKey);
+      return { status: 'deleted', contentDigest };
     }
 
     const compressedValue = Buffer.from(legacyPayload.value, 'base64');
@@ -326,81 +343,84 @@ export class PackageCacheFile extends PackageCacheBase {
     try {
       serializedValue = await decompressFromBuffer(compressedValue);
     } catch {
-      await this.removeCacheIndexEntry(cacheKey);
-      return { digest, status: 'deleted' };
+      await this.removeCacheIndexEntry(cacheIndexKey);
+      return { status: 'deleted', contentDigest };
     }
 
     if (parseJsonSafe(serializedValue) === undefined) {
-      await this.removeCacheIndexEntry(cacheKey);
-      return { digest, status: 'deleted' };
+      await this.removeCacheIndexEntry(cacheIndexKey);
+      return { status: 'deleted', contentDigest };
     }
 
-    const migratedDigest = await this.writeCacheEntry(
-      cacheKey,
+    const liveContentDigest = await this.writeCacheIndexEntry(
+      cacheIndexKey,
       compressedValue,
       legacyPayload.expiry,
     );
 
     return {
-      liveDigest: migratedDigest,
-      replacedDigest: digest,
       status: 'migrated',
+      liveContentDigest,
+      replacedContentDigest: contentDigest,
     };
   }
 
-  private async classifyCacheIndexEntry(
-    cacheEntry: CacheEntry,
-  ): Promise<CacheSweepResult> {
+  private async sweepCacheIndexEntry(
+    cacheIndexEntry: CacheIndexEntry,
+  ): Promise<CacheIndexSweepResult> {
     const {
-      key: cacheKey,
+      key: cacheIndexKey,
       metadata: rawMetadata,
-      integrity: digest,
-    } = cacheEntry;
+      integrity: contentDigest,
+    } = cacheIndexEntry;
 
     if (rawMetadata === undefined) {
-      return this.migrateLegacyCacheEntry(cacheKey, digest);
+      return this.migrateLegacyCacheIndexEntry(cacheIndexKey, contentDigest);
     }
 
-    const parsedMetadata = parseCacheMetadata(rawMetadata);
+    const parsedMetadata = parseCacheIndexMetadata(rawMetadata);
     if (!parsedMetadata) {
-      await this.removeCacheIndexEntry(cacheKey);
-      return { digest, status: 'deleted' };
+      await this.removeCacheIndexEntry(cacheIndexKey);
+      return { status: 'deleted', contentDigest };
     }
 
     if (isExpired(parsedMetadata.expiry)) {
-      await this.removeCacheIndexEntry(cacheKey);
-      return { digest, status: 'deleted' };
+      await this.removeCacheIndexEntry(cacheIndexKey);
+      return { status: 'deleted', contentDigest };
     }
 
-    return { digest, status: 'kept' };
+    return { status: 'kept', contentDigest };
   }
 
-  private async safeClassifyCacheIndexEntry(
-    cacheEntry: CacheEntry,
-  ): Promise<CacheSweepResult | undefined> {
+  private async trySweepCacheIndexEntry(
+    cacheIndexEntry: CacheIndexEntry,
+  ): Promise<CacheIndexSweepResult | undefined> {
     try {
-      return await this.classifyCacheIndexEntry(cacheEntry);
+      return await this.sweepCacheIndexEntry(cacheIndexEntry);
     } catch (err) {
       logger.trace({ err }, 'Error classifying cache entry');
       return undefined;
     }
   }
 
-  private async cleanupUnreferencedContent(
-    candidateDigests: ReadonlySet<string>,
-    liveDigests: ReadonlySet<string>,
+  private async removeUnreferencedContent(
+    candidateContentDigests: ReadonlySet<string>,
+    liveContentDigests: ReadonlySet<string>,
   ): Promise<number> {
     let errorCount = 0;
 
-    for (const digest of candidateDigests) {
-      if (liveDigests.has(digest)) {
+    for (const contentDigest of candidateContentDigests) {
+      if (liveContentDigests.has(contentDigest)) {
         continue;
       }
 
       try {
-        await cacache.rm.content(this.cachePath, digest);
+        await cacache.rm.content(this.cachePath, contentDigest);
       } catch (err) {
-        logger.trace({ err, digest }, 'Error cleaning up cache content');
+        logger.trace(
+          { err, digest: contentDigest },
+          'Error cleaning up cache content',
+        );
         errorCount += 1;
       }
     }
@@ -408,15 +428,15 @@ export class PackageCacheFile extends PackageCacheBase {
     return errorCount;
   }
 
-  private async removeCacheEntry(
+  private async removeLogicalCacheEntry(
     namespace: PackageCacheNamespace,
     key: string,
   ): Promise<void> {
     logger.trace({ namespace, key }, 'Removing cache entry');
-    await this.removeCacheIndexEntry(this.getCacheKey(namespace, key));
+    await this.removeCacheIndexEntry(this.getCacheIndexKey(namespace, key));
   }
 
-  private async removeCacheIndexEntry(cacheKey: string): Promise<void> {
-    await cacache.rm.entry(this.cachePath, cacheKey);
+  private async removeCacheIndexEntry(cacheIndexKey: string): Promise<void> {
+    await cacache.rm.entry(this.cachePath, cacheIndexKey);
   }
 }

--- a/lib/util/cache/package/impl/file.ts
+++ b/lib/util/cache/package/impl/file.ts
@@ -19,15 +19,15 @@ interface PackageCacheLegacyEntry {
   value: string;
 }
 
-interface PackageCacheMetadata {
+interface CacheMetadata {
   expiry: string;
   version: number;
 }
 
-type PackageCacheLegacyMigrationResult = 'deleted' | 'migrated';
-type PackageCacheCleanupResult = 'deleted' | 'kept';
+type LegacyMigrationStatus = 'deleted' | 'migrated';
+type CacheCleanupStatus = 'deleted' | 'kept';
 
-function parseJson<T>(text: string): T | undefined {
+function parseJsonSafe<T>(text: string): T | undefined {
   try {
     return JSON.parse(text) as T;
   } catch {
@@ -35,7 +35,7 @@ function parseJson<T>(text: string): T | undefined {
   }
 }
 
-function isExpired(expiry: string, now: DateTime): boolean {
+function isExpiredAt(expiry: string, now: DateTime): boolean {
   const expiryDateTime = DateTime.fromISO(expiry);
   if (!expiryDateTime.isValid) {
     return true;
@@ -44,7 +44,7 @@ function isExpired(expiry: string, now: DateTime): boolean {
   return now >= expiryDateTime;
 }
 
-function parseCacheMetadata(value: unknown): PackageCacheMetadata | undefined {
+function parseCacheMetadata(value: unknown): CacheMetadata | undefined {
   if (!isPlainObject(value)) {
     return undefined;
   }
@@ -58,10 +58,10 @@ function parseCacheMetadata(value: unknown): PackageCacheMetadata | undefined {
   return { expiry, version };
 }
 
-function parseLegacyCacheEntry(
+function parseLegacyCachePayload(
   data: Buffer,
 ): PackageCacheLegacyEntry | undefined {
-  const parsed = parseJson<unknown>(data.toString());
+  const parsed = parseJsonSafe<unknown>(data.toString());
   if (parsed === undefined) {
     logger.debug('Error parsing cached value - deleting');
     return undefined;
@@ -84,9 +84,9 @@ function parseLegacyCacheEntry(
   return { compress, expiry, value };
 }
 
-async function deserializeCurrentValue<T>(data: Buffer): Promise<T> {
+async function decodeValue<T>(data: Buffer): Promise<T> {
   const json = await decompressFromBuffer(data);
-  const parsed = parseJson<T>(json);
+  const parsed = parseJsonSafe<T>(json);
 
   if (parsed === undefined) {
     throw new Error('Failed to deserialize cached value');
@@ -95,11 +95,11 @@ async function deserializeCurrentValue<T>(data: Buffer): Promise<T> {
   return parsed;
 }
 
-async function deserializeLegacyValue<T>(
+async function decodeLegacyValue<T>(
   entry: PackageCacheLegacyEntry,
 ): Promise<T> {
   const json = await decompressFromBase64(entry.value);
-  const parsed = parseJson<T>(json);
+  const parsed = parseJsonSafe<T>(json);
 
   if (parsed === undefined) {
     throw new Error('Failed to deserialize cached value');
@@ -126,7 +126,7 @@ export class PackageCacheFile extends PackageCacheBase {
     return `${namespace}-${key}`;
   }
 
-  private async putCurrentEntry(
+  private async putCacheEntry(
     cacheKey: string,
     serializedValue: string,
     expiry: string,
@@ -144,57 +144,57 @@ export class PackageCacheFile extends PackageCacheBase {
     cacheKey: string,
   ): Promise<T | undefined> {
     const cacheEntry = await cacache.get(this.cacheFileName, cacheKey);
-    const legacyEntry = parseLegacyCacheEntry(cacheEntry.data);
+    const legacyEntry = parseLegacyCachePayload(cacheEntry.data);
 
     if (!legacyEntry) {
       await this.rm(namespace, key);
       return undefined;
     }
 
-    if (isExpired(legacyEntry.expiry, DateTime.local())) {
+    if (isExpiredAt(legacyEntry.expiry, DateTime.local())) {
       await this.rm(namespace, key);
       return undefined;
     }
 
     logger.trace({ namespace, key }, 'Returning cached value');
-    return await deserializeLegacyValue<T>(legacyEntry);
+    return await decodeLegacyValue<T>(legacyEntry);
   }
 
-  private async getCurrent<T>(
+  private async getValue<T>(
     namespace: PackageCacheNamespace,
     key: string,
     cacheKey: string,
   ): Promise<T> {
     const cacheEntry = await cacache.get(this.cacheFileName, cacheKey);
     logger.trace({ namespace, key }, 'Returning cached value');
-    return await deserializeCurrentValue<T>(cacheEntry.data);
+    return await decodeValue<T>(cacheEntry.data);
   }
 
-  private async migrateLegacyEntry(
+  private async migrateLegacyCacheEntry(
     cacheKey: string,
-  ): Promise<PackageCacheLegacyMigrationResult> {
+  ): Promise<LegacyMigrationStatus> {
     const legacyEntry = await cacache.get(this.cacheFileName, cacheKey);
-    const cachedValue = parseLegacyCacheEntry(legacyEntry.data);
+    const cachedValue = parseLegacyCachePayload(legacyEntry.data);
 
     if (!cachedValue) {
       await this.rmEntry(cacheKey);
       return 'deleted';
     }
 
-    if (isExpired(cachedValue.expiry, DateTime.local())) {
+    if (isExpiredAt(cachedValue.expiry, DateTime.local())) {
       await this.rmEntry(cacheKey);
       return 'deleted';
     }
 
     const serializedValue = await decompressFromBase64(cachedValue.value);
-    await this.putCurrentEntry(cacheKey, serializedValue, cachedValue.expiry);
+    await this.putCacheEntry(cacheKey, serializedValue, cachedValue.expiry);
     return 'migrated';
   }
 
-  private async cleanupLegacyEntry(
+  private async cleanupLegacyCacheEntry(
     cacheKey: string,
-  ): Promise<PackageCacheCleanupResult> {
-    const migrationResult = await this.migrateLegacyEntry(cacheKey);
+  ): Promise<CacheCleanupStatus> {
+    const migrationResult = await this.migrateLegacyCacheEntry(cacheKey);
     if (migrationResult === 'deleted') {
       return 'deleted';
     }
@@ -202,18 +202,18 @@ export class PackageCacheFile extends PackageCacheBase {
     return 'kept';
   }
 
-  private async cleanupEntry(
+  private async cleanupEntryWithMetadata(
     cacheKey: string,
     rawMetadata: unknown,
     now: DateTime,
-  ): Promise<PackageCacheCleanupResult> {
+  ): Promise<CacheCleanupStatus> {
     const metadata = parseCacheMetadata(rawMetadata);
     if (!metadata) {
       await this.rmEntry(cacheKey);
       return 'deleted';
     }
 
-    if (isExpired(metadata.expiry, now)) {
+    if (isExpiredAt(metadata.expiry, now)) {
       await this.rmEntry(cacheKey);
       return 'deleted';
     }
@@ -236,12 +236,12 @@ export class PackageCacheFile extends PackageCacheBase {
 
       if (cacheInfo.metadata !== undefined) {
         const metadata = parseCacheMetadata(cacheInfo.metadata);
-        if (metadata === undefined || isExpired(metadata.expiry, now)) {
+        if (metadata === undefined || isExpiredAt(metadata.expiry, now)) {
           await this.rm(namespace, key);
           return undefined;
         }
 
-        return await this.getCurrent<T>(namespace, key, cacheKey);
+        return await this.getValue<T>(namespace, key, cacheKey);
       }
 
       return await this.getLegacy<T>(namespace, key, cacheKey);
@@ -265,7 +265,7 @@ export class PackageCacheFile extends PackageCacheBase {
     }
 
     const cacheKey = this.getKey(namespace, key);
-    await this.putCurrentEntry(cacheKey, serialized, expiry);
+    await this.putCacheEntry(cacheKey, serialized, expiry);
   }
 
   override async destroy(): Promise<void> {
@@ -282,8 +282,12 @@ export class PackageCacheFile extends PackageCacheBase {
 
         const cleanupResult =
           cacheEntry.metadata === undefined
-            ? await this.cleanupLegacyEntry(cacheEntry.key)
-            : await this.cleanupEntry(cacheEntry.key, cacheEntry.metadata, now);
+            ? await this.cleanupLegacyCacheEntry(cacheEntry.key)
+            : await this.cleanupEntryWithMetadata(
+                cacheEntry.key,
+                cacheEntry.metadata,
+                now,
+              );
 
         if (cleanupResult === 'deleted') {
           deletedCount += 1;

--- a/lib/util/cache/package/impl/file.ts
+++ b/lib/util/cache/package/impl/file.ts
@@ -202,7 +202,7 @@ export class PackageCacheFile extends PackageCacheBase {
     return 'kept';
   }
 
-  private async cleanupEntryWithMetadata(
+  private async cleanupEntry(
     cacheKey: string,
     rawMetadata: unknown,
     now: DateTime,
@@ -283,11 +283,7 @@ export class PackageCacheFile extends PackageCacheBase {
         const cleanupResult =
           cacheEntry.metadata === undefined
             ? await this.cleanupLegacyCacheEntry(cacheEntry.key)
-            : await this.cleanupEntryWithMetadata(
-                cacheEntry.key,
-                cacheEntry.metadata,
-                now,
-              );
+            : await this.cleanupEntry(cacheEntry.key, cacheEntry.metadata, now);
 
         if (cleanupResult === 'deleted') {
           deletedCount += 1;

--- a/lib/util/cache/package/impl/file.ts
+++ b/lib/util/cache/package/impl/file.ts
@@ -11,8 +11,7 @@ import {
 import type { PackageCacheNamespace } from '../types.ts';
 import { PackageCacheBase } from './base.ts';
 
-const currentCacheFormat = 'br-json';
-const currentCacheVersion = 2;
+const CACHE_VERSION = 2;
 
 interface PackageCacheLegacyEntry {
   compress: true;
@@ -22,8 +21,27 @@ interface PackageCacheLegacyEntry {
 
 interface PackageCacheMetadata {
   expiry: string;
-  format: typeof currentCacheFormat;
-  version: typeof currentCacheVersion;
+  version: number;
+}
+
+type PackageCacheLegacyMigrationResult = 'deleted' | 'migrated';
+type PackageCacheCleanupResult = 'deleted' | 'kept';
+
+function parseJson<T>(text: string): T | undefined {
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    return undefined;
+  }
+}
+
+function isExpired(expiry: string, now: DateTime): boolean {
+  const expiryDateTime = DateTime.fromISO(expiry);
+  if (!expiryDateTime.isValid) {
+    return true;
+  }
+
+  return now >= expiryDateTime;
 }
 
 function parseCacheMetadata(value: unknown): PackageCacheMetadata | undefined {
@@ -31,23 +49,24 @@ function parseCacheMetadata(value: unknown): PackageCacheMetadata | undefined {
     return undefined;
   }
 
-  const { expiry, format, version } = value;
+  const { expiry, version } = value;
 
-  if (
-    typeof expiry !== 'string' ||
-    format !== currentCacheFormat ||
-    version !== currentCacheVersion
-  ) {
+  if (typeof expiry !== 'string' || version !== CACHE_VERSION) {
     return undefined;
   }
 
-  return { expiry, format, version };
+  return { expiry, version };
 }
 
 function parseLegacyCacheEntry(
   data: Buffer,
 ): PackageCacheLegacyEntry | undefined {
-  const parsed: unknown = JSON.parse(data.toString());
+  const parsed = parseJson<unknown>(data.toString());
+  if (parsed === undefined) {
+    logger.debug('Error parsing cached value - deleting');
+    return undefined;
+  }
+
   if (!isPlainObject(parsed)) {
     return undefined;
   }
@@ -62,23 +81,31 @@ function parseLegacyCacheEntry(
     return undefined;
   }
 
-  return {
-    compress,
-    expiry,
-    value,
-  };
+  return { compress, expiry, value };
 }
 
 async function deserializeCurrentValue<T>(data: Buffer): Promise<T> {
   const json = await decompressFromBuffer(data);
-  return JSON.parse(json) as T;
+  const parsed = parseJson<T>(json);
+
+  if (parsed === undefined) {
+    throw new Error('Failed to deserialize cached value');
+  }
+
+  return parsed;
 }
 
 async function deserializeLegacyValue<T>(
   entry: PackageCacheLegacyEntry,
 ): Promise<T> {
   const json = await decompressFromBase64(entry.value);
-  return JSON.parse(json) as T;
+  const parsed = parseJson<T>(json);
+
+  if (parsed === undefined) {
+    throw new Error('Failed to deserialize cached value');
+  }
+
+  return parsed;
 }
 
 export class PackageCacheFile extends PackageCacheBase {
@@ -105,12 +132,9 @@ export class PackageCacheFile extends PackageCacheBase {
     expiry: string,
   ): Promise<void> {
     const compressedValue = await compressToBuffer(serializedValue);
+    const metadata = { version: CACHE_VERSION, expiry };
     await cacache.put(this.cacheFileName, cacheKey, compressedValue, {
-      metadata: {
-        expiry,
-        format: currentCacheFormat,
-        version: currentCacheVersion,
-      },
+      metadata,
     });
   }
 
@@ -127,8 +151,7 @@ export class PackageCacheFile extends PackageCacheBase {
       return undefined;
     }
 
-    const expiry = DateTime.fromISO(legacyEntry.expiry);
-    if (!expiry.isValid || DateTime.local() >= expiry) {
+    if (isExpired(legacyEntry.expiry, DateTime.local())) {
       await this.rm(namespace, key);
       return undefined;
     }
@@ -137,30 +160,65 @@ export class PackageCacheFile extends PackageCacheBase {
     return await deserializeLegacyValue<T>(legacyEntry);
   }
 
-  private async migrateLegacyEntry(cacheKey: string): Promise<boolean> {
-    const legacyEntry = await cacache.get(this.cacheFileName, cacheKey);
-    let cachedValue: PackageCacheLegacyEntry | undefined;
+  private async getCurrent<T>(
+    namespace: PackageCacheNamespace,
+    key: string,
+    cacheKey: string,
+  ): Promise<T> {
+    const cacheEntry = await cacache.get(this.cacheFileName, cacheKey);
+    logger.trace({ namespace, key }, 'Returning cached value');
+    return await deserializeCurrentValue<T>(cacheEntry.data);
+  }
 
-    try {
-      cachedValue = parseLegacyCacheEntry(legacyEntry.data);
-    } catch {
-      logger.debug('Error parsing cached value - deleting');
-    }
+  private async migrateLegacyEntry(
+    cacheKey: string,
+  ): Promise<PackageCacheLegacyMigrationResult> {
+    const legacyEntry = await cacache.get(this.cacheFileName, cacheKey);
+    const cachedValue = parseLegacyCacheEntry(legacyEntry.data);
 
     if (!cachedValue) {
       await this.rmEntry(cacheKey);
-      return true;
+      return 'deleted';
     }
 
-    const expiry = DateTime.fromISO(cachedValue.expiry);
-    if (!expiry.isValid || DateTime.local() >= expiry) {
+    if (isExpired(cachedValue.expiry, DateTime.local())) {
       await this.rmEntry(cacheKey);
-      return true;
+      return 'deleted';
     }
 
     const serializedValue = await decompressFromBase64(cachedValue.value);
     await this.putCurrentEntry(cacheKey, serializedValue, cachedValue.expiry);
-    return false;
+    return 'migrated';
+  }
+
+  private async cleanupLegacyEntry(
+    cacheKey: string,
+  ): Promise<PackageCacheCleanupResult> {
+    const migrationResult = await this.migrateLegacyEntry(cacheKey);
+    if (migrationResult === 'deleted') {
+      return 'deleted';
+    }
+
+    return 'kept';
+  }
+
+  private async cleanupEntry(
+    cacheKey: string,
+    rawMetadata: unknown,
+    now: DateTime,
+  ): Promise<PackageCacheCleanupResult> {
+    const metadata = parseCacheMetadata(rawMetadata);
+    if (!metadata) {
+      await this.rmEntry(cacheKey);
+      return 'deleted';
+    }
+
+    if (isExpired(metadata.expiry, now)) {
+      await this.rmEntry(cacheKey);
+      return 'deleted';
+    }
+
+    return 'kept';
   }
 
   override async get<T = unknown>(
@@ -170,6 +228,7 @@ export class PackageCacheFile extends PackageCacheBase {
     try {
       const cacheKey = this.getKey(namespace, key);
       const cacheInfo = await cacache.get.info(this.cacheFileName, cacheKey);
+      const now = DateTime.local();
 
       if (!cacheInfo) {
         return undefined;
@@ -177,20 +236,12 @@ export class PackageCacheFile extends PackageCacheBase {
 
       if (cacheInfo.metadata !== undefined) {
         const metadata = parseCacheMetadata(cacheInfo.metadata);
-        if (!metadata) {
+        if (metadata === undefined || isExpired(metadata.expiry, now)) {
           await this.rm(namespace, key);
           return undefined;
         }
 
-        const expiry = DateTime.fromISO(metadata.expiry);
-        if (!expiry.isValid || DateTime.local() >= expiry) {
-          await this.rm(namespace, key);
-          return undefined;
-        }
-
-        const cacheEntry = await cacache.get(this.cacheFileName, cacheKey);
-        logger.trace({ namespace, key }, 'Returning cached value');
-        return await deserializeCurrentValue<T>(cacheEntry.data);
+        return await this.getCurrent<T>(namespace, key, cacheKey);
       }
 
       return await this.getLegacy<T>(namespace, key, cacheKey);
@@ -213,7 +264,8 @@ export class PackageCacheFile extends PackageCacheBase {
       throw new Error('Invalid package cache expiry');
     }
 
-    await this.putCurrentEntry(this.getKey(namespace, key), serialized, expiry);
+    const cacheKey = this.getKey(namespace, key);
+    await this.putCurrentEntry(cacheKey, serialized, expiry);
   }
 
   override async destroy(): Promise<void> {
@@ -222,30 +274,20 @@ export class PackageCacheFile extends PackageCacheBase {
     let deletedCount = 0;
     let errorCount = 0;
     const startTime = Date.now();
+    const now = DateTime.local();
     for await (const item of cacache.ls.stream(this.cacheFileName)) {
       try {
         totalCount += 1;
         const cacheEntry = item as unknown as cacache.CacheObject;
 
-        if (cacheEntry.metadata !== undefined) {
-          const metadata = parseCacheMetadata(cacheEntry.metadata);
-          if (!metadata) {
-            await this.rmEntry(cacheEntry.key);
-            deletedCount += 1;
-            continue;
-          }
+        const cleanupResult =
+          cacheEntry.metadata === undefined
+            ? await this.cleanupLegacyEntry(cacheEntry.key)
+            : await this.cleanupEntry(cacheEntry.key, cacheEntry.metadata, now);
 
-          const expiry = DateTime.fromISO(metadata.expiry);
-          if (expiry.isValid && DateTime.local() <= expiry) {
-            continue;
-          }
-
-          await this.rmEntry(cacheEntry.key);
+        if (cleanupResult === 'deleted') {
           deletedCount += 1;
-          continue;
         }
-
-        deletedCount += (await this.migrateLegacyEntry(cacheEntry.key)) ? 1 : 0;
       } catch (err) {
         logger.trace({ err }, 'Error cleaning up cache entry');
         errorCount += 1;

--- a/lib/util/cache/package/impl/file.ts
+++ b/lib/util/cache/package/impl/file.ts
@@ -148,14 +148,13 @@ export class PackageCacheFile extends PackageCacheBase {
       return undefined;
     }
 
-    if (cacheIndexEntry.metadata !== undefined) {
-      const metadata = parseCacheIndexMetadata(cacheIndexEntry.metadata);
+    if (cacheIndexEntry.metadata === undefined) {
+      return await this.readLegacyCachedValue<T>(namespace, key, cacheIndexKey);
+    }
 
-      if (metadata === undefined || isExpired(metadata.expiry)) {
-        await this.removeLogicalCacheEntry(namespace, key);
-        return undefined;
-      }
+    const metadata = parseCacheIndexMetadata(cacheIndexEntry.metadata);
 
+    if (metadata !== undefined && !isExpired(metadata.expiry)) {
       return await this.readCurrentCachedValue<T>(
         namespace,
         key,
@@ -163,7 +162,8 @@ export class PackageCacheFile extends PackageCacheBase {
       );
     }
 
-    return await this.readLegacyCachedValue<T>(namespace, key, cacheIndexKey);
+    await this.removeLogicalCacheEntry(namespace, key);
+    return undefined;
   }
 
   override async set(
@@ -287,18 +287,13 @@ export class PackageCacheFile extends PackageCacheBase {
       const storedEntry = await cacache.get(this.cachePath, cacheIndexKey);
       const legacyPayload = parseLegacyPayload(storedEntry.data);
 
-      if (!legacyPayload) {
-        await this.removeLogicalCacheEntry(namespace, key);
-        return undefined;
+      if (legacyPayload !== undefined && !isExpired(legacyPayload.expiry)) {
+        logger.trace({ namespace, key }, 'Returning cached value');
+        return await decodeLegacyStoredValue<T>(legacyPayload);
       }
 
-      if (isExpired(legacyPayload.expiry)) {
-        await this.removeLogicalCacheEntry(namespace, key);
-        return undefined;
-      }
-
-      logger.trace({ namespace, key }, 'Returning cached value');
-      return await decodeLegacyStoredValue<T>(legacyPayload);
+      await this.removeLogicalCacheEntry(namespace, key);
+      return undefined;
     } catch (err) {
       logger.trace({ err, namespace, key }, 'Cache miss');
       return undefined;

--- a/lib/util/cache/package/impl/file.ts
+++ b/lib/util/cache/package/impl/file.ts
@@ -141,14 +141,22 @@ export class PackageCacheFile extends PackageCacheBase {
 
   private async putCacheEntry(
     cacheKey: string,
-    serializedValue: string,
+    compressedValue: Buffer,
     expiry: string,
   ): Promise<void> {
-    const compressedValue = await compressToBuffer(serializedValue);
     const metadata = { version: CACHE_VERSION, expiry };
     await cacache.put(this.cacheFileName, cacheKey, compressedValue, {
       metadata,
     });
+  }
+
+  private async putSerializedCacheEntry(
+    cacheKey: string,
+    serializedValue: string,
+    expiry: string,
+  ): Promise<void> {
+    const compressedValue = await compressToBuffer(serializedValue);
+    await this.putCacheEntry(cacheKey, compressedValue, expiry);
   }
 
   private async getLegacy<T>(
@@ -209,9 +217,11 @@ export class PackageCacheFile extends PackageCacheBase {
       return 'deleted';
     }
 
+    const compressedValue = Buffer.from(cachedValue.value, 'base64');
+
     let serializedValue: string;
     try {
-      serializedValue = await decompressFromBase64(cachedValue.value);
+      serializedValue = await decompressFromBuffer(compressedValue);
     } catch {
       await this.rmEntry(cacheKey);
       return 'deleted';
@@ -222,7 +232,7 @@ export class PackageCacheFile extends PackageCacheBase {
       return 'deleted';
     }
 
-    await this.putCacheEntry(cacheKey, serializedValue, cachedValue.expiry);
+    await this.putCacheEntry(cacheKey, compressedValue, cachedValue.expiry);
     return 'migrated';
   }
 
@@ -291,7 +301,7 @@ export class PackageCacheFile extends PackageCacheBase {
     const expiry = DateTime.local().plus({ minutes: hardTtlMinutes }).toISO();
 
     const cacheKey = this.getKey(namespace, key);
-    await this.putCacheEntry(cacheKey, serialized, expiry);
+    await this.putSerializedCacheEntry(cacheKey, serialized, expiry);
   }
 
   override async destroy(): Promise<void> {

--- a/lib/util/cache/package/impl/file.ts
+++ b/lib/util/cache/package/impl/file.ts
@@ -1,4 +1,4 @@
-import { isPlainObject } from '@sindresorhus/is';
+import { isNonEmptyString, isPlainObject, isString } from '@sindresorhus/is';
 import cacache from 'cacache';
 import { DateTime } from 'luxon';
 import upath from 'upath';
@@ -13,8 +13,7 @@ import { PackageCacheBase } from './base.ts';
 
 const CACHE_VERSION = 2;
 
-interface PackageCacheLegacyEntry {
-  compress: true;
+interface LegacyPayload {
   expiry: string;
   value: string;
 }
@@ -24,14 +23,16 @@ interface CacheMetadata {
   version: number;
 }
 
-type CacheCleanupResult =
-  | { digest: string; status: 'deleted' }
-  | { digest: string; status: 'kept' }
-  | {
-      liveDigest: string;
-      replacedDigest: string;
-      status: 'migrated';
-    };
+interface CacheEntry {
+  key: string;
+  integrity: string;
+  metadata?: unknown;
+}
+
+type CacheSweepResult =
+  | { status: 'deleted'; digest: string }
+  | { status: 'kept'; digest: string }
+  | { status: 'migrated'; liveDigest: string; replacedDigest: string };
 
 function parseJsonSafe<T = unknown>(text: string): T | undefined {
   try {
@@ -51,22 +52,18 @@ function isExpired(expiry: string): boolean {
 }
 
 function parseCacheMetadata(value: unknown): CacheMetadata | undefined {
-  if (!isPlainObject(value)) {
+  if (!isPlainObject(value) || !isString(value.expiry)) {
     return undefined;
   }
 
-  const { expiry, version } = value;
-
-  if (typeof expiry !== 'string' || version !== CACHE_VERSION) {
+  if (value.version !== CACHE_VERSION) {
     return undefined;
   }
 
-  return { expiry, version };
+  return { expiry: value.expiry, version: value.version };
 }
 
-function parseLegacyCachePayload(
-  data: Buffer,
-): PackageCacheLegacyEntry | undefined {
+function parseLegacyPayload(data: Buffer): LegacyPayload | undefined {
   const parsed = parseJsonSafe(data.toString());
   if (parsed === undefined) {
     logger.debug('Error parsing cached value - deleting');
@@ -77,20 +74,24 @@ function parseLegacyCachePayload(
     return undefined;
   }
 
-  const { compress, expiry, value } = parsed;
+  const { expiry, value } = parsed;
 
-  if (
-    compress !== true ||
-    typeof expiry !== 'string' ||
-    typeof value !== 'string'
-  ) {
+  if (!isString(expiry) || !isString(value)) {
     return undefined;
   }
 
-  return { compress, expiry, value };
+  return { expiry, value };
 }
 
-async function decodeValue<T>(data: Buffer): Promise<T> {
+function isCacheEntry(value: unknown): value is CacheEntry {
+  if (!isPlainObject(value)) {
+    return false;
+  }
+
+  return isNonEmptyString(value.key) && isNonEmptyString(value.integrity);
+}
+
+async function decodeStoredValue<T>(data: Buffer): Promise<T> {
   const json = await decompressFromBuffer(data);
   const parsed = parseJsonSafe<T>(json);
 
@@ -101,10 +102,8 @@ async function decodeValue<T>(data: Buffer): Promise<T> {
   return parsed;
 }
 
-async function decodeLegacyValue<T>(
-  entry: PackageCacheLegacyEntry,
-): Promise<T> {
-  const json = await decompressFromBase64(entry.value);
+async function decodeLegacyPayloadValue<T>(payload: LegacyPayload): Promise<T> {
+  const json = await decompressFromBase64(payload.value);
   const parsed = parseJsonSafe<T>(json);
 
   if (parsed === undefined) {
@@ -116,217 +115,45 @@ async function decodeLegacyValue<T>(
 
 export class PackageCacheFile extends PackageCacheBase {
   static create(cacheDir: string): PackageCacheFile {
-    const cacheFileName = upath.join(cacheDir, '/renovate/renovate-cache-v1');
-    logger.debug(`Initializing Renovate internal cache into ${cacheFileName}`);
-    return new PackageCacheFile(cacheFileName);
+    const cachePath = upath.join(cacheDir, '/renovate/renovate-cache-v1');
+    logger.debug(`Initializing Renovate internal cache into ${cachePath}`);
+    return new PackageCacheFile(cachePath);
   }
 
-  private readonly cacheFileName: string;
+  private readonly cachePath: string;
 
-  private constructor(cacheFileName: string) {
+  private constructor(cachePath: string) {
     super();
-    this.cacheFileName = cacheFileName;
-  }
-
-  private getKey(namespace: PackageCacheNamespace, key: string): string {
-    return `${namespace}-${key}`;
-  }
-
-  private async getCacheInfo(
-    cacheKey: string,
-    namespace: PackageCacheNamespace,
-    key: string,
-  ): Promise<cacache.CacheObject | null> {
-    try {
-      return await cacache.get.info(this.cacheFileName, cacheKey);
-    } catch (err) {
-      logger.trace({ err, namespace, key }, 'Cache miss');
-      return null;
-    }
-  }
-
-  private async putCacheEntry(
-    cacheKey: string,
-    compressedValue: Buffer,
-    expiry: string,
-  ): Promise<string> {
-    const metadata = { version: CACHE_VERSION, expiry };
-    return await cacache.put(this.cacheFileName, cacheKey, compressedValue, {
-      metadata,
-    });
-  }
-
-  private async putSerializedCacheEntry(
-    cacheKey: string,
-    serializedValue: string,
-    expiry: string,
-  ): Promise<void> {
-    const compressedValue = await compressToBuffer(serializedValue);
-    await this.putCacheEntry(cacheKey, compressedValue, expiry);
-  }
-
-  private async getLegacy<T>(
-    namespace: PackageCacheNamespace,
-    key: string,
-    cacheKey: string,
-  ): Promise<T | undefined> {
-    try {
-      const cacheEntry = await cacache.get(this.cacheFileName, cacheKey);
-      const legacyEntry = parseLegacyCachePayload(cacheEntry.data);
-
-      if (!legacyEntry) {
-        await this.rm(namespace, key);
-        return undefined;
-      }
-
-      if (isExpired(legacyEntry.expiry)) {
-        await this.rm(namespace, key);
-        return undefined;
-      }
-
-      logger.trace({ namespace, key }, 'Returning cached value');
-      return await decodeLegacyValue<T>(legacyEntry);
-    } catch (err) {
-      logger.trace({ err, namespace, key }, 'Cache miss');
-      return undefined;
-    }
-  }
-
-  private async getValue<T>(
-    namespace: PackageCacheNamespace,
-    key: string,
-    cacheKey: string,
-  ): Promise<T | undefined> {
-    try {
-      const cacheEntry = await cacache.get(this.cacheFileName, cacheKey);
-      logger.trace({ namespace, key }, 'Returning cached value');
-      return await decodeValue<T>(cacheEntry.data);
-    } catch (err) {
-      logger.trace({ err, namespace, key }, 'Cache miss');
-      return undefined;
-    }
-  }
-
-  private async migrateLegacyCacheEntry(
-    cacheKey: string,
-    digest: string,
-  ): Promise<CacheCleanupResult> {
-    const legacyEntry = await cacache.get(this.cacheFileName, cacheKey);
-    const cachedValue = parseLegacyCachePayload(legacyEntry.data);
-
-    if (!cachedValue) {
-      await this.rmEntry(cacheKey);
-      return { digest, status: 'deleted' };
-    }
-
-    if (isExpired(cachedValue.expiry)) {
-      await this.rmEntry(cacheKey);
-      return { digest, status: 'deleted' };
-    }
-
-    const compressedValue = Buffer.from(cachedValue.value, 'base64');
-
-    let serializedValue: string;
-    try {
-      serializedValue = await decompressFromBuffer(compressedValue);
-    } catch {
-      await this.rmEntry(cacheKey);
-      return { digest, status: 'deleted' };
-    }
-
-    if (parseJsonSafe(serializedValue) === undefined) {
-      await this.rmEntry(cacheKey);
-      return { digest, status: 'deleted' };
-    }
-
-    const migratedDigest = await this.putCacheEntry(
-      cacheKey,
-      compressedValue,
-      cachedValue.expiry,
-    );
-
-    return {
-      liveDigest: migratedDigest,
-      replacedDigest: digest,
-      status: 'migrated',
-    };
-  }
-
-  private async cleanupEntry(
-    cacheKey: string,
-    rawMetadata: unknown,
-    digest: string,
-  ): Promise<CacheCleanupResult> {
-    const metadata = parseCacheMetadata(rawMetadata);
-    if (!metadata) {
-      await this.rmEntry(cacheKey);
-      return { digest, status: 'deleted' };
-    }
-
-    if (isExpired(metadata.expiry)) {
-      await this.rmEntry(cacheKey);
-      return { digest, status: 'deleted' };
-    }
-
-    return { digest, status: 'kept' };
-  }
-
-  private async getCleanupResult(
-    cacheEntry: cacache.CacheObject,
-  ): Promise<CacheCleanupResult> {
-    const { integrity: digest } = cacheEntry;
-
-    if (cacheEntry.metadata === undefined) {
-      return this.migrateLegacyCacheEntry(cacheEntry.key, digest);
-    }
-
-    return this.cleanupEntry(cacheEntry.key, cacheEntry.metadata, digest);
-  }
-
-  private async cleanupContent(
-    candidateDigests: ReadonlySet<string>,
-    liveDigests: ReadonlySet<string>,
-  ): Promise<number> {
-    let errorCount = 0;
-
-    for (const digest of candidateDigests) {
-      if (liveDigests.has(digest)) {
-        continue;
-      }
-
-      try {
-        await cacache.rm.content(this.cacheFileName, digest);
-      } catch (err) {
-        logger.trace({ err, digest }, 'Error cleaning up cache content');
-        errorCount += 1;
-      }
-    }
-
-    return errorCount;
+    this.cachePath = cachePath;
   }
 
   override async get<T = unknown>(
     namespace: PackageCacheNamespace,
     key: string,
   ): Promise<T | undefined> {
-    const cacheKey = this.getKey(namespace, key);
-    const cacheInfo = await this.getCacheInfo(cacheKey, namespace, key);
+    const cacheKey = this.getCacheKey(namespace, key);
+    const cacheIndexEntry = await this.getCacheIndexEntry(
+      cacheKey,
+      namespace,
+      key,
+    );
 
-    if (!cacheInfo) {
+    if (!cacheIndexEntry) {
       return undefined;
     }
 
-    if (cacheInfo.metadata !== undefined) {
-      const metadata = parseCacheMetadata(cacheInfo.metadata);
+    if (cacheIndexEntry.metadata !== undefined) {
+      const metadata = parseCacheMetadata(cacheIndexEntry.metadata);
+
       if (metadata === undefined || isExpired(metadata.expiry)) {
-        await this.rm(namespace, key);
+        await this.removeCacheEntry(namespace, key);
         return undefined;
       }
 
-      return await this.getValue<T>(namespace, key, cacheKey);
+      return await this.getCurrentValue<T>(namespace, key, cacheKey);
     }
 
-    return await this.getLegacy<T>(namespace, key, cacheKey);
+    return await this.getLegacyValue<T>(namespace, key, cacheKey);
   }
 
   override async set(
@@ -339,8 +166,8 @@ export class PackageCacheFile extends PackageCacheBase {
     const serialized = JSON.stringify(value);
     const expiry = DateTime.local().plus({ minutes: hardTtlMinutes }).toISO();
 
-    const cacheKey = this.getKey(namespace, key);
-    await this.putSerializedCacheEntry(cacheKey, serialized, expiry);
+    const cacheKey = this.getCacheKey(namespace, key);
+    await this.writeSerializedCacheEntry(cacheKey, serialized, expiry);
   }
 
   override async destroy(): Promise<void> {
@@ -354,33 +181,39 @@ export class PackageCacheFile extends PackageCacheBase {
     const candidateDigests = new Set<string>();
     const liveDigests = new Set<string>();
 
-    for await (const item of cacache.ls.stream(this.cacheFileName)) {
-      try {
-        totalCount += 1;
-        const cacheEntry = item as unknown as cacache.CacheObject;
-
-        const cleanupResult = await this.getCleanupResult(cacheEntry);
-
-        switch (cleanupResult.status) {
-          case 'deleted':
-            deletedCount += 1;
-            candidateDigests.add(cleanupResult.digest);
-            break;
-          case 'kept':
-            liveDigests.add(cleanupResult.digest);
-            break;
-          case 'migrated':
-            candidateDigests.add(cleanupResult.replacedDigest);
-            liveDigests.add(cleanupResult.liveDigest);
-            break;
-        }
-      } catch (err) {
-        logger.trace({ err }, 'Error cleaning up cache entry');
+    for await (const item of cacache.ls.stream(this.cachePath)) {
+      totalCount += 1;
+      if (!isCacheEntry(item)) {
+        logger.trace('Invalid cache index entry stream payload');
         errorCount += 1;
+        continue;
       }
+
+      const cacheSweepResult = await this.safeClassifyCacheIndexEntry(item);
+      if (cacheSweepResult === undefined) {
+        errorCount += 1;
+        continue;
+      }
+
+      if (cacheSweepResult.status === 'deleted') {
+        deletedCount += 1;
+        candidateDigests.add(cacheSweepResult.digest);
+        continue;
+      }
+
+      if (cacheSweepResult.status === 'kept') {
+        liveDigests.add(cacheSweepResult.digest);
+        continue;
+      }
+
+      candidateDigests.add(cacheSweepResult.replacedDigest);
+      liveDigests.add(cacheSweepResult.liveDigest);
     }
 
-    errorCount += await this.cleanupContent(candidateDigests, liveDigests);
+    errorCount += await this.cleanupUnreferencedContent(
+      candidateDigests,
+      liveDigests,
+    );
 
     if (errorCount > 0) {
       logger.debug(`Error count cleaning up cache: ${errorCount}`);
@@ -391,15 +224,199 @@ export class PackageCacheFile extends PackageCacheBase {
     );
   }
 
-  private async rm(
+  private getCacheKey(namespace: PackageCacheNamespace, key: string): string {
+    return `${namespace}-${key}`;
+  }
+
+  private async getCacheIndexEntry(
+    cacheKey: string,
+    namespace: PackageCacheNamespace,
+    key: string,
+  ): Promise<CacheEntry | null> {
+    try {
+      return await cacache.get.info(this.cachePath, cacheKey);
+    } catch (err) {
+      logger.trace({ err, namespace, key }, 'Cache miss');
+      return null;
+    }
+  }
+
+  private async writeCacheEntry(
+    cacheKey: string,
+    compressedValue: Buffer,
+    expiry: string,
+  ): Promise<string> {
+    const metadata = { version: CACHE_VERSION, expiry };
+    return await cacache.put(this.cachePath, cacheKey, compressedValue, {
+      metadata,
+    });
+  }
+
+  private async writeSerializedCacheEntry(
+    cacheKey: string,
+    serializedValue: string,
+    expiry: string,
+  ): Promise<void> {
+    const compressedValue = await compressToBuffer(serializedValue);
+    await this.writeCacheEntry(cacheKey, compressedValue, expiry);
+  }
+
+  private async getLegacyValue<T>(
+    namespace: PackageCacheNamespace,
+    key: string,
+    cacheKey: string,
+  ): Promise<T | undefined> {
+    try {
+      const cacheEntry = await cacache.get(this.cachePath, cacheKey);
+      const legacyPayload = parseLegacyPayload(cacheEntry.data);
+
+      if (!legacyPayload) {
+        await this.removeCacheEntry(namespace, key);
+        return undefined;
+      }
+
+      if (isExpired(legacyPayload.expiry)) {
+        await this.removeCacheEntry(namespace, key);
+        return undefined;
+      }
+
+      logger.trace({ namespace, key }, 'Returning cached value');
+      return await decodeLegacyPayloadValue<T>(legacyPayload);
+    } catch (err) {
+      logger.trace({ err, namespace, key }, 'Cache miss');
+      return undefined;
+    }
+  }
+
+  private async getCurrentValue<T>(
+    namespace: PackageCacheNamespace,
+    key: string,
+    cacheKey: string,
+  ): Promise<T | undefined> {
+    try {
+      const cacheEntry = await cacache.get(this.cachePath, cacheKey);
+      logger.trace({ namespace, key }, 'Returning cached value');
+      return await decodeStoredValue<T>(cacheEntry.data);
+    } catch (err) {
+      logger.trace({ err, namespace, key }, 'Cache miss');
+      return undefined;
+    }
+  }
+
+  private async migrateLegacyCacheEntry(
+    cacheKey: string,
+    digest: string,
+  ): Promise<CacheSweepResult> {
+    const legacyEntry = await cacache.get(this.cachePath, cacheKey);
+    const legacyPayload = parseLegacyPayload(legacyEntry.data);
+
+    if (!legacyPayload) {
+      await this.removeCacheIndexEntry(cacheKey);
+      return { digest, status: 'deleted' };
+    }
+
+    if (isExpired(legacyPayload.expiry)) {
+      await this.removeCacheIndexEntry(cacheKey);
+      return { digest, status: 'deleted' };
+    }
+
+    const compressedValue = Buffer.from(legacyPayload.value, 'base64');
+
+    let serializedValue: string;
+    try {
+      serializedValue = await decompressFromBuffer(compressedValue);
+    } catch {
+      await this.removeCacheIndexEntry(cacheKey);
+      return { digest, status: 'deleted' };
+    }
+
+    if (parseJsonSafe(serializedValue) === undefined) {
+      await this.removeCacheIndexEntry(cacheKey);
+      return { digest, status: 'deleted' };
+    }
+
+    const migratedDigest = await this.writeCacheEntry(
+      cacheKey,
+      compressedValue,
+      legacyPayload.expiry,
+    );
+
+    return {
+      liveDigest: migratedDigest,
+      replacedDigest: digest,
+      status: 'migrated',
+    };
+  }
+
+  private async classifyCacheIndexEntry(
+    cacheEntry: CacheEntry,
+  ): Promise<CacheSweepResult> {
+    const {
+      key: cacheKey,
+      metadata: rawMetadata,
+      integrity: digest,
+    } = cacheEntry;
+
+    if (rawMetadata === undefined) {
+      return this.migrateLegacyCacheEntry(cacheKey, digest);
+    }
+
+    const parsedMetadata = parseCacheMetadata(rawMetadata);
+    if (!parsedMetadata) {
+      await this.removeCacheIndexEntry(cacheKey);
+      return { digest, status: 'deleted' };
+    }
+
+    if (isExpired(parsedMetadata.expiry)) {
+      await this.removeCacheIndexEntry(cacheKey);
+      return { digest, status: 'deleted' };
+    }
+
+    return { digest, status: 'kept' };
+  }
+
+  private async safeClassifyCacheIndexEntry(
+    cacheEntry: CacheEntry,
+  ): Promise<CacheSweepResult | undefined> {
+    try {
+      return await this.classifyCacheIndexEntry(cacheEntry);
+    } catch (err) {
+      logger.trace({ err }, 'Error classifying cache entry');
+      return undefined;
+    }
+  }
+
+  private async cleanupUnreferencedContent(
+    candidateDigests: ReadonlySet<string>,
+    liveDigests: ReadonlySet<string>,
+  ): Promise<number> {
+    let errorCount = 0;
+
+    for (const digest of candidateDigests) {
+      if (liveDigests.has(digest)) {
+        continue;
+      }
+
+      try {
+        await cacache.rm.content(this.cachePath, digest);
+      } catch (err) {
+        logger.trace({ err, digest }, 'Error cleaning up cache content');
+        errorCount += 1;
+      }
+    }
+
+    return errorCount;
+  }
+
+  private async removeCacheEntry(
     namespace: PackageCacheNamespace,
     key: string,
   ): Promise<void> {
     logger.trace({ namespace, key }, 'Removing cache entry');
-    await this.rmEntry(this.getKey(namespace, key));
+    await this.removeCacheIndexEntry(this.getCacheKey(namespace, key));
   }
 
-  private async rmEntry(cacheKey: string): Promise<void> {
-    await cacache.rm.entry(this.cacheFileName, cacheKey);
+  private async removeCacheIndexEntry(cacheKey: string): Promise<void> {
+    await cacache.rm.entry(this.cachePath, cacheKey);
   }
 }

--- a/lib/util/compress.spec.ts
+++ b/lib/util/compress.spec.ts
@@ -1,4 +1,9 @@
-import { compressToBase64, decompressFromBase64 } from './compress.ts';
+import {
+  compressToBase64,
+  compressToBuffer,
+  decompressFromBase64,
+  decompressFromBuffer,
+} from './compress.ts';
 
 describe('util/compress', () => {
   it('compresses strings', async () => {
@@ -8,6 +13,16 @@ describe('util/compress', () => {
     expect(compressed).toBe('iwKAZm9vYmFyAw==');
 
     const decompressed = await decompressFromBase64(compressed);
+    expect(decompressed).toBe(input);
+  });
+
+  it('compresses strings to buffers', async () => {
+    const input = 'foobar';
+
+    const compressed = await compressToBuffer(input);
+    const decompressed = await decompressFromBuffer(compressed);
+
+    expect(Buffer.isBuffer(compressed)).toBeTrue();
     expect(decompressed).toBe(input);
   });
 });

--- a/lib/util/compress.ts
+++ b/lib/util/compress.ts
@@ -4,18 +4,28 @@ import zlib, { constants } from 'node:zlib';
 const brotliCompress = promisify(zlib.brotliCompress);
 const brotliDecompress = promisify(zlib.brotliDecompress);
 
+const brotliOptions = {
+  params: {
+    [constants.BROTLI_PARAM_MODE]: constants.BROTLI_MODE_TEXT,
+    [constants.BROTLI_PARAM_QUALITY]: 8,
+  },
+};
+
+export async function compressToBuffer(input: string): Promise<Buffer> {
+  return await brotliCompress(input, brotliOptions);
+}
+
+export async function decompressFromBuffer(input: Buffer): Promise<string> {
+  const decompressed = await brotliDecompress(input);
+  return decompressed.toString('utf8');
+}
+
 export async function compressToBase64(input: string): Promise<string> {
-  const buf = await brotliCompress(input, {
-    params: {
-      [constants.BROTLI_PARAM_MODE]: constants.BROTLI_MODE_TEXT,
-      [constants.BROTLI_PARAM_QUALITY]: 8,
-    },
-  });
+  const buf = await compressToBuffer(input);
   return buf.toString('base64');
 }
 
 export async function decompressFromBase64(input: string): Promise<string> {
   const buf = Buffer.from(input, 'base64');
-  const str = await brotliDecompress(buf);
-  return str.toString('utf8');
+  return await decompressFromBuffer(buf);
 }


### PR DESCRIPTION
## Changes

This refactors the package cache `file` backend to store expiry/version in `cacache` index metadata instead of inside the cached payload.

- New entries store the compressed value directly as cache content, with `expiry` and `version` in index metadata.
- Reads check expiry from metadata first, so current-format entries can usually be validated without reading and parsing the cached blob.
- Cleanup (`destroy()`) uses that same metadata to remove expired/invalid index entries more cheaply.
- Valid legacy entries are still supported and are lazily migrated to the new format during cleanup, without recompressing their stored value.
- Content GC is now safer: removing a cache key does not immediately delete the underlying cached blob, because another live key may still point to the same content. Cleanup first treats removed blobs as "maybe unused", keeps track of blobs still referenced by surviving entries, and only deletes blobs that are no longer referenced by anything live.

## Context

- Supersedes: #42531

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — substantive assistance (code and tests were authored/refined with AI support).

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

