### PR TITLE
feat(manager/npm): pass --before to npm install when minimumReleaseAge is set

### DIFF
--- a/docs/usage/key-concepts/minimum-release-age.md
+++ b/docs/usage/key-concepts/minimum-release-age.md
@@ -44,6 +44,20 @@ To protect against this, it's recommended to ensure that your package manager co
 There is ongoing work to [integrate more closely with package manager checks](https://github.com/renovatebot/renovate/issues/41652) to make sure that Renovate's minimum release age configuration is specified when calling package managers that support it.
 If you have a package manager you'd like supported, please raise a [Suggest an Idea Discussion](https://github.com/renovatebot/renovate/discussions/new?category=suggest-an-idea).
 
+#### npm
+
+When `minimumReleaseAge` is configured, Renovate passes `--before=<date>` to npm commands during lock file generation.
+This ensures that npm only resolves package versions that were available before the cooldown threshold, protecting against newly published (and potentially malicious) transitive dependencies.
+
+The `--before` date is calculated as `now - minimumReleaseAge`.
+If a `before=<date>` or `min-release-age=<days>` setting already exists in the project's `.npmrc`, Renovate uses the stricter (older) of the two dates.
+
+If the existing lock file contains packages published after the `--before` cutoff (for example, from dependencies merged before `minimumReleaseAge` was configured), npm will fail with an `ETARGET` error.
+In this case, Renovate automatically retries without `--before` and logs a warning.
+This ensures existing lock files are never broken by the `--before` flag.
+
+After the next lock file maintenance run (which regenerates the lock file from scratch with `--before`), subsequent updates will fully enforce the `minimumReleaseAge` constraint.
+
 ### What happens if the datasource and/or registry does not provide a release timestamp, when using `minimumReleaseAge`?
 
 <!-- prettier-ignore -->

--- a/lib/modules/manager/npm/post-update/index.spec.ts
+++ b/lib/modules/manager/npm/post-update/index.spec.ts
@@ -421,6 +421,7 @@ describe('modules/manager/npm/post-update/index', () => {
         await getAdditionalFiles({ ...updateConfig }, additionalFiles),
       ).toStrictEqual({
         artifactErrors: [],
+        artifactNotices: [],
         updatedArtifacts: [],
       });
     });
@@ -440,6 +441,7 @@ describe('modules/manager/npm/post-update/index', () => {
         ),
       ).toStrictEqual({
         artifactErrors: [],
+        artifactNotices: [],
         updatedArtifacts: [
           {
             type: 'addition',
@@ -456,6 +458,36 @@ describe('modules/manager/npm/post-update/index', () => {
         ['randomFolder/.npmrc'],
         ['packages/pnpm/.npmrc'],
       ]);
+    });
+
+    it('adds artifact notice on beforeFallback', async () => {
+      spyNpm.mockResolvedValueOnce({
+        error: false,
+        lockFile: '{}',
+        beforeFallback: true,
+      });
+      fs.readLocalFile.mockImplementation((f): Promise<string> => {
+        if (f === '.npmrc') {
+          return Promise.resolve('# dummy');
+        }
+        return Promise.resolve('');
+      });
+      const res = await getAdditionalFiles(
+        { ...updateConfig, reuseExistingBranch: true },
+        additionalFiles,
+      );
+
+      expect(res.artifactNotices).toEqual([
+        {
+          file: 'package-lock.json',
+          message:
+            'npm `--before` could not be enforced because existing locked packages were published after the `minimumReleaseAge` cutoff. This will resolve after the next lock file maintenance run.',
+        },
+      ]);
+      expect(logger.logger.warn).toHaveBeenCalledWith(
+        { npmLock: 'package-lock.json' },
+        'npm `--before` could not be enforced because existing locked packages were published after the `minimumReleaseAge` cutoff. This will resolve after the next lock file maintenance run.',
+      );
     });
 
     it('detects if lock file contents are unchanged(reuseExistingBranch=true)', async () => {
@@ -523,6 +555,7 @@ describe('modules/manager/npm/post-update/index', () => {
         ),
       ).toStrictEqual({
         artifactErrors: [],
+        artifactNotices: [],
         updatedArtifacts: [
           {
             type: 'addition',
@@ -555,6 +588,7 @@ describe('modules/manager/npm/post-update/index', () => {
         ),
       ).toStrictEqual({
         artifactErrors: [],
+        artifactNotices: [],
         updatedArtifacts: [
           {
             type: 'addition',
@@ -569,6 +603,7 @@ describe('modules/manager/npm/post-update/index', () => {
     it('no npm files', async () => {
       expect(await getAdditionalFiles(baseConfig, {})).toStrictEqual({
         artifactErrors: [],
+        artifactNotices: [],
         updatedArtifacts: [],
       });
     });
@@ -578,6 +613,7 @@ describe('modules/manager/npm/post-update/index', () => {
         await getAdditionalFiles(baseConfig, additionalFiles),
       ).toStrictEqual({
         artifactErrors: [],
+        artifactNotices: [],
         updatedArtifacts: [],
       });
     });
@@ -604,6 +640,7 @@ describe('modules/manager/npm/post-update/index', () => {
         ),
       ).toStrictEqual({
         artifactErrors: [],
+        artifactNotices: [],
         updatedArtifacts: [],
       });
       expect(spyNpm).not.toHaveBeenCalled();
@@ -625,6 +662,7 @@ describe('modules/manager/npm/post-update/index', () => {
         ),
       ).toStrictEqual({
         artifactErrors: [],
+        artifactNotices: [],
         updatedArtifacts: [],
       });
     });
@@ -644,6 +682,7 @@ describe('modules/manager/npm/post-update/index', () => {
         ),
       ).toStrictEqual({
         artifactErrors: [],
+        artifactNotices: [],
         updatedArtifacts: [],
       });
     });
@@ -656,6 +695,7 @@ describe('modules/manager/npm/post-update/index', () => {
         artifactErrors: [
           { fileName: 'package-lock.json', stderr: 'some-error' },
         ],
+        artifactNotices: [],
         updatedArtifacts: [],
       });
     });
@@ -669,6 +709,7 @@ describe('modules/manager/npm/post-update/index', () => {
         ),
       ).toStrictEqual({
         artifactErrors: [{ fileName: 'yarn.lock', stderr: 'some-error' }],
+        artifactNotices: [],
         updatedArtifacts: [],
       });
     });
@@ -692,6 +733,7 @@ describe('modules/manager/npm/post-update/index', () => {
         artifactErrors: [
           { fileName: 'packages/pnpm/pnpm-lock.yaml', stderr: 'some-error' },
         ],
+        artifactNotices: [],
         updatedArtifacts: [],
       });
     });

--- a/lib/modules/manager/npm/post-update/index.ts
+++ b/lib/modules/manager/npm/post-update/index.ts
@@ -21,6 +21,7 @@ import { NpmDatasource } from '../../../datasource/npm/index.ts';
 import { scm } from '../../../platform/scm.ts';
 import type {
   ArtifactError,
+  ArtifactNotice,
   PackageFile,
   PostUpdateConfig,
   Upgrade,
@@ -398,13 +399,14 @@ export async function getAdditionalFiles(
 ): Promise<WriteExistingFilesResult> {
   logger.trace({ config }, 'getAdditionalFiles');
   const artifactErrors: ArtifactError[] = [];
+  const artifactNotices: ArtifactNotice[] = [];
   const updatedArtifacts: FileChange[] = [];
   if (!packageFiles.npm?.length) {
-    return { artifactErrors, updatedArtifacts };
+    return { artifactErrors, artifactNotices, updatedArtifacts };
   }
   if (config.skipArtifactsUpdate) {
     logger.debug('Skipping lock file generation');
-    return { artifactErrors, updatedArtifacts };
+    return { artifactErrors, artifactNotices, updatedArtifacts };
   }
   logger.debug('Getting updated lock files');
   if (
@@ -413,7 +415,7 @@ export async function getAdditionalFiles(
     (await scm.branchExists(config.branchName))
   ) {
     logger.debug('Skipping lockFileMaintenance update');
-    return { artifactErrors, updatedArtifacts };
+    return { artifactErrors, artifactNotices, updatedArtifacts };
   }
   const dirs = determineLockFileDirs(config, packageFiles);
   logger.trace({ dirs }, 'lock file dirs');
@@ -460,6 +462,7 @@ export async function getAdditionalFiles(
       fileName,
       config,
       upgrades,
+      npmrcContent,
     );
     if (res.error) {
       /* v8 ignore next -- needs test */
@@ -487,6 +490,12 @@ export async function getAdditionalFiles(
         stderr: res.stderr,
       });
     } else if (res.lockFile) {
+      if (res.beforeFallback) {
+        const message =
+          'npm `--before` could not be enforced because existing locked packages were published after the `minimumReleaseAge` cutoff. This will resolve after the next lock file maintenance run.';
+        logger.warn({ npmLock }, message);
+        artifactNotices.push({ file: npmLock, message });
+      }
       const existingContent = await getFile(
         npmLock,
         config.reuseExistingBranch ? config.branchName : config.baseBranch,
@@ -665,5 +674,5 @@ export async function getAdditionalFiles(
     await resetNpmrcContent(lockFileDir, npmrcContent);
   }
 
-  return { artifactErrors, updatedArtifacts };
+  return { artifactErrors, artifactNotices, updatedArtifacts };
 }

--- a/lib/modules/manager/npm/post-update/npm.spec.ts
+++ b/lib/modules/manager/npm/post-update/npm.spec.ts
@@ -1188,9 +1188,11 @@ describe('modules/manager/npm/post-update/npm', () => {
       it.each`
         content
         ${null}
+        ${''}
         ${'registry=https://registry.npmjs.org\n'}
         ${'before=not-a-date\n'}
         ${'before=2026-13-99T00:00:00.000Z\n'}
+        ${'min-release-age=not-a-number\n'}
       `('for: $content', ({ content }: { content: string | null }) => {
         expect(npmHelper.parseNpmrcCooldownDate(content)).toBeNull();
       });

--- a/lib/modules/manager/npm/post-update/npm.spec.ts
+++ b/lib/modules/manager/npm/post-update/npm.spec.ts
@@ -1,8 +1,9 @@
 import upath from 'upath';
-import { envMock, mockExecAll } from '~test/exec-util.ts';
+import { envMock, mockExecAll, mockExecSequence } from '~test/exec-util.ts';
 import { Fixtures } from '~test/fixtures.ts';
 import { env, fs } from '~test/util.ts';
 import { GlobalConfig } from '../../../../config/global.ts';
+import { ExecError } from '../../../../util/exec/exec-error.ts';
 import { getNodeToolConstraint } from './node-version.ts';
 import * as npmHelper from './npm.ts';
 
@@ -952,6 +953,274 @@ describe('modules/manager/npm/post-update/npm', () => {
           cmd: "npm install --package-lock-only --no-audit --ignore-scripts '; date; echo @11.1.0'",
         },
       ]);
+    });
+  });
+
+  describe('--before with minimumReleaseAge', () => {
+    let execSnapshots: ReturnType<typeof mockExecAll>;
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-06-15T12:00:00.000Z'));
+      execSnapshots = mockExecAll();
+      fs.readLocalFile.mockResolvedValueOnce('{}');
+      const packageLockContents = JSON.stringify({
+        packages: {},
+        lockfileVersion: 3,
+      });
+      fs.readLocalFile
+        .mockResolvedValueOnce(packageLockContents)
+        .mockResolvedValueOnce(packageLockContents);
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('sets --before from minimumReleaseAge', async () => {
+      const res = await npmHelper.generateLockFile(
+        'some-dir',
+        {},
+        'package-lock.json',
+        { skipInstalls: true, minimumReleaseAge: '3 days' },
+        [
+          {
+            packageName: 'some-dep',
+            newVersion: '1.0.1',
+            isLockfileUpdate: false,
+          },
+        ],
+      );
+
+      expect(res.error).toBeFalse();
+      expect(res.beforeFallback).toBeFalse();
+      expect(execSnapshots).toMatchObject([
+        {
+          cmd: 'npm install --package-lock-only --no-audit --ignore-scripts --before=2026-06-12T12:00:00.000Z',
+        },
+      ]);
+    });
+
+    it('skips --before on unparseable minimumReleaseAge', async () => {
+      await npmHelper.generateLockFile(
+        'some-dir',
+        {},
+        'package-lock.json',
+        { skipInstalls: true, minimumReleaseAge: 'invalid garbage' },
+        [
+          {
+            packageName: 'some-dep',
+            newVersion: '1.0.1',
+            isLockfileUpdate: false,
+          },
+        ],
+      );
+
+      expect(execSnapshots).toMatchObject([
+        {
+          cmd: 'npm install --package-lock-only --no-audit --ignore-scripts',
+        },
+      ]);
+    });
+
+    it('uses stricter npmrc before date when older than minimumReleaseAge', async () => {
+      // npmrc (June 1) is earlier than minimumReleaseAge (3 days = June 12)
+      await npmHelper.generateLockFile(
+        'some-dir',
+        {},
+        'package-lock.json',
+        { skipInstalls: true, minimumReleaseAge: '3 days' },
+        [
+          {
+            packageName: 'some-dep',
+            newVersion: '1.0.1',
+            isLockfileUpdate: false,
+          },
+        ],
+        'registry=https://registry.npmjs.org\nbefore=2026-06-01T00:00:00.000Z\n',
+      );
+
+      expect(execSnapshots).toMatchObject([
+        {
+          cmd: 'npm install --package-lock-only --no-audit --ignore-scripts --before=2026-06-01T00:00:00.000Z',
+        },
+      ]);
+    });
+
+    it('uses minimumReleaseAge date when stricter than npmrc before date', async () => {
+      // minimumReleaseAge (3 days = June 12) is earlier than npmrc (June 14)
+      await npmHelper.generateLockFile(
+        'some-dir',
+        {},
+        'package-lock.json',
+        { skipInstalls: true, minimumReleaseAge: '3 days' },
+        [
+          {
+            packageName: 'some-dep',
+            newVersion: '1.0.1',
+            isLockfileUpdate: false,
+          },
+        ],
+        'before=2026-06-14T00:00:00.000Z\n',
+      );
+
+      expect(execSnapshots).toMatchObject([
+        {
+          cmd: 'npm install --package-lock-only --no-audit --ignore-scripts --before=2026-06-12T12:00:00.000Z',
+        },
+      ]);
+    });
+
+    it('skips --before when minimumReleaseAge is absent even if npmrc has before', async () => {
+      await npmHelper.generateLockFile(
+        'some-dir',
+        {},
+        'package-lock.json',
+        { skipInstalls: true },
+        [
+          {
+            packageName: 'some-dep',
+            newVersion: '1.0.1',
+            isLockfileUpdate: false,
+          },
+        ],
+        'before=2026-06-01T00:00:00.000Z\n',
+      );
+
+      expect(execSnapshots).toMatchObject([
+        {
+          cmd: 'npm install --package-lock-only --no-audit --ignore-scripts',
+        },
+      ]);
+    });
+
+    it('retries without --before on ETARGET with "with a date before"', async () => {
+      const etargetError = new ExecError('npm error code ETARGET', {
+        cmd: 'npm install --package-lock-only --no-audit --ignore-scripts --before=2026-06-12T12:00:00.000Z',
+        stdout: '',
+        stderr:
+          'npm error code ETARGET\nnpm error notarget No matching version found for @scope/pkg@1.2.3 with a date before 6/12/2026, 12:00:00 PM.',
+        options: {},
+      });
+      const packageLockContents = JSON.stringify({
+        packages: {},
+        lockfileVersion: 3,
+      });
+      execSnapshots = mockExecSequence([
+        etargetError,
+        { stdout: '', stderr: '' },
+      ]);
+      fs.readLocalFile
+        .mockResolvedValueOnce(packageLockContents)
+        .mockResolvedValueOnce(packageLockContents);
+
+      const res = await npmHelper.generateLockFile(
+        'some-dir',
+        {},
+        'package-lock.json',
+        { skipInstalls: true, minimumReleaseAge: '3 days' },
+        [
+          {
+            packageName: 'some-dep',
+            newVersion: '1.0.1',
+            isLockfileUpdate: false,
+          },
+        ],
+      );
+
+      expect(res.error).toBeFalse();
+      expect(res.beforeFallback).toBeTrue();
+      expect(execSnapshots).toMatchObject([
+        {
+          cmd: 'npm install --package-lock-only --no-audit --ignore-scripts --before=2026-06-12T12:00:00.000Z',
+        },
+        {
+          cmd: 'npm install --package-lock-only --no-audit --ignore-scripts',
+        },
+      ]);
+    });
+
+    it('does not retry on non-before ETARGET errors', async () => {
+      const otherError = new ExecError('npm error code ETARGET', {
+        cmd: 'npm install --package-lock-only --no-audit --ignore-scripts --before=2026-06-12T12:00:00.000Z',
+        stdout: '',
+        stderr:
+          'npm error code ETARGET\nnpm error notarget No matching version found for @scope/pkg@999.999.999.',
+        options: {},
+      });
+      execSnapshots = mockExecSequence([otherError]);
+
+      const res = await npmHelper.generateLockFile(
+        'some-dir',
+        {},
+        'package-lock.json',
+        { skipInstalls: true, minimumReleaseAge: '3 days' },
+        [
+          {
+            packageName: 'some-dep',
+            newVersion: '1.0.1',
+            isLockfileUpdate: false,
+          },
+        ],
+      );
+
+      expect(res.error).toBeTrue();
+      expect(res.beforeFallback).toBeUndefined();
+      expect(execSnapshots).toMatchObject([
+        {
+          cmd: 'npm install --package-lock-only --no-audit --ignore-scripts --before=2026-06-12T12:00:00.000Z',
+        },
+      ]);
+    });
+  });
+
+  describe('parseNpmrcCooldownDate', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-06-15T12:00:00.000Z'));
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    describe('returns null', () => {
+      it.each`
+        content
+        ${null}
+        ${'registry=https://registry.npmjs.org\n'}
+        ${'before=not-a-date\n'}
+        ${'before=2026-13-99T00:00:00.000Z\n'}
+      `('for: $content', ({ content }: { content: string | null }) => {
+        expect(npmHelper.parseNpmrcCooldownDate(content)).toBeNull();
+      });
+    });
+
+    describe('parses before= key', () => {
+      it.each`
+        input
+        ${'before=2026-06-01T00:00:00.000Z\n'}
+        ${'before="2026-06-01T00:00:00.000Z"\n'}
+        ${'registry=https://registry.npmjs.org\nbefore=2026-06-01T00:00:00.000Z # some comment\naudit=false\n'}
+      `('$input', ({ input }: { input: string }) => {
+        expect(npmHelper.parseNpmrcCooldownDate(input)?.toISO()).toBe(
+          '2026-06-01T00:00:00.000Z',
+        );
+      });
+    });
+
+    describe('parses min-release-age= key', () => {
+      it.each`
+        input
+        ${'min-release-age=30\n'}
+        ${'min-release-age="30"\n'}
+        ${'min-release-age=30 # 30 days\n'}
+        ${'registry=https://registry.npmjs.org\nmin-release-age=30 # 30 days\n'}
+      `('$input', ({ input }: { input: string }) => {
+        expect(npmHelper.parseNpmrcCooldownDate(input)?.toISO()).toBe(
+          '2026-05-16T12:00:00.000Z',
+        );
+      });
     });
   });
 });

--- a/lib/modules/manager/npm/post-update/npm.ts
+++ b/lib/modules/manager/npm/post-update/npm.ts
@@ -1,5 +1,6 @@
 // TODO: types (#22198)
-import { isNonEmptyString, isString } from '@sindresorhus/is';
+import { isNonEmptyString, isNumber, isString } from '@sindresorhus/is';
+import ini from 'ini';
 import { DateTime } from 'luxon';
 import semver from 'semver';
 import { quote } from 'shlex';
@@ -24,7 +25,6 @@ import {
 } from '../../../../util/fs/index.ts';
 import { minimatch } from '../../../../util/minimatch.ts';
 import { toMs } from '../../../../util/pretty-time.ts';
-import { regEx } from '../../../../util/regex.ts';
 import { Result } from '../../../../util/result.ts';
 import { trimSlashes } from '../../../../util/url.ts';
 import type { PostUpdateConfig, Upgrade } from '../../types.ts';
@@ -38,30 +38,33 @@ import {
   lazyLoadPackageJson,
 } from './utils.ts';
 
-const npmrcBeforeRegex = regEx(
-  /^\s*before\s*=\s*"?(\d{4}-\d{2}-\d{2}(?:T[\d:.]+Z?)?)"?(?:\s+[;#].*)?\s*$/m,
-);
-const npmrcMinReleaseAgeRegex = regEx(
-  /^\s*min-release-age\s*=\s*"?(\d+)"?(?:\s+[;#].*)?\s*$/m,
-);
-
 export function parseNpmrcCooldownDate(
   npmrcContent: string | null,
 ): DateTime<true> | null {
-  const dateStr = npmrcContent?.match(npmrcBeforeRegex)?.[1];
-  if (dateStr) {
-    const parsed = DateTime.fromISO(dateStr, { zone: 'utc' });
+  if (!npmrcContent) {
+    return null;
+  }
+
+  const parsed = ini.parse(npmrcContent);
+
+  const before = parsed.before;
+  if (isNonEmptyString(before)) {
+    const parsed = DateTime.fromISO(before, { zone: 'utc' });
     if (parsed.isValid) {
       return parsed;
     }
-    logger.debug(`Invalid before date in .npmrc: ${dateStr}, ignoring`);
+    logger.debug(`Invalid before date in .npmrc: ${before}, ignoring`);
   }
 
-  const daysStr = npmrcContent?.match(npmrcMinReleaseAgeRegex)?.[1];
-  if (daysStr) {
-    return DateTime.now()
-      .minus({ days: parseInt(daysStr, 10) })
-      .toUTC();
+  const minReleaseAge = parsed['min-release-age'];
+  if (isNonEmptyString(minReleaseAge)) {
+    const days = parseInt(minReleaseAge, 10);
+    if (isNumber(days) && days >= 0) {
+      return DateTime.now().minus({ days }).toUTC();
+    }
+    logger.debug(
+      `Invalid min-release-age in .npmrc: ${minReleaseAge}, ignoring`,
+    );
   }
 
   return null;

--- a/lib/modules/manager/npm/post-update/npm.ts
+++ b/lib/modules/manager/npm/post-update/npm.ts
@@ -1,5 +1,6 @@
 // TODO: types (#22198)
 import { isNonEmptyString, isString } from '@sindresorhus/is';
+import { DateTime } from 'luxon';
 import semver from 'semver';
 import { quote } from 'shlex';
 import upath from 'upath';
@@ -22,6 +23,8 @@ import {
   renameLocalFile,
 } from '../../../../util/fs/index.ts';
 import { minimatch } from '../../../../util/minimatch.ts';
+import { toMs } from '../../../../util/pretty-time.ts';
+import { regEx } from '../../../../util/regex.ts';
 import { Result } from '../../../../util/result.ts';
 import { trimSlashes } from '../../../../util/url.ts';
 import type { PostUpdateConfig, Upgrade } from '../../types.ts';
@@ -34,6 +37,35 @@ import {
   getPackageManagerVersion,
   lazyLoadPackageJson,
 } from './utils.ts';
+
+const npmrcBeforeRegex = regEx(
+  /^\s*before\s*=\s*"?(\d{4}-\d{2}-\d{2}(?:T[\d:.]+Z?)?)"?(?:\s+[;#].*)?\s*$/m,
+);
+const npmrcMinReleaseAgeRegex = regEx(
+  /^\s*min-release-age\s*=\s*"?(\d+)"?(?:\s+[;#].*)?\s*$/m,
+);
+
+export function parseNpmrcCooldownDate(
+  npmrcContent: string | null,
+): DateTime<true> | null {
+  const dateStr = npmrcContent?.match(npmrcBeforeRegex)?.[1];
+  if (dateStr) {
+    const parsed = DateTime.fromISO(dateStr, { zone: 'utc' });
+    if (parsed.isValid) {
+      return parsed;
+    }
+    logger.debug(`Invalid before date in .npmrc: ${dateStr}, ignoring`);
+  }
+
+  const daysStr = npmrcContent?.match(npmrcMinReleaseAgeRegex)?.[1];
+  if (daysStr) {
+    return DateTime.now()
+      .minus({ days: parseInt(daysStr, 10) })
+      .toUTC();
+  }
+
+  return null;
+}
 
 async function getNpmConstraintFromPackageLock(
   lockFileDir: string,
@@ -67,6 +99,7 @@ export async function generateLockFile(
   filename: string,
   config: Partial<PostUpdateConfig> = {},
   upgrades: Upgrade[] = [],
+  npmrcContent: string | null = null,
 ): Promise<GenerateLockFileResult> {
   // TODO: don't assume package-lock.json is in the same directory
   const lockFileName = upath.join(lockFileDir, filename);
@@ -75,6 +108,7 @@ export async function generateLockFile(
   const { skipInstalls, postUpdateOptions } = config;
 
   let lockFile: string | null = null;
+  let beforeFallback = false;
   try {
     const lazyPkgJson = lazyLoadPackageJson(lockFileDir);
     const npmToolConstraint: ToolConstraint = {
@@ -111,6 +145,43 @@ export async function generateLockFile(
       cmdOptions += ' --ignore-scripts';
     }
 
+    let beforeFlag = '';
+    if (config.minimumReleaseAge) {
+      const ms = toMs(config.minimumReleaseAge);
+      if (ms === null) {
+        logger.debug(
+          {
+            minimumReleaseAge: config.minimumReleaseAge,
+          },
+          'Invalid minimumReleaseAge, skipping --before for npm install',
+        );
+      } else {
+        let beforeDate = DateTime.now().minus(ms).toUTC();
+
+        const npmrcDate = parseNpmrcCooldownDate(npmrcContent);
+        if (npmrcDate && npmrcDate < beforeDate) {
+          logger.debug(
+            {
+              npmrcDate: npmrcDate.toISO(),
+              beforeDate: beforeDate.toISO(),
+            },
+            'Using stricter .npmrc cooldown date over minimumReleaseAge date',
+          );
+          beforeDate = npmrcDate;
+        }
+
+        const beforeISO = beforeDate.toISO();
+        logger.debug(
+          {
+            beforeISO,
+            minimumReleaseAge: config.minimumReleaseAge,
+          },
+          'Setting npm --before based on minimumReleaseAge',
+        );
+        beforeFlag = ` --before=${beforeISO}`;
+      }
+    }
+
     const extraEnv: ExtraEnv = {
       NPM_CONFIG_CACHE: env.NPM_CONFIG_CACHE,
       npm_config_store: env.npm_config_store,
@@ -140,7 +211,7 @@ export async function generateLockFile(
 
     if (!upgrades.every((upgrade) => upgrade.isLockfileUpdate)) {
       // This command updates the lock file based on package.json
-      commands.push(`npm install ${cmdOptions}`.trim());
+      commands.push(`npm install ${cmdOptions}${beforeFlag}`.trim());
     }
 
     // rangeStrategy = update-lockfile
@@ -160,7 +231,7 @@ export async function generateLockFile(
 
         // v8 ignore else -- TODO: add test #40625
         if (currentWorkspaceUpdates.length) {
-          const updateCmd = `npm install ${cmdOptions} --workspace=${quote(workspace)} ${currentWorkspaceUpdates
+          const updateCmd = `npm install ${cmdOptions}${beforeFlag} --workspace=${quote(workspace)} ${currentWorkspaceUpdates
             .map(quote)
             .join(' ')}`;
           commands.push(updateCmd);
@@ -170,7 +241,7 @@ export async function generateLockFile(
 
     if (lockRootUpdates.length) {
       logger.debug('Performing lockfileUpdate (npm)');
-      const updateCmd = `npm install ${cmdOptions} ${lockRootUpdates
+      const updateCmd = `npm install ${cmdOptions}${beforeFlag} ${lockRootUpdates
         .map((update) => update.managerData?.packageKey)
         .map(quote)
         .join(' ')}`;
@@ -179,7 +250,7 @@ export async function generateLockFile(
 
     if (upgrades.some((upgrade) => upgrade.isRemediation)) {
       // We need to run twice to get the correct lock file
-      commands.push(`npm install ${cmdOptions}`.trim());
+      commands.push(`npm install ${cmdOptions}${beforeFlag}`.trim());
     }
 
     // postUpdateOptions
@@ -220,8 +291,18 @@ export async function generateLockFile(
       }
     }
 
-    // Run the commands
-    await exec(commands, execOptions);
+    // Run the commands, retrying without --before on ETARGET if needed
+    await exec(commands, execOptions).catch(async (err) => {
+      if (beforeFlag && err.stderr?.includes('with a date before')) {
+        logger.debug('npm --before caused ETARGET, retrying without --before');
+        const commandsWithoutBefore = commands.map((cmd) =>
+          cmd.replace(beforeFlag, ''),
+        );
+        beforeFallback = true;
+        return exec(commandsWithoutBefore, execOptions);
+      }
+      throw err;
+    });
 
     // massage to shrinkwrap if necessary
     if (
@@ -284,7 +365,7 @@ export async function generateLockFile(
     }
     return { error: true, stderr: err.stderr };
   }
-  return { error: !lockFile, lockFile };
+  return { error: !lockFile, lockFile, beforeFallback };
 }
 
 export function divideWorkspaceAndRootDeps(

--- a/lib/modules/manager/npm/post-update/types.ts
+++ b/lib/modules/manager/npm/post-update/types.ts
@@ -1,5 +1,9 @@
 import type { FileChange } from '../../../../util/git/types.ts';
-import type { ArtifactError, PackageFile } from '../../types.ts';
+import type {
+  ArtifactError,
+  ArtifactNotice,
+  PackageFile,
+} from '../../types.ts';
 import type { NpmManagerData } from '../types.ts';
 
 export interface DetermineLockFileDirsResult {
@@ -14,6 +18,7 @@ export interface AdditionalPackageFiles {
 
 export interface WriteExistingFilesResult {
   artifactErrors: ArtifactError[];
+  artifactNotices?: ArtifactNotice[];
   updatedArtifacts: FileChange[];
 }
 
@@ -22,6 +27,7 @@ export interface GenerateLockFileResult {
   lockFile?: string | null;
   stderr?: string;
   stdout?: string;
+  beforeFallback?: boolean;
 }
 
 // the dependencies schema is different for v6 and other lockfile versions

--- a/lib/modules/manager/types.ts
+++ b/lib/modules/manager/types.ts
@@ -9,6 +9,7 @@ import type { Category } from '../../constants/index.ts';
 import type {
   MaybePromise,
   ModuleApi,
+  Nullish,
   RangeStrategy,
   SkipReason,
   StageName,
@@ -389,5 +390,6 @@ export interface PostUpdateConfig<T = Record<string, any>>
   reuseExistingBranch?: boolean;
   toolSettings?: ToolSettingsOptions;
 
+  minimumReleaseAge?: Nullish<string>;
   isLockFileMaintenance?: boolean;
 }

--- a/lib/workers/repository/update/branch/index.ts
+++ b/lib/workers/repository/update/branch/index.ts
@@ -627,6 +627,9 @@ export async function processBranch(
       config.artifactErrors = (config.artifactErrors ?? []).concat(
         additionalFiles.artifactErrors,
       );
+      config.artifactNotices = (config.artifactNotices ?? []).concat(
+        additionalFiles.artifactNotices ?? [],
+      );
       config.updatedArtifacts = (config.updatedArtifacts ?? []).concat(
         additionalFiles.updatedArtifacts,
       );

--- a/lib/workers/repository/update/branch/lock-files/index.spec.ts
+++ b/lib/workers/repository/update/branch/lock-files/index.spec.ts
@@ -90,7 +90,11 @@ describe('workers/repository/update/branch/lock-files/index', () => {
     it('returns no error and empty lockfiles if skipArtifactsUpdate is true', async () => {
       config.skipArtifactsUpdate = true;
       const res = await getAdditionalFiles(config, { npm: [{}] });
-      expect(res).toEqual({ artifactErrors: [], updatedArtifacts: [] });
+      expect(res).toEqual({
+        artifactErrors: [],
+        artifactNotices: [],
+        updatedArtifacts: [],
+      });
     });
 
     it('returns no error and empty lockfiles if lock file maintenance exists', async () => {
@@ -98,7 +102,11 @@ describe('workers/repository/update/branch/lock-files/index', () => {
       config.reuseExistingBranch = true;
       git.branchExists.mockReturnValueOnce(true);
       const res = await getAdditionalFiles(config, { npm: [{}] });
-      expect(res).toEqual({ artifactErrors: [], updatedArtifacts: [] });
+      expect(res).toEqual({
+        artifactErrors: [],
+        artifactNotices: [],
+        updatedArtifacts: [],
+      });
     });
   });
 });


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

https://github.com/renovatebot/renovate/pull/42051 added functionality to prevent npm from resolving newly published transitive dependencies that haven't yet passed the cooldown threshold. It has been reverted in https://github.com/renovatebot/renovate/pull/42198 because it broke lockfile maintenance for dependencies that were already contained in `package-lock.json`  and newer than the date specified via `--before`, see https://github.com/renovatebot/renovate/issues/41657#issuecomment-4142032301.

The new solution extends https://github.com/renovatebot/renovate/pull/42051 with a retry / fallback handling for the case "_lockfile exists but some deps in it are too new_":

- Try `npm install --before=X`
- In case of `ETARGET` error that is related to `--before`, retry without `--before`
- If the fallback was used, add a warning to the PR body / log
  - `logger.warn` provides operational visibility on the dependency dashboard (which doesn't exist on all platforms) that the policy was relaxed
  - The `ArtifactNotice` on the PR informs reviewers that the lock file was generated without the cooldown constraint and doesn't have the same supply chain protection as usual
- In subsequent lockfile maintenance tasks, the lockfile may coverge to the `--before` date, warning disappears

#### Scenarios covered by the fallback

The edge-case that no version of a dep satisfies its required range before the `--before` date, can occur in these cases:

1. **@SchroederSteffen's case** (see https://github.com/renovatebot/renovate/issues/41657#issuecomment-4142032301): lockfile maintenance, global `minimumReleaseAge: "3 days"`, per-package `minimumReleaseAge` overrides, e.g., with `minimumReleaseAge: null`. During lockfile maintenance, the global `minimumReleaseAge` still computes the `--before` date, so renovate bumps `@scope/internal-package` to 1.2.3 (published today), then runs `npm install` with threshold `now - 3 days`. Since 1.2.3 didn't exist 3 days ago, there is a direct conflict between per-package and global `minimumReleaseAge`.

2. **Developer manually bumps a range in in `package.json`**: if any dep in `package.json` was manually bumped to a version published within the `minimumReleaseAge` window, the fresh `npm install --before=<date>` will fail because that version doesn't exist before the cutoff.

3. **Developer manually updates `package-lock.json`**: runs `npm install` locally, gets the latest transitive deps, commits. Renovate then bumps another dep and runs `npm install --before=<date>`. If `package.json` changed, npm re-resolves the tree, and some transitive dep version ranges might only be satisfiable by versions published after the cutoff.

6. **Newly introduced dependency ranges**: new major version of a dep introduces a transitive dep with a range like ^1.0.0 where 1.0.0 was published yesterday. No version satisfies ^1.0.0 before the --before date.

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: https://github.com/renovatebot/renovate/issues/41657 <!-- NOTE that this should NOT be a Discussion -->
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/renovate-demo/41657-npm-lockfile-before-with-fallback

Normal dependency update with `--before`:

- https://github.com/renovate-demo/41657-npm-lockfile-before-with-fallback/pull/1

```
DEBUG: Updating vite in package.json (repository=renovate-demo/41657-npm-lockfile-before-with-fallback, branch=renovate/vite-8.x)
DEBUG: updateArtifacts for updatedPackageFiles (repository=renovate-demo/41657-npm-lockfile-before-with-fallback, branch=renovate/vite-8.x)
DEBUG: Updating lock file only (repository=renovate-demo/41657-npm-lockfile-before-with-fallback, branch=renovate/vite-8.x)
DEBUG: Setting npm --before based on minimumReleaseAge (repository=renovate-demo/41657-npm-lockfile-before-with-fallback, branch=renovate/vite-8.x)
       "beforeISO": "2026-04-06T20:29:06.045Z",
       "minimumReleaseAge": "5 days"
DEBUG: Executing command (repository=renovate-demo/41657-npm-lockfile-before-with-fallback, branch=renovate/vite-8.x)
       "command": "npm install --package-lock-only --no-audit --ignore-scripts --before=2026-04-06T20:29:06.045Z"
DEBUG: exec completed (repository=renovate-demo/41657-npm-lockfile-before-with-fallback, branch=renovate/vite-8.x)
       "durationMs": 1282,
       "stdout": "\nup to date in 1s\n\n8 packages are looking for funding\n  run `npm fund` for details\n",
```

Lockfile maintenance **with fallback:**

- https://github.com/renovate-demo/41657-npm-lockfile-before-with-fallback/issues/3
- https://github.com/renovate-demo/41657-npm-lockfile-before-with-fallback/pull/2

```
DEBUG: updateArtifacts for lockFileMaintenanceFiles (repository=renovate-demo/41657-npm-lockfile-before-with-fallback, branch=renovate/lock-file-maintenance)
DEBUG: npm.updateArtifacts(package.json) (repository=renovate-demo/41657-npm-lockfile-before-with-fallback, branch=renovate/lock-file-maintenance)
DEBUG: Updating lock file only (repository=renovate-demo/41657-npm-lockfile-before-with-fallback, branch=renovate/lock-file-maintenance)
DEBUG: Setting npm --before based on minimumReleaseAge (repository=renovate-demo/41657-npm-lockfile-before-with-fallback, branch=renovate/lock-file-maintenance)
       "beforeISO": "2026-04-06T20:29:14.128Z",
       "minimumReleaseAge": "5 days"
DEBUG: Removing package-lock.json first due to lock file maintenance upgrade (repository=renovate-demo/41657-npm-lockfile-before-with-fallback, branch=renovate/lock-file-maintenance)
DEBUG: Executing command (repository=renovate-demo/41657-npm-lockfile-before-with-fallback, branch=renovate/lock-file-maintenance)
       "command": "npm install --package-lock-only --no-audit --ignore-scripts --before=2026-04-06T20:29:14.128Z"
DEBUG: rawExec err (repository=renovate-demo/41657-npm-lockfile-before-with-fallback, branch=renovate/lock-file-maintenance)
       "err": {
         "cmd": "C:\\WINDOWS\\system32\\cmd.exe /q /d /s /c \"npm ^\"install^\" ^\"--package-lock-only^\" ^\"--no-audit^\" ^\"--ignore-scripts^\" ^\"--before=2026-04-06T20:29:14.128Z^\"\"",
         "stderr": "npm warn Unknown env config \"store\". This will stop working in the next major version of npm.\nnpm error code ETARGET\nnpm error notarget No matching version found for postcss@^8.5.9 with a date before 6.4.2026, 22:29:14.\nnpm error notarget In most cases you or one of your dependencies are requesting\nnpm error notarget a package version that doesn't exist.\nnpm error A complete log of this run can be found in: ...\n",
         "stdout": "",
         "exitCode": 1,
         "name": "ExecError",
         "message": "Command failed: C:\\WINDOWS\\system32\\cmd.exe /q /d /s /c \"npm ^\"install^\" ^\"--package-lock-only^\" ^\"--no-audit^\" ^\"--ignore-scripts^\" ^\"--before=2026-04-06T20:29:14.128Z^\"\"\nnpm warn Unknown env config \"store\". This will stop working in the next major version of npm.\nnpm error code ETARGET\nnpm error notarget No matching version found for postcss@^8.5.9 with a date before 6.4.2026, 22:29:14.\nnpm error notarget In most cases you or one of your dependencies are requesting\nnpm error notarget a package version that doesn't exist.\nnpm error A complete log of this run can be found in: ...\n",
         "stack": "..."
       },
       "durationMs": 1388
DEBUG: npm --before caused ETARGET, retrying without --before (repository=renovate-demo/41657-npm-lockfile-before-with-fallback, branch=renovate/lock-file-maintenance)
DEBUG: Executing command (repository=renovate-demo/41657-npm-lockfile-before-with-fallback, branch=renovate/lock-file-maintenance)
       "command": "npm install --package-lock-only --no-audit --ignore-scripts"
DEBUG: exec completed (repository=renovate-demo/41657-npm-lockfile-before-with-fallback, branch=renovate/lock-file-maintenance)
       "durationMs": 1440,
       "stdout": "\nup to date in 1s\n\n5 packages are looking for funding\n  run `npm fund` for details\n",
       "stderr": "npm warn Unknown env config \"store\". This will stop working in the next major version of npm.\n"
 WARN: npm `--before` could not be enforced because existing locked packages were published after the `minimumReleaseAge` cutoff. This will resolve after the next lock file maintenance run. (repository=renovate-demo/41657-npm-lockfile-before-with-fallback, branch=renovate/lock-file-maintenance)
       "npmLock": "package-lock.json"
```

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
