### PR TITLE
feat(datasource/go): conditionally expose `constraints`

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -932,6 +932,7 @@ Additionally, the "datasource" within Renovate must be capable of returning `con
 This feature is limited to the following datasources:
 
 - `crate`
+- `go`
 - `jenkins-plugins`
 - `npm`
 - `packagist`

--- a/lib/modules/datasource/go/index.spec.ts
+++ b/lib/modules/datasource/go/index.spec.ts
@@ -2,6 +2,8 @@ import { mockDeep } from 'vitest-mock-extended';
 import { Fixtures } from '~test/fixtures.ts';
 import * as httpMock from '~test/http-mock.ts';
 import * as _hostRules from '../../../util/host-rules.ts';
+import type { ReleaseResult } from '../index.ts';
+import { getPkgReleases } from '../index.ts';
 import { GoDatasource } from './index.ts';
 
 vi.mock('../../../util/host-rules.ts', () => mockDeep());
@@ -235,6 +237,107 @@ describe('modules/datasource/go/index', () => {
           'v1.2.3',
         );
         expect(res).toBeNull();
+      });
+    });
+  });
+
+  describe('using getPkgReleases', () => {
+    beforeEach(() => {
+      hostRules.find.mockReturnValue({});
+      hostRules.hosts.mockReturnValue([]);
+    });
+
+    afterEach(() => {
+      delete process.env.GOPROXY;
+    });
+
+    describe('constraints', () => {
+      // TODO deprecated #42600
+      it('are respected based on an exact match on the `go` constraint', async () => {
+        const expected: ReleaseResult = {
+          releases: [
+            // Go 1.24
+            {
+              version: 'v0.32.0',
+              constraints: {
+                go: ['1.24.0'],
+              },
+            },
+            {
+              version: 'v0.33.0',
+              constraints: {
+                go: ['1.24.2'],
+              },
+            },
+            // Go 1.25
+            {
+              version: 'v0.34.0',
+              constraints: {
+                go: ['1.25.0'],
+              },
+            },
+          ],
+        };
+
+        getReleasesProxyMock.mockResolvedValue(expected);
+        getReleasesDirectMock.mockResolvedValue(null);
+
+        const res = await getPkgReleases({
+          datasource: GoDatasource.id,
+          packageName: 'golang.org/x/mod',
+
+          constraints: { go: '1.24.0' },
+          constraintsFiltering: 'strict',
+        });
+
+        expect(res).toBeDefined();
+        expect(res?.releases).toHaveLength(1);
+        expect(res?.releases[0].version).toEqual('v0.32.0');
+      });
+
+      it('are respected based on a SemVer-style range based on the `%goMod` constraint', async () => {
+        const expected: ReleaseResult = {
+          releases: [
+            // Go 1.24
+            {
+              version: 'v0.32.0',
+              constraints: {
+                '%goMod': ['1.24.0'],
+              },
+            },
+            {
+              version: 'v0.33.0',
+              constraints: {
+                '%goMod': ['1.24.1'],
+              },
+            },
+            // Go 1.25
+            {
+              version: 'v0.34.0',
+              constraints: {
+                '%goMod': ['1.25.0'],
+              },
+            },
+          ],
+        };
+
+        getReleasesProxyMock.mockResolvedValue(expected);
+        getReleasesDirectMock.mockResolvedValue(null);
+
+        const res = await getPkgReleases({
+          datasource: GoDatasource.id,
+          packageName: 'golang.org/x/mod',
+          constraints: { '%goMod': '~1.24.x' },
+          constraintsFiltering: 'strict',
+          constraintsVersioning: {
+            '%goMod': 'semver-coerced',
+          },
+        });
+
+        expect(res).toBeDefined();
+        expect(res?.releases).toHaveLength(2);
+        expect(res?.releases[0].version).toEqual('v0.32.0');
+        expect(res?.releases[1].version).toEqual('v0.33.0');
       });
     });
   });

--- a/lib/modules/datasource/go/releases-goproxy.spec.ts
+++ b/lib/modules/datasource/go/releases-goproxy.spec.ts
@@ -684,5 +684,383 @@ describe('modules/datasource/go/releases-goproxy', () => {
         tags: { latest: 'v0.0.0-20230905200255-921286631fa9' },
       });
     });
+
+    describe('looks up `go` directive requirements if constraintsFiltering=strict', () => {
+      it('and returns unfiltered `constraints` in the Release', async () => {
+        httpMock
+          .scope(`${baseUrl}/golang.org/x/mod`)
+          .get('/@v/list')
+          .reply(
+            200,
+            codeBlock`
+            v0.32.0
+            v0.33.0
+            v0.34.0
+          `,
+          )
+          .get('/@v/v0.32.0.info')
+          .reply(200, { Version: 'v0.32.0', Time: '2026-01-09T16:07:51Z' })
+          .get('/@v/v0.32.0.mod')
+          .reply(
+            200,
+            codeBlock`
+            module golang.org/x/mod
+
+            go 1.24.0
+
+            require golang.org/x/tools v0.40.0 // tagx:ignore
+          `,
+          )
+          .get('/@v/v0.33.0.info')
+          .reply(200, { Version: 'v0.33.0', Time: '2026-02-09T16:11:19Z' })
+          .get('/@v/v0.33.0.mod')
+          .reply(
+            200,
+            codeBlock`
+            module golang.org/x/mod
+
+            go 1.24.0
+
+            require golang.org/x/tools v0.41.0 // tagx:ignore
+          `,
+          )
+          .get('/@v/v0.34.0.info')
+          .reply(200, { Version: 'v0.34.0', Time: '2026-03-10T01:41:08Z' })
+          .get('/@v/v0.34.0.mod')
+          .reply(
+            200,
+            codeBlock`
+          module golang.org/x/mod
+
+          go 1.25.0
+
+          require golang.org/x/tools v0.42.0 // tagx:ignore
+          `,
+          )
+          .get('/@latest')
+          .reply(200, { Version: 'v0.34.0' })
+          .get('/v2/@v/list')
+          .reply(404);
+        httpMock.scope('https://golang.org/x/mod').get('?go-get=1').reply(200);
+
+        const res = await datasource.getReleases({
+          packageName: 'golang.org/x/mod',
+          constraintsFiltering: 'strict',
+        });
+
+        expect(res).toEqual({
+          releases: [
+            {
+              version: 'v0.32.0',
+              releaseTimestamp: '2026-01-09T16:07:51.000Z',
+              constraints: {
+                ['%goMod']: ['1.24.0'],
+              },
+            },
+            {
+              version: 'v0.33.0',
+              releaseTimestamp: '2026-02-09T16:11:19.000Z',
+              constraints: {
+                ['%goMod']: ['1.24.0'],
+              },
+            },
+            {
+              version: 'v0.34.0',
+              releaseTimestamp: '2026-03-10T01:41:08.000Z',
+              constraints: {
+                ['%goMod']: ['1.25.0'],
+              },
+            },
+          ],
+          tags: { latest: 'v0.34.0' },
+        });
+      });
+
+      it('handles HTTP errors by omitting constraints on failed HTTP requests', async () => {
+        httpMock
+          .scope(`${baseUrl}/golang.org/x/mod`)
+          .get('/@v/list')
+          .reply(
+            200,
+            codeBlock`
+            v0.32.0
+            v0.33.0
+          `,
+          )
+          .get('/@v/v0.32.0.info')
+          .reply(200, { Version: 'v0.32.0', Time: '2026-01-09T16:07:51Z' })
+          .get('/@v/v0.32.0.mod')
+          .reply(
+            200,
+            codeBlock`
+            module golang.org/x/mod
+
+            go 1.24.0
+
+            require golang.org/x/tools v0.40.0 // tagx:ignore
+          `,
+          )
+          .get('/@v/v0.33.0.info')
+          .reply(200, { Version: 'v0.33.0', Time: '2026-02-09T16:11:19Z' })
+          .get('/@v/v0.33.0.mod')
+          .reply(429, '')
+          .get('/@latest')
+          .reply(200, { Version: 'v0.33.0' })
+          .get('/v2/@v/list')
+          .reply(404);
+        httpMock.scope('https://golang.org/x/mod').get('?go-get=1').reply(200);
+
+        const res = await datasource.getReleases({
+          packageName: 'golang.org/x/mod',
+          constraintsFiltering: 'strict',
+        });
+
+        expect(res).toEqual({
+          releases: [
+            {
+              version: 'v0.32.0',
+              releaseTimestamp: '2026-01-09T16:07:51.000Z',
+              constraints: {
+                ['%goMod']: ['1.24.0'],
+              },
+            },
+            {
+              version: 'v0.33.0',
+              releaseTimestamp: '2026-02-09T16:11:19.000Z',
+            },
+          ],
+          tags: { latest: 'v0.33.0' },
+        });
+      });
+
+      it('does not set constraints if no `go` directive', async () => {
+        httpMock
+          .scope(`${baseUrl}/golang.org/x/mod`)
+          .get('/@v/list')
+          .reply(
+            200,
+            codeBlock`
+            v0.32.0
+          `,
+          )
+          .get('/@v/v0.32.0.info')
+          .reply(200, { Version: 'v0.32.0', Time: '2026-01-09T16:07:51Z' })
+          .get('/@v/v0.32.0.mod')
+          .reply(
+            200,
+            codeBlock`
+            module golang.org/x/mod
+          `,
+          )
+          .get('/@latest')
+          .reply(200, { Version: 'v0.32.0' })
+          .get('/v2/@v/list')
+          .reply(404);
+        httpMock.scope('https://golang.org/x/mod').get('?go-get=1').reply(200);
+
+        const res = await datasource.getReleases({
+          packageName: 'golang.org/x/mod',
+          constraintsFiltering: 'strict',
+        });
+
+        expect(res).toEqual({
+          releases: [
+            {
+              version: 'v0.32.0',
+              releaseTimestamp: '2026-01-09T16:07:51.000Z',
+            },
+          ],
+          tags: { latest: 'v0.32.0' },
+        });
+      });
+
+      // TODO #42566
+      it.each([
+        ['1', '1.0.0'],
+        ['1.25.0.1.1', '1.25.0'],
+      ])(
+        `normalises constraints if not full SemVer \`go\` directive: %s`,
+        async (version, expected) => {
+          httpMock
+            .scope(`${baseUrl}/golang.org/x/mod`)
+            .get('/@v/list')
+            .reply(
+              200,
+              codeBlock`
+            v0.32.0
+          `,
+            )
+            .get('/@v/v0.32.0.info')
+            .reply(200, { Version: 'v0.32.0', Time: '2026-01-09T16:07:51Z' })
+            .get('/@v/v0.32.0.mod')
+            .reply(
+              200,
+              codeBlock`
+            module golang.org/x/mod
+
+            go ${version}
+          `,
+            )
+            .get('/@latest')
+            .reply(200, { Version: 'v0.32.0' })
+            .get('/v2/@v/list')
+            .reply(404);
+          httpMock
+            .scope('https://golang.org/x/mod')
+            .get('?go-get=1')
+            .reply(200);
+
+          const res = await datasource.getReleases({
+            packageName: 'golang.org/x/mod',
+            constraintsFiltering: 'strict',
+          });
+
+          expect(res).toEqual({
+            releases: [
+              {
+                version: 'v0.32.0',
+                releaseTimestamp: '2026-01-09T16:07:51.000Z',
+                constraints: {
+                  '%goMod': [expected],
+                },
+              },
+            ],
+            tags: { latest: 'v0.32.0' },
+          });
+        },
+      );
+
+      it('converts minor-only version numbers to include patch of .0', async () => {
+        httpMock
+          .scope(`${baseUrl}/example.org/pkg`)
+          .get('/@v/list')
+          .reply(
+            200,
+            codeBlock`
+            v0.1.0
+          `,
+          )
+          .get('/@v/v0.1.0.info')
+          .reply(200, { Version: 'v0.1.0', Time: '2019-10-16T16:15:28Z' })
+          .get('/@v/v0.1.0.mod')
+          .reply(
+            200,
+            codeBlock`
+            module example.org/pkg
+
+            go 1.18
+          `,
+          )
+          .get('/@latest')
+          .reply(200, { Version: 'v0.1.0' })
+          .get('/v2/@v/list')
+          .reply(404);
+        httpMock.scope('https://example.org/pkg').get('?go-get=1').reply(200);
+
+        const res = await datasource.getReleases({
+          packageName: 'example.org/pkg',
+          constraintsFiltering: 'strict',
+        });
+
+        expect(res).toEqual({
+          releases: [
+            {
+              version: 'v0.1.0',
+              releaseTimestamp: '2019-10-16T16:15:28.000Z',
+              constraints: {
+                // to allow it to work with full SemVer
+                ['%goMod']: ['1.18.0'],
+              },
+            },
+          ],
+          tags: { latest: 'v0.1.0' },
+        });
+      });
+
+      it('skips `toolchain` directive', async () => {
+        httpMock
+          .scope(`${baseUrl}/example.org/pkg`)
+          .get('/@v/list')
+          .reply(
+            200,
+            codeBlock`
+            v0.1.0
+          `,
+          )
+          .get('/@v/v0.1.0.info')
+          .reply(200, { Version: 'v0.1.0', Time: '2019-10-16T16:15:28.000Z' })
+          .get('/@v/v0.1.0.mod')
+          .reply(
+            200,
+            codeBlock`
+            module example.org/pkg
+
+            go 1.20.5
+
+            toolchain 1.26.2
+          `,
+          )
+          .get('/@latest')
+          .reply(200, { Version: 'v0.1.0' })
+          .get('/v2/@v/list')
+          .reply(404);
+        httpMock.scope('https://example.org/pkg').get('?go-get=1').reply(200);
+
+        const res = await datasource.getReleases({
+          packageName: 'example.org/pkg',
+          constraintsFiltering: 'strict',
+        });
+
+        expect(res).toEqual({
+          releases: [
+            {
+              version: 'v0.1.0',
+              releaseTimestamp: '2019-10-16T16:15:28.000Z',
+              constraints: {
+                ['%goMod']: ['1.20.5'],
+              },
+            },
+          ],
+          tags: { latest: 'v0.1.0' },
+        });
+      });
+
+      it('does not look up `go` directive requirements if constraintsFiltering=none', async () => {
+        httpMock
+          .scope(`${baseUrl}/example.org/pkg`)
+          .get('/@v/list')
+          .reply(
+            200,
+            codeBlock`
+            v0.1.0
+          `,
+          )
+          .get('/@v/v0.1.0.info')
+          .reply(200, { Version: 'v0.1.0', Time: '2019-10-16T16:15:28.000Z' })
+          .get('/@latest')
+          .reply(200, { Version: 'v0.1.0' })
+          .get('/v2/@v/list')
+          .reply(404);
+        httpMock.scope('https://example.org/pkg').get('?go-get=1').reply(200);
+
+        const res = await datasource.getReleases({
+          packageName: 'example.org/pkg',
+          constraints: {
+            ['%goMod']: '1.24.0',
+          },
+          constraintsFiltering: 'none',
+        });
+
+        expect(res).toEqual({
+          releases: [
+            {
+              version: 'v0.1.0',
+              releaseTimestamp: '2019-10-16T16:15:28.000Z',
+            },
+          ],
+          tags: { latest: 'v0.1.0' },
+        });
+      });
+    });
   });
 });

--- a/lib/modules/datasource/go/releases-goproxy.spec.ts
+++ b/lib/modules/datasource/go/releases-goproxy.spec.ts
@@ -776,6 +776,126 @@ describe('modules/datasource/go/releases-goproxy', () => {
         });
       });
 
+      it('handles major version updates', async () => {
+        httpMock
+          .scope(`${baseUrl}/golang.org/x/mod`)
+          .get('/@v/list')
+          .reply(
+            200,
+            codeBlock`
+            v0.32.0
+            v0.33.0
+            v0.34.0
+          `,
+          )
+          .get('/@v/v0.32.0.info')
+          .reply(200, { Version: 'v0.32.0', Time: '2026-01-09T16:07:51Z' })
+          .get('/@v/v0.32.0.mod')
+          .reply(
+            200,
+            codeBlock`
+            module golang.org/x/mod
+
+            go 1.24.0
+
+            require golang.org/x/tools v0.40.0 // tagx:ignore
+          `,
+          )
+          .get('/@v/v0.33.0.info')
+          .reply(200, { Version: 'v0.33.0', Time: '2026-02-09T16:11:19Z' })
+          .get('/@v/v0.33.0.mod')
+          .reply(
+            200,
+            codeBlock`
+            module golang.org/x/mod
+
+            go 1.24.0
+
+            require golang.org/x/tools v0.41.0 // tagx:ignore
+          `,
+          )
+          .get('/@v/v0.34.0.info')
+          .reply(200, { Version: 'v0.34.0', Time: '2026-03-10T01:41:08Z' })
+          .get('/@v/v0.34.0.mod')
+          .reply(
+            200,
+            codeBlock`
+          module golang.org/x/mod
+
+          go 1.25.0
+
+          require golang.org/x/tools v0.42.0 // tagx:ignore
+          `,
+          )
+          .get('/@latest')
+          .reply(200, { Version: 'v0.34.0' })
+          .get('/v2/@v/list')
+          .reply(
+            200,
+            codeBlock`
+          v2.0.0
+        `,
+          )
+          .get('/v2/@v/v2.0.0.info')
+          .reply(200, { Version: 'v2.0.0', Time: '2026-04-01T01:41:08Z' })
+          .get('/v2/@v/v2.0.0.mod')
+          .reply(
+            200,
+            codeBlock`
+          module golang.org/x/mod/v2
+
+          go 1.26.0
+
+          require golang.org/x/tools v0.42.0 // tagx:ignore
+          `,
+          )
+          .get('/v2/@latest')
+          .reply(200, { Version: 'v2.0.0' })
+          .get('/v3/@v/list')
+          .reply(403);
+
+        httpMock.scope('https://golang.org/x/mod').get('?go-get=1').reply(200);
+
+        const res = await datasource.getReleases({
+          packageName: 'golang.org/x/mod',
+          constraintsFiltering: 'strict',
+        });
+
+        expect(res).toEqual({
+          releases: [
+            {
+              version: 'v0.32.0',
+              releaseTimestamp: '2026-01-09T16:07:51.000Z',
+              constraints: {
+                ['%goMod']: ['1.24.0'],
+              },
+            },
+            {
+              version: 'v0.33.0',
+              releaseTimestamp: '2026-02-09T16:11:19.000Z',
+              constraints: {
+                ['%goMod']: ['1.24.0'],
+              },
+            },
+            {
+              version: 'v0.34.0',
+              releaseTimestamp: '2026-03-10T01:41:08.000Z',
+              constraints: {
+                ['%goMod']: ['1.25.0'],
+              },
+            },
+            {
+              version: 'v2.0.0',
+              releaseTimestamp: '2026-04-01T01:41:08.000Z',
+              constraints: {
+                ['%goMod']: ['1.26.0'],
+              },
+            },
+          ],
+          tags: { latest: 'v2.0.0' },
+        });
+      });
+
       it('handles HTTP errors by omitting constraints on failed HTTP requests', async () => {
         httpMock
           .scope(`${baseUrl}/golang.org/x/mod`)

--- a/lib/modules/datasource/go/releases-goproxy.ts
+++ b/lib/modules/datasource/go/releases-goproxy.ts
@@ -1,4 +1,5 @@
 import { isNonEmptyStringAndNotWhitespace, isTruthy } from '@sindresorhus/is';
+import type { ConstraintsFilter } from '../../../config/types.ts';
 import { logger } from '../../../logger/index.ts';
 import { ExternalHostError } from '../../../types/errors/external-host-error.ts';
 import { withCache } from '../../../util/cache/package/with-cache.ts';
@@ -17,6 +18,9 @@ import { getSourceUrl } from './common.ts';
 import { parseGoproxy, parseNoproxy } from './goproxy-parser.ts';
 import { GoDirectDatasource } from './releases-direct.ts';
 import type { VersionInfo } from './types.ts';
+
+/** TODO #42566 */
+const goVersionRegex = regEx(/^\s*go\s+(?<version>[^\s]+)\s*$/);
 
 const modRegex = regEx(/^(?<baseMod>.*?)(?:[./]v(?<majorVersion>\d+))?$/);
 
@@ -81,7 +85,11 @@ export class GoProxyDatasource extends Datasource {
           break;
         }
 
-        const res = await this.getVersionsWithInfo(url, packageName);
+        const res = await this.getVersionsWithInfo(
+          url,
+          packageName,
+          config.constraintsFiltering,
+        );
         if (res.releases.length) {
           result = res;
           break;
@@ -187,6 +195,66 @@ export class GoProxyDatasource extends Datasource {
     return result;
   }
 
+  /**
+   * Retrieve the `go` directive for a given Go Module.
+   *
+   * NOTE that this means the `go` directive, not the `toolchain` directive.
+   */
+  async retrieveGoDirectiveForModule(
+    baseUrl: string,
+    packageName: string,
+    version: string,
+  ): Promise<string | undefined> {
+    return withCache(
+      {
+        namespace: `datasource-${GoProxyDatasource.id}`,
+        key: GoProxyDatasource.getVersionedCacheKey(packageName, version),
+        fallback: true,
+        // a module's `go.mod` should /never/ change after it's published. If going via the Go Proxy and the Go Checksum Database, a change in this value will result in build failures.
+        ttlMinutes: 100 * 24 * 60,
+      },
+      () => this._retrieveGoDirectiveForModule(baseUrl, packageName, version),
+    );
+  }
+
+  async _retrieveGoDirectiveForModule(
+    baseUrl: string,
+    packageName: string,
+    version: string,
+  ): Promise<string | undefined> {
+    const url = joinUrlParts(
+      baseUrl,
+      this.encodeCase(packageName),
+      '@v',
+      `${version}.mod`,
+    );
+    const res = await this.http.getText(url);
+
+    let goDirective: string | undefined = undefined;
+
+    for (const line of res.body.split('\n')) {
+      const goVersionMatches = goVersionRegex.exec(line)?.groups;
+      if (goVersionMatches) {
+        goDirective = goVersionMatches.version;
+        break;
+      }
+    }
+
+    if (!goDirective) {
+      return goDirective;
+    }
+
+    // always return it in full SemVer format, which can then be matched on using `semver` or `semver-coerced`
+    const parts = goDirective.split('.');
+    if (parts.length === 1) {
+      return `${parts[0]}.0.0`;
+    } else if (parts.length === 2) {
+      return `${parts[0]}.${parts[1]}.0`;
+    } else {
+      return `${parts[0]}.${parts[1]}.${parts[2]}`;
+    }
+  }
+
   async getLatestVersion(
     baseUrl: string,
     packageName: string,
@@ -208,6 +276,7 @@ export class GoProxyDatasource extends Datasource {
   async getVersionsWithInfo(
     baseUrl: string,
     packageName: string,
+    constraintsFiltering: ConstraintsFilter | undefined,
   ): Promise<ReleaseResult> {
     const isGopkgin = packageName.startsWith('gopkg.in/');
     const majorSuffixSeparator = isGopkgin ? '.' : '/';
@@ -254,6 +323,31 @@ export class GoProxyDatasource extends Datasource {
             return { version };
           }
         });
+
+        if (constraintsFiltering === 'strict') {
+          releases = await p.map(releases, async (rel) => {
+            try {
+              const goDirective = await this.retrieveGoDirectiveForModule(
+                baseUrl,
+                packageName,
+                rel.version,
+              );
+              if (goDirective) {
+                rel.constraints ??= {};
+                rel.constraints['%goMod'] ??= [];
+                rel.constraints['%goMod'].push(goDirective);
+              }
+            } catch (err) {
+              logger.trace(
+                { err },
+                `Can't obtain \`go\` directive from ${baseUrl}`,
+              );
+            }
+
+            return rel;
+          });
+        }
+
         result.releases.push(...releases);
       } catch (err) {
         const potentialHttpError =
@@ -298,5 +392,12 @@ export class GoProxyDatasource extends Datasource {
     const noproxy = parseNoproxy();
     // TODO: types (#22198)
     return `${packageName}@@${goproxy}@@${noproxy?.toString()}`;
+  }
+
+  static getVersionedCacheKey(packageName: string, version: string): string {
+    const goproxy = getEnv().GOPROXY;
+    const noproxy = parseNoproxy();
+    // TODO: types (#22198)
+    return `${packageName}@@${version}@@${goproxy}@@${noproxy?.toString()}`;
   }
 }

--- a/lib/modules/datasource/go/releases-goproxy.ts
+++ b/lib/modules/datasource/go/releases-goproxy.ts
@@ -329,7 +329,7 @@ export class GoProxyDatasource extends Datasource {
             try {
               const goDirective = await this.retrieveGoDirectiveForModule(
                 baseUrl,
-                packageName,
+                pkg,
                 rel.version,
               );
               if (goDirective) {

--- a/lib/modules/datasource/go/releases-goproxy.ts
+++ b/lib/modules/datasource/go/releases-goproxy.ts
@@ -209,7 +209,6 @@ export class GoProxyDatasource extends Datasource {
       {
         namespace: `datasource-${GoProxyDatasource.id}`,
         key: GoProxyDatasource.getVersionedCacheKey(packageName, version),
-        fallback: true,
         // a module's `go.mod` should /never/ change after it's published. If going via the Go Proxy and the Go Checksum Database, a change in this value will result in build failures.
         ttlMinutes: 100 * 24 * 60,
       },

--- a/lib/modules/manager/gomod/integration.spec.ts
+++ b/lib/modules/manager/gomod/integration.spec.ts
@@ -1,0 +1,142 @@
+import { codeBlock } from 'common-tags';
+import * as httpMock from '~test/http-mock.ts';
+import { partial } from '~test/util.ts';
+import { getConfig } from '../../../config/defaults.ts';
+import { fetchUpdates } from '../../../workers/repository/process/fetch.ts';
+import type { LookupUpdateConfig } from '../../../workers/repository/process/lookup/types.ts';
+import type { PackageFile } from '../types.ts';
+import { extractPackageFile } from './extract.ts';
+
+describe('modules/manager/gomod/integration', () => {
+  let baseConfig: LookupUpdateConfig;
+
+  beforeEach(() => {
+    // TODO: fix types #22198
+    baseConfig = partial<LookupUpdateConfig>(getConfig() as never);
+    baseConfig.manager = 'gomod';
+    baseConfig.constraintsFiltering = 'strict';
+  });
+
+  describe('when constraintsFiltering=strict', () => {
+    it('only suggests updates within the minor version of the `go` directive', async () => {
+      // make sure we can validate all suggested releases
+      baseConfig.separateMultipleMinor = true;
+
+      const goMod = codeBlock`
+        module github.com/renovate-tests/gomod
+        go 1.22.5
+
+        require github.com/renovate-tests/some-module v0.1.0
+      `;
+      const extracted = extractPackageFile(goMod);
+      expect(extracted).not.toBeNull();
+      expect(extracted?.deps).toHaveLength(2);
+
+      const dep = extracted!.deps.find(
+        (d) => d.depName === 'github.com/renovate-tests/some-module',
+      );
+      expect(dep).toBeDefined();
+
+      httpMock
+        .scope('https://raw.githubusercontent.com')
+        .get('/golang/website/HEAD/internal/history/release.go')
+        .reply(200, '');
+      httpMock
+        .scope('https://proxy.golang.org')
+        .get('/github.com/renovate-tests/some-module/@v/list')
+        .reply(
+          200,
+          codeBlock`
+            v0.2.0
+            v0.3.0
+            v0.4.0
+            v0.5.0
+            v0.6.0
+        `,
+        );
+
+      const versions = {
+        'v0.2.0': '1.18',
+        'v0.3.0': '1.22.2',
+        'v0.4.0': '1.22.5',
+        'v0.5.0': '1.22.1000',
+        'v0.6.0': '1.30.0',
+      };
+      for (const [k, v] of Object.entries(versions)) {
+        httpMock
+          .scope('https://proxy.golang.org')
+          .get(`/github.com/renovate-tests/some-module/@v/${k}.info`)
+          .reply(200, {
+            Version: k,
+          });
+        httpMock
+          .scope('https://proxy.golang.org')
+          .get(`/github.com/renovate-tests/some-module/@v/${k}.mod`)
+          .reply(
+            200,
+            codeBlock`module github.com/renovate-tests/some-module
+               go ${v}
+        `,
+          );
+      }
+
+      httpMock
+        .scope('https://proxy.golang.org')
+        .get('/github.com/renovate-tests/some-module/v2/@v/list')
+        .reply(404);
+
+      httpMock
+        .scope('https://proxy.golang.org')
+        .get('/github.com/renovate-tests/some-module/@latest')
+        .reply(200, 'v0.6.0');
+
+      const packageFiles: Record<string, PackageFile[]> = {
+        gomod: [
+          partial({
+            ...extracted,
+            packageFile: 'go.mod',
+          }),
+        ],
+      };
+
+      await fetchUpdates(baseConfig, packageFiles);
+
+      const updates = packageFiles.gomod[0].deps[1].updates;
+      expect(updates).toEqual([
+        {
+          bucket: 'v0.3',
+          hasAttestation: undefined,
+          isBreaking: true,
+          newMajor: 0,
+          newMinor: 3,
+          newPatch: 0,
+          newValue: 'v0.3.0',
+          newVersion: 'v0.3.0',
+          updateType: 'minor',
+        },
+        {
+          bucket: 'v0.4',
+          hasAttestation: undefined,
+          isBreaking: true,
+          newMajor: 0,
+          newMinor: 4,
+          newPatch: 0,
+          newValue: 'v0.4.0',
+          newVersion: 'v0.4.0',
+          updateType: 'minor',
+        },
+        {
+          bucket: 'v0.5',
+          hasAttestation: undefined,
+          isBreaking: true,
+          newMajor: 0,
+          newMinor: 5,
+          newPatch: 0,
+          newValue: 'v0.5.0',
+          newVersion: 'v0.5.0',
+          updateType: 'minor',
+        },
+      ]);
+    });
+  });
+});

--- a/lib/modules/manager/gomod/readme.md
+++ b/lib/modules/manager/gomod/readme.md
@@ -24,9 +24,9 @@ Unlike the `go` directive, it's valid to keep bumping this, and you should see u
 ### Only suggesting updates that match your `go` directive
 
 In `go.mod`, the `go` directive essentially means "Compatible with this version or later".
-It is generally recommended for Go projects to _not_ bump this version unless necessary, and as [noted above](#updating-of-go-mod-and-toolchain-directives), Renovate doesn't update this.
+It is generally recommended for Go projects to _not_ bump this version unless necessary.
 
-However, dependency updates can lead to a package you rely on bumping their `go` directive, which means you can't accept the proposed update without also bumping your `go` directive.
+As [noted above](#updating-of-go-mod-and-toolchain-directives), Renovate doesn't update this directly, but dependency updates can lead to a package you rely on bumping their `go` directive, which means you can't accept the proposed update without also bumping your `go` directive.
 
 To make this simpler, you can use [`constraintsFiltering=strict`](../../../configuration-options.md#constraintsfiltering) to make sure that Renovate will only propose updates that match the [`constraints`](../../../configuration-options.md#constraints) you specify.
 

--- a/lib/modules/manager/gomod/readme.md
+++ b/lib/modules/manager/gomod/readme.md
@@ -21,6 +21,46 @@ If you are sure you want to always bump it to latest, then you need the followin
 In `go.mod`, the `toolchain` directive essentially means "Use this exact version of go".
 Unlike the `go` directive, it's valid to keep bumping this, and you should see updates to it proposed by default.
 
+### Only suggesting updates that match your `go` directive
+
+In `go.mod`, the `go` directive essentially means "Compatible with this version or later".
+It is generally recommended for Go projects to _not_ bump this version unless necessary, and as [noted above](#updating-of-go-mod-and-toolchain-directives), Renovate doesn't update this.
+
+However, dependency updates can lead to a package you rely on bumping their `go` directive, which means you can't accept the proposed update without also bumping your `go` directive.
+
+To make this simpler, you can use [`constraintsFiltering=strict`](../../../configuration-options.md#constraintsfiltering) to make sure that Renovate will only propose updates that match the [`constraints`](../../../configuration-options.md#constraints) you specify.
+
+For example, given the `go.mod`:
+
+```gomod
+module example
+
+go 1.24.0
+
+require golang.org/x/mod v0.32.0
+```
+
+We can then configure Renovate to set the same constraint when updating any Go dependencies:
+
+```json
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "packageRules": [
+    {
+      "description": "Ensure source compatibility with Go version used by this project",
+      "matchManagers": ["gomod"],
+      "constraintsFiltering": "strict"
+    }
+  ]
+}
+```
+
+In this case, Renovate would only propose an update to a version of `golang.org/x/mod` that supports Go 1.24.x.
+
+<!-- prettier-ignore -->
+!!! note
+    It is recommended to read the [`constraintsFiltering`](../../../configuration-options.md#constraintsfiltering) documentation and [Language constraints and upgrading](../../../language-constraints-and-upgrading.md) for more information about how the filtering works and how _strict_ this can be.
+
 ### Post-Update Options
 
 You might be interested in the following `postUpdateOptions`:


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->


As noted in #42567, some Go modules are constrained by their
compatibility with the source compatibility with the Go language as per
the `go` directive.

Bumping the `go` directive will result in all of a library's consumers
also needing to bump their own `go`, which can be something library
authors will attempt to avoid.

Previously, Renovate users would receive an update from any modules that
have a new release, regardless of whether they will bump the `go`
directive.

With this change, users who use `constraintsFiltering=strict` will have
the filtering applied, so they only receive updates for Go modules in
their current minor version.

Due to the additional API calls needed, this is an opt-in feature, and
only includes the API calls when the using
`constraintsFiltering=strict`.

We can also add an integration test to build our confidence in the
end-to-end flow.




## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #42567
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/JamieTanna-Mend-testing/renovate-discussions-42459

```
env GITHUB_COM_TOKEN=$(gh auth token) LOG_LEVEL=debug node ~/workspaces/renovate/lib/renovate.ts --platform local --dry-run=lookup
```

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
