### PR TITLE
feat(manager/gomod): extract the `go` and `toolchain` directives as `constraints`

### DIFF
--- a/lib/modules/manager/gomod/extract.spec.ts
+++ b/lib/modules/manager/gomod/extract.spec.ts
@@ -1,5 +1,7 @@
 import { codeBlock } from 'common-tags';
 import { Fixtures } from '~test/fixtures.ts';
+import { getDefaultVersioning } from '../../datasource/common.ts';
+import * as allVersioning from '../../versioning/index.ts';
 import { extractPackageFile } from './index.ts';
 
 const gomod1 = Fixtures.get('1/go-mod');
@@ -122,6 +124,12 @@ describe('modules/manager/gomod/extract', () => {
             datasource: 'go',
           },
         ],
+        extractedConstraints: {
+          '%goMod': '~1.23.x',
+        },
+        constraintsVersioning: {
+          '%goMod': 'semver-coerced',
+        },
       });
     });
 
@@ -172,6 +180,12 @@ describe('modules/manager/gomod/extract', () => {
             versioning: 'loose',
           },
         ],
+        extractedConstraints: {
+          '%goMod': '~1.25.x',
+        },
+        constraintsVersioning: {
+          '%goMod': 'semver-coerced',
+        },
       });
     });
 
@@ -236,6 +250,13 @@ describe('modules/manager/gomod/extract', () => {
             datasource: 'go',
           },
         ],
+        extractedConstraints: {
+          '%goMod': '~1.23.x',
+          golang: '1.23.3',
+        },
+        constraintsVersioning: {
+          '%goMod': 'semver-coerced',
+        },
       });
     });
 
@@ -495,6 +516,90 @@ describe('modules/manager/gomod/extract', () => {
           skipReason: 'invalid-version',
         },
       ],
+      extractedConstraints: {
+        '%goMod': '~1.19.x',
+      },
+      constraintsVersioning: {
+        '%goMod': 'semver-coerced',
+      },
+    });
+  });
+
+  it.each(['1.19', '1.19.0', '1.19.5'])(
+    'extracts `go` directive %s as a `%goMod` extracted constraint as a SemVer-minor compatible range',
+    (goDirective) => {
+      const goMod = codeBlock`
+        module github.com/renovate-tests/gomod
+        go ${goDirective}
+      `;
+      const res = extractPackageFile(goMod);
+      expect(res).toEqual({
+        deps: [
+          {
+            managerData: {
+              lineNumber: 1,
+            },
+            depName: 'go',
+            depType: 'golang',
+            currentValue: goDirective,
+            datasource: 'golang-version',
+            versioning: 'go-mod-directive',
+            commitMessageTopic: 'go module directive',
+          },
+        ],
+        extractedConstraints: {
+          // NOTE that this is extracted as a range for the whole SemVer minor version
+          '%goMod': '~1.19.x',
+        },
+        constraintsVersioning: {
+          '%goMod': 'semver-coerced',
+        },
+      });
+    },
+  );
+
+  describe('the extracted version can be used as a SemVer constraint', () => {
+    const goMod = codeBlock`
+        module github.com/renovate-tests/gomod
+        go 1.19
+      `;
+    const res = extractPackageFile(goMod);
+
+    const datasourceVersioningName = getDefaultVersioning(
+      res!.deps[0].datasource,
+    );
+    // NOTE that this is not the `go-mod-directive` versioning, as that comes from `constraintsVersioning`
+    expect(datasourceVersioningName).toEqual('semver');
+
+    expect(res!.constraintsVersioning).toBeDefined();
+    const versioningName = res!.constraintsVersioning!['%goMod'];
+    expect(versioningName).toBeDefined();
+
+    const versioning = allVersioning.get(versioningName);
+    expect(versioning).toBeDefined();
+
+    const constraint = res!.extractedConstraints!['%goMod']!;
+    it(`${constraint} is a valid constraint`, () => {
+      expect(versioning.isValid(constraint)).toBeTrue();
+    });
+
+    it('matches version 1.19, even though it is not valid SemVer', () => {
+      expect(versioning.matches('1.19', constraint)).toBeTrue();
+    });
+
+    it('matches the current SemVer minor', () => {
+      expect(versioning.matches('1.19.0', constraint)).toBeTrue();
+      expect(versioning.matches('1.19.10', constraint)).toBeTrue();
+    });
+
+    it('does not match the next SemVer minor', () => {
+      expect(versioning.matches('1.20.0', constraint)).toBeFalse();
+      expect(versioning.matches('1.20.10', constraint)).toBeFalse();
+    });
+
+    it('does not match the previous SemVer minor', () => {
+      expect(versioning.matches('1.18.0', constraint)).toBeFalse();
+      expect(versioning.matches('1.18.5', constraint)).toBeFalse();
     });
   });
 });

--- a/lib/modules/manager/gomod/extract.ts
+++ b/lib/modules/manager/gomod/extract.ts
@@ -72,5 +72,58 @@ export function extractPackageFile(content: string): PackageFileContent | null {
     return null;
   }
 
-  return { deps };
+  const packageFile: PackageFileContent = {
+    deps,
+  };
+
+  const goDirective = packageFile.deps.find(
+    (dep) =>
+      dep.depName === 'go' &&
+      dep.depType === 'golang' &&
+      dep.datasource === 'golang-version',
+  );
+  if (goDirective?.currentValue) {
+    packageFile.extractedConstraints ??= {};
+    const range = convertGoDirectiveToSemVerRange(goDirective.currentValue);
+    if (range.version) {
+      packageFile.extractedConstraints['%goMod'] = range.version;
+
+      packageFile.constraintsVersioning ??= {};
+      packageFile.constraintsVersioning['%goMod'] = range.versioning;
+    }
+  }
+
+  const toolchainDirective = packageFile.deps.find(
+    (dep) =>
+      dep.depName === 'go' &&
+      dep.depType === 'toolchain' &&
+      dep.datasource === 'golang-version',
+  );
+  if (toolchainDirective?.currentValue) {
+    packageFile.extractedConstraints ??= {};
+    packageFile.extractedConstraints.golang = toolchainDirective.currentValue;
+  }
+
+  return packageFile;
+}
+
+function convertGoDirectiveToSemVerRange(goDirective: string | undefined):
+  | {
+      version: string;
+      versioning: string;
+    }
+  | {
+      version: undefined;
+    } {
+  if (!goDirective) {
+    return {
+      version: undefined,
+    };
+  }
+
+  const parts = goDirective.split('.');
+  return {
+    version: `~${parts[0]}.${parts[1]}.x`,
+    versioning: 'semver-coerced',
+  };
 }

--- a/lib/util/exec/types.ts
+++ b/lib/util/exec/types.ts
@@ -219,6 +219,11 @@ Must be prefixed with \`v\`.`,
     description:
       'Used in the `cpanfile` manager to track Perl version required.',
   },
+  {
+    name: '%goMod',
+    description:
+      'Used in the `gomod` manager to determine the [minimum version of Go required to use this module](https://go.dev/ref/mod#go-mod-file-go).\n\nNote that this is prefixed with a `%` to explicilty note that this is not a tool that Containerbase knows.',
+  },
 ] as const satisfies ConstraintDefinition[];
 
 /**


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
As part of future changes in #42567 to surface the `constraints` of a
given Go module, we should first extract the constraints from the
package file.

To make this simpler for users, we can make sure we extract these at
parse time:

- the `toolchain` directive becomes the `go` constraint, as it is the
  toolchain actually running Go, and mirrors how a `constraints.go`
  would be expected to control the `go` toolchain version for
  Containerbase
- the `go` directive becomes a new `go-mod` constraint, which keeps it
  separate from the version of the Go toolchain actually used to run


## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
