### PR TITLE
feat(manager/mise): add support for openfga

### DIFF
--- a/lib/modules/manager/mise/extract.spec.ts
+++ b/lib/modules/manager/mise/extract.spec.ts
@@ -72,6 +72,7 @@ describe('modules/manager/mise/extract', () => {
       lychee = "0.19.1"
       npm = "11.2.0"
       opentofu = "1.6.1"
+      openfga = "1.14.0"
       packer = "1.15.0"
       pipx = "1.7.1"
       pkl = "0.28.2"
@@ -238,6 +239,13 @@ describe('modules/manager/mise/extract', () => {
             depName: 'opentofu',
             extractVersion: '^v(?<version>\\S+)',
             packageName: 'opentofu/opentofu',
+          },
+          {
+            currentValue: '1.14.0',
+            datasource: 'github-releases',
+            depName: 'openfga',
+            extractVersion: '^v(?<version>\\S+)',
+            packageName: 'openfga/openfga',
           },
           {
             currentValue: '1.15.0',

--- a/lib/modules/manager/mise/upgradeable-tooling.ts
+++ b/lib/modules/manager/mise/upgradeable-tooling.ts
@@ -369,6 +369,14 @@ const miseRegistryTooling: Record<string, ToolingDefinition> = {
       extractVersion: '^v(?<version>\\S+)',
     },
   },
+  openfga: {
+    misePluginUrl: 'https://mise.jdx.dev/registry.html#tools',
+    config: {
+      packageName: 'openfga/openfga',
+      datasource: GithubReleasesDatasource.id,
+      extractVersion: '^v(?<version>\\S+)',
+    },
+  },
   packer: {
     misePluginUrl: 'https://mise.jdx.dev/registry.html#tools',
     config: {


### PR DESCRIPTION
## Changes

Adds `openfga` ([OpenFGA](https://github.com/openfga/openfga)) to the set of mise tools for renovate to manage. OpenFGA is a high performance and flexible authorization/permission engine built for developers and inspired by Google Zanzibar.

## Context

- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, and documentation).

## Documentation (please check one with an [x])

- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Newly added/modified unit tests