### PR TITLE
feat(dashboard): print schedule(s) for awaiting PRs

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -1553,6 +1553,14 @@ This helps you identify dependencies that may need attention due to lack of main
 
 Set this to `false` if you prefer not to see abandoned packages in your dependency dashboard.
 
+## dependencyDashboardReportSchedules
+
+Controls whether schedule descriptions are reported in the dependency dashboard..
+
+When enabled (default), Renovate will display the schedule details for any PR awaiting schedule..
+
+Set this to `false` if you prefer not to see schedule descriptions in your dependency dashboard.
+
 ## dependencyDashboardTitle
 
 Configure this option if you prefer a different title for the Dependency Dashboard.

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -2107,6 +2107,13 @@ const options: Readonly<RenovateOptions>[] = [
     default: true,
   },
   {
+    name: 'dependencyDashboardReportSchedules',
+    description:
+      'Controls whether waiting schedule descriptions are reported in the dependency dashboard.',
+    type: 'boolean',
+    default: true,
+  },
+  {
     name: 'internalChecksAsSuccess',
     description:
       'Whether to consider passing internal checks such as `minimumReleaseAge` when determining branch status.',

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -411,6 +411,7 @@ export interface RenovateConfig
   dependencyDashboardLabels?: string[];
   dependencyDashboardOSVVulnerabilitySummary?: 'none' | 'all' | 'unresolved';
   dependencyDashboardReportAbandonment?: boolean;
+  dependencyDashboardReportSchedules?: boolean;
   mode?: 'silent' | 'full';
   packageFile?: string;
   packageRules?: PackageRule[];

--- a/lib/util/schedule.spec.ts
+++ b/lib/util/schedule.spec.ts
@@ -1,0 +1,43 @@
+import { getReadableCronSchedule } from './schedule.ts';
+
+describe('util/schedule', () => {
+  describe('getReadableCronSchedule', () => {
+    it('returns null for non-cron (Later.js) schedule', () => {
+      expect(getReadableCronSchedule(['before 5am on Monday'])).toBeNull();
+    });
+
+    it('returns null for "at any time"', () => {
+      expect(getReadableCronSchedule(['at any time'])).toBeNull();
+    });
+
+    it('converts a simple daily cron expression', () => {
+      expect(getReadableCronSchedule(['* 5 * * *'])).toEqual([
+        'At 05:00 AM (`* 5 * * *`)',
+      ]);
+    });
+
+    it('converts a weekly cron expression', () => {
+      expect(getReadableCronSchedule(['* 5 * * 1'])).toEqual([
+        'At 05:00 AM, only on Monday (`* 5 * * 1`)',
+      ]);
+    });
+
+    it('converts multiple cron expressions', () => {
+      expect(getReadableCronSchedule(['* 5 * * 1', '* 5 * * 3'])).toEqual([
+        'At 05:00 AM, only on Monday (`* 5 * * 1`)',
+        'At 05:00 AM, only on Wednesday (`* 5 * * 3`)',
+      ]);
+    });
+
+    it('strips leading "Every minute, " prefix from cronstrue output', () => {
+      const result = getReadableCronSchedule(['* * * * 1']);
+      expect(result).not.toBeNull();
+      expect(result![0]).not.toContain('Every minute,');
+    });
+
+    it('capitalizes the first letter of the description', () => {
+      const result = getReadableCronSchedule(['* 5 * * *']);
+      expect(result![0][0]).toBe(result![0][0].toUpperCase());
+    });
+  });
+});

--- a/lib/util/schedule.spec.ts
+++ b/lib/util/schedule.spec.ts
@@ -12,20 +12,20 @@ describe('util/schedule', () => {
 
     it('converts a simple daily cron expression', () => {
       expect(getReadableCronSchedule(['* 5 * * *'])).toEqual([
-        'At 05:00 AM (`* 5 * * *`)',
+        'Between 05:00 AM and 05:59 AM (`* 5 * * *`)',
       ]);
     });
 
     it('converts a weekly cron expression', () => {
       expect(getReadableCronSchedule(['* 5 * * 1'])).toEqual([
-        'At 05:00 AM, only on Monday (`* 5 * * 1`)',
+        'Between 05:00 AM and 05:59 AM, only on Monday (`* 5 * * 1`)',
       ]);
     });
 
     it('converts multiple cron expressions', () => {
       expect(getReadableCronSchedule(['* 5 * * 1', '* 5 * * 3'])).toEqual([
-        'At 05:00 AM, only on Monday (`* 5 * * 1`)',
-        'At 05:00 AM, only on Wednesday (`* 5 * * 3`)',
+        'Between 05:00 AM and 05:59 AM, only on Monday (`* 5 * * 1`)',
+        'Between 05:00 AM and 05:59 AM, only on Wednesday (`* 5 * * 3`)',
       ]);
     });
 

--- a/lib/util/schedule.ts
+++ b/lib/util/schedule.ts
@@ -1,0 +1,28 @@
+import { CronPattern } from 'croner';
+import cronstrue from 'cronstrue';
+import { capitalize } from './string.ts';
+
+/**
+ * Return human-readable cron schedule summary if the schedule is a valid cron
+ * else return null
+ */
+export function getReadableCronSchedule(
+  scheduleText: string[],
+): string[] | null {
+  // assuming if one schedule is cron the others in the array will be cron too
+  try {
+    new CronPattern(scheduleText[0]); // validate cron
+    return scheduleText.map(
+      (cron) =>
+        capitalize(
+          cronstrue
+            .toString(cron, {
+              throwExceptionOnParseError: false,
+            })
+            .replace('Every minute, ', ''),
+        ) + ` (\`${cron}\`)`,
+    );
+  } catch {
+    return null;
+  }
+}

--- a/lib/workers/repository/__fixtures__/dependency-dashboard-with-10-PR.txt
+++ b/lib/workers/repository/__fixtures__/dependency-dashboard-with-10-PR.txt
@@ -12,8 +12,8 @@ The following branches are pending approval. To create them, click on a checkbox
 
 The following updates are awaiting their schedule. To get an update now, click on a checkbox below.
 
- - [ ] <!-- unschedule-branch=branchName3 -->pr3
- - [ ] <!-- unschedule-branch=branchName4 -->pr4
+ - [ ] <!-- unschedule-branch=branchName3 -->pr3 → [Schedule: Between 12:00 AM and 03:59 AM (`* 0-3 * * *`)]
+ - [ ] <!-- unschedule-branch=branchName4 -->pr4 → [Schedule: Between 12:00 AM and 03:59 AM (`* 0-3 * * *`)]
  - [ ] <!-- create-all-awaiting-schedule-prs -->🔐 **Create all awaiting schedule PRs at once** 🔐
 
 ## Rate-Limited

--- a/lib/workers/repository/__snapshots__/dependency-dashboard.spec.ts.snap
+++ b/lib/workers/repository/__snapshots__/dependency-dashboard.spec.ts.snap
@@ -29,11 +29,11 @@ The following updates are awaiting their schedule. To get an update now, click o
 
 ### Category #1
 
- - [ ] <!-- unschedule-branch=branchName4 -->pr4
+ - [ ] <!-- unschedule-branch=branchName4 -->pr4 → [Schedule: Between 12:00 AM and 03:59 AM (\`* 0-3 * * *\`)]
 
 ### Others
 
- - [ ] <!-- unschedule-branch=branchName3 -->pr3
+ - [ ] <!-- unschedule-branch=branchName3 -->pr3 → [Schedule: Between 12:00 AM and 03:59 AM (\`* 0-3 * * *\`)]
 
 ### All
 
@@ -608,7 +608,7 @@ The following branches are pending approval. To create them, click on a checkbox
 
 The following updates are awaiting their schedule. To get an update now, click on a checkbox below.
 
- - [x] <!-- unschedule-branch=branchName3 -->pr3
+ - [x] <!-- unschedule-branch=branchName3 -->pr3 → [Schedule: Between 12:00 AM and 03:59 AM (\`* 0-3 * * *\`)]
 
 ## Detected Dependencies
 

--- a/lib/workers/repository/dependency-dashboard.spec.ts
+++ b/lib/workers/repository/dependency-dashboard.spec.ts
@@ -530,6 +530,7 @@ describe('workers/repository/dependency-dashboard', () => {
           prTitle: 'pr3',
           upgrades: [{ ...mock<PrUpgrade>(), depName: 'dep3' }],
           result: 'not-scheduled',
+          schedule: ['* 0-3 * * *'],
           branchName: 'branchName3',
         },
         {
@@ -537,6 +538,7 @@ describe('workers/repository/dependency-dashboard', () => {
           prTitle: 'pr4',
           upgrades: [{ ...mock<PrUpgrade>(), depName: 'dep4' }],
           result: 'not-scheduled',
+          schedule: ['* 0-3 * * *'],
           branchName: 'branchName4',
         },
         {
@@ -634,6 +636,7 @@ describe('workers/repository/dependency-dashboard', () => {
           prTitle: 'pr3',
           upgrades: [{ ...mock<PrUpgrade>(), depName: 'dep3' }],
           result: 'not-scheduled',
+          schedule: ['* 0-3 * * *'],
           branchName: 'branchName3',
         },
         {
@@ -641,6 +644,7 @@ describe('workers/repository/dependency-dashboard', () => {
           prTitle: 'pr4',
           upgrades: [{ ...mock<PrUpgrade>(), depName: 'dep4' }],
           result: 'not-scheduled',
+          schedule: ['* 0-3 * * *'],
           branchName: 'branchName4',
           dependencyDashboardCategory: 'Category #1',
         },
@@ -1293,6 +1297,7 @@ None detected
           prTitle: 'pr3',
           upgrades: [{ ...mock<PrUpgrade>(), depName: 'dep3' }],
           result: 'not-scheduled',
+          schedule: ['* 0-3 * * *'],
           branchName: 'branchName3',
         },
       ];
@@ -1318,7 +1323,7 @@ None detected
 
         The following updates are awaiting their schedule. To get an update now, click on a checkbox below.
 
-         - [x] <!-- unschedule-branch=branchName3 -->pr3
+         - [x] <!-- unschedule-branch=branchName3 -->pr3 → [Schedule: Between 12:00 AM and 03:59 AM (\`* 0-3 * * *\`)]
 
          - [x] <!-- rebase-all-open-prs -->'
         `,

--- a/lib/workers/repository/dependency-dashboard.ts
+++ b/lib/workers/repository/dependency-dashboard.ts
@@ -215,7 +215,11 @@ function formatAsMarkdownLink(name: string, url?: string | null): string {
   return url ? `[${name}](${url})` : `\`${name}\``;
 }
 
-function getListItem(branch: BranchConfig, type: string): string {
+function getListItem(
+  config: RenovateConfig,
+  branch: BranchConfig,
+  type: string,
+): string {
   let item = getCheckbox(`${type}-branch=${branch.branchName}`);
   if (branch.prNo) {
     // TODO: types (#22198)
@@ -227,7 +231,11 @@ function getListItem(branch: BranchConfig, type: string): string {
     // TODO: types (#22198)
     ...new Set(branch.upgrades.map((upgrade) => `\`${upgrade.depName!}\``)),
   ];
-  if (type === 'unschedule' && branch.schedule?.length) {
+  if (
+    config.dependencyDashboardReportSchedules &&
+    type === 'unschedule' &&
+    branch.schedule?.length
+  ) {
     item += ` → [Schedule: ${getReadableCronSchedule(branch.schedule)?.join(',')}]`;
   }
   if (uniquePackages.length < 2) {
@@ -259,13 +267,20 @@ function splitBranchesByCategory(filteredBranches: BranchConfig[]): {
   return { categories, uncategorized, hasCategorized, hasUncategorized };
 }
 
-function getBranchList(branches: BranchConfig[], listItemType: string): string {
+function getBranchList(
+  config: RenovateConfig,
+  branches: BranchConfig[],
+  listItemType: string,
+): string {
   return branches
-    .map((branch: BranchConfig): string => getListItem(branch, listItemType))
+    .map((branch: BranchConfig): string =>
+      getListItem(config, branch, listItemType),
+    )
     .join('');
 }
 
 function getBranchesListMd(
+  config: RenovateConfig,
   branches: BranchConfig[],
   predicate: (
     value: BranchConfig,
@@ -293,7 +308,7 @@ function getBranchesListMd(
     )) {
       result = result.trimEnd() + '\n\n';
       result += `### ${category}\n\n`;
-      result += getBranchList(branches, listItemType);
+      result += getBranchList(config, branches, listItemType);
     }
     if (hasUncategorized) {
       result = result.trimEnd() + '\n\n';
@@ -301,7 +316,7 @@ function getBranchesListMd(
     }
   }
   result = result.trimEnd() + '\n\n';
-  result += getBranchList(uncategorized, listItemType);
+  result += getBranchList(config, uncategorized, listItemType);
 
   if (bulkComment && bulkMessage && filteredBranches.length > 1) {
     if (hasCategorized) {
@@ -483,6 +498,7 @@ export async function ensureDependencyDashboard(
   }
 
   issueBody += getBranchesListMd(
+    config,
     branches,
     (branch) => branch.result === 'needs-approval',
     'Pending Approval',
@@ -493,6 +509,7 @@ export async function ensureDependencyDashboard(
     '🔐',
   );
   issueBody += getBranchesListMd(
+    config,
     branches,
     (branch) => branch.result === 'minimum-group-size-not-met',
     'Group Size Not Met',
@@ -500,6 +517,7 @@ export async function ensureDependencyDashboard(
     'approveGroup',
   );
   issueBody += getBranchesListMd(
+    config,
     branches,
     (branch) => branch.result === 'not-scheduled',
     'Awaiting Schedule',
@@ -510,6 +528,7 @@ export async function ensureDependencyDashboard(
     '🔐',
   );
   issueBody += getBranchesListMd(
+    config,
     branches,
     (branch) =>
       branch.result === 'branch-limit-reached' ||
@@ -524,6 +543,7 @@ export async function ensureDependencyDashboard(
     '🔐',
   );
   issueBody += getBranchesListMd(
+    config,
     branches,
     (branch) => branch.result === 'error',
     'Errored',
@@ -531,12 +551,14 @@ export async function ensureDependencyDashboard(
     'retry',
   );
   issueBody += getBranchesListMd(
+    config,
     branches,
     (branch) => branch.result === 'needs-pr-approval',
     'PR Creation Approval Required',
     'The following branches exist but PR creation requires approval. To approve PR creation, click on a checkbox below.',
   );
   issueBody += getBranchesListMd(
+    config,
     branches,
     (branch) => branch.result === 'pr-edited',
     'PR Edited (Blocked)',
@@ -544,12 +566,14 @@ export async function ensureDependencyDashboard(
     'rebase',
   );
   issueBody += getBranchesListMd(
+    config,
     branches,
     (branch) => branch.result === 'pending',
     'Pending Status Checks',
     'The following updates await pending status checks. To force their creation now, click on a checkbox below.',
   );
   issueBody += getBranchesListMd(
+    config,
     branches,
     (branch) => branch.prBlockedBy === 'BranchAutomerge',
     'Pending Branch Automerge',
@@ -583,6 +607,7 @@ export async function ensureDependencyDashboard(
       branch.prBlockedBy !== 'BranchAutomerge',
   );
   issueBody += getBranchesListMd(
+    config,
     inProgress,
     (branch) => !!branch.prBlockedBy || !branch.prNo,
     'Other Branches',
@@ -590,6 +615,7 @@ export async function ensureDependencyDashboard(
     'other',
   );
   issueBody += getBranchesListMd(
+    config,
     inProgress,
     (branch) => branch.prNo && !branch.prBlockedBy,
     'Open',
@@ -600,6 +626,7 @@ export async function ensureDependencyDashboard(
   );
 
   issueBody += getBranchesListMd(
+    config,
     branches,
     (branch) => branch.result === 'already-existed',
     'PR Closed (Blocked)',

--- a/lib/workers/repository/dependency-dashboard.ts
+++ b/lib/workers/repository/dependency-dashboard.ts
@@ -14,6 +14,7 @@ import { platform } from '../../modules/platform/index.ts';
 import { coerceArray } from '../../util/array.ts';
 import { emojify } from '../../util/emoji.ts';
 import { regEx } from '../../util/regex.ts';
+import { getReadableCronSchedule } from '../../util/schedule.ts';
 import { coerceString } from '../../util/string.ts';
 import * as template from '../../util/template/index.ts';
 import type { BranchConfig, SelectAllConfig } from '../types.ts';
@@ -226,6 +227,9 @@ function getListItem(branch: BranchConfig, type: string): string {
     // TODO: types (#22198)
     ...new Set(branch.upgrades.map((upgrade) => `\`${upgrade.depName!}\``)),
   ];
+  if (type === 'unschedule' && branch.schedule?.length) {
+    item += ` → [Schedule: ${getReadableCronSchedule(branch.schedule)?.join(',')}]`;
+  }
   if (uniquePackages.length < 2) {
     return item + '\n';
   }

--- a/lib/workers/repository/update/pr/body/config-description.ts
+++ b/lib/workers/repository/update/pr/body/config-description.ts
@@ -1,7 +1,5 @@
-import { CronPattern } from 'croner';
-import cronstrue from 'cronstrue';
 import { emojify } from '../../../../../util/emoji.ts';
-import { capitalize } from '../../../../../util/string.ts';
+import { getReadableCronSchedule } from '../../../../../util/schedule.ts';
 import type { BranchConfig } from '../../../../types.ts';
 
 export function getPrConfigDescription(config: BranchConfig): string {
@@ -74,27 +72,4 @@ function scheduleToString(
     scheduleLines.push('At any time (no schedule defined)');
   }
   return '  - ' + scheduleLines.join('\n  - ');
-}
-
-/**
- * Return human-readable cron schedule summary if the schedule is a valid cron
- * else return null
- */
-function getReadableCronSchedule(scheduleText: string[]): string[] | null {
-  // assuming if one schedule is cron the others in the array will be cron too
-  try {
-    new CronPattern(scheduleText[0]); // validate cron
-    return scheduleText.map(
-      (cron) =>
-        capitalize(
-          cronstrue
-            .toString(cron, {
-              throwExceptionOnParseError: false,
-            })
-            .replace('Every minute, ', ''),
-        ) + ` (\`${cron}\`)`,
-    );
-  } catch {
-    return null;
-  }
 }


### PR DESCRIPTION
## Changes

Group updates in the Dependency Dashboard awaiting-schedule section under schedule and timezone headings. Each schedule is printed once, while the existing per-update checkboxes remain available beneath it.

Schedule reporting is explicitly opt-in via `dependencyDashboardReportSchedules: true`. This keeps existing dashboards unchanged and avoids increasing issue size unless users request the extra context.

The revived implementation also:

- updates the branch to current `main`
- preserves `dependencyDashboardCategory` as the outer grouping
- includes the effective timezone in schedule headings
- supports both cron and Renovate Later.js schedule syntax
- shares cron description formatting with PR configuration descriptions

## Context

This revisits the original need with the dashboard-size feedback from the earlier discussion incorporated. Grouping avoids repeating the same schedule against every checkbox. The proposed dashboard configuration object did not land, so this uses the existing flat `dependencyDashboard*` option model and defaults the new detail to off.

- [x] This does not close an issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

- [x] Yes, substantive assistance. GitHub Copilot was used to update the branch, resolve conflicts, modernize the implementation, and add tests and documentation.

## Documentation

- [x] I have updated the documentation

## Testing

- [x] Updated unit tests

Validated locally with:

- `pnpm vitest lib/util/schedule.spec.ts lib/workers/repository/dependency-dashboard.spec.ts --run` (79 tests)
- `pnpm type-check`
- `pnpm test-schema`
- `pnpm biome`
- `pnpm oxlint`
- focused Prettier checks