### PR TITLE
feat(manager/ant): add <import> file traversal

### DIFF
--- a/lib/modules/manager/ant/extract.spec.ts
+++ b/lib/modules/manager/ant/extract.spec.ts
@@ -626,6 +626,138 @@ describe('modules/manager/ant/extract', () => {
       ]);
     });
 
+    it('follows import file references', async () => {
+      fs.readLocalFile.mockImplementation((fileName: string) => {
+        const files: Record<string, string> = {
+          'build.xml': codeBlock`
+            <project>
+              <import file="deps.xml" />
+            </project>
+          `,
+          'deps.xml': codeBlock`
+            <project>
+              <artifact:dependencies>
+                <dependency groupId="junit" artifactId="junit" version="4.13.2" />
+              </artifact:dependencies>
+            </project>
+          `,
+        };
+        return Promise.resolve(files[fileName] ?? null);
+      });
+
+      const result = await extractAllPackageFiles({}, ['build.xml']);
+
+      expect(result).toEqual([
+        {
+          packageFile: 'deps.xml',
+          deps: [
+            expect.objectContaining({
+              depName: 'junit:junit',
+              currentValue: '4.13.2',
+            }),
+          ],
+        },
+      ]);
+    });
+
+    it('skips missing import files', async () => {
+      fs.readLocalFile.mockImplementation((fileName: string) => {
+        const files: Record<string, string> = {
+          'build.xml': codeBlock`
+            <project>
+              <import file="missing.xml" />
+              <artifact:dependencies>
+                <dependency groupId="junit" artifactId="junit" version="4.13.2" />
+              </artifact:dependencies>
+            </project>
+          `,
+        };
+        return Promise.resolve(files[fileName] ?? null);
+      });
+
+      const result = await extractAllPackageFiles({}, ['build.xml']);
+
+      expect(result).toEqual([
+        {
+          packageFile: 'build.xml',
+          deps: [
+            expect.objectContaining({
+              depName: 'junit:junit',
+              currentValue: '4.13.2',
+            }),
+          ],
+        },
+      ]);
+    });
+
+    it('does not loop on self-importing files', async () => {
+      fs.readLocalFile.mockImplementation((fileName: string) => {
+        const files: Record<string, string> = {
+          'build.xml': codeBlock`
+            <project>
+              <import file="build.xml" />
+              <artifact:dependencies>
+                <dependency groupId="junit" artifactId="junit" version="4.13.2" />
+              </artifact:dependencies>
+            </project>
+          `,
+        };
+        return Promise.resolve(files[fileName] ?? null);
+      });
+
+      const result = await extractAllPackageFiles({}, ['build.xml']);
+
+      expect(result).toEqual([
+        {
+          packageFile: 'build.xml',
+          deps: [
+            expect.objectContaining({
+              depName: 'junit:junit',
+              currentValue: '4.13.2',
+            }),
+          ],
+        },
+      ]);
+    });
+
+    it('shares properties across imported files', async () => {
+      fs.readLocalFile.mockImplementation((fileName: string) => {
+        const files: Record<string, string> = {
+          'build.xml': codeBlock`
+            <project>
+              <property name="junit.version" value="4.13.2" />
+              <import file="deps.xml" />
+            </project>
+          `,
+          'deps.xml': codeBlock`
+            <project>
+              <artifact:dependencies>
+                <dependency groupId="junit" artifactId="junit" version="\${junit.version}" />
+              </artifact:dependencies>
+            </project>
+          `,
+        };
+        return Promise.resolve(files[fileName] ?? null);
+      });
+
+      const result = await extractAllPackageFiles({}, ['build.xml']);
+
+      expect(fs.readLocalFile).toHaveBeenCalledWith('deps.xml', 'utf8');
+      expect(result).toEqual([
+        {
+          packageFile: 'build.xml',
+          deps: [
+            expect.objectContaining({
+              depName: 'junit:junit',
+              currentValue: '4.13.2',
+              sharedVariableName: 'junit.version',
+              editFile: 'build.xml',
+            }),
+          ],
+        },
+      ]);
+    });
+
     it('handles chain referencing undefined property', async () => {
       fs.readLocalFile.mockResolvedValue(codeBlock`
         <project>

--- a/lib/modules/manager/ant/extract.ts
+++ b/lib/modules/manager/ant/extract.ts
@@ -158,6 +158,11 @@ async function walkNodeInOrder(
           }
         }
       }
+    } else if (child.name === 'import' && child.attr.file) {
+      const importedFile = upath.normalize(
+        upath.join(baseDir, child.attr.file),
+      );
+      await walkXmlFile(importedFile, visitedFiles, allProps, allRawDeps);
     } else if (child.name === 'dependency') {
       const rawDep = collectDependency(child, packageFile, content);
       if (rawDep) {
@@ -182,6 +187,9 @@ async function walkXmlFile(
   allProps: Record<string, AntProp>,
   allRawDeps: RawDep[],
 ): Promise<void> {
+  if (visitedFiles.has(packageFile)) {
+    return;
+  }
   visitedFiles.add(packageFile);
 
   const content = await readLocalFile(packageFile, 'utf8');


### PR DESCRIPTION



<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- Support `<import file="..."/>` elements in Ant build files to follow cross-file dependencies. 
- Properties defined before the `<import>`  are available in the imported file. 
- Cycle detection via visited-file tracking prevents infinite loops. 
- Missing or unreadable imported files are skipped gracefully.  

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #42181
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/RahulGautamSingh/ant-import-traversal/pulls

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
