### PR TITLE
feat(platform/bitbucket): remove deprecated issue tracking integration

### DIFF
--- a/lib/modules/platform/bitbucket/__snapshots__/index.spec.ts.snap
+++ b/lib/modules/platform/bitbucket/__snapshots__/index.spec.ts.snap
@@ -6,13 +6,6 @@ exports[`modules/platform/bitbucket/index > ensureComment() > does not throw 1`]
 
 exports[`modules/platform/bitbucket/index > ensureCommentRemoval() > does not throw 1`] = `undefined`;
 
-exports[`modules/platform/bitbucket/index > findIssue() > does not throw 1`] = `
-{
-  "body": "content",
-  "number": 25,
-}
-`;
-
 exports[`modules/platform/bitbucket/index > findPr() > finds pr 1`] = `
 {
   "bodyStruct": {
@@ -39,27 +32,6 @@ exports[`modules/platform/bitbucket/index > getBranchPr() > bitbucket finds PR f
   "targetBranch": "master",
   "title": "title",
 }
-`;
-
-exports[`modules/platform/bitbucket/index > getIssueList() > get issues 1`] = `
-[
-  {
-    "content": {
-      "raw": "content",
-    },
-    "id": 25,
-    "kind": "task",
-    "title": "title",
-  },
-  {
-    "content": {
-      "raw": "content",
-    },
-    "id": 26,
-    "kind": "task",
-    "title": "title",
-  },
-]
 `;
 
 exports[`modules/platform/bitbucket/index > getPr() > canRebase 1`] = `

--- a/lib/modules/platform/bitbucket/index.spec.ts
+++ b/lib/modules/platform/bitbucket/index.spec.ts
@@ -585,227 +585,24 @@ describe('modules/platform/bitbucket/index', () => {
     });
   });
 
-  describe('findIssue()', () => {
-    it('does not throw', async () => {
-      httpMock.scope(baseUrl).get('/2.0/user').reply(200, { uuid: '12345' });
-      await bitbucket.initPlatform({ username: 'renovate', password: 'pass' });
-      const scope = await initRepoMock({}, { has_issues: true });
-      scope
-        .get(
-          '/2.0/repositories/some/repo/issues?q=title%3D%22title%22%20AND%20(state%20%3D%20%22new%22%20OR%20state%20%3D%20%22open%22)%20AND%20reporter.uuid%3D%2212345%22',
-        )
-        .reply(200, {
-          values: [
-            {
-              id: 25,
-              title: 'title',
-              kind: 'task',
-              content: { raw: 'content' },
-            },
-            {
-              id: 26,
-              title: 'title',
-              kind: 'task',
-              content: { raw: 'content' },
-            },
-          ],
-        });
-      expect(await bitbucket.findIssue('title')).toMatchSnapshot();
-    });
-
-    it('returns null if no issues', async () => {
-      const scope = await initRepoMock(
-        {
-          repository: 'some/empty',
-        },
-        { has_issues: true },
-      );
-      scope
-        .get(
-          '/2.0/repositories/some/empty/issues?q=title%3D%22title%22%20AND%20(state%20%3D%20%22new%22%20OR%20state%20%3D%20%22open%22)',
-        )
-        .reply(200, {
-          values: [],
-        });
-      expect(await bitbucket.findIssue('title')).toBeNull();
-    });
+  it('ensureIssueClosing()', async () => {
+    await expect(
+      bitbucket.ensureIssueClosing('title'),
+    ).resolves.toBeUndefined();
   });
 
-  describe('ensureIssue()', () => {
-    it('updates existing issues', async () => {
-      const scope = await initRepoMock({}, { has_issues: true });
-      scope
-        .get(
-          '/2.0/repositories/some/repo/issues?q=title%3D%22title%22%20AND%20(state%20%3D%20%22new%22%20OR%20state%20%3D%20%22open%22)',
-        )
-        .reply(200, {
-          values: [
-            {
-              id: 25,
-              title: 'title',
-              kind: 'task',
-              content: { raw: 'content' },
-            },
-            {
-              id: 26,
-              title: 'title',
-              kind: 'task',
-              content: { raw: 'content' },
-            },
-          ],
-        })
-        .put('/2.0/repositories/some/repo/issues/25')
-        .reply(200)
-        .put('/2.0/repositories/some/repo/issues/26')
-        .reply(200);
-      expect(
-        await bitbucket.ensureIssue({ title: 'title', body: 'body' }),
-      ).toBe('updated');
-    });
-
-    it('creates new issue', async () => {
-      const scope = await initRepoMock(
-        { repository: 'some/empty' },
-        { has_issues: true },
-      );
-      scope
-        .get(
-          '/2.0/repositories/some/empty/issues?q=title%3D%22title%22%20AND%20(state%20%3D%20%22new%22%20OR%20state%20%3D%20%22open%22)',
-        )
-        .reply(200, { values: [] })
-        .get(
-          '/2.0/repositories/some/empty/issues?q=title%3D%22old-title%22%20AND%20(state%20%3D%20%22new%22%20OR%20state%20%3D%20%22open%22)',
-        )
-        .reply(200, { values: [] })
-        .post('/2.0/repositories/some/empty/issues')
-        .reply(200);
-      expect(
-        await bitbucket.ensureIssue({
-          title: 'title',
-          reuseTitle: 'old-title',
-          body: 'body',
-        }),
-      ).toBe('created');
-    });
-
-    it('noop for existing issue', async () => {
-      const scope = await initRepoMock({}, { has_issues: true });
-      scope
-        .get(
-          '/2.0/repositories/some/repo/issues?q=title%3D%22title%22%20AND%20(state%20%3D%20%22new%22%20OR%20state%20%3D%20%22open%22)',
-        )
-        .reply(200, {
-          values: [
-            {
-              id: 25,
-              title: 'title',
-              kind: 'task',
-              content: { raw: 'content' },
-            },
-            {
-              id: 26,
-              title: 'title',
-              kind: 'task',
-              content: { raw: 'content' },
-            },
-          ],
-        })
-        .put('/2.0/repositories/some/repo/issues/26')
-        .reply(200);
-      expect(
-        await bitbucket.ensureIssue({
-          title: 'title',
-          body: '\n content \n',
-        }),
-      ).toBeNull();
-    });
+  it('ensureIssue()', async () => {
+    await expect(
+      bitbucket.ensureIssue({ body: 'body', title: 'title' }),
+    ).resolves.toBeNull();
   });
 
-  describe('ensureIssueClosing()', () => {
-    it('does not throw for disabled issues', async () => {
-      await initRepoMock({ repository: 'some/repo' }, { has_issues: false });
-      await expect(bitbucket.ensureIssueClosing('title')).toResolve();
-    });
-
-    it('closes issue', async () => {
-      const scope = await initRepoMock({}, { has_issues: true });
-      scope
-        .get(
-          '/2.0/repositories/some/repo/issues?q=title%3D%22title%22%20AND%20(state%20%3D%20%22new%22%20OR%20state%20%3D%20%22open%22)',
-        )
-        .reply(200, {
-          values: [
-            {
-              id: 25,
-              title: 'title',
-              kind: 'task',
-              content: { raw: 'content' },
-            },
-            {
-              id: 26,
-              title: 'title',
-              kind: 'task',
-              content: { raw: 'content' },
-            },
-          ],
-        })
-        .put('/2.0/repositories/some/repo/issues/25')
-        .reply(200)
-        .put('/2.0/repositories/some/repo/issues/26')
-        .reply(200);
-      await expect(bitbucket.ensureIssueClosing('title')).toResolve();
-    });
+  it('findIssue()', async () => {
+    await expect(bitbucket.findIssue('title')).resolves.toBeNull();
   });
 
-  describe('getIssueList()', () => {
-    it('returns empty array for disabled issues', async () => {
-      await initRepoMock({ repository: 'some/repo' }, { has_issues: false });
-      expect(await bitbucket.getIssueList()).toEqual([]);
-    });
-
-    it('get issues', async () => {
-      httpMock.scope(baseUrl).get('/2.0/user').reply(200, { uuid: '12345' });
-      await bitbucket.initPlatform({ username: 'renovate', password: 'pass' });
-      const scope = await initRepoMock({}, { has_issues: true });
-      scope
-        .get('/2.0/repositories/some/repo/issues')
-        .query({
-          q: '(state = "new" OR state = "open") AND reporter.uuid="12345"',
-        })
-        .reply(200, {
-          values: [
-            {
-              id: 25,
-              title: 'title',
-              kind: 'task',
-              content: { raw: 'content' },
-            },
-            {
-              id: 26,
-              title: 'title',
-              kind: 'task',
-              content: { raw: 'content' },
-            },
-          ],
-        });
-      const issues = await bitbucket.getIssueList();
-
-      expect(issues).toHaveLength(2);
-      expect(issues).toMatchSnapshot();
-    });
-
-    it('does not throw', async () => {
-      const scope = await initRepoMock({}, { has_issues: true });
-      scope
-        .get('/2.0/repositories/some/repo/issues')
-        .query({
-          q: '(state = "new" OR state = "open")',
-        })
-        .reply(500, {});
-      const issues = await bitbucket.getIssueList();
-
-      expect(issues).toHaveLength(0);
-    });
+  it('getIssueList()', async () => {
+    await expect(bitbucket.getIssueList()).resolves.toStrictEqual([]);
   });
 
   describe('addAssignees()', () => {

--- a/lib/modules/platform/bitbucket/index.ts
+++ b/lib/modules/platform/bitbucket/index.ts
@@ -38,7 +38,6 @@ import type {
 } from '../types.ts';
 import { repoFingerprint } from '../util.ts';
 import { smartTruncate } from '../utils/pr-body.ts';
-import { readOnlyIssueBody } from '../utils/read-only-issue-body.ts';
 import * as comments from './comments.ts';
 import { BitbucketPrCache } from './pr-cache.ts';
 import {
@@ -579,64 +578,8 @@ export async function setBranchStatus({
   aggressiveRepoCacheProvider.markSynced('get', branchStatusesUrl, false);
 }
 
-interface BbIssue {
-  id: number;
-  title: string;
-  kind: string;
-  content?: { raw: string };
-}
-
-async function findOpenIssues(title: string): Promise<BbIssue[]> {
-  try {
-    const filters = [
-      `title=${JSON.stringify(title)}`,
-      '(state = "new" OR state = "open")',
-    ];
-    if (renovateUserUuid) {
-      filters.push(`reporter.uuid="${renovateUserUuid}"`);
-    }
-    const filter = encodeURIComponent(filters.join(' AND '));
-    // v8 ignore next -- TODO: add test #40625
-    return (
-      (
-        await bitbucketHttp.getJsonUnchecked<{ values: BbIssue[] }>(
-          `/2.0/repositories/${config.repository}/issues?q=${filter}`,
-          { cacheProvider: aggressiveRepoCacheProvider },
-        )
-      ).body.values || []
-    );
-  } catch (err) /* v8 ignore next */ {
-    logger.warn({ err }, 'Error finding issues');
-    return [];
-  }
-}
-
-export async function findIssue(title: string): Promise<Issue | null> {
-  logger.debug(`findIssue(${title})`);
-
-  /* v8 ignore next */
-  if (!config.has_issues) {
-    logger.debug('Issues are disabled - cannot findIssue');
-    return null;
-  }
-  const issues = await findOpenIssues(title);
-  if (!issues.length) {
-    return null;
-  }
-  const [issue] = issues;
-  return {
-    number: issue.id,
-    body: issue.content?.raw,
-  };
-}
-
-async function closeIssue(issueNumber: number): Promise<void> {
-  await bitbucketHttp.putJson(
-    `/2.0/repositories/${config.repository}/issues/${issueNumber}`,
-    {
-      body: { state: 'closed' },
-    },
-  );
+export async function findIssue(_title: string): Promise<Issue | null> {
+  return Promise.resolve(null);
 }
 
 /**
@@ -760,115 +703,18 @@ export function maxBodyLength(): number {
   return 250000;
 }
 
-export async function ensureIssue({
-  title,
-  reuseTitle,
-  body,
-}: EnsureIssueConfig): Promise<EnsureIssueResult | null> {
-  logger.debug(`ensureIssue()`);
-  /* v8 ignore next */
-  if (!config.has_issues) {
-    logger.debug('Issues are disabled - cannot ensureIssue');
-    logger.debug(`Failed to ensure Issue with title:${title}`);
-    return null;
-  }
-  try {
-    let issues = await findOpenIssues(title);
-    const description = massageMarkdown(sanitize(body));
-    const issueKind = 'task';
-
-    if (!issues.length && reuseTitle) {
-      issues = await findOpenIssues(reuseTitle);
-    }
-    if (issues.length) {
-      // Close any duplicates
-      for (const issue of issues.slice(1)) {
-        await closeIssue(issue.id);
-      }
-      const [issue] = issues;
-
-      if (
-        issue.title !== title ||
-        String(issue.content?.raw).trim() !== description.trim() ||
-        issue.kind !== issueKind
-      ) {
-        logger.debug('Issue updated');
-        await bitbucketHttp.putJson(
-          `/2.0/repositories/${config.repository}/issues/${issue.id}`,
-          {
-            body: {
-              kind: issueKind,
-              content: {
-                raw: readOnlyIssueBody(description),
-                markup: 'markdown',
-              },
-            },
-          },
-        );
-        return 'updated';
-      }
-    } else {
-      logger.info('Issue created');
-      await bitbucketHttp.postJson(
-        `/2.0/repositories/${config.repository}/issues`,
-        {
-          body: {
-            title,
-            kind: issueKind,
-            content: {
-              raw: readOnlyIssueBody(description),
-              markup: 'markdown',
-            },
-          },
-        },
-      );
-      return 'created';
-    }
-  } catch (err) /* v8 ignore next */ {
-    if (err.message.startsWith('Repository has no issue tracker.')) {
-      logger.debug(`Issues are disabled, so could not create issue: ${title}`);
-    } else {
-      logger.warn({ err }, 'Could not ensure issue');
-    }
-  }
-  return null;
+export async function ensureIssue(
+  _issueConfig: EnsureIssueConfig,
+): Promise<EnsureIssueResult | null> {
+  return Promise.resolve(null);
 }
 
-/* v8 ignore next */
 export async function getIssueList(): Promise<Issue[]> {
-  logger.debug(`getIssueList()`);
-
-  if (!config.has_issues) {
-    logger.debug('Issues are disabled - cannot getIssueList');
-    return [];
-  }
-  try {
-    const filters = ['(state = "new" OR state = "open")'];
-    if (renovateUserUuid) {
-      filters.push(`reporter.uuid="${renovateUserUuid}"`);
-    }
-    const filter = encodeURIComponent(filters.join(' AND '));
-    const url = `/2.0/repositories/${config.repository}/issues?q=${filter}`;
-    const res = await bitbucketHttp.getJsonUnchecked<{ values: Issue[] }>(url, {
-      cacheProvider: repoCacheProvider,
-    });
-    return res.body.values || [];
-  } catch (err) {
-    logger.warn({ err }, 'Error finding issues');
-    return [];
-  }
+  return Promise.resolve([]);
 }
 
 export async function ensureIssueClosing(title: string): Promise<void> {
-  /* v8 ignore next */
-  if (!config.has_issues) {
-    logger.debug('Issues are disabled - cannot ensureIssueClosing');
-    return;
-  }
-  const issues = await findOpenIssues(title);
-  for (const issue of issues) {
-    await closeIssue(issue.id);
-  }
+  return Promise.resolve();
 }
 
 export function addAssignees(

--- a/lib/modules/platform/bitbucket/readme.md
+++ b/lib/modules/platform/bitbucket/readme.md
@@ -31,8 +31,6 @@ Give the bot API token the following permission scopes:
 | [`read:pullrequest:bitbucket`](https://developer.atlassian.com/cloud/bitbucket/rest/intro/#read-pullrequest-bitbucket)   | Pull requests: Read  |
 | [`write:pullrequest:bitbucket`](https://developer.atlassian.com/cloud/bitbucket/rest/intro/#write-pullrequest-bitbucket) | Pull requests: Write |
 | [`read:user:bitbucket`](https://developer.atlassian.com/cloud/bitbucket/rest/intro/#read-user-bitbucket)                 | User: Read           |
-| [`read:issue:bitbucket`](https://developer.atlassian.com/cloud/bitbucket/rest/intro/#read-issue-bitbucket)               | Issues: Read         |
-| [`write:issue:bitbucket`](https://developer.atlassian.com/cloud/bitbucket/rest/intro/#write-issue-bitbucket)             | Issues: Write        |
 | [`read:workspace:bitbucket`](https://developer.atlassian.com/cloud/bitbucket/rest/intro/#read-workspace-bitbucket)       | Workspace: Read      |
 
 The bot also needs to validate the workspace membership status of pull-request reviewers, for that, [create a new user group](https://support.atlassian.com/bitbucket-cloud/docs/organize-workspace-members-into-groups/) in the workspace with the **Create repositories** permission and add the bot user to it.
@@ -50,6 +48,7 @@ Remember to:
 
 ## Unsupported platform features/concepts
 
+- Bitbucket Cloud issue tracking, see [feature sunset announcement](https://community.atlassian.com/forums/Bitbucket-articles/Announcing-sunset-of-Bitbucket-Issues-and-Wikis/ba-p/3193882)
 - Adding assignees to PRs not supported (does not seem to be a Bitbucket concept)
 - `automergeStrategy=rebase` not supported by Bitbucket Cloud, see [Jira issue BCLOUD-16610](https://jira.atlassian.com/browse/BCLOUD-16610)
 - Markdown support for collapsible syntax, see [Jira issue BCLOUD-20231](https://jira.atlassian.com/browse/BCLOUD-20231)


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Remove `Bitbucket Cloud` platform support for issues (create, list, update, close, etc).

<!-- Describe what behavior is changed by this PR. -->

## Context

In anticipating of the imminent sunset of Bitbucket Cloud's native issue tracking - see https://community.atlassian.com/forums/Bitbucket-articles/Announcing-sunset-of-Bitbucket-Issues-and-Wikis/ba-p/3193882 😢 

> _**What’s changing?**_
> _Starting in April 2026, Issues and Wikis will no longer be available to turn on for repositories where these features are not currently used._
> _Existing Issues and Wikis will be fully sunset and removed from Bitbucket in mid-August, 2026._

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
