### PR TITLE
feat(manager/ant): add `coords=` attribute syntax support

### DIFF
--- a/lib/modules/manager/ant/extract.spec.ts
+++ b/lib/modules/manager/ant/extract.spec.ts
@@ -758,6 +758,196 @@ describe('modules/manager/ant/extract', () => {
       ]);
     });
 
+    it('extracts dependency from 3-part coords attribute', async () => {
+      fs.readLocalFile.mockImplementation((fileName: string) => {
+        const files: Record<string, string> = {
+          'build.xml': codeBlock`
+            <project>
+              <artifact:dependencies>
+                <dependency coords="junit:junit:4.13.2" />
+              </artifact:dependencies>
+            </project>
+          `,
+        };
+        return Promise.resolve(files[fileName] ?? null);
+      });
+
+      const result = await extractAllPackageFiles({}, ['build.xml']);
+
+      expect(result).toEqual([
+        {
+          packageFile: 'build.xml',
+          deps: [
+            expect.objectContaining({
+              datasource: 'maven',
+              depName: 'junit:junit',
+              currentValue: '4.13.2',
+              depType: 'compile',
+              registryUrls: [],
+            }),
+          ],
+        },
+      ]);
+    });
+
+    it('extracts scope from 4-part coords attribute', async () => {
+      fs.readLocalFile.mockImplementation((fileName: string) => {
+        const files: Record<string, string> = {
+          'build.xml': codeBlock`
+            <project>
+              <artifact:dependencies>
+                <dependency coords="junit:junit:4.13.2:test" />
+              </artifact:dependencies>
+            </project>
+          `,
+        };
+        return Promise.resolve(files[fileName] ?? null);
+      });
+
+      const result = await extractAllPackageFiles({}, ['build.xml']);
+
+      expect(result).toEqual([
+        {
+          packageFile: 'build.xml',
+          deps: [
+            expect.objectContaining({
+              depName: 'junit:junit',
+              currentValue: '4.13.2',
+              depType: 'test',
+            }),
+          ],
+        },
+      ]);
+    });
+
+    it('ignores coords with fewer than 3 parts', async () => {
+      fs.readLocalFile.mockImplementation((fileName: string) => {
+        const files: Record<string, string> = {
+          'build.xml': codeBlock`
+            <project>
+              <artifact:dependencies>
+                <dependency coords="junit:junit" />
+              </artifact:dependencies>
+            </project>
+          `,
+        };
+        return Promise.resolve(files[fileName] ?? null);
+      });
+
+      await expect(
+        extractAllPackageFiles({}, ['build.xml']),
+      ).resolves.toBeNull();
+    });
+
+    it('ignores coords with empty groupId', async () => {
+      fs.readLocalFile.mockImplementation((fileName: string) => {
+        const files: Record<string, string> = {
+          'build.xml': codeBlock`
+            <project>
+              <artifact:dependencies>
+                <dependency coords=":junit:4.13.2" />
+              </artifact:dependencies>
+            </project>
+          `,
+        };
+        return Promise.resolve(files[fileName] ?? null);
+      });
+
+      await expect(
+        extractAllPackageFiles({}, ['build.xml']),
+      ).resolves.toBeNull();
+    });
+
+    it('resolves property references in coords version', async () => {
+      fs.readLocalFile.mockImplementation((fileName: string) => {
+        const files: Record<string, string> = {
+          'build.xml': codeBlock`
+            <project>
+              <property name="junit.version" value="4.13.2" />
+              <artifact:dependencies>
+                <dependency coords="junit:junit:\${junit.version}" />
+              </artifact:dependencies>
+            </project>
+          `,
+        };
+        return Promise.resolve(files[fileName] ?? null);
+      });
+
+      const result = await extractAllPackageFiles({}, ['build.xml']);
+
+      expect(result).toEqual([
+        {
+          packageFile: 'build.xml',
+          deps: [
+            expect.objectContaining({
+              depName: 'junit:junit',
+              currentValue: '4.13.2',
+              sharedVariableName: 'junit.version',
+            }),
+          ],
+        },
+      ]);
+    });
+
+    it('marks coords dependency with unresolvable property', async () => {
+      fs.readLocalFile.mockImplementation((fileName: string) => {
+        const files: Record<string, string> = {
+          'build.xml': codeBlock`
+            <project>
+              <artifact:dependencies>
+                <dependency coords="junit:junit:\${missing}" />
+              </artifact:dependencies>
+            </project>
+          `,
+        };
+        return Promise.resolve(files[fileName] ?? null);
+      });
+
+      const result = await extractAllPackageFiles({}, ['build.xml']);
+
+      expect(result).toEqual([
+        {
+          packageFile: 'build.xml',
+          deps: [
+            expect.objectContaining({
+              depName: 'junit:junit',
+              skipReason: 'version-placeholder',
+            }),
+          ],
+        },
+      ]);
+    });
+
+    it('treats last part as version when it is not a known scope', async () => {
+      fs.readLocalFile.mockImplementation((fileName: string) => {
+        const files: Record<string, string> = {
+          'build.xml': codeBlock`
+            <project>
+              <artifact:dependencies>
+                <dependency coords="org.example:lib:jar:1.0.0" />
+              </artifact:dependencies>
+            </project>
+          `,
+        };
+        return Promise.resolve(files[fileName] ?? null);
+      });
+
+      const result = await extractAllPackageFiles({}, ['build.xml']);
+
+      expect(result).toEqual([
+        {
+          packageFile: 'build.xml',
+          deps: [
+            expect.objectContaining({
+              depName: 'org.example:lib',
+              currentValue: '1.0.0',
+              depType: 'compile',
+            }),
+          ],
+        },
+      ]);
+    });
+
     it('handles chain referencing undefined property', async () => {
       fs.readLocalFile.mockResolvedValue(codeBlock`
         <project>

--- a/lib/modules/manager/ant/extract.ts
+++ b/lib/modules/manager/ant/extract.ts
@@ -36,9 +36,69 @@ function getDependencyType(scope: string | undefined): string {
   return 'compile';
 }
 
+function parseCoords(coordsStr: string): {
+  groupId: string;
+  artifactId: string;
+  rawVersion: string;
+  scope: string | undefined;
+} | null {
+  const parts = coordsStr.split(':');
+  if (parts.length < 3) {
+    return null;
+  }
+
+  const [groupId, artifactId] = parts;
+  if (!groupId || !artifactId) {
+    return null;
+  }
+
+  let scope: string | undefined;
+  let rawVersion: string;
+
+  if (parts.length >= 4 && scopeNames.has(parts.at(-1)!)) {
+    scope = parts.at(-1);
+    rawVersion = parts.at(-2)!;
+  } else {
+    rawVersion = parts.at(-1)!;
+  }
+
+  return { groupId, artifactId, rawVersion, scope };
+}
+
 interface RawDep {
   dep: PackageDependency;
   depPackageFile: string;
+}
+
+function collectCoordsDependency(
+  node: XmlElement,
+  packageFile: string,
+  content: string,
+): RawDep | null {
+  const coordsStr = node.attr.coords;
+  if (!coordsStr) {
+    return null;
+  }
+
+  const parsed = parseCoords(coordsStr);
+  if (!parsed) {
+    return null;
+  }
+
+  const dep: PackageDependency = {
+    datasource: MavenDatasource.id,
+    depName: `${parsed.groupId}:${parsed.artifactId}`,
+    currentValue: parsed.rawVersion,
+    depType: getDependencyType(parsed.scope ?? node.attr.scope),
+    registryUrls: [],
+  };
+
+  // Position at the version substring within the coords attribute value
+  const coordsValuePos = findAttrValuePosition(content, node, 'coords');
+  const versionOffset = coordsStr.lastIndexOf(parsed.rawVersion);
+  dep.fileReplacePosition = coordsValuePos + versionOffset;
+
+  return { dep, depPackageFile: packageFile };
 }
 
 function collectDependency(
@@ -46,6 +106,10 @@ function collectDependency(
   packageFile: string,
   content: string,
 ): RawDep | null {
+  if (node.attr.coords) {
+    return collectCoordsDependency(node, packageFile, content);
+  }
+
   const { groupId, artifactId, version, scope } = node.attr;
 
   if (!version || !groupId || !artifactId) {

--- a/lib/modules/manager/ant/extract.ts
+++ b/lib/modules/manager/ant/extract.ts
@@ -44,11 +44,16 @@ function parseCoords(coordsStr: string): {
 } | null {
   const parts = coordsStr.split(':');
   if (parts.length < 3) {
+    logger.trace({ coordsStr }, 'ant manager: coords has fewer than 3 parts');
     return null;
   }
 
   const [groupId, artifactId] = parts;
   if (!groupId || !artifactId) {
+    logger.trace(
+      { coordsStr },
+      'ant manager: coords has empty groupId or artifactId',
+    );
     return null;
   }
 

--- a/lib/modules/manager/ant/extract.ts
+++ b/lib/modules/manager/ant/extract.ts
@@ -81,9 +81,6 @@ function collectCoordsDependency(
   content: string,
 ): RawDep | null {
   const coordsStr = node.attr.coords;
-  if (!coordsStr) {
-    return null;
-  }
 
   const parsed = parseCoords(coordsStr);
   if (!parsed) {

--- a/lib/modules/manager/ant/update.spec.ts
+++ b/lib/modules/manager/ant/update.spec.ts
@@ -119,6 +119,42 @@ describe('modules/manager/ant/update', () => {
     expect(result).toBeNull();
   });
 
+  it('updates version within coords attribute', () => {
+    const fileContent =
+      '<project><dependency coords="junit:junit:4.13.2" /></project>';
+
+    const result = updateDependency({
+      fileContent,
+      packageFile: 'build.xml',
+      upgrade: {
+        depName: 'junit:junit',
+        currentValue: '4.13.2',
+        newValue: '4.13.3',
+        fileReplacePosition: fileContent.indexOf('4.13.2'),
+      },
+    });
+
+    expect(result).toContain('coords="junit:junit:4.13.3"');
+  });
+
+  it('updates version within 4-part coords attribute', () => {
+    const fileContent =
+      '<project><dependency coords="junit:junit:4.13.2:test" /></project>';
+
+    const result = updateDependency({
+      fileContent,
+      packageFile: 'build.xml',
+      upgrade: {
+        depName: 'junit:junit',
+        currentValue: '4.13.2',
+        newValue: '4.13.3',
+        fileReplacePosition: fileContent.indexOf('4.13.2'),
+      },
+    });
+
+    expect(result).toContain('coords="junit:junit:4.13.3:test"');
+  });
+
   it('returns null when value at position does not match', () => {
     const fileContent =
       '<dependency groupId="junit" artifactId="junit" version="9.9.9" />';

--- a/lib/modules/manager/ant/update.ts
+++ b/lib/modules/manager/ant/update.ts
@@ -22,9 +22,26 @@ export function updateDependency({
   if (quoteChar === '"' || quoteChar === "'") {
     endIndex = rightPart.indexOf(quoteChar);
   } else {
-    // .properties file: value ends at newline or EOF
+    // Could be a .properties file or a substring inside a coords attribute
     const newlineIndex = rightPart.indexOf('\n');
-    endIndex = newlineIndex === -1 ? rightPart.length : newlineIndex;
+    const lineEnd = newlineIndex === -1 ? rightPart.length : newlineIndex;
+
+    // Check for closing quote before newline (indicates coords attribute)
+    const nearestQuote = [
+      rightPart.indexOf('"'),
+      rightPart.indexOf("'"),
+    ].filter((i) => i !== -1 && i < lineEnd);
+
+    if (nearestQuote.length > 0) {
+      // Inside a quoted attribute (coords) - version ends at : or closing quote
+      const quoteEnd = Math.min(...nearestQuote);
+      const colonIndex = rightPart.indexOf(':');
+      endIndex =
+        colonIndex !== -1 && colonIndex < quoteEnd ? colonIndex : quoteEnd;
+    } else {
+      // .properties file: value ends at newline or EOF
+      endIndex = lineEnd;
+    }
   }
 
   const currentFound = rightPart.slice(0, endIndex);


### PR DESCRIPTION


<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
Support Maven coords attribute format (`group:artifact:version` and `group:artifact:version:scope`) as an alternative to separate `groupId/artifactId/version` attributes.
<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #42180
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/RahulGautamSingh/ant-coords/pulls

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
