### PR TITLE
fix(vulnerability): remove matchFileNames restriction from GitHub vulnerability alerts

### DIFF
--- a/lib/workers/repository/init/vulnerability.spec.ts
+++ b/lib/workers/repository/init/vulnerability.spec.ts
@@ -157,7 +157,8 @@ describe('workers/repository/init/vulnerability', () => {
             severity: 'medium',
           },
           security_vulnerability: {
-            package: { name: 'foo', ecosystem: 'go' },
+            // @ts-expect-error invalid options
+            package: null,
             first_patched_version: { identifier: '1.8.3' },
             vulnerable_version_range: '>= 1.8, < 1.8.3',
             severity: 'medium',
@@ -198,7 +199,6 @@ describe('workers/repository/init/vulnerability', () => {
           {
             matchDatasources: ['go'],
             matchPackageNames: ['foo'],
-            matchFileNames: ['go.mod'],
             matchCurrentVersion: '< 1.8.3',
             vulnerabilityFixVersion: '1.8.3',
             vulnerabilitySeverity: 'HIGH',
@@ -261,7 +261,6 @@ describe('workers/repository/init/vulnerability', () => {
           {
             matchDatasources: ['maven'],
             matchPackageNames: ['com.fasterxml.jackson.core:jackson-databind'],
-            matchFileNames: ['pom.xml'],
             matchCurrentVersion: '(,2.7.9.4)',
             vulnerabilityFixVersion: '2.7.9.4',
             prBodyNotes: [
@@ -324,7 +323,6 @@ describe('workers/repository/init/vulnerability', () => {
           {
             matchDatasources: ['nuget'],
             matchPackageNames: ['Microsoft.NETCore.App'],
-            matchFileNames: ['test.csproj'],
             matchCurrentVersion: '(,2.0.3)',
             vulnerabilityFixVersion: '2.0.3',
             prBodyNotes: [
@@ -496,7 +494,6 @@ describe('workers/repository/init/vulnerability', () => {
           {
             matchDatasources: ['pypi'],
             matchPackageNames: ['ansible'],
-            matchFileNames: ['requirements.txt'],
             matchCurrentVersion: '< 2.2.1.0',
             vulnerabilityFixVersion: '2.2.1.0',
             prBodyNotes: [
@@ -556,7 +553,6 @@ describe('workers/repository/init/vulnerability', () => {
           {
             matchDatasources: ['github-tags'],
             matchPackageNames: ['j178/prek-action'],
-            matchFileNames: ['.github/workflows/j178.yml'],
             matchCurrentVersion: '!/^1\\.0\\.6$/',
             vulnerabilityFixVersion: '1.0.6',
             prBodyNotes: [

--- a/lib/workers/repository/init/vulnerability.ts
+++ b/lib/workers/repository/init/vulnerability.ts
@@ -3,7 +3,6 @@ import type { PackageRule, RenovateConfig } from '../../../config/types.ts';
 import { NO_VULNERABILITY_ALERTS } from '../../../constants/error-messages.ts';
 import { logger } from '../../../logger/index.ts';
 import { GithubTagsDatasource } from '../../../modules/datasource/github-tags/index.ts';
-import { GoDatasource } from '../../../modules/datasource/go/index.ts';
 import { MavenDatasource } from '../../../modules/datasource/maven/index.ts';
 import { NugetDatasource } from '../../../modules/datasource/nuget/index.ts';
 import type { SecurityAdvisory } from '../../../modules/platform/github/schema.ts';
@@ -26,21 +25,16 @@ import {
 
 type Datasource = string;
 type DependencyName = string;
-type FileName = string;
 
 type CombinedAlert = Record<
-  FileName,
+  Datasource,
   Record<
-    Datasource,
-    Record<
-      DependencyName,
-      {
-        advisories: SecurityAdvisory[];
-        fileType?: string;
-        firstPatchedVersion?: string;
-        severity?: string;
-      }
-    >
+    DependencyName,
+    {
+      advisories: SecurityAdvisory[];
+      firstPatchedVersion?: string;
+      severity?: string;
+    }
   >
 >;
 
@@ -99,18 +93,15 @@ export async function detectVulnerabilityAlerts(
           alert.security_vulnerability.package.ecosystem
         ];
       const depName = alert.security_vulnerability.package.name;
-      const fileName = alert.dependency.manifest_path;
-      const fileType = fileName.split('/').pop();
       const firstPatchedVersion =
         alert.security_vulnerability.first_patched_version.identifier;
       const advisory = alert.security_advisory;
 
-      combinedAlerts[fileName] ??= {};
-      combinedAlerts[fileName][datasource] ??= {};
-      combinedAlerts[fileName][datasource][depName] ??= {
+      combinedAlerts[datasource] ??= {};
+      combinedAlerts[datasource][depName] ??= {
         advisories: [],
       };
-      const alertDetails = combinedAlerts[fileName][datasource][depName];
+      const alertDetails = combinedAlerts[datasource][depName];
       alertDetails.advisories.push(advisory);
       alertDetails.severity = getHighestVulnerabilitySeverity(
         { vulnerabilitySeverity: alertDetails.severity },
@@ -130,95 +121,85 @@ export async function detectVulnerabilityAlerts(
       } else {
         logger.debug('Invalid firstPatchedVersion: ' + firstPatchedVersion);
       }
-      alertDetails.fileType = fileType;
     } catch (err) {
       logger.warn({ err }, 'Error parsing vulnerability alert');
     }
   }
   const alertPackageRules: PackageRule[] = [];
   config.remediations = {} as never;
-  for (const [fileName, files] of Object.entries(combinedAlerts)) {
-    for (const [datasource, dependencies] of Object.entries(files)) {
-      for (const [depName, val] of Object.entries(dependencies)) {
-        if (!val.firstPatchedVersion) {
-          continue;
-        }
-
-        let prBodyNotes: string[] = [];
-        try {
-          prBodyNotes = ['### GitHub Vulnerability Alerts'].concat(
-            val.advisories.map((advisory) => {
-              const identifiers = advisory.identifiers;
-              const description = advisory.description;
-              let content = '#### ';
-              let heading: string;
-              if (identifiers.some((id) => id.type === 'CVE')) {
-                heading = identifiers
-                  .filter((id) => id.type === 'CVE')
-                  .map((id) => id.value)
-                  .join(' / ');
-              } else {
-                heading = identifiers.map((id) => id.value).join(' / ');
-              }
-              if (advisory.references?.length) {
-                heading = `[${heading}](${advisory.references[0].url})`;
-              }
-              content += heading;
-              content += '\n\n';
-
-              content += sanitizeMarkdown(description);
-
-              content += '\n\n##### Severity\n';
-              const { cvss_v4, cvss_v3 } = advisory.cvss_severities ?? {};
-              const cvss = cvss_v4?.vector_string ? cvss_v4 : cvss_v3;
-              if (is.number(cvss?.score) && cvss?.vector_string) {
-                content += `- CVSS Score: ${cvss.score.toFixed(1)} / 10 (${titleCase(advisory.severity)})\n`;
-                content += `- Vector String: \`${cvss.vector_string}\``;
-              } else {
-                content += titleCase(advisory.severity);
-              }
-
-              return content;
-            }),
-          );
-        } catch (err) /* istanbul ignore next */ {
-          logger.warn({ err }, 'Error generating vulnerability PR notes');
-        }
-        // TODO: types (#22198)
-        const matchFileNames =
-          datasource === GoDatasource.id
-            ? [fileName.replace('go.sum', 'go.mod')]
-            : [fileName];
-        let matchRule: PackageRule = {
-          matchDatasources: [datasource],
-          matchPackageNames: [depName],
-          matchFileNames,
-        };
-
-        let matchCurrentVersion = `< ${val.firstPatchedVersion}`;
-        if (
-          datasource === MavenDatasource.id ||
-          datasource === NugetDatasource.id
-        ) {
-          matchCurrentVersion = `(,${val.firstPatchedVersion})`;
-        } else if (datasource === GithubTagsDatasource.id) {
-          matchCurrentVersion = `!/^${escapeRegExp(val.firstPatchedVersion)}$/`;
-        }
-
-        // Remediate only direct dependencies
-        matchRule = {
-          ...matchRule,
-          matchCurrentVersion,
-          vulnerabilityFixVersion: val.firstPatchedVersion,
-          vulnerabilitySeverity: val.severity,
-          prBodyNotes,
-          isVulnerabilityAlert: true,
-          force: {
-            ...config.vulnerabilityAlerts,
-          },
-        };
-        alertPackageRules.push(matchRule);
+  for (const [datasource, dependencies] of Object.entries(combinedAlerts)) {
+    for (const [depName, val] of Object.entries(dependencies)) {
+      if (!val.firstPatchedVersion) {
+        continue;
       }
+
+      let prBodyNotes: string[] = [];
+      try {
+        prBodyNotes = ['### GitHub Vulnerability Alerts'].concat(
+          val.advisories.map((advisory) => {
+            const identifiers = advisory.identifiers;
+            const description = advisory.description;
+            let content = '#### ';
+            let heading: string;
+            if (identifiers.some((id) => id.type === 'CVE')) {
+              heading = identifiers
+                .filter((id) => id.type === 'CVE')
+                .map((id) => id.value)
+                .join(' / ');
+            } else {
+              heading = identifiers.map((id) => id.value).join(' / ');
+            }
+            if (advisory.references?.length) {
+              heading = `[${heading}](${advisory.references[0].url})`;
+            }
+            content += heading;
+            content += '\n\n';
+
+            content += sanitizeMarkdown(description);
+
+            content += '\n\n##### Severity\n';
+            const { cvss_v4, cvss_v3 } = advisory.cvss_severities ?? {};
+            const cvss = cvss_v4?.vector_string ? cvss_v4 : cvss_v3;
+            if (is.number(cvss?.score) && cvss?.vector_string) {
+              content += `- CVSS Score: ${cvss.score.toFixed(1)} / 10 (${titleCase(advisory.severity)})\n`;
+              content += `- Vector String: \`${cvss.vector_string}\``;
+            } else {
+              content += titleCase(advisory.severity);
+            }
+
+            return content;
+          }),
+        );
+      } catch (err) /* istanbul ignore next */ {
+        logger.warn({ err }, 'Error generating vulnerability PR notes');
+      }
+      let matchRule: PackageRule = {
+        matchDatasources: [datasource],
+        matchPackageNames: [depName],
+      };
+
+      let matchCurrentVersion = `< ${val.firstPatchedVersion}`;
+      if (
+        datasource === MavenDatasource.id ||
+        datasource === NugetDatasource.id
+      ) {
+        matchCurrentVersion = `(,${val.firstPatchedVersion})`;
+      } else if (datasource === GithubTagsDatasource.id) {
+        matchCurrentVersion = `!/^${escapeRegExp(val.firstPatchedVersion)}$/`;
+      }
+
+      matchRule = {
+        ...matchRule,
+        matchCurrentVersion,
+        vulnerabilityFixVersion: val.firstPatchedVersion,
+        vulnerabilitySeverity: val.severity,
+        prBodyNotes,
+        isVulnerabilityAlert: true,
+        force: {
+          ...config.vulnerabilityAlerts,
+        },
+      };
+      alertPackageRules.push(matchRule);
     }
   }
   logger.debug({ alertPackageRules }, 'alert package rules');


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

GitHub Dependabot alerts tend to report only one file path, if a vulnerable package is used in one version across multiple files. This resulted in renovate creating vulnerability fix PRs that didn't address all possible locations, since package rules used `matchFileNames` set to an exact `dependency.manifest_path`.

With this PR, `matchFileNames` is dropped from package rules,  identical to how `osvVulnerabilityAlerts` work. I didn't remove `dependency.manifest_path` from the schema for now but technically it's not used anywhere else now.

_Side note:_ `fileType` is unrelated but was dead-code, so also removed here.

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

- https://github.com/renovatebot/renovate/discussions/42634

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
