### PR TITLE
feat(manager/ant): support custom `registryUrls`

### DIFF
--- a/docs/usage/java.md
+++ b/docs/usage/java.md
@@ -205,10 +205,3 @@ To avoid JSON-in-JSON wrapping, which can cause problems, encode the JSON servic
      ]
    }
    ```
-
-## Ant
-
-Renovate can extract dependencies from Apache Ant `build.xml` files that use the `maven-resolver-ant-tasks` or `maven-ant-tasks` library.
-Dependencies are looked up using the Maven datasource.
-
-Refer to the [Ant manager documentation](../modules/manager/ant/index.md) for supported syntax, property resolution, file traversal, and registry URL discovery.

--- a/docs/usage/java.md
+++ b/docs/usage/java.md
@@ -5,7 +5,7 @@ description: Java versions support in Renovate
 
 # Java Dependency Updates
 
-Renovate can update Gradle and Maven dependencies.
+Renovate can update Gradle, Maven, and Ant dependencies.
 This includes libraries and plugins as well as the Gradle Wrapper.
 
 ## LTS releases
@@ -205,3 +205,34 @@ To avoid JSON-in-JSON wrapping, which can cause problems, encode the JSON servic
      ]
    }
    ```
+
+## Ant
+
+Renovate can extract dependencies from Apache Ant `build.xml` files that use the `maven-resolver-ant-tasks` or `maven-ant-tasks` library.
+Dependencies are looked up using the Maven datasource.
+
+### Supported syntax
+
+Renovate extracts dependencies from `<dependency>` elements in two formats:
+
+- Separate attributes: `groupId`, `artifactId`, `version`, and optional `scope`
+- Coords attribute: `coords="group:artifact:version"` or `coords="group:artifact:version:scope"`
+
+### Property resolution
+
+Version values can reference Ant properties defined via `<property name="..." value="..."/>` or loaded from external `.properties` files via `<property file="..."/>`.
+Ant's first-definition-wins semantics are respected.
+
+### File traversal
+
+Renovate follows `<import file="..."/>` elements to extract dependencies from imported build files.
+Properties defined before an `<import>` are available in the imported file.
+
+### Registry URLs
+
+Renovate discovers Maven registry URLs from:
+
+- `settingsFile` attribute on `<artifact:dependencies>` elements (parsed as a Maven `settings.xml`)
+- Inline `<remoteRepository url="..." />` elements within dependency blocks
+
+Discovered registries are scoped to their dependency block.

--- a/docs/usage/java.md
+++ b/docs/usage/java.md
@@ -211,28 +211,4 @@ To avoid JSON-in-JSON wrapping, which can cause problems, encode the JSON servic
 Renovate can extract dependencies from Apache Ant `build.xml` files that use the `maven-resolver-ant-tasks` or `maven-ant-tasks` library.
 Dependencies are looked up using the Maven datasource.
 
-### Supported syntax
-
-Renovate extracts dependencies from `<dependency>` elements in two formats:
-
-- Separate attributes: `groupId`, `artifactId`, `version`, and optional `scope`
-- Coords attribute: `coords="group:artifact:version"` or `coords="group:artifact:version:scope"`
-
-### Property resolution
-
-Version values can reference Ant properties defined via `<property name="..." value="..."/>` or loaded from external `.properties` files via `<property file="..."/>`.
-Ant's first-definition-wins semantics are respected.
-
-### File traversal
-
-Renovate follows `<import file="..."/>` elements to extract dependencies from imported build files.
-Properties defined before an `<import>` are available in the imported file.
-
-### Registry URLs
-
-Renovate discovers Maven registry URLs from:
-
-- `settingsFile` attribute on `<artifact:dependencies>` elements (parsed as a Maven `settings.xml`)
-- Inline `<remoteRepository url="..." />` elements within dependency blocks
-
-Discovered registries are scoped to their dependency block.
+Refer to the [Ant manager documentation](../modules/manager/ant/index.md) for supported syntax, property resolution, file traversal, and registry URL discovery.

--- a/lib/modules/manager/ant/extract.spec.ts
+++ b/lib/modules/manager/ant/extract.spec.ts
@@ -976,6 +976,36 @@ describe('modules/manager/ant/extract', () => {
       ]);
     });
 
+    it('passes registry URLs to coords-style dependencies', async () => {
+      fs.readLocalFile.mockImplementation((fileName: string) => {
+        const files: Record<string, string> = {
+          'build.xml': codeBlock`
+            <project>
+              <artifact:dependencies>
+                <remoteRepository url="https://repo.example.com/maven2" />
+                <dependency coords="junit:junit:4.13.2" />
+              </artifact:dependencies>
+            </project>
+          `,
+        };
+        return Promise.resolve(files[fileName] ?? null);
+      });
+
+      const result = await extractAllPackageFiles({}, ['build.xml']);
+
+      expect(result).toEqual([
+        {
+          packageFile: 'build.xml',
+          deps: [
+            expect.objectContaining({
+              depName: 'junit:junit',
+              registryUrls: ['https://repo.example.com/maven2'],
+            }),
+          ],
+        },
+      ]);
+    });
+
     it('collects registry URLs from settingsFile attribute', async () => {
       fs.readLocalFile.mockImplementation((fileName: string) => {
         const files: Record<string, string> = {

--- a/lib/modules/manager/ant/extract.spec.ts
+++ b/lib/modules/manager/ant/extract.spec.ts
@@ -1058,6 +1058,73 @@ describe('modules/manager/ant/extract', () => {
       ]);
     });
 
+    it('handles absolute settingsFile path', async () => {
+      fs.readLocalFile.mockImplementation((fileName: string) => {
+        const files: Record<string, string> = {
+          'build.xml': codeBlock`
+            <project>
+              <artifact:dependencies settingsFile="/etc/maven/settings.xml">
+                <dependency groupId="junit" artifactId="junit" version="4.13.2" />
+              </artifact:dependencies>
+            </project>
+          `,
+          '/etc/maven/settings.xml': codeBlock`
+            <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0">
+              <mirrors>
+                <mirror>
+                  <url>https://internal.example.com/maven</url>
+                </mirror>
+              </mirrors>
+            </settings>
+          `,
+        };
+        return Promise.resolve(files[fileName] ?? null);
+      });
+
+      const result = await extractAllPackageFiles({}, ['build.xml']);
+
+      expect(result).toEqual([
+        {
+          packageFile: 'build.xml',
+          deps: [
+            expect.objectContaining({
+              depName: 'junit:junit',
+              registryUrls: ['https://internal.example.com/maven'],
+            }),
+          ],
+        },
+      ]);
+    });
+
+    it('logs debug when settingsFile cannot be read', async () => {
+      fs.readLocalFile.mockImplementation((fileName: string) => {
+        const files: Record<string, string> = {
+          'build.xml': codeBlock`
+            <project>
+              <artifact:dependencies settingsFile="missing/settings.xml">
+                <dependency groupId="junit" artifactId="junit" version="4.13.2" />
+              </artifact:dependencies>
+            </project>
+          `,
+        };
+        return Promise.resolve(files[fileName] ?? null);
+      });
+
+      const result = await extractAllPackageFiles({}, ['build.xml']);
+
+      expect(result).toEqual([
+        {
+          packageFile: 'build.xml',
+          deps: [
+            expect.objectContaining({
+              depName: 'junit:junit',
+              registryUrls: [],
+            }),
+          ],
+        },
+      ]);
+    });
+
     it('does not pass registries to dependencies outside the block', async () => {
       fs.readLocalFile.mockImplementation((fileName: string) => {
         const files: Record<string, string> = {

--- a/lib/modules/manager/ant/extract.spec.ts
+++ b/lib/modules/manager/ant/extract.spec.ts
@@ -948,6 +948,153 @@ describe('modules/manager/ant/extract', () => {
       ]);
     });
 
+    it('collects registry URLs from remoteRepository elements', async () => {
+      fs.readLocalFile.mockImplementation((fileName: string) => {
+        const files: Record<string, string> = {
+          'build.xml': codeBlock`
+            <project>
+              <artifact:dependencies>
+                <remoteRepository url="https://repo.example.com/maven2" />
+                <dependency groupId="junit" artifactId="junit" version="4.13.2" />
+              </artifact:dependencies>
+            </project>
+          `,
+        };
+        return Promise.resolve(files[fileName] ?? null);
+      });
+
+      const result = await extractAllPackageFiles({}, ['build.xml']);
+
+      expect(result).toEqual([
+        {
+          packageFile: 'build.xml',
+          deps: [
+            expect.objectContaining({
+              depName: 'junit:junit',
+              registryUrls: ['https://repo.example.com/maven2'],
+            }),
+          ],
+        },
+      ]);
+    });
+
+    it('collects registry URLs from settingsFile attribute', async () => {
+      fs.readLocalFile.mockImplementation((fileName: string) => {
+        const files: Record<string, string> = {
+          'build.xml': codeBlock`
+            <project>
+              <artifact:dependencies settingsFile="build/settings.xml">
+                <dependency groupId="junit" artifactId="junit" version="4.13.2" />
+              </artifact:dependencies>
+            </project>
+          `,
+          'build/settings.xml': codeBlock`
+            <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0">
+              <mirrors>
+                <mirror>
+                  <url>https://artifactory.example.com/maven</url>
+                </mirror>
+              </mirrors>
+            </settings>
+          `,
+        };
+        return Promise.resolve(files[fileName] ?? null);
+      });
+
+      const result = await extractAllPackageFiles({}, ['build.xml']);
+
+      expect(result).toEqual([
+        {
+          packageFile: 'build.xml',
+          deps: [
+            expect.objectContaining({
+              depName: 'junit:junit',
+              registryUrls: ['https://artifactory.example.com/maven'],
+            }),
+          ],
+        },
+      ]);
+    });
+
+    it('merges registries from settingsFile and remoteRepository', async () => {
+      fs.readLocalFile.mockImplementation((fileName: string) => {
+        const files: Record<string, string> = {
+          'build.xml': codeBlock`
+            <project>
+              <artifact:dependencies settingsFile="build/settings.xml">
+                <remoteRepository url="https://repo.example.com/maven2" />
+                <dependency groupId="junit" artifactId="junit" version="4.13.2" />
+              </artifact:dependencies>
+            </project>
+          `,
+          'build/settings.xml': codeBlock`
+            <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0">
+              <mirrors>
+                <mirror>
+                  <url>https://artifactory.example.com/maven</url>
+                </mirror>
+              </mirrors>
+            </settings>
+          `,
+        };
+        return Promise.resolve(files[fileName] ?? null);
+      });
+
+      const result = await extractAllPackageFiles({}, ['build.xml']);
+
+      expect(result).toEqual([
+        {
+          packageFile: 'build.xml',
+          deps: [
+            expect.objectContaining({
+              depName: 'junit:junit',
+              registryUrls: [
+                'https://artifactory.example.com/maven',
+                'https://repo.example.com/maven2',
+              ],
+            }),
+          ],
+        },
+      ]);
+    });
+
+    it('does not pass registries to dependencies outside the block', async () => {
+      fs.readLocalFile.mockImplementation((fileName: string) => {
+        const files: Record<string, string> = {
+          'build.xml': codeBlock`
+            <project>
+              <artifact:dependencies>
+                <remoteRepository url="https://repo.example.com/maven2" />
+                <dependency groupId="junit" artifactId="junit" version="4.13.2" />
+              </artifact:dependencies>
+              <artifact:dependencies>
+                <dependency groupId="org.slf4j" artifactId="slf4j-api" version="1.7.36" />
+              </artifact:dependencies>
+            </project>
+          `,
+        };
+        return Promise.resolve(files[fileName] ?? null);
+      });
+
+      const result = await extractAllPackageFiles({}, ['build.xml']);
+
+      expect(result).toEqual([
+        {
+          packageFile: 'build.xml',
+          deps: [
+            expect.objectContaining({
+              depName: 'junit:junit',
+              registryUrls: ['https://repo.example.com/maven2'],
+            }),
+            expect.objectContaining({
+              depName: 'org.slf4j:slf4j-api',
+              registryUrls: [],
+            }),
+          ],
+        },
+      ]);
+    });
+
     it('handles chain referencing undefined property', async () => {
       fs.readLocalFile.mockResolvedValue(codeBlock`
         <project>

--- a/lib/modules/manager/ant/extract.spec.ts
+++ b/lib/modules/manager/ant/extract.spec.ts
@@ -25,7 +25,6 @@ describe('modules/manager/ant/extract', () => {
             depName: 'junit:junit',
             currentValue: '4.13.2',
             depType: 'test',
-            registryUrls: [],
           }),
         ],
       });
@@ -783,7 +782,6 @@ describe('modules/manager/ant/extract', () => {
               depName: 'junit:junit',
               currentValue: '4.13.2',
               depType: 'compile',
-              registryUrls: [],
             }),
           ],
         },
@@ -1118,7 +1116,6 @@ describe('modules/manager/ant/extract', () => {
           deps: [
             expect.objectContaining({
               depName: 'junit:junit',
-              registryUrls: [],
             }),
           ],
         },
@@ -1155,7 +1152,6 @@ describe('modules/manager/ant/extract', () => {
             }),
             expect.objectContaining({
               depName: 'org.slf4j:slf4j-api',
-              registryUrls: [],
             }),
           ],
         },

--- a/lib/modules/manager/ant/extract.ts
+++ b/lib/modules/manager/ant/extract.ts
@@ -128,7 +128,7 @@ function collectCoordsDependency(
     depName: `${parsed.groupId}:${parsed.artifactId}`,
     currentValue: parsed.rawVersion,
     depType: getDependencyType(parsed.scope ?? node.attr.scope),
-    registryUrls,
+    ...(registryUrls?.length && { registryUrls }),
   };
 
   // Position at the version substring within the coords attribute value
@@ -160,7 +160,7 @@ function collectDependency(
     depName: `${groupId}:${artifactId}`,
     currentValue: version,
     depType: getDependencyType(scope),
-    registryUrls,
+    ...(registryUrls?.length && { registryUrls }),
   };
 
   dep.fileReplacePosition = findAttrValuePosition(content, node, 'version');

--- a/lib/modules/manager/ant/extract.ts
+++ b/lib/modules/manager/ant/extract.ts
@@ -4,6 +4,7 @@ import { XmlDocument } from 'xmldoc';
 import { logger } from '../../../logger/index.ts';
 import { readLocalFile } from '../../../util/fs/index.ts';
 import { MavenDatasource } from '../../datasource/maven/index.ts';
+import { extractRegistries } from '../maven/extract.ts';
 import { isXmlElement } from '../nuget/util.ts';
 import type {
   ExtractConfig,
@@ -75,10 +76,45 @@ interface RawDep {
   depPackageFile: string;
 }
 
+async function collectRegistryUrls(
+  node: XmlElement,
+  baseDir: string,
+): Promise<string[]> {
+  const urls: string[] = [];
+
+  // Read registry URLs from settingsFile attribute
+  const settingsFile = node.attr.settingsFile;
+  if (settingsFile) {
+    const settingsPath = settingsFile.startsWith('/')
+      ? settingsFile
+      : upath.join(baseDir, settingsFile);
+    const settingsContent = await readLocalFile(settingsPath, 'utf8');
+    if (settingsContent) {
+      urls.push(...extractRegistries(settingsContent));
+    } else {
+      logger.debug(`ant manager: could not read settings file ${settingsPath}`);
+    }
+  }
+
+  // Collect inline <remoteRepository url="..." /> elements
+  for (const child of node.children) {
+    if (
+      isXmlElement(child) &&
+      child.name === 'remoteRepository' &&
+      child.attr.url
+    ) {
+      urls.push(child.attr.url);
+    }
+  }
+
+  return [...new Set(urls)];
+}
+
 function collectCoordsDependency(
   node: XmlElement,
   packageFile: string,
   content: string,
+  registryUrls: string[],
 ): RawDep | null {
   const coordsStr = node.attr.coords;
 
@@ -92,7 +128,7 @@ function collectCoordsDependency(
     depName: `${parsed.groupId}:${parsed.artifactId}`,
     currentValue: parsed.rawVersion,
     depType: getDependencyType(parsed.scope ?? node.attr.scope),
-    registryUrls: [],
+    registryUrls,
   };
 
   // Position at the version substring within the coords attribute value
@@ -107,9 +143,10 @@ function collectDependency(
   node: XmlElement,
   packageFile: string,
   content: string,
+  registryUrls: string[] = [],
 ): RawDep | null {
   if (node.attr.coords) {
-    return collectCoordsDependency(node, packageFile, content);
+    return collectCoordsDependency(node, packageFile, content, registryUrls);
   }
 
   const { groupId, artifactId, version, scope } = node.attr;
@@ -123,7 +160,7 @@ function collectDependency(
     depName: `${groupId}:${artifactId}`,
     currentValue: version,
     depType: getDependencyType(scope),
-    registryUrls: [],
+    registryUrls,
   };
 
   dep.fileReplacePosition = findAttrValuePosition(content, node, 'version');
@@ -188,6 +225,7 @@ async function walkNodeInOrder(
   visitedFiles: Set<string>,
   allProps: Record<string, AntProp>,
   allRawDeps: RawDep[],
+  registryUrls: string[] = [],
 ): Promise<void> {
   const baseDir = upath.dirname(packageFile);
 
@@ -230,11 +268,20 @@ async function walkNodeInOrder(
       );
       await walkXmlFile(importedFile, visitedFiles, allProps, allRawDeps);
     } else if (child.name === 'dependency') {
-      const rawDep = collectDependency(child, packageFile, content);
+      const rawDep = collectDependency(
+        child,
+        packageFile,
+        content,
+        registryUrls,
+      );
       if (rawDep) {
         allRawDeps.push(rawDep);
       }
     } else {
+      // Collect registry URLs from settingsFile and remoteRepository
+      const childRegistries = await collectRegistryUrls(child, baseDir);
+      const mergedUrls =
+        childRegistries.length > 0 ? childRegistries : registryUrls;
       await walkNodeInOrder(
         child,
         packageFile,
@@ -242,6 +289,7 @@ async function walkNodeInOrder(
         visitedFiles,
         allProps,
         allRawDeps,
+        mergedUrls,
       );
     }
   }

--- a/lib/modules/manager/ant/readme.md
+++ b/lib/modules/manager/ant/readme.md
@@ -1,2 +1,28 @@
-Extracts Apache Ant dependencies from `build.xml` files that use the `maven-resolver-ant-tasks` library.
+Extracts Apache Ant dependencies from `build.xml` files that use the `maven-resolver-ant-tasks` or `maven-ant-tasks` library.
 Dependencies are looked up using the Maven datasource.
+
+### Supported syntax
+
+Renovate extracts dependencies from `<dependency>` elements in two formats:
+
+- Separate attributes: `groupId`, `artifactId`, `version`, and optional `scope`
+- Coords attribute: `coords="group:artifact:version"` or `coords="group:artifact:version:scope"`
+
+### Property resolution
+
+Version values can reference Ant properties defined via `<property name="..." value="..."/>` or loaded from external `.properties` files via `<property file="..."/>`.
+Ant's first-definition-wins semantics are respected.
+
+### File traversal
+
+Renovate follows `<import file="..."/>` elements to extract dependencies from imported build files.
+Properties defined before an `<import>` are available in the imported file.
+
+### Registry URLs
+
+Renovate discovers Maven registry URLs from:
+
+- `settingsFile` attribute on `<artifact:dependencies>` elements (parsed as a Maven `settings.xml`)
+- Inline `<remoteRepository url="..." />` elements within dependency blocks
+
+Discovered registries are scoped to their dependency block.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- Add support for discovering Maven registry URLs from `settingsFile` attributes and inline `<remoteRepository>` elements within Ant dependency blocks.                                                                                                                                                                                                                                                   
- Parse `settingsFile` attribute on `<artifact:dependencies>` using the existing Maven `extractRegistries` to read mirror and repository URLs from Maven `settings.xml`                                                                                                     
- Collect `<remoteRepository url="..." />` elements within dependency blocks                                                          
- Merge and deduplicate registries from both sources                                                                                
- Registries are scoped to their dependency block .. so they don't leak to dependencies in other blocks  
<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #42182 
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
