### PR TITLE
fix(instrumentation): re-add `span_id` and `trace_id` to logs

### DIFF
--- a/lib/instrumentation/index.spec.ts
+++ b/lib/instrumentation/index.spec.ts
@@ -1,3 +1,4 @@
+import { createRequire } from 'node:module';
 import * as api from '@opentelemetry/api';
 import { ProxyTracerProvider } from '@opentelemetry/api';
 import {
@@ -150,6 +151,25 @@ describe('instrumentation/index', () => {
           },
         ],
       },
+    });
+  });
+
+  describe('BunyanInstrumentation', () => {
+    // OpenTelemetry's context propagation currently uses `AsyncLocalStorage`, which does not behave the same way in vitest worker threads as in a real Node.js process, so we cannot write a full end-to-end here to validate the `span_id`, `trace_id` and `trace_flags` are set
+    //
+    // Claude Sonnet 4.6 suggests that we instead create an (admittedly brittle) test to validate that this is marked as `__wrapped`.
+    it('patches bunyan Logger._emit when tracing is enabled', () => {
+      process.env.RENOVATE_TRACING_CONSOLE_EXPORTER = 'true';
+      init();
+
+      const bunyan = createRequire(import.meta.url)(
+        'bunyan',
+      ) as typeof import('bunyan');
+
+      // shimmer marks wrapped functions with __wrapped = true
+      expect(
+        (bunyan.prototype as unknown as Record<string, unknown>)._emit,
+      ).toHaveProperty('__wrapped', true);
     });
   });
 

--- a/lib/logger/bunyan.ts
+++ b/lib/logger/bunyan.ts
@@ -1,9 +1,16 @@
+import { createRequire } from 'node:module';
 import {
   isNonEmptyStringAndNotWhitespace,
   isString,
   isUndefined,
 } from '@sindresorhus/is';
-import * as bunyan from 'bunyan';
+
+// Use createRequire so that @opentelemetry/instrumentation-bunyan can patch
+// bunyan via require-in-the-middle. A plain ESM `import` bypasses the hook.
+const bunyan = createRequire(import.meta.url)(
+  'bunyan',
+) as typeof import('bunyan');
+
 import fs from 'fs-extra';
 import upath from 'upath';
 import cmdSerializer from './cmd-serializer.ts';


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes



As part of recent changes to how our logger is initialised, we
accidentally broke the propagation of OpenTelemtry `span_id` and
`trace_id` into the Bunyan log context.

We already registered `BunyanInstrumentation`, but because of the
`import`, the instrumentation could not man-in-the-middle the import and
register the instrumentation.

This is slightly more complex, and brittle, test, but does capture the
current behaviour of `BunyanInstrumentation`, if it were removed.


## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #41847 <!-- NOTE that this should NOT be a Discussion -->
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe): Claude Sonnet 4.6

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
