### PR TITLE
ci: auto-label `needs-discussion` on externally-raised Issues

### DIFF
--- a/.github/workflows/auto-label-needs-discussion.yml
+++ b/.github/workflows/auto-label-needs-discussion.yml
@@ -1,0 +1,49 @@
+name: 'Auto-apply `needs-discussion` label to externally raised Issues'
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  label-if-external:
+    runs-on: ubuntu-latest
+    if: github.repository == 'renovatebot/renovate'
+    steps:
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const author = context.payload.issue.user.login;
+
+            let roleName;
+            try {
+              const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username: author,
+              });
+              roleName = data.role_name;
+            } catch (err) {
+              if (err.status === 404) {
+                // User is not a collaborator — treat as no access
+                roleName = 'none';
+              } else {
+                throw err;
+              }
+            }
+
+            // allow users who have a minimum of Triage access on the project to raise Issues without auto-labelling
+            const triagePlus = ['admin', 'maintain', 'write', 'triage'];
+            if (!triagePlus.includes(roleName)) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.issue.number,
+                labels: ['needs-discussion'],
+              });
+              core.info(`Added 'needs-discussion' label (author role: ${roleName})`);
+            } else {
+              core.info(`Skipping label — author has ${roleName} access`);
+            }


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
We're seeing an increase in (LLM-generated) Issues being created on the
project, which is not our contribution model.

As a way to reduce the time of maintainers to manually label these when
we see them, we can automagically determine this based on existing
access to the repo.

Using Triage+ allows any collaborators on the Renovate project to raise
Issues unimpeded.

## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe): Claude Sonnet 4.6

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
