### PR TITLE
fix(package-rules): correctly merge `force.enabled`

### DIFF
--- a/lib/util/package-rules/index.spec.ts
+++ b/lib/util/package-rules/index.spec.ts
@@ -199,6 +199,116 @@ describe('util/package-rules/index', () => {
     expect(res.skipStage).toBeUndefined();
   });
 
+  it('does not set skipReason=package-rules if the last packageRule has force.enabled=true', async () => {
+    const dep: any = {
+      depName: 'foo',
+      packageRules: [
+        {
+          enabled: false,
+        },
+        {
+          // this is a vulnerability alert
+          force: {
+            enabled: true,
+          },
+        },
+      ],
+    };
+    const res = await applyPackageRules(dep, 'datasource-merge');
+    expect(res.enabled).toBeTrue();
+    expect(res.skipReason).toBeUndefined();
+    expect(res.skipStage).toBeUndefined();
+  });
+
+  it('does not set skipReason=package-rules if the last packageRule has force.enabled=true (if config.enabled=false)', async () => {
+    const dep: any = {
+      depName: 'foo',
+      enabled: false,
+      packageRules: [
+        {
+          enabled: false,
+        },
+        {
+          // this is a vulnerability alert
+          force: {
+            enabled: true,
+          },
+        },
+      ],
+    };
+    const res = await applyPackageRules(dep, 'datasource-merge');
+    expect(res.enabled).toBeTrue();
+    expect(res.skipReason).toBeUndefined();
+    expect(res.skipStage).toBeUndefined();
+  });
+
+  it('does not set skipReason=package-rules if the last packageRule has enabled=true (if config.force.enabled=false)', async () => {
+    const dep: any = {
+      depName: 'foo',
+      enabled: false,
+      // for instance, if we've already merged a vulnrability alert
+      force: {
+        enabled: true,
+      },
+      packageRules: [
+        {
+          enabled: false,
+        },
+      ],
+    };
+    const res = await applyPackageRules(dep, 'datasource-merge');
+    expect(res.enabled).toBeTrue();
+    expect(res.skipReason).toBeUndefined();
+    expect(res.skipStage).toBeUndefined();
+  });
+
+  // TODO naming
+
+  it('sets skipReason=package-rules if the last packageRule has force.enabled=false (if config.force.enabled=false)', async () => {
+    const dep: any = {
+      depName: 'foo',
+      enabled: false,
+      // for instance, if we've already merged a vulnerability alert
+      force: {
+        enabled: true,
+      },
+      packageRules: [
+        {
+          enabled: false,
+        },
+        {
+          force: {
+            enabled: false,
+          },
+        },
+      ],
+    };
+    const res = await applyPackageRules(dep, 'datasource-merge');
+    expect(res.enabled).toBeFalse();
+    expect(res.skipReason).toBe('package-rules');
+    expect(res.skipStage).toBe('datasource-merge');
+  });
+
+  it('sets skipReason=package-rules if the last packageRule has force.enabled=false', async () => {
+    const dep: any = {
+      depName: 'foo',
+      packageRules: [
+        {
+          enabled: true,
+        },
+        {
+          force: {
+            enabled: false,
+          },
+        },
+      ],
+    };
+    const res = await applyPackageRules(dep, 'datasource-merge');
+    expect(res.enabled).toBeFalse();
+    expect(res.skipReason).toBe('package-rules');
+    expect(res.skipStage).toBe('datasource-merge');
+  });
+
   it('skips skipReason=package-rules if enabled=true', async () => {
     const dep: any = {
       enabled: false,

--- a/lib/util/package-rules/index.ts
+++ b/lib/util/package-rules/index.ts
@@ -67,9 +67,7 @@ export async function applyPackageRules<T extends PackageRuleInputConfig>(
         }
       }
 
-      const currentlyEnabled = config.force?.enabled ?? config.enabled;
-      const applyWillEnable = toApply.force?.enabled ?? toApply.enabled;
-      if (applyWillEnable && currentlyEnabled === false) {
+      if (toApply.force?.enabled || toApply.enabled) {
         delete config.skipReason;
         delete config.skipStage;
       }

--- a/lib/util/package-rules/index.ts
+++ b/lib/util/package-rules/index.ts
@@ -53,13 +53,23 @@ export async function applyPackageRules<T extends PackageRuleInputConfig>(
           lower: true,
         });
       }
-      if (toApply.enabled === false && config.enabled !== false) {
+
+      if (
+        // if it's got higher precedence, as it's a force'd config option
+        // multiple force'd config options are "last defined wins"
+        toApply.force?.enabled === false ||
+        // otherwise, if it has regular precedence, compare
+        (toApply.enabled === false && config.enabled !== false)
+      ) {
         config.skipReason = 'package-rules';
         if (stageName) {
           config.skipStage = stageName;
         }
       }
-      if (toApply.enabled === true && config.enabled === false) {
+
+      const currentlyEnabled = config.force?.enabled ?? config.enabled;
+      const applyWillEnable = toApply.force?.enabled ?? toApply.enabled;
+      if (applyWillEnable && currentlyEnabled === false) {
         delete config.skipReason;
         delete config.skipStage;
       }
@@ -104,7 +114,9 @@ export async function applyPackageRules<T extends PackageRuleInputConfig>(
 
 function removeMatchers<T extends Record<string, unknown>>(
   packageRule: T,
-): Record<string, unknown> {
+): Record<string, unknown> & {
+  force?: Record<string, unknown>;
+} {
   for (const key of Object.keys(packageRule)) {
     if (key.startsWith('match') || key.startsWith('exclude')) {
       delete packageRule[key];


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
As noted in #42666 after changes in
#42595, we're skipping vulnerability
alert PRs when using the `security:only-security-updates` preset.

This happens because the `enabled=false` that exists on the all
dependencies are not correctly merged into the `force` config in the
`vulnerabilityAlert` update.

To fix this, we need to take `force.enabled` into account when merging
config options.

To slightly improve the type checking, we can also make sure that
`removeMatchers` knows that `force` is field we want typed, too.


## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes #42666
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe): Claude Sonnet 4.6 helped work out where we needed to correct the logic, but I added tests + fix

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/JamieTanna-Mend-testing/test-any-updates-2

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
