### PR TITLE
feat(manager/github-actions): use `semver-partial` as default versioning

### DIFF
--- a/lib/config/presets/internal/helpers.preset.ts
+++ b/lib/config/presets/internal/helpers.preset.ts
@@ -111,8 +111,6 @@ export const presets: Record<string, Preset> = {
       {
         extends: ['helpers:pinGitHubActionDigests'],
         extractVersion: '^(?<version>v?\\d+\\.\\d+\\.\\d+)$',
-        versioning:
-          'regex:^v?(?<major>\\d+)(\\.(?<minor>\\d+)\\.(?<patch>\\d+))?$',
       },
     ],
   },

--- a/lib/modules/manager/github-actions/__snapshots__/extract.spec.ts.snap
+++ b/lib/modules/manager/github-actions/__snapshots__/extract.spec.ts.snap
@@ -21,7 +21,7 @@ exports[`modules/manager/github-actions/extract > extractPackageFile() > extract
     "depName": "docker/setup-qemu-action",
     "depType": "action",
     "replaceString": "docker/setup-qemu-action@c308fdd69d26ed66f4506ebd74b180abe5362145 # renovate: tag=v1.1.0",
-    "versioning": "docker",
+    "versioning": "semver-partial",
   },
   {
     "autoReplaceStringTemplate": "{{depName}}@{{#if newDigest}}{{newDigest}}{{#if newValue}} # {{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}",
@@ -31,7 +31,7 @@ exports[`modules/manager/github-actions/extract > extractPackageFile() > extract
     "depName": "actions/checkout",
     "depType": "action",
     "replaceString": "actions/checkout@1.0.0",
-    "versioning": "docker",
+    "versioning": "semver-partial",
   },
   {
     "autoReplaceStringTemplate": "{{depName}}@{{#if newDigest}}{{newDigest}}{{#if newValue}} # {{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}",
@@ -44,7 +44,7 @@ exports[`modules/manager/github-actions/extract > extractPackageFile() > extract
     "enabled": false,
     "replaceString": "docker/setup-qemu-action@c308fdd69d26ed66f4506ebd74b180abe5362145",
     "skipReason": "unversioned-reference",
-    "versioning": "docker",
+    "versioning": "semver-partial",
   },
   {
     "autoReplaceStringTemplate": "{{depName}}@{{#if newDigest}}{{newDigest}}{{#if newValue}} # {{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}",
@@ -54,7 +54,7 @@ exports[`modules/manager/github-actions/extract > extractPackageFile() > extract
     "depName": "docker/build-push-action",
     "depType": "action",
     "replaceString": "docker/build-push-action@v2",
-    "versioning": "docker",
+    "versioning": "semver-partial",
   },
   {
     "autoReplaceStringTemplate": "{{depName}}@{{#if newDigest}}{{newDigest}}{{#if newValue}} # {{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}",
@@ -65,7 +65,7 @@ exports[`modules/manager/github-actions/extract > extractPackageFile() > extract
     "depName": "actions/checkout",
     "depType": "action",
     "replaceString": "actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # tag=v2.4.0",
-    "versioning": "docker",
+    "versioning": "semver-partial",
   },
   {
     "autoReplaceStringTemplate": "{{depName}}@{{#if newDigest}}{{newDigest}}{{#if newValue}} # {{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}",
@@ -76,7 +76,7 @@ exports[`modules/manager/github-actions/extract > extractPackageFile() > extract
     "depName": "actions-rs/toolchain",
     "depType": "action",
     "replaceString": "actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # renovate: tag=v1.0.7",
-    "versioning": "docker",
+    "versioning": "semver-partial",
   },
   {
     "autoReplaceStringTemplate": "{{depName}}@{{#if newDigest}}{{newDigest}}{{#if newValue}} # {{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}",
@@ -86,7 +86,7 @@ exports[`modules/manager/github-actions/extract > extractPackageFile() > extract
     "depName": "actions-rs/cargo",
     "depType": "action",
     "replaceString": "actions-rs/cargo@v1.0.3",
-    "versioning": "docker",
+    "versioning": "semver-partial",
   },
   {
     "autoReplaceStringTemplate": "{{depName}}-{{newValue}}",

--- a/lib/modules/manager/github-actions/extract.spec.ts
+++ b/lib/modules/manager/github-actions/extract.spec.ts
@@ -163,7 +163,7 @@ describe('modules/manager/github-actions/extract', () => {
           depName: 'pascalgn/automerge-action',
           depType: 'action',
           replaceString: '"pascalgn/automerge-action@v0.13.1"',
-          versioning: 'docker',
+          versioning: 'semver-partial',
         },
         {
           currentValue: 'v2.3.5',
@@ -172,7 +172,7 @@ describe('modules/manager/github-actions/extract', () => {
           depType: 'action',
           replaceString:
             'actions/checkout@1e204e9a9253d643386038d443f96446fa156a97 # renovate: tag=v2.3.5',
-          versioning: 'docker',
+          versioning: 'semver-partial',
         },
         {
           currentValue: 'v1',
@@ -180,7 +180,7 @@ describe('modules/manager/github-actions/extract', () => {
           depName: 'actions/checkout',
           depType: 'action',
           replaceString: 'actions/checkout@v1',
-          versioning: 'docker',
+          versioning: 'semver-partial',
         },
         {
           currentValue: 'v1.1.2',
@@ -188,7 +188,7 @@ describe('modules/manager/github-actions/extract', () => {
           depName: 'actions/checkout',
           depType: 'action',
           replaceString: '"actions/checkout@v1.1.2"',
-          versioning: 'docker',
+          versioning: 'semver-partial',
         },
         {
           currentValue: '1.37.0-glibc',
@@ -236,7 +236,7 @@ describe('modules/manager/github-actions/extract', () => {
           depName: 'actions/setup-node',
           commitMessageTopic: '{{{depName}}} action',
           datasource: 'github-tags',
-          versioning: 'docker',
+          versioning: 'semver-partial',
           depType: 'action',
           replaceString:
             'actions/setup-node@56337c425554a6be30cdef71bf441f15be286854 # tag=v3.1.1',
@@ -249,7 +249,7 @@ describe('modules/manager/github-actions/extract', () => {
           depName: 'actions/setup-node',
           commitMessageTopic: '{{{depName}}} action',
           datasource: 'github-tags',
-          versioning: 'docker',
+          versioning: 'semver-partial',
           depType: 'action',
           replaceString:
             "'actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561' # tag=v3.1.1",
@@ -262,7 +262,7 @@ describe('modules/manager/github-actions/extract', () => {
           depName: 'actions/setup-node',
           commitMessageTopic: '{{{depName}}} action',
           datasource: 'github-tags',
-          versioning: 'docker',
+          versioning: 'semver-partial',
           depType: 'action',
           replaceString:
             '"actions/setup-node@1f8c6b94b26d0feae1e387ca63ccbdc44d27b561" # tag=v2.5.1',
@@ -275,7 +275,7 @@ describe('modules/manager/github-actions/extract', () => {
           depName: 'actions/checkout',
           commitMessageTopic: '{{{depName}}} action',
           datasource: 'github-tags',
-          versioning: 'docker',
+          versioning: 'semver-partial',
           depType: 'action',
           replaceString: '"actions/checkout@v2"',
           autoReplaceStringTemplate:
@@ -286,7 +286,7 @@ describe('modules/manager/github-actions/extract', () => {
           depName: 'actions/setup-java',
           commitMessageTopic: '{{{depName}}} action',
           datasource: 'github-tags',
-          versioning: 'docker',
+          versioning: 'semver-partial',
           depType: 'action',
           replaceString: '"actions/setup-java@v2"',
           autoReplaceStringTemplate:
@@ -575,7 +575,7 @@ describe('modules/manager/github-actions/extract', () => {
       expect(res?.deps[0]).toEqual({
         depName: 'actions/checkout',
         commitMessageTopic: '{{{depName}}} action',
-        versioning: 'docker',
+        versioning: 'semver-partial',
         depType: 'action',
         replaceString:
           'actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v4',
@@ -600,7 +600,7 @@ describe('modules/manager/github-actions/extract', () => {
       expect(res?.deps[0]).toEqual({
         depName: 'actions/checkout',
         commitMessageTopic: '{{{depName}}} action',
-        versioning: 'docker',
+        versioning: 'semver-partial',
         depType: 'action',
         replaceString: 'actions/checkout@c85c95e # v4',
         autoReplaceStringTemplate:
@@ -776,7 +776,7 @@ describe('modules/manager/github-actions/extract', () => {
           depName: 'actions/setup-node',
           depType: 'action',
           replaceString: 'actions/setup-node@v3',
-          versioning: 'docker',
+          versioning: 'semver-partial',
         },
         {
           autoReplaceStringTemplate:
@@ -787,7 +787,7 @@ describe('modules/manager/github-actions/extract', () => {
           depName: 'actions/setup-node',
           depType: 'action',
           replaceString: 'actions/setup-node@v3',
-          versioning: 'docker',
+          versioning: 'semver-partial',
         },
         {
           autoReplaceStringTemplate:
@@ -798,7 +798,7 @@ describe('modules/manager/github-actions/extract', () => {
           depName: 'actions/setup-go',
           depType: 'action',
           replaceString: 'actions/setup-go@v5',
-          versioning: 'docker',
+          versioning: 'semver-partial',
         },
         {
           autoReplaceStringTemplate:
@@ -809,7 +809,7 @@ describe('modules/manager/github-actions/extract', () => {
           depName: 'actions/setup-python',
           depType: 'action',
           replaceString: 'actions/setup-python@v3',
-          versioning: 'docker',
+          versioning: 'semver-partial',
         },
         {
           autoReplaceStringTemplate:
@@ -820,7 +820,7 @@ describe('modules/manager/github-actions/extract', () => {
           depName: 'actions/setup-node',
           depType: 'action',
           replaceString: 'actions/setup-node@v3',
-          versioning: 'docker',
+          versioning: 'semver-partial',
         },
         {
           depName: 'node',
@@ -926,7 +926,7 @@ describe('modules/manager/github-actions/extract', () => {
           depName: 'actions/setup-node',
           depType: 'action',
           replaceString: 'actions/setup-node@v3',
-          versioning: 'docker',
+          versioning: 'semver-partial',
         },
         {
           autoReplaceStringTemplate:
@@ -937,7 +937,7 @@ describe('modules/manager/github-actions/extract', () => {
           depName: 'actions/setup-node',
           depType: 'action',
           replaceString: 'actions/setup-node@v3',
-          versioning: 'docker',
+          versioning: 'semver-partial',
         },
         {
           autoReplaceStringTemplate:
@@ -948,7 +948,7 @@ describe('modules/manager/github-actions/extract', () => {
           depName: 'actions/setup-go',
           depType: 'action',
           replaceString: 'actions/setup-go@v5',
-          versioning: 'docker',
+          versioning: 'semver-partial',
         },
         {
           autoReplaceStringTemplate:
@@ -959,7 +959,7 @@ describe('modules/manager/github-actions/extract', () => {
           depName: 'actions/setup-python',
           depType: 'action',
           replaceString: 'actions/setup-python@v3',
-          versioning: 'docker',
+          versioning: 'semver-partial',
         },
         {
           autoReplaceStringTemplate:
@@ -970,7 +970,7 @@ describe('modules/manager/github-actions/extract', () => {
           depName: 'actions/setup-node',
           depType: 'action',
           replaceString: 'actions/setup-node@v3',
-          versioning: 'docker',
+          versioning: 'semver-partial',
         },
         {
           depName: 'node',

--- a/lib/modules/manager/github-actions/extract.ts
+++ b/lib/modules/manager/github-actions/extract.ts
@@ -13,6 +13,7 @@ import * as dockerVersioning from '../../versioning/docker/index.ts';
 import * as exactVersioning from '../../versioning/exact/index.ts';
 import * as nodeVersioning from '../../versioning/node/index.ts';
 import * as npmVersioning from '../../versioning/npm/index.ts';
+import * as semverPartialVersioning from '../../versioning/semver-partial/index.ts';
 import { getDep } from '../dockerfile/extract.ts';
 import type {
   ExtractConfig,
@@ -86,7 +87,7 @@ function extractRepositoryAction(
   const dep: PackageDependency = {
     depName,
     commitMessageTopic: '{{{depName}}} action',
-    versioning: dockerVersioning.id,
+    versioning: semverPartialVersioning.id,
     depType: 'action',
     replaceString: valueString,
     autoReplaceStringTemplate: `${quote}{{depName}}${pathSuffix}@{{#if newDigest}}{{newDigest}}${quote}{{#if newValue}}${commentWs}# {{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}${quote}{{/unless}}`,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
As per #42331, we should migrate to using `semver-partial` for GitHub
Actions' tags versions, instead of `docker`.

This mirrors actual usage of the way that the ecosystem tags Action
versions, and also has the benefit of automagically migrating users of
Actions that have enabled Immutable Tags, which now must be a full
SemVer tagged version.

This replaces the need for https://github.com/renovatebot/renovate/pull/42683, as we'll automagically perform the update.

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #42331
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/JamieTanna-Mend-testing/setup-uv/pull/5

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
