### PR TITLE
fix(manager/github-actions): override `versioning` for Actions with Immutable Tags

### DIFF
--- a/lib/modules/manager/github-actions/extract.spec.ts
+++ b/lib/modules/manager/github-actions/extract.spec.ts
@@ -1469,4 +1469,45 @@ describe('modules/manager/github-actions/extract', () => {
       expected,
     );
   });
+
+  it.each([
+    {
+      step: {
+        uses: 'astral-sh/setup-uv@v7',
+      },
+      expected: {
+        currentValue: 'v7',
+        datasource: 'github-tags',
+        depName: 'astral-sh/setup-uv',
+        depType: 'action',
+      },
+    },
+    {
+      step: {
+        uses: 'astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57',
+      },
+      expected: {
+        currentDigest: 'cec208311dfd045dd5311c1add060b2062131d57',
+        datasource: 'github-tags',
+        depName: 'astral-sh/setup-uv',
+        depType: 'action',
+      },
+    },
+  ])(
+    'overrides versioning for actions with Immutable tags: $step.uses',
+    ({ step, expected }) => {
+      const yamlContent = yaml.dump({ jobs: { build: { steps: [step] } } });
+
+      const res = extractPackageFile(yamlContent, 'workflow.yml');
+      expect(res?.deps.filter((pkg) => pkg.depType === 'action')).toMatchObject(
+        [
+          {
+            versioning:
+              'regex:^v?(?<major>\\d+)(\\.(?<minor>\\d+)\\.(?<patch>\\d+))?$',
+            ...expected,
+          },
+        ],
+      );
+    },
+  );
 });

--- a/lib/modules/manager/github-actions/extract.ts
+++ b/lib/modules/manager/github-actions/extract.ts
@@ -21,10 +21,14 @@ import type {
   PackageFileContent,
 } from '../types.ts';
 import { CommunityActions } from './community.ts';
+import { ActionsUsingGitHubImmutableTags } from './immutable-actions.ts';
 import type { DockerReference, RepositoryReference } from './parse.ts';
 import { isSha, isShortSha, parseUsesLine, versionLikeRe } from './parse.ts';
 import type { Steps } from './schema.ts';
 import { Workflow } from './schema.ts';
+
+const semverWithOptionalMinorAndPatchversioning =
+  'regex:^v?(?<major>\\d+)(\\.(?<minor>\\d+)\\.(?<patch>\\d+))?$';
 
 // detects if we run against a Github Enterprise Server and adds the URL to the beginning of the registryURLs for looking up Actions
 // This reflects the behavior of how GitHub looks up Actions
@@ -365,6 +369,14 @@ export function extractPackageFile(
 
   if (!deps.length) {
     return null;
+  }
+
+  for (const dep of deps) {
+    if (
+      ActionsUsingGitHubImmutableTags.includes(dep.packageName ?? dep.depName!)
+    ) {
+      dep.versioning = semverWithOptionalMinorAndPatchversioning;
+    }
   }
 
   return { deps };

--- a/lib/modules/manager/github-actions/immutable-actions.ts
+++ b/lib/modules/manager/github-actions/immutable-actions.ts
@@ -1,0 +1,7 @@
+/**
+ * Community actions which have migrated to Immutable Tags, which requires using strict SemVer
+ */
+export const ActionsUsingGitHubImmutableTags = [
+  /** https://github.com/astral-sh/setup-uv/issues/830 */
+  'astral-sh/setup-uv',
+];


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

The changes in #42685 mostly worked,
but given `astral-sh/setup-uv` is now using Immutable Tags it _must_ be
resolved as `versioning=semver`, to make sure that version updates are
correctly raised.

However, we can't treat it as `versioning=semver`, as that will then
fail to parse the current version correctly.

Instead, we must use a `regex` versioning scheme, which allows us to
optionally parse the minor and patch versions.

This allows `newVersion` to be pinned accordingly to SemVer, but does
not require previous versions to be so.

We can do this - for now - with an explicit allowlist.

(As noted on https://github.com/renovatebot/renovate/pull/42685#issuecomment-4260469805 this doesn't quite fix issues noted in https://github.com/astral-sh/setup-uv/issues/830)



## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
