### PR TITLE
chore(versioning): allow providing known versions to module

### DIFF
--- a/lib/modules/versioning/types.ts
+++ b/lib/modules/versioning/types.ts
@@ -7,6 +7,12 @@ export interface NewValueConfig {
   currentVersion?: string;
   newVersion: string;
   isReplacement?: boolean;
+  /**
+   * All versions numbers that this given Release has.
+   *
+   * Allows Versioning modules to determine whether the version they're proposing matches a known version.
+   */
+  allVersions?: string[];
 }
 export interface VersioningApi {
   // validation

--- a/lib/workers/repository/process/lookup/generate.ts
+++ b/lib/workers/repository/process/lookup/generate.ts
@@ -17,6 +17,7 @@ export async function generateUpdate(
   currentVersion: string,
   bucket: string,
   release: Release,
+  allVersions: string[],
 ): Promise<LookupUpdate> {
   const newVersion = release.version;
   const update: LookupUpdate = {
@@ -60,6 +61,7 @@ export async function generateUpdate(
         rangeStrategy,
         currentVersion,
         newVersion,
+        allVersions,
       })!;
     } catch (err) /* istanbul ignore next */ {
       logger.warn(

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -486,6 +486,7 @@ export async function lookupUpdates(
         const sortedReleases = releases.sort((r1, r2) =>
           versioningApi.sortVersions(r1.version, r2.version),
         );
+        const allReleaseVersions = releases.map((r) => r.version);
         const { release, pendingChecks, pendingReleases } =
           await filterInternalChecks(
             depResultConfig,
@@ -508,6 +509,7 @@ export async function lookupUpdates(
           config.lockedVersion ?? currentVersion!,
           bucket,
           release,
+          allReleaseVersions,
         );
 
         // #29034


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
As part of future changes, we'll introduce a new Versioning module for
GitHub Actions, which requires knowing if the version it's proposing
actually exists.

This is a more useful concept for Versioning modules to be able to take
advantage of, so we can expose this as an optional capability that
Versioning modules can use.


## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
