### PR TITLE
feat(nuget): update lock files when `Directory.Build.props` is changed

### DIFF
--- a/lib/modules/manager/nuget/__fixtures__/two-one-reference-with-directory-build-props/Directory.Build.props
+++ b/lib/modules/manager/nuget/__fixtures__/two-one-reference-with-directory-build-props/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <ItemGroup>
+    <PackageReference Include="Serilog" Version="2.10.0" />
+  </ItemGroup>
+</Project>

--- a/lib/modules/manager/nuget/__fixtures__/two-one-reference-with-directory-build-props/one/one.csproj
+++ b/lib/modules/manager/nuget/__fixtures__/two-one-reference-with-directory-build-props/one/one.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Serilog" />
+  </ItemGroup>
+
+</Project>

--- a/lib/modules/manager/nuget/__fixtures__/two-one-reference-with-directory-build-props/two/two.csproj
+++ b/lib/modules/manager/nuget/__fixtures__/two-one-reference-with-directory-build-props/two/two.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Serilog" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../one/one.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/lib/modules/manager/nuget/artifacts.spec.ts
+++ b/lib/modules/manager/nuget/artifacts.spec.ts
@@ -191,6 +191,80 @@ describe('modules/manager/nuget/artifacts', () => {
     expect(execSnapshots).toBeEmptyArray();
   });
 
+  it('updates lock file for Directory.Build.props', async () => {
+    const execSnapshots = mockExecAll();
+    scm.getFileList.mockReset();
+    scm.getFileList.mockResolvedValueOnce(['project.csproj']);
+    fs.getSiblingFileName
+      .mockReturnValueOnce('packages.lock.json')
+      .mockReturnValueOnce('packages.lock.json');
+    git.getFiles.mockResolvedValueOnce({
+      'packages.lock.json': 'Current packages.lock.json',
+    });
+    fs.getLocalFiles.mockResolvedValueOnce({
+      'packages.lock.json': 'New packages.lock.json',
+    });
+
+    expect(
+      await nuget.updateArtifacts({
+        packageFileName: 'Directory.Build.props',
+        updatedDeps: [{ depName: 'dep' }],
+        newPackageFileContent: '{}',
+        config,
+      }),
+    ).toEqual([
+      {
+        file: {
+          contents: 'New packages.lock.json',
+          path: 'packages.lock.json',
+          type: 'addition',
+        },
+      },
+    ]);
+    expect(execSnapshots).toMatchObject([
+      {
+        cmd: 'dotnet restore project.csproj --force-evaluate --configfile /tmp/renovate/cache/__renovate-private-cache/nuget/nuget.config',
+      },
+    ]);
+  });
+
+  it('updates lock file for nested Directory.Build.props', async () => {
+    const execSnapshots = mockExecAll();
+    scm.getFileList.mockReset();
+    scm.getFileList.mockResolvedValueOnce(['src/project.csproj']);
+    fs.getSiblingFileName
+      .mockReturnValueOnce('src/packages.lock.json')
+      .mockReturnValueOnce('src/packages.lock.json');
+    git.getFiles.mockResolvedValueOnce({
+      'src/packages.lock.json': 'Current packages.lock.json',
+    });
+    fs.getLocalFiles.mockResolvedValueOnce({
+      'src/packages.lock.json': 'New packages.lock.json',
+    });
+
+    expect(
+      await nuget.updateArtifacts({
+        packageFileName: 'src/Directory.Build.props',
+        updatedDeps: [{ depName: 'dep' }],
+        newPackageFileContent: '{}',
+        config,
+      }),
+    ).toEqual([
+      {
+        file: {
+          contents: 'New packages.lock.json',
+          path: 'src/packages.lock.json',
+          type: 'addition',
+        },
+      },
+    ]);
+    expect(execSnapshots).toMatchObject([
+      {
+        cmd: 'dotnet restore src/project.csproj --force-evaluate --configfile /tmp/renovate/cache/__renovate-private-cache/nuget/nuget.config',
+      },
+    ]);
+  });
+
   it('does not update lock file when no deps changed', async () => {
     const execSnapshots = mockExecAll();
     fs.getSiblingFileName.mockReturnValueOnce('packages.lock.json');

--- a/lib/modules/manager/nuget/artifacts.ts
+++ b/lib/modules/manager/nuget/artifacts.ts
@@ -23,6 +23,7 @@ import type {
 } from '../types.ts';
 import { createNuGetConfigXml } from './config-formatter.ts';
 import {
+  DIRECTORY_BUILD_PROPS,
   GLOBAL_JSON,
   MSBUILD_CENTRAL_FILE,
   NUGET_CENTRAL_FILE,
@@ -125,9 +126,14 @@ export async function updateArtifacts({
 
   const isGlobalJson = packageFileName === GLOBAL_JSON;
 
+  const isDirectoryBuildProps =
+    packageFileName === DIRECTORY_BUILD_PROPS ||
+    packageFileName.endsWith(`/${DIRECTORY_BUILD_PROPS}`);
+
   if (
     !isCentralManagement &&
     !isGlobalJson &&
+    !isDirectoryBuildProps &&
     !regEx(/(?:cs|vb|fs)proj$/i).test(packageFileName)
   ) {
     // This could be implemented in the future if necessary.
@@ -143,7 +149,7 @@ export async function updateArtifacts({
 
   const deps = await getDependentPackageFiles(
     packageFileName,
-    isCentralManagement,
+    isCentralManagement || isDirectoryBuildProps,
     isGlobalJson,
   );
   const packageFiles = deps.filter((d) => d.isLeaf).map((d) => d.name);

--- a/lib/modules/manager/nuget/package-tree.spec.ts
+++ b/lib/modules/manager/nuget/package-tree.spec.ts
@@ -96,6 +96,50 @@ describe('modules/manager/nuget/package-tree', () => {
       ]);
     });
 
+    it('returns projects for two projects with one reference and Directory.Build.props', async () => {
+      scm.getFileList.mockResolvedValue(['one/one.csproj', 'two/two.csproj']);
+      Fixtures.mock({
+        '/tmp/repo/one/one.csproj': Fixtures.get(
+          'two-one-reference-with-directory-build-props/one/one.csproj',
+        ),
+        '/tmp/repo/two/two.csproj': Fixtures.get(
+          'two-one-reference-with-directory-build-props/two/two.csproj',
+        ),
+        '/tmp/repo/Directory.Build.props': Fixtures.get(
+          'two-one-reference-with-directory-build-props/Directory.Build.props',
+        ),
+      });
+
+      expect(
+        await getDependentPackageFiles('Directory.Build.props', true),
+      ).toEqual([
+        { isLeaf: false, name: 'one/one.csproj' },
+        { isLeaf: true, name: 'two/two.csproj' },
+      ]);
+    });
+
+    it('returns only projects under nested Directory.Build.props directory', async () => {
+      scm.getFileList.mockResolvedValue([
+        'src/one/one.csproj',
+        'other/two.csproj',
+      ]);
+      Fixtures.mock({
+        '/tmp/repo/src/one/one.csproj': Fixtures.get(
+          'two-one-reference-with-directory-build-props/one/one.csproj',
+        ),
+        '/tmp/repo/other/two.csproj': Fixtures.get(
+          'two-one-reference-with-directory-build-props/one/one.csproj',
+        ),
+        '/tmp/repo/src/Directory.Build.props': Fixtures.get(
+          'two-one-reference-with-directory-build-props/Directory.Build.props',
+        ),
+      });
+
+      expect(
+        await getDependentPackageFiles('src/Directory.Build.props', true),
+      ).toEqual([{ isLeaf: true, name: 'src/one/one.csproj' }]);
+    });
+
     it('returns project for two projects with one reference and global.json', async () => {
       scm.getFileList.mockResolvedValue(['one/one.csproj', 'two/two.csproj']);
       Fixtures.mock({

--- a/lib/modules/manager/nuget/package-tree.ts
+++ b/lib/modules/manager/nuget/package-tree.ts
@@ -10,19 +10,20 @@ import { readFileAsXmlDocument } from './util.ts';
 export const GLOBAL_JSON = 'global.json';
 export const NUGET_CENTRAL_FILE = 'Directory.Packages.props';
 export const MSBUILD_CENTRAL_FILE = 'Packages.props';
+export const DIRECTORY_BUILD_PROPS = 'Directory.Build.props';
 
 /**
  * Get all leaf package files of ancestry that depend on packageFileName.
  */
 export async function getDependentPackageFiles(
   packageFileName: string,
-  isCentralManagement = false,
+  isPropsFile = false,
   isGlobalJson = false,
 ): Promise<ProjectFile[]> {
   const packageFiles = await getAllPackageFiles();
   const graph = new Graph();
 
-  if (isCentralManagement) {
+  if (isPropsFile) {
     graph.addNode(packageFileName);
   }
 
@@ -33,7 +34,8 @@ export async function getDependentPackageFiles(
   const parentDir =
     packageFileName === NUGET_CENTRAL_FILE ||
     packageFileName === MSBUILD_CENTRAL_FILE ||
-    packageFileName === GLOBAL_JSON
+    packageFileName === GLOBAL_JSON ||
+    packageFileName === DIRECTORY_BUILD_PROPS
       ? ''
       : upath.dirname(packageFileName);
 
@@ -41,7 +43,7 @@ export async function getDependentPackageFiles(
     graph.addNode(f);
 
     if (
-      (isCentralManagement || isGlobalJson) &&
+      (isPropsFile || isGlobalJson) &&
       upath.dirname(f).startsWith(parentDir)
     ) {
       graph.addEdge(packageFileName, f);
@@ -80,7 +82,7 @@ export async function getDependentPackageFiles(
   const deps = new Map<string, boolean>();
   recursivelyGetDependentPackageFiles(packageFileName, graph, deps);
 
-  if (isCentralManagement || isGlobalJson) {
+  if (isPropsFile || isGlobalJson) {
     // remove props file, as we don't need it
     deps.delete(packageFileName);
   }


### PR DESCRIPTION
## Changes

`Directory.Build.props` is a standard MSBuild import file that can contain `<PackageReference>` elements inherited by all projects in the same directory and below. When Renovate updates packages referenced in this file, lock file (`packages.lock.json`) regeneration was skipped because `updateArtifacts` only handled `.csproj`/`.vbproj`/`.fsproj`, `Directory.Packages.props`/`Packages.props`, and `global.json`.

This extends the existing logic to treat `Directory.Build.props` the same way as central management files — all project files under its parent directory have their lock files regenerated via `dotnet restore`.

In my case, I use `Directory.Build.props` to set common packages across a monorepo. Renovate PRs that update packages in this file always fail CI because the dependent project lock files are stale. This requires manually pulling down the branch and running `dotnet restore` to regenerate the lock files — which defeats the purpose of automated dependency updates.

Changes:
- `package-tree.ts`: Added `DIRECTORY_BUILD_PROPS` constant, added it to the `parentDir` resolution, renamed `isCentralManagement` parameter to `isPropsFile` for clarity since it now covers both central management and `Directory.Build.props`
- `artifacts.ts`: Added `isDirectoryBuildProps` detection, updated the guard clause to allow `Directory.Build.props` through, passed the combined flag to `getDependentPackageFiles`
- Added 4 new test cases covering root-level and nested `Directory.Build.props` for both dependency resolution and lock file updates
- Added new test fixture directory

## Context

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

Related: #15696 (the analogous fix for `Directory.Packages.props`), #8010 (original lock file update issue)

## AI assistance disclosure

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository