### PR TITLE
feat(manager/pixi): set currentVersion field for exact pypi dependency versions

### DIFF
--- a/lib/modules/manager/pixi/extract.spec.ts
+++ b/lib/modules/manager/pixi/extract.spec.ts
@@ -95,6 +95,7 @@ numpy = { version = "*", build = "py312*" }
 [pypi-dependencies]
 requests = '*'
 requests2 = {version = '*'}
+mako = "==1.3.9"
 
 [target.win-64.pypi-dependencies]
 urllib3 = {version = '*'}
@@ -409,6 +410,13 @@ describe('modules/manager/pixi/extract', () => {
             currentValue: '*',
             datasource: 'pypi',
             depName: 'requests2',
+            versioning: 'pep440',
+          },
+          {
+            currentValue: '==1.3.9',
+            currentVersion: '1.3.9',
+            datasource: 'pypi',
+            depName: 'mako',
             versioning: 'pep440',
           },
           {

--- a/lib/modules/manager/pixi/schema.ts
+++ b/lib/modules/manager/pixi/schema.ts
@@ -38,11 +38,15 @@ const PypiDependency = z
     z.object({ version: z.string() }),
   ])
   .transform(({ version }) => {
-    return {
+    const dep: PixiPackageDependency = {
       currentValue: version,
       versioning: pep440VersionID,
       datasource: PypiDatasource.id,
-    } satisfies PixiPackageDependency;
+    };
+    if (version.startsWith('==')) {
+      dep.currentVersion = version.replace(/^==\s*/, '');
+    }
+    return dep;
   });
 
 const PypiGitDependency = z


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Sets `currentVersion` on extracted `pypi-dependencies` entries that use an exact version specifier (`==x.y.z`). This strips the `==` prefix into `currentVersion`, which is what `fetchVulnerabilities` requires to pass the `isVersion()` check before performing an OSV lookup.

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

- https://github.com/renovatebot/renovate/discussions/42730
- https://github.com/renovatebot/renovate/pull/27061

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
