### PR TITLE
fix(vulnerability): use datasource default versioning instead of hardcoded map

### DIFF
--- a/lib/workers/repository/init/vulnerability.ts
+++ b/lib/workers/repository/init/vulnerability.ts
@@ -2,18 +2,13 @@ import is from '@sindresorhus/is';
 import type { PackageRule, RenovateConfig } from '../../../config/types.ts';
 import { NO_VULNERABILITY_ALERTS } from '../../../constants/error-messages.ts';
 import { logger } from '../../../logger/index.ts';
+import { getDefaultVersioning } from '../../../modules/datasource/common.ts';
 import { GithubTagsDatasource } from '../../../modules/datasource/github-tags/index.ts';
 import { MavenDatasource } from '../../../modules/datasource/maven/index.ts';
 import { NugetDatasource } from '../../../modules/datasource/nuget/index.ts';
 import type { SecurityAdvisory } from '../../../modules/platform/github/schema.ts';
 import { platform } from '../../../modules/platform/index.ts';
-import * as composerVersioning from '../../../modules/versioning/composer/index.ts';
 import * as allVersioning from '../../../modules/versioning/index.ts';
-import * as mavenVersioning from '../../../modules/versioning/maven/index.ts';
-import * as npmVersioning from '../../../modules/versioning/npm/index.ts';
-import * as pep440Versioning from '../../../modules/versioning/pep440/index.ts';
-import * as rubyVersioning from '../../../modules/versioning/ruby/index.ts';
-import * as semverVersioning from '../../../modules/versioning/semver/index.ts';
 import { sanitizeMarkdown } from '../../../util/markdown.ts';
 import { escapeRegExp, regEx } from '../../../util/regex.ts';
 import { titleCase } from '../../../util/string.ts';
@@ -65,16 +60,6 @@ export async function detectVulnerabilityAlerts(
     return input;
   }
   const config = { ...input };
-  const versionings: Record<string, string> = {
-    'github-tags': semverVersioning.id,
-    go: semverVersioning.id,
-    packagist: composerVersioning.id,
-    maven: mavenVersioning.id,
-    npm: npmVersioning.id,
-    nuget: semverVersioning.id,
-    pypi: pep440Versioning.id,
-    rubygems: rubyVersioning.id,
-  };
   const combinedAlerts: CombinedAlert = {};
   for (const alert of alerts) {
     try {
@@ -107,7 +92,7 @@ export async function detectVulnerabilityAlerts(
         { vulnerabilitySeverity: alertDetails.severity },
         { vulnerabilitySeverity: alert.security_vulnerability.severity },
       );
-      const versioningApi = allVersioning.get(versionings[datasource]);
+      const versioningApi = allVersioning.get(getDefaultVersioning(datasource));
       if (versioningApi.isVersion(firstPatchedVersion)) {
         if (
           !alertDetails.firstPatchedVersion ||
@@ -138,7 +123,7 @@ export async function detectVulnerabilityAlerts(
         prBodyNotes = val.advisories.flatMap((advisory) =>
           generatePrBodyNotes(advisory),
         );
-      } catch (err) /* istanbul ignore next */ {
+      } catch (err) /* v8 ignore next */ {
         logger.warn({ err }, 'Error generating vulnerability PR notes');
       }
       let matchRule: PackageRule = {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Removes the hardcoded `versionings` map in `detectVulnerabilityAlerts` and replaces it with `getDefaultVersioning(datasource)`, consistent with how OSV alerts are processed.

Also fixes two inconsistencies:
  - `github-tags` was mapped to `semver` -> actual default is `semver-coerced`
  - `nuget` was mapped to `semver` -> actual default is `nuget`

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
