### PR TITLE
feat(manager/gradle): add support for implicit version catalog accessor syntax

### DIFF
--- a/lib/modules/manager/gradle/extract.spec.ts
+++ b/lib/modules/manager/gradle/extract.spec.ts
@@ -1103,6 +1103,27 @@ describe('modules/manager/gradle/extract', () => {
       ]);
     });
 
+    it('ignores version catalog accessor with non-get provider method', async () => {
+      const fsMock = {
+        'gradle/libs.versions.toml': codeBlock`
+          [versions]
+          detekt = "1.18.1"
+        `,
+        'build.gradle.kts': codeBlock`
+          detekt {
+            toolVersion = libs.versions.detekt.getOrNull()
+          }
+        `,
+      };
+      mockFs(fsMock);
+
+      const res = await extractAllPackageFiles(
+        partial<ExtractConfig>(),
+        Object.keys(fsMock),
+      );
+      expect(res).toBeNull();
+    });
+
     it('aligns sharedVariableName if version reference has multiple aliases', async () => {
       const fsMock = {
         'gradle/libs.versions.toml': codeBlock`

--- a/lib/modules/manager/gradle/extract.spec.ts
+++ b/lib/modules/manager/gradle/extract.spec.ts
@@ -1002,6 +1002,152 @@ describe('modules/manager/gradle/extract', () => {
         },
       ]);
     });
+
+    it('provides versions from external version catalogs to gradle files', async () => {
+      const fsMock = {
+        'gradle/libs.versions.toml': codeBlock`
+          [versions]
+          detekt = "1.18.1"
+          kotlin = "2.2.20"
+          springBoot = "3.5.4"
+        `,
+        'build.gradle.kts': codeBlock`
+          plugins {
+            id "org.springframework.boot" version libs.versions.springBoot
+          }
+          detekt {
+            toolVersion = libs.versions.detekt.get()
+          }
+          dependencies {
+            classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:\${libs.versions.kotlin.get()}")
+          }
+        `,
+      };
+      mockFs(fsMock);
+
+      const res = await extractAllPackageFiles(
+        partial<ExtractConfig>(),
+        Object.keys(fsMock),
+      );
+      expect(res).toMatchObject([
+        {
+          packageFile: 'gradle/libs.versions.toml',
+          deps: [
+            {
+              packageName:
+                'org.springframework.boot:org.springframework.boot.gradle.plugin',
+              currentValue: '3.5.4',
+              sharedVariableName: 'libs.versions.springBoot',
+            },
+            {
+              packageName: 'io.gitlab.arturbosch.detekt:detekt-core',
+              currentValue: '1.18.1',
+              sharedVariableName: 'libs.versions.detekt',
+            },
+            {
+              depName: 'org.jetbrains.kotlin:kotlin-gradle-plugin',
+              currentValue: '2.2.20',
+              sharedVariableName: 'libs.versions.kotlin',
+            },
+          ],
+        },
+        {
+          packageFile: 'build.gradle.kts',
+          deps: [],
+        },
+      ]);
+    });
+
+    it('provides versions to gradle files with changed default catalog name', async () => {
+      const fsMock = {
+        'gradle/libs.versions.toml': codeBlock`
+          [versions]
+          kotlin = "2.2.20"
+        `,
+        'settings.gradle.kts': codeBlock`
+          dependencyResolutionManagement {
+            defaultLibrariesExtensionName = "projectLibs"
+          }
+        `,
+        'build.gradle.kts': codeBlock`
+          dependencies {
+            classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:\${projectLibs.versions.kotlin.get()}")
+          }
+        `,
+      };
+      mockFs(fsMock);
+
+      const res = await extractAllPackageFiles(
+        partial<ExtractConfig>(),
+        Object.keys(fsMock),
+      );
+      expect(res).toMatchObject([
+        {
+          packageFile: 'settings.gradle.kts',
+          deps: [],
+        },
+        {
+          packageFile: 'gradle/libs.versions.toml',
+          deps: [
+            {
+              depName: 'org.jetbrains.kotlin:kotlin-gradle-plugin',
+              currentValue: '2.2.20',
+              sharedVariableName: 'projectLibs.versions.kotlin',
+            },
+          ],
+        },
+        {
+          packageFile: 'build.gradle.kts',
+          deps: [],
+        },
+      ]);
+    });
+
+    it('aligns sharedVariableName if version reference has multiple aliases', async () => {
+      const fsMock = {
+        'gradle/libs.versions.toml': codeBlock`
+          [versions]
+          android-test = "1.0.2"
+
+          [libraries]
+          android-test-runner = { group = "com.android.support.test", name = "runner", version.ref = "android-test" }
+        `,
+        'build.gradle.kts': codeBlock`
+          dependencies {
+            classpath("com.android.support.test:rules:\${libs.versions.android.test.get()}")
+          }
+        `,
+      };
+      mockFs(fsMock);
+
+      const res = await extractAllPackageFiles(
+        partial<ExtractConfig>(),
+        Object.keys(fsMock),
+      );
+      expect(res).toMatchObject([
+        {
+          packageFile: 'gradle/libs.versions.toml',
+          deps: [
+            {
+              depName: 'com.android.support.test:runner',
+              currentValue: '1.0.2',
+              fileReplacePosition: 27,
+              sharedVariableName: 'android.test',
+            },
+            {
+              depName: 'com.android.support.test:rules',
+              currentValue: '1.0.2',
+              fileReplacePosition: 27,
+              sharedVariableName: 'android.test',
+            },
+          ],
+        },
+        {
+          packageFile: 'build.gradle.kts',
+          deps: [],
+        },
+      ]);
+    });
   });
 
   describe('apply from', () => {

--- a/lib/modules/manager/gradle/extract.ts
+++ b/lib/modules/manager/gradle/extract.ts
@@ -10,7 +10,10 @@ import type {
   PackageDependency,
   PackageFile,
 } from '../types.ts';
-import { parseCatalog } from './extract/catalog.ts';
+import {
+  parseCatalog,
+  unifyCatalogSharedVariableNames,
+} from './extract/catalog.ts';
 import {
   isGcvPropsFile,
   parseGcv,
@@ -33,6 +36,7 @@ import {
   reorderFiles,
   toAbsolutePath,
   updateVars,
+  updateVarsFromDefaultCatalog,
 } from './utils.ts';
 
 const mavenDatasource = MavenDatasource.id;
@@ -191,7 +195,13 @@ async function parsePackageFiles(
         updateVars(varRegistry, packageFileDir, vars);
         extractedDeps.push(...deps);
       } else if (isTOMLFile(packageFile)) {
-        const deps = parseCatalog(packageFile, content);
+        const { vars, deps } = parseCatalog(packageFile, content);
+        updateVarsFromDefaultCatalog(
+          varRegistry,
+          packageFileDir,
+          packageFile,
+          vars,
+        );
         extractedDeps.push(...deps);
       } else if (
         isGcvPropsFile(packageFile) &&
@@ -253,6 +263,8 @@ export async function extractAllPackageFiles(
   if (!extractedDeps.length) {
     return null;
   }
+
+  unifyCatalogSharedVariableNames(extractedDeps);
 
   for (const dep of extractedDeps) {
     dep.fileReplacePosition = dep?.managerData?.fileReplacePosition; // #8224

--- a/lib/modules/manager/gradle/extract/catalog.spec.ts
+++ b/lib/modules/manager/gradle/extract/catalog.spec.ts
@@ -182,6 +182,24 @@ describe('modules/manager/gradle/extract/catalog', () => {
     expect(res).toStrictEqual({ vars: {}, deps: [] });
   });
 
+  it('skips version entries with no resolvable literal value', () => {
+    const input = codeBlock`
+      [versions]
+      kotlin = "1.5.21"
+      bad = { reject = "1.0.0" }
+    `;
+    const res = parseCatalog('gradle/libs.versions.toml', input);
+
+    expect(res.vars).toStrictEqual({
+      kotlin: {
+        key: 'kotlin',
+        value: '1.5.21',
+        fileReplacePosition: 21,
+        packageFile: 'gradle/libs.versions.toml',
+      },
+    });
+  });
+
   it('changes the dependency version, not the comment version', () => {
     const input = codeBlock`
       [versions]

--- a/lib/modules/manager/gradle/extract/catalog.spec.ts
+++ b/lib/modules/manager/gradle/extract/catalog.spec.ts
@@ -23,7 +23,21 @@ describe('modules/manager/gradle/extract/catalog', () => {
       multiJvm = "org.danilopianini.multi-jvm-test-plugin:0.3.0"
     `;
     const res = parseCatalog('gradle/libs.versions.toml', input);
-    expect(res).toStrictEqual([
+    expect(res.vars).toStrictEqual({
+      kotlin: {
+        key: 'kotlin',
+        value: '1.5.21',
+        fileReplacePosition: 21,
+        packageFile: 'gradle/libs.versions.toml',
+      },
+      'retro.fit': {
+        key: 'retro.fit',
+        value: '2.8.2',
+        fileReplacePosition: 42,
+        packageFile: 'gradle/libs.versions.toml',
+      },
+    });
+    expect(res.deps).toStrictEqual([
       {
         depName: 'com.squareup.okhttp3:okhttp',
         currentValue: '4.9.0',
@@ -130,7 +144,15 @@ describe('modules/manager/gradle/extract/catalog', () => {
     `;
     const res = parseCatalog('gradle/libs.versions.toml', input);
 
-    expect(res).toStrictEqual([
+    expect(res.vars).toStrictEqual({
+      detekt: {
+        key: 'detekt',
+        value: '1.18.1',
+        fileReplacePosition: 21,
+        packageFile: 'gradle/libs.versions.toml',
+      },
+    });
+    expect(res.deps).toStrictEqual([
       {
         depName: 'io.gitlab.arturbosch.detekt:detekt-formatting',
         sharedVariableName: 'detekt',
@@ -157,7 +179,7 @@ describe('modules/manager/gradle/extract/catalog', () => {
 
   it('ignores empty TOML file', () => {
     const res = parseCatalog('gradle/libs.versions.toml', '');
-    expect(res).toBeEmptyArray();
+    expect(res).toStrictEqual({ vars: {}, deps: [] });
   });
 
   it('changes the dependency version, not the comment version', () => {
@@ -175,7 +197,21 @@ describe('modules/manager/gradle/extract/catalog', () => {
     `;
     const res = parseCatalog('gradle/libs.versions.toml', input);
 
-    expect(res).toStrictEqual([
+    expect(res.vars).toStrictEqual({
+      'mocha.junit.reporter': {
+        key: 'mocha.junit.reporter',
+        value: '2.0.2',
+        fileReplacePosition: 82,
+        packageFile: 'gradle/libs.versions.toml',
+      },
+      junit: {
+        key: 'junit',
+        value: '1.4.9',
+        fileReplacePosition: 124,
+        packageFile: 'gradle/libs.versions.toml',
+      },
+    });
+    expect(res.deps).toStrictEqual([
       {
         depName: 'junit:junit',
         sharedVariableName: 'junit',
@@ -215,7 +251,21 @@ describe('modules/manager/gradle/extract/catalog', () => {
     `;
     const res = parseCatalog('gradle/libs.versions.toml', input);
 
-    expect(res).toStrictEqual([
+    expect(res.vars).toStrictEqual({
+      'mocha.junit.reporter': {
+        key: 'mocha.junit.reporter',
+        value: '2.0.2',
+        fileReplacePosition: 82,
+        packageFile: 'gradle/libs.versions.toml',
+      },
+      junit: {
+        key: 'junit',
+        value: '1.4.9',
+        fileReplacePosition: 166,
+        packageFile: 'gradle/libs.versions.toml',
+      },
+    });
+    expect(res.deps).toStrictEqual([
       {
         depName: 'junit:junit',
         sharedVariableName: 'junit',

--- a/lib/modules/manager/gradle/extract/catalog.ts
+++ b/lib/modules/manager/gradle/extract/catalog.ts
@@ -12,8 +12,10 @@ import type {
   GradleManagerData,
   GradleVersionCatalogVersion,
   GradleVersionPointerTarget,
+  PackageVariables,
   VersionPointer,
 } from '../types.ts';
+import { isTOMLFile } from '../utils.ts';
 
 function findVersionIndex(
   content: string,
@@ -245,7 +247,7 @@ function extractDependency({
 export function parseCatalog(
   packageFile: string,
   content: string,
-): PackageDependency<GradleManagerData>[] {
+): { vars: PackageVariables; deps: PackageDependency<GradleManagerData>[] } {
   const tomlContent = parseToml(massage(content)) as GradleCatalog;
   const versions = tomlContent.versions ?? {};
   const libs = tomlContent.libraries ?? {};
@@ -254,6 +256,25 @@ export function parseCatalog(
   const versionStartIndex = content.indexOf('versions');
   const versionSubContent = content.slice(versionStartIndex);
   const extractedDeps: PackageDependency<GradleManagerData>[] = [];
+  const vars: PackageVariables = {};
+
+  for (const [key, version] of Object.entries(versions)) {
+    const { currentValue, fileReplacePosition } = extractLiteralVersion({
+      version,
+      depStartIndex: versionStartIndex,
+      depSubContent: versionSubContent,
+      sectionKey: key,
+    });
+    if (currentValue && fileReplacePosition !== undefined) {
+      vars[normalizeAlias(key)] = {
+        key: normalizeAlias(key),
+        value: currentValue,
+        fileReplacePosition,
+        packageFile,
+      };
+    }
+  }
+
   for (const libraryName of Object.keys(libs)) {
     const libDescriptor = libs[libraryName];
     const dependency = extractDependency({
@@ -308,5 +329,42 @@ export function parseCatalog(
   const deps = extractedDeps.map((dep) => {
     return deepmerge(dep, { managerData: { packageFile } });
   });
-  return deps;
+  return { vars, deps };
+}
+
+function makeCatalogGroupKey(
+  dep: PackageDependency<GradleManagerData>,
+): string {
+  return `${dep.managerData!.packageFile}:${dep.managerData!.fileReplacePosition}`;
+}
+
+export function unifyCatalogSharedVariableNames(
+  deps: PackageDependency<GradleManagerData>[],
+): void {
+  const aliasMap: Record<string, string[]> = {};
+  const catalogDeps: PackageDependency<GradleManagerData>[] = [];
+
+  for (const dep of deps) {
+    const packageFile = dep.managerData?.packageFile;
+    if (
+      packageFile &&
+      dep.managerData?.fileReplacePosition !== undefined &&
+      dep.sharedVariableName &&
+      isTOMLFile(packageFile)
+    ) {
+      catalogDeps.push(dep);
+
+      const key = makeCatalogGroupKey(dep);
+      (aliasMap[key] ??= []).push(dep.sharedVariableName);
+    }
+  }
+
+  for (const dep of catalogDeps) {
+    const key = makeCatalogGroupKey(dep);
+    const aliases = aliasMap[key];
+    if (aliases.length > 1) {
+      const name = aliases[0];
+      dep.sharedVariableName = name.replace(regEx(/^[^.]+\.versions\./), '');
+    }
+  }
 }

--- a/lib/modules/manager/gradle/parser/common.ts
+++ b/lib/modules/manager/gradle/parser/common.ts
@@ -210,6 +210,22 @@ export const qStringValueAsSymbol = q.str((ctx: Ctx, node: lexer.Token) => {
   return ctx;
 });
 
+// https://docs.gradle.org/current/javadoc/org/gradle/api/provider/Provider.html#get()
+export const qProviderValue = q
+  .tree({
+    maxDepth: 1,
+    type: 'wrapped-tree',
+    startsWith: '(',
+    endsWith: ')',
+    search: q.begin<Ctx>().end(),
+  })
+  .handler((ctx) => {
+    if (ctx.varTokens.length > 1 && ctx.varTokens.at(-1)?.value === 'get') {
+      ctx.varTokens.pop();
+    }
+    return ctx;
+  });
+
 // foo.bar["baz"] = "1.2.3"
 export const qVariableAssignmentIdentifier = q
   .sym(storeVarToken)
@@ -237,6 +253,7 @@ export const qVariableAccessIdentifier = q
     return ctx;
   })
   .join(qVariableAssignmentIdentifier)
+  .opt(qProviderValue)
   .handler(coalesceVariable)
   .handler((ctx) => {
     ctx.varTokens = [

--- a/lib/modules/manager/gradle/utils.spec.ts
+++ b/lib/modules/manager/gradle/utils.spec.ts
@@ -3,7 +3,9 @@ import {
   getVars,
   isDependencyString,
   isGradleBuildFile,
+  isGradleDefaultCatalogFile,
   isGradleScriptFile,
+  isGradleSettingsFile,
   isGradleVersionsFile,
   isKotlinSourceFile,
   isPropsFile,
@@ -12,6 +14,7 @@ import {
   reorderFiles,
   toAbsolutePath,
   updateVars,
+  updateVarsFromDefaultCatalog,
   versionLikeSubstring,
 } from './utils.ts';
 
@@ -103,6 +106,11 @@ describe('modules/manager/gradle/utils', () => {
     expect(isGradleScriptFile('/a/Somefile.gradle.kts')).toBeTrue();
     expect(isGradleScriptFile('/a/Somefile.gradle')).toBeTrue();
     expect(isGradleVersionsFile('/a/versions.gradle.kts')).toBeTrue();
+    expect(isGradleSettingsFile('/a/settings.gradle')).toBeTrue();
+    expect(isGradleSettingsFile('/a/settings.gradle.kts')).toBeTrue();
+    expect(
+      isGradleDefaultCatalogFile('/a/gradle/libs.versions.toml'),
+    ).toBeTrue();
     expect(isGradleBuildFile('/a/build.gradle')).toBeTrue();
     expect(isPropsFile('/a/gradle.properties')).toBeTrue();
     expect(isKotlinSourceFile('/a/Somefile.kt')).toBeTrue();
@@ -157,6 +165,58 @@ describe('modules/manager/gradle/utils', () => {
     expect(
       reorderFiles(['b.gradle', 'c.gradle', 'a.gradle', 'gradle.properties']),
     ).toStrictEqual(['gradle.properties', 'a.gradle', 'b.gradle', 'c.gradle']);
+
+    expect(
+      reorderFiles([
+        'b.gradle',
+        'settings.gradle',
+        'gradle/libs.versions.toml',
+        'gradle.properties',
+      ]),
+    ).toStrictEqual([
+      'gradle.properties',
+      'settings.gradle',
+      'gradle/libs.versions.toml',
+      'b.gradle',
+    ]);
+
+    expect(
+      reorderFiles([
+        'independent-project-in-subfolder/some.gradle',
+        'build.gradle',
+        'independent-project-in-subfolder/gradle/libs.versions.toml',
+        'settings.gradle',
+        'gradle/libs.versions.toml',
+        'independent-project-in-subfolder/gradle.properties',
+        'gradle.properties',
+        'gradle/commonLibs.versions.toml',
+        'b/another.gradle',
+        'independent-project-in-subfolder/settings.gradle',
+        'someothergradle.gradle',
+        'z/some.gradle',
+        'gradle/whatever.gradle',
+        'o/build.gradle',
+        'a/some.gradle',
+        'o/settings.gradle',
+      ]),
+    ).toStrictEqual([
+      'gradle.properties',
+      'settings.gradle',
+      'gradle/libs.versions.toml',
+      'someothergradle.gradle',
+      'build.gradle',
+      'a/some.gradle',
+      'b/another.gradle',
+      'gradle/commonLibs.versions.toml',
+      'gradle/whatever.gradle',
+      'independent-project-in-subfolder/gradle.properties',
+      'independent-project-in-subfolder/settings.gradle',
+      'independent-project-in-subfolder/gradle/libs.versions.toml',
+      'independent-project-in-subfolder/some.gradle',
+      'o/settings.gradle',
+      'o/build.gradle',
+      'z/some.gradle',
+    ]);
 
     expect(
       reorderFiles([
@@ -238,6 +298,113 @@ describe('modules/manager/gradle/utils', () => {
         bar: { key: 'bar', value: 'bar' },
         baz: { key: 'baz', value: 'baz' },
         qux: { key: 'qux', value: 'qux' },
+      });
+    });
+  });
+
+  describe('updateVarsFromDefaultCatalog', () => {
+    it('no default catalog file', () => {
+      const registry: VariableRegistry = {};
+      updateVarsFromDefaultCatalog(
+        registry,
+        '/a/gradle',
+        '/a/gradle/other-catalog.toml',
+        {},
+      );
+      expect(registry).toStrictEqual({});
+    });
+
+    it('adds variables with default "libs" prefix', () => {
+      const registry: VariableRegistry = {};
+      const newVars: PackageVariables = {
+        kotlin: {
+          key: 'kotlin',
+          value: '1.5.21',
+          fileReplacePosition: 10,
+          packageFile: '/project/gradle/libs.versions.toml',
+        },
+        coroutines: {
+          key: 'coroutines',
+          value: '1.5.0',
+          fileReplacePosition: 40,
+          packageFile: '/project/gradle/libs.versions.toml',
+        },
+      };
+      updateVarsFromDefaultCatalog(
+        registry,
+        '/project/gradle',
+        '/project/gradle/libs.versions.toml',
+        newVars,
+      );
+
+      const res = getVars(registry, '/project/build.gradle');
+      expect(res).toStrictEqual({
+        'libs.versions.kotlin': {
+          key: 'libs.versions.kotlin',
+          value: '1.5.21',
+          fileReplacePosition: 10,
+          packageFile: '/project/gradle/libs.versions.toml',
+        },
+        'libs.versions.coroutines': {
+          key: 'libs.versions.coroutines',
+          value: '1.5.0',
+          fileReplacePosition: 40,
+          packageFile: '/project/gradle/libs.versions.toml',
+        },
+      });
+    });
+
+    it('adds variables with custom libraries extension name', () => {
+      const registry: VariableRegistry = {};
+      const newVars: PackageVariables = {
+        kotlin: {
+          key: 'kotlin',
+          value: '1.5.21',
+          fileReplacePosition: 10,
+          packageFile: '/project/gradle/libs.versions.toml',
+        },
+        coroutines: {
+          key: 'coroutines',
+          value: '1.5.0',
+          fileReplacePosition: 40,
+          packageFile: '/project/gradle/libs.versions.toml',
+        },
+      };
+      updateVars(registry, '/project', {
+        defaultLibrariesExtensionName: {
+          key: 'defaultLibrariesExtensionName',
+          value: 'myLibs',
+          fileReplacePosition: 50,
+          packageFile: '/project/settings.gradle',
+        },
+      });
+      updateVarsFromDefaultCatalog(
+        registry,
+        '/project/gradle',
+        '/project/gradle/libs.versions.toml',
+        newVars,
+      );
+
+      const res = getVars(registry, '/project/build.gradle');
+      expect(res).toStrictEqual({
+        defaultLibrariesExtensionName: {
+          key: 'defaultLibrariesExtensionName',
+          value: 'myLibs',
+          fileReplacePosition: 50,
+          packageFile: '/project/settings.gradle',
+        },
+        'myLibs.versions.kotlin': {
+          key: 'myLibs.versions.kotlin',
+          value: '1.5.21',
+          fileReplacePosition: 10,
+          packageFile: '/project/gradle/libs.versions.toml',
+        },
+        'myLibs.versions.coroutines': {
+          key: 'myLibs.versions.coroutines',
+          value: '1.5.0',
+          fileReplacePosition: 40,
+          packageFile: '/project/gradle/libs.versions.toml',
+        },
       });
     });
   });

--- a/lib/modules/manager/gradle/utils.ts
+++ b/lib/modules/manager/gradle/utils.ts
@@ -78,6 +78,7 @@ export function parseDependencyString(
 
 const gradleVersionsFileRegex = regEx('^versions\\.gradle(?:\\.kts)?$', 'i');
 const gradleBuildFileRegex = regEx('^build\\.gradle(?:\\.kts)?$', 'i');
+const gradleSettingsFileRegex = regEx('^settings\\.gradle(?:\\.kts)?$', 'i');
 
 export function isGradleScriptFile(path: string): boolean {
   const filename = upath.basename(path).toLowerCase();
@@ -92,6 +93,15 @@ export function isGradleVersionsFile(path: string): boolean {
 export function isGradleBuildFile(path: string): boolean {
   const filename = upath.basename(path);
   return gradleBuildFileRegex.test(filename);
+}
+
+export function isGradleSettingsFile(path: string): boolean {
+  const filename = upath.basename(path);
+  return gradleSettingsFileRegex.test(filename);
+}
+
+export function isGradleDefaultCatalogFile(path: string): boolean {
+  return path.endsWith('/gradle/libs.versions.toml');
 }
 
 export function isPropsFile(path: string): boolean {
@@ -117,23 +127,33 @@ function getFileRank(filename: string): number {
   if (isPropsFile(filename)) {
     return 0;
   }
-  if (isGradleVersionsFile(filename)) {
+  if (isGradleSettingsFile(filename)) {
     return 1;
   }
-  if (isGradleBuildFile(filename)) {
+  if (isGradleDefaultCatalogFile(filename)) {
+    return 2;
+  }
+  if (isGradleVersionsFile(filename)) {
     return 3;
   }
-  return 2;
+  if (isGradleBuildFile(filename)) {
+    return 5;
+  }
+  return 4;
 }
 
 export function reorderFiles(packageFiles: string[]): string[] {
   return packageFiles
     .map((path) => {
       const absPath = toAbsolutePath(path);
+      const currentDir = upath.dirname(absPath);
+
       return {
         path,
         absPath,
-        dir: upath.dirname(absPath),
+        dir: isGradleDefaultCatalogFile(absPath)
+          ? upath.dirname(currentDir)
+          : currentDir,
         rank: getFileRank(absPath),
       };
     })
@@ -176,4 +196,33 @@ export function updateVars(
 ): void {
   const oldVars = registry[dir] ?? {};
   registry[dir] = { ...oldVars, ...newVars };
+}
+
+export function updateVarsFromDefaultCatalog(
+  registry: VariableRegistry,
+  dir: string,
+  packageFile: string,
+  newVars: PackageVariables,
+): void {
+  if (!isGradleDefaultCatalogFile(toAbsolutePath(packageFile))) {
+    return;
+  }
+
+  const rootDir = upath.dirname(dir);
+  const oldVars = registry[rootDir] ?? {};
+  let defaultLibsExtName = 'libs';
+  if (
+    oldVars.defaultLibrariesExtensionName?.packageFile &&
+    isGradleSettingsFile(oldVars.defaultLibrariesExtensionName.packageFile)
+  ) {
+    defaultLibsExtName = oldVars.defaultLibrariesExtensionName.value;
+  }
+
+  const newVarsRemapped: PackageVariables = {};
+  for (const [oldKey, variableData] of Object.entries(newVars)) {
+    const key = `${defaultLibsExtName}.versions.${oldKey}`;
+    newVarsRemapped[key] = { ...variableData, key };
+  }
+
+  registry[rootDir] = { ...oldVars, ...newVarsRemapped };
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Renovate supports Gradle version catalogs via `gradle/libs.versions.toml`, but until now it could not resolve version references accessed through the implicit catalog accessor syntax, e.g. `libs.versions.detekt.get()` or `${libs.versions.kotlin.get()}` in gradle build files. These references were silently dropped, leaving those dependencies unmanaged.

This PR allows to update Gradle dependency versions that are referenced through version catalog accessor syntax (`libs.versions.foo.get()`) in build files. What it does precisely:

- **Reorder file processing** to guarantee settings -> catalog -> build files, ensuring the extension name and catalog variables are registered before build files are parsed
- **Extract catalog versions into the variable registry** so that  `libs.versions.<name>` and custom extension names configured via `defaultLibrariesExtensionName` are available when parsing build files
- **Parse `.get()` calls** on `Provider<String>` accessors via an extension to `qProviderValue`, stripping the trailing `get` token before variable lookup
- **Unify `sharedVariableName`** across deps that share the same version position in the TOML, collapsing `projectLibs.versions.detekt` (from the build file) and `detekt` (from the catalog) into a single shared name. This is needed to avoid alias confusion, i.e., two PRs trying to update the same variable / dependency twice.

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

- https://github.com/renovatebot/renovate/discussions/40147

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/renovate-demo/40147-implicit-gradle-version-catalog-access

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
