### PR TITLE
fix(versioning/github-actions): allow `v1.2` to be treated as a version

### DIFF
--- a/lib/modules/versioning/github-actions/index.spec.ts
+++ b/lib/modules/versioning/github-actions/index.spec.ts
@@ -25,13 +25,13 @@ describe('modules/versioning/github-actions/index', () => {
     it.each`
       version           | expected
       ${'1'}            | ${false}
-      ${'1.2'}          | ${false}
+      ${'1.2'}          | ${true}
       ${'1.2.3'}        | ${true}
       ${'~latest'}      | ${false}
       ${'1.2.3-alpha'}  | ${true}
       ${'1.2.3-rc.1'}   | ${true}
       ${'v1'}           | ${false}
-      ${'v1.2'}         | ${false}
+      ${'v1.2'}         | ${true}
       ${'v1.2.3'}       | ${true}
       ${'v1.2.3-alpha'} | ${true}
       ${'v1.2.3-rc.1'}  | ${true}
@@ -60,6 +60,8 @@ describe('modules/versioning/github-actions/index', () => {
       ${'1.0.0'}          | ${true}
       ${'v1.0.0'}         | ${true}
       ${'v1.0.0-alpha'}   | ${false}
+      ${'1.2'}            | ${true}
+      ${'v1.2'}           | ${true}
       ${'1'}              | ${false}
       ${'not-a-version'}  | ${false}
     `('isStable("$version") === $expected', ({ version, expected }) => {
@@ -229,6 +231,9 @@ describe('modules/versioning/github-actions/index', () => {
       ${'v1.0.0'}  | ${'1.1'}     | ${true}
       ${'v2.0.0'}  | ${'1'}       | ${false}
       ${'2.0.0'}   | ${'v1'}      | ${false}
+      ${'v1.2'}    | ${'v1.3'}    | ${true}
+      ${'v1.3'}    | ${'v1.2'}    | ${false}
+      ${'v1.2'}    | ${'v1.2'}    | ${false}
     `(
       'isLessThanRange("$version", "$range") === $expected',
       ({ version, range, expected }) => {
@@ -251,6 +256,10 @@ describe('modules/versioning/github-actions/index', () => {
       ${'1.0.0'}   | ${'v1.0.0'}  | ${true}
       ${'v1.0.0'}  | ${'1.0.1'}   | ${false}
       ${'1.0.1'}   | ${'v1.0.0'}  | ${false}
+      ${'v1.2'}    | ${'v1.2'}    | ${true}
+      ${'v1.2'}    | ${'v1.3'}    | ${false}
+      ${'v1.2'}    | ${'1.2'}     | ${true}
+      ${'v1'}      | ${'v1'}      | ${false}
     `(
       'equals("$version", "$other") === $expected',
       ({ version, other, expected }) => {
@@ -266,6 +275,7 @@ describe('modules/versioning/github-actions/index', () => {
       ${'2.3.4'}   | ${2}
       ${'v1.0.0'}  | ${1}
       ${'v2.3.4'}  | ${2}
+      ${'v1.2'}    | ${1}
       ${'invalid'} | ${null}
     `('getMajor("$version") === $expected', ({ version, expected }) => {
       expect(githubActions.getMajor(version)).toBe(expected);
@@ -279,6 +289,7 @@ describe('modules/versioning/github-actions/index', () => {
       ${'2.3.4'}   | ${3}
       ${'v1.0.0'}  | ${0}
       ${'v2.3.4'}  | ${3}
+      ${'v1.2'}    | ${2}
       ${'invalid'} | ${null}
     `('getMinor("$version") === $expected', ({ version, expected }) => {
       expect(githubActions.getMinor(version)).toBe(expected);
@@ -292,6 +303,7 @@ describe('modules/versioning/github-actions/index', () => {
       ${'2.3.4'}   | ${4}
       ${'v1.0.0'}  | ${0}
       ${'v2.3.4'}  | ${4}
+      ${'v1.2'}    | ${0}
       ${'invalid'} | ${null}
     `('getPatch("$version") === $expected', ({ version, expected }) => {
       expect(githubActions.getPatch(version)).toBe(expected);
@@ -315,6 +327,11 @@ describe('modules/versioning/github-actions/index', () => {
       ${'2.0.0'}   | ${'v1.0.0'}  | ${true}
       ${'v1.9.9'}  | ${'1.9.8'}   | ${true}
       ${'1.9.9'}   | ${'v1.9.8'}  | ${true}
+      ${'v1.3'}    | ${'v1.2'}    | ${true}
+      ${'v1.2'}    | ${'v1.3'}    | ${false}
+      ${'v1.3.0'}  | ${'v1.2'}    | ${true}
+      ${'v1.2'}    | ${'v1.2'}    | ${false}
+      ${'v1'}      | ${'v1.2'}    | ${false}
     `(
       'isGreaterThan("$version", "$other") === $expected',
       ({ version, other, expected }) => {
@@ -340,6 +357,10 @@ describe('modules/versioning/github-actions/index', () => {
       ${'1.0.0'}   | ${'v1.0.0'}  | ${0}
       ${'v1.0.0'}  | ${'1.0.1'}   | ${-1}
       ${'1.0.1'}   | ${'v1.0.0'}  | ${1}
+      ${'v1.3'}    | ${'v1.2'}    | ${1}
+      ${'v1.2'}    | ${'v1.3'}    | ${-1}
+      ${'v1.2'}    | ${'v1.2'}    | ${0}
+      ${'v1.3'}    | ${'v1.3.0'}  | ${0}
     `('sortVersions("$a", "$b") === $expected', ({ a, b, expected }) => {
       expect(githubActions.sortVersions(a, b)).toBe(expected);
     });

--- a/lib/modules/versioning/github-actions/index.ts
+++ b/lib/modules/versioning/github-actions/index.ts
@@ -41,6 +41,22 @@ function parseRange(input: string): Range | null {
   return { major, minor };
 }
 
+/*
+ * Like parseVersion but also accepts floating minor-level tags (e.g. `v1.2`)
+ * by coercing them to full semver. Rejects major-only tags (e.g. `v1`).
+ */
+function parseVersionCoerced(input: string): SemVer | null {
+  const v = parseVersion(input);
+  if (v) {
+    return v;
+  }
+  const stripped = massageValue(input);
+  if (regEx(/^\d+$/).test(stripped)) {
+    return null;
+  }
+  return semver.coerce(stripped);
+}
+
 function isValid(input: string): boolean {
   return !!parseVersion(input) || !!parseRange(input);
 }
@@ -50,11 +66,21 @@ function isVersion(input: string | undefined | null): boolean {
     return false;
   }
 
-  return !!parseVersion(input);
+  if (parseVersion(input)) {
+    return true;
+  }
+
+  const stripped = massageValue(input);
+  if (!regEx(/^\d/).test(stripped)) {
+    return false;
+  }
+
+  const r = parseRange(input);
+  return r !== null && !isUndefined(r.minor);
 }
 
 function isStable(version: string): boolean {
-  const v = parseVersion(version);
+  const v = parseVersionCoerced(version);
   if (!v) {
     return false;
   }
@@ -63,24 +89,24 @@ function isStable(version: string): boolean {
 }
 
 function isSingleVersion(input: string): boolean {
-  return isVersion(input);
+  return !!parseVersion(input);
 }
 
 function getMajor(version: string): number | null {
-  return parseVersion(version)?.major ?? null;
+  return parseVersionCoerced(version)?.major ?? null;
 }
 
 function getMinor(version: string): number | null {
-  return parseVersion(version)?.minor ?? null;
+  return parseVersionCoerced(version)?.minor ?? null;
 }
 
 function getPatch(version: string): number | null {
-  return parseVersion(version)?.patch ?? null;
+  return parseVersionCoerced(version)?.patch ?? null;
 }
 
 function sortVersions(x: string, y: string): number {
-  const a = parseVersion(x);
-  const b = parseVersion(y);
+  const a = parseVersionCoerced(x);
+  const b = parseVersionCoerced(y);
   if (!a || !b) {
     return 0;
   }
@@ -88,8 +114,8 @@ function sortVersions(x: string, y: string): number {
 }
 
 function equals(x: string, y: string): boolean {
-  const a = parseVersion(x);
-  const b = parseVersion(y);
+  const a = parseVersionCoerced(x);
+  const b = parseVersionCoerced(y);
   if (!a || !b) {
     return false;
   }
@@ -97,8 +123,8 @@ function equals(x: string, y: string): boolean {
 }
 
 function isGreaterThan(x: string, y: string): boolean {
-  const a = parseVersion(x);
-  const b = parseVersion(y);
+  const a = parseVersionCoerced(x);
+  const b = parseVersionCoerced(y);
   if (!a || !b) {
     return false;
   }
@@ -163,7 +189,7 @@ function minSatisfyingVersion(
 }
 
 function isLessThanRange(version: string, range: string): boolean {
-  const v = parseVersion(version);
+  const v = parseVersionCoerced(version);
   const r = parseRange(range);
 
   if (!v || !r) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
When using `docker` versioning, we correctly treat a `v1.2` -> `v1.3`
version update as valid.

However, when using the previous implementation of `github-actions`'
versioning, we would silently ignore them, filtering them in
`filterValidVersions`.

This leads to cases where a `v1.2` would be upgraded to `v1.3.0`, which
wasn't correct.





## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe): Claude Sonnet 4.6

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/JamieTanna-Mend-testing/setup-uv/pull/7 (previously, would update to `v7.6.0` in `.github/workflows/ci-another.yml`)

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
