### PR TITLE
fix(versioning/github-actions): correctly handle `major.minor` and `major`

### DIFF
--- a/lib/modules/manager/github-actions/integration.spec.ts
+++ b/lib/modules/manager/github-actions/integration.spec.ts
@@ -1,0 +1,947 @@
+import { codeBlock } from 'common-tags';
+import * as httpMock from '~test/http-mock.ts';
+import { partial } from '~test/util.ts';
+import { getConfig } from '../../../config/defaults.ts';
+import * as hostRules from '../../../util/host-rules.ts';
+import { Result } from '../../../util/result.ts';
+import * as lookup from '../../../workers/repository/process/lookup/index.ts';
+import type { LookupUpdateConfig } from '../../../workers/repository/process/lookup/types.ts';
+import { GithubTagsDatasource } from '../../datasource/github-tags/index.ts';
+import { id as githubActionsVersioningId } from '../../versioning/github-actions/index.ts';
+import type { PackageDependency } from '../types.ts';
+import { extractPackageFile } from './index.ts';
+
+describe('modules/manager/github-actions/integration', () => {
+  describe('when using versioning=github-actions', () => {
+    const getGithubTags = vi.spyOn(
+      GithubTagsDatasource.prototype,
+      'getReleases',
+    );
+    const getGithubDigest = vi.spyOn(
+      GithubTagsDatasource.prototype,
+      'getDigest',
+    );
+
+    let baseConfig: LookupUpdateConfig;
+
+    beforeEach(() => {
+      // TODO: fix types #22198
+      baseConfig = partial<LookupUpdateConfig>(getConfig() as never);
+      baseConfig.manager = 'github-actions';
+    });
+
+    afterEach(() => {
+      httpMock.clear(false);
+      hostRules.clear();
+    });
+
+    function makeConfig(dep: PackageDependency): LookupUpdateConfig {
+      return {
+        ...baseConfig,
+        ...dep,
+        currentValue: dep.currentValue ?? undefined,
+        // isGetPkgReleasesConfig() requires a non-empty packageName, even though `extractPackageFile` does not set a `packageName` if it has the same value as `depName`
+        packageName: dep.packageName ?? dep.depName!,
+        // Override dep's default 'docker' versioning with 'github-actions', as if configured through packageRules
+        versioning: githubActionsVersioningId,
+      };
+    }
+
+    it('proposes major update when using tagged major, if a major is available', async () => {
+      const workflow = codeBlock`
+      on: push
+      jobs:
+        test:
+          runs-on: ubuntu-latest
+          steps:
+            - uses: actions/checkout@v1
+    `;
+
+      const extracted = extractPackageFile(
+        workflow,
+        '.github/workflows/test.yml',
+        {},
+      );
+      expect(extracted).not.toBeNull();
+
+      const dep = extracted!.deps.find((d) => d.depName === 'actions/checkout');
+      expect(dep).toBeDefined();
+
+      getGithubTags.mockResolvedValueOnce({
+        releases: [
+          { version: 'v1.0.0' },
+          // additional majors to show they're skipped, as expected
+          { version: 'v2' },
+          { version: 'v3' },
+          // this will be used as it's the shortest match
+          { version: 'v4' },
+          // these are added to make it clear they won't be used
+          { version: 'v4.0' },
+          { version: 'v4.0.0' },
+          { version: 'v4.1.0' },
+        ],
+      });
+
+      const { updates } = await Result.wrap(
+        lookup.lookupUpdates(makeConfig(dep!)),
+      ).unwrapOrThrow();
+
+      expect(updates).toEqual([
+        {
+          bucket: 'major',
+          hasAttestation: undefined,
+          isBreaking: false,
+          newMajor: 4,
+          newMinor: 1,
+          newPatch: 0,
+          newValue: 'v4',
+          newVersion: 'v4.1.0',
+          updateType: 'major',
+        },
+      ]);
+    });
+
+    it('switches major-only version to major.minor if no major is available', async () => {
+      const workflow = codeBlock`
+      on: push
+      jobs:
+        test:
+          runs-on: ubuntu-latest
+          steps:
+            - uses: actions/checkout@v1
+    `;
+
+      const extracted = extractPackageFile(
+        workflow,
+        '.github/workflows/test.yml',
+        {},
+      );
+      expect(extracted).not.toBeNull();
+
+      const dep = extracted!.deps.find((d) => d.depName === 'actions/checkout');
+      expect(dep).toBeDefined();
+
+      getGithubTags.mockResolvedValueOnce({
+        releases: [
+          { version: 'v1.0.0' },
+          { version: 'v2' },
+          { version: 'v3' },
+          // no major
+          { version: 'v4.1' },
+          // this will not be used as a shorter version is available
+          { version: 'v4.1.0' },
+        ],
+      });
+
+      const { updates } = await Result.wrap(
+        lookup.lookupUpdates(makeConfig(dep!)),
+      ).unwrapOrThrow();
+
+      expect(updates).toEqual([
+        {
+          bucket: 'major',
+          hasAttestation: undefined,
+          isBreaking: false,
+          newMajor: 4,
+          newMinor: 1,
+          newPatch: 0,
+          newValue: 'v4.1',
+          newVersion: 'v4.1.0',
+          updateType: 'major',
+        },
+      ]);
+    });
+
+    it('proposes major and minor updates for tagged major.minor', async () => {
+      const workflow = codeBlock`
+      on: push
+      jobs:
+        test:
+          runs-on: ubuntu-latest
+          steps:
+            - uses: actions/checkout@v1.2
+    `;
+
+      const extracted = extractPackageFile(
+        workflow,
+        '.github/workflows/test.yml',
+        {},
+      );
+      expect(extracted).not.toBeNull();
+
+      const dep = extracted!.deps.find((d) => d.depName === 'actions/checkout');
+      expect(dep).toBeDefined();
+
+      getGithubTags.mockResolvedValueOnce({
+        releases: [
+          { version: 'v1' },
+          { version: 'v1.2.0' },
+          { version: 'v1.6.0' },
+          { version: 'v2.0.0' },
+          { version: 'v3.0.0' },
+          { version: 'v4.0.0' },
+          { version: 'v4.1' },
+          // this will not be used, as it's longer than what we're currently using
+          { version: 'v4.1.0' },
+        ],
+      });
+
+      const { updates } = await Result.wrap(
+        lookup.lookupUpdates(makeConfig(dep!)),
+      ).unwrapOrThrow();
+
+      expect(updates).toEqual([
+        {
+          bucket: 'non-major',
+          hasAttestation: undefined,
+          isBreaking: false,
+          newMajor: 1,
+          newMinor: 6,
+          newPatch: 0,
+          // a non-major bump gets a longer version, as there's no `v1.6`
+          newValue: 'v1.6.0',
+          newVersion: 'v1.6.0',
+          updateType: 'minor',
+        },
+        {
+          bucket: 'major',
+          hasAttestation: undefined,
+          isBreaking: false,
+          newMajor: 4,
+          newMinor: 1,
+          newPatch: 0,
+          newValue: 'v4.1',
+          newVersion: 'v4.1.0',
+          updateType: 'major',
+        },
+      ]);
+    });
+
+    it('proposes minor update for full semver', async () => {
+      const workflow = codeBlock`
+      on: push
+      jobs:
+        test:
+          runs-on: ubuntu-latest
+          steps:
+            - uses: actions/checkout@v4.0.0
+    `;
+
+      const extracted = extractPackageFile(
+        workflow,
+        '.github/workflows/test.yml',
+        {},
+      );
+      expect(extracted).not.toBeNull();
+
+      const dep = extracted!.deps.find((d) => d.depName === 'actions/checkout');
+      expect(dep).toBeDefined();
+
+      getGithubTags.mockResolvedValueOnce({
+        releases: [
+          // won't be used, even though it's shorter than our current tagging
+          { version: 'v4' },
+          { version: 'v4.0.0' },
+          { version: 'v4.1.0' },
+          { version: 'v4.2.0' },
+        ],
+      });
+
+      const { updates } = await Result.wrap(
+        lookup.lookupUpdates(makeConfig(dep!)),
+      ).unwrapOrThrow();
+
+      expect(updates).toEqual([
+        {
+          bucket: 'non-major',
+          hasAttestation: undefined,
+          isBreaking: false,
+          newMajor: 4,
+          newMinor: 2,
+          newPatch: 0,
+          newValue: 'v4.2.0',
+          newVersion: 'v4.2.0',
+          updateType: 'minor',
+        },
+      ]);
+    });
+
+    it('proposes updates for SHA-pinned action with major-only comment', async () => {
+      const workflow = codeBlock`
+      on: push
+      jobs:
+        build:
+          runs-on: ubuntu-latest
+          steps:
+            - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+    `;
+
+      const extracted = extractPackageFile(
+        workflow,
+        '.github/workflows/ci-pinning.yml',
+        {},
+      );
+      expect(extracted).not.toBeNull();
+
+      const dep = extracted!.deps.find((d) => d.depName === 'actions/checkout');
+      expect(dep).toBeDefined();
+
+      getGithubTags.mockResolvedValueOnce({
+        releases: [
+          { version: 'v5.0.0' },
+          { version: 'v5.1.0' },
+          { version: 'v6.0.0' },
+          { version: 'v6.1.0' },
+        ],
+      });
+      // getDigest is called once per update (major version + digest update)
+      getGithubDigest
+        .mockResolvedValueOnce(
+          'aaaaaaaabbbbbbbbccccccccddddddddeeeeeeee11111111',
+        ) // v6.1.0
+        .mockResolvedValueOnce(
+          'ffffffffffffffffffffffffffffffffffffffff22222222',
+        ); // digest (v5)
+
+      const { updates } = await Result.wrap(
+        lookup.lookupUpdates(makeConfig(dep!)),
+      ).unwrapOrThrow();
+
+      expect(updates).toEqual([
+        {
+          bucket: 'major',
+          hasAttestation: undefined,
+          isBreaking: false,
+          newDigest: 'aaaaaaaabbbbbbbbccccccccddddddddeeeeeeee11111111',
+          newMajor: 6,
+          newMinor: 1,
+          newPatch: 0,
+          newValue: 'v6.1.0',
+          newVersion: 'v6.1.0',
+          updateType: 'major',
+        },
+        {
+          newDigest: 'ffffffffffffffffffffffffffffffffffffffff22222222',
+          newValue: 'v5',
+          updateType: 'digest',
+        },
+      ]);
+    });
+
+    it('proposes updates for SHA-pinned action with major.minor comment', async () => {
+      const workflow = codeBlock`
+      on: push
+      jobs:
+        build:
+          runs-on: ubuntu-latest
+          steps:
+            - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0
+    `;
+
+      const extracted = extractPackageFile(
+        workflow,
+        '.github/workflows/ci-pinning.yml',
+        {},
+      );
+      expect(extracted).not.toBeNull();
+
+      const dep = extracted!.deps.find((d) => d.depName === 'actions/checkout');
+      expect(dep).toBeDefined();
+
+      getGithubTags.mockResolvedValueOnce({
+        releases: [
+          { version: 'v5.0.0' },
+          { version: 'v5.1' },
+          { version: 'v5.1.0' },
+          { version: 'v6.0.0' },
+          { version: 'v6.1.0' },
+        ],
+      });
+      // getDigest is called once per update (major version + digest update)
+      getGithubDigest
+        .mockResolvedValueOnce(
+          'bbbbbbbbcccccccccceeeeeeeeefffffaaaaaa1111111112',
+        ) // v5.1.0
+        .mockResolvedValueOnce(
+          'aaaaaaaabbbbbbbbccccccccddddddddeeeeeeee11111111',
+        ) // v6.1.0
+        .mockResolvedValueOnce(
+          'ffffffffffffffffffffffffffffffffffffffff22222222',
+        ); // digest (v5)
+
+      const { updates } = await Result.wrap(
+        lookup.lookupUpdates(makeConfig(dep!)),
+      ).unwrapOrThrow();
+
+      expect(updates).toEqual([
+        {
+          bucket: 'non-major',
+          hasAttestation: undefined,
+          isBreaking: false,
+          newDigest: 'bbbbbbbbcccccccccceeeeeeeeefffffaaaaaa1111111112',
+          newMajor: 5,
+          newMinor: 1,
+          newPatch: 0,
+          newValue: 'v5.1',
+          newVersion: 'v5.1.0',
+          updateType: 'minor',
+        },
+        {
+          bucket: 'major',
+          hasAttestation: undefined,
+          isBreaking: false,
+          newDigest: 'aaaaaaaabbbbbbbbccccccccddddddddeeeeeeee11111111',
+          newMajor: 6,
+          newMinor: 1,
+          newPatch: 0,
+          newValue: 'v6.1.0',
+          newVersion: 'v6.1.0',
+          updateType: 'major',
+        },
+        {
+          newDigest: 'ffffffffffffffffffffffffffffffffffffffff22222222',
+          newValue: 'v5.0',
+          updateType: 'digest',
+        },
+      ]);
+    });
+
+    it('proposes updates for SHA-pinned action with full semver comment', async () => {
+      const workflow = codeBlock`
+      on: push
+      jobs:
+        build:
+          runs-on: ubuntu-latest
+          steps:
+            - uses: astral-sh/setup-uv@e06108dd0aef18192324c70427afc47652e63a82 # v7.5.0
+    `;
+
+      const extracted = extractPackageFile(
+        workflow,
+        '.github/workflows/ci-pinning-semver.yml',
+        {},
+      );
+      expect(extracted).not.toBeNull();
+
+      const dep = extracted!.deps.find(
+        (d) => d.depName === 'astral-sh/setup-uv',
+      );
+      expect(dep).toBeDefined();
+
+      getGithubTags.mockResolvedValueOnce({
+        releases: [
+          { version: 'v7.5.0' },
+          { version: 'v7.6.0' },
+          { version: 'v8.0.0' },
+        ],
+      });
+      // getDigest is called once per update (minor + major + digest update)
+      getGithubDigest
+        .mockResolvedValueOnce(
+          'aaaaaaaabbbbbbbbccccccccddddddddeeeeeeee11111111',
+        ) // v7.6.0
+        .mockResolvedValueOnce(
+          'ffffffffffffffffffffffffffffffffffffffff22222222',
+        ) // v8.0.0
+        .mockResolvedValueOnce(
+          '1111111122222222333333334444444455555555aaaaaaaa',
+        ); // digest (v7.5.0)
+
+      const { updates } = await Result.wrap(
+        lookup.lookupUpdates(makeConfig(dep!)),
+      ).unwrapOrThrow();
+
+      expect(updates).toEqual([
+        {
+          bucket: 'non-major',
+          hasAttestation: undefined,
+          isBreaking: false,
+          newDigest: 'aaaaaaaabbbbbbbbccccccccddddddddeeeeeeee11111111',
+          newMajor: 7,
+          newMinor: 6,
+          newPatch: 0,
+          newValue: 'v7.6.0',
+          newVersion: 'v7.6.0',
+          updateType: 'minor',
+        },
+        {
+          bucket: 'major',
+          hasAttestation: undefined,
+          isBreaking: false,
+          newDigest: 'ffffffffffffffffffffffffffffffffffffffff22222222',
+          newMajor: 8,
+          newMinor: 0,
+          newPatch: 0,
+          newValue: 'v8.0.0',
+          newVersion: 'v8.0.0',
+          updateType: 'major',
+        },
+        {
+          newDigest: '1111111122222222333333334444444455555555aaaaaaaa',
+          newValue: 'v7.5.0',
+          updateType: 'digest',
+        },
+      ]);
+    });
+
+    it('proposes minor and major updates for floating minor tag', async () => {
+      const workflow = codeBlock`
+      on: push
+      jobs:
+        build:
+          runs-on: ubuntu-latest
+          steps:
+            - uses: actions/checkout@v4
+            - uses: astral-sh/setup-uv@v7.5
+    `;
+
+      const extracted = extractPackageFile(
+        workflow,
+        '.github/workflows/ci-another.yml',
+        {},
+      );
+      expect(extracted).not.toBeNull();
+
+      const dep = extracted!.deps.find(
+        (d) => d.depName === 'astral-sh/setup-uv',
+      );
+      expect(dep).toBeDefined();
+
+      getGithubTags.mockResolvedValueOnce({
+        releases: [
+          { version: 'v7.5' },
+          { version: 'v7.5.0' },
+          { version: 'v7.5.1' },
+          { version: 'v7.6' },
+          { version: 'v7.6.0' },
+          // for instance, now using Immutable Releases so requiring full SemVer
+          { version: 'v8.0.0' },
+          { version: 'v8.1.0' },
+        ],
+      });
+
+      const { updates } = await Result.wrap(
+        lookup.lookupUpdates(makeConfig(dep!)),
+      ).unwrapOrThrow();
+
+      expect(updates).toEqual([
+        {
+          bucket: 'non-major',
+          hasAttestation: undefined,
+          isBreaking: false,
+          newMajor: 7,
+          newMinor: 6,
+          newPatch: 0,
+          newValue: 'v7.6',
+          newVersion: 'v7.6.0',
+          updateType: 'minor',
+        },
+        {
+          bucket: 'major',
+          hasAttestation: undefined,
+          isBreaking: false,
+          newMajor: 8,
+          newMinor: 1,
+          newPatch: 0,
+          newValue: 'v8.1.0',
+          newVersion: 'v8.1.0',
+          updateType: 'major',
+        },
+      ]);
+    });
+
+    it('proposes no update for major, when only newer patch/minor releases exist', async () => {
+      const workflow = codeBlock`
+      on: push
+      jobs:
+        build:
+          runs-on: ubuntu-latest
+          steps:
+            - uses: actions/checkout@v4
+    `;
+
+      const extracted = extractPackageFile(
+        workflow,
+        '.github/workflows/ci.yml',
+        {},
+      );
+      expect(extracted).not.toBeNull();
+
+      const dep = extracted!.deps.find((d) => d.depName === 'actions/checkout');
+      expect(dep).toBeDefined();
+
+      getGithubTags.mockResolvedValueOnce({
+        releases: [
+          { version: 'v4.0.0' },
+          { version: 'v4.3.1' },
+          // no v4.3 floating tag
+        ],
+      });
+
+      const { updates } = await Result.wrap(
+        lookup.lookupUpdates(makeConfig(dep!)),
+      ).unwrapOrThrow();
+
+      expect(updates).toEqual([]);
+    });
+
+    it('proposes minor+major+digest updates for SHA-pinned with floating major comment', async () => {
+      const workflow = codeBlock`
+      on: push
+      jobs:
+        build:
+          runs-on: ubuntu-latest
+          steps:
+            - uses: astral-sh/setup-uv@e06108dd0aef18192324c70427afc47652e63a82 # v7
+    `;
+
+      const extracted = extractPackageFile(
+        workflow,
+        '.github/workflows/ci-pinning-best-practices.yml',
+        {},
+      );
+      expect(extracted).not.toBeNull();
+
+      const dep = extracted!.deps.find(
+        (d) => d.depName === 'astral-sh/setup-uv',
+      );
+      expect(dep).toBeDefined();
+
+      getGithubTags.mockResolvedValueOnce({
+        releases: [
+          { version: 'v7.5.0' },
+          { version: 'v7.6' },
+          { version: 'v7.6.0' },
+          { version: 'v8.0.0' },
+          { version: 'v8.1.0' },
+        ],
+      });
+      getGithubDigest
+        .mockResolvedValueOnce(
+          'aaaaaaaabbbbbbbbccccccccddddddddeeeeeeee11111111',
+        ) // v8.1.0 major
+        .mockResolvedValueOnce(
+          'ffffffffffffffffffffffffffffffffffffffff22222222',
+        ); // digest (v7)
+
+      const { updates } = await Result.wrap(
+        lookup.lookupUpdates(makeConfig(dep!)),
+      ).unwrapOrThrow();
+
+      expect(updates).toEqual([
+        {
+          bucket: 'major',
+          hasAttestation: undefined,
+          isBreaking: false,
+          newDigest: 'aaaaaaaabbbbbbbbccccccccddddddddeeeeeeee11111111',
+          newMajor: 8,
+          newMinor: 1,
+          newPatch: 0,
+          newValue: 'v8.1.0',
+          newVersion: 'v8.1.0',
+          updateType: 'major',
+        },
+        {
+          newDigest: 'ffffffffffffffffffffffffffffffffffffffff22222222',
+          newValue: 'v7',
+          updateType: 'digest',
+        },
+      ]);
+    });
+
+    it('proposes no update for SHA-pinned when only patch version available and digest unchanged', async () => {
+      const workflow = codeBlock`
+      on: push
+      jobs:
+        build:
+          runs-on: ubuntu-latest
+          steps:
+            - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+    `;
+
+      const extracted = extractPackageFile(
+        workflow,
+        '.github/workflows/ci-pinning.yml',
+        {},
+      );
+      expect(extracted).not.toBeNull();
+
+      const dep = extracted!.deps.find((d) => d.depName === 'actions/checkout');
+      expect(dep).toBeDefined();
+
+      getGithubTags.mockResolvedValueOnce({
+        releases: [{ version: 'v5.0.0' }, { version: 'v5.0.1' }],
+      });
+      // the same SHA as we're already using
+      getGithubDigest.mockResolvedValueOnce(
+        '93cb6efe18208431cddfb8368fd83d5badbf9bfd',
+      );
+
+      const { updates } = await Result.wrap(
+        lookup.lookupUpdates(makeConfig(dep!)),
+      ).unwrapOrThrow();
+
+      expect(updates).toEqual([]);
+    });
+
+    it('preserves floating major tag when newer patch/minor versions exist with full semver', async () => {
+      const workflow = codeBlock`
+      on: push
+      jobs:
+        build:
+          runs-on: ubuntu-latest
+          steps:
+            - uses: astral-sh/setup-uv@v7
+    `;
+
+      const extracted = extractPackageFile(
+        workflow,
+        '.github/workflows/ci.yml',
+        {},
+      );
+      expect(extracted).not.toBeNull();
+
+      const dep = extracted!.deps.find(
+        (d) => d.depName === 'astral-sh/setup-uv',
+      );
+      expect(dep).toBeDefined();
+
+      getGithubTags.mockResolvedValueOnce({
+        releases: [
+          { version: 'v7' },
+          { version: 'v7.5.0' },
+          { version: 'v7.6' },
+          { version: 'v7.6.0' },
+          { version: 'v8.0.0' },
+          { version: 'v8.1.0' },
+        ],
+      });
+
+      const { updates } = await Result.wrap(
+        lookup.lookupUpdates(makeConfig(dep!)),
+      ).unwrapOrThrow();
+
+      expect(updates).toEqual([
+        {
+          bucket: 'major',
+          hasAttestation: undefined,
+          isBreaking: false,
+          newMajor: 8,
+          newMinor: 1,
+          newPatch: 0,
+          newValue: 'v8.1.0',
+          newVersion: 'v8.1.0',
+          updateType: 'major',
+        },
+      ]);
+    });
+
+    it('preserves floating major tag when only floating minor tags exist', async () => {
+      const workflow = codeBlock`
+      on: push
+      jobs:
+        build:
+          runs-on: ubuntu-latest
+          steps:
+            - uses: astral-sh/setup-uv@v7
+    `;
+
+      const extracted = extractPackageFile(
+        workflow,
+        '.github/workflows/ci.yml',
+        {},
+      );
+      expect(extracted).not.toBeNull();
+
+      const dep = extracted!.deps.find(
+        (d) => d.depName === 'astral-sh/setup-uv',
+      );
+      expect(dep).toBeDefined();
+
+      getGithubTags.mockResolvedValueOnce({
+        releases: [{ version: 'v7' }, { version: 'v7.5' }, { version: 'v7.6' }],
+      });
+
+      const { updates } = await Result.wrap(
+        lookup.lookupUpdates(makeConfig(dep!)),
+      ).unwrapOrThrow();
+
+      expect(updates).toEqual([]);
+    });
+
+    it('migrates floating major tag to major.minor when only floating minor tags exist', async () => {
+      const workflow = codeBlock`
+      on: push
+      jobs:
+        build:
+          runs-on: ubuntu-latest
+          steps:
+            - uses: astral-sh/setup-uv@v7
+    `;
+
+      const extracted = extractPackageFile(
+        workflow,
+        '.github/workflows/ci.yml',
+        {},
+      );
+      expect(extracted).not.toBeNull();
+
+      const dep = extracted!.deps.find(
+        (d) => d.depName === 'astral-sh/setup-uv',
+      );
+      expect(dep).toBeDefined();
+
+      getGithubTags.mockResolvedValueOnce({
+        releases: [
+          // no major
+          { version: 'v7.5' },
+          { version: 'v7.6' },
+        ],
+      });
+
+      const { updates } = await Result.wrap(
+        lookup.lookupUpdates(makeConfig(dep!)),
+      ).unwrapOrThrow();
+
+      expect(updates).toEqual([
+        {
+          bucket: 'non-major',
+          hasAttestation: undefined,
+          isBreaking: false,
+          newMajor: 7,
+          newMinor: 6,
+          newPatch: 0,
+          newValue: 'v7.6',
+          newVersion: 'v7.6',
+          updateType: 'minor',
+        },
+      ]);
+    });
+
+    it('proposes minor update for floating minor tag without returning less-specific floating major', async () => {
+      const workflow = codeBlock`
+      on: push
+      jobs:
+        build:
+          runs-on: ubuntu-latest
+          steps:
+            - uses: astral-sh/setup-uv@v7.5
+    `;
+
+      const extracted = extractPackageFile(
+        workflow,
+        '.github/workflows/ci.yml',
+        {},
+      );
+      expect(extracted).not.toBeNull();
+
+      const dep = extracted!.deps.find(
+        (d) => d.depName === 'astral-sh/setup-uv',
+      );
+      expect(dep).toBeDefined();
+
+      getGithubTags.mockResolvedValueOnce({
+        releases: [
+          { version: 'v7' },
+          { version: 'v7.5.0' },
+          { version: 'v7.6' },
+          { version: 'v7.6.0' },
+        ],
+      });
+
+      const { updates } = await Result.wrap(
+        lookup.lookupUpdates(makeConfig(dep!)),
+      ).unwrapOrThrow();
+
+      expect(updates).toEqual([
+        {
+          bucket: 'non-major',
+          hasAttestation: undefined,
+          isBreaking: false,
+          newMajor: 7,
+          newMinor: 6,
+          newPatch: 0,
+          newValue: 'v7.6',
+          newVersion: 'v7.6.0',
+          updateType: 'minor',
+        },
+      ]);
+    });
+
+    it('handles multiple deps in one workflow', async () => {
+      const workflow = codeBlock`
+      on: push
+      jobs:
+        test:
+          runs-on: ubuntu-latest
+          steps:
+            - uses: actions/checkout@v1
+            - uses: actions/setup-node@v2
+    `;
+
+      const extracted = extractPackageFile(
+        workflow,
+        '.github/workflows/test.yml',
+        {},
+      );
+      expect(extracted).not.toBeNull();
+
+      const actionDeps = extracted!.deps.filter(
+        (d) => d.datasource === GithubTagsDatasource.id,
+      );
+      expect(actionDeps).toHaveLength(2);
+
+      getGithubTags
+        .mockResolvedValueOnce({
+          releases: [{ version: 'v1.0.0' }, { version: 'v4.0.0' }],
+        })
+        .mockResolvedValueOnce({
+          releases: [{ version: 'v2.0.0' }, { version: 'v4.0.0' }],
+        });
+
+      const results = await Promise.all(
+        actionDeps.map(async (dep) => {
+          const { updates } = await Result.wrap(
+            lookup.lookupUpdates(makeConfig(dep)),
+          ).unwrapOrThrow();
+          return { depName: dep.depName, updates };
+        }),
+      );
+
+      expect(results).toEqual([
+        {
+          depName: 'actions/checkout',
+          updates: [
+            {
+              bucket: 'major',
+              hasAttestation: undefined,
+              isBreaking: false,
+              newMajor: 4,
+              newMinor: 0,
+              newPatch: 0,
+              newValue: 'v4.0.0',
+              newVersion: 'v4.0.0',
+              updateType: 'major',
+            },
+          ],
+        },
+        {
+          depName: 'actions/setup-node',
+          updates: [
+            {
+              bucket: 'major',
+              hasAttestation: undefined,
+              isBreaking: false,
+              newMajor: 4,
+              newMinor: 0,
+              newPatch: 0,
+              newValue: 'v4.0.0',
+              newVersion: 'v4.0.0',
+              updateType: 'major',
+            },
+          ],
+        },
+      ]);
+    });
+  });
+});

--- a/lib/modules/manager/github-actions/integration.spec.ts
+++ b/lib/modules/manager/github-actions/integration.spec.ts
@@ -1,8 +1,6 @@
 import { codeBlock } from 'common-tags';
-import * as httpMock from '~test/http-mock.ts';
 import { partial } from '~test/util.ts';
 import { getConfig } from '../../../config/defaults.ts';
-import * as hostRules from '../../../util/host-rules.ts';
 import { Result } from '../../../util/result.ts';
 import * as lookup from '../../../workers/repository/process/lookup/index.ts';
 import type { LookupUpdateConfig } from '../../../workers/repository/process/lookup/types.ts';
@@ -28,11 +26,6 @@ describe('modules/manager/github-actions/integration', () => {
       // TODO: fix types #22198
       baseConfig = partial<LookupUpdateConfig>(getConfig() as never);
       baseConfig.manager = 'github-actions';
-    });
-
-    afterEach(() => {
-      httpMock.clear(false);
-      hostRules.clear();
     });
 
     function makeConfig(dep: PackageDependency): LookupUpdateConfig {

--- a/lib/modules/versioning/github-actions/index.spec.ts
+++ b/lib/modules/versioning/github-actions/index.spec.ts
@@ -658,6 +658,27 @@ describe('modules/versioning/github-actions/index', () => {
         expect(res).toEqual('v8.0.0-rc3');
       });
 
+      it('returns newVersion when newVersion is a floating tag and allVersions is not set', () => {
+        const res = githubActions.getNewValue({
+          currentValue: 'v7',
+          currentVersion: 'v7.6.0',
+          newVersion: 'v8',
+          rangeStrategy: 'replace',
+        });
+        expect(res).toEqual('v8');
+      });
+
+      it('returns the floating newVersion when it exists in allVersions', () => {
+        const res = githubActions.getNewValue({
+          currentValue: 'v7',
+          currentVersion: 'v7.6.0',
+          newVersion: 'v8',
+          rangeStrategy: 'replace',
+          allVersions: new Set(['v7.6.0', 'v8']),
+        });
+        expect(res).toEqual('v8');
+      });
+
       describe('if the newVersion is not found in allVersions', () => {
         // because this is not a valid case - if the newVersion wasn't found in allVersions, how would we have been called?
         it('newVersion is returned anyway', () => {

--- a/lib/modules/versioning/github-actions/index.spec.ts
+++ b/lib/modules/versioning/github-actions/index.spec.ts
@@ -545,6 +545,102 @@ describe('modules/versioning/github-actions/index', () => {
         expect(res).toEqual(expected);
       });
 
+      it.each([
+        {
+          description:
+            'newVersion is full semver, no floating minor in allVersions',
+          newVersion: 'v7.6.0',
+          allVersions: ['v7.5.0', 'v7.6.0'],
+        },
+        {
+          description:
+            'newVersion is full semver, floating minor tag also in allVersions',
+          newVersion: 'v7.6.0',
+          allVersions: ['v7.5.0', 'v7.6', 'v7.6.0'],
+        },
+        {
+          description:
+            'newVersion is itself a floating minor (v7.6) — real-world case when floating tags sort equal to their full-semver counterpart',
+          newVersion: 'v7.6',
+          allVersions: [
+            'v7.5.0',
+            'v7.6',
+            'v7.6.0',
+            // only if the v7 tag exists
+            'v7',
+          ],
+        },
+        {
+          description:
+            'newVersion is floating minor with no full semver counterpart in allVersions',
+          newVersion: 'v7.6',
+          allVersions: [
+            'v7.5.0',
+            'v7.6',
+            // only if the v7 tag exists
+            'v7',
+          ],
+        },
+      ])(
+        'preserves floating major for non-major updates ($description)',
+        ({ newVersion, allVersions }) => {
+          // When the user has @v7, they want to track the major. A non-major update
+          // should NOT narrow them to @v7.6 — the floating major should be preserved.
+          const res = githubActions.getNewValue({
+            currentValue: 'v7',
+            currentVersion: 'v7.0.0',
+            newVersion,
+            rangeStrategy: 'replace',
+            allVersions: new Set(allVersions),
+          });
+          expect(res).toEqual('v7');
+        },
+      );
+
+      it('migrates from a floating major to a floating major.minor if the floating major no longer exists', () => {
+        const res = githubActions.getNewValue({
+          currentValue: 'v7',
+          currentVersion: 'v7.0.0',
+          newVersion: 'v7.6',
+          rangeStrategy: 'replace',
+          allVersions: new Set(['v7.5.0', 'v7.6', 'v7.6.0']),
+        });
+        expect(res).toEqual('v7.6');
+      });
+
+      it.each([
+        {
+          description: 'only full semver available',
+          allVersions: ['v7.5.0', 'v7.6.0'],
+          expected: 'v7.6.0',
+        },
+        {
+          description: 'floating minor tag available (v7.6)',
+          allVersions: ['v7.5.0', 'v7.6', 'v7.6.0'],
+          expected: 'v7.6',
+        },
+        {
+          description:
+            'floating major tag present but ignored (must not go less specific)',
+          allVersions: ['v7', 'v7.5.0', 'v7.6', 'v7.6.0'],
+          expected: 'v7.6',
+        },
+      ])(
+        'preserves floating minor for non-major updates ($description)',
+        ({ allVersions, expected }) => {
+          // When the user has @v7.5, Renovate should stay at the minor level.
+          // It must NOT return v7 (less specific), even if v7 appears in allVersions.
+          const res = githubActions.getNewValue({
+            currentValue: 'v7.5',
+            currentVersion: 'v7.5.0',
+            newVersion: 'v7.6.0',
+            rangeStrategy: 'replace',
+            allVersions: new Set(allVersions),
+          });
+          expect(res).toEqual(expected);
+        },
+      );
+
       it('when a release candidate version exists, that exact version is used', () => {
         const res = githubActions.getNewValue({
           currentValue: 'v7',

--- a/lib/modules/versioning/github-actions/index.ts
+++ b/lib/modules/versioning/github-actions/index.ts
@@ -297,7 +297,7 @@ function getShortestMatchingVersion(
   prefix: string,
   newParsed: SemVer,
   allVersions: Set<string>,
-  minLevel: 'major' | 'minor' | 'patch' = 'major',
+  minLevel: 'major' | 'minor' = 'major',
 ): string | null {
   const { major, minor, patch } = newParsed;
   const versions = new Set(allVersions);
@@ -310,11 +310,9 @@ function getShortestMatchingVersion(
     }
   }
 
-  if (minLevel !== 'patch') {
-    const v = `${prefix}${major}.${minor}`;
-    if (versions.has(v)) {
-      return v;
-    }
+  const v = `${prefix}${major}.${minor}`;
+  if (versions.has(v)) {
+    return v;
   }
 
   const patchVersion = `${prefix}${major}.${minor}.${patch}`;

--- a/lib/modules/versioning/github-actions/index.ts
+++ b/lib/modules/versioning/github-actions/index.ts
@@ -226,8 +226,25 @@ function getNewValue({
     return newVersion;
   }
 
+  // When a minor (i.e. `v1.2`), don't return a less-specific tag (i.e. `v1`), even if it's found in `allVersions`
+  const minLevel = isUndefined(range.minor) ? 'major' : 'minor';
+  const [prefix] = currentValue.split(massageValue(currentValue));
   const newParsed = parseVersion(newVersion);
   if (!newParsed) {
+    const newCoerced = parseVersionCoerced(newVersion);
+    if (newCoerced) {
+      // check that we're not returning a version that doesn't exist
+      // for instance, in the case `v5.5` is tagged, but there's no `v5` (or if it's been deleted)
+      const shortest = getShortestMatchingVersion(
+        prefix,
+        newCoerced,
+        allVersions ?? new Set(),
+        minLevel,
+      );
+      if (shortest) {
+        return shortest;
+      }
+    }
     return newVersion;
   }
 
@@ -238,8 +255,6 @@ function getNewValue({
     return newVersion;
   }
 
-  const [prefix] = currentValue.split(massageValue(currentValue));
-
   if (isUndefined(allVersions) || allVersions.size === 0) {
     if (isUndefined(range.minor)) {
       return `${prefix}${newParsed.major}`;
@@ -248,7 +263,17 @@ function getNewValue({
     return `${prefix}${newParsed.major}.${newParsed.minor}`;
   }
 
-  const shortest = getShortestMatchingVersion(prefix, newParsed, allVersions);
+  // If a major (i.e. `v7`), and the proposed update is a minor i.e. (`v7.6`), return the existing major version instead of updating to the new minor, as the major should have been re-tagged, too
+  if (isUndefined(range.minor) && newParsed.major === range.major) {
+    return `${prefix}${newParsed.major}`;
+  }
+
+  const shortest = getShortestMatchingVersion(
+    prefix,
+    newParsed,
+    allVersions,
+    minLevel,
+  );
   if (shortest) {
     return shortest;
   }
@@ -272,19 +297,34 @@ function getShortestMatchingVersion(
   prefix: string,
   newParsed: SemVer,
   allVersions: Set<string>,
+  minLevel: 'major' | 'minor' | 'patch' = 'major',
 ): string | null {
-  // in shortest-first order
-  const options = [
-    `${prefix}${newParsed.major}`,
-    `${prefix}${newParsed.major}.${newParsed.minor}`,
-    `${prefix}${newParsed.major}.${newParsed.minor}.${newParsed.patch}`,
-    `${prefix}${newParsed.toString()}`,
-  ];
+  const { major, minor, patch } = newParsed;
+  const versions = new Set(allVersions);
 
-  for (const option of options) {
-    if (allVersions.has(option)) {
-      return option;
+  // in shortest-first order: major, minor, patch, full
+  if (minLevel === 'major') {
+    const v = `${prefix}${major}`;
+    if (versions.has(v)) {
+      return v;
     }
+  }
+
+  if (minLevel !== 'patch') {
+    const v = `${prefix}${major}.${minor}`;
+    if (versions.has(v)) {
+      return v;
+    }
+  }
+
+  const patchVersion = `${prefix}${major}.${minor}.${patch}`;
+  if (versions.has(patchVersion)) {
+    return patchVersion;
+  }
+
+  const fullVersion = `${prefix}${newParsed.toString()}`;
+  if (versions.has(fullVersion)) {
+    return fullVersion;
   }
 
   return null;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

As part of the final set of changes needed to support Immutable Releases
with GitHub Actions and the `github-actions` versioning, we need to
modify how our versioning works to handle correctly surfacing the
shortest version available.

To make this more resilient, and help us test-drive the change, we'll
also add an integration test that:

- extracts from a GitHub Actions workflow
- performs a lookup (with mocked data)
- determines the available updates that would be proposed

This provides more confidence in the change itself, as well as
validates the intended changes.

## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/JamieTanna-Mend-testing/setup-uv/issues/3

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
