### PR TITLE
fix(manager): add missing categories exports

### DIFF
--- a/lib/modules/manager/copier/index.ts
+++ b/lib/modules/manager/copier/index.ts
@@ -1,4 +1,8 @@
+import type { Category } from '../../../constants/index.ts';
 import { GitTagsDatasource } from '../../datasource/git-tags/index.ts';
+
+export const categories: Category[] = ['python'];
+
 import * as pep440 from '../../versioning/pep440/index.ts';
 
 export { updateArtifacts } from './artifacts.ts';

--- a/lib/modules/manager/fvm/index.ts
+++ b/lib/modules/manager/fvm/index.ts
@@ -1,4 +1,8 @@
+import type { Category } from '../../../constants/index.ts';
 import { FlutterVersionDatasource } from '../../datasource/flutter-version/index.ts';
+
+export const categories: Category[] = ['dart'];
+
 import * as semverVersioning from '../../versioning/semver/index.ts';
 
 export { extractPackageFile } from './extract.ts';

--- a/lib/modules/manager/gleam/index.ts
+++ b/lib/modules/manager/gleam/index.ts
@@ -1,4 +1,8 @@
+import type { Category } from '../../../constants/index.ts';
 import { HexDatasource } from '../../datasource/hex/index.ts';
+
+export const categories: Category[] = ['elixir'];
+
 import * as hexVersioning from '../../versioning/hex/index.ts';
 
 export { updateArtifacts } from './artifacts.ts';

--- a/lib/modules/manager/osgi/index.ts
+++ b/lib/modules/manager/osgi/index.ts
@@ -1,4 +1,7 @@
+import type { Category } from '../../../constants/index.ts';
 import { MavenDatasource } from '../../datasource/maven/index.ts';
+
+export const categories: Category[] = ['java'];
 
 export { extractPackageFile } from './extract.ts';
 

--- a/lib/modules/manager/pre-commit/index.ts
+++ b/lib/modules/manager/pre-commit/index.ts
@@ -1,4 +1,8 @@
+import type { Category } from '../../../constants/index.ts';
 import { getEnv } from '../../../util/env.ts';
+
+export const categories: Category[] = ['python'];
+
 import { GithubTagsDatasource } from '../../datasource/github-tags/index.ts';
 import { GitlabTagsDatasource } from '../../datasource/gitlab-tags/index.ts';
 

--- a/lib/modules/manager/unity3d/index.ts
+++ b/lib/modules/manager/unity3d/index.ts
@@ -1,4 +1,7 @@
+import type { Category } from '../../../constants/index.ts';
 import { Unity3dDatasource } from '../../datasource/unity3d/index.ts';
+
+export const categories: Category[] = ['dotnet'];
 
 export { extractPackageFile } from './extract.ts';
 

--- a/lib/modules/manager/vendir/index.ts
+++ b/lib/modules/manager/vendir/index.ts
@@ -1,4 +1,8 @@
+import type { Category } from '../../../constants/index.ts';
 import { DockerDatasource } from '../../datasource/docker/index.ts';
+
+export const categories: Category[] = ['helm', 'kubernetes'];
+
 import { HelmDatasource } from '../../datasource/helm/index.ts';
 
 export { updateArtifacts } from './artifacts.ts';


### PR DESCRIPTION
## Changes

Add missing `categories` exports to 7 managers: copier, fvm, gleam, osgi, pre-commit, unity3d, vendir

## Context

- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).

Used Claude Code to identify managers missing categories and generate the additions.

## Documentation

- [x] No documentation update is required

## How I've tested my work

- [x] Code inspection only