### PR TITLE
fix(config): only migrate standalone legacy template identifiers

### DIFF
--- a/lib/config/migration.spec.ts
+++ b/lib/config/migration.spec.ts
@@ -693,6 +693,31 @@ describe('config/migration', () => {
     expect(migratedConfig).toMatchSnapshot();
   });
 
+  it('does not migrate legacy template identifiers within larger identifiers', () => {
+    const config: RenovateConfig = {
+      autoReplaceStringTemplate:
+        'val correttoVersion = "{{{newValue}}}"\n    val imageSha256 = "{{{newDigest}}}"',
+    };
+    const { isMigrated, migratedConfig } =
+      configMigration.migrateConfig(config);
+    expect(isMigrated).toBeFalse();
+    expect(migratedConfig).toEqual(config);
+  });
+
+  it('migrates standalone legacy template identifiers in template expressions', () => {
+    const config: RenovateConfig = {
+      commitMessage:
+        '{{#if toVersion}}{{fromVersion}} -> {{{toVersion}}} {{newValueMajor}}/{{newValueMinor}} {{newVersionMajor}}/{{newVersionMinor}}{{/if}}',
+    };
+    const { isMigrated, migratedConfig } =
+      configMigration.migrateConfig(config);
+    expect(isMigrated).toBeTrue();
+    expect(migratedConfig).toEqual({
+      commitMessage:
+        '{{#if newVersion}}{{currentVersion}} -> {{{newVersion}}} {{newMajor}}/{{newMinor}} {{newMajor}}/{{newMinor}}{{/if}}',
+    });
+  });
+
   it('migrates pip-compile', () => {
     const config: RenovateConfig = {
       // @ts-expect-error -- TODO: fix me

--- a/lib/config/migration.spec.ts
+++ b/lib/config/migration.spec.ts
@@ -694,10 +694,10 @@ describe('config/migration', () => {
   });
 
   it('does not migrate legacy template identifiers within larger identifiers', () => {
-    const config: RenovateConfig = {
+    const config = {
       autoReplaceStringTemplate:
         'val correttoVersion = "{{{newValue}}}"\n    val imageSha256 = "{{{newDigest}}}"',
-    };
+    } as RenovateConfig;
     const { isMigrated, migratedConfig } =
       configMigration.migrateConfig(config);
     expect(isMigrated).toBeFalse();

--- a/lib/config/migration.ts
+++ b/lib/config/migration.ts
@@ -9,7 +9,7 @@ import {
 import { dequal } from 'dequal';
 import { logger } from '../logger/index.ts';
 import { clone } from '../util/clone.ts';
-import { regEx } from '../util/regex.ts';
+import { escapeRegExp, regEx } from '../util/regex.ts';
 import { MigrationsService } from './migrations/index.ts';
 import { getOptions } from './options/index.ts';
 import type {
@@ -22,8 +22,43 @@ import type {
 import { mergeChildConfig } from './utils.ts';
 
 const options = getOptions();
+const migratedTemplates = {
+  fromVersion: 'currentVersion',
+  newValueMajor: 'newMajor',
+  newValueMinor: 'newMinor',
+  newVersionMajor: 'newMajor',
+  newVersionMinor: 'newMinor',
+  toVersion: 'newVersion',
+} as const;
+const templateIdentifierCharRegex = regEx(/[A-Za-z0-9_]/);
+
 export function fixShortHours(input: string): string {
   return input.replace(regEx(/( \d?\d)((a|p)m)/g), '$1:00$2');
+}
+
+function isTemplateIdentifierChar(char: string | undefined): boolean {
+  return !!char && templateIdentifierCharRegex.test(char);
+}
+
+function replaceStandaloneTemplateIdentifier(
+  input: string,
+  from: string,
+  to: string,
+): string {
+  return input.replace(
+    regEx(escapeRegExp(from), 'g'),
+    (match: string, offset: number, fullString: string): string => {
+      const previousChar = fullString[offset - 1];
+      const nextChar = fullString[offset + match.length];
+      if (
+        isTemplateIdentifierChar(previousChar) ||
+        isTemplateIdentifierChar(nextChar)
+      ) {
+        return match;
+      }
+      return to;
+    },
+  );
 }
 
 let optionTypes: Record<string, RenovateOptions['type']>;
@@ -114,20 +149,13 @@ export function migrateConfig(
         }
       }
 
-      const migratedTemplates = {
-        fromVersion: 'currentVersion',
-        newValueMajor: 'newMajor',
-        newValueMinor: 'newMinor',
-        newVersionMajor: 'newMajor',
-        newVersionMinor: 'newMinor',
-        toVersion: 'newVersion',
-      };
       // @ts-expect-error -- TODO: fix me
       if (isString(migratedConfig[key])) {
         for (const [from, to] of Object.entries(migratedTemplates)) {
           // @ts-expect-error -- TODO: fix me
-          migratedConfig[key] = (migratedConfig[key] as string).replace(
-            regEx(from, 'g'),
+          migratedConfig[key] = replaceStandaloneTemplateIdentifier(
+            migratedConfig[key] as string,
+            from,
             to,
           );
         }

--- a/lib/config/migration.ts
+++ b/lib/config/migration.ts
@@ -149,16 +149,17 @@ export function migrateConfig(
         }
       }
 
-      // @ts-expect-error -- TODO: fix me
-      if (isString(migratedConfig[key])) {
+      const migratedValue = Reflect.get(migratedConfig, key);
+      if (typeof migratedValue === 'string') {
+        let migratedStringValue = migratedValue;
         for (const [from, to] of Object.entries(migratedTemplates)) {
-          // @ts-expect-error -- TODO: fix me
-          migratedConfig[key] = replaceStandaloneTemplateIdentifier(
-            migratedConfig[key] as string,
+          migratedStringValue = replaceStandaloneTemplateIdentifier(
+            migratedStringValue,
             from,
             to,
           );
         }
+        Reflect.set(migratedConfig, key, migratedStringValue);
       }
     }
     const languages = [


### PR DESCRIPTION
## Changes

Fix config migration so legacy template variables are only migrated when they appear as standalone identifiers.

This preserves the existing migration behavior for valid legacy template expressions such as `{{toVersion}}` and `{{#if toVersion}}`, while avoiding false-positive replacements inside larger identifiers like `correttoVersion`. As a result, strict config validation no longer fails for configs that were already valid.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Used Cursor AI assistance for the migration implementation and regression tests.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: N/A