### PR TITLE
fix(versioning/github-actions): treat floating tags as equal

### DIFF
--- a/lib/modules/versioning/github-actions/index.spec.ts
+++ b/lib/modules/versioning/github-actions/index.spec.ts
@@ -108,8 +108,8 @@ describe('modules/versioning/github-actions/index', () => {
       ${'1.0.0-rc'}       | ${'1.0'}     | ${false}
       ${'invalid'}        | ${'1'}       | ${false}
       ${'~latest'}        | ${'1'}       | ${false}
-      ${'1'}              | ${'1'}       | ${false}
-      ${'1.2'}            | ${'1.2'}     | ${false}
+      ${'1'}              | ${'1'}       | ${true}
+      ${'1.2'}            | ${'1.2'}     | ${true}
       ${'1.2.3'}          | ${'1.2.3'}   | ${true}
       ${'1.2.4'}          | ${'1.2.3'}   | ${false}
       ${'not-semver-ver'} | ${'1'}       | ${false}

--- a/lib/modules/versioning/github-actions/index.spec.ts
+++ b/lib/modules/versioning/github-actions/index.spec.ts
@@ -109,8 +109,13 @@ describe('modules/versioning/github-actions/index', () => {
       ${'invalid'}        | ${'1'}       | ${false}
       ${'~latest'}        | ${'1'}       | ${false}
       ${'1'}              | ${'1'}       | ${true}
+      ${'1'}              | ${'v1'}      | ${true}
+      ${'v1'}             | ${'v1'}      | ${true}
+      ${'v1'}             | ${'1'}       | ${true}
       ${'1.2'}            | ${'1.2'}     | ${true}
-      ${'1.2.3'}          | ${'1.2.3'}   | ${true}
+      ${'1.2'}            | ${'v1.2'}    | ${true}
+      ${'v1.2'}           | ${'v1.2'}    | ${true}
+      ${'v1.2'}           | ${'1.2'}     | ${true}
       ${'1.2.4'}          | ${'1.2.3'}   | ${false}
       ${'not-semver-ver'} | ${'1'}       | ${false}
       ${'1.0.0-alpha'}    | ${'1'}       | ${false}

--- a/lib/modules/versioning/github-actions/index.ts
+++ b/lib/modules/versioning/github-actions/index.ts
@@ -132,7 +132,10 @@ function isGreaterThan(x: string, y: string): boolean {
 
 function matches(version: string, range: string): boolean {
   // if we have a valid floating tag provided, and it's the same as the range, treat it as the same
-  if (parseVersionCoerced(version) && version === range) {
+  if (
+    parseVersionCoerced(version) &&
+    massageValue(version) === massageValue(range)
+  ) {
     return true;
   }
 

--- a/lib/modules/versioning/github-actions/index.ts
+++ b/lib/modules/versioning/github-actions/index.ts
@@ -131,6 +131,11 @@ function isGreaterThan(x: string, y: string): boolean {
 }
 
 function matches(version: string, range: string): boolean {
+  // if we have a valid floating tag provided, and it's the same as the range, treat it as the same
+  if (parseVersionCoerced(version) && version === range) {
+    return true;
+  }
+
   const v = parseVersion(version);
   if (!v) {
     return false;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

As noted in #42662, if a floating tag `@v2` is used, Renovate currently
tries to roll it back to `@v1`, as it doesn't see that `@v2 === @v2`.

## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: https://github.com/JamieTanna-Mend-testing/copr-ci/pull/1 is autoclosed, because Renovate knows it does _not_ need to do this

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
