### PR TITLE
ci: never cancel in-progress release jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -784,11 +784,14 @@ jobs:
       - name: Check for newer commits on ${{ github.ref_name }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REF_NAME: ${{ github.ref_name }}
+          EXPECTED_SHA: ${{ github.sha }}
+          RUN_ID: ${{ github.run_id }}
         run: |
-          latest_sha=$(git ls-remote origin "refs/heads/${{ github.ref_name }}" | cut -f1)
-          if [[ "$latest_sha" != "${{ github.sha }}" ]]; then
-            echo "Newer commit detected on ${{ github.ref_name }} ($latest_sha), cancelling release run"
-            gh run cancel "${{ github.run_id }}"
+          latest_sha=$(git ls-remote origin "refs/heads/$REF_NAME" | cut -f1)
+          if [[ "$latest_sha" != "$EXPECTED_SHA" ]]; then
+            echo "Newer commit detected on $REF_NAME ($latest_sha), cancelling release run"
+            gh run cancel "$RUN_ID"
           fi
 
       - run: df -h
@@ -866,11 +869,14 @@ jobs:
       - name: Check for newer commits on ${{ github.ref_name }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REF_NAME: ${{ github.ref_name }}
+          EXPECTED_SHA: ${{ github.sha }}
+          RUN_ID: ${{ github.run_id }}
         run: |
-          latest_sha=$(git ls-remote origin "refs/heads/${{ github.ref_name }}" | cut -f1)
-          if [[ "$latest_sha" != "${{ github.sha }}" ]]; then
-            echo "Newer commit detected on ${{ github.ref_name }} ($latest_sha), cancelling release run"
-            gh run cancel "${{ github.run_id }}"
+          latest_sha=$(git ls-remote origin "refs/heads/$REF_NAME" | cut -f1)
+          if [[ "$latest_sha" != "$EXPECTED_SHA" ]]; then
+            echo "Newer commit detected on $REF_NAME ($latest_sha), cancelling release run"
+            gh run cancel "$RUN_ID"
           fi
 
       - name: semantic-release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
 
 env:
   # are we on a release branch?
@@ -772,6 +772,7 @@ jobs:
       # never cancel a release that has already started, as it may have started pushing artifacts
       cancel-in-progress: false
     permissions:
+      actions: write
       contents: write
       issues: write
       pull-requests: write
@@ -779,6 +780,17 @@ jobs:
       packages: write
 
     steps:
+      # right at the start of the job, make sure we're not seeing another commit that's landed
+      - name: Check for newer commits on ${{ github.ref_name }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          latest_sha=$(git ls-remote origin "refs/heads/${{ github.ref_name }}" | cut -f1)
+          if [[ "$latest_sha" != "${{ github.sha }}" ]]; then
+            echo "Newer commit detected on ${{ github.ref_name }} ($latest_sha), cancelling release run"
+            gh run cancel "${{ github.run_id }}"
+          fi
+
       - run: df -h
 
       # Ensure docker is using /mnt/docker for data storage on x86_64 runners to avoid disk space issues
@@ -848,6 +860,17 @@ jobs:
             echo "DRY_RUN=false" >> "$GITHUB_ENV"
           elif [[ "${{env.DO_RELEASE}}" == "true" ]]; then
             echo "DRY_RUN=false" >> "$GITHUB_ENV"
+          fi
+
+      # and one final check, in case preparing the environment has taken long enough for new commits
+      - name: Check for newer commits on ${{ github.ref_name }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          latest_sha=$(git ls-remote origin "refs/heads/${{ github.ref_name }}" | cut -f1)
+          if [[ "$latest_sha" != "${{ github.sha }}" ]]; then
+            echo "Newer commit detected on ${{ github.ref_name }} ($latest_sha), cancelling release run"
+            gh run cancel "${{ github.run_id }}"
           fi
 
       - name: semantic-release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -781,7 +781,7 @@ jobs:
 
     steps:
       # right at the start of the job, make sure we're not seeing another commit that's landed
-      - name: Check for newer commits on ${{ github.ref_name }}
+      - name: Check for newer commits
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REF_NAME: ${{ github.ref_name }}
@@ -866,7 +866,7 @@ jobs:
           fi
 
       # and one final check, in case preparing the environment has taken long enough for new commits
-      - name: Check for newer commits on ${{ github.ref_name }}
+      - name: Check for newer commits
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REF_NAME: ${{ github.ref_name }}


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
We currently try not to cancel a release when it's already running, but
we sometimes do end up with it being cancelled part-way through due to
our current `cancel-in-progress`.

We can adapt this to only trigger that case when in a PR/Merge Group
event, and then provide custom logic to cancel the release job (at the
start of the job and right before `semantic-release` runs) when we're
not the latest commit.

Follow-up to changes from https://github.com/renovatebot/renovate/pull/40630

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the below:

- [x] This closes an existing Issue: Closes #40632
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
