### PR TITLE
chore(workers/repository): provide more detail when rolling back

### DIFF
--- a/lib/modules/datasource/common.ts
+++ b/lib/modules/datasource/common.ts
@@ -272,6 +272,10 @@ export function applyConstraintsFiltering<
     const packageName = config.packageName;
     const releases = filteredReleases.join(', ');
     logger.debug(
+      {
+        datasource: config.datasource,
+        packageName: config.packageName,
+      },
       `Filtered out ${count} non-matching releases out of ${startingLength} total for ${packageName} due to constraintsFiltering=strict: ${releases}`,
     );
   }

--- a/lib/modules/manager/types.ts
+++ b/lib/modules/manager/types.ts
@@ -132,6 +132,8 @@ export interface LookupUpdate {
    * Renovate does NOT validate the attestation, only determine whether the field is present and set to a value.
    */
   hasAttestation?: boolean;
+
+  prBodyNotes?: string[];
 }
 
 /**

--- a/lib/workers/repository/process/lookup/index.spec.ts
+++ b/lib/workers/repository/process/lookup/index.spec.ts
@@ -149,6 +149,9 @@ describe('workers/repository/process/lookup/index', () => {
           newVersion: '0.9.7',
           registryUrl: undefined,
           updateType: 'rollback',
+          prBodyNotes: expect.arrayContaining([
+            expect.stringContaining('The version of `q` in use (`0.9.99`)'),
+          ]),
         },
         {
           bucket: 'major',
@@ -185,6 +188,9 @@ describe('workers/repository/process/lookup/index', () => {
           newVersion: '0.9.7',
           registryUrl: undefined,
           updateType: 'rollback',
+          prBodyNotes: expect.arrayContaining([
+            expect.stringContaining('The version of `q` in use (`^0.9.99`)'),
+          ]),
         },
       ]);
     });
@@ -3012,6 +3018,11 @@ describe('workers/repository/process/lookup/index', () => {
           newVersion: '3.0.1-insiders.20180726',
           registryUrl: undefined,
           updateType: 'rollback',
+          prBodyNotes: expect.arrayContaining([
+            expect.stringContaining(
+              'The version of `typescript` in use (`3.1.0-dev.20180813`)',
+            ),
+          ]),
         },
       ]);
     });
@@ -3267,6 +3278,11 @@ describe('workers/repository/process/lookup/index', () => {
           newVersion: '1.16.0',
           registryUrl: undefined,
           updateType: 'rollback',
+          prBodyNotes: expect.arrayContaining([
+            expect.stringContaining(
+              'The version of `coffeelint` in use (`1.16.1`)',
+            ),
+          ]),
         },
       ]);
     });
@@ -5468,6 +5484,9 @@ describe('workers/repository/process/lookup/index', () => {
           newValue: `2.5.16`,
           newVersion: `2.5.16`,
           updateType: `rollback`,
+          prBodyNotes: expect.arrayContaining([
+            expect.stringContaining('The version of `vue` in use (`2.5.17`)'),
+          ]),
         },
       ]);
     });

--- a/lib/workers/repository/process/lookup/rollback.ts
+++ b/lib/workers/repository/process/lookup/rollback.ts
@@ -9,7 +9,14 @@ export function getRollbackUpdate(
   versions: Release[],
   versioningApi: VersioningApi,
 ): LookupUpdate | null {
-  const { packageFile, versioning, depName, currentValue } = config;
+  const {
+    packageFile,
+    versioning,
+    packageName,
+    depName,
+    currentValue,
+    datasource,
+  } = config;
   // istanbul ignore if
   if (!('isLessThanRange' in versioningApi)) {
     logger.debug(
@@ -78,5 +85,8 @@ export function getRollbackUpdate(
     newVersion,
     registryUrl,
     updateType: 'rollback',
+    prBodyNotes: [
+      `The version of \`${depName ?? packageName}\` in use (\`${currentValue}\`) was not found once Renovate filtered the dependencies. The ${datasource} datasource returned ${versions.length} entries, but when Renovate applied its filtering, none were left, so Renovate will roll back to a supported version`,
+    ],
   };
 }

--- a/lib/workers/repository/process/lookup/types.ts
+++ b/lib/workers/repository/process/lookup/types.ts
@@ -24,9 +24,11 @@ export interface FilterConfig {
 
 export interface RollbackConfig {
   currentValue?: string;
+  packageName: string;
   depName?: string;
   packageFile?: string;
   versioning?: string;
+  datasource: string;
 }
 
 export interface LookupUpdateConfig


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

To help debug the case where rollbacks are being initiated, we can:

- add slightly more information to the `Filtered out ...` log line
- add `prBodyNotes` to the resulting PR

This requires we expose the `prBodyNotes` field to `LookupUpdate`, and
the `packageName` and `datasource` to `RollbackConfig`, so we can log
them.

Also, log `datasource` and `packageName` when filtering

Noticed as part of https://github.com/renovatebot/renovate/discussions/42662

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/JamieTanna-Mend-testing/copr-ci/pull/1

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
