### PR TITLE
feat: Limit effects of maxMajorIncrement

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2695,6 +2695,8 @@ Add to this object if you wish to define rules that apply only to major updates.
 ## maxMajorIncrement
 
 This is particularly useful for preventing upgrades from [SemVer](https://semver.org/)-based versions to [CalVer](https://calver.org/)-based ones.
+Be aware that in some cases, `maxMajorIncrement` will also prevent legitimate updates within a CalVer versioning scheme, e.g. `20251231` to `20260101`.
+In order to distinguish between SemVer and CalVer, please refer to [maxMajorIncrementThreshold](#maxmajorincrementthreshold).
 
 For example, if you're on version `19.0.0`, Renovate will upgrade to `22.0.0` but filter out versions like `999.0.0` and `2025.0.0`.
 
@@ -2727,6 +2729,20 @@ Alternatively, to limit major upgrades to within 10 versions:
   ]
 }
 ```
+
+## maxMajorIncrementThreshold
+
+`maxMajorIncrement` prevents updating too many major versions at once.
+While this may be a good practice in general, it will lead to missed updates in versioning schemes like [CalVer](https://calver.org/) or similar.
+
+`maxMajorIncrementThreshold` can be used to define a threshold for the current major version, from which on it is OK to suggest updates exceeding the `maxMajorIncrement` restriction.
+
+For example with `maxMajorIncrement` set to 10 and `maxMajorIncrementThreshold` set to 1000, Renovate will:
+
+- ignore an update from version `12.34` to `20260101`
+- allow an update from version `20250101` to `20260101`
+
+The threshold is disabled by setting `maxMajorIncrementThreshold` to `0`.
 
 ## managerFilePatterns
 

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -1837,6 +1837,16 @@ const options: Readonly<RenovateOptions>[] = [
     env: false,
   },
   {
+    name: 'maxMajorIncrementThreshold',
+    description:
+      'Disables maxMajorIncrement if the current version exceeds this threshold. Set to 0 to disable.',
+    stage: 'package',
+    type: 'integer',
+    default: 1000,
+    cli: false,
+    env: false,
+  },
+  {
     name: 'respectLatest',
     description: 'Ignore versions newer than npm "latest" version.',
     stage: 'package',

--- a/lib/workers/repository/process/lookup/filter.spec.ts
+++ b/lib/workers/repository/process/lookup/filter.spec.ts
@@ -240,6 +240,78 @@ describe('workers/repository/process/lookup/filter', () => {
       ]);
     });
 
+    it('applies maxMajorIncrement if maxMajorIncrementThreshold is 0', () => {
+      const releases = [
+        { version: '20251231.0.0' },
+        { version: '20260101.0.0' },
+      ] satisfies Release[];
+
+      const config = partial<FilterConfig>({
+        maxMajorIncrement: 50,
+        maxMajorIncrementThreshold: 0,
+      });
+      const currentVersion = '20251231.0.0';
+      const latestVersion = '20260101.0.0';
+
+      const filteredVersions = filterVersions(
+        config,
+        currentVersion,
+        latestVersion,
+        releases,
+        versioning,
+      );
+
+      expect(filteredVersions).toEqual([]);
+    });
+
+    it('applies maxMajorIncrement if maxMajorIncrementThreshold is not exceeded', () => {
+      const releases = [
+        { version: '20251231.0.0' },
+        { version: '20260101.0.0' },
+      ] satisfies Release[];
+
+      const config = partial<FilterConfig>({
+        maxMajorIncrement: 50,
+        maxMajorIncrementThreshold: 99999999,
+      });
+      const currentVersion = '20251231.0.0';
+      const latestVersion = '20260101.0.0';
+
+      const filteredVersions = filterVersions(
+        config,
+        currentVersion,
+        latestVersion,
+        releases,
+        versioning,
+      );
+
+      expect(filteredVersions).toEqual([]);
+    });
+
+    it('ignores maxMajorIncrement if maxMajorIncrementThreshold is exceeded', () => {
+      const releases = [
+        { version: '20251231.0.0' },
+        { version: '20260101.0.0' },
+      ] satisfies Release[];
+
+      const config = partial<FilterConfig>({
+        maxMajorIncrement: 50,
+        maxMajorIncrementThreshold: 1000,
+      });
+      const currentVersion = '20251231.0.0';
+      const latestVersion = '20260101.0.0';
+
+      const filteredVersions = filterVersions(
+        config,
+        currentVersion,
+        latestVersion,
+        releases,
+        versioning,
+      );
+
+      expect(filteredVersions).toEqual([{ version: '20260101.0.0' }]);
+    });
+
     it('filters with maxMajorIncrement set to 1', () => {
       const releases = [
         { version: '1.0.1' },

--- a/lib/workers/repository/process/lookup/filter.ts
+++ b/lib/workers/repository/process/lookup/filter.ts
@@ -29,6 +29,7 @@ function filterByMaxMajorIncrement(
   releases: Release[],
   currentVersion: string,
   maxMajorIncrement: number,
+  maxMajorIncrementThreshold: number,
   versioningApi: VersioningApi,
   depName: string,
 ): Release[] {
@@ -37,6 +38,18 @@ function filterByMaxMajorIncrement(
   if (currentMajor === null) {
     return releases;
   }
+
+  if (
+    maxMajorIncrementThreshold > 0 &&
+    currentMajor >= maxMajorIncrementThreshold
+  ) {
+    logger.debug(
+      { depName },
+      `Skipping max major increment filter because current major version ${currentMajor} exceeds threshold ${maxMajorIncrementThreshold}`,
+    );
+    return releases;
+  }
+
   return releases.filter((r) => {
     const releaseMajor = versioningApi.getMajor(r.version);
     /* v8 ignore next 3 -- shouldn't happen */
@@ -46,6 +59,7 @@ function filterByMaxMajorIncrement(
     const majorIncrement = releaseMajor - currentMajor;
     if (majorIncrement > maxMajorIncrement) {
       logger.once.debug(
+        { depName },
         `Skipping ${depName}@${r.version} because major increment ${majorIncrement} exceeds maxMajorIncrement ${maxMajorIncrement}`,
       );
       return false;
@@ -61,8 +75,13 @@ export function filterVersions(
   releases: Release[],
   versioningApi: VersioningApi,
 ): Release[] {
-  const { ignoreUnstable, ignoreDeprecated, respectLatest, maxMajorIncrement } =
-    config;
+  const {
+    ignoreUnstable,
+    ignoreDeprecated,
+    respectLatest,
+    maxMajorIncrement,
+    maxMajorIncrementThreshold,
+  } = config;
 
   /* v8 ignore next 3 -- shouldn't happen */
   if (!currentVersion) {
@@ -101,6 +120,7 @@ export function filterVersions(
       filteredReleases,
       currentVersion,
       maxMajorIncrement,
+      maxMajorIncrementThreshold ?? 0,
       versioningApi,
       config.depName!,
     );

--- a/lib/workers/repository/process/lookup/types.ts
+++ b/lib/workers/repository/process/lookup/types.ts
@@ -17,6 +17,7 @@ export interface FilterConfig {
   ignoreDeprecated?: boolean;
   ignoreUnstable?: boolean;
   maxMajorIncrement?: number;
+  maxMajorIncrementThreshold?: number;
   respectLatest?: boolean;
   updatePinnedDependencies?: boolean;
   versioning?: string;


### PR DESCRIPTION
## Changes

This PR introduces the configuration option `maxMajorIncrementThreshold` to limit the effects of `maxMajorIncrement`.

As noted in #40554, a global configuration of `maxMajorIncrement` most certainly hides updates to CalVer versioned dependencies silently. A major example for such a dependency is the `ca-certificates` package in all Linux distros.

The logic effectively breaks down to: 
- If the current verision is below `maxMajorIncrementThreshold`, be careful and pay respect to `maxMajorIncrement` to prevent accidentally performing unintended version jumps.
- If the current version is already past a sensible threshold, it is fine to assume major version increments are not intended to indicate breaking changes and we should ignore `maxMajorIncrement`.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

This does in fact not address an issue but a discussion: #40554

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
