### PR TITLE
fix(versioning/github-actions): don't parse `allowedVersion`-style ranges as a range

### DIFF
--- a/lib/modules/versioning/github-actions/index.spec.ts
+++ b/lib/modules/versioning/github-actions/index.spec.ts
@@ -16,6 +16,10 @@ describe('modules/versioning/github-actions/index', () => {
       ${'v1.2.3-alpha'} | ${true}
       ${'invalid'}      | ${false}
       ${''}             | ${false}
+      ${'<6'}           | ${false}
+      ${'>=5'}          | ${false}
+      ${'~4'}           | ${false}
+      ${'^3'}           | ${false}
     `('isValid("$version") === $expected', ({ version, expected }) => {
       expect(githubActions.isValid(version)).toBe(expected);
     });

--- a/lib/modules/versioning/github-actions/index.ts
+++ b/lib/modules/versioning/github-actions/index.ts
@@ -13,6 +13,9 @@ export const urls = [
 export const supportsRanges = true;
 export const supportedRangeStrategies = ['pin', 'replace'];
 
+const floatingMinorTagRegex = regEx(/^\d+(\.\d+)?$/);
+const majorOnlyRegex = regEx(/^\d+$/);
+
 function massageValue(input: string): string {
   return input.trim().replace(regEx(/^v/i), '');
 }
@@ -28,7 +31,7 @@ interface Range {
 
 function parseRange(input: string): Range | null {
   const stripped = massageValue(input);
-  if (!regEx(/^\d+(\.\d+)?$/).test(stripped)) {
+  if (!floatingMinorTagRegex.test(stripped)) {
     return null;
   }
   const coerced = semver.coerce(stripped);
@@ -37,7 +40,7 @@ function parseRange(input: string): Range | null {
   }
   const { major, minor } = coerced;
 
-  if (regEx(/^\d+$/).test(stripped)) {
+  if (majorOnlyRegex.test(stripped)) {
     return { major };
   }
 

--- a/lib/modules/versioning/github-actions/index.ts
+++ b/lib/modules/versioning/github-actions/index.ts
@@ -35,6 +35,7 @@ function parseRange(input: string): Range | null {
     return null;
   }
   const coerced = semver.coerce(stripped);
+  /* v8 ignore next -- unreachable: floatingMinorTagRegex should guarantee coerce() succeeds */
   if (!coerced) {
     return null;
   }

--- a/lib/modules/versioning/github-actions/index.ts
+++ b/lib/modules/versioning/github-actions/index.ts
@@ -35,7 +35,7 @@ function parseRange(input: string): Range | null {
     return null;
   }
   const coerced = semver.coerce(stripped);
-  /* v8 ignore next -- unreachable: floatingMinorTagRegex should guarantee coerce() succeeds */
+  /* v8 ignore if -- unreachable: floatingMinorTagRegex should guarantee coerce() succeeds */
   if (!coerced) {
     return null;
   }

--- a/lib/modules/versioning/github-actions/index.ts
+++ b/lib/modules/versioning/github-actions/index.ts
@@ -28,6 +28,9 @@ interface Range {
 
 function parseRange(input: string): Range | null {
   const stripped = massageValue(input);
+  if (!regEx(/^\d+(\.\d+)?$/).test(stripped)) {
+    return null;
+  }
   const coerced = semver.coerce(stripped);
   if (!coerced) {
     return null;


### PR DESCRIPTION

<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
As noted in #42824, when using a range for `allowedVersion`, changes to
how ranges are parsed with `semver.coerce` led to incorrectly matching
this as a version that would like to be updated to.

We can guard this by making sure a SemVer style version number is used.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
