### PR TITLE
fix(autoreplace): handle digest-only update without replaceString

### DIFF
--- a/lib/workers/repository/update/branch/auto-replace.spec.ts
+++ b/lib/workers/repository/update/branch/auto-replace.spec.ts
@@ -263,7 +263,7 @@ describe('workers/repository/update/branch/auto-replace', () => {
       await expect(res).rejects.toThrow(WORKER_FILE_UPDATE_FAILED);
     });
 
-    it('fails with digest mismatch', async () => {
+    it('updates digest when only digest changes and no replaceString is set', async () => {
       const dockerfile = codeBlock`
         FROM java:11@sha256-1234 as build
       `;
@@ -277,8 +277,8 @@ describe('workers/repository/update/branch/auto-replace', () => {
       upgrade.newValue = '11';
       upgrade.newDigest = 'sha256-5678';
       upgrade.packageFile = 'Dockerfile';
-      const res = doAutoReplace(upgrade, dockerfile, reuseExistingBranch);
-      await expect(res).rejects.toThrow(WORKER_FILE_UPDATE_FAILED);
+      const res = await doAutoReplace(upgrade, dockerfile, reuseExistingBranch);
+      expect(res).toBe('FROM java:11@sha256-5678 as build');
     });
 
     it('updates with docker replacement', async () => {
@@ -1427,6 +1427,30 @@ describe('workers/repository/update/branch/auto-replace', () => {
       const res = await doAutoReplace(upgrade, source, reuseExistingBranch);
       expect(res).toBe(
         '[ { "version": "1.2.4", "digest": "badbeef", "package": "foo" } ]',
+      );
+    });
+
+    it('jsonata: update currentDigest with currentValue captured', async () => {
+      const source =
+        '[ { "version": "1.2.3", "digest": "abcdef", "package": "foo" } ]';
+      upgrade.manager = 'jsonata';
+      upgrade.depName = 'foo';
+      upgrade.currentValue = '1.2.3';
+      upgrade.currentDigest = 'abcdef';
+      upgrade.newDigest = 'badbeef';
+      upgrade.depIndex = 0;
+      upgrade.packageFile = 'deps.json';
+      // @ts-expect-error -- TODO: improve typing
+      upgrade.fileFormat = 'json';
+      // @ts-expect-error -- TODO: improve typing
+      upgrade.datasourceTemplate = 'github-releases';
+      // @ts-expect-error -- TODO: improve typing
+      upgrade.matchStrings = [
+        '*.{"depName": package, "currentDigest": digest, "currentValue": version }',
+      ];
+      const res = await doAutoReplace(upgrade, source, reuseExistingBranch);
+      expect(res).toBe(
+        '[ { "version": "1.2.3", "digest": "badbeef", "package": "foo" } ]',
       );
     });
 

--- a/lib/workers/repository/update/branch/auto-replace.ts
+++ b/lib/workers/repository/update/branch/auto-replace.ts
@@ -197,28 +197,6 @@ async function checkExistingBranch(
   return existingContent;
 }
 
-/**
- * Check if an update from `current` to `newString` should be performed and return 1 if so.
- *
- * @remarks
- * Useful for counting the number of updates to do.
- *
- * @param current The current value (if undefined then no update is required)
- * @param newString The new value (if undefined then no update is required)
- *
- * @returns 1 if `current !== newString` and 0 if they are equal or at least one is undefined.
- */
-function updatedToInt(
-  current: string | undefined | null,
-  newString: string | undefined | null,
-): number {
-  if (current && newString && newString !== current) {
-    return 1;
-  } else {
-    return 0;
-  }
-}
-
 export async function doAutoReplace(
   upgrade: BranchUpgradeConfig,
   existingContent: string,
@@ -247,27 +225,31 @@ export async function doAutoReplace(
   if (reuseExistingBranch) {
     return await checkExistingBranch(upgrade, existingContent);
   }
-
-  // count how many strings need to be updated
-  const changedCount =
-    updatedToInt(depName, newName) +
-    updatedToInt(currentValue, newValue) +
-    updatedToInt(currentDigest, newDigest);
-  if (changedCount > 1) {
-    logger.debug(
-      { packageFile, depName, changedCount },
-      'Multiple changed values, might need special handling (#36461)',
-    );
+  const valueChanging =
+    isString(currentValue) && isString(newValue) && currentValue !== newValue;
+  const digestChanging =
+    isString(currentDigest) &&
+    isString(newDigest) &&
+    currentDigest !== newDigest;
+  let replaceWithoutReplaceString =
+    isString(newName) &&
+    newName !== depName &&
+    (isUndefined(upgrade.replaceString) ||
+      !upgrade.replaceString?.includes(depName!));
+  // fallback must contain the field being updated, else the replacement is
+  // a no-op for managers where value and digest live in separate tokens
+  let replaceString = upgrade.replaceString;
+  if (isUndefined(replaceString)) {
+    if (valueChanging && digestChanging) {
+      // no single fallback covers both — use the per-field path
+      replaceWithoutReplaceString = true;
+      replaceString = currentValue ?? currentDigest;
+    } else if (digestChanging) {
+      replaceString = currentDigest ?? currentValue;
+    } else {
+      replaceString = currentValue ?? currentDigest;
+    }
   }
-
-  const replaceWithoutReplaceString =
-    (isString(newName) &&
-      newName !== depName &&
-      (isUndefined(upgrade.replaceString) ||
-        !upgrade.replaceString?.includes(depName!))) ||
-    // for jsonata manager, fixes #36461
-    (isUndefined(upgrade.replaceString) && changedCount > 1);
-  const replaceString = upgrade.replaceString ?? currentValue ?? currentDigest;
   logger.trace({ depName, replaceString }, 'autoReplace replaceString');
   let searchIndex: number;
   if (replaceWithoutReplaceString) {

--- a/lib/workers/repository/update/branch/auto-replace.ts
+++ b/lib/workers/repository/update/branch/auto-replace.ts
@@ -243,9 +243,9 @@ export async function doAutoReplace(
     if (valueChanging && digestChanging) {
       // no single fallback covers both — use the per-field path
       replaceWithoutReplaceString = true;
-      replaceString = currentValue ?? currentDigest;
+      replaceString = currentValue;
     } else if (digestChanging) {
-      replaceString = currentDigest ?? currentValue;
+      replaceString = currentDigest;
     } else {
       replaceString = currentValue ?? currentDigest;
     }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Pick the fallback `replaceString` based on which field is actually changing:

- digest-only updates anchor on `currentDigest`
- value-only updates anchor on `currentValue`
- updates where both value and digest change fall through to the per-field replacement path

Replaces the `changedCount > 1` heuristic from #38308, which missed the digest-only case when `currentValue` is also captured. The old heuristic also had to special-case `currentDigestShort` to avoid a bazel regression (#38252); switching to a semantic check makes that special case unnecessary.

Fixes the shape reported in discussion #36967 and #36461 .. jsonata custom managers where `currentValue` and `currentDigest` live in separate tokens and only the digest needs updating.

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->