### PR TITLE
chore(azure): simplify calculation for `getMergeMethod`

### DIFF
--- a/lib/modules/platform/azure/azure-helper.spec.ts
+++ b/lib/modules/platform/azure/azure-helper.spec.ts
@@ -217,6 +217,58 @@ describe('modules/platform/azure/azure-helper', () => {
       );
     });
 
+    it('should return NoFastForward when policy explicitly set', async () => {
+      azureApi.policyApi.mockImplementationOnce(
+        () =>
+          ({
+            getPolicyConfigurations: vi.fn(() => [
+              {
+                settings: {
+                  allowNoFastForward: true,
+                  scope: [
+                    {
+                      repositoryId: '',
+                    },
+                  ],
+                },
+                type: {
+                  id: 'fa4e907d-c16b-4a4c-9dfa-4916e5d171ab',
+                },
+              },
+            ]),
+          }) as any,
+      );
+      expect(await azureHelper.getMergeMethod('', '')).toEqual(
+        GitPullRequestMergeStrategy.NoFastForward,
+      );
+    });
+
+    it('should return RebaseMerge', async () => {
+      azureApi.policyApi.mockImplementationOnce(
+        () =>
+          ({
+            getPolicyConfigurations: vi.fn(() => [
+              {
+                settings: {
+                  allowRebaseMerge: true,
+                  scope: [
+                    {
+                      repositoryId: '',
+                    },
+                  ],
+                },
+                type: {
+                  id: 'fa4e907d-c16b-4a4c-9dfa-4916e5d171ab',
+                },
+              },
+            ]),
+          }) as any,
+      );
+      expect(await azureHelper.getMergeMethod('', '')).toEqual(
+        GitPullRequestMergeStrategy.RebaseMerge,
+      );
+    });
+
     it('should return Squash', async () => {
       azureApi.policyApi.mockImplementationOnce(
         () =>

--- a/lib/modules/platform/azure/azure-helper.ts
+++ b/lib/modules/platform/azure/azure-helper.ts
@@ -117,6 +117,23 @@ export async function getCommitDetails(
   return results;
 }
 
+interface MergeStrategyPolicyConfiguration {
+  allowNoFastForward?: boolean;
+  allowSquash?: boolean;
+  allowRebase?: boolean;
+  allowRebaseMerge?: boolean;
+}
+
+const policyKeyByStrategy: Record<
+  GitPullRequestMergeStrategy,
+  keyof MergeStrategyPolicyConfiguration
+> = {
+  [GitPullRequestMergeStrategy.NoFastForward]: 'allowNoFastForward',
+  [GitPullRequestMergeStrategy.Squash]: 'allowSquash',
+  [GitPullRequestMergeStrategy.Rebase]: 'allowRebase',
+  [GitPullRequestMergeStrategy.RebaseMerge]: 'allowRebaseMerge',
+};
+
 export async function getMergeMethod(
   repoId: string,
   project: string,
@@ -165,30 +182,24 @@ export async function getMergeMethod(
     `getMergeMethod(branchRef=${branchRef!}) determining mergeMethod from matched policy`,
   );
 
-  try {
-    // TODO: fix me, wrong types
-    const method = Object.keys(policyConfigurations)
-      .map(
-        (p) =>
-          GitPullRequestMergeStrategy[
-            p.slice(5) as never
-          ] as never as GitPullRequestMergeStrategy,
-      )
-      .find((p) => p)!;
-    logger.debug(
-      { policyConfigurations },
-      // TODO: types (#22198)
-      `getMergeMethod(branchRef=${branchRef!})=${GitPullRequestMergeStrategy[method]}`,
-    );
-    return method;
-  } catch {
-    logger.debug(
-      { policyConfigurations },
-      // TODO: types (#22198)
-      `getMergeMethod(branchRef=${branchRef!})=NoFastForward, as an error occured`,
-    );
-    return GitPullRequestMergeStrategy.NoFastForward;
+  // Note that this will iterate in the order of GitPullRequestMergeStrategy
+  for (const [key, policyKey] of Object.entries(policyKeyByStrategy)) {
+    if (policyConfigurations?.[policyKey] === true) {
+      const method = Number(key) satisfies GitPullRequestMergeStrategy;
+      logger.debug(
+        { policyConfigurations },
+        `getMergeMethod(branchRef=${branchRef!})=${GitPullRequestMergeStrategy[method]}`,
+      );
+      return method;
+    }
   }
+
+  logger.debug(
+    { policyConfigurations },
+    // TODO: types (#22198)
+    `getMergeMethod(branchRef=${branchRef!})=${GitPullRequestMergeStrategy[GitPullRequestMergeStrategy.NoFastForward]}`,
+  );
+  return GitPullRequestMergeStrategy.NoFastForward;
 }
 
 export async function getAllProjectTeams(

--- a/lib/modules/platform/azure/azure-helper.ts
+++ b/lib/modules/platform/azure/azure-helper.ts
@@ -185,7 +185,7 @@ export async function getMergeMethod(
   // Note that this will iterate in the order of GitPullRequestMergeStrategy
   for (const [key, policyKey] of Object.entries(policyKeyByStrategy)) {
     if (policyConfigurations?.[policyKey] === true) {
-      const method = Number(key) satisfies GitPullRequestMergeStrategy;
+      const method = parseInt(key, 10) satisfies GitPullRequestMergeStrategy;
       logger.debug(
         { policyConfigurations },
         `getMergeMethod(branchRef=${branchRef!})=${GitPullRequestMergeStrategy[method]}`,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Instead of the complicated check we were previously performing which:

- recovered from errors if `policyConfigurations` wasn't undefined, or
  other errors occurred
- trimmed the field names and checked if they were one of the
  `GitPullRequestMergeStrategy` options

We can instead rewrite this with stronger types and compile time checks
to confirm that the mapping from a policy configuration matches the
different `GitPullRequestMergeStrategy`s.

This provides a clearer intent for what this code is doing.

This changes behaviour slightly - previously, the first JSON key defined
that was a `GitPullRequestMergeStrategy` would be used (which is JSON
implementation specific), whereas now it is a defined order.

We also add coverage for the new behaviour.

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
