### PR TITLE
fix(changelog): skip link reference definitions in body matcher

### DIFF
--- a/lib/workers/repository/update/pr/changelog/release-notes.spec.ts
+++ b/lib/workers/repository/update/pr/changelog/release-notes.spec.ts
@@ -81,6 +81,29 @@ release-plan 0.14.0 (minor)
   * [#152](https://github.com/embroider-build/release-plan/pull/152) remove conditional coverage run
 `;
 
+// Keep-a-Changelog style: trailing link reference definitions after the last dated section
+// mention every version. The body-matcher must not treat those ref-defs as real mentions,
+// or it will return the oldest section's body for every version (regression for #42829).
+const keepAChangelogMd = `# Changelog
+
+## [Unreleased]
+
+- Enhance security when \`dry-run\` is true.
+
+## [1.30.1] - 2026-04-17
+
+- Enhance security against supply chain attacks.
+
+## [1.0.0] - 2021-02-03
+
+Initial release
+
+[Unreleased]: https://github.com/taiki-e/upload-rust-binary-action/compare/v1.30.2...HEAD
+[1.30.2]: https://github.com/taiki-e/upload-rust-binary-action/compare/v1.30.1...v1.30.2
+[1.30.1]: https://github.com/taiki-e/upload-rust-binary-action/compare/v1.30.0...v1.30.1
+[1.0.0]: https://github.com/taiki-e/upload-rust-binary-action/releases/tag/v1.0.0
+`;
+
 const bitbucketTreeResponse = {
   values: [
     {
@@ -1560,6 +1583,32 @@ describe('workers/repository/update/pr/changelog/release-notes', () => {
         expect(res?.url).toStrictEqual(
           'https://github.com/embroider-build/release-plan/blob/HEAD/CHANGELOG.md#Release-2025-03-03',
         );
+      });
+
+      it('ignores trailing link reference definitions when searching body', async () => {
+        httpMock
+          .scope('https://api.github.com')
+          .get('/repos/taiki-e/upload-rust-binary-action')
+          .reply(200, { default_branch: 'main' })
+          .get('/repos/taiki-e/upload-rust-binary-action/git/trees/main')
+          .reply(200, githubTreeResponse)
+          .get('/repos/taiki-e/upload-rust-binary-action/git/blobs/abcd')
+          .reply(200, {
+            content: toBase64(keepAChangelogMd),
+          });
+        const res = await getReleaseNotesMd(
+          {
+            ...githubProject,
+            repository: 'taiki-e/upload-rust-binary-action',
+            packageName: 'taiki-e/upload-rust-binary-action',
+          },
+          partial<ChangeLogRelease>({
+            version: '1.30.2',
+            gitRef: '1.30.2',
+          }),
+        );
+
+        expect(res).toBeNull();
       });
 
       it('handles gitlab sourceDirectory', async () => {

--- a/lib/workers/repository/update/pr/changelog/release-notes.spec.ts
+++ b/lib/workers/repository/update/pr/changelog/release-notes.spec.ts
@@ -81,9 +81,6 @@ release-plan 0.14.0 (minor)
   * [#152](https://github.com/embroider-build/release-plan/pull/152) remove conditional coverage run
 `;
 
-// Keep-a-Changelog style: trailing link reference definitions after the last dated section
-// mention every version. The body-matcher must not treat those ref-defs as real mentions,
-// or it will return the oldest section's body for every version (regression for #42829).
 const keepAChangelogMd = `# Changelog
 
 ## [Unreleased]

--- a/lib/workers/repository/update/pr/changelog/release-notes.ts
+++ b/lib/workers/repository/update/pr/changelog/release-notes.ts
@@ -409,13 +409,17 @@ export async function getReleaseNotesMd(
           const releasesRegex = regEx(/([0-9]{4}-[0-9]{2}-[0-9]{2})/);
           if (packageName && heading.search(releasesRegex) !== -1) {
             // Now check if any line contains both the package name and the version
+            // Skip Markdown link reference definitions (e.g. `[1.2.3]: https://…/compare/...`)
+            // which Keep-a-Changelog files list at the bottom and would otherwise match every version.
+            const linkRefDefRegex = regEx(/^\s*\[[^\]]+\]:\s*\S+/);
             const bodyLines = body.split('\n');
             if (
               bodyLines.some(
                 (line) =>
                   line.includes(packageName) &&
                   line.includes(version) &&
-                  !isHttpUrl(line),
+                  !isHttpUrl(line) &&
+                  !linkRefDefRegex.test(line),
               )
             ) {
               logger.trace({ body }, 'Found release notes for v' + version);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Body lines matching `^\s*\[[^\]]+\]:\s*\S+` are now skipped so trailing reference definitions no longer produce false positives. Regression test added.

Discussion: https://github.com/renovatebot/renovate/discussions/42829

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation). Claude Code assisted with root-cause analysis, the code change, and the regression test.
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/RahulGautamSingh/renovatebot-renovate-discussions-42829/pull/1

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->