### PR TITLE
feat(manager/renovate-config): extract `constraints`

### DIFF
--- a/lib/modules/manager/renovate-config/extract.spec.ts
+++ b/lib/modules/manager/renovate-config/extract.spec.ts
@@ -14,42 +14,43 @@ describe('modules/manager/renovate-config/extract', () => {
       ).toBeNull();
     });
 
-    it('returns null for a config file without presets', () => {
-      expect(
-        extractPackageFile(
-          codeBlock`
+    describe('presets', () => {
+      it('returns null for a config file without presets', () => {
+        expect(
+          extractPackageFile(
+            codeBlock`
             {
               "draftPR": true
             }
           `,
-          'renovate.json',
-        ),
-      ).toBeNull();
-      expect(logger.logger.warn).not.toHaveBeenCalled();
-      expect(logger.logger.info).not.toHaveBeenCalled();
-      expect(logger.logger.debug).not.toHaveBeenCalled();
-    });
+            'renovate.json',
+          ),
+        ).toBeNull();
+        expect(logger.logger.warn).not.toHaveBeenCalled();
+        expect(logger.logger.info).not.toHaveBeenCalled();
+        expect(logger.logger.debug).not.toHaveBeenCalled();
+      });
 
-    it('returns null for a config file only contains built-in presets', () => {
-      expect(
-        extractPackageFile(
-          codeBlock`
+      it('returns null for a config file only contains built-in presets', () => {
+        expect(
+          extractPackageFile(
+            codeBlock`
             {
               "extends": ["config:recommended", ":label(test)", "helpers:pinGitHubActionDigests"]
             }
           `,
-          'renovate.json',
-        ),
-      ).toBeNull();
-      expect(logger.logger.warn).not.toHaveBeenCalled();
-      expect(logger.logger.info).not.toHaveBeenCalled();
-      expect(logger.logger.debug).not.toHaveBeenCalled();
-    });
+            'renovate.json',
+          ),
+        ).toBeNull();
+        expect(logger.logger.warn).not.toHaveBeenCalled();
+        expect(logger.logger.info).not.toHaveBeenCalled();
+        expect(logger.logger.debug).not.toHaveBeenCalled();
+      });
 
-    it('provides skipReason for unsupported preset sources', () => {
-      expect(
-        extractPackageFile(
-          codeBlock`
+      it('provides skipReason for unsupported preset sources', () => {
+        expect(
+          extractPackageFile(
+            codeBlock`
             {
               "extends": [
                 "fastcore",
@@ -59,35 +60,35 @@ describe('modules/manager/renovate-config/extract', () => {
               ]
             }
           `,
-          'renovate.json',
-        ),
-      ).toEqual({
-        deps: [
-          {
-            depName: 'renovate-config-fastcore',
-            skipReason: 'unsupported-datasource',
-          },
-          {
-            depName:
-              'http://my.server/users/me/repos/renovate-presets/raw/default.json',
-            skipReason: 'unsupported-datasource',
-          },
-          {
-            depName: 'renovate/presets',
-            skipReason: 'unsupported-datasource',
-          },
-          {
-            depName: 'renovate/presets2',
-            skipReason: 'unsupported-datasource',
-          },
-        ],
+            'renovate.json',
+          ),
+        ).toEqual({
+          deps: [
+            {
+              depName: 'renovate-config-fastcore',
+              skipReason: 'unsupported-datasource',
+            },
+            {
+              depName:
+                'http://my.server/users/me/repos/renovate-presets/raw/default.json',
+              skipReason: 'unsupported-datasource',
+            },
+            {
+              depName: 'renovate/presets',
+              skipReason: 'unsupported-datasource',
+            },
+            {
+              depName: 'renovate/presets2',
+              skipReason: 'unsupported-datasource',
+            },
+          ],
+        });
       });
-    });
 
-    it('provides skipReason for presets without versions', () => {
-      expect(
-        extractPackageFile(
-          codeBlock`
+      it('provides skipReason for presets without versions', () => {
+        expect(
+          extractPackageFile(
+            codeBlock`
             {
               "extends": [
                 "github>abc/foo",
@@ -96,30 +97,30 @@ describe('modules/manager/renovate-config/extract', () => {
               ]
             }
           `,
-          'renovate.json',
-        ),
-      ).toEqual({
-        deps: [
-          {
-            depName: 'abc/foo',
-            skipReason: 'unspecified-version',
-          },
-          {
-            depName: 'abc/bar',
-            skipReason: 'unspecified-version',
-          },
-          {
-            depName: 'cde/foo',
-            skipReason: 'unspecified-version',
-          },
-        ],
+            'renovate.json',
+          ),
+        ).toEqual({
+          deps: [
+            {
+              depName: 'abc/foo',
+              skipReason: 'unspecified-version',
+            },
+            {
+              depName: 'abc/bar',
+              skipReason: 'unspecified-version',
+            },
+            {
+              depName: 'cde/foo',
+              skipReason: 'unspecified-version',
+            },
+          ],
+        });
       });
-    });
 
-    it('extracts from a config file with GitHub hosted presets', () => {
-      expect(
-        extractPackageFile(
-          codeBlock`
+      it('extracts from a config file with GitHub hosted presets', () => {
+        expect(
+          extractPackageFile(
+            codeBlock`
             {
               "extends": [
                 "github>abc/foo#1.2.3",
@@ -129,38 +130,38 @@ describe('modules/manager/renovate-config/extract', () => {
               ]
             }
           `,
-          'renovate.json',
-        ),
-      ).toEqual({
-        deps: [
-          {
-            datasource: 'github-tags',
-            depName: 'abc/foo',
-            currentValue: '1.2.3',
-          },
-          {
-            datasource: 'github-tags',
-            depName: 'abc/bar',
-            currentValue: '1.2.3',
-          },
-          {
-            datasource: 'github-tags',
-            depName: 'cde/foo',
-            currentValue: '1.2.3',
-          },
-          {
-            datasource: 'github-tags',
-            depName: 'cde/bar',
-            currentValue: '1.2.3',
-          },
-        ],
+            'renovate.json',
+          ),
+        ).toEqual({
+          deps: [
+            {
+              datasource: 'github-tags',
+              depName: 'abc/foo',
+              currentValue: '1.2.3',
+            },
+            {
+              datasource: 'github-tags',
+              depName: 'abc/bar',
+              currentValue: '1.2.3',
+            },
+            {
+              datasource: 'github-tags',
+              depName: 'cde/foo',
+              currentValue: '1.2.3',
+            },
+            {
+              datasource: 'github-tags',
+              depName: 'cde/bar',
+              currentValue: '1.2.3',
+            },
+          ],
+        });
       });
-    });
 
-    it('extracts from a config file with GitLab hosted presets', () => {
-      expect(
-        extractPackageFile(
-          codeBlock`
+      it('extracts from a config file with GitLab hosted presets', () => {
+        expect(
+          extractPackageFile(
+            codeBlock`
             {
               "extends": [
                 "gitlab>abc/foo#1.2.3",
@@ -170,38 +171,38 @@ describe('modules/manager/renovate-config/extract', () => {
               ]
             }
           `,
-          'renovate.json',
-        ),
-      ).toEqual({
-        deps: [
-          {
-            datasource: 'gitlab-tags',
-            depName: 'abc/foo',
-            currentValue: '1.2.3',
-          },
-          {
-            datasource: 'gitlab-tags',
-            depName: 'abc/bar',
-            currentValue: '1.2.3',
-          },
-          {
-            datasource: 'gitlab-tags',
-            depName: 'cde/foo',
-            currentValue: '1.2.3',
-          },
-          {
-            datasource: 'gitlab-tags',
-            depName: 'cde/bar',
-            currentValue: '1.2.3',
-          },
-        ],
+            'renovate.json',
+          ),
+        ).toEqual({
+          deps: [
+            {
+              datasource: 'gitlab-tags',
+              depName: 'abc/foo',
+              currentValue: '1.2.3',
+            },
+            {
+              datasource: 'gitlab-tags',
+              depName: 'abc/bar',
+              currentValue: '1.2.3',
+            },
+            {
+              datasource: 'gitlab-tags',
+              depName: 'cde/foo',
+              currentValue: '1.2.3',
+            },
+            {
+              datasource: 'gitlab-tags',
+              depName: 'cde/bar',
+              currentValue: '1.2.3',
+            },
+          ],
+        });
       });
-    });
 
-    it('extracts from a config file with Gitea hosted presets', () => {
-      expect(
-        extractPackageFile(
-          codeBlock`
+      it('extracts from a config file with Gitea hosted presets', () => {
+        expect(
+          extractPackageFile(
+            codeBlock`
             {
               "extends": [
                 "gitea>abc/foo#1.2.3",
@@ -211,38 +212,38 @@ describe('modules/manager/renovate-config/extract', () => {
               ]
             }
           `,
-          'renovate.json',
-        ),
-      ).toEqual({
-        deps: [
-          {
-            datasource: 'gitea-tags',
-            depName: 'abc/foo',
-            currentValue: '1.2.3',
-          },
-          {
-            datasource: 'gitea-tags',
-            depName: 'abc/bar',
-            currentValue: '1.2.3',
-          },
-          {
-            datasource: 'gitea-tags',
-            depName: 'cde/foo',
-            currentValue: '1.2.3',
-          },
-          {
-            datasource: 'gitea-tags',
-            depName: 'cde/bar',
-            currentValue: '1.2.3',
-          },
-        ],
+            'renovate.json',
+          ),
+        ).toEqual({
+          deps: [
+            {
+              datasource: 'gitea-tags',
+              depName: 'abc/foo',
+              currentValue: '1.2.3',
+            },
+            {
+              datasource: 'gitea-tags',
+              depName: 'abc/bar',
+              currentValue: '1.2.3',
+            },
+            {
+              datasource: 'gitea-tags',
+              depName: 'cde/foo',
+              currentValue: '1.2.3',
+            },
+            {
+              datasource: 'gitea-tags',
+              depName: 'cde/bar',
+              currentValue: '1.2.3',
+            },
+          ],
+        });
       });
-    });
 
-    it('supports JSON5', () => {
-      expect(
-        extractPackageFile(
-          codeBlock`
+      it('supports JSON5', () => {
+        expect(
+          extractPackageFile(
+            codeBlock`
             {
               // comments are permitted
               "extends": [
@@ -250,7 +251,313 @@ describe('modules/manager/renovate-config/extract', () => {
               ],
             }
           `,
-          'renovate.json5',
+            'renovate.json5',
+          ),
+        ).toEqual({
+          deps: [
+            {
+              datasource: 'github-tags',
+              depName: 'abc/foo',
+              currentValue: '1.2.3',
+            },
+          ],
+        });
+      });
+    });
+
+    describe('constraints', () => {
+      it('returns null for a config file without constraints', () => {
+        expect(
+          extractPackageFile(
+            codeBlock`
+            {
+              "draftPR": true
+            }
+          `,
+            'renovate.json',
+          ),
+        ).toBeNull();
+      });
+
+      it('returns null for a config file has an empty constraints', () => {
+        expect(
+          extractPackageFile(
+            codeBlock`
+            {
+              "constraints": {}
+            }
+          `,
+            'renovate.json',
+          ),
+        ).toBeNull();
+      });
+
+      it('extracts known `ToolName`s with explicit versions', () => {
+        expect(
+          extractPackageFile(
+            codeBlock`
+            {
+              "constraints": {
+                "bazelisk": "1.2.3",
+                "maven": "4.0.0"
+              }
+            }
+          `,
+            'renovate.json',
+          ),
+        ).toEqual({
+          deps: [
+            {
+              datasource: 'github-releases',
+              depName: 'bazelisk',
+              packageName: 'bazelbuild/bazelisk',
+              versioning: 'semver',
+              currentValue: '1.2.3',
+              depType: 'tool-constraint',
+              commitMessageTopic: '{{{depName}}} tool constraint',
+            },
+            {
+              datasource: 'github-releases',
+              depName: 'maven',
+              packageName: 'containerbase/maven-prebuild',
+              versioning: 'maven',
+              currentValue: '4.0.0',
+              depType: 'tool-constraint',
+              commitMessageTopic: '{{{depName}}} tool constraint',
+            },
+          ],
+        });
+      });
+
+      it('extracts known `ToolName`s with ranges versions', () => {
+        expect(
+          extractPackageFile(
+            codeBlock`
+            {
+              "constraints": {
+                "bazelisk": ">= 1.2.3",
+                "maven": "< 4.0.0"
+              }
+            }
+          `,
+            'renovate.json',
+          ),
+        ).toEqual({
+          deps: [
+            {
+              datasource: 'github-releases',
+              depName: 'bazelisk',
+              packageName: 'bazelbuild/bazelisk',
+              versioning: 'semver',
+              currentValue: '>= 1.2.3',
+              depType: 'tool-constraint',
+              commitMessageTopic: '{{{depName}}} tool constraint',
+            },
+            {
+              datasource: 'github-releases',
+              depName: 'maven',
+              packageName: 'containerbase/maven-prebuild',
+              versioning: 'maven',
+              currentValue: '< 4.0.0',
+              depType: 'tool-constraint',
+              commitMessageTopic: '{{{depName}}} tool constraint',
+            },
+          ],
+        });
+      });
+
+      it('extracts `ToolName`s from packageRules', () => {
+        expect(
+          extractPackageFile(
+            codeBlock`
+            {
+              "constraints": {
+                "golang": "1.20.5"
+              },
+              "packageRules": [
+                {
+                  "matchFileNames": ["go.mod"],
+                  "constraints": {
+                    "golang": "1.26.0",
+                    "gomodMod": "1.2.0"
+                  }
+                }
+              ]
+            }
+          `,
+            'renovate.json',
+          ),
+        ).toEqual({
+          deps: [
+            {
+              datasource: 'github-releases',
+              depName: 'golang',
+              packageName: 'containerbase/golang-prebuild',
+              versioning: 'npm',
+              currentValue: '1.20.5',
+              depType: 'tool-constraint',
+              commitMessageTopic: '{{{depName}}} tool constraint',
+            },
+            {
+              datasource: 'github-releases',
+              depName: 'golang',
+              packageName: 'containerbase/golang-prebuild',
+              versioning: 'npm',
+              currentValue: '1.26.0',
+              depType: 'tool-constraint',
+              commitMessageTopic: '{{{depName}}} tool constraint',
+            },
+            {
+              depName: 'gomodMod',
+              skipReason: 'unsupported',
+              currentValue: '1.2.0',
+              depType: 'constraint',
+              commitMessageTopic: '{{{depName}}} constraint',
+            },
+          ],
+        });
+      });
+
+      it('handles no `constraints` in packageRules', () => {
+        expect(
+          extractPackageFile(
+            codeBlock`
+            {
+              "constraints": {
+                "golang": "1.20.5"
+              },
+              "packageRules": [
+                {}
+              ]
+            }
+          `,
+            'renovate.json',
+          ),
+        ).toEqual({
+          deps: [
+            {
+              datasource: 'github-releases',
+              depName: 'golang',
+              packageName: 'containerbase/golang-prebuild',
+              versioning: 'npm',
+              currentValue: '1.20.5',
+              depType: 'tool-constraint',
+              commitMessageTopic: '{{{depName}}} tool constraint',
+            },
+          ],
+        });
+      });
+
+      it('sets skipReason=unsupported for a constraint that is not a tool', () => {
+        expect(
+          extractPackageFile(
+            codeBlock`
+            {
+              "constraints": {
+                "gomodMod": "1.2.0"
+              }
+            }
+          `,
+            'renovate.json',
+          ),
+        ).toEqual({
+          deps: [
+            {
+              depName: 'gomodMod',
+              skipReason: 'unsupported',
+              currentValue: '1.2.0',
+              depType: 'constraint',
+              commitMessageTopic: '{{{depName}}} constraint',
+            },
+          ],
+        });
+      });
+
+      it('extracts known `ToolName`s with ranges versions', () => {
+        expect(
+          extractPackageFile(
+            codeBlock`
+            {
+              "constraints": {
+                "bazelisk": ">= 1.2.3",
+                "maven": "< 4.0.0"
+              }
+            }
+          `,
+            'renovate.json',
+          ),
+        ).toEqual({
+          deps: [
+            {
+              datasource: 'github-releases',
+              depName: 'bazelisk',
+              packageName: 'bazelbuild/bazelisk',
+              versioning: 'semver',
+              currentValue: '>= 1.2.3',
+              depType: 'tool-constraint',
+              commitMessageTopic: '{{{depName}}} tool constraint',
+            },
+            {
+              datasource: 'github-releases',
+              depName: 'maven',
+              packageName: 'containerbase/maven-prebuild',
+              versioning: 'maven',
+              currentValue: '< 4.0.0',
+              depType: 'tool-constraint',
+              commitMessageTopic: '{{{depName}}} tool constraint',
+            },
+          ],
+        });
+      });
+
+      it('supports JSON5', () => {
+        expect(
+          extractPackageFile(
+            codeBlock`
+                    {
+                      // comments are permitted
+                      "constraints": {
+                        // and no quotes around keys
+                        gleam: "3.4.5", // and trailing comma
+                      }
+                    }
+                  `,
+            'renovate.json5',
+          ),
+        ).toEqual({
+          deps: [
+            {
+              datasource: 'github-releases',
+              depName: 'gleam',
+              packageName: 'gleam-lang/gleam',
+              versioning: 'semver',
+              currentValue: '3.4.5',
+              depType: 'tool-constraint',
+              commitMessageTopic: '{{{depName}}} tool constraint',
+            },
+          ],
+        });
+      });
+    });
+
+    it('extracts all types of configuration', () => {
+      expect(
+        extractPackageFile(
+          codeBlock`
+            {
+              "extends": [
+                "github>abc/foo#1.2.3",
+                "github>abc/bar:xyz#1.2.3",
+                "github>cde/foo//path/xyz#1.2.3",
+                "github>cde/bar:xyz/sub#1.2.3"
+              ],
+              "constraints": {
+                "bazelisk": ">= 1.2.3",
+                "maven": "< 4.0.0"
+              }
+            }
+          `,
+          'renovate.json',
         ),
       ).toEqual({
         deps: [
@@ -258,6 +565,40 @@ describe('modules/manager/renovate-config/extract', () => {
             datasource: 'github-tags',
             depName: 'abc/foo',
             currentValue: '1.2.3',
+          },
+          {
+            datasource: 'github-tags',
+            depName: 'abc/bar',
+            currentValue: '1.2.3',
+          },
+          {
+            datasource: 'github-tags',
+            depName: 'cde/foo',
+            currentValue: '1.2.3',
+          },
+          {
+            datasource: 'github-tags',
+            depName: 'cde/bar',
+            currentValue: '1.2.3',
+          },
+
+          {
+            datasource: 'github-releases',
+            depName: 'bazelisk',
+            packageName: 'bazelbuild/bazelisk',
+            versioning: 'semver',
+            currentValue: '>= 1.2.3',
+            depType: 'tool-constraint',
+            commitMessageTopic: '{{{depName}}} tool constraint',
+          },
+          {
+            datasource: 'github-releases',
+            depName: 'maven',
+            packageName: 'containerbase/maven-prebuild',
+            versioning: 'maven',
+            currentValue: '< 4.0.0',
+            depType: 'tool-constraint',
+            commitMessageTopic: '{{{depName}}} tool constraint',
           },
         ],
       });

--- a/lib/modules/manager/renovate-config/extract.ts
+++ b/lib/modules/manager/renovate-config/extract.ts
@@ -80,31 +80,27 @@ export function extractPackageFile(
     }
   }
 
-  if (config.data.packageRules) {
-    for (const packageRule of config.data.packageRules) {
-      if (packageRule.constraints) {
-        for (const [constraint, value] of Object.entries(
-          packageRule.constraints,
-        )) {
-          if (isToolName(constraint)) {
-            const toolConfig = getToolConfig(constraint);
-            deps.push({
-              ...toolConfig,
-              depName: constraint,
-              currentValue: value,
-              depType: 'tool-constraint',
-              commitMessageTopic: '{{{depName}}} tool constraint',
-            });
-          } else {
-            deps.push({
-              depName: constraint,
-              currentValue: value,
-              skipReason: 'unsupported',
-              depType: 'constraint',
-              commitMessageTopic: '{{{depName}}} constraint',
-            });
-          }
-        }
+  for (const packageRule of config.data.packageRules ?? []) {
+    for (const [constraint, value] of Object.entries(
+      packageRule.constraints ?? {},
+    )) {
+      if (isToolName(constraint)) {
+        const toolConfig = getToolConfig(constraint);
+        deps.push({
+          ...toolConfig,
+          depName: constraint,
+          currentValue: value,
+          depType: 'tool-constraint',
+          commitMessageTopic: '{{{depName}}} tool constraint',
+        });
+      } else {
+        deps.push({
+          depName: constraint,
+          currentValue: value,
+          skipReason: 'unsupported',
+          depType: 'constraint',
+          commitMessageTopic: '{{{depName}}} constraint',
+        });
       }
     }
   }

--- a/lib/modules/manager/renovate-config/extract.ts
+++ b/lib/modules/manager/renovate-config/extract.ts
@@ -1,6 +1,8 @@
 import { isNonEmptyArray, isNullOrUndefined } from '@sindresorhus/is';
 import { parsePreset } from '../../../config/presets/parse.ts';
 import { logger } from '../../../logger/index.ts';
+import { getToolConfig } from '../../../util/exec/containerbase.ts';
+import { isToolName } from '../../../util/exec/types.ts';
 import { GiteaTagsDatasource } from '../../datasource/gitea-tags/index.ts';
 import { GithubTagsDatasource } from '../../datasource/github-tags/index.ts';
 import { GitlabTagsDatasource } from '../../datasource/gitlab-tags/index.ts';
@@ -53,6 +55,58 @@ export function extractPackageFile(
       datasource,
       currentValue: parsedPreset.tag,
     });
+  }
+
+  for (const [constraint, value] of Object.entries(
+    config.data.constraints ?? {},
+  )) {
+    if (isToolName(constraint)) {
+      const toolConfig = getToolConfig(constraint);
+      deps.push({
+        ...toolConfig,
+        depName: constraint,
+        currentValue: value,
+        depType: 'tool-constraint',
+        commitMessageTopic: '{{{depName}}} tool constraint',
+      });
+    } else {
+      deps.push({
+        depName: constraint,
+        currentValue: value,
+        skipReason: 'unsupported',
+        depType: 'constraint',
+        commitMessageTopic: '{{{depName}}} constraint',
+      });
+    }
+  }
+
+  if (config.data.packageRules) {
+    for (const packageRule of config.data.packageRules) {
+      if (packageRule.constraints) {
+        for (const [constraint, value] of Object.entries(
+          packageRule.constraints,
+        )) {
+          if (isToolName(constraint)) {
+            const toolConfig = getToolConfig(constraint);
+            deps.push({
+              ...toolConfig,
+              depName: constraint,
+              currentValue: value,
+              depType: 'tool-constraint',
+              commitMessageTopic: '{{{depName}}} tool constraint',
+            });
+          } else {
+            deps.push({
+              depName: constraint,
+              currentValue: value,
+              skipReason: 'unsupported',
+              depType: 'constraint',
+              commitMessageTopic: '{{{depName}}} constraint',
+            });
+          }
+        }
+      }
+    }
   }
 
   return isNonEmptyArray(deps) ? { deps } : null;

--- a/lib/modules/manager/renovate-config/index.ts
+++ b/lib/modules/manager/renovate-config/index.ts
@@ -1,11 +1,10 @@
 import { getConfigFileNames } from '../../../config/app-strings.ts';
+import { allToolConfig } from '../../../util/exec/containerbase.ts';
 import { GiteaTagsDatasource } from '../../datasource/gitea-tags/index.ts';
 import { GithubTagsDatasource } from '../../datasource/github-tags/index.ts';
 import { GitlabTagsDatasource } from '../../datasource/gitlab-tags/index.ts';
 
 export { extractPackageFile } from './extract.ts';
-
-export const url = '../../../config-presets.md';
 
 export const defaultConfig = {
   managerFilePatterns: getConfigFileNames().filter(
@@ -17,4 +16,6 @@ export const supportedDatasources = [
   GithubTagsDatasource.id,
   GitlabTagsDatasource.id,
   GiteaTagsDatasource.id,
+
+  ...Object.values(allToolConfig).map((conf) => conf.datasource),
 ];

--- a/lib/modules/manager/renovate-config/readme.md
+++ b/lib/modules/manager/renovate-config/readme.md
@@ -21,3 +21,11 @@ For example, `github>user/renovate-config#1.2.3` will be updated to `github>user
 - [`package.json` file config](../../../configuration-options.md) (deprecated)
 - [`npm` hosted presets](../../../config-presets.md#npm-hosted-presets) (deprecated)
 - `extends` inside sub objects, like `packageRules`
+
+### Tool constraints
+
+Renovate will extract + suggest updates for package manager/tool versions in the [`constraints`](../../../configuration-options.md#constraints) configuration.
+
+Constraints set on tools that [Containerbase](https://github.com/containerbase/base/) supports will result in Renovate updates.
+
+Other constraints will not be updated by Renovate.

--- a/lib/modules/manager/renovate-config/schema.ts
+++ b/lib/modules/manager/renovate-config/schema.ts
@@ -4,5 +4,13 @@ import { Json5 } from '../../../util/schema-utils/index.ts';
 export const RenovateJson = Json5.pipe(
   z.object({
     extends: z.array(z.string()).optional(),
+    constraints: z.record(z.string(), z.string()).optional(),
+    packageRules: z
+      .array(
+        z.object({
+          constraints: z.record(z.string(), z.string()).optional(),
+        }),
+      )
+      .optional(),
   }),
 );

--- a/lib/util/exec/containerbase.ts
+++ b/lib/util/exec/containerbase.ts
@@ -19,7 +19,7 @@ import { id as semverCoercedVersioningId } from '../../modules/versioning/semver
 import { getEnv } from '../env.ts';
 import type { Opt, ToolConfig, ToolConstraint, ToolName } from './types.ts';
 
-const allToolConfig: Record<ToolName, ToolConfig> = {
+export const allToolConfig: Record<ToolName, ToolConfig> = {
   bazelisk: {
     datasource: 'github-releases',
     packageName: 'bazelbuild/bazelisk',
@@ -244,7 +244,7 @@ const allToolConfig: Record<ToolName, ToolConfig> = {
     packageName: 'carvel-dev/vendir',
     versioning: semverVersioningId,
   },
-};
+} as const;
 
 let _getPkgReleases: Promise<
   typeof import('../../modules/datasource/index.ts')


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

As noted in #41571, it would be useful to detect and suggest updates
when specifying `constraints` in Renovate config, where it's a known
tool we provide versioning information for.

We can extend our existing `renovate-config` manager to add support for
`constraints` that are known Containerbase tools.

We can support top-level `constraints` as well as `constraints` inside
`packageRules`.




## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #41571
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/JamieTanna-Mend-testing/constraints-testing/pulls

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
