### PR TITLE
feat(github-actions): extract Docker version from setup-docker-action

### DIFF
--- a/lib/modules/manager/github-actions/community.ts
+++ b/lib/modules/manager/github-actions/community.ts
@@ -121,6 +121,13 @@ export const communityActions: Record<string, CommunityActionConfig> = {
     packageName: 'deno',
     withSchema: valSchema('deno-version'),
   },
+  // https://github.com/docker/setup-docker-action
+  'docker/setup-docker-action': {
+    datasource: GithubReleasesDatasource.id,
+    depName: 'docker/setup-docker-action',
+    packageName: 'moby/moby',
+    extractVersion: '^docker-(?<version>.+)$',
+  },
   'golangci/golangci-lint-action': {
     datasource: GithubReleasesDatasource.id,
     packageName: 'golangci/golangci-lint',

--- a/lib/modules/manager/github-actions/extract.spec.ts
+++ b/lib/modules/manager/github-actions/extract.spec.ts
@@ -1579,6 +1579,22 @@ describe('modules/manager/github-actions/extract', () => {
         },
       ],
     },
+    {
+      step: {
+        uses: 'docker/setup-docker-action@v4',
+        with: { version: 'v27.1.0' },
+      },
+      expected: [
+        {
+          currentValue: 'v27.1.0',
+          datasource: 'github-releases',
+          depName: 'docker/setup-docker-action',
+          depType: 'uses-with',
+          packageName: 'moby/moby',
+          extractVersion: '^docker-(?<version>.+)$',
+        },
+      ],
+    },
   ])('extract from $step.uses', ({ step, expected }) => {
     const yamlContent = yaml.dump({ jobs: { build: { steps: [step] } } });
 


### PR DESCRIPTION
## Changes

Add support for detecting and updating the `version` property in `docker/setup-docker-action` GitHub Action workflows.

The `version` input of `docker/setup-docker-action` refers to the Docker CE engine version, which is released from the `moby/moby` repository with tags like `docker-v29.4.1`. The `extractVersion` regex strips the `docker-` prefix to match the version format used in the action (e.g., `v27.1.0`).

## Context

- [x] This closes an existing Issue: Closes #42586

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Claude Code was used to analyze the codebase patterns and generate the implementation.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository