### PR TITLE
docs(util/exec): add `description` field for `ConstraintName`/`ToolName`

### DIFF
--- a/lib/util/exec/types.ts
+++ b/lib/util/exec/types.ts
@@ -1,134 +1,244 @@
 import { isString } from '@sindresorhus/is';
 import type { Options as ExecaOptions } from 'execa';
 
+export interface ConstraintDefinition {
+  name: string;
+  description?: string;
+}
+
 /**
  * A `tool` that Containerbase supports.
  *
  * TODO #41849 replace with upstream types
  */
-export const toolNames = [
-  'bazelisk',
-  'bun',
-  'bundler',
-  'cocoapods',
-  'composer',
-  'conan',
-  'copier',
-  'corepack',
-  'devbox',
-  'dotnet',
-  'erlang',
-  'elixir',
-  'flux',
-  'gleam',
-  'golang',
-  'gradle',
-  'hashin',
-  'helm',
-  'helmfile',
-  'java',
-  'java-maven',
-  'jb',
-  'kustomize',
-  'maven',
-  'nix',
-  'node',
-  'npm',
-  'pdm',
-  'php',
-  'pip-tools',
-  'pipenv',
-  'pnpm',
-  'pixi',
-  'poetry',
-  'python',
-  /** also used in the `rubygems` datasource */
-  'ruby',
-  'rust',
-  'uv',
-  'yarn',
-  'yarn-slim',
-  'dart',
-  'flutter',
-  'vendir',
-] as const;
+export const toolDefinitions = [
+  {
+    name: 'bazelisk',
+  },
+  {
+    name: 'bun',
+  },
+  {
+    name: 'bundler',
+  },
+  {
+    name: 'cocoapods',
+  },
+  {
+    name: 'composer',
+  },
+  {
+    name: 'conan',
+  },
+  {
+    name: 'copier',
+  },
+  {
+    name: 'corepack',
+  },
+  {
+    name: 'devbox',
+  },
+  {
+    name: 'dotnet',
+  },
+  {
+    name: 'erlang',
+  },
+  {
+    name: 'elixir',
+  },
+  {
+    name: 'flux',
+  },
+  {
+    name: 'gleam',
+  },
+  {
+    name: 'golang',
+  },
+  {
+    name: 'gradle',
+  },
+  {
+    name: 'hashin',
+  },
+  {
+    name: 'helm',
+  },
+  {
+    name: 'helmfile',
+  },
+  {
+    name: 'java',
+  },
+  {
+    name: 'java-maven',
+  },
+  {
+    name: 'jb',
+  },
+  {
+    name: 'kustomize',
+  },
+  {
+    name: 'maven',
+  },
+  {
+    name: 'nix',
+  },
+  {
+    name: 'node',
+  },
+  {
+    name: 'npm',
+  },
+  {
+    name: 'pdm',
+  },
+  {
+    name: 'php',
+  },
+  {
+    name: 'pip-tools',
+  },
+  {
+    name: 'pipenv',
+  },
+  {
+    name: 'pnpm',
+  },
+  {
+    name: 'pixi',
+  },
+  {
+    name: 'poetry',
+  },
+  {
+    name: 'python',
+  },
+  {
+    name: 'ruby',
+    description: 'Also used in the `rubygems` Datasource',
+  },
+  {
+    name: 'rust',
+  },
+  {
+    name: 'uv',
+  },
+  {
+    name: 'yarn',
+  },
+  {
+    name: 'yarn-slim',
+  },
+  {
+    name: 'dart',
+  },
+  {
+    name: 'flutter',
+  },
+  {
+    name: 'vendir',
+  },
+] as const satisfies ConstraintDefinition[];
 
-export type ToolName = (typeof toolNames)[number];
+/**
+ * A `tool` that Containerbase supports.
+ */
+export type ToolName = (typeof toolDefinitions)[number]['name'];
+
+/**
+ * A `tool` that Containerbase supports.
+ */
+export const toolNames: ToolName[] = toolDefinitions.map((t) => t.name);
 
 export function isToolName(value: unknown): value is ToolName {
-  return isString(value) && toolNames.includes(value as ToolName);
+  return isString(value) && (toolNames as readonly string[]).includes(value);
 }
 
 /**
- * Additional constraints that can be specified for some Managers, but are **not** tools that Containerbase supports.
+ * Additional constraints that can be specified for some Managers, but are **not** tools that Containerbase supports, with optional description.
  */
-export const additionalConstraintNames = [
+export const additionalConstraintDefinitions = [
   /**
-   * Used in the `gomod` manager to specify the version of the Go toolchain to use.
-   *
-   * In precedence order:
-   *
-   * 1. config: `constraints.go`
-   * 1. `go.mod`: `toolchain` directive
-   * 1. `go.mod`: `go` directive
-   *
-   * NOTE that the `constraints.golang` is not used (https://github.com/renovatebot/renovate/issues/42601)
-   *
    * @deprecated TODO remove in #42600
    */
-  'go',
-  /**
-   * Used in the `gomod` manager to specify a tag for `github.com/marwan-at-work/mod`.
-   *
-   * Must be prefixed with `v`.
-   *
-   * @see https://github.com/marwan-at-work/mod
-   */
-  'gomodMod',
-  /**
-   * Used in the `jenkins-plugins` datasource to specify a minimum version of the Jenkins that a plugin must support.
-   */
-  'jenkins',
-  /**
-   * Used in the `pip-compile` manager to specify a version of `pip-tools` to use.
-   *
-   * @deprecated TODO remove in #42599
-   */
-  'pipTools',
-  /**
-   * Used in the `rubygems` datasource to specify the `platform` of that the Gem dependency supports.
-   */
-  'platform',
-  /**
-   * Used in the `rubygems` datasource to specify the version of the `rubygems` tool that is needed to use this Gem.
-   */
-  'rubygems',
-  /**
-   * Used in the `npm` manager to track the version of VSCode that the package is compatible with.
-   */
-  'vscode',
-  /**
-   * Used in the `nuget` manager to track .NET SDK version required.
-   */
-  'dotnet-sdk',
-  /**
-   * Used in the `cpanfile` manager to track Perl version required.
-   */
-  'perl',
-] as const;
+  {
+    name: 'go',
+    description: `Used in the \`gomod\` manager to specify the version of the Go toolchain to use.
+
+In precedence order:
+
+1. config: \`constraints.go\`
+1. \`go.mod\`: \`toolchain\` directive
+1. \`go.mod\`: \`go\` directive
+
+NOTE that the \`constraints.golang\` is not used (https://github.com/renovatebot/renovate/issues/42601)
+  `,
+  },
+  {
+    name: 'gomodMod',
+    description: `Used in the \`gomod\` manager to specify a tag for [\`github.com/marwan-at-work/mod\`](https://github.com/marwan-at-work/mod).
+
+Must be prefixed with \`v\`.`,
+  },
+  {
+    name: 'jenkins',
+    description:
+      'Used in the `jenkins-plugins` datasource to specify a minimum version of Jenkins that a plugin must support.',
+  },
+  {
+    name: 'pipTools',
+    description:
+      'Used in the `pip-compile` manager to specify a version of `pip-tools` to use. @deprecated TODO remove in #42599',
+  },
+  {
+    name: 'platform',
+    description:
+      'Used in the `rubygems` datasource to specify the `platform` that the Gem dependency supports.',
+  },
+  {
+    name: 'rubygems',
+    description:
+      'Used in the `rubygems` datasource to specify the version of the `rubygems` tool that is needed to use this Gem.',
+  },
+  {
+    name: 'vscode',
+    description:
+      'Used in the `npm` manager to track the version of VSCode that the package is compatible with.',
+  },
+  {
+    name: 'dotnet-sdk',
+    description:
+      'Used in the `nuget` manager to track .NET SDK version required.',
+  },
+  {
+    name: 'perl',
+    description:
+      'Used in the `cpanfile` manager to track Perl version required.',
+  },
+] as const satisfies ConstraintDefinition[];
 
 /**
  * Additional constraints that can be specified for some Managers, but are **not** tools that Containerbase supports.
  */
 export type AdditionalConstraintName =
-  (typeof additionalConstraintNames)[number];
+  (typeof additionalConstraintDefinitions)[number]['name'];
+
+/**
+ * Additional constraints that can be specified for some Managers, but are **not** tools that Containerbase supports.
+ */
+export const additionalConstraintNames: AdditionalConstraintName[] =
+  additionalConstraintDefinitions.map((c) => c.name);
 
 export function isAdditionalConstraintName(
   value: unknown,
 ): value is AdditionalConstraintName {
   return (
     isString(value) &&
-    additionalConstraintNames.includes(value as AdditionalConstraintName)
+    (additionalConstraintNames as readonly string[]).includes(value)
   );
 }
 

--- a/tools/docs/schema.ts
+++ b/tools/docs/schema.ts
@@ -4,9 +4,10 @@ import type {
   RenovateRequiredOption,
 } from '../../lib/config/types.ts';
 import { pkg } from '../../lib/expose.ts';
+import type { ConstraintDefinition } from '../../lib/util/exec/types.ts';
 import {
-  additionalConstraintNames,
-  toolNames,
+  additionalConstraintDefinitions,
+  toolDefinitions,
 } from '../../lib/util/exec/types.ts';
 import { hasKey } from '../../lib/util/object.ts';
 import { updateFile } from '../utils/index.ts';
@@ -131,17 +132,25 @@ function createSingleConfig(option: RenovateOptions): Record<string, unknown> {
     temp.additionalProperties = false;
     temp.properties = {};
 
-    for (const tool of [...toolNames]) {
-      temp.properties[tool] = {
+    for (const {
+      name,
+      description,
+    } of toolDefinitions as readonly ConstraintDefinition[]) {
+      const base = `A constraint for the \`${name}\` Containerbase tool`;
+      temp.properties[name] = {
         type: 'string',
-        description: `A constraint for the \`${tool}\` Containerbase tool`,
+        description: description ? `${base}. ${description}` : base,
       };
     }
 
-    for (const constraintName of [...additionalConstraintNames]) {
-      temp.properties[constraintName] = {
+    for (const {
+      name,
+      description,
+    } of additionalConstraintDefinitions as readonly ConstraintDefinition[]) {
+      temp.properties[name] = {
         type: 'string',
-        description: `A constraint for \`${constraintName}\``,
+        // prioritise contraint definitions, as they're more useful than the generated one
+        description: description ?? `A constraint for \`${name}\``,
       };
     }
   }
@@ -150,10 +159,14 @@ function createSingleConfig(option: RenovateOptions): Record<string, unknown> {
     temp.additionalProperties = false;
     temp.properties = {};
 
-    for (const tool of [...toolNames]) {
-      temp.properties[tool] = {
+    for (const {
+      name,
+      description,
+    } of toolDefinitions as readonly ConstraintDefinition[]) {
+      const base = `Install the \`${name}\` Containerbase tool`;
+      temp.properties[name] = {
         type: 'object',
-        description: `Install the \`${tool}\` Containerbase tool`,
+        description: description ? `${base}. ${description}` : base,
         additionalProperties: false,
       };
     }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->


Instead of inline documentation with JSDoc, we can use an optional
`description` field that can be accessed programatically.

This means the `description` can also be added to our JSON Schema for a
Tool, or be the only output when a non-Tool constraint, as the
description for non-Tools are more clear than the autogenerated text.

We can make sure we continue to export the known names, as well as the
full definitions.

Used more in https://github.com/renovatebot/renovate/pull/42837


## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
