### PR TITLE
feat(manager/mise): add support for clang-format

### DIFF
--- a/lib/modules/manager/mise/extract.spec.ts
+++ b/lib/modules/manager/mise/extract.spec.ts
@@ -58,6 +58,7 @@ describe('modules/manager/mise/extract', () => {
       buf = "1.27.0"
       caddy = "2.10.2"
       ccache = "4.11.3"
+      clang-format = "20.1.0"
       committed = "1.1.7"
       conan = "2.24.0"
       consul = "1.14.3"
@@ -144,6 +145,13 @@ describe('modules/manager/mise/extract', () => {
             depName: 'ccache',
             extractVersion: '^v(?<version>\\S+)',
             packageName: 'ccache/ccache',
+          },
+          {
+            currentValue: '20.1.0',
+            datasource: 'github-releases',
+            depName: 'clang-format',
+            extractVersion: '^llvmorg-(?<version>\\S+)',
+            packageName: 'llvm/llvm-project',
           },
           {
             currentValue: '1.1.7',

--- a/lib/modules/manager/mise/upgradeable-tooling.ts
+++ b/lib/modules/manager/mise/upgradeable-tooling.ts
@@ -252,6 +252,14 @@ const miseRegistryTooling: Record<string, ToolingDefinition> = {
       extractVersion: '^v(?<version>\\S+)',
     },
   },
+  'clang-format': {
+    misePluginUrl: 'https://mise.jdx.dev/registry.html#tools',
+    config: {
+      packageName: 'llvm/llvm-project',
+      datasource: GithubReleasesDatasource.id,
+      extractVersion: '^llvmorg-(?<version>\\S+)',
+    },
+  },
   committed: {
     misePluginUrl: 'https://mise.jdx.dev/registry.html#tools',
     config: {


### PR DESCRIPTION
## Changes

Adds `clang-format` ([clang-format](https://clang.llvm.org/docs/ClangFormat.html), part of [LLVM](https://github.com/llvm/llvm-project)) to the set of mise tools for renovate to manage. clang-format is a tool to format C/C++/Java/JavaScript/JSON/Objective-C/Protobuf/C# code.

Versions are sourced from `llvm/llvm-project` GitHub releases (tagged `llvmorg-X.Y.Z`), which matches what the mise registry installs.

## Context

- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, and documentation).

## Documentation (please check one with an [x])

- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Newly added/modified unit tests