### PR TITLE
fix(datasource): handle both config and release constraints as a range

### DIFF
--- a/lib/modules/datasource/common.spec.ts
+++ b/lib/modules/datasource/common.spec.ts
@@ -281,6 +281,46 @@ describe('modules/datasource/common', () => {
         releases: [{ version: '2.0.0' }],
       });
     });
+
+    it('should handle config with a range constraint, and a release with an exact version', () => {
+      // TODO
+      const config = {
+        datasource: 'pypi',
+        packageName: 'bar',
+        versioning: 'pep440',
+        constraintsFiltering: 'strict' as const,
+        constraints: { python: '>=3.8' },
+      };
+      const releaseResult = {
+        releases: [
+          { version: '1.0.0', constraints: { python: ['1.0.0'] } },
+          { version: '2.0.0', constraints: { python: ['3.8.1'] } },
+        ],
+      };
+      expect(applyConstraintsFiltering(releaseResult, config)).toEqual({
+        releases: [{ version: '2.0.0' }],
+      });
+    });
+
+    it('should handle config with an exact version, and a release with a range constraint', () => {
+      // TODO
+      const config = {
+        datasource: 'pypi',
+        packageName: 'bar',
+        versioning: 'pep440',
+        constraintsFiltering: 'strict' as const,
+        constraints: { python: '3.8.1' },
+      };
+      const releaseResult = {
+        releases: [
+          { version: '1.0.0', constraints: { python: ['1.0.0'] } },
+          { version: '2.0.0', constraints: { python: ['3.8.1'] } },
+        ],
+      };
+      expect(applyConstraintsFiltering(releaseResult, config)).toEqual({
+        releases: [{ version: '2.0.0' }],
+      });
+    });
   });
 
   describe('applyVersionCompatibility', () => {

--- a/lib/modules/datasource/common.ts
+++ b/lib/modules/datasource/common.ts
@@ -326,7 +326,7 @@ export function applyConstraintsFiltering<
             configConstraint,
             releaseConstraint,
           },
-          `applyConstraintsFiltering(${release.version}): versioning.subset?.(${configConstraint}, ${releaseConstraint}=${isSubset}`,
+          `applyConstraintsFiltering(${release.version}): versioning.subset?.(${configConstraint}, ${releaseConstraint})=${isSubset}`,
         );
         if (isSubset) {
           satisfiesConstraints = true;
@@ -344,7 +344,7 @@ export function applyConstraintsFiltering<
             configConstraint,
             releaseConstraint,
           },
-          `applyConstraintsFiltering(${release.version}): versioning.matches(${configConstraint}, ${releaseConstraint}=${isSubset}`,
+          `applyConstraintsFiltering(${release.version}): versioning.matches(${configConstraint}, ${releaseConstraint})=${isSubset}`,
         );
         if (doesMatch) {
           satisfiesConstraints = true;

--- a/lib/modules/datasource/common.ts
+++ b/lib/modules/datasource/common.ts
@@ -333,7 +333,7 @@ export function applyConstraintsFiltering<
           break;
         }
 
-        const doesMatch = versioning.matches(
+        const doesMatchConfig = versioning.matches(
           configConstraint,
           releaseConstraint,
         );
@@ -346,7 +346,20 @@ export function applyConstraintsFiltering<
           },
           `applyConstraintsFiltering(${release.version}): versioning.matches(${configConstraint}, ${releaseConstraint})=${isSubset}`,
         );
-        if (doesMatch) {
+        const doesMatchRelease = versioning.matches(
+          releaseConstraint,
+          configConstraint,
+        );
+        logger.trace(
+          {
+            release,
+            versioning: versioningName,
+            configConstraint,
+            releaseConstraint,
+          },
+          `applyConstraintsFiltering(${release.version}): versioning.matches(${releaseConstraint}, ${configConstraint})=${isSubset}`,
+        );
+        if (doesMatchConfig || doesMatchRelease) {
           satisfiesConstraints = true;
           break;
         }

--- a/lib/modules/datasource/index.spec.ts
+++ b/lib/modules/datasource/index.spec.ts
@@ -939,7 +939,11 @@ describe('modules/datasource/index', () => {
             constraintsFiltering: 'strict',
           });
           expect(res).toMatchObject({
-            releases: [{ version: '0.0.3' }, { version: '0.0.4' }],
+            releases: [
+              { version: '0.0.2' },
+              { version: '0.0.3' },
+              { version: '0.0.4' },
+            ],
           });
         });
       });


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
In the case that the user's config is a range, but the release itself
provides an exact value for the constraint, we currently do not
correctly filter it.

Noticed as part of https://github.com/renovatebot/renovate/pull/42921 where this is needed before we can make the change.

## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
