### PR TITLE
chore(datasource): add trace logging for `applyConstraintsFiltering`

### DIFF
--- a/lib/modules/datasource/common.spec.ts
+++ b/lib/modules/datasource/common.spec.ts
@@ -245,6 +245,24 @@ describe('modules/datasource/common', () => {
       });
     });
 
+    it('should return all releases when no configConstraints', () => {
+      const config = {
+        datasource: 'pypi',
+        packageName: 'bar',
+        versioning: 'pep440',
+        constraintsFiltering: 'strict' as const,
+      };
+      const releaseResult = {
+        releases: [
+          { version: '1.0.0', constraints: { python: ['^1.0.0'] } },
+          { version: '2.0.0' },
+        ],
+      };
+      expect(applyConstraintsFiltering(releaseResult, config)).toEqual({
+        releases: [{ version: '1.0.0' }, { version: '2.0.0' }],
+      });
+    });
+
     it('should match exact constraints', () => {
       const config = {
         datasource: 'pypi',

--- a/lib/modules/datasource/common.ts
+++ b/lib/modules/datasource/common.ts
@@ -187,9 +187,25 @@ export function applyConstraintsFiltering<
   const filteredReleases: string[] = [];
   const startingLength = releaseResult.releases.length;
   releaseResult.releases = filterMap(releaseResult.releases, (release) => {
+    logger.trace(
+      {
+        release,
+        versioning: versioningName,
+      },
+      `applyConstraintsFiltering(${release.version})`,
+    );
     const releaseConstraints = release.constraints;
     delete release.constraints;
 
+    logger.trace(
+      {
+        release,
+        versioning: versioningName,
+        configConstraints: configConstraints ?? 'undefined',
+        releaseConstraints: releaseConstraints ?? 'undefined',
+      },
+      `applyConstraintsFiltering(${release.version}): checking constraints`,
+    );
     if (!configConstraints || !releaseConstraints) {
       return release;
     }
@@ -197,7 +213,25 @@ export function applyConstraintsFiltering<
     for (const [name, configConstraint] of Object.entries(
       configConstraints,
     ) as [ConstraintName, string][]) {
-      if (!versioning.isValid(configConstraint)) {
+      logger.trace(
+        {
+          release,
+          versioning: versioningName,
+          constraintName: name,
+          constraint: configConstraint,
+        },
+        `applyConstraintsFiltering(${release.version}) for constraint ${name}`,
+      );
+
+      const isValid = versioning.isValid(configConstraint);
+      logger.trace(
+        {
+          release,
+          versioning: versioningName,
+        },
+        `applyConstraintsFiltering(${release.version}): versioning.isValid(${configConstraint})=${isValid}`,
+      );
+      if (!isValid) {
         logger.once.warn(
           {
             packageName: config.packageName,
@@ -210,6 +244,13 @@ export function applyConstraintsFiltering<
       }
 
       const constraint = releaseConstraints[name];
+      logger.trace(
+        {
+          release,
+          versioning: versioningName,
+        },
+        `applyConstraintsFiltering(${release.version}): releaseConstraints[${name}]=${JSON.stringify(constraint)}`,
+      );
       if (!isNonEmptyArray(constraint)) {
         // A release with no constraints is OK
         continue;
@@ -217,6 +258,14 @@ export function applyConstraintsFiltering<
 
       let satisfiesConstraints = false;
       for (const releaseConstraint of constraint) {
+        logger.trace(
+          {
+            release,
+            versioning: versioningName,
+            releaseConstraint,
+          },
+          `applyConstraintsFiltering(${release.version}): releaseConstraint=${releaseConstraint}`,
+        );
         if (!releaseConstraint) {
           satisfiesConstraints = true;
           logger.once.debug(
@@ -230,7 +279,16 @@ export function applyConstraintsFiltering<
           break;
         }
 
-        if (!versioning.isValid(releaseConstraint)) {
+        const isValid = versioning.isValid(releaseConstraint);
+        logger.trace(
+          {
+            release,
+            versioning: versioningName,
+            releaseConstraint,
+          },
+          `applyConstraintsFiltering(${release.version}): versioning.isValid(${releaseConstraint})=${isValid}`,
+        );
+        if (!isValid) {
           logger.once.debug(
             {
               packageName: config.packageName,
@@ -242,22 +300,65 @@ export function applyConstraintsFiltering<
           break;
         }
 
-        if (configConstraint === releaseConstraint) {
+        const isEqual = configConstraint === releaseConstraint;
+        logger.trace(
+          {
+            release,
+            versioning: versioningName,
+            configConstraint,
+            releaseConstraint,
+          },
+          `applyConstraintsFiltering(${release.version}): ${configConstraint} === ${releaseConstraint}=${isValid}`,
+        );
+        if (isEqual) {
           satisfiesConstraints = true;
           break;
         }
 
-        if (versioning.subset?.(configConstraint, releaseConstraint)) {
+        const isSubset = versioning.subset?.(
+          configConstraint,
+          releaseConstraint,
+        );
+        logger.trace(
+          {
+            release,
+            versioning: versioningName,
+            configConstraint,
+            releaseConstraint,
+          },
+          `applyConstraintsFiltering(${release.version}): versioning.subset?.(${configConstraint}, ${releaseConstraint}=${isSubset}`,
+        );
+        if (isSubset) {
           satisfiesConstraints = true;
           break;
         }
 
-        if (versioning.matches(configConstraint, releaseConstraint)) {
+        const doesMatch = versioning.matches(
+          configConstraint,
+          releaseConstraint,
+        );
+        logger.trace(
+          {
+            release,
+            versioning: versioningName,
+            configConstraint,
+            releaseConstraint,
+          },
+          `applyConstraintsFiltering(${release.version}): versioning.matches(${configConstraint}, ${releaseConstraint}=${isSubset}`,
+        );
+        if (doesMatch) {
           satisfiesConstraints = true;
           break;
         }
       }
 
+      logger.trace(
+        {
+          release,
+          versioning: versioningName,
+        },
+        `applyConstraintsFiltering(${release.version}): satisfiesConstraints=${satisfiesConstraints}`,
+      );
       if (!satisfiesConstraints) {
         filteredReleases.push(release.version);
         return null;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
As a way to provide more additional information to users who are
debugging when `constraintsFiltering=strict`, we can add some TRACE
logs.

We can use the prefix `applyConstraintsFiltering` for all log lines, so
we can use `logLevelRemap` more easily.


## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
