### PR TITLE
feat(vulnerability): Add vulnerability alerts to deps-edn + lein

### DIFF
--- a/lib/util/vulnerability/ecosystem.spec.ts
+++ b/lib/util/vulnerability/ecosystem.spec.ts
@@ -32,23 +32,27 @@ describe('util/vulnerability/ecosystem', () => {
 
   describe('githubEcosystemToDatasource', () => {
     it('maps actions to github-tags datasource', () => {
-      expect(githubEcosystemToDatasource.actions).toBe('github-tags');
+      expect(githubEcosystemToDatasource.actions).toEqual(['github-tags']);
     });
 
     it('maps pip to pypi datasource', () => {
-      expect(githubEcosystemToDatasource.pip).toBe('pypi');
+      expect(githubEcosystemToDatasource.pip).toEqual(['pypi']);
     });
 
     it('maps rust to crate datasource', () => {
-      expect(githubEcosystemToDatasource.rust).toBe('crate');
+      expect(githubEcosystemToDatasource.rust).toEqual(['crate']);
     });
 
     it('maps npm to npm datasource', () => {
-      expect(githubEcosystemToDatasource.npm).toBe('npm');
+      expect(githubEcosystemToDatasource.npm).toEqual(['npm']);
     });
 
     it('maps composer to packagist datasource', () => {
-      expect(githubEcosystemToDatasource.composer).toBe('packagist');
+      expect(githubEcosystemToDatasource.composer).toEqual(['packagist']);
+    });
+
+    it('maps maven to both maven and clojure datasources', () => {
+      expect(githubEcosystemToDatasource.maven).toEqual(['maven', 'clojure']);
     });
   });
 });

--- a/lib/util/vulnerability/ecosystem.spec.ts
+++ b/lib/util/vulnerability/ecosystem.spec.ts
@@ -9,6 +9,10 @@ describe('util/vulnerability/ecosystem', () => {
       expect(datasourceToOsvEcosystem.crate).toBe('crates.io');
     });
 
+    it('maps clojure datasource to Maven ecosystem', () => {
+      expect(datasourceToOsvEcosystem.clojure).toBe('Maven');
+    });
+
     it('maps go datasource to Go ecosystem', () => {
       expect(datasourceToOsvEcosystem.go).toBe('Go');
     });

--- a/lib/util/vulnerability/ecosystem.ts
+++ b/lib/util/vulnerability/ecosystem.ts
@@ -22,9 +22,8 @@ export const datasourceToOsvEcosystem: Record<
   string,
   OsvEcosystem | undefined
 > = {
-  // ClojureDatasource extends MavenDatasource and OSV indexes Clojars and
-  // Maven Central artifacts under the same Maven ecosystem, so deps.edn and
-  // Leiningen packages share the maven entry below.
+  // ClojureDatasource extends MavenDatasource and OSV indexes Clojars and Maven Central artifacts under the same Maven
+  // ecosystem, so deps.edn and Leiningen packages share the maven entry below.
   [ClojureDatasource.id]: 'Maven',
   [CrateDatasource.id]: 'crates.io',
   [GoDatasource.id]: 'Go',

--- a/lib/util/vulnerability/ecosystem.ts
+++ b/lib/util/vulnerability/ecosystem.ts
@@ -43,14 +43,14 @@ export const datasourceToOsvEcosystem: Record<
  *
  * @see https://docs.github.com/en/rest/dependabot/alerts
  */
-export const githubEcosystemToDatasource: Record<GithubEcosystem, string> = {
-  actions: GithubTagsDatasource.id,
-  composer: PackagistDatasource.id,
-  go: GoDatasource.id,
-  maven: MavenDatasource.id,
-  npm: NpmDatasource.id,
-  nuget: NugetDatasource.id,
-  pip: PypiDatasource.id,
-  rubygems: RubygemsDatasource.id,
-  rust: CrateDatasource.id,
+export const githubEcosystemToDatasource: Record<GithubEcosystem, string[]> = {
+  actions: [GithubTagsDatasource.id],
+  composer: [PackagistDatasource.id],
+  go: [GoDatasource.id],
+  maven: [MavenDatasource.id, ClojureDatasource.id],
+  npm: [NpmDatasource.id],
+  nuget: [NugetDatasource.id],
+  pip: [PypiDatasource.id],
+  rubygems: [RubygemsDatasource.id],
+  rust: [CrateDatasource.id],
 };

--- a/lib/util/vulnerability/ecosystem.ts
+++ b/lib/util/vulnerability/ecosystem.ts
@@ -1,4 +1,5 @@
 import type { Ecosystem as OsvEcosystem } from '@renovatebot/osv-offline';
+import { ClojureDatasource } from '../../modules/datasource/clojure/index.ts';
 import { CrateDatasource } from '../../modules/datasource/crate/index.ts';
 import { GithubTagsDatasource } from '../../modules/datasource/github-tags/index.ts';
 import { GoDatasource } from '../../modules/datasource/go/index.ts';
@@ -21,6 +22,10 @@ export const datasourceToOsvEcosystem: Record<
   string,
   OsvEcosystem | undefined
 > = {
+  // ClojureDatasource extends MavenDatasource and OSV indexes Clojars and
+  // Maven Central artifacts under the same Maven ecosystem, so deps.edn and
+  // Leiningen packages share the maven entry below.
+  [ClojureDatasource.id]: 'Maven',
   [CrateDatasource.id]: 'crates.io',
   [GoDatasource.id]: 'Go',
   [HackageDatasource.id]: 'Hackage',

--- a/lib/workers/repository/init/vulnerability.spec.ts
+++ b/lib/workers/repository/init/vulnerability.spec.ts
@@ -292,7 +292,7 @@ describe('workers/repository/init/vulnerability', () => {
       expect(res).toMatchObject({
         packageRules: [
           {
-            matchDatasources: ['maven'],
+            matchDatasources: ['maven', 'clojure'],
             matchPackageNames: ['com.fasterxml.jackson.core:jackson-databind'],
             matchCurrentVersion: '(,2.7.9.4)',
             vulnerabilityFixVersion: '2.7.9.4',

--- a/lib/workers/repository/init/vulnerability.ts
+++ b/lib/workers/repository/init/vulnerability.ts
@@ -129,10 +129,10 @@ export async function detectVulnerabilityAlerts(
       }
       // GitHub reports JVM advisories under the maven ecosystem, but Renovate tags deps.edn and Leiningen dependencies
       // with the clojure datasource. Widen the rule so a maven advisory also applies to those managers.
-      let matchDatasources = [datasource];
-      if (datasource === MavenDatasource.id) {
-        matchDatasources = [MavenDatasource.id, ClojureDatasource.id];
-      }
+      const matchDatasources =
+        datasource === MavenDatasource.id
+          ? [MavenDatasource.id, ClojureDatasource.id]
+          : [datasource];
 
       let matchRule: PackageRule = {
         matchDatasources,

--- a/lib/workers/repository/init/vulnerability.ts
+++ b/lib/workers/repository/init/vulnerability.ts
@@ -2,12 +2,14 @@ import is from '@sindresorhus/is';
 import type { PackageRule, RenovateConfig } from '../../../config/types.ts';
 import { NO_VULNERABILITY_ALERTS } from '../../../constants/error-messages.ts';
 import { logger } from '../../../logger/index.ts';
-import { ClojureDatasource } from '../../../modules/datasource/clojure/index.ts';
 import { getDefaultVersioning } from '../../../modules/datasource/common.ts';
 import { GithubTagsDatasource } from '../../../modules/datasource/github-tags/index.ts';
 import { MavenDatasource } from '../../../modules/datasource/maven/index.ts';
 import { NugetDatasource } from '../../../modules/datasource/nuget/index.ts';
-import type { SecurityAdvisory } from '../../../modules/platform/github/schema.ts';
+import type {
+  Ecosystem,
+  SecurityAdvisory,
+} from '../../../modules/platform/github/schema.ts';
 import { platform } from '../../../modules/platform/index.ts';
 import * as allVersioning from '../../../modules/versioning/index.ts';
 import { sanitizeMarkdown } from '../../../util/markdown.ts';
@@ -19,18 +21,19 @@ import {
   getHighestVulnerabilitySeverity,
 } from '../../../util/vulnerability/utils.ts';
 
-type Datasource = string;
 type DependencyName = string;
 
-type CombinedAlert = Record<
-  Datasource,
+type CombinedAlert = Partial<
   Record<
-    DependencyName,
-    {
-      advisories: SecurityAdvisory[];
-      firstPatchedVersion?: string;
-      severity?: string;
-    }
+    Ecosystem,
+    Record<
+      DependencyName,
+      {
+        advisories: SecurityAdvisory[];
+        firstPatchedVersion?: string;
+        severity?: string;
+      }
+    >
   >
 >;
 
@@ -74,26 +77,28 @@ export async function detectVulnerabilityAlerts(
         );
         continue;
       }
-      const datasource =
-        githubEcosystemToDatasource[
-          alert.security_vulnerability.package.ecosystem
-        ];
+      const ecosystem = alert.security_vulnerability.package.ecosystem;
+      const datasources = githubEcosystemToDatasource[ecosystem];
       const depName = alert.security_vulnerability.package.name;
       const firstPatchedVersion =
         alert.security_vulnerability.first_patched_version.identifier;
       const advisory = alert.security_advisory;
 
-      combinedAlerts[datasource] ??= {};
-      combinedAlerts[datasource][depName] ??= {
+      // Keying off of ecosystem instead of datasource because now a single ecosystem (such as maven) could have
+      // multiple datasources.
+      combinedAlerts[ecosystem] ??= {};
+      combinedAlerts[ecosystem][depName] ??= {
         advisories: [],
       };
-      const alertDetails = combinedAlerts[datasource][depName];
+      const alertDetails = combinedAlerts[ecosystem][depName];
       alertDetails.advisories.push(advisory);
       alertDetails.severity = getHighestVulnerabilitySeverity(
         { vulnerabilitySeverity: alertDetails.severity },
         { vulnerabilitySeverity: alert.security_vulnerability.severity },
       );
-      const versioningApi = allVersioning.get(getDefaultVersioning(datasource));
+      const versioningApi = allVersioning.get(
+        getDefaultVersioning(datasources[0]),
+      );
       if (versioningApi.isVersion(firstPatchedVersion)) {
         if (
           !alertDetails.firstPatchedVersion ||
@@ -113,7 +118,10 @@ export async function detectVulnerabilityAlerts(
   }
   const alertPackageRules: PackageRule[] = [];
   config.remediations = {} as never;
-  for (const [datasource, dependencies] of Object.entries(combinedAlerts)) {
+  for (const [ecosystem, dependencies] of Object.entries(combinedAlerts)) {
+    const matchDatasources =
+      githubEcosystemToDatasource[ecosystem as Ecosystem];
+    const primaryDatasource = matchDatasources[0];
     for (const [depName, val] of Object.entries(dependencies)) {
       if (!val.firstPatchedVersion) {
         continue;
@@ -127,12 +135,6 @@ export async function detectVulnerabilityAlerts(
       } catch (err) /* v8 ignore next */ {
         logger.warn({ err }, 'Error generating vulnerability PR notes');
       }
-      // GitHub reports JVM advisories under the maven ecosystem, but Renovate tags deps.edn and Leiningen dependencies
-      // with the clojure datasource. Widen the rule so a maven advisory also applies to those managers.
-      const matchDatasources =
-        datasource === MavenDatasource.id
-          ? [MavenDatasource.id, ClojureDatasource.id]
-          : [datasource];
 
       let matchRule: PackageRule = {
         matchDatasources,
@@ -141,11 +143,11 @@ export async function detectVulnerabilityAlerts(
 
       let matchCurrentVersion = `< ${val.firstPatchedVersion}`;
       if (
-        datasource === MavenDatasource.id ||
-        datasource === NugetDatasource.id
+        primaryDatasource === MavenDatasource.id ||
+        primaryDatasource === NugetDatasource.id
       ) {
         matchCurrentVersion = `(,${val.firstPatchedVersion})`;
-      } else if (datasource === GithubTagsDatasource.id) {
+      } else if (primaryDatasource === GithubTagsDatasource.id) {
         matchCurrentVersion = `!/^${escapeRegExp(val.firstPatchedVersion)}$/`;
       }
 

--- a/lib/workers/repository/init/vulnerability.ts
+++ b/lib/workers/repository/init/vulnerability.ts
@@ -2,6 +2,7 @@ import is from '@sindresorhus/is';
 import type { PackageRule, RenovateConfig } from '../../../config/types.ts';
 import { NO_VULNERABILITY_ALERTS } from '../../../constants/error-messages.ts';
 import { logger } from '../../../logger/index.ts';
+import { ClojureDatasource } from '../../../modules/datasource/clojure/index.ts';
 import { getDefaultVersioning } from '../../../modules/datasource/common.ts';
 import { GithubTagsDatasource } from '../../../modules/datasource/github-tags/index.ts';
 import { MavenDatasource } from '../../../modules/datasource/maven/index.ts';
@@ -126,8 +127,15 @@ export async function detectVulnerabilityAlerts(
       } catch (err) /* v8 ignore next */ {
         logger.warn({ err }, 'Error generating vulnerability PR notes');
       }
+      // GitHub reports JVM advisories under the maven ecosystem, but Renovate tags deps.edn and Leiningen dependencies
+      // with the clojure datasource. Widen the rule so a maven advisory also applies to those managers.
+      let matchDatasources = [datasource];
+      if (datasource === MavenDatasource.id) {
+        matchDatasources = [MavenDatasource.id, ClojureDatasource.id];
+      }
+
       let matchRule: PackageRule = {
-        matchDatasources: [datasource],
+        matchDatasources,
         matchPackageNames: [depName],
       };
 

--- a/lib/workers/repository/process/vulnerabilities.spec.ts
+++ b/lib/workers/repository/process/vulnerabilities.spec.ts
@@ -1731,6 +1731,58 @@ describe('workers/repository/process/vulnerabilities', () => {
       ]);
     });
 
+    it('returns packageRule for deps-edn package using OSV Maven ecosystem', async () => {
+      const packageFiles: Record<string, PackageFile[]> = {
+        'deps-edn': [
+          {
+            deps: [
+              {
+                depName: 'org.clojure/clojure',
+                packageName: 'org.clojure:clojure',
+                currentValue: '1.10.0',
+                datasource: 'clojure',
+              },
+            ],
+            packageFile: 'deps.edn',
+          },
+        ],
+      };
+      getVulnerabilitiesMock.mockResolvedValueOnce([
+        {
+          id: 'GHSA-jfh8-c2jp-clj1',
+          modified: '',
+          affected: [
+            {
+              package: {
+                name: 'org.clojure:clojure',
+                ecosystem: 'Maven',
+                purl: 'pkg:maven/org.clojure/clojure',
+              },
+              ranges: [
+                {
+                  type: 'ECOSYSTEM',
+                  events: [{ introduced: '0' }, { fixed: '1.11.0' }],
+                },
+              ],
+            },
+          ],
+        },
+      ]);
+
+      await vulnerabilities.appendVulnerabilityPackageRules(
+        config,
+        packageFiles,
+      );
+      expect(config.packageRules).toMatchObject([
+        {
+          matchDatasources: ['clojure'],
+          matchPackageNames: ['org.clojure:clojure'],
+          matchCurrentVersion: '1.10.0',
+          allowedVersions: '[1.11.0,)',
+        },
+      ]);
+    });
+
     it('returns packageRule based on last_affected version', async () => {
       const packageFiles: Record<string, PackageFile[]> = {
         npm: [


### PR DESCRIPTION
deps-edn and lein both essentially use maven upstream for several packages. Some packages come from clojars directly but others are typical java packages. If there is an OSV alert for a maven package however, it will not propagate to the deps-edn or lein dependency update from renovate. This tries to adjust that so that clojure can derive dependency alerts from maven as well so that those dependencies are treated the same way.

Not sure if this qualifies as a bugfix or a feature? I was unable to find a github issue for this at the time of opening it but I'm happy to make a github issue and/or a reproduction of the problem in another repo if needed.

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Allow maven vulnerability alerts to propagate to clojure's deps-edn and lein dependency managers so that those dependency updates will not just be tagged as regular updates but can be treated as security updates in general.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [x] Yes — other (please describe): I used AI to help research where to make changes in the code and to validate that there was not another way to achieve this behavior using the existing code and configuration changes.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->

Here is an example PR though of how the vulnerabilities do not propagate today: 
https://github.com/treasuryprime/com.treasuryprime.clj-cron-parse/pull/11 

That PR contains an update for Clojure that references https://github.com/advisories/GHSA-vr64-r9qj-h27f but because the PR is for deps-edn only it does not tag the PR as security.