### PR TITLE
feat: allow separate versioning for constraints

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -966,6 +966,30 @@ When using with `npm`, we recommend you:
 - Use `constraintsFiltering` on `dependencies`, not `devDependencies` (usually you do not need to be strict about development dependencies)
 - Do _not_ enable `rollbackPrs` at the same time (otherwise your _current_ version may be rolled back if it's incompatible)
 
+## `constraintsVersioning`
+
+Use `constraintsVersioning` to override the versioning scheme used when filtering releases by specific constraint names with [`constraintsFiltering`](#constraintsfiltering).
+
+<!-- prettier-ignore -->
+!!! note
+    Each key must be an [additional constraint name](#constraints) (i.e. not a tool name), and each value must be a valid versioning scheme ID.
+
+Datasources that support constraints filtering may set sensible defaults for their constraints.
+You can override these defaults in your Renovate config.
+
+For example, to use a SemVer-style versioning scheme when defining the `rubygems` constraint:
+
+```json title="Use SemVer-style range for defining version constraint, instead of 'ruby' versioning"
+{
+  "constraints": {
+    "rubygems": "^1.3"
+  },
+  "constraintsVersioning": {
+    "rubygems": "semver-coerced"
+  }
+}
+```
+
 ## `customDatasources`
 
 Use `customDatasources` to fetch releases from APIs or statically hosted sites and Renovate has no own datasource.

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -3480,6 +3480,20 @@ const options: Readonly<RenovateOptions>[] = [
     cli: false,
     env: false,
   },
+  {
+    name: 'constraintsVersioning',
+    description:
+      'Override the versioning scheme used when filtering releases by specific constraint names. Does not apply to tools.',
+    type: 'object',
+    default: {},
+    mergeable: true,
+    cli: false,
+    env: false,
+    freeChoice: true,
+    additionalProperties: {
+      type: 'string',
+    },
+  },
 ];
 
 export function getOptions(): Readonly<RenovateOptions>[] {

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -458,6 +458,9 @@ export interface RenovateConfig
   variables?: Record<string, string>;
 
   constraints?: Partial<Record<ConstraintName, string>>;
+  /**
+   * Any specific overrides for the versioning for the `AdditionalConstraintName`s.
+   */
   constraintsVersioning?: Partial<Record<AdditionalConstraintName, string>>;
   skipInstalls?: boolean | null;
 

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -11,7 +11,11 @@ import type {
   SkipReason,
 } from '../types/index.ts';
 import type { StageName } from '../types/skip-reason.ts';
-import type { ConstraintName, ToolName } from '../util/exec/types.ts';
+import type {
+  AdditionalConstraintName,
+  ConstraintName,
+  ToolName,
+} from '../util/exec/types.ts';
 import type { GitNoVerifyOption } from '../util/git/types.ts';
 import type { MergeConfidence } from '../util/merge-confidence/types.ts';
 import type { Timestamp } from '../util/timestamp.ts';
@@ -454,6 +458,7 @@ export interface RenovateConfig
   variables?: Record<string, string>;
 
   constraints?: Partial<Record<ConstraintName, string>>;
+  constraintsVersioning?: Partial<Record<AdditionalConstraintName, string>>;
   skipInstalls?: boolean | null;
 
   constraintsFiltering?: ConstraintsFilter;

--- a/lib/config/validation.spec.ts
+++ b/lib/config/validation.spec.ts
@@ -1138,6 +1138,146 @@ describe('config/validation', () => {
       });
     });
 
+    describe('constraintsVersioning', () => {
+      it('cannot contain a valid tool name for Containerbase', async () => {
+        const config: RenovateConfig = {
+          constraintsVersioning: {
+            // @ts-expect-error: not an AdditionalConstraintName
+            golang: 'semver',
+          },
+        };
+        const { warnings, errors } = await configValidation.validateConfig(
+          'repo',
+          config,
+          true,
+        );
+        expect(warnings).toHaveLength(0);
+        expect(errors).toEqual([
+          {
+            topic: 'Configuration Error',
+            message:
+              'Configuration option `constraintsVersioning.golang` is not a valid additional constraint name, as `golang` is a tool name, and `constraintsVersioning` can only override the versioning for a non-tool constraint',
+          },
+        ]);
+      });
+
+      it('can contain a constraint for a non-Containerbase tool', async () => {
+        const config: RenovateConfig = {
+          constraintsVersioning: {
+            gomodMod: 'semver',
+          },
+        };
+        const { warnings, errors } = await configValidation.validateConfig(
+          'repo',
+          config,
+          true,
+        );
+        expect(warnings).toHaveLength(0);
+        expect(errors).toHaveLength(0);
+      });
+
+      it('cannot contain an additional constraint name with an invalid versioning scheme', async () => {
+        const config: RenovateConfig = {
+          constraintsVersioning: {
+            gomodMod: 'not-supported-versioning',
+          },
+        };
+        const { warnings, errors } = await configValidation.validateConfig(
+          'repo',
+          config,
+          true,
+        );
+        expect(warnings).toHaveLength(0);
+        expect(errors).toEqual([
+          {
+            topic: 'Configuration Error',
+            message:
+              'Configuration option `constraintsVersioning.gomodMod=not-supported-versioning`: `not-supported-versioning` is not a valid versioning scheme',
+          },
+        ]);
+      });
+
+      it('can contain an additional constraint name with a regex versioning scheme', async () => {
+        const config: RenovateConfig = {
+          constraintsVersioning: {
+            gomodMod:
+              'regex:^(?<major>\\d+?)\\.(?<minor>\\d+?)(\\.(?<patch>\\d+))?$',
+          },
+        };
+        const { warnings, errors } = await configValidation.validateConfig(
+          'repo',
+          config,
+          true,
+        );
+        expect(warnings).toHaveLength(0);
+        expect(errors).toHaveLength(0);
+      });
+
+      it('cannot contain an unsupported constraint', async () => {
+        const config: RenovateConfig = {
+          constraintsVersioning: {
+            // @ts-expect-error: contains invalid values
+            'not-supported': '4.5.6',
+          },
+        };
+        const { warnings, errors } = await configValidation.validateConfig(
+          'repo',
+          config,
+          true,
+        );
+        expect(warnings).toHaveLength(0);
+        expect(errors).toEqual([
+          {
+            topic: 'Configuration Error',
+            message:
+              'Configuration option `constraintsVersioning.not-supported`: `not-supported` is not a known additional constraint name',
+          },
+        ]);
+      });
+
+      it('errors if constraintsVersioning is a malformed object', async () => {
+        const config: RenovateConfig = {
+          constraintsVersioning: {
+            // @ts-expect-error: contains invalid values
+            packageRules: [{}],
+          },
+        };
+        const { warnings, errors } = await configValidation.validateConfig(
+          'repo',
+          config,
+          true,
+        );
+        expect(warnings).toHaveLength(0);
+        expect(errors).toEqual([
+          {
+            topic: 'Configuration Error',
+            message:
+              'Configuration option `constraintsVersioning.packageRules` should be an object of key-value pairs of additional constraint names and their versioning',
+          },
+        ]);
+      });
+
+      it('errors if constraintsVersioning is a malformed array', async () => {
+        const config: RenovateConfig = {
+          // @ts-expect-error: contains invalid values
+          constraintsVersioning: [1, 2, 3],
+        };
+        const { warnings, errors } = await configValidation.validateConfig(
+          'repo',
+          config,
+          true,
+        );
+        expect(warnings).toHaveLength(0);
+        expect(errors).toEqual([
+          {
+            topic: 'Configuration Error',
+            message:
+              'Configuration option `constraintsVersioning` should be a json object',
+          },
+        ]);
+      });
+    });
+
     it('validates object with ignored children', async () => {
       const config = {
         prBodyDefinitions: {},

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -789,6 +789,36 @@ export async function validateConfig(
                   }
                 }
               }
+            } else if (key === 'constraintsVersioning') {
+              for (const [k, v] of Object.entries(val)) {
+                if (!isString(v)) {
+                  errors.push({
+                    topic: 'Configuration Error',
+                    message: `Configuration option \`${currentPath}.${k}\` should be an object of key-value pairs of additional constraint names and their versioning`,
+                  });
+                  break;
+                }
+
+                if (isToolName(k)) {
+                  errors.push({
+                    topic: 'Configuration Error',
+                    message: `Configuration option \`${currentPath}.${k}\` is not a valid additional constraint name, as \`${k}\` is a tool name, and \`constraintsVersioning\` can only override the versioning for a non-tool constraint`,
+                  });
+                } else if (isConstraintName(k)) {
+                  const versioningName = v.split(':')[0];
+                  if (!allVersioning.getVersionings().get(versioningName)) {
+                    errors.push({
+                      topic: 'Configuration Error',
+                      message: `Configuration option \`${currentPath}.${k}=${v}\`: \`${v}\` is not a valid versioning scheme`,
+                    });
+                  }
+                } else {
+                  errors.push({
+                    topic: 'Configuration Error',
+                    message: `Configuration option \`${currentPath}.${k}\`: \`${k}\` is not a known additional constraint name`,
+                  });
+                }
+              }
             } else {
               const ignoredObjects = options
                 .filter((option) => option.freeChoice)

--- a/lib/modules/datasource/common.spec.ts
+++ b/lib/modules/datasource/common.spec.ts
@@ -1,5 +1,7 @@
 import { logger } from '~test/util.ts';
 import { defaultVersioning } from '../versioning/index.ts';
+import ruby from '../versioning/ruby/index.ts';
+import semverCoerced from '../versioning/semver-coerced/index.ts';
 import {
   applyConstraintsFiltering,
   applyExtractVersion,
@@ -12,7 +14,7 @@ import {
 } from './common.ts';
 import { CustomDatasource } from './custom/index.ts';
 import { NpmDatasource } from './npm/index.ts';
-import type { ReleaseResult } from './types.ts';
+import type { GetPkgReleasesConfig, ReleaseResult } from './types.ts';
 
 describe('modules/datasource/common', () => {
   describe('getDatasourceFor', () => {
@@ -317,6 +319,44 @@ describe('modules/datasource/common', () => {
       };
       expect(applyConstraintsFiltering(releaseResult, config)).toEqual({
         releases: [{ version: '2.0.0' }],
+      });
+    });
+
+    it(`should allow constraintsVersioning to override the datasource's default versioning`, () => {
+      const config: GetPkgReleasesConfig = {
+        datasource: 'rubygems',
+        packageName: 'rails',
+        versioning: 'ruby',
+        constraintsFiltering: 'strict' as const,
+        constraints: {
+          // anything between 1.3.0 and less than 2.0.0
+          rubygems: '^1.3',
+        },
+        constraintsVersioning: {
+          // instead of using ruby version, which doesn't support this syntax
+          rubygems: 'semver-coerced',
+        },
+      };
+
+      // make sure that it's currently an invalid constraint for ruby
+      expect(config.constraints?.rubygems).toBeDefined();
+      expect(ruby.isValid(config.constraints!.rubygems!)).toBeFalse();
+      // but that it works when using semver-coerced
+      expect(semverCoerced.isValid(config.constraints!.rubygems!)).toBeTrue();
+
+      const releaseResult = {
+        releases: [
+          // slightly modified from upstream
+          { version: '0.9.1', constraints: { rubygems: ['1.0.0'] } },
+          { version: '3.1.3', constraints: { rubygems: ['1.2.3'] } },
+
+          // using upstraem data
+          { version: '4.1.2', constraints: { rubygems: ['>= 1.8.11'] } },
+          { version: '8.1.3', constraints: { rubygems: ['>= 1.8.11'] } },
+        ],
+      };
+      expect(applyConstraintsFiltering(releaseResult, config)).toEqual({
+        releases: [{ version: '4.1.2' }, { version: '8.1.3' }],
       });
     });
   });

--- a/lib/modules/datasource/common.ts
+++ b/lib/modules/datasource/common.ts
@@ -3,7 +3,10 @@ import {
   isNonEmptyStringAndNotWhitespace,
 } from '@sindresorhus/is';
 import { logger } from '../../logger/index.ts';
-import type { ConstraintName } from '../../util/exec/types.ts';
+import {
+  type ConstraintName,
+  isAdditionalConstraintName,
+} from '../../util/exec/types.ts';
 import { filterMap } from '../../util/filter-map.ts';
 import { regEx } from '../../util/regex.ts';
 import * as allVersioning from '../versioning/index.ts';
@@ -165,6 +168,7 @@ export function applyConstraintsFiltering<
   Config extends Pick<
     GetPkgReleasesConfig,
     | 'constraintsFiltering'
+    | 'constraintsVersioning'
     | 'versioning'
     | 'datasource'
     | 'constraints'
@@ -213,21 +217,34 @@ export function applyConstraintsFiltering<
     for (const [name, configConstraint] of Object.entries(
       configConstraints,
     ) as [ConstraintName, string][]) {
+      let constraintVersioningName = versioningName;
+      if (
+        isAdditionalConstraintName(name) &&
+        config.constraintsVersioning?.[name]
+      ) {
+        const val = config.constraintsVersioning[name];
+        logger.debug(
+          `applyConstraintsFiltering(${release.version}): overriding constraintsVersioning from ${constraintVersioningName} to ${val}`,
+        );
+        constraintVersioningName = val;
+      }
+      const constraintVersioning = allVersioning.get(constraintVersioningName);
+
       logger.trace(
         {
           release,
-          versioning: versioningName,
+          versioning: constraintVersioningName,
           constraintName: name,
           constraint: configConstraint,
         },
         `applyConstraintsFiltering(${release.version}) for constraint ${name}`,
       );
 
-      const isValid = versioning.isValid(configConstraint);
+      const isValid = constraintVersioning.isValid(configConstraint);
       logger.trace(
         {
           release,
-          versioning: versioningName,
+          versioning: constraintVersioningName,
         },
         `applyConstraintsFiltering(${release.version}): versioning.isValid(${configConstraint})=${isValid}`,
       );
@@ -236,7 +253,7 @@ export function applyConstraintsFiltering<
           {
             packageName: config.packageName,
             constraint: configConstraint,
-            versioning: versioningName,
+            versioning: constraintVersioningName,
           },
           'Invalid constraint used with strict constraintsFiltering',
         );
@@ -247,7 +264,7 @@ export function applyConstraintsFiltering<
       logger.trace(
         {
           release,
-          versioning: versioningName,
+          versioning: constraintVersioningName,
         },
         `applyConstraintsFiltering(${release.version}): releaseConstraints[${name}]=${JSON.stringify(constraint)}`,
       );
@@ -261,7 +278,7 @@ export function applyConstraintsFiltering<
         logger.trace(
           {
             release,
-            versioning: versioningName,
+            versioning: constraintVersioningName,
             releaseConstraint,
           },
           `applyConstraintsFiltering(${release.version}): releaseConstraint=${releaseConstraint}`,
@@ -271,7 +288,7 @@ export function applyConstraintsFiltering<
           logger.once.debug(
             {
               packageName: config.packageName,
-              versioning: versioningName,
+              versioning: constraintVersioningName,
               constraint: releaseConstraint,
             },
             'Undefined release constraint',
@@ -279,20 +296,30 @@ export function applyConstraintsFiltering<
           break;
         }
 
-        const isValid = versioning.isValid(releaseConstraint);
+        const isValidConstraintVersion =
+          constraintVersioning.isValid(releaseConstraint);
         logger.trace(
           {
             release,
-            versioning: versioningName,
+            versioning: constraintVersioningName,
             releaseConstraint,
           },
-          `applyConstraintsFiltering(${release.version}): versioning.isValid(${releaseConstraint})=${isValid}`,
+          `applyConstraintsFiltering(${release.version}): constraintVersioning.isValid(${releaseConstraint})=${isValidConstraintVersion}`,
         );
-        if (!isValid) {
+        const isValidVersion = versioning.isValid(releaseConstraint);
+        logger.trace(
+          {
+            release,
+            versioning: constraintVersioningName,
+            releaseConstraint,
+          },
+          `applyConstraintsFiltering(${release.version}): versioning.isValid(${releaseConstraint})=${isValidVersion}`,
+        );
+        if (!isValidVersion || !isValidConstraintVersion) {
           logger.once.debug(
             {
               packageName: config.packageName,
-              versioning: versioningName,
+              versioning: constraintVersioningName,
               constraint: releaseConstraint,
             },
             'Invalid release constraint',
@@ -304,7 +331,7 @@ export function applyConstraintsFiltering<
         logger.trace(
           {
             release,
-            versioning: versioningName,
+            versioning: constraintVersioningName,
             configConstraint,
             releaseConstraint,
           },
@@ -315,14 +342,14 @@ export function applyConstraintsFiltering<
           break;
         }
 
-        const isSubset = versioning.subset?.(
+        const isSubset = constraintVersioning.subset?.(
           configConstraint,
           releaseConstraint,
         );
         logger.trace(
           {
             release,
-            versioning: versioningName,
+            versioning: constraintVersioningName,
             configConstraint,
             releaseConstraint,
           },
@@ -333,27 +360,27 @@ export function applyConstraintsFiltering<
           break;
         }
 
-        const doesMatchConfig = versioning.matches(
+        const doesMatchConfig = constraintVersioning.matches(
           configConstraint,
           releaseConstraint,
         );
         logger.trace(
           {
             release,
-            versioning: versioningName,
+            versioning: constraintVersioningName,
             configConstraint,
             releaseConstraint,
           },
           `applyConstraintsFiltering(${release.version}): versioning.matches(${configConstraint}, ${releaseConstraint})=${doesMatchConfig}`,
         );
-        const doesMatchRelease = versioning.matches(
+        const doesMatchRelease = constraintVersioning.matches(
           releaseConstraint,
           configConstraint,
         );
         logger.trace(
           {
             release,
-            versioning: versioningName,
+            versioning: constraintVersioningName,
             configConstraint,
             releaseConstraint,
           },
@@ -368,7 +395,7 @@ export function applyConstraintsFiltering<
       logger.trace(
         {
           release,
-          versioning: versioningName,
+          versioning: constraintVersioningName,
         },
         `applyConstraintsFiltering(${release.version}): satisfiesConstraints=${satisfiesConstraints}`,
       );

--- a/lib/modules/datasource/common.ts
+++ b/lib/modules/datasource/common.ts
@@ -224,6 +224,7 @@ export function applyConstraintsFiltering<
       ) {
         const val = config.constraintsVersioning[name];
         logger.debug(
+          { packageName: config.packageName, release },
           `applyConstraintsFiltering(${release.version}): overriding constraintsVersioning from ${constraintVersioningName} to ${val}`,
         );
         constraintVersioningName = val;

--- a/lib/modules/datasource/types.ts
+++ b/lib/modules/datasource/types.ts
@@ -3,7 +3,10 @@ import type {
   CustomDatasourceConfig,
 } from '../../config/types.ts';
 import type { ModuleApi } from '../../types/index.ts';
-import type { ConstraintName } from '../../util/exec/types.ts';
+import type {
+  AdditionalConstraintName,
+  ConstraintName,
+} from '../../util/exec/types.ts';
 import type { Timestamp } from '../../util/timestamp.ts';
 
 export interface GetDigestInputConfig {
@@ -34,6 +37,7 @@ export interface GetReleasesConfig {
   registryUrl?: string;
   currentValue?: string;
   constraints?: Partial<Record<ConstraintName, string>>;
+  constraintsVersioning?: Partial<Record<AdditionalConstraintName, string>>;
   constraintsFiltering?: ConstraintsFilter;
 }
 
@@ -54,6 +58,7 @@ export interface GetPkgReleasesConfig {
   replacementName?: string;
   replacementVersion?: string;
   constraintsFiltering?: ConstraintsFilter;
+  constraintsVersioning?: Partial<Record<AdditionalConstraintName, string>>;
   registryStrategy?: RegistryStrategy;
 }
 

--- a/lib/modules/datasource/types.ts
+++ b/lib/modules/datasource/types.ts
@@ -37,6 +37,9 @@ export interface GetReleasesConfig {
   registryUrl?: string;
   currentValue?: string;
   constraints?: Partial<Record<ConstraintName, string>>;
+  /**
+   * Any specific overrides for the versioning for the `AdditionalConstraintName`s.
+   */
   constraintsVersioning?: Partial<Record<AdditionalConstraintName, string>>;
   constraintsFiltering?: ConstraintsFilter;
 }
@@ -58,6 +61,9 @@ export interface GetPkgReleasesConfig {
   replacementName?: string;
   replacementVersion?: string;
   constraintsFiltering?: ConstraintsFilter;
+  /**
+   * Any specific overrides for the versioning for the `AdditionalConstraintName`s.
+   */
   constraintsVersioning?: Partial<Record<AdditionalConstraintName, string>>;
   registryStrategy?: RegistryStrategy;
 }

--- a/lib/modules/manager/types.ts
+++ b/lib/modules/manager/types.ts
@@ -13,7 +13,10 @@ import type {
   SkipReason,
   StageName,
 } from '../../types/index.ts';
-import type { ConstraintName } from '../../util/exec/types.ts';
+import type {
+  AdditionalConstraintName,
+  ConstraintName,
+} from '../../util/exec/types.ts';
 import type { FileChange } from '../../util/git/types.ts';
 import type { MergeConfidence } from '../../util/merge-confidence/types.ts';
 import type { Timestamp } from '../../util/timestamp.ts';
@@ -66,6 +69,10 @@ export interface PackageFileContent<
 > extends ManagerData<T> {
   autoReplaceStringTemplate?: string;
   extractedConstraints?: Partial<Record<ConstraintName, string>>;
+  /**
+   * Any specific overrides for the versioning for the `AdditionalConstraintName`s.
+   */
+  constraintsVersioning?: Partial<Record<AdditionalConstraintName, string>>;
   datasource?: string;
   registryUrls?: string[];
   additionalRegistryUrls?: string[];

--- a/lib/workers/repository/process/fetch.spec.ts
+++ b/lib/workers/repository/process/fetch.spec.ts
@@ -115,6 +115,99 @@ describe('workers/repository/process/fetch', () => {
       });
     });
 
+    describe('constraintsVersioning', () => {
+      it('is merged from packageFile with config', async () => {
+        config.constraintsVersioning = { gomodMod: 'config-version' };
+        const packageFiles: any = {
+          maven: [
+            {
+              packageFile: 'pom.xml',
+              constraintsVersioning: {
+                gomodMod: 'pfile-version',
+                go: 'go-version',
+              },
+              deps: [{ datasource: MavenDatasource.id, depName: 'bbb' }],
+            },
+          ],
+        };
+        lookupUpdates.mockResolvedValue({ updates: [] } as never);
+
+        await fetchUpdates(config, packageFiles);
+
+        expect(lookupUpdates).toHaveBeenCalledWith(
+          expect.objectContaining({
+            constraintsVersioning: {
+              gomodMod: 'config-version',
+              go: 'go-version',
+            },
+          }),
+        );
+      });
+
+      it('is set from packageFile if only set on packageFile', async () => {
+        const packageFiles: any = {
+          maven: [
+            {
+              packageFile: 'pom.xml',
+              constraintsVersioning: { go: 'go-version' },
+              deps: [{ datasource: MavenDatasource.id, depName: 'bbb' }],
+            },
+          ],
+        };
+        lookupUpdates.mockResolvedValue({ updates: [] } as never);
+
+        await fetchUpdates(config, packageFiles);
+
+        expect(lookupUpdates).toHaveBeenCalledWith(
+          expect.objectContaining({
+            constraintsVersioning: { go: 'go-version' },
+          }),
+        );
+      });
+
+      it('is not set if neither config nor packageFile are set', async () => {
+        const packageFiles: any = {
+          maven: [
+            {
+              packageFile: 'pom.xml',
+              // no constraintsVersioning on pFile
+              deps: [{ datasource: MavenDatasource.id, depName: 'bbb' }],
+            },
+          ],
+        };
+        lookupUpdates.mockResolvedValue({ updates: [] } as never);
+
+        await fetchUpdates(config, packageFiles);
+
+        expect(lookupUpdates).toHaveBeenCalledWith(
+          expect.objectContaining({
+            constraintsVersioning: {},
+          }),
+        );
+      });
+
+      it('is set if config is set', async () => {
+        config.rangeStrategy = 'auto';
+        config.constraintsVersioning = { gomodMod: 'config-version' };
+        const packageFiles: any = {
+          maven: [
+            {
+              packageFile: 'pom.xml',
+              // no constraintsVersioning on pFile
+              deps: [{ datasource: MavenDatasource.id, depName: 'bbb' }],
+            },
+          ],
+        };
+        lookupUpdates.mockResolvedValue({ updates: [] } as never);
+        await fetchUpdates(config, packageFiles);
+        expect(lookupUpdates).toHaveBeenCalledWith(
+          expect.objectContaining({
+            constraintsVersioning: { gomodMod: 'config-version' },
+          }),
+        );
+      });
+    });
+
     it('skips deps with empty names', async () => {
       const packageFiles: Record<string, PackageFile[]> = {
         docker: [

--- a/lib/workers/repository/process/fetch.ts
+++ b/lib/workers/repository/process/fetch.ts
@@ -127,6 +127,13 @@ async function fetchManagerPackagerFileUpdates(
       ...config.constraints,
     };
   }
+  const mergedConstraintsVersioning = {
+    ...pFile.constraintsVersioning,
+    ...config.constraintsVersioning,
+  };
+  if (Object.keys(mergedConstraintsVersioning).length > 0) {
+    packageFileConfig.constraintsVersioning = mergedConstraintsVersioning;
+  }
   const { manager } = packageFileConfig;
   const queue = pFile.deps.map(
     (dep) => async (): Promise<PackageDependency> => {

--- a/tools/docs/schema.ts
+++ b/tools/docs/schema.ts
@@ -155,6 +155,22 @@ function createSingleConfig(option: RenovateOptions): Record<string, unknown> {
     }
   }
 
+  if (option.name === 'constraintsVersioning') {
+    temp.additionalProperties = false;
+    temp.properties = {};
+
+    for (const {
+      name,
+      description,
+    } of additionalConstraintDefinitions as readonly ConstraintDefinition[]) {
+      temp.properties[name] = {
+        type: 'string',
+        // prioritise contraint definitions, as they're more useful than the generated one
+        description: description ?? `A constraint for \`${name}\``,
+      };
+    }
+  }
+
   if (option.name === 'installTools') {
     temp.additionalProperties = false;
     temp.properties = {};


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

As noted in #31831, there are times where it can be useful to override
the version that a given datasource uses, when performing
`constraintsFiltering=strict.`

This should only be applicable to the "additional" constraints, so we
make sure to validate this.

As this is new functionality, any misconfiguration should be marked as
an error.

We can make sure to provide a real-world usecase for this (taking
inspiration from `rails`' versioning of the `rubygems` constraint).

This will be used in the future by the extraction of the `go` directive,
which requires a different versioning to the default `semver` (see https://github.com/renovatebot/renovate/pull/42582 and https://github.com/renovatebot/renovate/pull/42569)


## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #31831
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
