### PR TITLE
feat(terraform-module): use registry v2 API for release timestamps

### DIFF
--- a/docs/usage/key-concepts/minimum-release-age.md
+++ b/docs/usage/key-concepts/minimum-release-age.md
@@ -207,6 +207,7 @@ The below is a non-exhaustive list of public registries which support release ti
 | `docker`             | `https://ghcr.io`                                  | ❌        | [Issue](https://github.com/renovatebot/renovate/issues/39064)    |
 | `docker`             | `https://quay.io`                                  | ❌        | [Issue](https://github.com/renovatebot/renovate/issues/38572)    |
 | `github-releases`    | `https://github.com`                               | ✅        |                                                                  |
+| `terraform-module`   | `https://registry.terraform.io`                    | ✅        |                                                                  |
 | `terraform-provider` | `https://registry.terraform.io`                    | ✅        |                                                                  |
 | `terraform-provider` | `https://registry.opentofu.org`                    | ✅        | Queries `api.opentofu.org` for release timestamps                |
 | `github-tags`        | `https://github.com`                               | ✅        |                                                                  |

--- a/lib/modules/datasource/terraform-module/index.spec.ts
+++ b/lib/modules/datasource/terraform-module/index.spec.ts
@@ -6,11 +6,28 @@ const serviceDiscoveryResult = {
   'modules.v1': '/v1/modules/',
 };
 
-const registryModuleResponse = {
-  source: 'https://github.com/hashicorp/terraform-aws-consul',
-  versions: ['0.3.8', '0.4.0'],
-  version: '0.4.0',
-  published_at: '2018-09-20T11:25:22.957Z',
+const registryModuleV2Response = {
+  data: {
+    attributes: {
+      source: 'https://github.com/hashicorp/terraform-aws-consul',
+    },
+  },
+  included: [
+    {
+      type: 'module-versions',
+      attributes: {
+        version: '0.3.8',
+        'published-at': '2018-08-21T22:26:36Z',
+      },
+    },
+    {
+      type: 'module-versions',
+      attributes: {
+        version: '0.4.0',
+        'published-at': '2018-09-20T11:25:22Z',
+      },
+    },
+  ],
 };
 
 const moduleVersionsResponse = {
@@ -23,13 +40,10 @@ const baseUrl = TerraformModuleDatasource.terraformRegistryUrl;
 type MockVariant = 'empty' | '404' | 'error';
 
 function mockDefaultRegistryLookup(variant: MockVariant): void {
-  httpMock
-    .scope(baseUrl)
-    .get('/.well-known/terraform.json')
-    .reply(200, serviceDiscoveryResult);
   const registryScope = httpMock
     .scope(baseUrl)
-    .get('/v1/modules/hashicorp/consul/aws');
+    .get('/v2/modules/hashicorp/consul/aws')
+    .query({ include: 'module-versions' });
 
   if (variant === 'empty') {
     registryScope.reply(200, {});
@@ -86,10 +100,9 @@ describe('modules/datasource/terraform-module/index', () => {
     it('returns releases, homepage, and source URL from the default registry', async () => {
       httpMock
         .scope(baseUrl)
-        .get('/v1/modules/hashicorp/consul/aws')
-        .reply(200, registryModuleResponse)
-        .get('/.well-known/terraform.json')
-        .reply(200, serviceDiscoveryResult);
+        .get('/v2/modules/hashicorp/consul/aws')
+        .query({ include: 'module-versions' })
+        .reply(200, registryModuleV2Response);
       const res = await getPkgReleases({
         datasource,
         packageName: 'hashicorp/consul/aws',
@@ -99,44 +112,12 @@ describe('modules/datasource/terraform-module/index', () => {
         registryUrl: 'https://registry.terraform.io',
         releases: [
           {
+            releaseTimestamp: '2018-08-21T22:26:36.000Z',
             version: '0.3.8',
           },
           {
-            releaseTimestamp: '2018-09-20T11:25:22.957Z',
+            releaseTimestamp: '2018-09-20T11:25:22.000Z',
             version: '0.4.0',
-          },
-        ],
-        sourceUrl: 'https://github.com/hashicorp/terraform-aws-consul',
-      });
-    });
-
-    it('omits releaseTimestamp when the reported latest version is absent from versions', async () => {
-      httpMock
-        .scope(baseUrl)
-        .get('/v1/modules/hashicorp/consul/aws')
-        .reply(200, {
-          namespace: 'hashicorp',
-          name: 'consul',
-          provider: 'aws',
-          versions: ['0.3.8'],
-          version: '9.9.9',
-          published_at: '2018-09-20T11:25:22.957Z',
-          source: 'https://github.com/hashicorp/terraform-aws-consul',
-        })
-        .get('/.well-known/terraform.json')
-        .reply(200, serviceDiscoveryResult);
-
-      const res = await getPkgReleases({
-        datasource,
-        packageName: 'hashicorp/consul/aws',
-      });
-
-      expect(res).toEqual({
-        homepage: 'https://registry.terraform.io/modules/hashicorp/consul/aws',
-        registryUrl: 'https://registry.terraform.io',
-        releases: [
-          {
-            version: '0.3.8',
           },
         ],
         sourceUrl: 'https://github.com/hashicorp/terraform-aws-consul',
@@ -218,10 +199,9 @@ describe('modules/datasource/terraform-module/index', () => {
     it('uses the registry embedded in packageName', async () => {
       httpMock
         .scope(baseUrl)
-        .get('/v1/modules/hashicorp/consul/aws')
-        .reply(200, registryModuleResponse)
-        .get('/.well-known/terraform.json')
-        .reply(200, serviceDiscoveryResult);
+        .get('/v2/modules/hashicorp/consul/aws')
+        .query({ include: 'module-versions' })
+        .reply(200, registryModuleV2Response);
       const res = await getPkgReleases({
         datasource,
         packageName: 'registry.terraform.io/hashicorp/consul/aws',
@@ -229,6 +209,41 @@ describe('modules/datasource/terraform-module/index', () => {
       expect(res).toEqual({
         homepage: 'https://registry.terraform.io/modules/hashicorp/consul/aws',
         registryUrl: 'https://registry.terraform.io',
+        releases: [
+          {
+            releaseTimestamp: '2018-08-21T22:26:36.000Z',
+            version: '0.3.8',
+          },
+          {
+            releaseTimestamp: '2018-09-20T11:25:22.000Z',
+            version: '0.4.0',
+          },
+        ],
+        sourceUrl: 'https://github.com/hashicorp/terraform-aws-consul',
+      });
+    });
+
+    it('uses the v1 extended endpoint for Terraform Cloud', async () => {
+      const cloudUrl = TerraformModuleDatasource.terraformCloudUrl;
+      httpMock
+        .scope(cloudUrl)
+        .get('/v1/modules/hashicorp/consul/aws')
+        .reply(200, {
+          source: 'https://github.com/hashicorp/terraform-aws-consul',
+          versions: ['0.3.8', '0.4.0'],
+          version: '0.4.0',
+          published_at: '2018-09-20T11:25:22.957Z',
+        })
+        .get('/.well-known/terraform.json')
+        .reply(200, serviceDiscoveryResult);
+      const res = await getPkgReleases({
+        datasource,
+        packageName: 'hashicorp/consul/aws',
+        registryUrls: [cloudUrl],
+      });
+      expect(res).toEqual({
+        homepage: 'https://app.terraform.io/modules/hashicorp/consul/aws',
+        registryUrl: 'https://app.terraform.io',
         releases: [
           {
             version: '0.3.8',

--- a/lib/modules/datasource/terraform-module/index.ts
+++ b/lib/modules/datasource/terraform-module/index.ts
@@ -1,10 +1,14 @@
 import { logger } from '../../../logger/index.ts';
 import { withCache } from '../../../util/cache/package/with-cache.ts';
-import { isHttpUrl } from '../../../util/url.ts';
+import { getQueryString, isHttpUrl, joinUrlParts } from '../../../util/url.ts';
 import * as hashicorpVersioning from '../../versioning/hashicorp/index.ts';
 import type { GetReleasesConfig, ReleaseResult } from '../types.ts';
 import { TerraformDatasource } from './base.ts';
-import { ProtocolModuleResponse, TerraformModuleResponse } from './schema.ts';
+import {
+  ProtocolModuleResponse,
+  TerraformModuleResponse,
+  TerraformModuleV2Response,
+} from './schema.ts';
 import { createSDBackendURL, getRegistryRepository } from './utils.ts';
 
 export class TerraformModuleDatasource extends TerraformDatasource {
@@ -14,11 +18,6 @@ export class TerraformModuleDatasource extends TerraformDatasource {
 
   static readonly defaultRegistryUrls = [
     TerraformModuleDatasource.terraformRegistryUrl,
-  ];
-
-  static readonly extendedApiRegistryUrls = [
-    TerraformModuleDatasource.terraformRegistryUrl,
-    TerraformModuleDatasource.terraformCloudUrl,
   ];
 
   constructor() {
@@ -32,7 +31,7 @@ export class TerraformModuleDatasource extends TerraformDatasource {
 
   override readonly releaseTimestampSupport = true;
   override readonly releaseTimestampNote =
-    'The release timestamp is only supported for the latest version, and is determined from the `published_at` field in the results.';
+    'For `registry.terraform.io`, release timestamps are determined from the `published-at` field of the v2 API response. For `app.terraform.io`, only the latest version is annotated, using the `published_at` field from the extended module endpoint.';
   override readonly sourceUrlSupport = 'package';
   override readonly sourceUrlNote =
     'The source URL is determined from the the `source` field in the results.';
@@ -63,9 +62,10 @@ export class TerraformModuleDatasource extends TerraformDatasource {
     );
 
     try {
-      if (
-        TerraformModuleDatasource.extendedApiRegistryUrls.includes(registry)
-      ) {
+      if (registry === TerraformModuleDatasource.terraformRegistryUrl) {
+        return await this.queryTerraformRegistryV2(registry, repository);
+      }
+      if (registry === TerraformModuleDatasource.terraformCloudUrl) {
         return await this.queryTerraformRegistry(registry, repository);
       }
 
@@ -85,6 +85,29 @@ export class TerraformModuleDatasource extends TerraformDatasource {
       },
       () => this._getReleases(config),
     );
+  }
+
+  /**
+   * Query the Terraform Registry using the undocumented v2 JSON:API.
+   *
+   * Returns release timestamps for all versions, unlike the v1 extended
+   * module endpoint which only exposed the timestamp for the latest version.
+   */
+  private async queryTerraformRegistryV2(
+    registryUrl: string,
+    repository: string,
+  ): Promise<ReleaseResult> {
+    const moduleUrl = `${joinUrlParts(
+      registryUrl,
+      'v2/modules',
+      repository,
+    )}?${getQueryString({ include: 'module-versions' })}`;
+    const { body: res } = await this.http.getJson(
+      moduleUrl,
+      TerraformModuleV2Response,
+    );
+    res.homepage = `${registryUrl}/modules/${repository}`;
+    return res;
   }
 
   /**

--- a/lib/modules/datasource/terraform-module/schema.ts
+++ b/lib/modules/datasource/terraform-module/schema.ts
@@ -2,7 +2,7 @@ import { isNonEmptyArray } from '@sindresorhus/is';
 import { z } from 'zod/v3';
 import { LooseArray } from '../../../util/schema-utils/index.ts';
 import { MaybeTimestamp } from '../../../util/timestamp.ts';
-import type { Release } from '../types.ts';
+import type { Release, ReleaseResult } from '../types.ts';
 
 export const ServiceDiscoveryResponse = z.object({
   'modules.v1': z.string().optional(),
@@ -32,6 +32,43 @@ export const TerraformModuleResponse = z
   }));
 
 export type TerraformModuleResponse = z.infer<typeof TerraformModuleResponse>;
+
+const ModuleAttributes = z.object({
+  source: z.string().optional(),
+});
+
+const ModuleVersion = z
+  .object({
+    type: z.literal('module-versions'),
+    attributes: z.object({
+      version: z.string(),
+      'published-at': MaybeTimestamp,
+    }),
+  })
+  .transform(
+    (resource): Release => ({
+      version: resource.attributes.version,
+      releaseTimestamp: resource.attributes['published-at'],
+    }),
+  );
+
+export const TerraformModuleV2Response = z
+  .object({
+    data: z.object({
+      attributes: ModuleAttributes,
+    }),
+    included: LooseArray(ModuleVersion).catch([]),
+  })
+  .transform(
+    (response): ReleaseResult => ({
+      sourceUrl: response.data.attributes.source,
+      releases: response.included,
+    }),
+  );
+
+export type TerraformModuleV2Response = z.infer<
+  typeof TerraformModuleV2Response
+>;
 
 export const TerraformModuleVersion = z
   .object({ version: z.string() })


### PR DESCRIPTION
## Changes

Switch the `terraform-module` datasource from the v1 extended module endpoint to the v2 API for `registry.terraform.io`.

- Add zod schema validation for the v2 API response (`schema.ts`)
- Use the v2 endpoint (no service discovery) for `registry.terraform.io`
- Release timestamps are now available for **all** versions, not just the latest
- Keep the v1 extended endpoint for `app.terraform.io` (Terraform Cloud), where the v2 API is not available
- Drop the unused `extendedApiRegistryUrls` static
- Add a `terraform-module` row to the registry release-timestamp support table

Follows the same pattern as #42340.

## Context

Related: https://github.com/renovatebot/renovate/issues/41652

Please select one of the following:

- [ ] This closes an existing Issue
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

AI was used for code exploration, implementation drafting, test generation, and PR text preparation via Claude Code.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository