### PR TITLE
feat(terraform-module): add OpenTofu registry API support

### DIFF
--- a/docs/usage/key-concepts/minimum-release-age.md
+++ b/docs/usage/key-concepts/minimum-release-age.md
@@ -208,6 +208,7 @@ The below is a non-exhaustive list of public registries which support release ti
 | `docker`             | `https://quay.io`                                  | ❌        | [Issue](https://github.com/renovatebot/renovate/issues/38572)    |
 | `github-releases`    | `https://github.com`                               | ✅        |                                                                  |
 | `terraform-module`   | `https://registry.terraform.io`                    | ✅        |                                                                  |
+| `terraform-module`   | `https://registry.opentofu.org`                    | ✅        | Queries `api.opentofu.org` for release timestamps                |
 | `terraform-provider` | `https://registry.terraform.io`                    | ✅        |                                                                  |
 | `terraform-provider` | `https://registry.opentofu.org`                    | ✅        | Queries `api.opentofu.org` for release timestamps                |
 | `github-tags`        | `https://github.com`                               | ✅        |                                                                  |

--- a/lib/modules/datasource/terraform-module/base.ts
+++ b/lib/modules/datasource/terraform-module/base.ts
@@ -12,6 +12,8 @@ export abstract class TerraformDatasource extends Datasource {
   static id = terraformId;
 
   static readonly terraformRegistryUrl = 'https://registry.terraform.io';
+  static readonly openTofuApiUrl = 'https://api.opentofu.org';
+  static readonly openTofuRegistryUrl = 'https://registry.opentofu.org';
 
   private async _getTerraformServiceDiscoveryResult(
     registryUrl: string,

--- a/lib/modules/datasource/terraform-module/index.spec.ts
+++ b/lib/modules/datasource/terraform-module/index.spec.ts
@@ -309,5 +309,60 @@ describe('modules/datasource/terraform-module/index', () => {
         ],
       });
     });
+
+    it('processes real data from OpenTofu registry docs API', async () => {
+      httpMock
+        .scope('https://api.opentofu.org')
+        .get('/registry/docs/modules/terraform-aws-modules/vpc/aws/index.json')
+        .reply(200, {
+          versions: [
+            { id: 'v0.4.0', published: '2018-09-20T11:25:22Z' },
+            { id: 'v0.3.8', published: '2018-08-21T22:26:36Z' },
+          ],
+        });
+
+      const res = await getPkgReleases({
+        datasource,
+        packageName: 'terraform-aws-modules/vpc/aws',
+        registryUrls: ['https://registry.opentofu.org'],
+      });
+
+      expect(res).toEqual({
+        homepage:
+          'https://search.opentofu.org/module/terraform-aws-modules/vpc/aws',
+        registryUrl: 'https://registry.opentofu.org',
+        sourceUrl: 'https://github.com/terraform-aws-modules/terraform-aws-vpc',
+        releases: [
+          {
+            releaseTimestamp: '2018-08-21T22:26:36.000Z',
+            version: 'v0.3.8',
+          },
+          {
+            releaseTimestamp: '2018-09-20T11:25:22.000Z',
+            version: 'v0.4.0',
+          },
+        ],
+      });
+    });
+
+    it('returns an empty release list for OpenTofu registry without versions', async () => {
+      httpMock
+        .scope('https://api.opentofu.org')
+        .get('/registry/docs/modules/terraform-aws-modules/vpc/aws/index.json')
+        .reply(200, {});
+
+      expect(
+        await getPkgReleases({
+          datasource,
+          packageName: 'terraform-aws-modules/vpc/aws',
+          registryUrls: ['https://registry.opentofu.org'],
+        }),
+      ).toEqual({
+        homepage:
+          'https://search.opentofu.org/module/terraform-aws-modules/vpc/aws',
+        sourceUrl: 'https://github.com/terraform-aws-modules/terraform-aws-vpc',
+        releases: [],
+      });
+    });
   });
 });

--- a/lib/modules/datasource/terraform-module/index.ts
+++ b/lib/modules/datasource/terraform-module/index.ts
@@ -5,6 +5,7 @@ import * as hashicorpVersioning from '../../versioning/hashicorp/index.ts';
 import type { GetReleasesConfig, ReleaseResult } from '../types.ts';
 import { TerraformDatasource } from './base.ts';
 import {
+  OpenTofuModuleDocsResponse,
   ProtocolModuleResponse,
   TerraformModuleResponse,
   TerraformModuleV2Response,
@@ -31,10 +32,10 @@ export class TerraformModuleDatasource extends TerraformDatasource {
 
   override readonly releaseTimestampSupport = true;
   override readonly releaseTimestampNote =
-    'For `registry.terraform.io`, release timestamps are determined from the `published-at` field of the v2 API response. For `app.terraform.io`, only the latest version is annotated, using the `published_at` field from the extended module endpoint.';
+    'For `registry.terraform.io` and `registry.opentofu.org` (via `api.opentofu.org`), release timestamps are available for all versions. For `app.terraform.io`, only the latest version is annotated, using the `published_at` field from the extended module endpoint.';
   override readonly sourceUrlSupport = 'package';
   override readonly sourceUrlNote =
-    'The source URL is determined from the the `source` field in the results.';
+    'For `registry.terraform.io` and `app.terraform.io`, the source URL is taken from the `source` field of the registry response. For `registry.opentofu.org`, it is derived from the package name following the OpenTofu registry policy of `github.com/NAMESPACE/terraform-TARGETSYSTEM-NAME`.';
 
   /**
    * Resolves a module release list for the configured registry.
@@ -64,6 +65,12 @@ export class TerraformModuleDatasource extends TerraformDatasource {
     try {
       if (registry === TerraformModuleDatasource.terraformRegistryUrl) {
         return await this.queryTerraformRegistryV2(registry, repository);
+      }
+      if (
+        registry === TerraformModuleDatasource.openTofuRegistryUrl ||
+        registry === TerraformModuleDatasource.openTofuApiUrl
+      ) {
+        return await this.queryOpenTofuRegistry(repository);
       }
       if (registry === TerraformModuleDatasource.terraformCloudUrl) {
         return await this.queryTerraformRegistry(registry, repository);
@@ -107,6 +114,38 @@ export class TerraformModuleDatasource extends TerraformDatasource {
       TerraformModuleV2Response,
     );
     res.homepage = `${registryUrl}/modules/${repository}`;
+    return res;
+  }
+
+  /**
+   * Query the OpenTofu registry docs API.
+   * https://api.opentofu.org/
+   *
+   * Used when the registry URL is `registry.opentofu.org`.
+   * Queries `api.opentofu.org` for module versions with release timestamps.
+   */
+  private async queryOpenTofuRegistry(
+    repository: string,
+  ): Promise<ReleaseResult> {
+    const docsUrl = joinUrlParts(
+      TerraformModuleDatasource.openTofuApiUrl,
+      'registry/docs/modules',
+      repository,
+      'index.json',
+    );
+    const { body: res } = await this.http.getJson(
+      docsUrl,
+      OpenTofuModuleDocsResponse,
+    );
+    res.homepage = `https://search.opentofu.org/module/${repository}`;
+
+    // The OpenTofu registry only indexes modules hosted on GitHub under the
+    // `NAMESPACE/terraform-TARGETSYSTEM-NAME` repository naming convention, so
+    // the source URL can be derived deterministically from the package name.
+    // https://github.com/opentofu/registry/blob/main/PROCEDURES.md
+    const [namespace, name, target] = repository.split('/');
+    res.sourceUrl = `https://github.com/${namespace}/terraform-${target}-${name}`;
+
     return res;
   }
 

--- a/lib/modules/datasource/terraform-module/schema.ts
+++ b/lib/modules/datasource/terraform-module/schema.ts
@@ -70,6 +70,32 @@ export type TerraformModuleV2Response = z.infer<
   typeof TerraformModuleV2Response
 >;
 
+const OpenTofuModuleVersion = z
+  .object({
+    id: z.string(),
+    published: MaybeTimestamp,
+  })
+  .transform(
+    (version): Release => ({
+      version: version.id,
+      releaseTimestamp: version.published,
+    }),
+  );
+
+export const OpenTofuModuleDocsResponse = z
+  .object({
+    versions: LooseArray(OpenTofuModuleVersion).catch([]),
+  })
+  .transform(
+    (response): ReleaseResult => ({
+      releases: response.versions,
+    }),
+  );
+
+export type OpenTofuModuleDocsResponse = z.infer<
+  typeof OpenTofuModuleDocsResponse
+>;
+
 export const TerraformModuleVersion = z
   .object({ version: z.string() })
   .transform(({ version }): Release => ({ version }));

--- a/lib/modules/datasource/terraform-provider/index.ts
+++ b/lib/modules/datasource/terraform-provider/index.ts
@@ -26,8 +26,6 @@ export class TerraformProviderDatasource extends TerraformDatasource {
   static override readonly id = 'terraform-provider';
 
   static readonly hashicorpReleaseUrl = 'https://releases.hashicorp.com';
-  static readonly openTofuApiUrl = 'https://api.opentofu.org';
-  static readonly openTofuRegistryUrl = 'https://registry.opentofu.org';
 
   static readonly defaultRegistryUrls = [
     TerraformProviderDatasource.terraformRegistryUrl,


### PR DESCRIPTION
## Changes

Add support for querying the OpenTofu registry docs API when the registry URL is `registry.opentofu.org`.

- Add zod schema validation for the OpenTofu docs API response (`schema.ts`)
- New `queryOpenTofuRegistry` method that queries `api.opentofu.org` for module versions
- Release timestamps available for all OpenTofu module versions
- Source URL derived from the package name following the OpenTofu module naming policy of `github.com/NAMESPACE/terraform-TARGETSYSTEM-NAME`
- Hoist the shared `openTofuApiUrl` / `openTofuRegistryUrl` constants onto the `TerraformDatasource` base class so they can be reused by both the provider and module datasources
- Update `releaseTimestampNote` and `sourceUrlNote` to document the OpenTofu API usage
- Update `minimum-release-age` docs table with OpenTofu registry support

> **Note:** When `registry.opentofu.org` is configured, Renovate queries `api.opentofu.org` instead of the registry directly. Users who partially block external traffic should allow `api.opentofu.org`.

Follows the same pattern as #42343.

## Context

Related: https://github.com/renovatebot/renovate/issues/41652
Fix: https://github.com/renovatebot/renovate/issues/41973

Please select one of the following:

- [ ] This closes an existing Issue
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

AI was used for code exploration, implementation drafting, test generation, and PR text preparation via Claude Code.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository