### PR TITLE
fix(git): not detecting commits modified through rebase or amend

### DIFF
--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -118,6 +118,16 @@ describe('util/git/index', { timeout: 10000 }, () => {
     await repo.addConfig('user.email', 'author2@example.com');
     await repo.commit('second commit', undefined, { '--allow-empty': null });
 
+    // Branch where author matches Renovate but committer is different
+    // (simulates rebase or amend and force push by a different user)
+    await repo.checkoutBranch('renovate/different_committer', defaultBranch);
+    await repo.addConfig('user.email', 'Jest@example.com');
+    process.env.GIT_COMMITTER_EMAIL = 'someone-else@example.com';
+    await fs.writeFile(base.path + '/committer_file', 'test');
+    await repo.add(['committer_file']);
+    await repo.commit('committed by someone else');
+    delete process.env.GIT_COMMITTER_EMAIL;
+
     await repo.checkout(defaultBranch);
   });
 
@@ -418,6 +428,15 @@ describe('util/git/index', { timeout: 10000 }, () => {
     it('should return true when custom author is unknown', async () => {
       expect(
         await git.isBranchModified('renovate/custom_author', defaultBranch),
+      ).toBeTrue();
+    });
+
+    it('should return true when committer is different from author', async () => {
+      expect(
+        await git.isBranchModified(
+          'renovate/different_committer',
+          defaultBranch,
+        ),
       ).toBeTrue();
     });
 

--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -446,6 +446,26 @@ describe('util/git/index', { timeout: 10000 }, () => {
         await git.isBranchModified('renovate/future_branch', defaultBranch),
       ).toBeTrue();
     });
+
+    it('should not be affected by new commits on the base branch', async () => {
+      // Add a commit to the base branch from a different author,
+      // causing the branches to diverge
+      const local = simpleGit(tmpDir.path);
+      await local.checkout(defaultBranch);
+      await local.addConfig('user.email', 'other-dev@example.com');
+      await fs.writeFile(tmpDir.path + '/diverge_file', 'diverge');
+      await local.add(['diverge_file']);
+      await local.commit('diverge commit');
+      await local.push('origin', defaultBranch);
+      // Re-init so Renovate picks up the new origin state
+      await git.initRepo({ url: origin.path });
+      git.setGitAuthor('Jest <Jest@example.com>');
+      await git.syncGit();
+
+      expect(
+        await git.isBranchModified('renovate/future_branch', defaultBranch),
+      ).toBeFalse();
+    });
   });
 
   describe('getBranchCommit(branchName)', () => {

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -811,6 +811,7 @@ export async function isBranchModified(
     const commits = await git.log({
       from: `origin/${baseBranch}`,
       to: `origin/${branchName}`,
+      symmetric: false, // means <from>..<to> instead of <from>...<to>
       format: {
         author_email: '%ae',
         committer_email: '%ce',

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -808,12 +808,18 @@ export async function isBranchModified(
   await syncGit();
   const committedAuthors = new Set<string>();
   try {
-    const commits = await git.log([
-      `origin/${baseBranch}..origin/${branchName}`,
-    ]);
+    const commits = await git.log({
+      from: `origin/${baseBranch}`,
+      to: `origin/${branchName}`,
+      format: {
+        author_email: '%ae',
+        committer_email: '%ce',
+      },
+    });
 
     for (const commit of commits.all) {
       committedAuthors.add(commit.author_email);
+      committedAuthors.add(commit.committer_email);
     }
   } catch (err) /* v8 ignore next -- TODO: add test #40625 */ {
     if (err.message?.includes('fatal: bad revision')) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Renovate was not detecting branches modified when the committer is different from the author (via rebase or amend and force push). It's also the case when a change is modified through the Gerrit UI.

The `git log` call now uses a custom format that captures both `author_email` and `committer_email`, and both are added to the `committedAuthors` set.

This ensures that such commits are correctly identified as modified, and therefore preventing Renovate from overwriting user changes.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

PS: This patch was tested internally against real repositories.

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
