### PR TITLE
feat(config/validation): warn on unwrapped regex in `matchPackageNames`

### DIFF
--- a/lib/config/validation.spec.ts
+++ b/lib/config/validation.spec.ts
@@ -463,6 +463,35 @@ describe('config/validation', () => {
       expect(errors).toMatchSnapshot();
     });
 
+    it('warns when matchPackageNames contains an unwrapped regex', async () => {
+      const config: RenovateConfig = {
+        packageRules: [
+          {
+            matchDatasources: ['npm'],
+            minimumReleaseAge: '3 days',
+            matchPackageNames: ['^(?!@scope/).+'],
+          },
+          {
+            matchDepNames: ['foo$'],
+            enabled: true,
+          },
+        ],
+      };
+      const { warnings, errors } = await configValidation.validateConfig(
+        'repo',
+        config,
+      );
+      expect(errors).toHaveLength(0);
+      expect(warnings).toHaveLength(2);
+      expect(warnings[0].message).toContain(
+        'packageRules[0].matchPackageNames: pattern `^(?!@scope/).+` looks like a regex',
+      );
+      expect(warnings[0].message).toContain('Wrap it as `/^(?!@scope/).+/`');
+      expect(warnings[1].message).toContain(
+        'packageRules[1].matchDepNames: pattern `foo$` looks like a regex',
+      );
+    });
+
     it('included managers of the wrong type', async () => {
       const config = {
         packageRules: [

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -19,6 +19,7 @@ import { regEx } from '../util/regex.ts';
 import {
   getRegexPredicate,
   isRegexMatch,
+  looksLikeUnwrappedRegex,
   matchRegexOrGlobList,
 } from '../util/string-match.ts';
 import * as template from '../util/template/index.ts';
@@ -605,6 +606,11 @@ export async function validateConfig(
                       message: `Invalid regExp for ${currentPath}: \`${pattern}\``,
                     });
                   }
+                } else if (looksLikeUnwrappedRegex(pattern)) {
+                  warnings.push({
+                    topic: 'Configuration Warning',
+                    message: `${currentPath}: pattern \`${pattern}\` looks like a regex but is not wrapped in slashes. It will be treated as a glob and likely match nothing. Wrap it as \`/${pattern.replace(/^!/, '')}/\` (prefix with \`!\` to negate) to use as a regex.`,
+                  });
                 }
               }
             }

--- a/lib/util/string-match.spec.ts
+++ b/lib/util/string-match.spec.ts
@@ -1,6 +1,7 @@
 import {
   anyMatchRegexOrGlobList,
   getRegexPredicate,
+  looksLikeUnwrappedRegex,
   matchRegexOrGlob,
   matchRegexOrGlobList,
 } from './string-match.ts';
@@ -115,6 +116,29 @@ describe('util/string-match', () => {
 
     it('returns false if negative pattern is matched', () => {
       expect(matchRegexOrGlob('test', '!/te/')).toBeFalse();
+    });
+  });
+
+  describe('looksLikeUnwrappedRegex()', () => {
+    it.each`
+      input               | expected
+      ${'^foo'}           | ${true}
+      ${'foo$'}           | ${true}
+      ${'^(?!@scope/).+'} | ${true}
+      ${'!^foo'}          | ${true}
+      ${'\\d+'}           | ${true}
+      ${'foo\\bbar'}      | ${true}
+      ${'/^foo/'}         | ${false}
+      ${'!/^foo/'}        | ${false}
+      ${'foo'}            | ${false}
+      ${'@scope/*'}       | ${false}
+      ${'**/*.json'}      | ${false}
+      ${'[^abc]'}         | ${false}
+      ${'foo?bar'}        | ${false}
+      ${''}               | ${false}
+      ${'!'}              | ${false}
+    `('returns $expected for $input', ({ input, expected }) => {
+      expect(looksLikeUnwrappedRegex(input)).toBe(expected);
     });
   });
 });

--- a/lib/util/string-match.ts
+++ b/lib/util/string-match.ts
@@ -104,3 +104,28 @@ export function getRegexPredicate(input: string): StringMatchPredicate | null {
   }
   return null;
 }
+
+const regexClassEscape = regEx(/\\[bdwsBDWS]/);
+
+/**
+ * Heuristically detect a pattern that looks like a regex but is not wrapped in
+ * `/.../` slashes. Such patterns silently fall through to glob matching and
+ * almost never match what the author intended.
+ */
+export function looksLikeUnwrappedRegex(input: unknown): boolean {
+  if (!isString(input) || isRegexMatch(input)) {
+    return false;
+  }
+  // Strip leading "!" used for negation in match lists
+  const raw: string = input;
+  const pattern = raw.startsWith('!') ? raw.slice(1) : raw;
+  if (!pattern) {
+    return false;
+  }
+  return (
+    pattern.startsWith('^') ||
+    pattern.endsWith('$') ||
+    pattern.includes('(?') ||
+    regexClassEscape.test(pattern)
+  );
+}


### PR DESCRIPTION
## Changes

Regex patterns in `matchPackageNames` and `matchDepNames` only take effect when wrapped in `/.../` slashes. Without the slashes, the pattern falls through to minimatch glob handling and silently matches nothing .. so any rule attached to it (`minimumReleaseAge`, `enabled: false`, etc.) is never applied.

This is a recurring footgun.

This PR adds a warning during config validation: when a non-slash-wrapped pattern in `matchPackageNames` / `matchDepNames` contains unambiguous regex shape -> leading `^`, trailing `$`, `(?…)`, or `\b`/`\d`/`\w`/`\s` (and uppercase variants)  log a `Configuration Warning` suggesting the slash-wrapped form to use.

It's a warning, not an error: globs that happen to look regex-shaped won't break, and existing valid configs are unaffected.

- `looksLikeUnwrappedRegex(input)` helper in `lib/util/string-match.ts`
- Wired into the existing `matchPackageNames` / `matchDepNames` block in `lib/config/validation.ts`
- Unit tests for the helper and integration tests for the warning path

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

Surfaced from discussion #42643, where the reporter believed `minimumReleaseAge` was being ignored when updating an open PR. The actual cause was an unwrapped regex in `matchPackageNames` that prevented their package rule from ever applying.

## AI assistance disclosure

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Used Claude Code to investigate the linked discussion, locate the relevant validation hook, draft the heuristic, and write tests.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: N/A