### PR TITLE
feat(datasource/maven): enrich lastModified from GCP Artifact Registr…

### DIFF
--- a/docs/usage/java.md
+++ b/docs/usage/java.md
@@ -148,6 +148,12 @@ module.exports = {
 
 There are multiple ways to configure Renovate to access Artifact Registry.
 
+<!-- prettier-ignore -->
+!!! note
+    When using the `artifactregistry://` protocol, Renovate automatically enriches release timestamps by querying the [Artifact Registry Files API](https://cloud.google.com/artifact-registry/docs/reference/rest/v1/projects.locations.repositories.files/get).
+    This means `releaseTimestamp` will be populated for packages fetched from Google Artifact Registry, enabling features like age-based update policies.
+    The same credentials used to fetch the artifact are reused for the API call; failures are handled gracefully and do not affect the dependency lookup.
+
 #### Using Application Default Credentials / Workload Identity (Self-Hosted only)
 
 Configure [ADC](https://cloud.google.com/docs/authentication/provide-credentials-adc) or [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) as normal and _don't_ provide a username, password or token.

--- a/lib/modules/datasource/maven/index.spec.ts
+++ b/lib/modules/datasource/maven/index.spec.ts
@@ -435,6 +435,8 @@ describe('modules/datasource/maven/index', () => {
 
   it('supports artifactregistry urls with auth', async () => {
     const pomfilePath = '/org/example/package/2.0.0/package-2.0.0.pom';
+    const arApiBase =
+      'https://artifactregistry.googleapis.com/v1/projects/some-project/locations/us/repositories/some-repository';
     hostRules.clear();
 
     httpMock
@@ -454,6 +456,17 @@ describe('modules/datasource/maven/index', () => {
         'Basic b2F1dGgyYWNjZXNzdG9rZW46c29tZS10b2tlbg==',
       )
       .reply(200, Fixtures.get('pom.xml'));
+
+    // Artifact Registry API calls for lastModified enrichment
+    httpMock
+      .scope(arApiBase)
+      .get('/files/org%2Fexample%2Fpackage%2Fmaven-metadata.xml')
+      .reply(200, { updateTime: '2024-01-01T00:00:00Z' });
+
+    httpMock
+      .scope(arApiBase)
+      .get('/files/org%2Fexample%2Fpackage%2F2.0.0%2Fpackage-2.0.0.pom')
+      .reply(200, { updateTime: '2024-01-01T00:00:00Z' });
 
     googleAuth.mockImplementation(
       // TODO: fix typing
@@ -496,6 +509,8 @@ describe('modules/datasource/maven/index', () => {
 
   it('supports artifactregistry urls without auth', async () => {
     const pomfilePath = '/org/example/package/2.0.0/package-2.0.0.pom';
+    const arApiBase =
+      'https://artifactregistry.googleapis.com/v1/projects/some-project/locations/us/repositories/some-repository';
     hostRules.clear();
 
     httpMock
@@ -507,6 +522,17 @@ describe('modules/datasource/maven/index', () => {
       .scope(baseUrlARHttps)
       .get(pomfilePath)
       .reply(200, Fixtures.get('pom.xml'));
+
+    // Artifact Registry API calls for lastModified enrichment (no auth)
+    httpMock
+      .scope(arApiBase)
+      .get('/files/org%2Fexample%2Fpackage%2Fmaven-metadata.xml')
+      .reply(200, { updateTime: '2024-01-01T00:00:00Z' });
+
+    httpMock
+      .scope(arApiBase)
+      .get('/files/org%2Fexample%2Fpackage%2F2.0.0%2Fpackage-2.0.0.pom')
+      .reply(200, { updateTime: '2024-01-01T00:00:00Z' });
 
     googleAuth.mockImplementation(
       // TODO: fix typing

--- a/lib/modules/datasource/maven/schema.ts
+++ b/lib/modules/datasource/maven/schema.ts
@@ -192,3 +192,7 @@ export function trimMavenXml(input: string): string {
 }
 
 export const CachedMavenXml = z.string().transform(trimMavenXml);
+
+export const ArtifactRegistryFileMetadata = z.object({
+  updateTime: z.string().optional(),
+});

--- a/lib/modules/datasource/maven/util.spec.ts
+++ b/lib/modules/datasource/maven/util.spec.ts
@@ -241,6 +241,39 @@ describe('modules/datasource/maven/util', () => {
     const arApiUrl =
       'https://artifactregistry.googleapis.com/v1/projects/some-project/locations/us/repositories/some-repository/files/org%2Fexample%2Fpackage%2F1.0.0%2Fpackage-1.0.0.pom';
 
+    it('uses RENOVATE_ARTIFACT_REGISTRY_URL env var as base URL for API calls', async () => {
+      process.env.RENOVATE_ARTIFACT_REGISTRY_URL =
+        'https://custom-artifact-registry.example.com';
+      const customApiUrl =
+        'https://custom-artifact-registry.example.com/v1/projects/some-project/locations/us/repositories/some-repository/files/org%2Fexample%2Fpackage%2F1.0.0%2Fpackage-1.0.0.pom';
+
+      const getJsonUnchecked = vi.fn().mockResolvedValue({
+        statusCode: 200,
+        body: { updateTime: '2024-06-01T12:00:00Z' },
+        headers: {},
+      });
+
+      const http = partial<Http>({
+        getText: () =>
+          Promise.resolve({
+            statusCode: 200,
+            body: 'pom content',
+            headers: {},
+            authorization: false,
+          }),
+        getJsonUnchecked,
+      });
+
+      await downloadArtifactRegistryProtocol(http, arUrl);
+
+      expect(getJsonUnchecked).toHaveBeenCalledWith(
+        customApiUrl,
+        expect.any(Object),
+      );
+
+      delete process.env.RENOVATE_ARTIFACT_REGISTRY_URL;
+    });
+
     it('enriches result with lastModified from Artifact Registry API', async () => {
       const http = partial<Http>({
         getText: () =>

--- a/lib/modules/datasource/maven/util.spec.ts
+++ b/lib/modules/datasource/maven/util.spec.ts
@@ -7,11 +7,14 @@ import { Http, HttpError } from '../../../util/http/index.ts';
 import { MAVEN_REPO } from './common.ts';
 import type { MavenFetchError } from './types.ts';
 import {
+  downloadArtifactRegistryProtocol,
   downloadHttpContent,
   downloadHttpProtocol,
   downloadMavenXml,
   downloadS3Protocol,
 } from './util.ts';
+
+vi.mock('google-auth-library');
 
 const http = new Http('test');
 
@@ -228,6 +231,130 @@ describe('modules/datasource/maven/util', () => {
         ok: false,
         err: { type: 'unsupported-host' } satisfies MavenFetchError,
       });
+    });
+  });
+
+  describe('downloadArtifactRegistryProtocol', () => {
+    const arUrl = new URL(
+      'artifactregistry://maven.pkg.dev/some-project/some-repository/org/example/package/1.0.0/package-1.0.0.pom',
+    );
+    const arApiUrl =
+      'https://artifactregistry.googleapis.com/v1/projects/some-project/locations/us/repositories/some-repository/files/org%2Fexample%2Fpackage%2F1.0.0%2Fpackage-1.0.0.pom';
+
+    it('enriches result with lastModified from Artifact Registry API', async () => {
+      const http = partial<Http>({
+        getText: () =>
+          Promise.resolve({
+            statusCode: 200,
+            body: 'pom content',
+            headers: {},
+            authorization: false,
+          }),
+        getJsonUnchecked: () =>
+          Promise.resolve({
+            statusCode: 200,
+            body: { updateTime: '2024-06-01T12:00:00Z' } as never,
+            headers: {},
+          }),
+      });
+
+      const res = await downloadArtifactRegistryProtocol(http, arUrl);
+      expect(res.unwrap()).toEqual({
+        ok: true,
+        val: {
+          data: 'pom content',
+          isCacheable: true,
+          lastModified: '2024-06-01T12:00:00.000Z',
+        },
+      });
+    });
+
+    it('does not overwrite lastModified if already set from Last-Modified header', async () => {
+      const http = partial<Http>({
+        getText: () =>
+          Promise.resolve({
+            statusCode: 200,
+            body: 'pom content',
+            headers: { 'last-modified': 'Mon, 01 Jan 2024 00:00:00 GMT' },
+            authorization: false,
+          }),
+        getJsonUnchecked: vi.fn(),
+      });
+
+      const res = await downloadArtifactRegistryProtocol(http, arUrl);
+      const { val } = res.unwrap();
+      expect(val?.lastModified).toBe('2024-01-01T00:00:00.000Z');
+      expect(http.getJsonUnchecked).not.toHaveBeenCalled();
+    });
+
+    it('falls back gracefully when Artifact Registry API call fails', async () => {
+      const http = partial<Http>({
+        getText: () =>
+          Promise.resolve({
+            statusCode: 200,
+            body: 'pom content',
+            headers: {},
+            authorization: false,
+          }),
+        getJsonUnchecked: () => Promise.reject(new Error('API error')),
+      });
+
+      const res = await downloadArtifactRegistryProtocol(http, arUrl);
+      expect(res.unwrap()).toEqual({
+        ok: true,
+        val: {
+          data: 'pom content',
+          isCacheable: true,
+        },
+      });
+      expect(logger.logger.debug).toHaveBeenCalledWith(
+        expect.objectContaining({ url: arApiUrl }),
+        'Failed to get Artifact Registry file metadata',
+      );
+    });
+
+    it('returns error when HTTP fetch fails', async () => {
+      const http = partial<Http>({
+        getText: () => Promise.reject(httpError({ code: 'ENOTFOUND' })),
+      });
+
+      const res = await downloadArtifactRegistryProtocol(http, arUrl);
+      expect(res.unwrap()).toEqual({
+        ok: false,
+        err: { type: 'not-found' } satisfies MavenFetchError,
+      });
+    });
+
+    it('parses location from regional hostname', async () => {
+      const regionalUrl = new URL(
+        'artifactregistry://europe-maven.pkg.dev/my-project/my-repo/com/example/artifact/1.0/artifact-1.0.pom',
+      );
+      const expectedApiUrl =
+        'https://artifactregistry.googleapis.com/v1/projects/my-project/locations/europe/repositories/my-repo/files/com%2Fexample%2Fartifact%2F1.0%2Fartifact-1.0.pom';
+
+      const getJsonUnchecked = vi.fn().mockResolvedValue({
+        statusCode: 200,
+        body: { updateTime: '2024-06-01T12:00:00Z' },
+        headers: {},
+      });
+
+      const http = partial<Http>({
+        getText: () =>
+          Promise.resolve({
+            statusCode: 200,
+            body: 'pom content',
+            headers: {},
+            authorization: false,
+          }),
+        getJsonUnchecked,
+      });
+
+      await downloadArtifactRegistryProtocol(http, regionalUrl);
+
+      expect(getJsonUnchecked).toHaveBeenCalledWith(
+        expectedApiUrl,
+        expect.any(Object),
+      );
     });
   });
 });

--- a/lib/modules/datasource/maven/util.spec.ts
+++ b/lib/modules/datasource/maven/util.spec.ts
@@ -247,7 +247,7 @@ describe('modules/datasource/maven/util', () => {
       const customApiUrl =
         'https://custom-artifact-registry.example.com/v1/projects/some-project/locations/us/repositories/some-repository/files/org%2Fexample%2Fpackage%2F1.0.0%2Fpackage-1.0.0.pom';
 
-      const getJsonUnchecked = vi.fn().mockResolvedValue({
+      const getJson = vi.fn().mockResolvedValue({
         statusCode: 200,
         body: { updateTime: '2024-06-01T12:00:00Z' },
         headers: {},
@@ -261,13 +261,14 @@ describe('modules/datasource/maven/util', () => {
             headers: {},
             authorization: false,
           }),
-        getJsonUnchecked,
+        getJson,
       });
 
       await downloadArtifactRegistryProtocol(http, arUrl);
 
-      expect(getJsonUnchecked).toHaveBeenCalledWith(
+      expect(getJson).toHaveBeenCalledWith(
         customApiUrl,
+        expect.any(Object),
         expect.any(Object),
       );
 
@@ -283,7 +284,7 @@ describe('modules/datasource/maven/util', () => {
             headers: {},
             authorization: false,
           }),
-        getJsonUnchecked: () =>
+        getJson: () =>
           Promise.resolve({
             statusCode: 200,
             body: { updateTime: '2024-06-01T12:00:00Z' } as never,
@@ -311,13 +312,13 @@ describe('modules/datasource/maven/util', () => {
             headers: { 'last-modified': 'Mon, 01 Jan 2024 00:00:00 GMT' },
             authorization: false,
           }),
-        getJsonUnchecked: vi.fn(),
+        getJson: vi.fn(),
       });
 
       const res = await downloadArtifactRegistryProtocol(http, arUrl);
       const { val } = res.unwrap();
       expect(val?.lastModified).toBe('2024-01-01T00:00:00.000Z');
-      expect(http.getJsonUnchecked).not.toHaveBeenCalled();
+      expect(http.getJson).not.toHaveBeenCalled();
     });
 
     it('falls back gracefully when Artifact Registry API call fails', async () => {
@@ -329,7 +330,7 @@ describe('modules/datasource/maven/util', () => {
             headers: {},
             authorization: false,
           }),
-        getJsonUnchecked: () => Promise.reject(new Error('API error')),
+        getJson: () => Promise.reject(new Error('API error')),
       });
 
       const res = await downloadArtifactRegistryProtocol(http, arUrl);
@@ -365,7 +366,7 @@ describe('modules/datasource/maven/util', () => {
       const expectedApiUrl =
         'https://artifactregistry.googleapis.com/v1/projects/my-project/locations/europe/repositories/my-repo/files/com%2Fexample%2Fartifact%2F1.0%2Fartifact-1.0.pom';
 
-      const getJsonUnchecked = vi.fn().mockResolvedValue({
+      const getJson = vi.fn().mockResolvedValue({
         statusCode: 200,
         body: { updateTime: '2024-06-01T12:00:00Z' },
         headers: {},
@@ -379,13 +380,14 @@ describe('modules/datasource/maven/util', () => {
             headers: {},
             authorization: false,
           }),
-        getJsonUnchecked,
+        getJson,
       });
 
       await downloadArtifactRegistryProtocol(http, regionalUrl);
 
-      expect(getJsonUnchecked).toHaveBeenCalledWith(
+      expect(getJson).toHaveBeenCalledWith(
         expectedApiUrl,
+        expect.any(Object),
         expect.any(Object),
       );
     });

--- a/lib/modules/datasource/maven/util.spec.ts
+++ b/lib/modules/datasource/maven/util.spec.ts
@@ -391,5 +391,81 @@ describe('modules/datasource/maven/util', () => {
         expect.any(Object),
       );
     });
+
+    it('does not call gcs ar backend if package url is invalid', async () => {
+      const invalidPackageUrl = new URL(
+        'artifactregistry://europe-maven.pkg.dev/my-project/my-repo',
+      );
+
+      const getJson = vi.fn();
+
+      const http = partial<Http>({
+        getText: () =>
+          Promise.resolve({
+            statusCode: 200,
+            body: 'pom content',
+            headers: {},
+            authorization: false,
+          }),
+        getJson,
+      });
+
+      const res = await downloadArtifactRegistryProtocol(
+        http,
+        invalidPackageUrl,
+      );
+
+      expect(getJson).to.have.callCount(0);
+
+      expect(res.unwrap()).toEqual({
+        ok: true,
+        val: {
+          data: 'pom content',
+          isCacheable: true,
+        },
+      });
+    });
+
+    it('does not use timestamp from gcs if it is not in a valid format', async () => {
+      const regionalUrl = new URL(
+        'artifactregistry://europe-maven.pkg.dev/my-project/my-repo/com/example/artifact/1.0/artifact-1.0.pom',
+      );
+
+      const expectedApiUrl =
+        'https://artifactregistry.googleapis.com/v1/projects/my-project/locations/europe/repositories/my-repo/files/com%2Fexample%2Fartifact%2F1.0%2Fartifact-1.0.pom';
+
+      const getJson = vi.fn().mockResolvedValue({
+        statusCode: 200,
+        body: { updateTime: 'Not a Data or Time' },
+        headers: {},
+      });
+
+      const http = partial<Http>({
+        getText: () =>
+          Promise.resolve({
+            statusCode: 200,
+            body: 'pom content',
+            headers: {},
+            authorization: false,
+          }),
+        getJson,
+      });
+
+      const res = await downloadArtifactRegistryProtocol(http, regionalUrl);
+
+      expect(getJson).toHaveBeenCalledWith(
+        expectedApiUrl,
+        expect.any(Object),
+        expect.any(Object),
+      );
+
+      expect(res.unwrap()).toEqual({
+        ok: true,
+        val: {
+          data: 'pom content',
+          isCacheable: true,
+        },
+      });
+    });
   });
 });

--- a/lib/modules/datasource/maven/util.ts
+++ b/lib/modules/datasource/maven/util.ts
@@ -265,6 +265,51 @@ export async function downloadS3Protocol(
     });
 }
 
+async function getArtifactRegistryLastModified(
+  http: Http,
+  pkgUrl: URL,
+  auth: string | null,
+): Promise<string | null> {
+  // Hostname format: "maven.pkg.dev" (multi-region) or "<location>-maven.pkg.dev"
+  const hostname = pkgUrl.hostname;
+  const location = hostname.endsWith('-maven.pkg.dev')
+    ? hostname.replace(/-maven\.pkg\.dev$/, '')
+    : 'us';
+
+  // Pathname: /<project>/<repository>/<file-path...>
+  const pathParts = pkgUrl.pathname.split('/').filter(Boolean);
+  if (pathParts.length < 3) {
+    return null;
+  }
+  const [project, repository, ...fileParts] = pathParts;
+  const filePath = fileParts.join('/');
+  const encodedFilePath = filePath
+    .split('/')
+    .map(encodeURIComponent)
+    .join('%2F');
+
+  const apiUrl = `https://artifactregistry.googleapis.com/v1/projects/${project}/locations/${location}/repositories/${repository}/files/${encodedFilePath}`;
+
+  try {
+    const apiOpts: HttpOptions = {};
+    if (auth) {
+      apiOpts.headers = { authorization: `Basic ${auth}` };
+    }
+    const res = await http.getJsonUnchecked<{ updateTime?: string }>(
+      apiUrl,
+      apiOpts,
+    );
+    const updateTime = res.body.updateTime;
+    return asTimestamp(updateTime) ?? null;
+  } catch (err) {
+    logger.debug(
+      { err, url: apiUrl },
+      'Failed to get Artifact Registry file metadata',
+    );
+    return null;
+  }
+}
+
 export async function downloadArtifactRegistryProtocol(
   http: Http,
   pkgUrl: URL,
@@ -286,7 +331,21 @@ export async function downloadArtifactRegistryProtocol(
 
   const url = pkgUrl.toString().replace('artifactregistry:', 'https:');
 
-  return downloadHttpProtocol(http, url, opts);
+  const result = await downloadHttpProtocol(http, url, opts);
+
+  return result.transform(async (fetchSuccess): Promise<MavenFetchResult> => {
+    if (!fetchSuccess.lastModified) {
+      const lastModified = await getArtifactRegistryLastModified(
+        http,
+        pkgUrl,
+        auth,
+      );
+      if (lastModified) {
+        return Result.ok({ ...fetchSuccess, lastModified });
+      }
+    }
+    return Result.ok(fetchSuccess);
+  });
 }
 
 function containsPlaceholder(str: string): boolean {

--- a/lib/modules/datasource/maven/util.ts
+++ b/lib/modules/datasource/maven/util.ts
@@ -18,7 +18,7 @@ import { asTimestamp } from '../../../util/timestamp.ts';
 import { ensureTrailingSlash, isHttpUrl, parseUrl } from '../../../util/url.ts';
 import { getGoogleAuthToken } from '../util.ts';
 import { MAVEN_REPO } from './common.ts';
-import { CachedMavenXml } from './schema.ts';
+import { ArtifactRegistryFileMetadata, CachedMavenXml } from './schema.ts';
 import type {
   DependencyInfo,
   MavenDependency,
@@ -300,9 +300,10 @@ async function getArtifactRegistryLastModified(
     if (auth) {
       apiOpts.headers = { authorization: `Basic ${auth}` };
     }
-    const res = await http.getJsonUnchecked<{ updateTime?: string }>(
+    const res = await http.getJson(
       apiUrl,
       apiOpts,
+      ArtifactRegistryFileMetadata,
     );
     const updateTime = res.body.updateTime;
     return asTimestamp(updateTime) ?? null;

--- a/lib/modules/datasource/maven/util.ts
+++ b/lib/modules/datasource/maven/util.ts
@@ -1,10 +1,12 @@
 import { Readable } from 'node:stream';
 import { GetObjectCommand } from '@aws-sdk/client-s3';
+import { isNonEmptyString } from '@sindresorhus/is';
 import { XmlDocument } from 'xmldoc';
 import { HOST_DISABLED } from '../../../constants/error-messages.ts';
 import { logger } from '../../../logger/index.ts';
 import { ExternalHostError } from '../../../types/errors/external-host-error.ts';
 import { getCacheType } from '../../../util/cache/package/index.ts';
+import { getEnv } from '../../../util/env.ts';
 import { PackageHttpCacheProvider } from '../../../util/http/cache/package-http-cache-provider.ts';
 import { type Http, HttpError } from '../../../util/http/index.ts';
 import type { HttpOptions, HttpResponse } from '../../../util/http/types.ts';
@@ -277,7 +279,7 @@ async function getArtifactRegistryLastModified(
     : 'us';
 
   // Pathname: /<project>/<repository>/<file-path...>
-  const pathParts = pkgUrl.pathname.split('/').filter(Boolean);
+  const pathParts = pkgUrl.pathname.split('/').filter(isNonEmptyString);
   if (pathParts.length < 3) {
     return null;
   }
@@ -288,7 +290,10 @@ async function getArtifactRegistryLastModified(
     .map(encodeURIComponent)
     .join('%2F');
 
-  const apiUrl = `https://artifactregistry.googleapis.com/v1/projects/${project}/locations/${location}/repositories/${repository}/files/${encodedFilePath}`;
+  const artifactRegistryBaseUrl =
+    getEnv().RENOVATE_ARTIFACT_REGISTRY_URL ??
+    'https://artifactregistry.googleapis.com';
+  const apiUrl = `${artifactRegistryBaseUrl}/v1/projects/${project}/locations/${location}/repositories/${repository}/files/${encodedFilePath}`;
 
   try {
     const apiOpts: HttpOptions = {};


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

- he problem: `downloadArtifactRegistryProtocol` never populated `lastModified` because the GCP Maven registry doesn't return a `Last-Modified` HTTP header

- The solution: a secondary call to the Artifact Registry REST API (`files.get`) to retrieve `updateTime`

- That it's non-breaking: failures fall back gracefully with no `lastModified` set


## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [X] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Claude Sonet 4.6. I generated the code and documentation and tests after instructed very clearly what needed to change.
Code changes were reviewed.

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [X] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [X] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [X] Code inspection only, or
- [X] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
