### PR TITLE
fix(datasource/go): include `constraintsFiltering` in cache key

### DIFF
--- a/lib/modules/datasource/go/releases-goproxy.ts
+++ b/lib/modules/datasource/go/releases-goproxy.ts
@@ -386,11 +386,18 @@ export class GoProxyDatasource extends Datasource {
     return result;
   }
 
-  static getCacheKey({ packageName }: GetReleasesConfig): string {
+  static getCacheKey({
+    packageName,
+    constraintsFiltering,
+  }: GetReleasesConfig): string {
     const goproxy = getEnv().GOPROXY;
     const noproxy = parseNoproxy();
+    const constraintsFilteringKey =
+      constraintsFiltering && constraintsFiltering !== 'none'
+        ? `@@${constraintsFiltering}`
+        : '';
     // TODO: types (#22198)
-    return `${packageName}@@${goproxy}@@${noproxy?.toString()}`;
+    return `${packageName}@@${goproxy}@@${noproxy?.toString()}${constraintsFilteringKey}`;
   }
 
   static getVersionedCacheKey(packageName: string, version: string): string {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
When running Renovate in a shared environment, such as Mend-hosted
Renovate, if relying on the new functionality for `constraintsFiltering`
checks in the Go datasource, it's possible to get data without
the `constraints` embedded in them.

This is due to us using a cache key that doesn't take into account
whether we are `constraintsFiltering`, which controls whether we look up
the `go` directive for a given Go module.

We can fix this by introducing an additional entry into the cache key
for the `constraintsFiltering` value.

We can make sure that this doesn't modify existing
(non-`constraintsFiltering`) entries, and only add additional keys if
`constraintsFiltering` is set to something other than the default.


<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
