### PR TITLE
refactor(json-schema): use `$ref`s for property definitions

### DIFF
--- a/tools/docs/schema.ts
+++ b/tools/docs/schema.ts
@@ -197,7 +197,7 @@ function createSchemaForParentConfigs(
 ): void {
   for (const option of options) {
     if (!option.parents || option.parents.includes('.')) {
-      properties[option.name] = createSingleConfig(option);
+      properties[option.name] = { $ref: `#/definitions/${option.name}` };
     }
   }
 }
@@ -268,8 +268,9 @@ function createSchemaForChildConfigs(
   for (const option of options) {
     if (option.parents) {
       for (const parent of option.parents.filter((parent) => parent !== '.')) {
-        properties[parent].items.allOf[0].properties[option.name] =
-          createSingleConfig(option);
+        properties[parent].items.allOf[0].properties[option.name] = {
+          $ref: `#/definitions/${option.name}`,
+        };
 
         for (const prop of option.requiredIf ?? []) {
           properties[parent].items.allOf.push(
@@ -311,6 +312,7 @@ export async function generateSchema(
     'x-renovate-version': `${version}`,
     allowComments: true,
     type: 'object',
+    definitions: {} as Record<string, any>,
     properties: {},
 
     /* any configuration items that should not be set - only used in inherited or repo config */
@@ -378,6 +380,11 @@ export async function generateSchema(
     }
     return 0;
   });
+  const definitions = schema.definitions;
+  for (const option of configurationOptions) {
+    definitions[option.name] = createSingleConfig(option);
+  }
+
   const properties = schema.properties as Record<string, any>;
 
   createSchemaForParentConfigs(configurationOptions, properties);


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
As part of future changes, we'll introduce coverage of all properties
under `packageRules`.

Before we do this, we should use `$ref`s to make sure that we don't
duplicate the definitions too much.


## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
