### PR TITLE
chore(json-schema): automagically populate `packageRules` with possible properties

### DIFF
--- a/tools/docs/schema.ts
+++ b/tools/docs/schema.ts
@@ -292,15 +292,15 @@ function createSchemaForChildConfigs(
     if (
       isUndefined(option.parents) &&
       isNullOrUndefined(
-        properties[parent].items.allOf[0].properties[option.name],
+        definitions[parent].items.allOf[0].properties[option.name],
       )
     ) {
-      properties[parent].items.allOf[0].properties[option.name] = {
+      definitions[parent].items.allOf[0].properties[option.name] = {
         $ref: `#/definitions/${option.name}`,
       };
 
       for (const prop of option.requiredIf ?? []) {
-        properties[parent].items.allOf.push(
+        definitions[parent].items.allOf.push(
           toRequiredPropertiesRule(prop, option),
         );
       }

--- a/tools/docs/schema.ts
+++ b/tools/docs/schema.ts
@@ -1,3 +1,4 @@
+import { isNullOrUndefined, isUndefined } from '@sindresorhus/is';
 import { getOptions } from '../../lib/config/options/index.ts';
 import type {
   RenovateOptions,
@@ -280,6 +281,28 @@ function createSchemaForChildConfigs(
             toRequiredPropertiesRule(prop, option),
           );
         }
+      }
+    }
+  }
+
+  // then make sure we set anything that's possible to be under packageRules
+  const parent = 'packageRules';
+  for (const option of options) {
+    // as long as it's not already got an entry
+    if (
+      isUndefined(option.parents) &&
+      isNullOrUndefined(
+        properties[parent].items.allOf[0].properties[option.name],
+      )
+    ) {
+      properties[parent].items.allOf[0].properties[option.name] = {
+        $ref: `#/definitions/${option.name}`,
+      };
+
+      for (const prop of option.requiredIf ?? []) {
+        properties[parent].items.allOf.push(
+          toRequiredPropertiesRule(prop, option),
+        );
       }
     }
   }


### PR DESCRIPTION
For a lot of our properties, even though we've not explicitly noted that
they can be used with `packageRules`, we can make the assumption that
they're possible to use.

This is a bit more of an assumption **??**.

In cases where there is incorrectly suggested **??**, we can **??**.

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
