### PR TITLE
fix(manager/deno): parse npm package name that includes `.` correctly 

### DIFF
--- a/lib/modules/manager/deno/post.spec.ts
+++ b/lib/modules/manager/deno/post.spec.ts
@@ -185,6 +185,24 @@ describe('modules/manager/deno/post', () => {
       expect(result).toBe('1.8.5');
     });
 
+    // https://github.com/renovatebot/renovate/discussions/43015
+    it('gets lockedVersion for npm package names containing dots', () => {
+      const result = getLockedVersion(
+        {
+          datasource: 'npm',
+          currentValue: '^14.0.0',
+          currentRawValue: 'npm:discord.js@^14.0.0',
+          depName: 'discord.js',
+        },
+        {
+          lockedVersions: {
+            'npm:discord.js@14': '14.26.3',
+          },
+        },
+      );
+      expect(result).toBe('14.26.3');
+    });
+
     it('invalid lock file content', () => {
       const result = getLockedVersion(
         {

--- a/lib/modules/manager/deno/schema.spec.ts
+++ b/lib/modules/manager/deno/schema.spec.ts
@@ -309,6 +309,23 @@ describe('modules/manager/deno/schema', () => {
   });
 
   describe('DenoDependency', () => {
+    // https://github.com/renovatebot/renovate/discussions/43015
+    it('parses npm package names containing dots', () => {
+      expect(
+        DenoDependency.parse({
+          depValue: 'npm:discord.js@14.26.3',
+          depType: 'imports',
+        }),
+      ).toEqual({
+        currentRawValue: 'npm:discord.js@14.26.3',
+        currentValue: '14.26.3',
+        datasource: 'npm',
+        depName: 'discord.js',
+        depType: 'imports',
+        versioning: 'deno',
+      });
+    });
+
     it('invalid npm package names', () => {
       expect(
         DenoDependency.parse({

--- a/lib/modules/manager/deno/utils.ts
+++ b/lib/modules/manager/deno/utils.ts
@@ -5,5 +5,5 @@ export const denoLandRegex = regEx(
 );
 // "deno task" could refer to another task e.g. "deno task npm:build"
 export const depValueRegex = regEx(
-  /(?:deno task\s+\w+:[^\s]+)|(?<datasource>\w+):\/?(?<depName>@?[\w-]+(?:\/[\w-]+)?)(?:@(?<currentValue>[^\s/]+))?\/?/,
+  /(?:deno task\s+\w+:[^\s]+)|(?<datasource>\w+):\/?(?<depName>@?[\w.-]+(?:\/[\w.-]+)?)(?:@(?<currentValue>[^\s/]+))?\/?/,
 );


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

filed:
- https://github.com/renovatebot/renovate/discussions/43015

The npm package names containing periods (.) like `discord.js` couldn't be parsed correctly.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [x] Yes — other (please describe):

I asked about what is wrong and the better way to handle package names.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
