### PR TITLE
feat(presets/monorepos): add confect

### DIFF
--- a/lib/data/monorepo.json
+++ b/lib/data/monorepo.json
@@ -150,6 +150,7 @@
       "https://github.com/Microsoft/ClearScript"
     ],
     "commitlint": "https://github.com/conventional-changelog/commitlint",
+    "confect": "https://github.com/rjdellecese/confect",
     "conform": "https://github.com/edmundhung/conform",
     "contentful-rich-text": "https://github.com/contentful/rich-text",
     "cspell": "https://github.com/streetsidesoftware/cspell",


### PR DESCRIPTION
## Changes

Add the `@confect/*` scoped packages to the monorepo presets so they are grouped together in a single Renovate PR. Confect is a framework that integrates Effect with Convex, with packages: `@confect/core`, `@confect/cli`, `@confect/server`, `@confect/react`, and `@confect/test`. All packages are released together from the same repository with synchronized versions.

## Context

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: https://github.com/rjdellecese/confect