### PR TITLE
feat(manager/mise): add support for neo4j

### DIFF
--- a/lib/modules/manager/mise/extract.spec.ts
+++ b/lib/modules/manager/mise/extract.spec.ts
@@ -71,6 +71,7 @@ describe('modules/manager/mise/extract', () => {
       lefthook = "1.11.13"
       localstack = "4.3.0"
       lychee = "0.19.1"
+      neo4j = "2026.04.0"
       npm = "11.2.0"
       opentofu = "1.6.1"
       openfga = "1.14.0"
@@ -234,6 +235,12 @@ describe('modules/manager/mise/extract', () => {
             depName: 'lychee',
             extractVersion: '^lychee-v(?<version>\\S+)',
             packageName: 'lycheeverse/lychee',
+          },
+          {
+            currentValue: '2026.04.0',
+            datasource: 'maven',
+            depName: 'neo4j',
+            packageName: 'org.neo4j:neo4j',
           },
           {
             currentValue: '11.2.0',

--- a/lib/modules/manager/mise/index.ts
+++ b/lib/modules/manager/mise/index.ts
@@ -6,6 +6,7 @@ import { GithubReleasesDatasource } from '../../datasource/github-releases/index
 import { GithubTagsDatasource } from '../../datasource/github-tags/index.ts';
 import { GoDatasource } from '../../datasource/go/index.ts';
 import { JavaVersionDatasource } from '../../datasource/java-version/index.ts';
+import { MavenDatasource } from '../../datasource/maven/index.ts';
 import { NodeVersionDatasource } from '../../datasource/node-version/index.ts';
 import { NpmDatasource } from '../../datasource/npm/index.ts';
 import { NugetDatasource } from '../../datasource/nuget/index.ts';
@@ -35,6 +36,7 @@ const backendDatasources = {
     GithubReleasesDatasource.id,
     GithubTagsDatasource.id,
     JavaVersionDatasource.id,
+    MavenDatasource.id,
     NodeVersionDatasource.id,
     RubyVersionDatasource.id,
   ],

--- a/lib/modules/manager/mise/upgradeable-tooling.ts
+++ b/lib/modules/manager/mise/upgradeable-tooling.ts
@@ -4,6 +4,7 @@ import { GithubReleasesDatasource } from '../../datasource/github-releases/index
 import { GithubTagsDatasource } from '../../datasource/github-tags/index.ts';
 import { HexpmBobDatasource } from '../../datasource/hexpm-bob/index.ts';
 import { JavaVersionDatasource } from '../../datasource/java-version/index.ts';
+import { MavenDatasource } from '../../datasource/maven/index.ts';
 import { NodeVersionDatasource } from '../../datasource/node-version/index.ts';
 import { NpmDatasource } from '../../datasource/npm/index.ts';
 import { RubyVersionDatasource } from '../../datasource/ruby-version/index.ts';
@@ -362,6 +363,13 @@ const miseRegistryTooling: Record<string, ToolingDefinition> = {
       packageName: 'lycheeverse/lychee',
       datasource: GithubReleasesDatasource.id,
       extractVersion: '^lychee-v(?<version>\\S+)',
+    },
+  },
+  neo4j: {
+    misePluginUrl: 'https://mise.jdx.dev/registry.html#tools',
+    config: {
+      packageName: 'org.neo4j:neo4j',
+      datasource: MavenDatasource.id,
     },
   },
   npm: {


### PR DESCRIPTION
## Changes

Adds `neo4j` ([Neo4j](https://neo4j.com)) to the set of mise tools renovate can manage. Neo4j is a high-performance, native graph database with full ACID transactions, the Cypher query language, and a flexible property graph model.

Versions are sourced from Maven Central (\`org.neo4j:neo4j\`), which is comprehensive — its \`maven-metadata.xml\` lists every published release back to 1.2.M01 and currently includes the latest \`2026.04.0\`. \`MavenDatasource\` is added to the mise manager's \`core\` supported datasources so registry tools (like neo4j) can use it.

This pairs with [jdx/mise#9525](https://github.com/jdx/mise/pull/9525), which adds the corresponding \`registry/neo4j.toml\` to the mise registry. After both land, users can drop manual \`# renovate:\` overrides and rely on the registry name:

\`\`\`toml
[tools]
neo4j = "2026.04.0"
\`\`\`

## Context

- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, and documentation).

## Documentation (please check one with an [x])

- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Newly added/modified unit tests