### PR TITLE
feat(manager/mise): add support for minio

### DIFF
--- a/lib/modules/manager/mise/extract.spec.ts
+++ b/lib/modules/manager/mise/extract.spec.ts
@@ -71,6 +71,7 @@ describe('modules/manager/mise/extract', () => {
       lefthook = "1.11.13"
       localstack = "4.3.0"
       lychee = "0.19.1"
+      minio = "RELEASE.2025-10-15T17-29-55Z"
       npm = "11.2.0"
       opentofu = "1.6.1"
       openfga = "1.14.0"
@@ -234,6 +235,14 @@ describe('modules/manager/mise/extract', () => {
             depName: 'lychee',
             extractVersion: '^lychee-v(?<version>\\S+)',
             packageName: 'lycheeverse/lychee',
+          },
+          {
+            currentValue: 'RELEASE.2025-10-15T17-29-55Z',
+            datasource: 'github-releases',
+            depName: 'minio',
+            packageName: 'minio/minio',
+            versioning:
+              'regex:^RELEASE\\.(?<major>\\d+)-(?<minor>\\d+)-(?<patch>\\d+)T(?<build>\\d+)-(?<revision>\\d+)-\\d+Z$',
           },
           {
             currentValue: '11.2.0',

--- a/lib/modules/manager/mise/upgradeable-tooling.ts
+++ b/lib/modules/manager/mise/upgradeable-tooling.ts
@@ -364,6 +364,18 @@ const miseRegistryTooling: Record<string, ToolingDefinition> = {
       extractVersion: '^lychee-v(?<version>\\S+)',
     },
   },
+  minio: {
+    misePluginUrl: 'https://mise.jdx.dev/registry.html#tools',
+    config: {
+      packageName: 'minio/minio',
+      datasource: GithubReleasesDatasource.id,
+      // MinIO tags use the calver-ish form `RELEASE.YYYY-MM-DDTHH-MM-SSZ`,
+      // which does not parse as semver. Map year/month/day/hour/minute onto
+      // the regex versioning's numeric release components; seconds are
+      // dropped since MinIO releases more than once per minute are unlikely.
+      versioning: `${regexVersioning.id}:^RELEASE\\.(?<major>\\d+)-(?<minor>\\d+)-(?<patch>\\d+)T(?<build>\\d+)-(?<revision>\\d+)-\\d+Z$`,
+    },
+  },
   npm: {
     misePluginUrl: 'https://mise.jdx.dev/registry.html#tools',
     config: {


### PR DESCRIPTION
## Changes

Adds `minio` ([MinIO](https://min.io)) to the set of mise tools that renovate can manage. MinIO is an S3-compatible object store published as GitHub releases at [`minio/minio`](https://github.com/minio/minio/releases).

MinIO release tags use a calver-style format `RELEASE.YYYY-MM-DDTHH-MM-SSZ` (e.g. `RELEASE.2025-10-15T17-29-55Z`), which does not parse as semver. The new entry uses `regex` versioning to map year/month/day/hour/minute onto the numeric release components (`major`/`minor`/`patch`/`build`/`revision`); seconds are dropped since MinIO releases more than once per minute are unlikely.

This pairs with [jdx/mise#9529](https://github.com/jdx/mise/pull/9529), which reorders MinIO's preferred backend in the mise registry to `go:github.com/minio/minio` ahead of the existing `conda:` and `asdf:` backends. After both land, users can drop manual `# renovate:` overrides and rely on the registry name:

```toml
[tools]
minio = "RELEASE.2025-10-15T17-29-55Z"
```

## Context

- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, and documentation).

## Documentation (please check one with an [x])

- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Newly added/modified unit tests

\`pnpm vitest run lib/modules/manager/mise/extract.spec.ts\` and \`pnpm vitest run lib/modules/manager/index.spec.ts\` both pass.