### PR TITLE
feat(manager/mise): add support for rustfs

### DIFF
--- a/lib/modules/manager/mise/extract.spec.ts
+++ b/lib/modules/manager/mise/extract.spec.ts
@@ -81,6 +81,7 @@ describe('modules/manager/mise/extract', () => {
       redis = "8.0.1"
       ruff = "0.11.12"
       rumdl = "0.1.58"
+      rustfs = "1.0.0-beta.1"
       shellcheck = "0.10.0"
       skeema = "1.12.3"
       sops = "3.10.2"
@@ -298,6 +299,12 @@ describe('modules/manager/mise/extract', () => {
             datasource: 'github-releases',
             depName: 'rumdl',
             packageName: 'rvben/rumdl',
+          },
+          {
+            currentValue: '1.0.0-beta.1',
+            datasource: 'github-releases',
+            depName: 'rustfs',
+            packageName: 'rustfs/rustfs',
           },
           {
             currentValue: '0.10.0',

--- a/lib/modules/manager/mise/upgradeable-tooling.ts
+++ b/lib/modules/manager/mise/upgradeable-tooling.ts
@@ -452,6 +452,13 @@ const miseRegistryTooling: Record<string, ToolingDefinition> = {
       datasource: GithubReleasesDatasource.id,
     },
   },
+  rustfs: {
+    misePluginUrl: 'https://mise.jdx.dev/registry.html#tools',
+    config: {
+      packageName: 'rustfs/rustfs',
+      datasource: GithubReleasesDatasource.id,
+    },
+  },
   shellcheck: {
     misePluginUrl: 'https://mise.jdx.dev/registry.html#tools',
     config: {


### PR DESCRIPTION
## Changes

Adds `rustfs` ([RustFS](https://rustfs.com)) to the set of mise tools that renovate can manage. RustFS is an Apache-2.0, S3-compatible object storage system written in Rust, published as GitHub releases at [`rustfs/rustfs`](https://github.com/rustfs/rustfs). Tags follow semver (e.g. \`1.0.0-beta.1\`) so the default \`GithubReleasesDatasource\` works without an \`extractVersion\` override.

This pairs with [jdx/mise#9530](https://github.com/jdx/mise/pull/9530), which adds the corresponding \`registry/rustfs.toml\` (github backend). After both land, users can drop manual \`# renovate:\` overrides and rely on the registry name:

\`\`\`toml
[tools]
rustfs = "1.0.0-beta.1"
\`\`\`

## Context

- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, and documentation).

## Documentation (please check one with an [x])

- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Newly added/modified unit tests

\`pnpm vitest run lib/modules/manager/mise/extract.spec.ts\` and \`pnpm vitest run lib/modules/manager/index.spec.ts\` both pass.