### PR TITLE
feat(azure-pipelines): support GitHub-hosted pipelines running on Azure Pipelines

### DIFF
--- a/lib/modules/datasource/azure-pipelines-tasks/index.spec.ts
+++ b/lib/modules/datasource/azure-pipelines-tasks/index.spec.ts
@@ -256,6 +256,68 @@ describe('modules/datasource/azure-pipelines-tasks/index', () => {
     });
   });
 
+  it('handles trailing slash on endpoint when platform is azure', async () => {
+    GlobalConfig.set({
+      platform: 'azure',
+      endpoint: 'https://dev.azure.com/hymans/',
+    });
+    hostRules.add({
+      hostType: AzurePipelinesTasksDatasource.id,
+      matchHost: 'dev.azure.com',
+      token: '123test',
+    });
+    httpMock
+      .scope('https://dev.azure.com')
+      .get('/hymans/_apis/distributedtask/tasks/')
+      .reply(200, Fixtures.get('tasks.json'));
+    expect(
+      await getPkgReleases({
+        datasource: AzurePipelinesTasksDatasource.id,
+        packageName: 'AzurePowerShell',
+      }),
+    ).toEqual({
+      releases: [
+        {
+          changelogContent:
+            'Added support for Az Module and cross platform agents.',
+          changelogUrl:
+            'https://github.com/microsoft/azure-pipelines-tasks/releases',
+          version: '5.248.3',
+        },
+      ],
+    });
+  });
+
+  it('handles trailing slash on SYSTEM_COLLECTIONURI when platform is github', async () => {
+    GlobalConfig.set({ platform: 'github' });
+    process.env.SYSTEM_COLLECTIONURI = 'https://dev.azure.com/hymans/';
+    hostRules.add({
+      hostType: AzurePipelinesTasksDatasource.id,
+      matchHost: 'dev.azure.com',
+      token: '123test',
+    });
+    httpMock
+      .scope('https://dev.azure.com')
+      .get('/hymans/_apis/distributedtask/tasks/')
+      .reply(200, Fixtures.get('tasks.json'));
+    expect(
+      await getPkgReleases({
+        datasource: AzurePipelinesTasksDatasource.id,
+        packageName: 'AzurePowerShell',
+      }),
+    ).toEqual({
+      releases: [
+        {
+          changelogContent:
+            'Added support for Az Module and cross platform agents.',
+          changelogUrl:
+            'https://github.com/microsoft/azure-pipelines-tasks/releases',
+          version: '5.248.3',
+        },
+      ],
+    });
+  });
+
   it('falls back to GitHub-hosted lists when platform is github but SYSTEM_COLLECTIONURI is not set', async () => {
     GlobalConfig.set({ platform: 'github' });
 

--- a/lib/modules/datasource/azure-pipelines-tasks/index.spec.ts
+++ b/lib/modules/datasource/azure-pipelines-tasks/index.spec.ts
@@ -16,6 +16,11 @@ describe('modules/datasource/azure-pipelines-tasks/index', () => {
   beforeEach(() => {
     GlobalConfig.reset();
     hostRules.clear();
+    delete process.env.SYSTEM_COLLECTIONURI;
+  });
+
+  afterEach(() => {
+    delete process.env.SYSTEM_COLLECTIONURI;
   });
 
   it('returns null for unknown task', async () => {
@@ -216,6 +221,55 @@ describe('modules/datasource/azure-pipelines-tasks/index', () => {
         },
       ],
     });
+  });
+
+  it('returns organization task when platform is github and SYSTEM_COLLECTIONURI is set', async () => {
+    GlobalConfig.set({ platform: 'github' });
+    process.env.SYSTEM_COLLECTIONURI = 'https://my.custom.domain';
+
+    hostRules.add({
+      hostType: AzurePipelinesTasksDatasource.id,
+      matchHost: 'my.custom.domain',
+      token: '123test',
+    });
+
+    httpMock
+      .scope('https://my.custom.domain')
+      .get('/_apis/distributedtask/tasks/')
+      .reply(200, Fixtures.get('tasks.json'));
+
+    expect(
+      await getPkgReleases({
+        datasource: AzurePipelinesTasksDatasource.id,
+        packageName: 'AzurePowerShell',
+      }),
+    ).toEqual({
+      releases: [
+        {
+          changelogContent:
+            'Added support for Az Module and cross platform agents.',
+          changelogUrl:
+            'https://github.com/microsoft/azure-pipelines-tasks/releases',
+          version: '5.248.3',
+        },
+      ],
+    });
+  });
+
+  it('falls back to GitHub-hosted lists when platform is github but SYSTEM_COLLECTIONURI is not set', async () => {
+    GlobalConfig.set({ platform: 'github' });
+
+    httpMock
+      .scope(gitHubHost)
+      .get(builtinTasksPath)
+      .reply(200, { automatedanalysis: ['0.171.0', '0.198.0'] });
+
+    expect(
+      await getPkgReleases({
+        datasource: AzurePipelinesTasksDatasource.id,
+        packageName: 'AutomatedAnalysis',
+      }),
+    ).toEqual({ releases: [{ version: '0.171.0' }, { version: '0.198.0' }] });
   });
 
   describe('compare semver', () => {

--- a/lib/modules/datasource/azure-pipelines-tasks/index.ts
+++ b/lib/modules/datasource/azure-pipelines-tasks/index.ts
@@ -1,5 +1,6 @@
 import type { TypeOf, ZodType } from 'zod/v3';
 import { GlobalConfig } from '../../../config/global.ts';
+import { AzurePipelines } from '../../../util/azure.ts';
 import { withCache } from '../../../util/cache/package/with-cache.ts';
 import * as hostRules from '../../../util/host-rules.ts';
 import type { HttpOptions } from '../../../util/http/types.ts';
@@ -34,19 +35,25 @@ export class AzurePipelinesTasksDatasource extends Datasource {
     packageName,
   }: GetReleasesConfig): Promise<ReleaseResult | null> {
     const platform = GlobalConfig.get('platform');
-    const endpoint = GlobalConfig.get('endpoint');
+    // Use endpoint from host rules for azure platform, check if azure pipelines is being used with a github platform, and if so use the SYSTEM_COLLECTIONURI environment variable as the endpoint
+    const azureEndpoint =
+      platform === 'azure'
+        ? GlobalConfig.get('endpoint')
+        : platform === 'github'
+          ? process.env[AzurePipelines.PredefinedVariables.systemCollectionUri]
+          : undefined;
     const { token } = hostRules.find({
       hostType: AzurePipelinesTasksDatasource.id,
-      url: endpoint,
+      url: azureEndpoint,
     });
 
-    if (platform === 'azure' && endpoint && token) {
+    if (azureEndpoint && token) {
       const auth = Buffer.from(`renovate:${token}`).toString('base64');
       const opts: HttpOptions = {
         headers: { authorization: `Basic ${auth}` },
       };
       const results = await this.getTasks(
-        `${endpoint}/_apis/distributedtask/tasks/`,
+        `${azureEndpoint}/_apis/distributedtask/tasks/`,
         opts,
         AzurePipelinesJSON,
       );

--- a/lib/modules/datasource/azure-pipelines-tasks/index.ts
+++ b/lib/modules/datasource/azure-pipelines-tasks/index.ts
@@ -4,6 +4,7 @@ import { AzurePipelines } from '../../../util/azure.ts';
 import { withCache } from '../../../util/cache/package/with-cache.ts';
 import * as hostRules from '../../../util/host-rules.ts';
 import type { HttpOptions } from '../../../util/http/types.ts';
+import { joinUrlParts } from '../../../util/url.ts';
 import { id as versioning } from '../../versioning/loose/index.ts';
 import { Datasource } from '../datasource.ts';
 import type { GetReleasesConfig, Release, ReleaseResult } from '../types.ts';
@@ -53,7 +54,7 @@ export class AzurePipelinesTasksDatasource extends Datasource {
         headers: { authorization: `Basic ${auth}` },
       };
       const results = await this.getTasks(
-        `${azureEndpoint}/_apis/distributedtask/tasks/`,
+        joinUrlParts(azureEndpoint, '_apis/distributedtask/tasks/'),
         opts,
         AzurePipelinesJSON,
       );

--- a/lib/modules/datasource/azure-pipelines-tasks/index.ts
+++ b/lib/modules/datasource/azure-pipelines-tasks/index.ts
@@ -1,5 +1,6 @@
 import type { TypeOf, ZodType } from 'zod/v3';
 import { GlobalConfig } from '../../../config/global.ts';
+import { logger } from '../../../logger/index.ts';
 import { AzurePipelines } from '../../../util/azure.ts';
 import { withCache } from '../../../util/cache/package/with-cache.ts';
 import * as hostRules from '../../../util/host-rules.ts';
@@ -37,12 +38,23 @@ export class AzurePipelinesTasksDatasource extends Datasource {
   }: GetReleasesConfig): Promise<ReleaseResult | null> {
     const platform = GlobalConfig.get('platform');
     // Use endpoint from host rules for azure platform, check if azure pipelines is being used with a github platform, and if so use the SYSTEM_COLLECTIONURI environment variable as the endpoint
-    const azureEndpoint =
-      platform === 'azure'
-        ? GlobalConfig.get('endpoint')
-        : platform === 'github'
-          ? process.env[AzurePipelines.PredefinedVariables.systemCollectionUri]
-          : undefined;
+    let azureEndpoint: string | undefined = undefined;
+
+    if (platform === 'azure') {
+      azureEndpoint = GlobalConfig.get('endpoint');
+    } else if (platform === 'github') {
+      const azurePipelinesSystemCollectionUri =
+        process.env[
+          AzurePipelines.PredefinedVariables.systemCollectionUri
+        ]?.toString();
+      if (azurePipelinesSystemCollectionUri) {
+        logger.info(
+          `Platform is ${platform} but found to be running under Azure Pipelines due to presence of ${AzurePipelines.PredefinedVariables.systemCollectionUri} environment variable. Using it as the endpoint for azure pipelines tasks datasource.`,
+        );
+        azureEndpoint = azurePipelinesSystemCollectionUri;
+      }
+    }
+
     const { token } = hostRules.find({
       hostType: AzurePipelinesTasksDatasource.id,
       url: azureEndpoint,

--- a/lib/modules/manager/azure-pipelines/extract.spec.ts
+++ b/lib/modules/manager/azure-pipelines/extract.spec.ts
@@ -20,6 +20,7 @@ const azurePipelinesNoDependency = Fixtures.get(
 describe('modules/manager/azure-pipelines/extract', () => {
   afterEach(() => {
     GlobalConfig.reset();
+    delete process.env.SYSTEM_COLLECTIONURI;
   });
 
   it('should parse a valid azure-pipelines file', () => {
@@ -180,6 +181,44 @@ describe('modules/manager/azure-pipelines/extract', () => {
           '',
         ),
       ).toBeNull();
+    });
+
+    it('should extract Azure repository information when platform is github and SYSTEM_COLLECTIONURI is set with project in name', () => {
+      GlobalConfig.set({ platform: 'github' });
+      process.env.SYSTEM_COLLECTIONURI = 'https://dev.azure.com/renovate-org';
+
+      expect(
+        extractRepository(
+          {
+            type: 'git',
+            name: 'project/repo',
+            ref: 'refs/tags/v1.0.0',
+          },
+          'otherProject/otherRepo',
+        ),
+      ).toMatchObject({
+        depName: 'project/repo',
+        packageName: 'https://dev.azure.com/renovate-org/project/_git/repo',
+      });
+    });
+
+    it('should extract Azure repository information when platform is github and SYSTEM_COLLECTIONURI is set with project from currentRepository', () => {
+      GlobalConfig.set({ platform: 'github' });
+      process.env.SYSTEM_COLLECTIONURI = 'https://dev.azure.com/renovate-org';
+
+      expect(
+        extractRepository(
+          {
+            type: 'git',
+            name: 'repo',
+            ref: 'refs/tags/v1.0.0',
+          },
+          'project/otherrepo',
+        ),
+      ).toMatchObject({
+        depName: 'project/repo',
+        packageName: 'https://dev.azure.com/renovate-org/project/_git/repo',
+      });
     });
   });
 

--- a/lib/modules/manager/azure-pipelines/extract.spec.ts
+++ b/lib/modules/manager/azure-pipelines/extract.spec.ts
@@ -220,6 +220,72 @@ describe('modules/manager/azure-pipelines/extract', () => {
         packageName: 'https://dev.azure.com/renovate-org/project/_git/repo',
       });
     });
+
+    it('should return null when platform is github, SYSTEM_COLLECTIONURI is set, but project not in name or currentRepository', () => {
+      GlobalConfig.set({ platform: 'github' });
+      process.env.SYSTEM_COLLECTIONURI = 'https://dev.azure.com/renovate-org';
+
+      expect(
+        extractRepository(
+          {
+            type: 'git',
+            name: 'repo',
+            ref: 'refs/tags/v1.0.0',
+          },
+          '',
+        ),
+      ).toBeNull();
+    });
+
+    it('should return null when platform is github, SYSTEM_COLLECTIONURI is set, but currentRepository is undefined', () => {
+      GlobalConfig.set({ platform: 'github' });
+      process.env.SYSTEM_COLLECTIONURI = 'https://dev.azure.com/renovate-org';
+
+      expect(
+        extractRepository(
+          {
+            type: 'git',
+            name: 'repo',
+            ref: 'refs/tags/v1.0.0',
+          },
+          undefined,
+        ),
+      ).toBeNull();
+    });
+
+    it('should extract Azure repository information when platform is github and SYSTEM_COLLECTIONURI has a trailing slash', () => {
+      GlobalConfig.set({ platform: 'github' });
+      process.env.SYSTEM_COLLECTIONURI = 'https://dev.azure.com/renovate-org/';
+
+      expect(
+        extractRepository(
+          {
+            type: 'git',
+            name: 'project/repo',
+            ref: 'refs/tags/v1.0.0',
+          },
+          'otherProject/otherRepo',
+        ),
+      ).toMatchObject({
+        depName: 'project/repo',
+        packageName: 'https://dev.azure.com/renovate-org/project/_git/repo',
+      });
+    });
+
+    it('should return null for git repo type if platform is not azure or github', () => {
+      GlobalConfig.set({ platform: 'gitlab' });
+
+      expect(
+        extractRepository(
+          {
+            type: 'git',
+            name: 'project/repo',
+            ref: 'refs/tags/v1.0.0',
+          },
+          'project/otherRepo',
+        ),
+      ).toBeNull();
+    });
   });
 
   describe('extractContainer()', () => {

--- a/lib/modules/manager/azure-pipelines/extract.ts
+++ b/lib/modules/manager/azure-pipelines/extract.ts
@@ -38,13 +38,23 @@ export function extractRepository(
     repositoryUrl = `https://github.com/${repository.name}.git`;
   } else if (repository.type === 'git') {
     const platform = GlobalConfig.get('platform');
-    // Use endpoint from host rules for azure platform, check if azure pipelines is being used with a github platform, and if so use the SYSTEM_COLLECTIONURI environment variable as the endpoint
-    const azureEndpoint =
-      platform === 'azure'
-        ? GlobalConfig.get('endpoint')
-        : platform === 'github'
-          ? process.env[AzurePipelines.PredefinedVariables.systemCollectionUri]
-          : undefined;
+
+    let azureEndpoint: string | undefined = undefined;
+
+    if (platform === 'azure') {
+      azureEndpoint = GlobalConfig.get('endpoint');
+    } else if (platform === 'github') {
+      const azurePipelinesSystemCollectionUri =
+        process.env[
+          AzurePipelines.PredefinedVariables.systemCollectionUri
+        ]?.toString();
+      if (azurePipelinesSystemCollectionUri) {
+        logger.info(
+          `Platform is ${platform} but found to be running under Azure Pipelines due to presence of ${AzurePipelines.PredefinedVariables.systemCollectionUri} environment variable. Using it as the Azure DevOps endpoint for repository URL resolution.`,
+        );
+        azureEndpoint = azurePipelinesSystemCollectionUri;
+      }
+    }
 
     if (azureEndpoint) {
       // extract the project name if the repository from which the pipline is referencing templates contains the Azure DevOps project name

--- a/lib/modules/manager/azure-pipelines/extract.ts
+++ b/lib/modules/manager/azure-pipelines/extract.ts
@@ -1,6 +1,7 @@
 import { GlobalConfig } from '../../../config/global.ts';
 import { logger } from '../../../logger/index.ts';
 import { coerceArray } from '../../../util/array.ts';
+import { AzurePipelines } from '../../../util/azure.ts';
 import { regEx } from '../../../util/regex.ts';
 import { joinUrlParts } from '../../../util/url.ts';
 import { AzurePipelinesTasksDatasource } from '../../datasource/azure-pipelines-tasks/index.ts';
@@ -12,7 +13,7 @@ import type {
   PackageFileContent,
 } from '../types.ts';
 import type {
-  AzurePipelines,
+  AzurePipelines as AzurePipelinesContent,
   Container,
   Deploy,
   Deployment,
@@ -37,14 +38,20 @@ export function extractRepository(
     repositoryUrl = `https://github.com/${repository.name}.git`;
   } else if (repository.type === 'git') {
     const platform = GlobalConfig.get('platform');
-    const endpoint = GlobalConfig.get('endpoint');
+    // Use endpoint from host rules for azure platform, check if azure pipelines is being used with a github platform, and if so use the SYSTEM_COLLECTIONURI environment variable as the endpoint
+    const azureEndpoint =
+      platform === 'azure'
+        ? GlobalConfig.get('endpoint')
+        : platform === 'github'
+          ? process.env[AzurePipelines.PredefinedVariables.systemCollectionUri]
+          : undefined;
 
-    if (platform === 'azure' && endpoint) {
+    if (azureEndpoint) {
       // extract the project name if the repository from which the pipline is referencing templates contains the Azure DevOps project name
       if (repository.name.includes('/')) {
         const [projectName, repoName] = repository.name.split('/');
         repositoryUrl = joinUrlParts(
-          endpoint,
+          azureEndpoint,
           encodeURIComponent(projectName),
           '_git',
           encodeURIComponent(repoName),
@@ -55,7 +62,7 @@ export function extractRepository(
         const projectName = currentRepository.split('/')[0];
         depName = `${projectName}/${repository.name}`;
         repositoryUrl = joinUrlParts(
-          endpoint,
+          azureEndpoint,
           encodeURIComponent(projectName),
           '_git',
           encodeURIComponent(repository.name),
@@ -121,7 +128,7 @@ export function extractAzurePipelinesTasks(
 export function parseAzurePipelines(
   content: string,
   packageFile: string,
-): AzurePipelines | null {
+): AzurePipelinesContent | null {
   const res = AzurePipelinesYaml.safeParse(content);
   if (res.success) {
     return res.data;

--- a/lib/util/azure.ts
+++ b/lib/util/azure.ts
@@ -1,0 +1,22 @@
+/**
+ * Azure Pipelines utility constants and helpers.
+ *
+ * @see https://learn.microsoft.com/azure/devops/pipelines/build/variables
+ */
+export const AzurePipelines = {
+  /**
+   * Azure Pipelines predefined environment variable key names.
+   * Use with `process.env[AzurePipelines.PredefinedVariables.xxx]`.
+   */
+  PredefinedVariables: {
+    /**
+     * The URI of the Azure DevOps collection.
+     * Set automatically by the Azure Pipelines agent.
+     * Also available when running GitHub-hosted pipelines via the Azure Pipelines app.
+     *
+     * @example 'https://dev.azure.com/myorg/'
+     * @see https://learn.microsoft.com/azure/devops/pipelines/build/variables#system-variables
+     */
+    systemCollectionUri: 'SYSTEM_COLLECTIONURI',
+  },
+} as const;


### PR DESCRIPTION
## Changes

This PR adds support for Renovate running as part of a GitHub-hosted pipeline that is orchestrated by Azure Pipelines (i.e. platform is `github` but the runner is an Azure Pipelines agent).

In this scenario the Azure Pipelines agent sets the `SYSTEM_COLLECTIONURI` environment variable containing the Azure DevOps collection URL. Renovate now detects this variable and uses it as the Azure DevOps endpoint in two places:

- **`azure-pipelines-tasks` datasource** — when resolving task versions from the organization's Azure DevOps instance rather than the GitHub-hosted fallback lists.
- **`azure-pipelines` manager (`extractRepository`)** — when constructing repository URLs for `git`-type pipeline resource references.

Previously both code paths only worked when `platform` was set to `azure`. With this change they also work when `platform` is `github` and `SYSTEM_COLLECTIONURI` is present, which is the case when GitHub Actions workflows are triggered via the Azure Pipelines app.

An informational log message is emitted when the fallback to `SYSTEM_COLLECTIONURI` is used, to make the behaviour transparent to users.

`lib/util/azure.ts` was also introduced to centralise the Azure Pipelines predefined-variable key names so they aren't hard-coded as magic strings across the codebase.

## Context

- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation). GitHub Copilot (Claude Sonnet 4.6) was used to review the implementation for bugs and code quality issues, and to apply fixes (replacing `console.log` with `logger.info`, correcting indentation, and fixing an inaccurate log message in `extract.ts`).

## Documentation (please check one with an [x])

- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Newly added/modified unit tests, and manually running the same Azure pipeline with this version of renovate for a GitHub hosted repository and an Azure DevOps hosted repository and both received bumps to azure repositories and internal azure pipelines tasks

New tests cover:
- Resolving tasks when `platform` is `github` and `SYSTEM_COLLECTIONURI` is set
- Falling back to GitHub-hosted lists when `platform` is `github` but `SYSTEM_COLLECTIONURI` is **not** set
- Trailing-slash handling on both `endpoint` (azure platform) and `SYSTEM_COLLECTIONURI` (github platform)
- Extracting Azure repository information when `platform` is `github` and `SYSTEM_COLLECTIONURI` is set