### PR TITLE
fix(poetry): perform deepmerge to fully enrich projectDep with info from poetryDep

### DIFF
--- a/lib/modules/manager/poetry/extract.spec.ts
+++ b/lib/modules/manager/poetry/extract.spec.ts
@@ -580,6 +580,14 @@ describe('modules/manager/poetry/extract', () => {
       expect(res).toEqual({
         deps: [
           {
+            currentValue: '==2.0.0',
+            currentVersion: '2.0.0',
+            datasource: 'pypi',
+            depName: 'poetry-core',
+            depType: 'build-system.requires',
+            packageName: 'poetry-core',
+          },
+          {
             currentValue: '==4.11.2',
             currentVersion: '4.11.2',
             datasource: 'pypi',
@@ -597,14 +605,6 @@ describe('modules/manager/poetry/extract', () => {
               depGroup: 'decouple',
             },
             packageName: 'python-decouple',
-          },
-          {
-            currentValue: '==2.0.0',
-            currentVersion: '2.0.0',
-            datasource: 'pypi',
-            depName: 'poetry-core',
-            depType: 'build-system.requires',
-            packageName: 'poetry-core',
           },
         ],
         extractedConstraints: {},
@@ -669,7 +669,7 @@ describe('modules/manager/poetry/extract', () => {
         [dependency-groups]
         typing = ["mypy==1.13.0", "types-requests"]
         [tool.poetry.dependencies]
-        click = { source = "artifactory" }
+        click = { version="==1.0.0", source = "artifactory" }
         zoom = { source = "artifactory" }
         [tool.poetry.group.typing.dependencies]
         types-requests = { source = "artifactory" }
@@ -682,18 +682,9 @@ describe('modules/manager/poetry/extract', () => {
         packageName: 'click',
         datasource: 'pypi',
         depType: 'project.dependencies',
-        skipReason: 'unspecified-version',
-        depName: 'click',
-        managerData: { sourceName: 'artifactory' },
-      },
-      {
-        packageName: 'zoom',
-        datasource: 'pypi',
-        depType: 'project.optional-dependencies',
         currentValue: '==1.0.0',
-        currentVersion: '1.0.0',
-        depName: 'zoom',
-        managerData: { depGroup: 'other', sourceName: 'artifactory' },
+        depName: 'click',
+        managerData: { nestedVersion: true, sourceName: 'artifactory' },
       },
       {
         packageName: 'mypy',
@@ -711,6 +702,15 @@ describe('modules/manager/poetry/extract', () => {
         skipReason: 'unspecified-version',
         depName: 'types-requests',
         managerData: { depGroup: 'typing', sourceName: 'artifactory' },
+      },
+      {
+        packageName: 'zoom',
+        datasource: 'pypi',
+        depType: 'project.optional-dependencies',
+        currentValue: '==1.0.0',
+        currentVersion: '1.0.0',
+        depName: 'zoom',
+        managerData: { depGroup: 'other', sourceName: 'artifactory' },
       },
     ]);
   });

--- a/lib/modules/manager/poetry/extract.spec.ts
+++ b/lib/modules/manager/poetry/extract.spec.ts
@@ -663,13 +663,14 @@ describe('modules/manager/poetry/extract', () => {
   it('enriches pep621/pep735 dependencies with poetry managerData', async () => {
     const content = codeBlock`
         [project]
-        dependencies = ["click"]
+        dependencies = ["click", "pytest-cov==5.0.0"]
         [project.optional-dependencies]
         other = ["zoom==1.0.0"]
         [dependency-groups]
         typing = ["mypy==1.13.0", "types-requests"]
         [tool.poetry.dependencies]
         click = { version="==1.0.0", source = "artifactory" }
+        pytest-cov = { version = "==5.0.0" }
         zoom = { source = "artifactory" }
         [tool.poetry.group.typing.dependencies]
         types-requests = { source = "artifactory" }
@@ -685,6 +686,16 @@ describe('modules/manager/poetry/extract', () => {
         currentValue: '==1.0.0',
         depName: 'click',
         managerData: { nestedVersion: true, sourceName: 'artifactory' },
+      },
+      {
+        currentValue: '==5.0.0',
+        currentVersion: '5.0.0',
+        datasource: 'pypi',
+        depName: 'pytest-cov',
+        depType: 'project.dependencies',
+        managerData: {},
+        packageName: 'pytest-cov',
+        skipReason: 'invalid-dependency-specification',
       },
       {
         packageName: 'mypy',

--- a/lib/modules/manager/poetry/schema.ts
+++ b/lib/modules/manager/poetry/schema.ts
@@ -1,3 +1,4 @@
+import deepmerge from 'deepmerge';
 import { z } from 'zod/v3';
 import { logger } from '../../../logger/index.ts';
 import { coerceArray } from '../../../util/array.ts';
@@ -338,16 +339,10 @@ export const PoetryPyProject = Toml.pipe(
       } = pyproject;
 
       const deps: PackageDependency[] = [];
-
       const projectDependencies = coerceArray(project?.dependencies);
-      deps.push(...projectDependencies);
-
       const projectOptionalDependencies = coerceArray(
         project?.['optional-dependencies'],
       );
-      deps.push(...projectOptionalDependencies);
-
-      deps.push(...dependencyGroups);
 
       const projectDepsByName: Record<string, PackageDependency> = {};
       for (const dep of [
@@ -375,15 +370,34 @@ export const PoetryPyProject = Toml.pipe(
         ...poetryDevDependencies,
         ...poetryGroupDependencies,
       ]) {
+        const depName = poetryDep.depName;
+        const projectDep = depName && projectDepsByName[depName];
         // When the same dep exists in project.dependencies or dependency-groups,
-        // Poetry just uses the Poetry dep for enrichment with source info.
-        if (poetryDep.depName && projectDepsByName[poetryDep.depName]) {
-          const dep = projectDepsByName[poetryDep.depName];
-          dep.managerData = { ...poetryDep.managerData, ...dep.managerData };
+        // Poetry just uses the Poetry dep to enrich the project dependency.
+        if (projectDep) {
+          const mergedDep = deepmerge<PackageDependency>(poetryDep, projectDep);
+          // Poetry supports specifying the version in project.dependencies and
+          // tool.poetry.dependencies *at the same time* and only errors if both
+          // are not compatible - we require a single constraint per dependency.
+          if (projectDep.currentValue && poetryDep.currentValue) {
+            mergedDep.skipReason = 'invalid-dependency-specification';
+          }
+          // When a skipReason is 'unspecified-version', we defer to the other skipReason,
+          // so that 'unspecified-version' only persists if both deps have no version.
+          if (mergedDep.skipReason === 'unspecified-version') {
+            if (poetryDep.skipReason === 'unspecified-version') {
+              mergedDep.skipReason = projectDep.skipReason;
+            } else {
+              mergedDep.skipReason = poetryDep.skipReason;
+            }
+          }
+          projectDepsByName[depName] = mergedDep;
         } else {
           deps.push(poetryDep);
         }
       }
+
+      deps.push(...Object.values(projectDepsByName));
 
       const packageFileVersion = tool?.poetry?.version;
       const packageFileContent: PackageFileContent = {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Since https://github.com/renovatebot/renovate/pull/39275, Renovate merges the dependency specifications from the `project` section and from `tool.poetry` into a single specification to align with Poetry behavior, which allows using `tool.poetry.dependencies` to *enrich* the specification under `project`.

Only `managerData` (for source info) was merged, as this information can not provided in the standards-based field. However, Poetry also allows enrichment of fields that *could* be provided in the `project` section, e.g. `version`.

This change performs a full deepmerge of the specifications, enabling full enrichment for further alignment with Poetry behavior.

### Notable decisions:

1. Poetry allows `version` to be specified twice, under `project` and `tool.poetry` at the same time. It combines the two constraints and only errors if the constraints are incompatible. I've opted to require a dependency version to be specified *once*, skipping with `invalid-dependency-specification`otherwise.
2. The desired precedence of `depType` is not clear to me - currently, we let the `depType` of the dependency under `project` take precendence:

```toml
[project]
dependencies = ["click"]
[project.optional-dependencies]
other = ["zoom==1.0.0"]
[dependency-groups]
typing = ["mypy==1.13.0", "types-requests"]

[tool.poetry.dependencies]
click = { version="==1.0.0", source = "artifactory" }
zoom = { source = "artifactory" }
[tool.poetry.group.typing.dependencies]
types-requests = { source = "artifactory" }
[tool.poetry.group.typing.dependencies.mypy]
source = "artifactory"

# currently, resolved depTypes are "project.dependencies", "project.optional-dependencies" and "dependency-groups"
# this would be "dependencies" and "typing" respectively, if Poetry specification had precedence
# a third option would be to use the depType of the dep that contributes the version?
```

<!-- Describe what behavior is changed by this PR. -->

## Context

This fixes the issue raised in discussion: https://github.com/renovatebot/renovate/discussions/43049

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository


<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
