### PR TITLE
refactor(config): use brace expansion for filenames

### DIFF
--- a/lib/config/app-strings.spec.ts
+++ b/lib/config/app-strings.spec.ts
@@ -17,6 +17,19 @@ describe('config/app-strings', () => {
     expect(filenames.includes('def')).toBeTrue();
   });
 
+  it('expands brace patterns for json and json5 filenames', () => {
+    const filenames = getConfigFileNames();
+
+    expect(filenames.includes('renovate.json')).toBeTrue();
+    expect(filenames.includes('renovate.json5')).toBeTrue();
+    expect(filenames.includes('.renovaterc.json')).toBeTrue();
+    expect(filenames.includes('.renovaterc.json5')).toBeTrue();
+
+    expect(filenames.includes('renovate.json{,5}')).toBeFalse();
+
+    expect(filenames.includes('package.json5')).toBeFalse();
+  });
+
   it('filters based on platform', () => {
     const filenames = getConfigFileNames('gitea');
     expect(filenames.includes('.github/renovate.json')).toBeFalse();

--- a/lib/config/app-strings.ts
+++ b/lib/config/app-strings.ts
@@ -1,19 +1,18 @@
 import { isNonEmptyString } from '@sindresorhus/is';
+import { braceExpand } from 'minimatch';
 import type { PlatformId } from '../constants/index.ts';
 import { regEx } from '../util/regex.ts';
 
-const configFileNames = [
-  'renovate.json',
-  'renovate.json5',
-  '.github/renovate.json',
-  '.github/renovate.json5',
-  '.gitlab/renovate.json',
-  '.gitlab/renovate.json5',
+const configFilePatterns = [
+  'renovate.json{,5}',
+  '.github/renovate.json{,5}',
+  '.gitlab/renovate.json{,5}',
   '.renovaterc',
-  '.renovaterc.json',
-  '.renovaterc.json5',
+  '.renovaterc.json{,5}',
   'package.json',
 ];
+
+const configFileNames = configFilePatterns.flatMap((p) => braceExpand(p));
 
 let userAddedConfigFileNames: string[] = [];
 


### PR DESCRIPTION
## Changes

Replace the explicit `.json`/`.json5` pairs in the config filename list with brace-expanded patterns, expanded once at module load via `minimatch`'s `braceExpand`. The behavior of `getConfigFileNames` is unchanged: same names, same order.

Picked up from #41258.

## Context

- [ ] This closes an existing Issue
- [x] This doesn't close an Issue

## AI assistance disclosure

- [x] No