### PR TITLE
fix(config): re-apply config.force in getRepositoryConfig

### DIFF
--- a/lib/workers/global/index.spec.ts
+++ b/lib/workers/global/index.spec.ts
@@ -97,12 +97,18 @@ describe('workers/global/index', () => {
       expect(repoConfig.repository).toBe('test/repo');
     });
 
-    it('applies force values over global config (e.g. CLI overrides platform defaults)', async () => {
+    it('applies force values over global config', async () => {
       const repoConfig = await globalWorker.getRepositoryConfig(
-        { ...globalConfig, dryRun: 'lookup', force: { dryRun: 'full' } },
+        {
+          ...globalConfig,
+          branchPrefix: 'renovate/',
+          labels: ['dependencies'],
+          force: { branchPrefix: 'cli-override/' },
+        },
         'test/repo',
       );
-      expect(repoConfig.dryRun).toBe('full');
+      expect(repoConfig.branchPrefix).toBe('cli-override/');
+      expect(repoConfig.labels).toEqual(['dependencies']);
     });
   });
 

--- a/lib/workers/global/index.spec.ts
+++ b/lib/workers/global/index.spec.ts
@@ -96,6 +96,14 @@ describe('workers/global/index', () => {
       expect(repoConfig.repositoryEntryConfig).toBeUndefined();
       expect(repoConfig.repository).toBe('test/repo');
     });
+
+    it('applies force values over global config (e.g. CLI overrides platform defaults)', async () => {
+      const repoConfig = await globalWorker.getRepositoryConfig(
+        { ...globalConfig, dryRun: 'lookup', force: { dryRun: 'full' } },
+        'test/repo',
+      );
+      expect(repoConfig.dryRun).toBe('full');
+    });
   });
 
   it('handles config warnings and errors', async () => {

--- a/lib/workers/global/index.ts
+++ b/lib/workers/global/index.ts
@@ -53,6 +53,7 @@ export async function getRepositoryConfig(
 
   const repoConfig: RepositoryWorkerConfig = {
     ...globalConfig,
+    ...globalConfig.force,
     repository: repoName,
   };
 


### PR DESCRIPTION
## Changes

Fix CLI-supplied global options (such as `--dry-run`, `--persist-repo-data`, `--require-config`) being silently overridden by platform defaults when used with  `--platform=local`.

The local platform's `initPlatform` returns hard-coded values for `dryRun: 'lookup'`, `persistRepoData: true` and `requireConfig: 'optional'` (none of which are part of the `PlatformResult` interface in `lib/modules/platform/types.ts`). The wrapper `initPlatform` in `lib/modules/platform/index.ts` spreads `platformInfo` over config, so those values clobber any user-supplied values from the CLI.

Historically this was compensated for in `getRepositoryConfig`: it used `mergeChildConfig`, whose body ends with `return { ...config, ...config.force }`, automatically reapplying CLI values (which `forceCli=true` puts into `config.force`). Commit `b24b88b` (#41477) replaced that `mergeChildConfig` call with a plain spread, which dropped the implicit `force`-application — so the platform's clobber was no longer being undone at the repo-config layer.

This PR re-applies `config.force` at that spread, restoring pre-`b24b88b` behaviour for all CLI-overridable global options.

## Context

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Used Claude Code to help trace the regression to b24b88b, identify the lost mergeChildConfig force-application behaviour, and draft the regression test.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: It was a local repository
