### PR TITLE
fix(github): Make GraphQL singleton data fetching explicit to bypass pagination

### DIFF
--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -544,6 +544,7 @@ export async function initRepo({
         ...(!config.ignorePrAuthor && { user: renovateUsername }),
       },
       readOnly: true,
+      count: 1, // bypass graphql check
     });
 
     if (res?.errors) {
@@ -1803,7 +1804,8 @@ async function tryPrAutomerge(
   try {
     const mergeMethod = config.mergeMethod?.toUpperCase() || 'MERGE';
     const variables = { pullRequestId: prNodeId, mergeMethod };
-    const queryOptions = { variables };
+    // set count to one bypass graphql check
+    const queryOptions = { variables, count: 1 };
 
     const res = await githubApi.requestGraphql<GhAutomergeResponse>(
       enableAutoMergeMutation,

--- a/lib/modules/platform/github/user.ts
+++ b/lib/modules/platform/github/user.ts
@@ -7,12 +7,13 @@ const githubApi = new githubHttp.GithubHttp();
 
 export async function getAppDetails(token: string): Promise<UserDetails> {
   try {
+    // set count to one bypass graphql check
     const appData = await githubApi.requestGraphql<{
       viewer: {
         login: string;
         databaseId: number;
       };
-    }>('query { viewer { login databaseId }}', { token });
+    }>('query { viewer { login databaseId }}', { token, count: 1 });
     if (!appData?.data) {
       throw new Error("Init: Can't get App details");
     }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
We only ever want one result, so set count to one.
This will bypass the default graphql error handling.
Currently a 502 on repo init will disable renovate.
- #12689

https://github.com/renovatebot/renovate/blob/eb0e1c4ca4c3789ac102202b55062c666adcdae6/lib/util/http/github.ts#L496-L499
https://github.com/renovatebot/renovate/blob/eb0e1c4ca4c3789ac102202b55062c666adcdae6/lib/modules/platform/github/index.ts#L559-L564
<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
