### PR TITLE
feat(manager/tekton): Add support for StepAction resource to tekton manager

### DIFF
--- a/lib/modules/manager/tekton/__fixtures__/multi-doc.yaml
+++ b/lib/modules/manager/tekton/__fixtures__/multi-doc.yaml
@@ -211,3 +211,7 @@ spec:
           steps:
             - image: example.com/triggertemplate/spec/resourcetemplates/0/taskrun/spec/taskSpec/steps/0/image
 ---
+kind: StepAction
+spec:
+  image: example.com/triggertemplate/spec/resourcetemplates/0/taskrun/spec/taskSpec/steps/0/image
+---

--- a/lib/modules/manager/tekton/__snapshots__/extract.spec.ts.snap
+++ b/lib/modules/manager/tekton/__snapshots__/extract.spec.ts.snap
@@ -375,6 +375,16 @@ exports[`modules/manager/tekton/extract > extractPackageFile() > extracts deps f
       "packageName": "example.com/triggertemplate/spec/resourcetemplates/0/taskrun/spec/taskSpec/steps/0/image",
       "replaceString": "example.com/triggertemplate/spec/resourcetemplates/0/taskrun/spec/taskSpec/steps/0/image",
     },
+    {
+      "autoReplaceStringTemplate": "{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
+      "currentDigest": undefined,
+      "currentValue": undefined,
+      "datasource": "docker",
+      "depName": "example.com/triggertemplate/spec/resourcetemplates/0/taskrun/spec/taskSpec/steps/0/image",
+      "depType": "tekton-step-image",
+      "packageName": "example.com/triggertemplate/spec/resourcetemplates/0/taskrun/spec/taskSpec/steps/0/image",
+      "replaceString": "example.com/triggertemplate/spec/resourcetemplates/0/taskrun/spec/taskSpec/steps/0/image",
+    },
   ],
 }
 `;

--- a/lib/modules/manager/tekton/extract.spec.ts
+++ b/lib/modules/manager/tekton/extract.spec.ts
@@ -9,7 +9,7 @@ describe('modules/manager/tekton/extract', () => {
         'test-file.yaml',
       );
       expect(result).toMatchSnapshot();
-      expect(result?.deps).toHaveLength(39);
+      expect(result?.deps).toHaveLength(40);
     });
 
     it('extracts deps from a file in annotations', () => {

--- a/lib/modules/manager/tekton/extract.ts
+++ b/lib/modules/manager/tekton/extract.ts
@@ -46,6 +46,9 @@ function getDeps(doc: TektonResource): PackageDependency[] {
     return deps;
   }
 
+  // Handle StepAction resource
+  addStepActionImage(doc.spec, deps);
+
   // Handle TaskRun resource
   addDep(doc.spec?.taskRef, deps);
   addStepImageSpec(doc.spec?.taskSpec, deps);
@@ -221,6 +224,32 @@ function addStepImageSpec(
     );
     deps.push(dep);
   }
+}
+
+function addStepActionImage(
+  spec: TektonResourceSpec | undefined,
+  deps: PackageDependency[],
+): void {
+  if (isNullOrUndefined(spec)) {
+    return;
+  }
+  if (isFalsy(spec.image)) {
+    return;
+  }
+
+  const image = spec.image;
+  const dep = getDep(image);
+
+  dep.depType = 'tekton-step-image';
+  logger.trace(
+    {
+      depName: dep.depName,
+      currentValue: dep.currentValue,
+      currentDigest: dep.currentDigest,
+    },
+    'Tekton step image dependency found',
+  );
+  deps.push(dep);
 }
 
 function getBundleValue(

--- a/lib/modules/manager/tekton/readme.md
+++ b/lib/modules/manager/tekton/readme.md
@@ -60,6 +60,7 @@ You can define Tekton Tasks within these Tekton resources:
 1. TaskRun
 1. Pipeline
 1. PipelineRun
+1. StepAction
 
 Renovate's Tekton manager supports all the image attributes for the Tekton resources mentioned above.
 

--- a/lib/modules/manager/tekton/types.ts
+++ b/lib/modules/manager/tekton/types.ts
@@ -7,6 +7,8 @@ export interface TektonResource {
 }
 
 export interface TektonResourceSpec {
+  // StepAction
+  image?: string;
   // TaskRun
   taskRef: TektonBundle;
   // TaskRun with inline Pipeline definition


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Modified the schema which Tekton manager use to parse Tekton resources. Added `spec.image` to the field which stepAction resource uses. see [tekton docs](https://tekton.dev/docs/pipelines/stepactions/)

## Context

This PR add support for StepAction resource to the Tekton manager. 

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [X] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [X] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [X] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
