### PR TITLE
fix(config-validator): use config options to validate all allowed values

### DIFF
--- a/lib/config/validation.spec.ts
+++ b/lib/config/validation.spec.ts
@@ -722,7 +722,7 @@ describe('config/validation', () => {
       expect(errors).toMatchInlineSnapshot(`
         [
           {
-            "message": "Invalid customType: unknown. Key is not a custom manager",
+            "message": "Invalid value \`unknown\` for \`customManagers[0].customType\`. The allowed values are jsonata, regex.",
             "topic": "Configuration Error",
           },
         ]
@@ -2162,7 +2162,7 @@ describe('config/validation', () => {
       expect(warnings).toEqual([
         {
           message:
-            'Invalid value `invalid` for `binarySource`. The allowed values are docker, global, install, hermit.',
+            'Invalid value `invalid` for `binarySource`. The allowed values are global, docker, install, hermit.',
           topic: 'Configuration Error',
         },
       ]);
@@ -2180,7 +2180,7 @@ describe('config/validation', () => {
         expect(warnings).toEqual([
           {
             message:
-              'Invalid value `invalid` for `binarySource`. The allowed values are docker, global, install, hermit.',
+              'Invalid value `invalid` for `binarySource`. The allowed values are global, docker, install, hermit.',
             topic: 'Configuration Error',
           },
         ]);
@@ -2247,7 +2247,7 @@ describe('config/validation', () => {
         expect(warnings).toEqual([
           {
             message:
-              'Invalid value `invalid` for `repositoryCache`. The allowed values are enabled, disabled, reset.',
+              'Invalid value `invalid` for `repositoryCache`. The allowed values are disabled, enabled, reset.',
             topic: 'Configuration Error',
           },
         ]);
@@ -2405,7 +2405,7 @@ describe('config/validation', () => {
         },
         {
           message:
-            'Invalid value for `gitNoVerify`. The allowed values are commit, push.',
+            'Invalid value `invalid` for `gitNoVerify`. The allowed values are commit, push.',
           topic: 'Configuration Error',
         },
       ]);
@@ -2673,6 +2673,64 @@ describe('config/validation', () => {
         },
       ]);
       expect(warnings).toHaveLength(2);
+      expect(errors).toHaveLength(1);
+    });
+
+    it('errors on invalid postUpdateOptions values', async () => {
+      const config = {
+        postUpdateOptions: ['goModTidy', 'gomodTidy', 'notAnOption'],
+      };
+      const { errors, warnings } = await configValidation.validateConfig(
+        'repo',
+        config,
+      );
+      expect(warnings).toHaveLength(0);
+      expect(errors).toMatchObject([
+        {
+          message: expect.stringContaining(
+            'Invalid value `goModTidy` for `postUpdateOptions`',
+          ),
+          topic: 'Configuration Error',
+        },
+        {
+          message: expect.stringContaining(
+            'Invalid value `notAnOption` for `postUpdateOptions`',
+          ),
+          topic: 'Configuration Error',
+        },
+      ]);
+      expect(errors).toHaveLength(2);
+    });
+
+    it('allows versioning with regex: prefix', async () => {
+      const config = {
+        versioning: 'regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)?$',
+      };
+      const { errors, warnings } = await configValidation.validateConfig(
+        'repo',
+        config,
+      );
+      expect(warnings).toHaveLength(0);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('errors on invalid versioning value', async () => {
+      const config = {
+        versioning: 'invalid-versioning',
+      };
+      const { errors, warnings } = await configValidation.validateConfig(
+        'repo',
+        config,
+      );
+      expect(warnings).toHaveLength(0);
+      expect(errors).toMatchObject([
+        {
+          message: expect.stringContaining(
+            'Invalid value `invalid-versioning` for `versioning`',
+          ),
+          topic: 'Configuration Error',
+        },
+      ]);
       expect(errors).toHaveLength(1);
     });
   });

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -41,7 +41,6 @@ import { GlobalConfig } from './global.ts';
 import { migrateConfig } from './migration.ts';
 import { getOptions } from './options/index.ts';
 import { resolveConfigPresets } from './presets/index.ts';
-import { supportedDatasources } from './presets/internal/merge-confidence.preset.ts';
 import { parsePreset } from './presets/parse.ts';
 import type {
   AllConfig,
@@ -73,6 +72,7 @@ let optionGlobals: Set<string>;
 let optionInherits: Set<string>;
 let optionRegexOrGlob: Set<string>;
 let optionAllowsNegativeIntegers: Set<string>;
+let optionAllowedValues: Record<string, string[]>;
 
 const managerList: readonly string[] = AllManagersListLiteral;
 
@@ -157,6 +157,7 @@ function initOptions(): void {
   optionRegexOrGlob = new Set();
   optionGlobals = new Set();
   optionAllowsNegativeIntegers = new Set();
+  optionAllowedValues = {};
 
   for (const option of options) {
     optionTypes[option.name] = option.type;
@@ -179,6 +180,10 @@ function initOptions(): void {
 
     if (option.allowNegative) {
       optionAllowsNegativeIntegers.add(option.name);
+    }
+
+    if (option.allowedValues) {
+      optionAllowedValues[option.name] = option.allowedValues;
     }
   }
 
@@ -598,11 +603,6 @@ export async function validateConfig(
                       topic: 'Configuration Error',
                       message: `Each Custom Manager must contain a non-empty customType string`,
                     });
-                  } else {
-                    errors.push({
-                      topic: 'Configuration Error',
-                      message: `Invalid customType: ${customManager.customType}. Key is not a custom manager`,
-                    });
                   }
                 }
               }
@@ -650,6 +650,17 @@ export async function validateConfig(
                 message: `${currentPath}: ${key} should be inside a \`packageRule\` only`,
               });
             }
+            const allowedValues = optionAllowedValues[key];
+            if (allowedValues) {
+              for (const subval of val) {
+                if (!allowedValues.includes(subval as string)) {
+                  errors.push({
+                    topic: 'Configuration Error',
+                    message: `Invalid value \`${subval as string}\` for \`${currentPath}\`. The allowed values are ${allowedValues.join(', ')}.`,
+                  });
+                }
+              }
+            }
           } else {
             errors.push({
               topic: 'Configuration Error',
@@ -657,7 +668,19 @@ export async function validateConfig(
             });
           }
         } else if (type === 'string') {
-          if (!isString(val)) {
+          if (isString(val)) {
+            const allowedValues = optionAllowedValues[key];
+            if (allowedValues && !allowedValues.includes(val)) {
+              // versioning supports 'name:config' format (e.g. 'regex:<pattern>')
+              const valToCheck = key === 'versioning' ? val.split(':')[0] : val;
+              if (!allowedValues.includes(valToCheck)) {
+                errors.push({
+                  topic: 'Configuration Error',
+                  message: `Invalid value \`${val}\` for \`${currentPath}\`. The allowed values are ${allowedValues.join(', ')}.`,
+                });
+              }
+            }
+          } else {
             errors.push({
               topic: 'Configuration Error',
               message: `Configuration option \`${currentPath}\` should be a string`,
@@ -983,46 +1006,14 @@ async function validateGlobalConfig(
               },
             ).join(', ')}.`,
           });
-        } else if (
-          key === 'repositoryCache' &&
-          !['enabled', 'disabled', 'reset'].includes(val)
-        ) {
-          warnings.push({
-            topic: 'Configuration Error',
-            message: `Invalid value \`${val}\` for \`${currentPath}\`. The allowed values are ${['enabled', 'disabled', 'reset'].join(', ')}.`,
-          });
-        } else if (
-          key === 'dryRun' &&
-          !['extract', 'lookup', 'full'].includes(val)
-        ) {
-          warnings.push({
-            topic: 'Configuration Error',
-            message: `Invalid value \`${val}\` for \`${currentPath}\`. The allowed values are ${['extract', 'lookup', 'full'].join(', ')}.`,
-          });
-        } else if (
-          key === 'binarySource' &&
-          !['docker', 'global', 'install', 'hermit'].includes(val)
-        ) {
-          warnings.push({
-            topic: 'Configuration Error',
-            message: `Invalid value \`${val}\` for \`${currentPath}\`. The allowed values are ${['docker', 'global', 'install', 'hermit'].join(', ')}.`,
-          });
-        } else if (
-          key === 'requireConfig' &&
-          !['required', 'optional', 'ignored'].includes(val)
-        ) {
-          warnings.push({
-            topic: 'Configuration Error',
-            message: `Invalid value \`${val}\` for \`${currentPath}\`. The allowed values are ${['required', 'optional', 'ignored'].join(', ')}.`,
-          });
-        } else if (
-          key === 'gitUrl' &&
-          !['default', 'ssh', 'endpoint'].includes(val)
-        ) {
-          warnings.push({
-            topic: 'Configuration Error',
-            message: `Invalid value \`${val}\` for \`${currentPath}\`. The allowed values are ${['default', 'ssh', 'endpoint'].join(', ')}.`,
-          });
+        } else {
+          const allowedValues = optionAllowedValues[key];
+          if (allowedValues && !allowedValues.includes(val)) {
+            warnings.push({
+              topic: 'Configuration Error',
+              message: `Invalid value \`${val}\` for \`${currentPath}\`. The allowed values are ${allowedValues.join(', ')}.`,
+            });
+          }
         }
 
         if (
@@ -1063,22 +1054,9 @@ async function validateGlobalConfig(
             }),
           );
         }
-        if (key === 'gitNoVerify') {
-          const allowedValues = ['commit', 'push'];
+        const allowedValues = optionAllowedValues[key];
+        if (allowedValues) {
           for (const value of val as string[]) {
-            // v8 ignore else -- TODO: add test #40625
-            if (!allowedValues.includes(value)) {
-              warnings.push({
-                topic: 'Configuration Error',
-                message: `Invalid value for \`${currentPath}\`. The allowed values are ${allowedValues.join(', ')}.`,
-              });
-            }
-          }
-        }
-        if (key === 'mergeConfidenceDatasources') {
-          const allowedValues = supportedDatasources;
-          for (const value of val as string[]) {
-            // v8 ignore else -- TODO: add test #40625
             if (!allowedValues.includes(value)) {
               warnings.push({
                 topic: 'Configuration Error',


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

I noticed that `config-validator` was not flagging `goModTidy` (instead of `gomodTidy`) as an invalid config option, even though the JSON schema was flagging it as invalid.

This PR updates the `config-validator` to validate all allowed values against their respective config options, which catches this issue and also a lot more potential misconfiguration. It should also make the validation more consistent with the JSON schema. A similar basis is being used to improve type strictness (https://github.com/renovatebot/renovate/pull/43109).

It also allowed for some code cleanup now that we no longer need certain hardcoded validation logic for specific options.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Used Claude Sonnet 4.6 to assist with implementing the idea and to scan the logic for potential regressions.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
