### PR TITLE
chore: Revert "chore(renovate): temporarily require dependency dashboard approval for Vite"

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -97,11 +97,6 @@
       "matchDatasources": ["npm"],
       "matchDepNames": ["got"],
       "separateMultipleMajor": true
-    },
-    {
-      "description": "Don't upgrade Vite automagically, due to a possible issue with flakey tests due to the upgrade: https://github.com/renovatebot/renovate/discussions/39921",
-      "matchDepNames": ["vite"],
-      "dependencyDashboardApproval": true
     }
   ],
   "customManagers": [


### PR DESCRIPTION
Reverts renovatebot/renovate#39932

we upgraded to vite v8 and don't see issues for now, so reverting the required approval.