### PR TITLE
test(git): cover filtered git env

### DIFF
--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -131,6 +131,7 @@ describe('util/git/index', { timeout: 10000 }, () => {
 
   beforeEach(async () => {
     process.env = { ...OLD_ENV };
+    setCustomEnv({});
     origin = await tmp.dir({ unsafeCleanup: true });
     const repo = simpleGit(origin.path);
     await repo.clone(base.path, '.', ['--bare']);
@@ -160,6 +161,7 @@ describe('util/git/index', { timeout: 10000 }, () => {
   });
 
   afterAll(async () => {
+    setCustomEnv({});
     process.env = OLD_ENV;
     await base?.cleanup();
   });
@@ -1489,13 +1491,40 @@ describe('util/git/index', { timeout: 10000 }, () => {
       delete process.env.RENOVATE_X_CLEAR_HOOKS;
     });
 
-    it('should work when GIT_CONFIG_COUNT authentication environment variables are set', async () => {
-      // Renovate sets GIT_CONFIG_COUNT + GIT_CONFIG_KEY_n + GIT_CONFIG_VALUE_n to
-      // pass url.*.insteadOf rewrites for token-based git authentication.
-      // simple-git 3.36.0 blocks git operations when these vars are present unless
+    it('should not inherit unsafe git environment variables from process.env', async () => {
+      process.env.GIT_CONFIG_COUNT = '1';
+      process.env.GIT_CONFIG_KEY_0 = 'core.hooksPath';
+      process.env.GIT_CONFIG_VALUE_0 = '/tmp/hooks';
+      process.env.GIT_CONFIG_GLOBAL = '/tmp/global-gitconfig';
+      process.env.GIT_CONFIG_SYSTEM = '/tmp/system-gitconfig';
+      process.env.GIT_SSH_COMMAND = 'ssh -o BatchMode=yes';
+      process.env.PAGER = 'less';
+
+      const envSpy = vi.spyOn(SimpleGit.prototype, 'env');
+      await git.initRepo({ url: origin.path });
+      await expect(git.syncGit()).resolves.toBeUndefined();
+      expect(envSpy).toHaveBeenCalledTimes(1);
+      const [gitEnv] = envSpy.mock.calls[0];
+      expect(gitEnv).toEqual(
+        expect.objectContaining({
+          LANG: 'C.UTF-8',
+          LC_ALL: 'C.UTF-8',
+        }),
+      );
+      expect(gitEnv).not.toHaveProperty('GIT_CONFIG_COUNT');
+      expect(gitEnv).not.toHaveProperty('GIT_CONFIG_KEY_0');
+      expect(gitEnv).not.toHaveProperty('GIT_CONFIG_VALUE_0');
+      expect(gitEnv).not.toHaveProperty('GIT_CONFIG_GLOBAL');
+      expect(gitEnv).not.toHaveProperty('GIT_CONFIG_SYSTEM');
+      expect(gitEnv).not.toHaveProperty('GIT_SSH_COMMAND');
+      expect(gitEnv).not.toHaveProperty('PAGER');
+    });
+
+    it('should work when GIT_CONFIG_COUNT authentication environment variables are configured', async () => {
+      // Self-hosted users can opt into passing GIT_CONFIG_COUNT + GIT_CONFIG_KEY_n
+      // + GIT_CONFIG_VALUE_n via customEnvVariables.
+      // simple-git >=3.36.0 blocks git operations when these vars are present unless
       // allowUnsafeConfigEnvCount is enabled in the simple-git config.
-      tmpDir = await tmp.dir({ unsafeCleanup: true });
-      GlobalConfig.set({ localDir: tmpDir.path });
       setCustomEnv({
         GIT_CONFIG_COUNT: '3',
         GIT_CONFIG_KEY_0: 'url.https://ssh:token@example.com/.insteadOf',
@@ -1518,18 +1547,16 @@ describe('util/git/index', { timeout: 10000 }, () => {
           GIT_CONFIG_VALUE_1: 'git@example.com:',
           GIT_CONFIG_KEY_2: 'url.https://token@example.com/.insteadOf',
           GIT_CONFIG_VALUE_2: 'https://example.com/',
+          LANG: 'C.UTF-8',
           LC_ALL: 'C.UTF-8',
         }),
       );
     });
 
-    it('should work when GIT_SSH_COMMAND is set in the environment', async () => {
-      // The git-refs datasource sets process.env.GIT_SSH_COMMAND = 'ssh -o BatchMode=yes'
-      // at module load time to prevent interactive SSH prompts. This ends up in the env
-      // passed to simple-git via getChildEnv(). simple-git 3.36.0 blocks git operations when
-      // GIT_SSH_COMMAND is present unless allowUnsafeSshCommand is enabled.
-      tmpDir = await tmp.dir({ unsafeCleanup: true });
-      GlobalConfig.set({ localDir: tmpDir.path });
+    it('should work when GIT_SSH_COMMAND is explicitly configured', async () => {
+      // Self-hosted users can opt into passing GIT_SSH_COMMAND via customEnvVariables.
+      // simple-git >=3.36.0 blocks git operations when GIT_SSH_COMMAND is present
+      // unless allowUnsafeSshCommand is enabled.
       setCustomEnv({ GIT_SSH_COMMAND: 'ssh -o BatchMode=yes' });
 
       const envSpy = vi.spyOn(SimpleGit.prototype, 'env');
@@ -1544,13 +1571,10 @@ describe('util/git/index', { timeout: 10000 }, () => {
       );
     });
 
-    it('should work when PAGER is set in the environment', async () => {
-      // Users often have PAGER=less (or similar) in their environment, set via their
-      // shell profile or git config. This ends up in the env passed to simple-git via
-      // getChildEnv(). simple-git 3.36.0 blocks git operations when PAGER is present unless
+    it('should work when PAGER is explicitly configured', async () => {
+      // Self-hosted users can opt into passing PAGER via customEnvVariables.
+      // simple-git >=3.36.0 blocks git operations when PAGER is present unless
       // allowUnsafePager is enabled.
-      tmpDir = await tmp.dir({ unsafeCleanup: true });
-      GlobalConfig.set({ localDir: tmpDir.path });
       setCustomEnv({ PAGER: 'less' });
 
       const envSpy = vi.spyOn(SimpleGit.prototype, 'env');


### PR DESCRIPTION
## Changes
- Add coverage that repo git commands do not inherit unsafe Git variables from `process.env`.
- Clarify the explicit `customEnvVariables` path for blocked `simple-git >=3.36.0` env variables.
- Reset custom env state around the spec to avoid cross-test leakage.

## Context
Follow-up for #43113.

## AI assistance disclosure

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: N/A

Test command: `pnpm check lib/util/git/index.spec.ts`