### PR TITLE
fix(platform): preserve explicit local dryRun

### DIFF
--- a/lib/modules/platform/local/index.spec.ts
+++ b/lib/modules/platform/local/index.spec.ts
@@ -13,13 +13,26 @@ describe('modules/platform/local/index', () => {
       `);
     });
 
-    it('preserves an explicit dryRun override', async () => {
+    it('preserves an explicit dryRun=extract override', async () => {
       await expect(
         platform.initPlatform({
           dryRun: 'extract',
         }),
       ).resolves.toEqual({
         dryRun: 'extract',
+        endpoint: 'local',
+        persistRepoData: true,
+        requireConfig: 'optional',
+      });
+    });
+
+    it('falls back to lookup when dryRun=full is requested', async () => {
+      await expect(
+        platform.initPlatform({
+          dryRun: 'full',
+        }),
+      ).resolves.toEqual({
+        dryRun: 'lookup',
         endpoint: 'local',
         persistRepoData: true,
         requireConfig: 'optional',

--- a/lib/modules/platform/local/index.spec.ts
+++ b/lib/modules/platform/local/index.spec.ts
@@ -14,18 +14,16 @@ describe('modules/platform/local/index', () => {
     });
 
     it('preserves an explicit dryRun override', async () => {
-      expect(
-        await platform.initPlatform({
+      await expect(
+        platform.initPlatform({
           dryRun: 'extract',
         }),
-      ).toMatchInlineSnapshot(`
-        {
-          "dryRun": "extract",
-          "endpoint": "local",
-          "persistRepoData": true,
-          "requireConfig": "optional",
-        }
-      `);
+      ).resolves.toEqual({
+        dryRun: 'extract',
+        endpoint: 'local',
+        persistRepoData: true,
+        requireConfig: 'optional',
+      });
     });
   });
 

--- a/lib/modules/platform/local/index.spec.ts
+++ b/lib/modules/platform/local/index.spec.ts
@@ -12,6 +12,21 @@ describe('modules/platform/local/index', () => {
         }
       `);
     });
+
+    it('preserves an explicit dryRun override', async () => {
+      expect(
+        await platform.initPlatform({
+          dryRun: 'extract',
+        }),
+      ).toMatchInlineSnapshot(`
+        {
+          "dryRun": "extract",
+          "endpoint": "local",
+          "persistRepoData": true,
+          "requireConfig": "optional",
+        }
+      `);
+    });
   });
 
   describe('getRepos', () => {

--- a/lib/modules/platform/local/index.ts
+++ b/lib/modules/platform/local/index.ts
@@ -10,9 +10,9 @@ import type {
 export const id = 'local';
 export const experimental = true;
 
-export function initPlatform(_params: PlatformParams): Promise<PlatformResult> {
+export function initPlatform(params: PlatformParams): Promise<PlatformResult> {
   return Promise.resolve({
-    dryRun: 'lookup',
+    dryRun: params.dryRun ?? 'lookup',
     endpoint: 'local',
     persistRepoData: true,
     requireConfig: 'optional',

--- a/lib/modules/platform/local/index.ts
+++ b/lib/modules/platform/local/index.ts
@@ -11,8 +11,9 @@ export const id = 'local';
 export const experimental = true;
 
 export function initPlatform(params: PlatformParams): Promise<PlatformResult> {
+  const dryRun = params.dryRun === 'extract' ? 'extract' : 'lookup';
   return Promise.resolve({
-    dryRun: params.dryRun ?? 'lookup',
+    dryRun,
     endpoint: 'local',
     persistRepoData: true,
     requireConfig: 'optional',

--- a/lib/modules/platform/local/readme.md
+++ b/lib/modules/platform/local/readme.md
@@ -7,6 +7,8 @@ This can be handy when testing a new Renovate configuration for example.
 
 Run the `renovate --platform=local` command in the directory you want Renovate to run in.
 In this mode, Renovate defaults to `dryRun=lookup`.
+You can override this by passing `--dry-run=extract` to stop after the extract phase.
+Other `dryRun` values (such as `full`) are not supported on the local platform and fall back to `lookup`.
 
 Avoid giving "repositories" arguments, as this command can only run in a _single_ directory, and it can only run in the _current working_ directory.
 

--- a/lib/modules/platform/types.ts
+++ b/lib/modules/platform/types.ts
@@ -6,6 +6,7 @@ import type { GithubVulnerabilityAlert } from './github/schema.ts';
 export type VulnerabilityAlert = GithubVulnerabilityAlert;
 
 export interface PlatformParams {
+  dryRun?: string;
   endpoint?: string;
   token?: string;
   username?: string;


### PR DESCRIPTION
## Changes

When the local platform initializer is called with an explicit `dryRun` value, preserve it instead of always overwriting with `lookup`. Only `extract` is preserved — anything else (including `full`, which would error against the local platform) falls back to `lookup`.

## Context

- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).

Used Claude Code for the initial diagnosis, code change, and test additions.

## Documentation (please check one with an [x])

- [x] No documentation update is required

## How I've tested my work (please select one)

- [x] Newly added/modified unit tests