### PR TITLE
fix(util/exec): allow setting `PNPM_WORKERS`/`PNPM_MAX_WORKERS` in environment

### DIFF
--- a/lib/config/presets/internal/global.preset.ts
+++ b/lib/config/presets/internal/global.preset.ts
@@ -7,6 +7,8 @@ export const presets: Record<string, GlobalPreset> = {
       'GO*',
       'GRADLE_OPTS',
       'RUSTC_BOOTSTRAP',
+      'PNPM_WORKERS',
+      'PNPM_MAX_WORKERS',
     ],
     description:
       'Hopefully safe environment variables to allow users to configure.',

--- a/lib/util/exec/env.ts
+++ b/lib/util/exec/env.ts
@@ -38,6 +38,9 @@ const basicEnvVars = [
   'COREPACK_NPM_USERNAME',
   'COREPACK_NPM_PASSWORD',
   'COREPACK_ROOT',
+  // pnpm specific variables
+  'PNPM_WORKERS',
+  'PNPM_MAX_WORKERS',
 ];
 
 export function getChildProcessEnv(


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

As found in #40942, we've been seeing increased memory usage by pnpm and
Yarn in recent months on Mend-hosted apps.

As a way to provide more control to test + validate fixes, as well as
provide self-serve for other environments, we can allowlist
`PNPM_WORKERS`/`PNPM_MAX_WORKERS` in both the "basic env vars" and the
allowed `global:safeEnv`.

---

Using `fix` to release it as-is.

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
