### PR TITLE
fix(deno): lockfile update in presence of private registries

### DIFF
--- a/lib/modules/manager/deno/artifacts.spec.ts
+++ b/lib/modules/manager/deno/artifacts.spec.ts
@@ -1,19 +1,15 @@
 import type { DirectoryResult } from 'tmp-promise';
 import tmp from 'tmp-promise';
-import { mockDeep } from 'vitest-mock-extended';
 import { mockExecAll } from '~test/exec-util.ts';
 import { fs } from '~test/util.ts';
 import { GlobalConfig } from '../../../config/global.ts';
 import { TEMPORARY_ERROR } from '../../../constants/error-messages.ts';
 import { ExecError } from '../../../util/exec/exec-error.ts';
-import * as _hostRules from '../../../util/host-rules.ts';
+import * as hostRules from '../../../util/host-rules.ts';
 import type { UpdateArtifact } from '../types.ts';
 import { updateArtifacts } from './artifacts.ts';
 
-vi.mock('../../../util/host-rules.ts', () => mockDeep());
 vi.mock('../../../util/fs/index.ts');
-
-const hostRules = vi.mocked(_hostRules);
 
 const updateArtifact: UpdateArtifact = {
   config: {
@@ -26,8 +22,7 @@ const updateArtifact: UpdateArtifact = {
 
 describe('modules/manager/deno/artifacts', () => {
   beforeEach(() => {
-    hostRules.getAll.mockReturnValue([]);
-    hostRules.findAll.mockReturnValue([]);
+    hostRules.clear();
   });
 
   describe('updateArtifacts()', () => {
@@ -298,16 +293,11 @@ describe('modules/manager/deno/artifacts', () => {
       fs.readLocalFile.mockResolvedValueOnce(null);
       const newLock = Buffer.from('new');
       fs.readLocalFile.mockResolvedValueOnce(newLock as never);
-      const customHostRules = [
-        {
-          token: 'some-token',
-          hostType: 'npm',
-          matchHost: 'https://private-registry.example',
-          resolvedHost: 'private-registry.example',
-        },
-      ];
-      hostRules.findAll.mockReturnValue(customHostRules);
-      hostRules.getAll.mockReturnValue(customHostRules);
+      hostRules.add({
+        token: 'some-token',
+        hostType: 'npm',
+        matchHost: 'https://private-registry.example',
+      });
       const execSnapshots = mockExecAll();
       expect(await updateArtifacts(updateArtifact)).toEqual([
         {

--- a/lib/modules/manager/deno/artifacts.spec.ts
+++ b/lib/modules/manager/deno/artifacts.spec.ts
@@ -1,14 +1,19 @@
 import type { DirectoryResult } from 'tmp-promise';
 import tmp from 'tmp-promise';
+import { mockDeep } from 'vitest-mock-extended';
+import { mockExecAll } from '~test/exec-util.ts';
 import { fs } from '~test/util.ts';
-import { mockExecAll } from '../../../../test/exec-util.ts';
 import { GlobalConfig } from '../../../config/global.ts';
 import { TEMPORARY_ERROR } from '../../../constants/error-messages.ts';
 import { ExecError } from '../../../util/exec/exec-error.ts';
+import * as _hostRules from '../../../util/host-rules.ts';
 import type { UpdateArtifact } from '../types.ts';
 import { updateArtifacts } from './artifacts.ts';
 
+vi.mock('../../../util/host-rules.ts', () => mockDeep());
 vi.mock('../../../util/fs/index.ts');
+
+const hostRules = vi.mocked(_hostRules);
 
 const updateArtifact: UpdateArtifact = {
   config: {
@@ -20,6 +25,11 @@ const updateArtifact: UpdateArtifact = {
 };
 
 describe('modules/manager/deno/artifacts', () => {
+  beforeEach(() => {
+    hostRules.getAll.mockReturnValue([]);
+    hostRules.findAll.mockReturnValue([]);
+  });
+
   describe('updateArtifacts()', () => {
     let localDirResult: DirectoryResult;
     let localDir: string;
@@ -60,6 +70,8 @@ describe('modules/manager/deno/artifacts', () => {
       updateArtifact.updatedDeps = [{ lockFiles: ['deno.lock'] }];
       const oldLock = Buffer.from('old');
       fs.readLocalFile.mockResolvedValueOnce(oldLock as never);
+      // Second read is .npmrc
+      fs.readLocalFile.mockResolvedValueOnce(null);
       fs.readLocalFile.mockResolvedValueOnce(oldLock as never);
       mockExecAll();
       expect(await updateArtifacts(updateArtifact)).toBeNull();
@@ -69,6 +81,8 @@ describe('modules/manager/deno/artifacts', () => {
       updateArtifact.updatedDeps = [{ lockFiles: ['deno.lock'] }];
       const oldLock = Buffer.from('old');
       fs.readLocalFile.mockResolvedValueOnce(oldLock as never);
+      // Second read is .npmrc
+      fs.readLocalFile.mockResolvedValueOnce(null);
       const newLock = Buffer.from('new');
       fs.readLocalFile.mockResolvedValueOnce(newLock as never);
       mockExecAll();
@@ -94,6 +108,8 @@ describe('modules/manager/deno/artifacts', () => {
       ];
       const oldLock = Buffer.from('old');
       fs.readLocalFile.mockResolvedValueOnce(oldLock as never);
+      // Second read is .npmrc
+      fs.readLocalFile.mockResolvedValueOnce(null);
       const newLock = Buffer.from('new');
       fs.readLocalFile.mockResolvedValueOnce(newLock as never);
       mockExecAll();
@@ -113,6 +129,8 @@ describe('modules/manager/deno/artifacts', () => {
       updateArtifact.config.updateType = 'lockFileMaintenance';
       const oldLock = Buffer.from('old');
       fs.readLocalFile.mockResolvedValueOnce(oldLock as never);
+      // Second read is .npmrc
+      fs.readLocalFile.mockResolvedValueOnce(null);
       const newLock = Buffer.from('new');
       fs.readLocalFile.mockResolvedValueOnce(newLock as never);
       mockExecAll();
@@ -171,6 +189,8 @@ describe('modules/manager/deno/artifacts', () => {
     };
     const oldLock = Buffer.from('old');
     fs.readLocalFile.mockResolvedValueOnce(oldLock as never);
+    // Second read is .npmrc
+    fs.readLocalFile.mockResolvedValueOnce(null);
     const newLock = Buffer.from('new');
     fs.readLocalFile.mockResolvedValueOnce(newLock as never);
 
@@ -195,6 +215,8 @@ describe('modules/manager/deno/artifacts', () => {
     };
     const oldLock = Buffer.from('old');
     fs.readLocalFile.mockResolvedValueOnce(oldLock as never);
+    // Second read is .npmrc
+    fs.readLocalFile.mockResolvedValueOnce(null);
     const newLock = Buffer.from('new');
     fs.readLocalFile.mockResolvedValueOnce(newLock as never);
 
@@ -214,6 +236,8 @@ describe('modules/manager/deno/artifacts', () => {
     updateArtifact.config.isLockFileMaintenance = true;
     const oldLock = Buffer.from('old');
     fs.readLocalFile.mockResolvedValueOnce(oldLock as never);
+    // Second read is .npmrc
+    fs.readLocalFile.mockResolvedValueOnce(null);
     const newLock = Buffer.from('new');
     fs.readLocalFile.mockResolvedValueOnce(newLock as never);
     const execSnapshots = mockExecAll();
@@ -243,6 +267,8 @@ describe('modules/manager/deno/artifacts', () => {
 
     const oldLock = Buffer.from('old');
     fs.readLocalFile.mockResolvedValueOnce(oldLock as never);
+    // Second read is .npmrc
+    fs.readLocalFile.mockResolvedValueOnce(null);
     const newLock = Buffer.from('new');
     fs.readLocalFile.mockResolvedValueOnce(newLock as never);
     const execSnapshots = mockExecAll();
@@ -253,5 +279,50 @@ describe('modules/manager/deno/artifacts', () => {
         cmd: 'deno install',
       },
     ]);
+  });
+
+  describe('private registries', () => {
+    it('should add private registries to deno install command allow-import option', async () => {
+      const updateArtifact: UpdateArtifact = {
+        config: {
+          updateType: 'lockFileMaintenance',
+          lockFiles: ['deno.lock'],
+        },
+        newPackageFileContent: '',
+        packageFileName: '',
+        updatedDeps: [],
+      };
+      const oldLock = Buffer.from('old');
+      fs.readLocalFile.mockResolvedValueOnce(oldLock as never);
+      // Second read is .npmrc
+      fs.readLocalFile.mockResolvedValueOnce(null);
+      const newLock = Buffer.from('new');
+      fs.readLocalFile.mockResolvedValueOnce(newLock as never);
+      const customHostRules = [
+        {
+          token: 'some-token',
+          hostType: 'npm',
+          matchHost: 'https://private-registry.example',
+          resolvedHost: 'private-registry.example',
+        },
+      ];
+      hostRules.findAll.mockReturnValue(customHostRules);
+      hostRules.getAll.mockReturnValue(customHostRules);
+      const execSnapshots = mockExecAll();
+      expect(await updateArtifacts(updateArtifact)).toEqual([
+        {
+          file: {
+            path: 'deno.lock',
+            type: 'addition',
+            contents: newLock,
+          },
+        },
+      ]);
+      expect(execSnapshots).toMatchObject([
+        {
+          cmd: 'deno install --frozen=false --allow-import=deno.land:443,esm.sh:443,jsr.io:443,cdn.jsdelivr.net:443,raw.githubusercontent.com:443,gist.githubusercontent.com:443,private-registry.example',
+        },
+      ]);
+    });
   });
 });

--- a/lib/modules/manager/deno/artifacts.ts
+++ b/lib/modules/manager/deno/artifacts.ts
@@ -1,4 +1,5 @@
 import { isEmptyArray } from '@sindresorhus/is';
+import upath from 'upath';
 import { TEMPORARY_ERROR } from '../../../constants/error-messages.ts';
 import { logger } from '../../../logger/index.ts';
 import { exec } from '../../../util/exec/index.ts';
@@ -8,6 +9,13 @@ import {
   readLocalFile,
   writeLocalFile,
 } from '../../../util/fs/index.ts';
+import * as hostRules from '../../../util/host-rules.ts';
+import { processHostRules } from '../npm/post-update/rules.ts';
+import {
+  getNpmrcContent,
+  resetNpmrcContent,
+  updateNpmrcContent,
+} from '../npm/utils.ts';
 import type { UpdateArtifact, UpdateArtifactsResult } from '../types.ts';
 import type { DenoManagerData } from './types.ts';
 
@@ -64,6 +72,11 @@ export async function updateArtifacts(
     }
   }
 
+  const pkgFileDir = upath.dirname(packageFileName);
+  const { additionalNpmrcContent } = processHostRules();
+  const npmrcContent = await getNpmrcContent(pkgFileDir);
+  await updateNpmrcContent(pkgFileDir, npmrcContent, additionalNpmrcContent);
+
   try {
     await writeLocalFile(packageFileName, newPackageFileContent);
 
@@ -93,6 +106,29 @@ export async function updateArtifacts(
       ],
     };
 
+    // defaults as per https://docs.deno.com/runtime/fundamentals/security/#importing-from-the-web
+    const defaultImportHosts = [
+      'deno.land:443',
+      'esm.sh:443',
+      'jsr.io:443',
+      'cdn.jsdelivr.net:443',
+      'raw.githubusercontent.com:443',
+      'gist.githubusercontent.com:443',
+    ];
+    const additionalImportHosts = hostRules
+      .findAll({ hostType: 'npm' })
+      .filter((rule) => rule.resolvedHost)
+      .map((rule) => rule.resolvedHost);
+
+    if (additionalImportHosts.length > 0) {
+      // combine default and additional import hosts, removing duplicates
+      const importHosts = [
+        ...new Set([...defaultImportHosts, ...additionalImportHosts]),
+      ].join(',');
+
+      args += ` --allow-import=${importHosts}`;
+    }
+
     // "deno install" don't execute lifecycle scripts of package.json by default
     // https://docs.deno.com/runtime/reference/cli/install/#native-node.js-addons
     // TODO: appending `--lockfile-only` is better to reduce disk usage
@@ -102,6 +138,7 @@ export async function updateArtifacts(
       command += args;
     }
     await exec(command, execOptions);
+    await resetNpmrcContent(pkgFileDir, npmrcContent);
 
     const newLockFileContent = await readLocalFile(lockFileName);
     if (


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

I tested the [recently introduced Deno manager support ](https://github.com/renovatebot/renovate/pull/37828) on one of our repositories that uses both packages from public npm and jsr registries as well as internal packages from a private registry, hoping that I would be able to update the packages from the public registry at least.

Unfortunately, Renovate was unable to update the lockfile when updating packages from public registries because it uses `deno install` to do so and deno complained about missing `--allow-import` argument for the private registries in `deno.json`.

This PR fixes this by processing host rules and configuring the `deno install` invocation for those private registries with `--allow-import`. It also creates a temporary `.npmrc` so deno can actually talk to those registries similar to how this is handled with the npm manager.

Note that this still doesn't mean support for updating packages from private registries, it just unblocks lockfile updates in projects where private registries are used in parallel to public registries.  
Also note that if your private registries are using custom TLS certificates, you need to configure CA trust separately.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [x] Yes — other (please describe):
Claude Code was used to analyze the existing code base and look for reference implementations of the desired behavior in existing manager implementations. After looking at those implementations I wrote the fix and test on my own, though I did use IDE autocomplete (VSCode/Github Copilot) when the suggestions made sense.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: none - verified against internal repository - can create minimal reproducible public repository if necessary

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
