### PR TITLE
fix(prune): use configured base branch when single non-default `baseBranchPatterns` is set

### DIFF
--- a/lib/workers/repository/finalize/prune.spec.ts
+++ b/lib/workers/repository/finalize/prune.spec.ts
@@ -121,6 +121,27 @@ describe('workers/repository/finalize/prune', () => {
       );
     });
 
+    it('uses single configured base branch instead of defaultBranch', async () => {
+      config.branchList = [];
+      config.baseBranchPatterns = ['renovate-updates'];
+      config.baseBranches = ['renovate-updates'];
+      config.defaultBranch = 'main';
+      git.getBranchList.mockReturnValueOnce(['renovate/dayjs-1.x']);
+      platform.findPr.mockResolvedValueOnce(null);
+
+      await cleanup.pruneStaleBranches(config, config.branchList);
+
+      expect(platform.findPr).toHaveBeenCalledExactlyOnceWith({
+        branchName: 'renovate/dayjs-1.x',
+        state: 'open',
+        targetBranch: 'renovate-updates',
+      });
+      expect(scm.isBranchModified).toHaveBeenCalledExactlyOnceWith(
+        'renovate/dayjs-1.x',
+        'renovate-updates',
+      );
+    });
+
     it('uses defaultBranch when baseBranchPatterns exist but baseBranches are not computed yet', async () => {
       config.branchList = [];
       config.baseBranchPatterns = ['/^release\\/.*/'];

--- a/lib/workers/repository/finalize/prune.ts
+++ b/lib/workers/repository/finalize/prune.ts
@@ -9,6 +9,7 @@ import { scm } from '../../../modules/platform/scm.ts';
 import { getBranchList, setUserRepoConfig } from '../../../util/git/index.ts';
 import { escapeRegExp, regEx } from '../../../util/regex.ts';
 import { uniqueStrings } from '../../../util/string.ts';
+import { isMultiBaseBranch } from '../process/index.ts';
 import { getReconfigureBranchName } from '../reconfigure/utils.ts';
 
 async function cleanUpBranches(
@@ -22,16 +23,20 @@ async function cleanUpBranches(
   // set Git author in case the repository is not initialized yet
   setUserRepoConfig(config);
 
-  // calculate regex to extract base branch from branch name
-  const baseBranchRe = calculateBaseBranchRegex(config);
+  // in multi-base mode the base branch is encoded in the branch name
+  const multiBase = isMultiBaseBranch(config);
+  const baseBranchRe = multiBase ? calculateBaseBranchRegex(config) : null;
 
   for (const branchName of remainingBranches) {
     try {
-      // get base branch from branch name if base branches are configured
-      // use default branch if no base branches are configured
-      // use default branch name if no match (can happen when base branches are configured later)
-      const baseBranch =
-        baseBranchRe?.exec(branchName)?.[1] ?? config.defaultBranch!;
+      let baseBranch: string;
+      if (multiBase) {
+        baseBranch =
+          baseBranchRe?.exec(branchName)?.[1] ?? config.defaultBranch!;
+      } else {
+        // single base branch: branch name doesn't encode it, use the configured one
+        baseBranch = config.baseBranches?.[0] ?? config.defaultBranch!;
+      }
       const pr = await platform.findPr({
         branchName,
         state: 'open',

--- a/lib/workers/repository/process/index.ts
+++ b/lib/workers/repository/process/index.ts
@@ -130,7 +130,7 @@ function unfoldBaseBranches(
   return [...new Set(unfoldedList)];
 }
 
-function isMultiBaseBranch(config: RenovateConfig): boolean {
+export function isMultiBaseBranch(config: RenovateConfig): boolean {
   if (!config.baseBranchPatterns?.length) {
     return false;
   }


### PR DESCRIPTION
## Changes

Use `isMultiBaseBranch` to check if `baseBranch` regex should be used or not before falling back to default branch.

This is needed as use can configure single baseBranch using baseBranchPatterns and we need to handle that case.

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #43151 <!-- NOTE that this should NOT be a Discussion -->
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation). Used Claude Code to investigate the bug, draft the fix, and write the regression test.
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/renovate-reproductions/39883-base-branch-abandoned