### PR TITLE
fix(gerrit): Use `addMessageIfNotAlreadyExists` in `updatePr`

### DIFF
--- a/lib/modules/platform/gerrit/index.spec.ts
+++ b/lib/modules/platform/gerrit/index.spec.ts
@@ -275,7 +275,7 @@ describe('modules/platform/gerrit/index', () => {
       expect(clientMock.abandonChange).toHaveBeenCalledExactlyOnceWith(123456);
     });
 
-    it('updatePr() - body set => add as message', async () => {
+    it('updatePr() - body set => add as message if needed', async () => {
       const change = partial<GerritChange>({});
       clientMock.getChange.mockResolvedValueOnce(change);
       await gerrit.updatePr({
@@ -283,7 +283,9 @@ describe('modules/platform/gerrit/index', () => {
         prTitle: change.subject,
         prBody: 'NEW PR-Body',
       });
-      expect(clientMock.addMessage).toHaveBeenCalledExactlyOnceWith(
+      expect(
+        clientMock.addMessageIfNotAlreadyExists,
+      ).toHaveBeenCalledExactlyOnceWith(
         123456,
         'NEW PR-Body',
         TAG_PULL_REQUEST_BODY,

--- a/lib/modules/platform/gerrit/index.ts
+++ b/lib/modules/platform/gerrit/index.ts
@@ -202,9 +202,8 @@ export async function getPr(number: number): Promise<Pr | null> {
 
 export async function updatePr(prConfig: UpdatePrConfig): Promise<void> {
   logger.debug(`updatePr(${prConfig.number}, ${prConfig.prTitle})`);
-  // prConfig.prBody will only be set if the body has changed
   if (prConfig.prBody) {
-    await client.addMessage(
+    await client.addMessageIfNotAlreadyExists(
       prConfig.number,
       prConfig.prBody,
       TAG_PULL_REQUEST_BODY,


### PR DESCRIPTION
## Changes

Restores Gerrit `updatePr` to dedupe PR-body messages before adding a new `pull-request` message.

This partially reverts the behavior from [PR #39015](https://github.com/renovatebot/renovate/pull/39015): `createPr` can still use `addMessage` directly, but `updatePr` must use `addMessageIfNotAlreadyExists` because `UpdatePrConfig.prBody` is not guaranteed to mean the body changed.

This prevents repeated self-hosted Gerrit runs from adding the same PR-body message again, as reported in [discussion #43145](https://github.com/renovatebot/renovate/discussions/43145).

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
