### PR TITLE
fix: passing `prBody` to `updatePr` even when not changed

### DIFF
--- a/lib/workers/repository/update/pr/index.spec.ts
+++ b/lib/workers/repository/update/pr/index.spec.ts
@@ -322,7 +322,9 @@ describe('workers/repository/update/pr/index', () => {
             },
           },
         });
-        expect(platform.updatePr).toHaveBeenCalled();
+        expect(platform.updatePr).toHaveBeenCalledWith(
+          expect.objectContaining({ prBody: expect.any(String) }),
+        );
         expect(platform.createPr).not.toHaveBeenCalled();
 
         expect(logger.logger.debug).toHaveBeenCalledWith(
@@ -422,7 +424,9 @@ describe('workers/repository/update/pr/index', () => {
         const res = await ensurePr(config);
 
         expect(res).toEqual({ type: 'with-pr', pr }); // we redo the prTitle as per config
-        expect(platform.updatePr).toHaveBeenCalled();
+        expect(platform.updatePr).toHaveBeenCalledWith(
+          expect.not.objectContaining({ prBody: expect.anything() }),
+        );
         expect(platform.createPr).not.toHaveBeenCalled();
 
         expect(logger.logger.info).toHaveBeenCalledWith(
@@ -442,13 +446,19 @@ describe('workers/repository/update/pr/index', () => {
         const res = await ensurePr(config);
 
         expect(res).toEqual({ type: 'with-pr', pr }); // we redo the prBody as per config
-        expect(platform.updatePr).toHaveBeenCalled();
+        expect(platform.updatePr).toHaveBeenCalledWith(
+          expect.objectContaining({ prBody: body }),
+        );
         expect(platform.createPr).not.toHaveBeenCalled();
         expect(prCache.setPrCache).toHaveBeenCalled();
 
         expect(logger.logger.info).toHaveBeenCalledWith(
           { pr: changedPr.number, prTitle },
           `PR updated`,
+        );
+        expect(logger.logger.debug).toHaveBeenCalledWith(
+          { prTitle },
+          'PR body changed',
         );
       });
 
@@ -457,7 +467,9 @@ describe('workers/repository/update/pr/index', () => {
 
         const res = await ensurePr({ ...config, baseBranch: 'new_base' }); // user changed base branch in config
 
-        expect(platform.updatePr).toHaveBeenCalled();
+        expect(platform.updatePr).toHaveBeenCalledWith(
+          expect.not.objectContaining({ prBody: expect.anything() }),
+        );
         expect(platform.createPr).not.toHaveBeenCalled();
         expect(prCache.setPrCache).toHaveBeenCalled();
 

--- a/lib/workers/repository/update/pr/index.ts
+++ b/lib/workers/repository/update/pr/index.ts
@@ -430,9 +430,11 @@ export async function ensurePr(
       const updatePrConfig: UpdatePrConfig = {
         number: existingPr.number,
         prTitle,
-        prBody,
         platformPrOptions: getPlatformPrOptions(config),
       };
+      if (existingPrBodyHash !== newPrBodyHash || labelsNeedUpdate) {
+        updatePrConfig.prBody = prBody;
+      }
       // PR must need updating
       if (existingPr?.targetBranch !== config.baseBranch) {
         logger.debug(
@@ -484,7 +486,11 @@ export async function ensurePr(
           },
           'PR title changed',
         );
-      } else if (!config.committedFiles && !config.rebaseRequested) {
+      } else if (
+        existingPrBodyHash !== newPrBodyHash &&
+        !config.committedFiles &&
+        !config.rebaseRequested
+      ) {
         logger.debug(
           {
             prTitle,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Renovate keeps track of current `prBody` through the `prBodyHash`, and in some cases uses that to avoid updating the PR when the body has not changed, like here:

https://github.com/renovatebot/renovate/blob/1045055b38e061dfb595af39f10b6146f682644a/lib/workers/repository/update/pr/index.ts#L415-L428

This fixes the issue so that the same logic is applied to all `updatePr` calls.

Fixes https://github.com/renovatebot/renovate/discussions/43145

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
