### PR TITLE
fix(manager/npm): skip --before flag when .npmrc contains min-release-age

### DIFF
--- a/lib/modules/manager/npm/post-update/npm.spec.ts
+++ b/lib/modules/manager/npm/post-update/npm.spec.ts
@@ -1094,6 +1094,29 @@ describe('modules/manager/npm/post-update/npm', () => {
       ]);
     });
 
+    it('skips --before when .npmrc has min-release-age to avoid npm conflict', async () => {
+      await npmHelper.generateLockFile(
+        'some-dir',
+        {},
+        'package-lock.json',
+        { skipInstalls: true, minimumReleaseAge: '3 days' },
+        [
+          {
+            packageName: 'some-dep',
+            newVersion: '1.0.1',
+            isLockfileUpdate: false,
+          },
+        ],
+        'min-release-age=30\n',
+      );
+
+      expect(execSnapshots).toMatchObject([
+        {
+          cmd: 'npm install --package-lock-only --no-audit --ignore-scripts',
+        },
+      ]);
+    });
+
     it('retries without --before on ETARGET with "with a date before"', async () => {
       const etargetError = new ExecError('npm error code ETARGET', {
         cmd: 'npm install --package-lock-only --no-audit --ignore-scripts --before=2026-06-12T12:00:00.000Z',
@@ -1205,9 +1228,9 @@ describe('modules/manager/npm/post-update/npm', () => {
         ${'before="2026-06-01T00:00:00.000Z"\n'}
         ${'registry=https://registry.npmjs.org\nbefore=2026-06-01T00:00:00.000Z # some comment\naudit=false\n'}
       `('$input', ({ input }: { input: string }) => {
-        expect(npmHelper.parseNpmrcCooldownDate(input)?.toISO()).toBe(
-          '2026-06-01T00:00:00.000Z',
-        );
+        const result = npmHelper.parseNpmrcCooldownDate(input);
+        expect(result?.date.toISO()).toBe('2026-06-01T00:00:00.000Z');
+        expect(result?.source).toBe('before');
       });
     });
 
@@ -1219,9 +1242,9 @@ describe('modules/manager/npm/post-update/npm', () => {
         ${'min-release-age=30 # 30 days\n'}
         ${'registry=https://registry.npmjs.org\nmin-release-age=30 # 30 days\n'}
       `('$input', ({ input }: { input: string }) => {
-        expect(npmHelper.parseNpmrcCooldownDate(input)?.toISO()).toBe(
-          '2026-05-16T12:00:00.000Z',
-        );
+        const result = npmHelper.parseNpmrcCooldownDate(input);
+        expect(result?.date.toISO()).toBe('2026-05-16T12:00:00.000Z');
+        expect(result?.source).toBe('min-release-age');
       });
     });
   });

--- a/lib/modules/manager/npm/post-update/npm.ts
+++ b/lib/modules/manager/npm/post-update/npm.ts
@@ -38,9 +38,14 @@ import {
   lazyLoadPackageJson,
 } from './utils.ts';
 
+export interface NpmrcCooldownResult {
+  date: DateTime<true>;
+  source: 'before' | 'min-release-age';
+}
+
 export function parseNpmrcCooldownDate(
   npmrcContent: string | null,
-): DateTime<true> | null {
+): NpmrcCooldownResult | null {
   if (!npmrcContent) {
     return null;
   }
@@ -49,9 +54,9 @@ export function parseNpmrcCooldownDate(
 
   const before = parsed.before;
   if (isNonEmptyString(before)) {
-    const parsed = DateTime.fromISO(before, { zone: 'utc' });
-    if (parsed.isValid) {
-      return parsed;
+    const dt = DateTime.fromISO(before, { zone: 'utc' });
+    if (dt.isValid) {
+      return { date: dt, source: 'before' };
     }
     logger.debug(`Invalid before date in .npmrc: ${before}, ignoring`);
   }
@@ -60,7 +65,10 @@ export function parseNpmrcCooldownDate(
   if (isNonEmptyString(minReleaseAge)) {
     const days = parseInt(minReleaseAge, 10);
     if (isNumber(days) && days >= 0) {
-      return DateTime.now().minus({ days }).toUTC();
+      return {
+        date: DateTime.now().minus({ days }).toUTC(),
+        source: 'min-release-age',
+      };
     }
     logger.debug(
       `Invalid min-release-age in .npmrc: ${minReleaseAge}, ignoring`,
@@ -159,29 +167,42 @@ export async function generateLockFile(
           'Invalid minimumReleaseAge, skipping --before for npm install',
         );
       } else {
-        let beforeDate = DateTime.now().minus(ms).toUTC();
+        const npmrcCooldown = parseNpmrcCooldownDate(npmrcContent);
 
-        const npmrcDate = parseNpmrcCooldownDate(npmrcContent);
-        if (npmrcDate && npmrcDate < beforeDate) {
+        // npm rejects --before when min-release-age is set in .npmrc,
+        // so let the .npmrc handle cooldown natively in that case
+        if (npmrcCooldown?.source === 'min-release-age') {
           logger.debug(
             {
-              npmrcDate: npmrcDate.toISO(),
-              beforeDate: beforeDate.toISO(),
+              npmrcMinReleaseAge: npmrcCooldown.date.toISO(),
+              minimumReleaseAge: config.minimumReleaseAge,
             },
-            'Using stricter .npmrc cooldown date over minimumReleaseAge date',
+            'Skipping --before flag because .npmrc already contains min-release-age',
           );
-          beforeDate = npmrcDate;
-        }
+        } else {
+          let beforeDate = DateTime.now().minus(ms).toUTC();
 
-        const beforeISO = beforeDate.toISO();
-        logger.debug(
-          {
-            beforeISO,
-            minimumReleaseAge: config.minimumReleaseAge,
-          },
-          'Setting npm --before based on minimumReleaseAge',
-        );
-        beforeFlag = ` --before=${beforeISO}`;
+          if (npmrcCooldown && npmrcCooldown.date < beforeDate) {
+            logger.debug(
+              {
+                npmrcDate: npmrcCooldown.date.toISO(),
+                beforeDate: beforeDate.toISO(),
+              },
+              'Using stricter .npmrc cooldown date over minimumReleaseAge date',
+            );
+            beforeDate = npmrcCooldown.date;
+          }
+
+          const beforeISO = beforeDate.toISO();
+          logger.debug(
+            {
+              beforeISO,
+              minimumReleaseAge: config.minimumReleaseAge,
+            },
+            'Setting npm --before based on minimumReleaseAge',
+          );
+          beforeFlag = ` --before=${beforeISO}`;
+        }
       }
     }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

npm rejects `--before` when min-release-age is also set, as they are mutually exclusive options. When .npmrc already contains min-release-age, let npm handle cooldown natively instead of passing `--before` on the CLI.

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

- #43178

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
