### PR TITLE
feat(github): enforce author and committer when using `platformCommit`

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -1958,10 +1958,6 @@ You can't use other filenames because Renovate only checks the default filename 
 You can customize the Git author that's used whenever Renovate creates a commit, although we do not recommend this.
 When this field is unset (default), Renovate will use its platform credentials (e.g. token) to learn/discover its account's git author automatically.
 
-<!-- prettier-ignore -->
-!!! note
-    If running as a GitHub App and using `platformCommit`, GitHub itself sets the git author in commits so you should not configure this field.
-
 The `gitAuthor` option accepts a [RFC5322](https://datatracker.ietf.org/doc/html/rfc5322)-compliant string.
 It's recommended to include a name followed by an email address, e.g.
 
@@ -4066,10 +4062,6 @@ It does not apply when you use a Personal Access Token as credential.
 
 When `platformCommit` is enabled, Renovate will create commits with GitHub's API instead of using `git` directly.
 This way Renovate can use GitHub's [Commit signing support for bots and other GitHub Apps](https://github.blog/2019-08-15-commit-signing-support-for-bots-and-other-github-apps/) feature.
-
-<!-- prettier-ignore -->
-!!! note
-    When using platform commits, GitHub determines the git author string to use and Renovate's own gitAuthor is ignored.
 
 ## `postUpdateOptions`
 

--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -5222,6 +5222,85 @@ describe('modules/platform/github/index', () => {
       expect(res).toBe('0abcdef');
     });
 
+    it('includes author and committer in commit when gitAuthor is set', async () => {
+      git.pushCommitToRenovateRef.mockResolvedValueOnce();
+      git.listCommitTree.mockResolvedValueOnce([]);
+      git.getGitAuthor.mockReturnValueOnce({
+        name: 'Renovate Bot',
+        email: 'renovate@example.com',
+      });
+
+      const scope = httpMock.scope(githubApiHost);
+
+      initRepoMock(scope, 'some/repo');
+      await github.initRepo({ repository: 'some/repo' });
+
+      scope
+        .post('/repos/some/repo/git/trees')
+        .reply(200, { sha: '111' })
+        .post('/repos/some/repo/git/commits')
+        .reply(200, { sha: '222' })
+        .head('/repos/some/repo/git/commits/222')
+        .reply(200)
+        .post('/repos/some/repo/git/refs')
+        .reply(200);
+      vi.spyOn(branch, 'remoteBranchExists').mockResolvedValueOnce(false);
+
+      const res = await github.commitFiles({
+        branchName: 'foo/bar',
+        files: [{ type: 'addition', path: 'foo.bar', contents: 'foobar' }],
+        message: 'Foobar',
+      });
+
+      expect(res).toBe('0abcdef');
+      const commitReq = httpMock
+        .getTrace()
+        .find(
+          (req) => req.method === 'POST' && req.url?.endsWith('/git/commits'),
+        );
+      expect(commitReq?.body).toMatchObject({
+        author: { name: 'Renovate Bot', email: 'renovate@example.com' },
+        committer: { name: 'Renovate Bot', email: 'renovate@example.com' },
+      });
+    });
+
+    it('omits author and committer in commit when gitAuthor is not set', async () => {
+      git.pushCommitToRenovateRef.mockResolvedValueOnce();
+      git.listCommitTree.mockResolvedValueOnce([]);
+      git.getGitAuthor.mockReturnValueOnce(null);
+
+      const scope = httpMock.scope(githubApiHost);
+
+      initRepoMock(scope, 'some/repo');
+      await github.initRepo({ repository: 'some/repo' });
+
+      scope
+        .post('/repos/some/repo/git/trees')
+        .reply(200, { sha: '111' })
+        .post('/repos/some/repo/git/commits')
+        .reply(200, { sha: '222' })
+        .head('/repos/some/repo/git/commits/222')
+        .reply(200)
+        .post('/repos/some/repo/git/refs')
+        .reply(200);
+      vi.spyOn(branch, 'remoteBranchExists').mockResolvedValueOnce(false);
+
+      const res = await github.commitFiles({
+        branchName: 'foo/bar',
+        files: [{ type: 'addition', path: 'foo.bar', contents: 'foobar' }],
+        message: 'Foobar',
+      });
+
+      expect(res).toBe('0abcdef');
+      const commitReq = httpMock
+        .getTrace()
+        .find(
+          (req) => req.method === 'POST' && req.url?.endsWith('/git/commits'),
+        );
+      expect(commitReq?.body).not.toHaveProperty('author');
+      expect(commitReq?.body).not.toHaveProperty('committer');
+    });
+
     it('performs rebase', async () => {
       git.pushCommitToRenovateRef.mockResolvedValueOnce();
       git.listCommitTree.mockResolvedValueOnce([]);

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -2197,9 +2197,20 @@ async function pushFiles(
     const treeSha = treeRes.body.sha;
 
     // Now we recreate the commit using the tree we recreated the step before
+    const commitBody: Record<string, any> = {
+      message,
+      tree: treeSha,
+      parents: [parentCommitSha],
+    };
+    const gitAuthor = git.getGitAuthor();
+    if (gitAuthor) {
+      commitBody.author = gitAuthor;
+      commitBody.committer = gitAuthor;
+    }
+
     const commitRes = await githubApi.postJson<{ sha: string }>(
       `/repos/${config.repository}/git/commits`,
-      { body: { message, tree: treeSha, parents: [parentCommitSha] } },
+      { body: commitBody },
     );
     incLimitedValue('Commits');
     const remoteCommitSha = commitRes.body.sha as LongCommitSha;

--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -1166,6 +1166,20 @@ describe('util/git/index', { timeout: 10000 }, () => {
     });
   });
 
+  describe('getGitAuthor()', () => {
+    it('returns author name and email when set', () => {
+      expect(git.getGitAuthor()).toEqual({
+        name: 'Jest',
+        email: 'Jest@example.com',
+      });
+    });
+
+    it('returns null when not set', async () => {
+      await git.initRepo({ url: origin.path });
+      expect(git.getGitAuthor()).toBeNull();
+    });
+  });
+
   describe('isBranchConflicted', () => {
     beforeAll(async () => {
       const repo = simpleGit(base.path);

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -314,6 +314,14 @@ export function setGitAuthor(gitAuthor: string | undefined): void {
   config.gitAuthorEmail = gitAuthorParsed.address;
 }
 
+export function getGitAuthor(): { name: string; email: string } | null {
+  const { gitAuthorName, gitAuthorEmail } = config;
+  if (!gitAuthorName || !gitAuthorEmail) {
+    return null;
+  }
+  return { name: gitAuthorName, email: gitAuthorEmail };
+}
+
 export async function writeGitAuthor(): Promise<void> {
   const { gitAuthorName, gitAuthorEmail, writeGitDone } = config;
   /* v8 ignore if -- TODO: add test #40625 */


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Currently, Renovate does not enforce the git author and committer when commiting through `platformCommit` (i.e. when the commit is created using the GitHub API).

I'm not sure why, but I suppose it was an oversight. Or maybe the API didn't support it at the time?

In any case, this PR changes it so that the git author and committer are always set when commiting through `platformCommit`, using the same values as we would use when commiting through git.

This would have prevented https://github.com/renovatebot/renovate/discussions/43164 from happening, and _potentially_ https://github.com/renovatebot/renovate/discussions/43112 as well, although in that case there is an additional issue which I will address in a separate PR.

Before this PR:

```
commit 18b5e7595280d91e382ce606b2c0811684dc830a (HEAD -> renovate/date-io-moment-2.x, origin/renovate/date-io-moment-2.x)
Author:     felipecrs-renovate[bot] <282970479+felipecrs-renovate[bot]@users.noreply.github.com>
AuthorDate: Fri May 8 17:51:16 2026 +0000
Commit:     GitHub <noreply@github.com>
CommitDate: Fri May 8 17:51:16 2026 +0000

    Update dependency @date-io/moment to v2.17.0
```

After this PR:

```
commit 2177ab544b523e47d5cee93d8875190c5fe7ab19 (HEAD -> renovate/date-io-moment-2.x, origin/renovate/date-io-moment-2.x)
Author:     felipecrs-renovate[bot] <282970479+felipecrs-renovate[bot]@users.noreply.github.com>
AuthorDate: Fri May 8 17:53:26 2026 +0000
Commit:     felipecrs-renovate[bot] <282970479+felipecrs-renovate[bot]@users.noreply.github.com>
CommitDate: Fri May 8 17:53:26 2026 +0000

    Update dependency @date-io/moment to v2.17.0
```

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/felipecrs/renovate-repro-tutorial

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
