### PR TITLE
feat(platform/gitlab): add MRs to merge trains via merge_trains API

### DIFF
--- a/docs/usage/faq.md
+++ b/docs/usage/faq.md
@@ -44,7 +44,6 @@ Some major platform features are not supported at all by Renovate.
 | --------------------------------------- | ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Jira issues                             | Bitbucket                                 | [#20568](https://github.com/renovatebot/renovate/issues/20568)                                                                                                                               |
 | Jira issues                             | Bitbucket Server                          | [#3796](https://github.com/renovatebot/renovate/issues/3796)                                                                                                                                 |
-| Merge trains                            | GitLab                                    | [#5573](https://github.com/renovatebot/renovate/issues/5573)                                                                                                                                 |
 | Configurable merge strategy and message | Only Bitbucket, Forgejo and Gitea for now | [#10867](https://github.com/renovatebot/renovate/issues/10867) [#10869](https://github.com/renovatebot/renovate/issues/10869) [#10870](https://github.com/renovatebot/renovate/issues/10870) |
 
 ## What is this `main` branch I see in the documentation?

--- a/docs/usage/upgrade-best-practices.md
+++ b/docs/usage/upgrade-best-practices.md
@@ -136,7 +136,7 @@ If you want a third-party dependency update _now_, instead of waiting two weeks,
 #### Use GitHub Pull Request Merge Queues
 
 You may also start using [GitHub's pull request merge queues](./key-concepts/automerge.md#github-merge-queue) to speed up the merge process.
-Renovate does not support GitLab's Merge Trains, see [issue #5573](https://github.com/renovatebot/renovate/issues/5573).
+On GitLab projects with merge trains enabled, Renovate adds automerged MRs to the merge train automatically (requires GitLab 17.11 or later).
 
 ## Starting from a new project
 

--- a/lib/modules/platform/gitlab/index.spec.ts
+++ b/lib/modules/platform/gitlab/index.spec.ts
@@ -2404,6 +2404,162 @@ describe('modules/platform/gitlab/index', () => {
       expect(timers.setTimeout.mock.calls).toMatchObject([[100], [400]]);
     });
 
+    it('adds the MR to a merge train when merge trains are enabled on the project', async () => {
+      await initPlatform('17.11.0-ee');
+      const scope = await initRepo(
+        { repository: 'some/repo' },
+        {
+          default_branch: 'master',
+          http_url_to_repo: `https://gitlab.com/some/repo.git`,
+          merge_trains_enabled: true,
+        },
+      );
+      scope
+        .get(
+          '/api/v4/projects/some%2Frepo/merge_requests?per_page=100&order_by=updated_at&sort=desc&scope=created_by_me',
+        )
+        .reply(200, [])
+        .post('/api/v4/projects/some%2Frepo/merge_requests')
+        .reply(200, {
+          id: 1,
+          iid: 12345,
+          title: 'some title',
+          source_branch: 'some-branch',
+          target_branch: 'master',
+          description: 'the-body',
+        })
+        .get('/api/v4/projects/some%2Frepo/merge_requests/12345')
+        .reply(200, {
+          merge_status: 'can_be_merged',
+          pipeline: { status: 'running' },
+        })
+        .post(
+          '/api/v4/projects/some%2Frepo/merge_trains/merge_requests/12345',
+          { auto_merge: true },
+        )
+        .reply(201);
+      expect(
+        await gitlab.createPr({
+          sourceBranch: 'some-branch',
+          targetBranch: 'master',
+          prTitle: 'some-title',
+          prBody: 'the-body',
+          labels: [],
+          platformPrOptions: {
+            usePlatformAutomerge: true,
+          },
+        }),
+      ).toMatchObject({
+        number: 12345,
+        sourceBranch: 'some-branch',
+        title: 'some title',
+      });
+    });
+
+    it('falls back to /merge endpoint when merge trains enabled but GitLab < 17.11', async () => {
+      await initPlatform('17.10.0-ee');
+      const scope = await initRepo(
+        { repository: 'some/repo' },
+        {
+          default_branch: 'master',
+          http_url_to_repo: `https://gitlab.com/some/repo.git`,
+          merge_trains_enabled: true,
+        },
+      );
+      scope
+        .get(
+          '/api/v4/projects/some%2Frepo/merge_requests?per_page=100&order_by=updated_at&sort=desc&scope=created_by_me',
+        )
+        .reply(200, [])
+        .post('/api/v4/projects/some%2Frepo/merge_requests')
+        .reply(200, {
+          id: 1,
+          iid: 12345,
+          title: 'some title',
+          source_branch: 'some-branch',
+          target_branch: 'master',
+          description: 'the-body',
+        })
+        .get('/api/v4/projects/some%2Frepo/merge_requests/12345')
+        .reply(200, {
+          merge_status: 'can_be_merged',
+          pipeline: { status: 'running' },
+        })
+        .put('/api/v4/projects/some%2Frepo/merge_requests/12345/merge')
+        .reply(200);
+      expect(
+        await gitlab.createPr({
+          sourceBranch: 'some-branch',
+          targetBranch: 'master',
+          prTitle: 'some-title',
+          prBody: 'the-body',
+          labels: [],
+          platformPrOptions: {
+            usePlatformAutomerge: true,
+          },
+        }),
+      ).toMatchObject({
+        number: 12345,
+        sourceBranch: 'some-branch',
+        title: 'some title',
+      });
+      expect(logger.logger.once.warn).toHaveBeenCalledWith(
+        { version: '17.10.0' },
+        'Merge trains require GitLab 17.11.0 or later, falling back to /merge endpoint',
+      );
+    });
+
+    it('retries the merge_trains endpoint on transient failure', async () => {
+      await initPlatform('17.11.0-ee');
+      const scope = await initRepo(
+        { repository: 'some/repo' },
+        {
+          default_branch: 'master',
+          http_url_to_repo: `https://gitlab.com/some/repo.git`,
+          merge_trains_enabled: true,
+        },
+      );
+      scope
+        .get(
+          '/api/v4/projects/some%2Frepo/merge_requests?per_page=100&order_by=updated_at&sort=desc&scope=created_by_me',
+        )
+        .reply(200, [])
+        .post('/api/v4/projects/some%2Frepo/merge_requests')
+        .reply(200, {
+          id: 1,
+          iid: 12345,
+          title: 'some title',
+          source_branch: 'some-branch',
+          target_branch: 'master',
+          description: 'the-body',
+        })
+        .get('/api/v4/projects/some%2Frepo/merge_requests/12345')
+        .reply(200, {
+          merge_status: 'can_be_merged',
+          pipeline: { status: 'running' },
+        })
+        .post('/api/v4/projects/some%2Frepo/merge_trains/merge_requests/12345')
+        .reply(405, {})
+        .post('/api/v4/projects/some%2Frepo/merge_trains/merge_requests/12345')
+        .reply(202);
+      expect(
+        await gitlab.createPr({
+          sourceBranch: 'some-branch',
+          targetBranch: 'master',
+          prTitle: 'some-title',
+          prBody: 'the-body',
+          labels: [],
+          platformPrOptions: {
+            usePlatformAutomerge: true,
+          },
+        }),
+      ).toMatchObject({
+        number: 12345,
+        sourceBranch: 'some-branch',
+        title: 'some title',
+      });
+    });
+
     it('should parse merge_status attribute if detailed_merge_status is not set (on < 15.6)', async () => {
       await initPlatform('13.3.6-ee');
       const reply_body = {

--- a/lib/modules/platform/gitlab/index.ts
+++ b/lib/modules/platform/gitlab/index.ts
@@ -639,19 +639,43 @@ async function tryPrAutomerge(
         await setTimeout(mergeDelay * attempt ** 2); // exponential backoff
       }
 
+      // The merge_trains endpoint's auto_merge parameter requires GitLab
+      // 17.11+. On older versions we fall back to the /merge endpoint so the
+      // MR still automerges, just not on the train.
+      // https://docs.gitlab.com/api/merge_trains/#add-a-merge-request-to-a-merge-train
+      const useMergeTrain =
+        config.mergeTrainsEnabled && !semver.lt(defaults.version, '17.11.0');
+      if (config.mergeTrainsEnabled && !useMergeTrain) {
+        logger.once.warn(
+          { version: defaults.version },
+          'Merge trains require GitLab 17.11.0 or later, falling back to /merge endpoint',
+        );
+      }
+
       // Even if Gitlab returns a "merge-able" merge request status, enabling auto-merge sometimes
       // returns a 405 Method Not Allowed. It seems to be a timing issue within Gitlab.
       for (let attempt = 1; attempt <= retryTimes; attempt += 1) {
         try {
-          await gitlabApi.putJson(
-            `projects/${config.repository}/merge_requests/${pr}/merge`,
-            {
-              body: {
-                should_remove_source_branch: true,
-                merge_when_pipeline_succeeds: true,
+          if (useMergeTrain) {
+            await gitlabApi.postJson(
+              `projects/${config.repository}/merge_trains/merge_requests/${pr}`,
+              {
+                body: {
+                  auto_merge: true,
+                },
               },
-            },
-          );
+            );
+          } else {
+            await gitlabApi.putJson(
+              `projects/${config.repository}/merge_requests/${pr}/merge`,
+              {
+                body: {
+                  should_remove_source_branch: true,
+                  merge_when_pipeline_succeeds: true,
+                },
+              },
+            );
+          }
           break;
         } catch (err) {
           logger.debug(

--- a/lib/modules/platform/gitlab/readme.md
+++ b/lib/modules/platform/gitlab/readme.md
@@ -96,6 +96,7 @@ By setting the server version yourself, you save a API call that fetches the ser
 - Use `Draft:` MR prefix instead of `WIP:` prefix since `v13.2.0`
 - Do not truncate Markdown body to 25K chars since `v13.4.0`
 - Allow configure reviewers since `v13.9.0`
+- Add automerged MRs to merge trains since `v17.11.0` (when [merge trains](https://docs.gitlab.com/ci/pipelines/merge_trains/) are enabled on the project)
 
 ## Multiple merge request assignees
 


### PR DESCRIPTION
## Changes

When a GitLab project has merge trains enabled, automerged MRs are now added to the merge train via the dedicated [Add a merge request to a merge train](https://docs.gitlab.com/api/merge_trains/#add-a-merge-request-to-a-merge-train) endpoint:

- New path: `POST /projects/:id/merge_trains/merge_requests/:iid` with body `{ "auto_merge": true }` — branched on the existing `mergeTrainsEnabled` flag captured at repo init.
- Non-train projects keep using `PUT /merge_requests/:iid/merge` exactly as before — zero behavior change for free-tier users.

### Why a different approach than the previous (reverted) attempt

A first implementation in #34102 used the `/merge` quick action via the Notes API. It was reverted in #34353 because the quick action's pipeline-success guarantee depends on the GitLab project setting `Pipelines must succeed`, so users who relied on Renovate setting `merge_when_pipeline_succeeds: true` themselves silently lost that guarantee.

The new merge_trains endpoint exposes an `auto_merge` parameter (added in GitLab 17.11) which is the direct replacement for the legacy `merge_when_pipeline_succeeds` — Renovate keeps controlling the safety, not the project config. This avoids the original revert reason entirely.

Requires GitLab 17.11+ for users on merge trains; older versions and non-train projects are unaffected.

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #5573
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Used Claude Code (Opus 4.7) for: reviewing the prior PR/revert discussion, drafting the implementation in `tryPrAutomerge`, writing the two new unit tests, and updating the FAQ / readme / upgrade-best-practices docs. All changes were reviewed by me before committing.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

Updated:
- `docs/usage/faq.md` — removed merge trains from the "not supported" table.
- `docs/usage/upgrade-best-practices.md` — replaced "not supported" line with a positive support statement.
- `lib/modules/platform/gitlab/readme.md` — added merge-train support to the version-dependent features list.

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

Two new tests cover the merge-trains path: a happy-path test (201 response) and a transient-failure retry test (405 → 202). All 165 GitLab platform tests pass; tsc / oxlint / biome / prettier are clean.
