### PR TITLE
fix(git): pass through Git CA certificate env vars

### DIFF
--- a/lib/util/exec/env.spec.ts
+++ b/lib/util/exec/env.spec.ts
@@ -11,6 +11,8 @@ describe('util/exec/env', () => {
     'LC_ALL',
     'LANG',
     'DOCKER_HOST',
+    'GIT_SSL_CAPATH',
+    'GIT_SSL_CAINFO',
     'SSL_CERT_FILE',
     'URL_REPLACE_1_FROM',
     'URL_REPLACE_1_TO',
@@ -33,6 +35,8 @@ describe('util/exec/env', () => {
   it('returns default environment variables', () => {
     expect(getChildProcessEnv()).toMatchObject({
       DOCKER_HOST: 'DOCKER_HOST',
+      GIT_SSL_CAPATH: 'GIT_SSL_CAPATH',
+      GIT_SSL_CAINFO: 'GIT_SSL_CAINFO',
       HOME: 'HOME',
       HTTPS_PROXY: 'HTTPS_PROXY',
       HTTP_PROXY: 'HTTP_PROXY',

--- a/lib/util/exec/env.ts
+++ b/lib/util/exec/env.ts
@@ -15,11 +15,13 @@ const basicEnvVars = [
   'DOCKER_HOST',
   'DOCKER_TLS_VERIFY',
   'DOCKER_CERT_PATH',
-  // Custom certificte variables
+  // Custom certificate variables
   // https://github.com/containerbase/base/blob/main/docs/custom-root-ca.md
   'SSL_CERT_DIR',
   'SSL_CERT_FILE',
   'NODE_EXTRA_CA_CERTS',
+  'GIT_SSL_CAPATH',
+  'GIT_SSL_CAINFO',
   // Required for NuGet to work on Windows.
   'PROGRAMFILES',
   'PROGRAMFILES(X86)',


### PR DESCRIPTION
## Changes

Pass through Git certificate trust environment variables when building child process environments:

- `GIT_SSL_CAINFO`
- `GIT_SSL_CAPATH`

This lets self-hosted Renovate users keep configuring Git HTTPS trust with `GIT_SSL_CAINFO` after the git environment allowlist change.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This does not close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

Discussion: #43193

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No - I did not use AI for this contribution.
- [ ] Yes - minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes - substantive assistance (Codex helped inspect the code path, implement the allowlist change, update tests, and prepare this PR).
- [ ] Yes - other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I have tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

Test command:

`pnpm check lib/util/exec/env.ts lib/util/exec/env.spec.ts`