### PR TITLE
feat(presets): add security:gomodIndirectSecurityUpdates preset

### DIFF
--- a/lib/config/presets/internal/security.preset.ts
+++ b/lib/config/presets/internal/security.preset.ts
@@ -1,6 +1,28 @@
+import { UpdateTypesOptions } from '../../types.ts';
 import type { Preset } from '../types.ts';
 
 export const presets: Record<string, Preset> = {
+  gomodIndirectSecurityUpdates: {
+    description:
+      'Enable go.mod indirect dependency updates only when vulnerabilities have been detected.',
+    extends: [':enableVulnerabilityAlerts'],
+    packageRules: [
+      {
+        description: 'Enable lookups for indirect go.mod dependencies',
+        enabled: true,
+        matchDepTypes: ['indirect'],
+        matchManagers: ['gomod'],
+      },
+      {
+        description:
+          'Disable non-security updates for indirect go.mod dependencies (vulnerability alerts use force to override this)',
+        enabled: false,
+        matchDepTypes: ['indirect'],
+        matchManagers: ['gomod'],
+        matchUpdateTypes: [...UpdateTypesOptions],
+      },
+    ],
+  },
   minimumReleaseAgeNpm: {
     description:
       'Wait until the npm package is three days old before raising the update. This a) introduces a short delay to allow for malware researchers and scanners to (possibly) detect any malicious behaviour in packages, and b) prevents the maintainer and/or NPM from unpublishing a package you already upgraded to, breaking builds.',


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Add a preset to allow users to opt-in to vulnerability-only updates for go.mod indirect dependencies.

## Context

Related to discussion #22487

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: https://github.com/maxbrunet/renovate-repro-22487

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
