### PR TITLE
fix(scm-manager):  add mapping of SCM-Manager specific PR states to the matching Renovate PR states

### DIFF
--- a/lib/modules/platform/scm-manager/index.spec.ts
+++ b/lib/modules/platform/scm-manager/index.spec.ts
@@ -201,7 +201,7 @@ describe('modules/platform/scm-manager/index', () => {
           createdAt: pullRequest.creationDate,
           labels: pullRequest.labels,
           number: parseInt(pullRequest.id, 10),
-          state: pullRequest.status,
+          state: 'open',
           targetBranch: pullRequest.target,
           title: pullRequest.title,
           hasAssignees: false,
@@ -407,15 +407,14 @@ describe('modules/platform/scm-manager/index', () => {
 
   describe('createPr', () => {
     it.each`
-      draftPr      | expectedState | expectedIsDraft
-      ${undefined} | ${'OPEN'}     | ${false}
-      ${false}     | ${'OPEN'}     | ${false}
-      ${true}      | ${'DRAFT'}    | ${true}
+      draftPr      | expectedIsDraft
+      ${undefined} | ${false}
+      ${false}     | ${false}
+      ${true}      | ${true}
     `(
       'should create PR with $draftPR and state $expectedState',
       async ({
         draftPr,
-        expectedState,
         expectedIsDraft,
       }: {
         draftPr: boolean | undefined;
@@ -469,7 +468,7 @@ describe('modules/platform/scm-manager/index', () => {
           labels: [],
           number: 1337,
           reviewers: [],
-          state: expectedState,
+          state: 'open',
         });
       },
     );

--- a/lib/modules/platform/scm-manager/mapper.spec.ts
+++ b/lib/modules/platform/scm-manager/mapper.spec.ts
@@ -1,44 +1,66 @@
 import { mapPrFromScmToRenovate } from './mapper.ts';
-import type { PullRequest } from './schema.ts';
+import type { PrState, PullRequest } from './schema.ts';
 
 describe('modules/platform/scm-manager/mapper', () => {
-  it('should correctly map the scm-manager type of a PR to the Renovate PR type', () => {
-    const scmPr: PullRequest = {
-      source: 'feat/new',
-      target: 'develop',
-      creationDate: '2024-12-24T18:21Z',
-      closeDate: '2024-12-25T18:21Z',
-      reviewer: [
-        { id: 'id', displayName: 'user', mail: 'user@user.de', approved: true },
-      ],
-      labels: ['label'],
-      id: '1',
-      status: 'OPEN',
-      title: 'Merge please',
-      description: 'Description',
-      tasks: { todo: 0, done: 0 },
-      _links: {},
-      _embedded: {
-        defaultConfig: {
-          mergeStrategy: 'SQUASH',
-          deleteBranchOnMerge: true,
+  it.each`
+    scmPrState    | renovatePrState | expectedIsDraft
+    ${'OPEN'}     | ${'open'}       | ${false}
+    ${'DRAFT'}    | ${'open'}       | ${true}
+    ${'REJECTED'} | ${'closed'}     | ${false}
+    ${'MERGED'}   | ${'merged'}     | ${false}
+  `(
+    'should correctly map the scm-manager type of a PR with the $scmPrState to the Renovate PR type',
+    ({
+      scmPrState,
+      renovatePrState,
+      expectedIsDraft,
+    }: {
+      scmPrState: PrState;
+      renovatePrState: string;
+      expectedIsDraft: boolean;
+    }) => {
+      const scmPr: PullRequest = {
+        source: 'feat/new',
+        target: 'develop',
+        creationDate: '2024-12-24T18:21Z',
+        closeDate: '2024-12-25T18:21Z',
+        reviewer: [
+          {
+            id: 'id',
+            displayName: 'user',
+            mail: 'user@user.de',
+            approved: true,
+          },
+        ],
+        labels: ['label'],
+        id: '1',
+        status: scmPrState,
+        title: 'Merge please',
+        description: 'Description',
+        tasks: { todo: 0, done: 0 },
+        _links: {},
+        _embedded: {
+          defaultConfig: {
+            mergeStrategy: 'SQUASH',
+            deleteBranchOnMerge: true,
+          },
         },
-      },
-    };
+      };
 
-    const result = mapPrFromScmToRenovate(scmPr);
-    expect(result).toEqual({
-      sourceBranch: 'feat/new',
-      targetBranch: 'develop',
-      createdAt: '2024-12-24T18:21Z',
-      closedAt: '2024-12-25T18:21Z',
-      hasAssignees: true,
-      labels: ['label'],
-      number: 1,
-      reviewers: ['user'],
-      state: 'OPEN',
-      title: 'Merge please',
-      isDraft: false,
-    });
-  });
+      const result = mapPrFromScmToRenovate(scmPr);
+      expect(result).toEqual({
+        sourceBranch: 'feat/new',
+        targetBranch: 'develop',
+        createdAt: '2024-12-24T18:21Z',
+        closedAt: '2024-12-25T18:21Z',
+        hasAssignees: true,
+        labels: ['label'],
+        number: 1,
+        reviewers: ['user'],
+        state: renovatePrState,
+        title: 'Merge please',
+        isDraft: expectedIsDraft,
+      });
+    },
+  );
 });

--- a/lib/modules/platform/scm-manager/mapper.ts
+++ b/lib/modules/platform/scm-manager/mapper.ts
@@ -1,5 +1,12 @@
 import type { Pr } from '../types.ts';
-import type { PullRequest } from './schema.ts';
+import type { PrState, PullRequest } from './schema.ts';
+
+const PR_STATE_MAP: Record<PrState, string> = {
+  DRAFT: 'open',
+  OPEN: 'open',
+  REJECTED: 'closed',
+  MERGED: 'merged',
+};
 
 export function mapPrFromScmToRenovate(pr: PullRequest): Pr {
   return {
@@ -11,7 +18,7 @@ export function mapPrFromScmToRenovate(pr: PullRequest): Pr {
     labels: pr.labels,
     number: parseInt(pr.id, 10),
     reviewers: pr.reviewer?.map((review) => review.displayName) ?? [],
-    state: pr.status,
+    state: PR_STATE_MAP[pr.status],
     title: pr.title,
     isDraft: pr.status === 'DRAFT',
   };

--- a/lib/modules/platform/scm-manager/utils.spec.ts
+++ b/lib/modules/platform/scm-manager/utils.spec.ts
@@ -59,23 +59,19 @@ describe('modules/platform/scm-manager/utils', () => {
     };
 
     it.each`
-      pr                                     | state       | expectedResult
-      ${{ ...defaultPr, state: 'OPEN' }}     | ${'all'}    | ${true}
-      ${{ ...defaultPr, state: 'DRAFT' }}    | ${'all'}    | ${true}
-      ${{ ...defaultPr, state: 'MERGED' }}   | ${'all'}    | ${true}
-      ${{ ...defaultPr, state: 'REJECTED' }} | ${'all'}    | ${true}
-      ${{ ...defaultPr, state: 'OPEN' }}     | ${'open'}   | ${true}
-      ${{ ...defaultPr, state: 'DRAFT' }}    | ${'open'}   | ${true}
-      ${{ ...defaultPr, state: 'MERGED' }}   | ${'open'}   | ${false}
-      ${{ ...defaultPr, state: 'REJECTED' }} | ${'open'}   | ${false}
-      ${{ ...defaultPr, state: 'OPEN' }}     | ${'!open'}  | ${false}
-      ${{ ...defaultPr, state: 'DRAFT' }}    | ${'!open'}  | ${false}
-      ${{ ...defaultPr, state: 'MERGED' }}   | ${'!open'}  | ${true}
-      ${{ ...defaultPr, state: 'REJECTED' }} | ${'!open'}  | ${true}
-      ${{ ...defaultPr, state: 'OPEN' }}     | ${'closed'} | ${false}
-      ${{ ...defaultPr, state: 'DRAFT' }}    | ${'closed'} | ${false}
-      ${{ ...defaultPr, state: 'MERGED' }}   | ${'closed'} | ${true}
-      ${{ ...defaultPr, state: 'REJECTED' }} | ${'closed'} | ${true}
+      pr                                   | state       | expectedResult
+      ${{ ...defaultPr, state: 'open' }}   | ${'all'}    | ${true}
+      ${{ ...defaultPr, state: 'merged' }} | ${'all'}    | ${true}
+      ${{ ...defaultPr, state: 'closed' }} | ${'all'}    | ${true}
+      ${{ ...defaultPr, state: 'open' }}   | ${'open'}   | ${true}
+      ${{ ...defaultPr, state: 'merged' }} | ${'open'}   | ${false}
+      ${{ ...defaultPr, state: 'closed' }} | ${'open'}   | ${false}
+      ${{ ...defaultPr, state: 'open' }}   | ${'!open'}  | ${false}
+      ${{ ...defaultPr, state: 'merged' }} | ${'!open'}  | ${true}
+      ${{ ...defaultPr, state: 'closed' }} | ${'!open'}  | ${true}
+      ${{ ...defaultPr, state: 'open' }}   | ${'closed'} | ${false}
+      ${{ ...defaultPr, state: 'merged' }} | ${'closed'} | ${false}
+      ${{ ...defaultPr, state: 'closed' }} | ${'closed'} | ${true}
     `(
       'match scm pr state $pr.state to renovate pr state $state',
       ({

--- a/lib/modules/platform/scm-manager/utils.ts
+++ b/lib/modules/platform/scm-manager/utils.ts
@@ -25,22 +25,11 @@ export function matchPrState(pr: Pr, state: PrFilterByState): boolean {
     return true;
   }
 
-  if (state === 'open' && (pr.state === 'OPEN' || pr.state === 'DRAFT')) {
+  if (state === '!open' && (pr.state === 'closed' || pr.state === 'merged')) {
     return true;
   }
 
-  if (state === '!open' && (pr.state === 'MERGED' || pr.state === 'REJECTED')) {
-    return true;
-  }
-
-  if (
-    state === 'closed' &&
-    (pr.state === 'MERGED' || pr.state === 'REJECTED')
-  ) {
-    return true;
-  }
-
-  return false;
+  return state === pr.state;
 }
 
 export function smartLinks(body: string): string {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

After fetching pull requests from the SCM-Manager, the states of the pull requests were not mapped  to the respective values that are expected from Renovate (open, closed, merged). Instead the SCM-Manager specific values were still in use. This led to the bug, that after the first renovation, open pull requests were interpreted as closed or merged unexpectedly. Therefore causing the renovation to get aborted.

Code that was conflicting with the SCM-Manager specific states:

`lib/workers/repository/update/branch/index.ts`

```ts
if (branchPr.state !== 'open') {
  logger.debug(
    'PR has been closed or merged since this run started - aborting',
  );
  throw new Error(REPOSITORY_CHANGED);
}
```

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [X] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [X] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [X] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [X] Both unit tests + ran on a real repository

The public repository: https://github.com/scm-manager/renovate

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
