### PR TITLE
docs: add a "deep dive" on environment variables

### DIFF
--- a/docs/usage/.pages
+++ b/docs/usage/.pages
@@ -33,6 +33,7 @@ nav:
       - 'Semantic Commit Messages': 'semantic-commits.md'
       - 'Noise Reduction': 'noise-reduction.md'
       - 'Upgrade best practices': 'upgrade-best-practices.md'
+      - 'Environment variable handling': 'environment-variable-handling.md'
       - "How does Renovate's Docker image get built?": 'docker-build-process.md'
   - Included Presets:
       - 'Abandonment Presets': 'presets-abandonments.md'

--- a/docs/usage/.pages
+++ b/docs/usage/.pages
@@ -34,6 +34,8 @@ nav:
       - 'Noise Reduction': 'noise-reduction.md'
       - 'Upgrade best practices': 'upgrade-best-practices.md'
       - "How does Renovate's Docker image get built?": 'docker-build-process.md'
+  - Tool Calling:
+      - 'Environment variable handling': 'environment-variable-handling.md'
   - Included Presets:
       - 'Abandonment Presets': 'presets-abandonments.md'
       - 'Custom Manager Presets': 'presets-customManagers.md'

--- a/docs/usage/.pages
+++ b/docs/usage/.pages
@@ -9,7 +9,6 @@ nav:
       - 'Self-hosted': 'self-hosted-configuration.md'
       - 'Presets': 'config-presets.md'
       - 'Validation': 'config-validation.md'
-      - 'Environment variable handling': 'environment-variable-handling.md'
       - 'JSON Schema': 'json-schema.md'
   - ... | mend-hosted
   - ... | key-concepts
@@ -34,6 +33,7 @@ nav:
       - 'Semantic Commit Messages': 'semantic-commits.md'
       - 'Noise Reduction': 'noise-reduction.md'
       - 'Upgrade best practices': 'upgrade-best-practices.md'
+      - 'Environment variable handling': 'environment-variable-handling.md'
       - "How does Renovate's Docker image get built?": 'docker-build-process.md'
   - Included Presets:
       - 'Abandonment Presets': 'presets-abandonments.md'

--- a/docs/usage/.pages
+++ b/docs/usage/.pages
@@ -9,6 +9,7 @@ nav:
       - 'Self-hosted': 'self-hosted-configuration.md'
       - 'Presets': 'config-presets.md'
       - 'Validation': 'config-validation.md'
+      - 'Environment variable handling': 'environment-variable-handling.md'
       - 'JSON Schema': 'json-schema.md'
   - ... | mend-hosted
   - ... | key-concepts
@@ -33,7 +34,6 @@ nav:
       - 'Semantic Commit Messages': 'semantic-commits.md'
       - 'Noise Reduction': 'noise-reduction.md'
       - 'Upgrade best practices': 'upgrade-best-practices.md'
-      - 'Environment variable handling': 'environment-variable-handling.md'
       - "How does Renovate's Docker image get built?": 'docker-build-process.md'
   - Included Presets:
       - 'Abandonment Presets': 'presets-abandonments.md'

--- a/docs/usage/environment-variable-handling.md
+++ b/docs/usage/environment-variable-handling.md
@@ -1,0 +1,22 @@
+# Environment Variable Handling
+
+For security reasons, Renovate does not expose all environment variables to child processes.
+Instead, Renovate will use an allowlist of environment variables which it passes to any processes it calls.
+
+By default, Renovate will **always** pass the following environment variables to child processes:
+
+<!-- Autogenerate basicEnvVars -->
+
+<!-- prettier-ignore -->
+!!! note
+    Some managers pass additional environment variables where necessary.
+    <br>
+    This is not currently documented in full - you will need to review Renovate's code to see the full list.
+
+As a self-hosted administrator, it is possible to allowlist other environment variables that repository owners can set, using:
+
+- [`allowedEnv`](./self-hosted-configuration.md#allowedenv)
+- [`customEnvVariables`](./self-hosted-configuration.md#customenvvariables)
+- [`extends: ["global:safeEnv"]`](./presets-global.md#globalsafeenv)
+
+When using `allowedEnv`, users will then be able to specify the value for any environment variables allowlisted, using the [`env`](./configuration-options.md#env) configuration option in their repository configuration.

--- a/docs/usage/environment-variable-handling.md
+++ b/docs/usage/environment-variable-handling.md
@@ -1,0 +1,88 @@
+# Environment Variable Handling
+
+## For Renovate
+
+Renovate itself can be configured through a number of environment variables that correspond with [global self-hosted configuration options](./self-hosted-configuration.md), as well as some [repository configuration options](./configuration-options.md).
+These environment variables have the prefix with `RENOVATE_`.
+
+Renovate also has some ["experimental" variables that can be used with self-hosted deployments](./self-hosted-experimental.md).
+
+It is also possible to use the following configuration options to control Renovate's environment variables:
+
+- [`processEnv`](./self-hosted-configuration.md#processenv): in a configuration file (i.e. `config.js`), allows specifying the values that Renovate will receive in its environment
+
+## With child processes
+
+For security reasons, Renovate does not expose all environment variables to child processes.
+Instead, Renovate will use an allowlist of environment variables which it passes to any processes it calls.
+
+This is an intentional decision to protect against two key attack vectors:
+
+- an ["insider attack"](./security-and-permissions.md#execution-of-code-insider-attack) from a user of your self-hosted Renovate deployment
+- an ["outsider attack"](./security-and-permissions.md#execution-of-code-outsider-attack) from a malicious dependency
+
+By limiting the environment variables provided to child processes, we can reduce the risk of a malicious actor from receiving access to potentially sensitive information, such as authentication tokens.
+
+By default, Renovate will **always** pass the following environment variables to child processes:
+
+<!-- Autogenerate basicEnvVars -->
+
+!!! note
+  Some managers pass additional environment variables where necessary.
+  <br>
+  For example, Renovate will convert Host Rules to the respective environment variables when calling `npm`, `pnpm` and `yarn`, including setting `GIT_CONFIG_` environment variables.
+  <br>
+  This is not currently documented in full - you will need to review Renovate's code to see the full list.
+
+As a self-hosted administrator, you can make it possible to specify other environment variables that repository owners can set, using:
+
+- [`allowedEnv`](./self-hosted-configuration.md#allowedenv): allows users to specify values for allowlisted environment variables in their repository configuration using [`env`](./configuration-options.md#env)
+- [`customEnvVariables`](./self-hosted-configuration.md#customenvvariables): administrator-defined environment variables, injected directly into every child process. Users cannot override these in their repository configuration
+- [`exposeAllEnv`](./self-hosted-configuration.md#exposeallenv): ⚠️ dangerously expose all environment variables from the Renovate process to all child processes
+- [`extends: ["global:safeEnv"]`](./presets-global.md#globalsafeenv): a curated list of commonly used environment variables that should be safe to allow users to configure with [`env`](./configuration-options.md#env). This is used by Mend-hosted Renovate
+
+With these option(s) configured, users will be able to set these environment variable(s) in their repository configuration using [`env`](./configuration-options.md#env), as well as [referencing them in any fields that support templating](#templating).
+
+## Using environment variables for secrets
+
+Where possible, Renovate will try and redact secrets in its log messages, and the log output from any child processes.
+This relies on knowing whether the value is a secret for instance those configured through [`secrets`](./self-hosted-configuration.md#secrets) or in [`hostRules`](./configuration-options.md#hostrules).
+
+If specifying an environment variable - through the above - with a value that isn't known to Renovate as a secret, this may lead to the secret being unknowingly exposed in the logs.
+
+## Precedence
+
+When determining which environment variables Renovate should pass to a child process, Renovate merges with the following precedence order:
+
+```mermaid
+flowchart TD
+    extraEnv["<strong><code>extraEnv</code></strong><br/><small>Manager-defined defaults/hints string value = default, null = inherit key only</small>"]
+    parentEnv["<strong><code>parentEnv</code></strong><br/><small>process.env filtered to basicEnvVars<sup>1</sup> + string keys from extraEnv</small>"]
+    globalConfigEnv["<strong><code>globalConfigEnv</code></strong><br/><small><code>customEnvVariables</code> set by self-hosted admin at startup</small>"]
+    userConfiguredEnv["<strong><code>userConfiguredEnv</code></strong><br/><small><code>env</code> config in Renovate config file</small>"]
+    forcedEnv["<strong><code>forcedEnv</code></strong><br/><small>Hardcoded per exec-call by Renovate internals</small>"]
+    childProcess["<strong>Child Process</strong>"]
+    exposeAllEnv["<strong><code>exposeAllEnv = true</code></strong><br/><small>Bypasses all layering, passes entire <code>process.env</code></small>"]
+    processEnvConfig["<strong><code>processEnv</code></strong><br/><small></small>"]
+    processEnv["<strong><code>process.env</code></strong><br/><small>The original process' <code>process.env</code> and <code>processEnv</code></small>"]
+    allowedEnv["<strong><code>allowedEnv</code></strong><br/><small>Admin-controlled allowlist gates which environment variables repo owners may set</small>"]
+
+    extraEnv -->|"overridden by"| parentEnv
+    parentEnv -->|"overridden by"| globalConfigEnv
+    globalConfigEnv -->|"overridden by"| userConfiguredEnv
+    userConfiguredEnv -->|"overridden by"| forcedEnv
+    forcedEnv --> childProcess
+
+    exposeAllEnv -.->|"short-circuits to"| childProcess
+    processEnvConfig -.->|"merged into"| processEnv
+    processEnv -.->|"filtered with <code>basicEnvVars</code>"| parentEnv
+    allowedEnv -.->|"restricts"| userConfiguredEnv
+
+```
+
+<sup>1</sup>: the list of environment variables [noted above](#with-child-processes) that are always passed to child processes
+
+## Templating
+
+Allowlisted environment variables can be referenced in templates.
+See [templates and environment variables](./templates.md#environment-variables) for more details.

--- a/docs/usage/environment-variable-handling.md
+++ b/docs/usage/environment-variable-handling.md
@@ -21,7 +21,7 @@ This is an intentional decision to protect against two key attack vectors:
 - an ["insider attack"](./security-and-permissions.md#execution-of-code-insider-attack) from a user of your self-hosted Renovate deployment
 - an ["outsider attack"](./security-and-permissions.md#execution-of-code-outsider-attack) from a malicious dependency
 
-By reducing the environment variables provided to child processes, we can reduce the risk of a malicious actor from receiving access to potentially sensitive information, such as authentication tokens.
+By limiting the environment variables provided to child processes, we can reduce the risk of a malicious actor from receiving access to potentially sensitive information, such as authentication tokens.
 
 By default, Renovate will **always** pass the following environment variables to child processes:
 
@@ -40,9 +40,7 @@ As a self-hosted administrator, it is possible to allowlist other environment va
 - [`allowedEnv`](./self-hosted-configuration.md#allowedenv): allows users to specify values for allowlisted environment variables in their repository configuration using [`env`](./configuration-options.md#env)
 - [`customEnvVariables`](./self-hosted-configuration.md#customenvvariables): administrator-defined environment variables, injected directly into every child process. Users cannot override these in their repository configuration
 - [`exposeAllEnv`](./self-hosted-configuration.md#exposeallenv): ⚠️ dangerously expose all environment variables from the Renovate process to all child processes
-- [`extends: ["global:safeEnv"]`](./presets-global.md#globalsafeenv): a curated list of commonly used environment variables that should be safe to allow users to configure with [`env`](./configuration-options.md#env)
-  - These were chosen to be safe to **??** to allow self-hosted administrators to decide **??**
-  - This is used by Mend-hosted Renovate
+- [`extends: ["global:safeEnv"]`](./presets-global.md#globalsafeenv): a curated list of commonly used environment variables that should be safe to allow users to configure with [`env`](./configuration-options.md#env). This is used by Mend-hosted Renovate
 
 With these option(s) configured, users will be able to set these environment variable(s) in their repository configuration using [`env`](./configuration-options.md#env).
 

--- a/docs/usage/environment-variable-handling.md
+++ b/docs/usage/environment-variable-handling.md
@@ -46,6 +46,29 @@ As a self-hosted administrator, it is possible to allowlist other environment va
 
 With these option(s) configured, users will be able to set these environment variable(s) in their repository configuration using [`env`](./configuration-options.md#env).
 
+## Precedence
+
+```mermaid
+flowchart TD
+    A["<b>extraEnv</b><br/><small>Manager-defined defaults/hints<br/>string value = default, null = inherit key only</small>"]
+    B["<b>parentEnv</b><br/><small>process.env filtered to basicEnvVars<br/>+ string keys from extraEnv</small>"]
+    C["<b>globalConfigEnv</b><br/><small>customEnvVariables<br/>set by self-hosted admin at startup</small>"]
+    D["<b>userConfiguredEnv</b><br/><small>env config in renovate.json<br/>repo owner, restricted by allowedEnv</small>"]
+    E["<b>forcedEnv</b><br/><small>Hardcoded per exec-call<br/>by Renovate internals</small>"]
+    F["<b>Child Process</b>"]
+
+    A -->|"overridden by"| B
+    B -->|"overridden by"| C
+    C -->|"overridden by"| D
+    D -->|"overridden by"| E
+    E --> F
+
+    G["<b>exposeAllEnv = true</b><br/><small>Bypasses all layering,<br/>passes entire process.env</small>"]
+    G -.->|"short-circuits to"| F
+```
+
+This flows lowest-to-highest precedence top-to-bottom. The `exposeAllEnv` bypass is shown as a dashed shortcut since it skips the whole chain entirely.
+
 ## Templating
 
 Allowlisted environment variables can be referenced in templates.

--- a/docs/usage/environment-variable-handling.md
+++ b/docs/usage/environment-variable-handling.md
@@ -67,6 +67,33 @@ flowchart TD
 
 This flows lowest-to-highest precedence top-to-bottom. The `exposeAllEnv` bypass is shown as a dashed shortcut since it skips the whole chain entirely.
 
+---
+
+```mermaid
+flowchart TD
+    A["<b>extraEnv</b><br/><small>Manager-defined defaults/hints<br/>string value = default, null = inherit key only</small>"]
+    B["<b>parentEnv</b><br/><small>process.env filtered to basicEnvVars<br/>+ string keys from extraEnv</small>"]
+    C["<b>globalConfigEnv</b><br/><small>customEnvVariables<br/>set by self-hosted admin at startup</small>"]
+    D["<b>userConfiguredEnv</b><br/><small>env config in renovate.json<br/>set by repo owner</small>"]
+    E["<b>forcedEnv</b><br/><small>Hardcoded per exec-call<br/>by Renovate internals</small>"]
+    F["<b>Child Process</b>"]
+
+    GATE["<b>allowedEnv / global:safeEnv</b><br/><small>Admin-controlled allowlist —<br/>gates which keys repo owners may set</small>"]
+
+    A -->|"overridden by"| B
+    B -->|"overridden by"| C
+    C -->|"overridden by"| D
+    D -->|"overridden by"| E
+    E --> F
+
+    GATE -.->|"restricts"| D
+
+    G["<b>exposeAllEnv = true</b><br/><small>Bypasses all layering,<br/>passes entire process.env</small>"]
+    G -.->|"short-circuits to"| F
+```
+
+The `allowedEnv`/`global:safeEnv` gate is shown as a dashed restrictor on the user env layer — it doesn't participate in the merge order itself, it just controls what `userConfiguredEnv` is allowed to contain.
+
 ## Templating
 
 Allowlisted environment variables can be referenced in templates.

--- a/docs/usage/environment-variable-handling.md
+++ b/docs/usage/environment-variable-handling.md
@@ -40,8 +40,13 @@ As a self-hosted administrator, it is possible to allowlist other environment va
 - [`allowedEnv`](./self-hosted-configuration.md#allowedenv): allows users to specify values for allowlisted environment variables in their repository configuration using [`env`](./configuration-options.md#env)
 - [`customEnvVariables`](./self-hosted-configuration.md#customenvvariables): administrator-defined environment variables, injected directly into every child process. Users cannot override these in their repository configuration
 - [`exposeAllEnv`](./self-hosted-configuration.md#exposeallenv): ⚠️ dangerously expose all environment variables from the Renovate process to all child processes
-- [`extends: ["global:safeEnv"]`](./presets-global.md#globalsafeenv): a curated list of commonly used environment variables that should be safe to allow users to configure with [`env`](./configuration-options.md#env). Used in Mend-hosted Renovate
+- [`extends: ["global:safeEnv"]`](./presets-global.md#globalsafeenv): a curated list of commonly used environment variables that should be safe to allow users to configure with [`env`](./configuration-options.md#env)
+  - These were chosen to be safe to **??** to allow self-hosted administrators to decide **??**
+  - This is used by Mend-hosted Renovate
 
 With these option(s) configured, users will be able to set these environment variable(s) in their repository configuration using [`env`](./configuration-options.md#env).
 
 ## Templating
+
+Allowlisted environment variables can be referenced in templates.
+See [templates and environment variables](./templates.md#environment-variables) for more details.

--- a/docs/usage/environment-variable-handling.md
+++ b/docs/usage/environment-variable-handling.md
@@ -50,7 +50,7 @@ With these option(s) configured, users will be able to set these environment var
 flowchart TD
     A["<b>extraEnv</b><br/><small>Manager-defined defaults/hints<br/>string value = default, null = inherit key only</small>"]
     B["<b>parentEnv</b><br/><small>process.env filtered to basicEnvVars<br/>+ string keys from extraEnv</small>"]
-    C["<b>globalConfigEnv</b><br/><small>customEnvVariables<br/>set by self-hosted admin at startup</small>"]
+    C["<b>globalConfigEnv</b><br/><small><code>customEnvVariables</code><br/>set by self-hosted admin at startup</small>"]
     D["<b>userConfiguredEnv</b><br/><small>env config in renovate.json<br/>repo owner, restricted by allowedEnv</small>"]
     E["<b>forcedEnv</b><br/><small>Hardcoded per exec-call<br/>by Renovate internals</small>"]
     F["<b>Child Process</b>"]

--- a/docs/usage/environment-variable-handling.md
+++ b/docs/usage/environment-variable-handling.md
@@ -1,7 +1,27 @@
 # Environment Variable Handling
 
+## For Renovate
+
+Renovate itself can be configured through a number of environment variables that correspond with [global self-hosted configuration options](./self-hosted-configuration.md), as well as some [repository configuration options](./configuration-options.md).
+These environment variables are prefixed with `RENOVATE_`.
+
+Renovate also has some ["experimental" variables that can be used with self-hosted deployments](./self-hosted-experimental.md).
+
+It is also possible to use the following configuration options to control Renovate's environment variables:
+
+- [`processEnv`](./self-hosted-configuration.md#processenv): in a configuration file (i.e. `config.js`), allows specifying the values that Renovate will receive in its environment
+
+## With child processes
+
 For security reasons, Renovate does not expose all environment variables to child processes.
 Instead, Renovate will use an allowlist of environment variables which it passes to any processes it calls.
+
+This is an intentional decision to protect against two key attack vectors:
+
+- an ["insider attack"](./security-and-permissions.md#execution-of-code-insider-attack) from a user of your self-hosted Renovate deployment
+- an ["outsider attack"](./security-and-permissions.md#execution-of-code-outsider-attack) from a malicious dependency
+
+By reducing the environment variables provided to child processes, we can reduce the risk of a malicious actor from receiving access to potentially sensitive information, such as authentication tokens.
 
 By default, Renovate will **always** pass the following environment variables to child processes:
 
@@ -11,12 +31,17 @@ By default, Renovate will **always** pass the following environment variables to
 !!! note
     Some managers pass additional environment variables where necessary.
     <br>
+    For example, Renovate will convert Host Rules to the respective environment variables when calling `npm`, `pnpm` and `yarn`.
+    <br>
     This is not currently documented in full - you will need to review Renovate's code to see the full list.
 
 As a self-hosted administrator, it is possible to allowlist other environment variables that repository owners can set, using:
 
-- [`allowedEnv`](./self-hosted-configuration.md#allowedenv)
-- [`customEnvVariables`](./self-hosted-configuration.md#customenvvariables)
-- [`extends: ["global:safeEnv"]`](./presets-global.md#globalsafeenv)
+- [`allowedEnv`](./self-hosted-configuration.md#allowedenv): allows users to specify values for allowlisted environment variables in their repository configuration using [`env`](./configuration-options.md#env)
+- [`customEnvVariables`](./self-hosted-configuration.md#customenvvariables): administrator-defined environment variables, injected directly into every child process. Users cannot override these in their repository configuration
+- [`exposeAllEnv`](./self-hosted-configuration.md#exposeallenv): ⚠️ dangerously expose all environment variables from the Renovate process to all child processes
+- [`extends: ["global:safeEnv"]`](./presets-global.md#globalsafeenv): a curated list of commonly used environment variables that should be safe to allow users to configure with [`env`](./configuration-options.md#env). Used in Mend-hosted Renovate
 
-When using `allowedEnv`, users will then be able to specify the value for any environment variables allowlisted, using the [`env`](./configuration-options.md#env) configuration option in their repository configuration.
+With these option(s) configured, users will be able to set these environment variable(s) in their repository configuration using [`env`](./configuration-options.md#env).
+
+## Templating

--- a/docs/usage/templates.md
+++ b/docs/usage/templates.md
@@ -184,11 +184,16 @@ If you want to convert key-value pairs to an object, use `toObject`, e.g.,
 
 ## Environment variables
 
-By default, you can only access a handful of basic environment variables like `HOME` or `PATH`.
+By default, templates can only access [a subset of environment variables](./environment-variable-handling.md#with-child-processes) like `HOME` or `PATH`.
 This is for security reasons.
+
+You can reference environment variables like so:
 
 `HOME is {{env.HOME}}`
 
-If you're self-hosting Renovate, you can expose more variables with the [`customEnvVariables`](./self-hosted-configuration.md#customenvvariables) config option.
+If you're self-hosting Renovate, you can expose more variables with the [`customEnvVariables`](./self-hosted-configuration.md#customenvvariables) config option, which will also be available to all child processes.
 
-You can also use the [`exposeAllEnv`](./self-hosted-configuration.md#exposeallenv) config option to allow all environment variables in templates, but make sure to consider the security implications of giving the scripts unrestricted access to all variables.
+See also: [environment variable handling](./environment-variable-handling.md).
+
+!!! warning
+  It is possible to use the [`exposeAllEnv`](./self-hosted-configuration.md#exposeallenv) config option to allow all environment variables in templates, but make sure to consider the security implications of giving the scripts unrestricted access to all variables.

--- a/docs/usage/templates.md
+++ b/docs/usage/templates.md
@@ -189,6 +189,10 @@ This is for security reasons.
 
 `HOME is {{env.HOME}}`
 
-If you're self-hosting Renovate, you can expose more variables with the [`customEnvVariables`](./self-hosted-configuration.md#customenvvariables) config option.
+If you're self-hosting Renovate, you can expose more variables with the [`customEnvVariables`](./self-hosted-configuration.md#customenvvariables) config option, which will also be available to all child processes.
 
-You can also use the [`exposeAllEnv`](./self-hosted-configuration.md#exposeallenv) config option to allow all environment variables in templates, but make sure to consider the security implications of giving the scripts unrestricted access to all variables.
+See also: [environment variable handling](./environment-variable-handling.md).
+
+<!-- prettier-ignore -->
+!!! warning
+    It is possible to use the [`exposeAllEnv`](./self-hosted-configuration.md#exposeallenv) config option to allow all environment variables in templates, but make sure to consider the security implications of giving the scripts unrestricted access to all variables.

--- a/lib/util/exec/env.ts
+++ b/lib/util/exec/env.ts
@@ -1,6 +1,6 @@
 import { GlobalConfig } from '../../config/global.ts';
 
-const basicEnvVars = [
+export const basicEnvVars = [
   'CI',
   'HTTP_PROXY',
   'HTTPS_PROXY',

--- a/lib/util/exec/env.ts
+++ b/lib/util/exec/env.ts
@@ -1,6 +1,6 @@
 import { GlobalConfig } from '../../config/global.ts';
 
-const basicEnvVars = [
+export const basicEnvVars = [
   'CI',
   'HTTP_PROXY',
   'HTTPS_PROXY',
@@ -46,7 +46,7 @@ const basicEnvVars = [
   // pnpm specific variables
   'PNPM_WORKERS',
   'PNPM_MAX_WORKERS',
-];
+] as const;
 
 export function getChildProcessEnv(
   customEnvVars: string[] = [],

--- a/lib/util/exec/env.ts
+++ b/lib/util/exec/env.ts
@@ -46,7 +46,7 @@ export const basicEnvVars = [
   // pnpm specific variables
   'PNPM_WORKERS',
   'PNPM_MAX_WORKERS',
-];
+] as const;
 
 export function getChildProcessEnv(
   customEnvVars: string[] = [],

--- a/tools/docs/env-vars.ts
+++ b/tools/docs/env-vars.ts
@@ -1,0 +1,16 @@
+import { basicEnvVars } from '../../lib/util/exec/env.ts';
+import { readFile, updateFile } from '../utils/index.ts';
+import { replaceContent } from './utils.ts';
+
+export async function generateEnvVars(dist: string): Promise<void> {
+  const list = basicEnvVars
+    // case-insensitive sort
+    .sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }))
+    .map((v) => ` - \`${v}\``)
+    .join('\n');
+  const txt = `${list}\n\n`;
+
+  let content = await readFile('docs/usage/environment-variable-handling.md');
+  content = replaceContent(content, txt, '<!-- Autogenerate basicEnvVars -->');
+  await updateFile(`${dist}/environment-variable-handling.md`, content);
+}

--- a/tools/docs/env-vars.ts
+++ b/tools/docs/env-vars.ts
@@ -1,0 +1,16 @@
+import { basicEnvVars } from '../../lib/util/exec/env.ts';
+import { readFile, updateFile } from '../utils/index.ts';
+import { replaceContent } from './utils.ts';
+
+export async function generateEnvVars(dist: string): Promise<void> {
+  const list = [...basicEnvVars]
+    // case-insensitive sort
+    .sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }))
+    .map((v) => ` - \`${v}\``)
+    .join('\n');
+  const txt = `${list}\n\n`;
+
+  let content = await readFile('docs/usage/environment-variable-handling.md');
+  content = replaceContent(content, txt, '<!-- Autogenerate basicEnvVars -->');
+  await updateFile(`${dist}/environment-variable-handling.md`, content);
+}

--- a/tools/docs/env-vars.ts
+++ b/tools/docs/env-vars.ts
@@ -3,7 +3,7 @@ import { readFile, updateFile } from '../utils/index.ts';
 import { replaceContent } from './utils.ts';
 
 export async function generateEnvVars(dist: string): Promise<void> {
-  const list = basicEnvVars
+  const list = [...basicEnvVars]
     // case-insensitive sort
     .sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }))
     .map((v) => ` - \`${v}\``)

--- a/tools/docs/index.ts
+++ b/tools/docs/index.ts
@@ -5,6 +5,7 @@ import { getProblems, logger } from '../../lib/logger/index.ts';
 import { generateConfig } from './config.ts';
 import { generateDatasources } from './datasources.ts';
 import { generateEnvOptions } from './env-options.ts';
+import { generateEnvVars } from './env-vars.ts';
 import { getOpenGitHubItems } from './github-query-items.ts';
 import { generateManagers } from './manager.ts';
 import { generateManagerAsdfSupportedPlugins } from './manager-asdf-supported-plugins.ts';
@@ -74,6 +75,10 @@ export async function generateDocs(
     // env-options
     logger.info('* env-options');
     await generateEnvOptions(dist);
+
+    // environment-variable-handling
+    logger.info('* environment-variable-handling');
+    await generateEnvVars(dist);
 
     // json-schema
     logger.info('* json-schema');


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->


As part of recent work around environment variable handling, it's clear
we should provide more user-facing documentation on how environment
variables are handled, and which are passed to child processes by
default.

We can create a "deep dive" page for this, with an autogenerated list of
the environment variables in `basicEnvVars` that are always passed to
child processes, if they're set.

We can also point self-hosted administrators and users alike to the
options they have to control this, too.




## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
