### PR TITLE
test(noNewURL): add new rule enforcing parseUrl() from 'lib/util/url.ts'

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -48,6 +48,7 @@
     "no-unassigned-vars": "error",
 
     "renovate/enforce-ts-extension": "error",
+    "renovate/no-new-url": "error",
     "renovate/no-tools-import": "error",
 
     "typescript/await-thenable": "error",

--- a/lib/modules/datasource/deb/url.spec.ts
+++ b/lib/modules/datasource/deb/url.spec.ts
@@ -37,6 +37,10 @@ describe('modules/datasource/deb/url', () => {
         'Missing required query parameter',
       );
     });
+
+    it('returns empty array for invalid registry URL', () => {
+      expect(constructComponentUrls('not-a-valid-url')).toEqual([]);
+    });
   });
 
   describe('checkIfModified', () => {

--- a/lib/modules/datasource/deb/url.ts
+++ b/lib/modules/datasource/deb/url.ts
@@ -1,6 +1,6 @@
 import { logger } from '../../../logger/index.ts';
 import type { Http, HttpOptions } from '../../../util/http/index.ts';
-import { joinUrlParts } from '../../../util/url.ts';
+import { joinUrlParts, parseUrl } from '../../../util/url.ts';
 
 /**
  * Extracts the base suite URL from a package URL by removing the last two path segments.
@@ -29,7 +29,10 @@ export function constructComponentUrls(registryUrl: string): string[] {
   const OPTIONAL_PARAMS = ['suite', 'release'];
 
   try {
-    const url = new URL(registryUrl);
+    const url = parseUrl(registryUrl);
+    if (!url) {
+      return [];
+    }
     validateUrlAndParams(url, REQUIRED_PARAMS);
 
     const suite = getReleaseParam(url, OPTIONAL_PARAMS);

--- a/lib/modules/datasource/docker/common.spec.ts
+++ b/lib/modules/datasource/docker/common.spec.ts
@@ -113,6 +113,15 @@ describe('modules/datasource/docker/common', () => {
     ])('($name, $url)', ({ name, url, res }) => {
       expect(getRegistryRepository(name, url)).toStrictEqual(res);
     });
+
+    it('returns raw registryHost and dockerRepository when fullUrl is invalid', () => {
+      // 'https://[/prefix' is a syntactically invalid URL (unclosed bracket)
+      const res = getRegistryRepository('[/prefix/image', 'https://[/prefix');
+      expect(res).toStrictEqual({
+        registryHost: 'https://[/prefix',
+        dockerRepository: 'image',
+      });
+    });
   });
 
   describe('getAuthHeaders', () => {

--- a/lib/modules/datasource/docker/common.ts
+++ b/lib/modules/datasource/docker/common.ts
@@ -171,6 +171,7 @@ export async function getAuthHeaders(
       return opts.headers ?? null;
     }
 
+    // already guarded by above clause
     const authUrl = parseUrl(`${authenticateHeader.params.realm}`)!;
 
     // repo isn't known to server yet, so causing wrong scope `repository:user/image:pull`
@@ -280,9 +281,12 @@ export function getRegistryRepository(
       }
       let dockerRepository = packageName.replace(registryEndingWithSlash, '');
       const fullUrl = `${registryHost}/${dockerRepository}`;
-      const { origin, pathname } = parseUrl(fullUrl)!;
-      registryHost = origin;
-      dockerRepository = pathname.substring(1);
+      const parsedFullUrl = parseUrl(fullUrl);
+      if (!parsedFullUrl) {
+        return { registryHost, dockerRepository };
+      }
+      registryHost = parsedFullUrl.origin;
+      dockerRepository = parsedFullUrl.pathname.substring(1);
       return {
         registryHost,
         dockerRepository,

--- a/lib/modules/datasource/docker/common.ts
+++ b/lib/modules/datasource/docker/common.ts
@@ -171,7 +171,7 @@ export async function getAuthHeaders(
       return opts.headers ?? null;
     }
 
-    const authUrl = new URL(`${authenticateHeader.params.realm}`);
+    const authUrl = parseUrl(`${authenticateHeader.params.realm}`)!;
 
     // repo isn't known to server yet, so causing wrong scope `repository:user/image:pull`
     if (

--- a/lib/modules/datasource/docker/index.ts
+++ b/lib/modules/datasource/docker/index.ts
@@ -739,7 +739,11 @@ export class DockerDatasource extends Datasource {
         // Artifactory bug: next link comes back without virtual-repo prefix (RTFACT-18971)
         if (linkHeader?.next?.last) {
           // parse the current URL, strip any old "last" param, then set the new one
-          const parsed: URL = parseUrl(url)!;
+          const parsed = parseUrl(url);
+          if (!parsed) {
+            url = null;
+            break;
+          }
           parsed.searchParams.delete('last');
           parsed.searchParams.set('last', linkHeader.next.last);
           url = parsed.href;

--- a/lib/modules/datasource/docker/index.ts
+++ b/lib/modules/datasource/docker/index.ts
@@ -740,7 +740,7 @@ export class DockerDatasource extends Datasource {
         if (linkHeader?.next?.last) {
           // parse the current URL, strip any old "last" param, then set the new one
           const parsed = parseUrl(url);
-          // istanbul ignore if: url is always a valid HTTP URL as `ensurePathPrefix`
+          // v8 ignore if: url is always a valid HTTP URL as `ensurePathPrefix`
           if (!parsed) {
             url = null;
             break;

--- a/lib/modules/datasource/docker/index.ts
+++ b/lib/modules/datasource/docker/index.ts
@@ -16,6 +16,7 @@ import {
   ensurePathPrefix,
   joinUrlParts,
   parseLinkHeader,
+  parseUrl,
 } from '../../../util/url.ts';
 import { id as dockerVersioningId } from '../../versioning/docker/index.ts';
 import { Datasource } from '../datasource.ts';
@@ -738,7 +739,7 @@ export class DockerDatasource extends Datasource {
         // Artifactory bug: next link comes back without virtual-repo prefix (RTFACT-18971)
         if (linkHeader?.next?.last) {
           // parse the current URL, strip any old "last" param, then set the new one
-          const parsed: URL = new URL(url);
+          const parsed: URL = parseUrl(url)!;
           parsed.searchParams.delete('last');
           parsed.searchParams.set('last', linkHeader.next.last);
           url = parsed.href;

--- a/lib/modules/datasource/docker/index.ts
+++ b/lib/modules/datasource/docker/index.ts
@@ -740,6 +740,7 @@ export class DockerDatasource extends Datasource {
         if (linkHeader?.next?.last) {
           // parse the current URL, strip any old "last" param, then set the new one
           const parsed = parseUrl(url);
+          // istanbul ignore if: url is always a valid HTTP URL as `ensurePathPrefix`
           if (!parsed) {
             url = null;
             break;

--- a/lib/modules/datasource/glasskube-packages/index.spec.ts
+++ b/lib/modules/datasource/glasskube-packages/index.spec.ts
@@ -1,23 +1,24 @@
 import { Fixtures } from '~test/fixtures.ts';
 import * as httpMock from '~test/http-mock.ts';
+import { parseUrl } from '../../../util/url.ts';
 import { getPkgReleases } from '../index.ts';
 import { GlasskubePackagesDatasource } from './index.ts';
 
 describe('modules/datasource/glasskube-packages/index', () => {
   const customRegistryUrl = 'https://packages.test.example/packages';
-  const customVersionsUrl = new URL(
+  const customVersionsUrl = parseUrl(
     `${customRegistryUrl}/cloudnative-pg/versions.yaml`,
-  );
-  const defaultVersionUrl = new URL(
+  )!;
+  const defaultVersionUrl = parseUrl(
     `${GlasskubePackagesDatasource.defaultRegistryUrl}/cloudnative-pg/versions.yaml`,
-  );
+  )!;
   const versionsYaml = Fixtures.get('versions.yaml');
-  const customPackageManifestUrl = new URL(
+  const customPackageManifestUrl = parseUrl(
     `${customRegistryUrl}/cloudnative-pg/v1.23.1+1/package.yaml`,
-  );
-  const defaultPackageManifestUrl = new URL(
+  )!;
+  const defaultPackageManifestUrl = parseUrl(
     `${GlasskubePackagesDatasource.defaultRegistryUrl}/cloudnative-pg/v1.23.1+1/package.yaml`,
-  );
+  )!;
   const packageManifestYaml = Fixtures.get('package.yaml');
   const packageManifestNoReferencesYaml = Fixtures.get(
     'package_no_references.yaml',

--- a/lib/modules/datasource/maven/util.spec.ts
+++ b/lib/modules/datasource/maven/util.spec.ts
@@ -4,6 +4,7 @@ import { HOST_DISABLED } from '../../../constants/error-messages.ts';
 import { ExternalHostError } from '../../../types/errors/external-host-error.ts';
 import * as packageCache from '../../../util/cache/package/index.ts';
 import { Http, HttpError } from '../../../util/http/index.ts';
+import { parseUrl } from '../../../util/url.ts';
 import { MAVEN_REPO } from './common.ts';
 import type { MavenFetchError } from './types.ts';
 import {
@@ -52,7 +53,7 @@ describe('modules/datasource/maven/util', () => {
     it('returns error for unsupported protocols', async () => {
       const res = await downloadMavenXml(
         http,
-        new URL('unsupported://server.com/'),
+        parseUrl('unsupported://server.com/')!,
       );
       expect(res.unwrap()).toEqual({
         ok: false,
@@ -69,7 +70,10 @@ describe('modules/datasource/maven/util', () => {
             headers: {},
           }),
       });
-      const res = await downloadMavenXml(http, new URL('https://example.com/'));
+      const res = await downloadMavenXml(
+        http,
+        parseUrl('https://example.com/')!,
+      );
       expect(res.unwrap()).toEqual({
         ok: false,
         err: { type: 'xml-parse-error', err: expect.any(Error) },
@@ -96,7 +100,7 @@ describe('modules/datasource/maven/util', () => {
 
   describe('downloadS3Protocol', () => {
     it('returns error for non-S3 URLs', async () => {
-      const res = await downloadS3Protocol(new URL('http://not-s3.com/'));
+      const res = await downloadS3Protocol(parseUrl('http://not-s3.com/')!);
       expect(res.unwrap()).toEqual({
         ok: false,
         err: { type: 'invalid-url' } satisfies MavenFetchError,

--- a/lib/modules/datasource/npm/get.spec.ts
+++ b/lib/modules/datasource/npm/get.spec.ts
@@ -4,6 +4,7 @@ import * as _packageCache from '../../../util/cache/package/index.ts';
 import * as hostRules from '../../../util/host-rules.ts';
 import { Http } from '../../../util/http/index.ts';
 import type { HttpResponse } from '../../../util/http/types.ts';
+import { parseUrl } from '../../../util/url.ts';
 import { defaultRegistryUrl } from './common.ts';
 import { getDependency } from './get.ts';
 import { resolveRegistryUrl, setNpmrc } from './npmrc.ts';
@@ -300,7 +301,7 @@ describe('modules/datasource/npm/get', () => {
   });
 
   it('do not throw ExternalHostError when error happens on registry.npmjs.org when hostRules without protocol disables abortOnError', async () => {
-    const host = new URL(defaultRegistryUrl).host;
+    const host = parseUrl(defaultRegistryUrl)!.host;
     hostRules.add({
       matchHost: host,
       abortOnError: false,

--- a/lib/modules/datasource/sbt-package/index.spec.ts
+++ b/lib/modules/datasource/sbt-package/index.spec.ts
@@ -3,9 +3,11 @@ import { Fixtures } from '~test/fixtures.ts';
 import * as httpMock from '~test/http-mock.ts';
 import * as _packageCache from '../../../util/cache/package/index.ts';
 import { regEx } from '../../../util/regex.ts';
+import * as urlUtil from '../../../util/url.ts';
 import * as mavenVersioning from '../../versioning/maven/index.ts';
 import { getPkgReleases } from '../index.ts';
 import { MAVEN_REPO } from '../maven/common.ts';
+import * as mavenUtil from '../maven/util.ts';
 import { SbtPackageDatasource } from './index.ts';
 import { extractPageLinks } from './util.ts';
 
@@ -278,6 +280,83 @@ describe('modules/datasource/sbt-package/index', () => {
       });
 
       expect(res).toMatchObject({});
+    });
+
+    it('continues when parseUrl returns null for packageRootUrl', async () => {
+      httpMock
+        .scope('https://repo.maven.apache.org/maven2/')
+        .get('/org/example/example/maven-metadata.xml')
+        .reply(404);
+
+      const downloadSpy = vi
+        .spyOn(mavenUtil, 'downloadHttpContent')
+        .mockResolvedValueOnce(
+          `<a href="example/" title='example/'>example/</a>`,
+        )
+        .mockResolvedValueOnce(null); // dot-separated group URL returns nothing
+
+      const realParseUrl = urlUtil.parseUrl;
+      const parseUrlSpy = vi
+        .spyOn(urlUtil, 'parseUrl')
+        .mockImplementation((url) => {
+          if (
+            typeof url === 'string' &&
+            url === 'https://repo.maven.apache.org/maven2/org/example/'
+          ) {
+            return null;
+          }
+          return realParseUrl(url);
+        });
+
+      const res = await getPkgReleases({
+        versioning: mavenVersioning.id,
+        datasource: SbtPackageDatasource.id,
+        packageName: 'org.example:example',
+        registryUrls: [MAVEN_REPO],
+      });
+
+      parseUrlSpy.mockRestore();
+      downloadSpy.mockRestore();
+      expect(res).toBeNull();
+    });
+
+    it('skips pkgUrl when parseUrl returns null for it', async () => {
+      httpMock
+        .scope('https://repo.maven.apache.org/maven2/')
+        .get('/org/example/example/maven-metadata.xml')
+        .reply(404);
+
+      const downloadSpy = vi
+        .spyOn(mavenUtil, 'downloadHttpContent')
+        .mockResolvedValueOnce(
+          `<a href="example/" title='example/'>example/</a>`,
+        )
+        .mockResolvedValueOnce(null) // dot-separated group URL returns nothing
+        .mockResolvedValueOnce(`<a href='1.2.3/'>1.2.3/</a>`); // artifact subdir
+
+      const realParseUrl = urlUtil.parseUrl;
+      const parseUrlSpy = vi
+        .spyOn(urlUtil, 'parseUrl')
+        .mockImplementation((url) => {
+          if (
+            typeof url === 'string' &&
+            url === 'https://repo.maven.apache.org/maven2/org/example/example/'
+          ) {
+            return null;
+          }
+          return realParseUrl(url);
+        });
+
+      const res = await getPkgReleases({
+        versioning: mavenVersioning.id,
+        datasource: SbtPackageDatasource.id,
+        packageName: 'org.example:example',
+        registryUrls: [MAVEN_REPO],
+      });
+
+      parseUrlSpy.mockRestore();
+      downloadSpy.mockRestore();
+      expect(res).toBeNull();
     });
   });
 

--- a/lib/modules/datasource/sbt-package/index.ts
+++ b/lib/modules/datasource/sbt-package/index.ts
@@ -7,7 +7,11 @@ import { Http } from '../../../util/http/index.ts';
 import { regEx } from '../../../util/regex.ts';
 import type { Timestamp } from '../../../util/timestamp.ts';
 import { asTimestamp } from '../../../util/timestamp.ts';
-import { ensureTrailingSlash, trimTrailingSlash } from '../../../util/url.ts';
+import {
+  ensureTrailingSlash,
+  parseUrl,
+  trimTrailingSlash,
+} from '../../../util/url.ts';
 import * as ivyVersioning from '../../versioning/ivy/index.ts';
 import { compare } from '../../versioning/maven/compare.ts';
 import { MAVEN_REPO } from '../maven/common.ts';
@@ -106,7 +110,7 @@ export class SbtPackageDatasource extends MavenDatasource {
 
       dependencyUrl = trimTrailingSlash(packageRootUrl);
 
-      const rootPath = new URL(packageRootUrl).pathname;
+      const rootPath = parseUrl(packageRootUrl)!.pathname;
       const artifactSubdirs = extractPageLinks(packageRootContent, (href) => {
         const path = href.replace(rootPath, '');
 
@@ -160,7 +164,7 @@ export class SbtPackageDatasource extends MavenDatasource {
         continue;
       }
 
-      const rootPath = new URL(pkgUrl).pathname;
+      const rootPath = parseUrl(pkgUrl)!.pathname;
       const versions = extractPageLinks(packageContent, (href) => {
         const path = href.replace(rootPath, '');
         if (path.startsWith('.')) {

--- a/lib/modules/datasource/sbt-package/index.ts
+++ b/lib/modules/datasource/sbt-package/index.ts
@@ -110,7 +110,12 @@ export class SbtPackageDatasource extends MavenDatasource {
 
       dependencyUrl = trimTrailingSlash(packageRootUrl);
 
-      const rootPath = parseUrl(packageRootUrl)!.pathname;
+      const parsedPackageRootUrl = parseUrl(packageRootUrl);
+      if (!parsedPackageRootUrl) {
+        logger.warn({ packageRootUrl }, 'Failed to parse packageURL');
+        continue;
+      }
+      const rootPath = parsedPackageRootUrl.pathname;
       const artifactSubdirs = extractPageLinks(packageRootContent, (href) => {
         const path = href.replace(rootPath, '');
 
@@ -157,6 +162,12 @@ export class SbtPackageDatasource extends MavenDatasource {
 
     const allVersions = new Set<string>();
     for (const pkgUrl of packageUrls) {
+      const parsedPkgUrl = parseUrl(pkgUrl);
+      if (!parsedPkgUrl) {
+        invalidPackageUrls.add(pkgUrl);
+        continue;
+      }
+
       const packageContent = await downloadHttpContent(this.http, pkgUrl);
       // istanbul ignore if
       if (!packageContent) {
@@ -164,7 +175,7 @@ export class SbtPackageDatasource extends MavenDatasource {
         continue;
       }
 
-      const rootPath = parseUrl(pkgUrl)!.pathname;
+      const rootPath = parsedPkgUrl.pathname;
       const versions = extractPageLinks(packageContent, (href) => {
         const path = href.replace(rootPath, '');
         if (path.startsWith('.')) {

--- a/lib/modules/datasource/unity3d/index.spec.ts
+++ b/lib/modules/datasource/unity3d/index.spec.ts
@@ -1,5 +1,6 @@
 import { Fixtures } from '~test/fixtures.ts';
 import * as httpMock from '~test/http-mock.ts';
+import { parseUrl } from '../../../util/url.ts';
 import { getPkgReleases } from '../index.ts';
 import { Unity3dDatasource } from './index.ts';
 import { UnityReleasesJSON } from './schema.ts';
@@ -16,7 +17,7 @@ describe('modules/datasource/unity3d/index', () => {
     for (const stream in streams) {
       const content = fixtures[stream];
 
-      const uri = new URL(streams[stream]);
+      const uri = parseUrl(streams[stream])!;
       httpMock
         .scope(uri.origin)
         .get(`${uri.pathname}${uri.search}`)
@@ -303,12 +304,12 @@ describe('modules/datasource/unity3d/index', () => {
   });
 
   it('uses pagination', async () => {
-    const uriPageOne = new URL(
+    const uriPageOne = parseUrl(
       `${Unity3dDatasource.streams.lts}&limit=25&offset=0`,
-    );
-    const uriPageTwo = new URL(
+    )!;
+    const uriPageTwo = parseUrl(
       `${Unity3dDatasource.streams.lts}&limit=25&offset=25`,
-    );
+    )!;
 
     const total = 30;
 

--- a/lib/modules/manager/cake/index.ts
+++ b/lib/modules/manager/cake/index.ts
@@ -36,40 +36,36 @@ const lexer = moo.states({
 });
 
 function parseDependencyLine(line: string): NugetPackageDependency | null {
-  try {
-    let url = line.replace(regEx(/^[^:]*:/), '');
-    const isEmptyHost = url.startsWith('?');
-    url = isEmptyHost ? `http://localhost/${url}` : url;
+  let url = line.replace(regEx(/^[^:]*:/), '');
+  const isEmptyHost = url.startsWith('?');
+  url = isEmptyHost ? `http://localhost/${url}` : url;
 
-    const parsedUrl = parseUrl(url);
-    if (!parsedUrl) {
-      return null;
-    }
-    const { origin, pathname, searchParams } = parsedUrl;
-
-    const registryUrl = `${origin}${pathname}`;
-
-    const depName = searchParams.get('package')!;
-    const currentValue = searchParams.get('version') ?? undefined;
-
-    const result: NugetPackageDependency = {
-      datasource: NugetDatasource.id,
-      depName,
-      currentValue,
-    };
-
-    if (!isEmptyHost) {
-      if (isHttpUrl(parsedUrl)) {
-        result.registryUrls = [registryUrl];
-      } else {
-        result.skipReason = 'unsupported-url';
-      }
-    }
-
-    return result;
-  } catch {
+  const parsedUrl = parseUrl(url);
+  if (!parsedUrl) {
     return null;
   }
+  const { origin, pathname, searchParams } = parsedUrl;
+
+  const registryUrl = `${origin}${pathname}`;
+
+  const depName = searchParams.get('package')!;
+  const currentValue = searchParams.get('version') ?? undefined;
+
+  const result: NugetPackageDependency = {
+    datasource: NugetDatasource.id,
+    depName,
+    currentValue,
+  };
+
+  if (!isEmptyHost) {
+    if (isHttpUrl(parsedUrl)) {
+      result.registryUrls = [registryUrl];
+    } else {
+      result.skipReason = 'unsupported-url';
+    }
+  }
+
+  return result;
 }
 
 function parseAndPushDependencyLine(

--- a/lib/modules/manager/cake/index.ts
+++ b/lib/modules/manager/cake/index.ts
@@ -1,7 +1,7 @@
 import moo from 'moo';
 import type { Category } from '../../../constants/index.ts';
 import { regEx } from '../../../util/regex.ts';
-import { isHttpUrl } from '../../../util/url.ts';
+import { isHttpUrl, parseUrl } from '../../../util/url.ts';
 import { NugetDatasource } from '../../datasource/nuget/index.ts';
 import type { NugetPackageDependency, Registry } from '../nuget/types.ts';
 import { applyRegistries, getConfiguredRegistries } from '../nuget/util.ts';
@@ -41,7 +41,10 @@ function parseDependencyLine(line: string): NugetPackageDependency | null {
     const isEmptyHost = url.startsWith('?');
     url = isEmptyHost ? `http://localhost/${url}` : url;
 
-    const parsedUrl = new URL(url);
+    const parsedUrl = parseUrl(url);
+    if (!parsedUrl) {
+      return null;
+    }
     const { origin, pathname, searchParams } = parsedUrl;
 
     const registryUrl = `${origin}${pathname}`;

--- a/lib/modules/manager/custom/regex/utils.spec.ts
+++ b/lib/modules/manager/custom/regex/utils.spec.ts
@@ -1,5 +1,16 @@
+import { partial } from '~test/util.ts';
+import { logger } from '../../../../logger/index.ts';
 import { regEx } from '../../../../util/regex.ts';
+import type { PackageFileInfo, RegexManagerConfig } from './types.ts';
 import * as utils from './utils.ts';
+
+const baseConfig = partial<RegexManagerConfig>({ matchStrings: [] });
+const baseFileInfo = partial<PackageFileInfo>({
+  packageFile: 'file.txt',
+  packageFileName: 'file.txt',
+  packageFileDir: '.',
+  content: '',
+});
 
 describe('modules/manager/custom/regex/utils', () => {
   it('does not crash for lazy regex', () => {
@@ -10,5 +21,83 @@ describe('modules/manager/custom/regex/utils', () => {
         '1f699d2bfc99bbbe4c1ed5bb8fc21e6911d69c6e\n',
       ),
     ).toBeArray();
+  });
+
+  describe('createDependency', () => {
+    it('sets registryUrls when registryUrl group is a valid URL', () => {
+      const dep = utils.createDependency(
+        {
+          groups: { registryUrl: 'https://registry.example.com/' },
+          replaceString: undefined,
+        },
+        baseConfig,
+        baseFileInfo,
+      );
+      expect(dep?.registryUrls).toEqual(['https://registry.example.com/']);
+    });
+
+    it('warns and skips registryUrls when registryUrl group is an invalid URL', () => {
+      const dep = utils.createDependency(
+        {
+          groups: { registryUrl: 'not-a-valid-url' },
+          replaceString: undefined,
+        },
+        baseConfig,
+        baseFileInfo,
+      );
+      expect(dep?.registryUrls).toBeUndefined();
+      expect(logger.warn).toHaveBeenCalledWith(
+        { value: 'not-a-valid-url' },
+        'Invalid regex manager registryUrl',
+      );
+    });
+
+    it('sets datasource when datasource group is provided', () => {
+      const dep = utils.createDependency(
+        {
+          groups: { datasource: 'npm', currentValue: '1.0.0', depName: 'foo' },
+          replaceString: undefined,
+        },
+        baseConfig,
+        baseFileInfo,
+      );
+      expect(dep?.datasource).toBe('npm');
+    });
+
+    it('sets indentation when indentation group is whitespace', () => {
+      const dep = utils.createDependency(
+        {
+          groups: { indentation: '  ', depName: 'foo' },
+          replaceString: undefined,
+        },
+        baseConfig,
+        baseFileInfo,
+      );
+      expect(dep?.indentation).toBe('  ');
+    });
+
+    it('sets empty indentation when indentation group is non-whitespace', () => {
+      const dep = utils.createDependency(
+        {
+          groups: { indentation: 'abc', depName: 'foo' },
+          replaceString: undefined,
+        },
+        baseConfig,
+        baseFileInfo,
+      );
+      expect(dep?.indentation).toBe('');
+    });
+
+    it('sets depName via default branch', () => {
+      const dep = utils.createDependency(
+        {
+          groups: { depName: 'my-package' },
+          replaceString: undefined,
+        },
+        baseConfig,
+        baseFileInfo,
+      );
+      expect(dep?.depName).toBe('my-package');
+    });
   });
 });

--- a/lib/modules/manager/custom/regex/utils.ts
+++ b/lib/modules/manager/custom/regex/utils.ts
@@ -19,19 +19,16 @@ function updateDependency(
   value: string,
 ): void {
   switch (field) {
-    case 'registryUrl':
+    case 'registryUrl': {
       // check if URL is valid and pack inside an array
-      try {
-        const url = parseUrl(value)?.toString();
-        if (url) {
-          dependency.registryUrls = [url];
-        } else {
-          logger.warn({ value }, 'Invalid regex manager registryUrl');
-        }
-      } catch {
+      const url = parseUrl(value)?.toString();
+      if (url) {
+        dependency.registryUrls = [url];
+      } else {
         logger.warn({ value }, 'Invalid regex manager registryUrl');
       }
       break;
+    }
     case 'datasource':
       dependency.datasource = migrateDatasource(value);
       break;

--- a/lib/modules/manager/custom/regex/utils.ts
+++ b/lib/modules/manager/custom/regex/utils.ts
@@ -2,6 +2,7 @@ import { isEmptyStringOrWhitespace } from '@sindresorhus/is';
 import { migrateDatasource } from '../../../../config/migrations/custom/datasource-migration.ts';
 import { logger } from '../../../../logger/index.ts';
 import * as template from '../../../../util/template/index.ts';
+import { parseUrl } from '../../../../util/url.ts';
 import type { PackageDependency } from '../../types.ts';
 import type { ValidMatchFields } from '../utils.ts';
 import { validMatchFields } from '../utils.ts';
@@ -21,8 +22,12 @@ function updateDependency(
     case 'registryUrl':
       // check if URL is valid and pack inside an array
       try {
-        const url = new URL(value).toString();
-        dependency.registryUrls = [url];
+        const url = parseUrl(value)?.toString();
+        if (url) {
+          dependency.registryUrls = [url];
+        } else {
+          logger.warn({ value }, 'Invalid regex manager registryUrl');
+        }
       } catch {
         logger.warn({ value }, 'Invalid regex manager registryUrl');
       }

--- a/lib/modules/manager/github-actions/extract.spec.ts
+++ b/lib/modules/manager/github-actions/extract.spec.ts
@@ -150,6 +150,18 @@ describe('modules/manager/github-actions/extract', () => {
       expect(res?.deps[0].registryUrls).toBeUndefined();
     });
 
+    it('returns undefined registryUrls when endpoint is invalid URL', () => {
+      GlobalConfig.set({
+        platform: 'github',
+        endpoint: 'not-a-valid-url',
+      });
+      const res = extractPackageFile(
+        Fixtures.get('workflow_2.yml'),
+        'workflow_2.yml',
+      );
+      expect(res?.deps[0].registryUrls).toBeUndefined();
+    });
+
     it('extracts multiple action tag lines with double quotes and comments', () => {
       const res = extractPackageFile(
         Fixtures.get('workflow_3.yml'),

--- a/lib/modules/manager/github-actions/extract.ts
+++ b/lib/modules/manager/github-actions/extract.ts
@@ -3,6 +3,7 @@ import { GlobalConfig } from '../../../config/global.ts';
 import { logger, withMeta } from '../../../logger/index.ts';
 import { detectPlatform } from '../../../util/common.ts';
 import { newlineRegex, regEx } from '../../../util/regex.ts';
+import { parseUrl } from '../../../util/url.ts';
 import { ForgejoTagsDatasource } from '../../datasource/forgejo-tags/index.ts';
 import { GiteaTagsDatasource } from '../../datasource/gitea-tags/index.ts';
 import { GithubDigestDatasource } from '../../datasource/github-digest/index.ts';
@@ -33,7 +34,7 @@ function detectCustomGitHubRegistryUrlsForActions(): PackageDependency {
   const endpoint = GlobalConfig.get('endpoint');
   const registryUrls = ['https://github.com'];
   if (endpoint && GlobalConfig.get('platform') === 'github') {
-    const parsedEndpoint = new URL(endpoint);
+    const parsedEndpoint = parseUrl(endpoint)!;
 
     if (
       parsedEndpoint.host !== 'github.com' &&

--- a/lib/modules/manager/github-actions/extract.ts
+++ b/lib/modules/manager/github-actions/extract.ts
@@ -34,7 +34,11 @@ function detectCustomGitHubRegistryUrlsForActions(): PackageDependency {
   const endpoint = GlobalConfig.get('endpoint');
   const registryUrls = ['https://github.com'];
   if (endpoint && GlobalConfig.get('platform') === 'github') {
-    const parsedEndpoint = parseUrl(endpoint)!;
+    const parsedEndpoint = parseUrl(endpoint);
+    if (!parsedEndpoint) {
+      logger.warn({ endpoint }, 'Failed to parse endpoint url');
+      return {};
+    }
 
     if (
       parsedEndpoint.host !== 'github.com' &&

--- a/lib/modules/manager/helm-requirements/extract.ts
+++ b/lib/modules/manager/helm-requirements/extract.ts
@@ -1,5 +1,6 @@
 import { isArray } from '@sindresorhus/is';
 import { logger } from '../../../logger/index.ts';
+import { parseUrl } from '../../../util/url.ts';
 import { parseSingleYaml } from '../../../util/yaml.ts';
 import { HelmDatasource } from '../../datasource/helm/index.ts';
 import type {
@@ -69,17 +70,12 @@ export function extractPackageFile(
 
       res.skipReason = 'placeholder-url';
     } else {
-      try {
-        const url = new URL(dep.repository);
-        if (url.protocol === 'file:') {
-          res.skipReason = 'local-dependency';
-        }
-      } catch (err) {
-        logger.debug(
-          { err, packageFile, url: dep.repository },
-          'Error parsing url',
-        );
+      const url = parseUrl(dep.repository);
+      if (!url) {
+        logger.debug({ packageFile, url: dep.repository }, 'Error parsing url');
         res.skipReason = 'invalid-url';
+      } else if (url.protocol === 'file:') {
+        res.skipReason = 'local-dependency';
       }
     }
     return res;

--- a/lib/modules/manager/helmv3/utils.ts
+++ b/lib/modules/manager/helmv3/utils.ts
@@ -14,7 +14,7 @@ export function parseRepository(
 
   const url = parseUrl(repositoryURL);
   if (!url) {
-    logger.debug('Error parsing url');
+    logger.debug({ repositoryURL }, 'Error parsing url');
     res.skipReason = 'invalid-url';
     return res;
   }

--- a/lib/modules/manager/helmv3/utils.ts
+++ b/lib/modules/manager/helmv3/utils.ts
@@ -1,5 +1,6 @@
 import upath from 'upath';
 import { logger } from '../../../logger/index.ts';
+import { parseUrl } from '../../../util/url.ts';
 import { DockerDatasource } from '../../datasource/docker/index.ts';
 import type { PackageDependency } from '../types.ts';
 import { removeOCIPrefix } from './oci.ts';
@@ -11,25 +12,25 @@ export function parseRepository(
 ): PackageDependency {
   const res: PackageDependency = {};
 
-  try {
-    const url = new URL(repositoryURL);
-    switch (url.protocol) {
-      case 'oci:':
-        res.datasource = DockerDatasource.id;
-        res.packageName = `${removeOCIPrefix(repositoryURL)}/${depName}`;
-        // https://github.com/helm/helm/issues/10312
-        // https://github.com/helm/helm/issues/10678
-        res.pinDigests = false;
-        break;
-      case 'file:':
-        res.skipReason = 'local-dependency';
-        break;
-      default:
-        res.registryUrls = [repositoryURL];
-    }
-  } catch (err) {
-    logger.debug({ err }, 'Error parsing url');
+  const url = parseUrl(repositoryURL);
+  if (!url) {
+    logger.debug('Error parsing url');
     res.skipReason = 'invalid-url';
+    return res;
+  }
+  switch (url.protocol) {
+    case 'oci:':
+      res.datasource = DockerDatasource.id;
+      res.packageName = `${removeOCIPrefix(repositoryURL)}/${depName}`;
+      // https://github.com/helm/helm/issues/10312
+      // https://github.com/helm/helm/issues/10678
+      res.pinDigests = false;
+      break;
+    case 'file:':
+      res.skipReason = 'local-dependency';
+      break;
+    default:
+      res.registryUrls = [repositoryURL];
   }
   return res;
 }

--- a/lib/modules/manager/pip-compile/artifacts.spec.ts
+++ b/lib/modules/manager/pip-compile/artifacts.spec.ts
@@ -596,6 +596,15 @@ describe('modules/manager/pip-compile/artifacts', () => {
       );
     });
 
+    it('does not add --no-emit-index-url when PIP_INDEX_URL has no credentials', () => {
+      process.env.PIP_INDEX_URL = 'https://example.com/pypi/simple';
+      expect(
+        constructPipCompileCmd(
+          extractHeaderCommand(simpleHeader, 'subdir/requirements.txt'),
+        ),
+      ).toBe('pip-compile requirements.in');
+    });
+
     it('returns --no-emit-index-url when credentials are found in PIP_INDEX_URL', () => {
       process.env.PIP_INDEX_URL = 'https://user:pass@example.com/pypi/simple';
       expect(
@@ -735,6 +744,60 @@ describe('modules/manager/pip-compile/artifacts', () => {
       ).toBe(
         'pip-compile --output-file=requirements.txt requirements.in --upgrade-package=foo==1.0.2 --upgrade-package=bar==2.0.0',
       );
+    });
+
+    it('skips source file package registry extraction when source file is not pip_requirements', async () => {
+      const header = getCommandInHeader(
+        'pip-compile --output-file=requirements.txt setup.cfg',
+      );
+      fs.readLocalFile.mockResolvedValueOnce(header);
+      const execSnapshots = mockExecAll();
+      git.getRepoStatus.mockResolvedValue(
+        partial<StatusResult>({
+          modified: ['requirements.txt'],
+        }),
+      );
+      fs.readLocalFile.mockResolvedValueOnce('new lock');
+      expect(
+        await updateArtifacts({
+          packageFileName: 'setup.cfg',
+          updatedDeps: [],
+          newPackageFileContent: 'some new content',
+          config: {
+            ...config,
+            lockFiles: ['requirements.txt'],
+          },
+        }),
+      ).not.toBeNull();
+      expect(execSnapshots).toMatchObject([
+        { cmd: 'pip-compile --output-file=requirements.txt setup.cfg' },
+      ]);
+    });
+
+    it('skips source file when readLocalFile returns null', async () => {
+      fs.readLocalFile.mockResolvedValueOnce(simpleHeader);
+      fs.readLocalFile.mockResolvedValueOnce(null); // source file read returns null
+      const execSnapshots = mockExecAll();
+      git.getRepoStatus.mockResolvedValue(
+        partial<StatusResult>({
+          modified: ['requirements.txt'],
+        }),
+      );
+      fs.readLocalFile.mockResolvedValueOnce('new lock');
+      expect(
+        await updateArtifacts({
+          packageFileName: 'requirements.in',
+          updatedDeps: [],
+          newPackageFileContent: 'some new content',
+          config: {
+            ...config,
+            lockFiles: ['requirements.txt'],
+          },
+        }),
+      ).not.toBeNull();
+      expect(execSnapshots).toMatchObject([
+        { cmd: 'pip-compile requirements.in' },
+      ]);
     });
 
     it('reports errors when a lock file is unchanged', async () => {

--- a/lib/modules/manager/pip-compile/artifacts.ts
+++ b/lib/modules/manager/pip-compile/artifacts.ts
@@ -10,6 +10,7 @@ import {
   writeLocalFile,
 } from '../../../util/fs/index.ts';
 import { getRepoStatus } from '../../../util/git/index.ts';
+import { parseUrl } from '../../../util/url.ts';
 import { extractPackageFileFlags as extractRequirementsFileFlags } from '../pip_requirements/common.ts';
 import type {
   PackageFileContent,
@@ -30,26 +31,25 @@ import { inferCommandExecDir } from './utils.ts';
 function haveCredentialsInPipEnvironmentVariables(): boolean {
   const env = getEnv();
   if (env.PIP_INDEX_URL) {
-    try {
-      const indexUrl = new URL(env.PIP_INDEX_URL);
-      if (!!indexUrl.username || !!indexUrl.password) {
-        return true;
-      }
-    } catch {
+    const indexUrl = parseUrl(env.PIP_INDEX_URL);
+    if (!indexUrl) {
       // Assume that an invalid URL contains credentials, just in case
+      return true;
+    }
+    if (!!indexUrl.username || !!indexUrl.password) {
       return true;
     }
   }
 
-  try {
-    if (env.PIP_EXTRA_INDEX_URL) {
-      return env.PIP_EXTRA_INDEX_URL.split(' ')
-        .map((urlString) => new URL(urlString))
-        .some((url) => !!url.username || !!url.password);
-    }
-  } catch {
-    // Assume that an invalid URL contains credentials, just in case
-    return true;
+  if (env.PIP_EXTRA_INDEX_URL) {
+    return env.PIP_EXTRA_INDEX_URL.split(' ').some((urlString) => {
+      const url = parseUrl(urlString);
+      if (!url) {
+        // Assume that an invalid URL contains credentials, just in case
+        return true;
+      }
+      return !!url.username || !!url.password;
+    });
   }
 
   return false;

--- a/lib/modules/manager/pip-compile/artifacts.ts
+++ b/lib/modules/manager/pip-compile/artifacts.ts
@@ -133,9 +133,7 @@ export async function updateArtifacts({
           const content = await readLocalFile(path, 'utf8');
           if (content) {
             const packageFile = extractRequirementsFileFlags(content);
-            if (packageFile) {
-              packageFiles.push(packageFile);
-            }
+            packageFiles.push(packageFile);
           }
         }
       }

--- a/lib/modules/manager/pip-compile/common.ts
+++ b/lib/modules/manager/pip-compile/common.ts
@@ -12,6 +12,7 @@ import { ensureCacheDir } from '../../../util/fs/index.ts';
 import { ensureLocalPath } from '../../../util/fs/util.ts';
 import * as hostRules from '../../../util/host-rules.ts';
 import { regEx } from '../../../util/regex.ts';
+import { parseUrl } from '../../../util/url.ts';
 import type { PackageFileContent, UpdateArtifactsConfig } from '../types.ts';
 import type {
   CommandType,
@@ -355,8 +356,11 @@ function getRegistryCredEnvVars(
 function cleanUrl(url: string): URL | null {
   try {
     // Strip everything but protocol, host, and port
-    const urlObj = new URL(url);
-    return new URL(urlObj.origin);
+    const urlObj = parseUrl(url);
+    if (!urlObj) {
+      return null;
+    }
+    return parseUrl(urlObj.origin);
   } catch {
     return null;
   }

--- a/lib/modules/manager/pip-compile/common.ts
+++ b/lib/modules/manager/pip-compile/common.ts
@@ -360,6 +360,7 @@ function cleanUrl(url: string): URL | null {
     if (!urlObj) {
       return null;
     }
+    // origin of a valid URL is always parseable
     return parseUrl(urlObj.origin);
   } catch {
     return null;

--- a/lib/modules/manager/pip-compile/common.ts
+++ b/lib/modules/manager/pip-compile/common.ts
@@ -354,17 +354,13 @@ function getRegistryCredEnvVars(
 }
 
 function cleanUrl(url: string): URL | null {
-  try {
-    // Strip everything but protocol, host, and port
-    const urlObj = parseUrl(url);
-    if (!urlObj) {
-      return null;
-    }
-    // origin of a valid URL is always parseable
-    return parseUrl(urlObj.origin);
-  } catch {
+  // Strip everything but protocol, host, and port
+  const urlObj = parseUrl(url);
+  if (!urlObj) {
     return null;
   }
+  // origin of a valid URL is always parseable
+  return parseUrl(urlObj.origin);
 }
 
 export function getRegistryCredVarsFromPackageFiles(

--- a/lib/modules/manager/swift/extract.ts
+++ b/lib/modules/manager/swift/extract.ts
@@ -1,5 +1,6 @@
 import { detectPlatform } from '../../../util/common.ts';
 import { regEx } from '../../../util/regex.ts';
+import { parseUrl } from '../../../util/url.ts';
 import { GitTagsDatasource } from '../../datasource/git-tags/index.ts';
 import { GithubTagsDatasource } from '../../datasource/github-tags/index.ts';
 import { GitlabTagsDatasource } from '../../datasource/gitlab-tags/index.ts';
@@ -130,41 +131,38 @@ function getMatch(str: string, state: string | null): MatchResult | null {
   return result;
 }
 
-function parseUrl(
+function parseDependencyUrl(
   url: string | null,
 ): { depName: string; datasource: string; registryUrls?: string[] } | null {
   // istanbul ignore if
   if (!url) {
     return null;
   }
-  try {
-    const parsedUrl = new URL(url);
-    const { host, pathname, protocol } = parsedUrl;
-    const platform = detectPlatform(url);
-    if (platform === 'github' || platform === 'gitlab') {
-      const depName = pathname
-        .replace(regEx(/^\//), '')
-        .replace(regEx(/\.git$/), '')
-        .replace(regEx(/\/$/), '');
-      const datasource =
-        platform === 'github'
-          ? GithubTagsDatasource.id
-          : GitlabTagsDatasource.id;
-
-      const isGitHubPublic = host === 'github.com';
-      const isGitLabPublic = host === 'gitlab.com';
-
-      if (!isGitHubPublic && !isGitLabPublic) {
-        const baseUrl = `${protocol}//${host}`;
-        return { depName, datasource, registryUrls: [baseUrl] };
-      }
-
-      return { depName, datasource };
-    }
-    return { depName: url, datasource: GitTagsDatasource.id };
-  } catch {
+  const parsedUrl = parseUrl(url);
+  if (!parsedUrl) {
     return null;
   }
+  const { host, pathname, protocol } = parsedUrl;
+  const platform = detectPlatform(url);
+  if (platform === 'github' || platform === 'gitlab') {
+    const depName = pathname
+      .replace(regEx(/^\//), '')
+      .replace(regEx(/\.git$/), '')
+      .replace(regEx(/\/$/), '');
+    const datasource =
+      platform === 'github' ? GithubTagsDatasource.id : GitlabTagsDatasource.id;
+
+    const isGitHubPublic = host === 'github.com';
+    const isGitLabPublic = host === 'gitlab.com';
+
+    if (!isGitHubPublic && !isGitLabPublic) {
+      const baseUrl = `${protocol}//${host}`;
+      return { depName, datasource, registryUrls: [baseUrl] };
+    }
+
+    return { depName, datasource };
+  }
+  return { depName: url, datasource: GitTagsDatasource.id };
 }
 
 export function extractPackageFile(content: string): PackageFileContent | null {
@@ -189,7 +187,7 @@ export function extractPackageFile(content: string): PackageFileContent | null {
     if (!packageName) {
       return;
     }
-    const parsedUrl = parseUrl(packageName);
+    const parsedUrl = parseDependencyUrl(packageName);
     if (parsedUrl && currentValue) {
       const { depName, datasource, registryUrls } = parsedUrl;
 

--- a/lib/modules/manager/terragrunt/modules.spec.ts
+++ b/lib/modules/manager/terragrunt/modules.spec.ts
@@ -1,4 +1,10 @@
-import { gitTagsRefMatchRegex, githubRefMatchRegex } from './modules.ts';
+import type { PackageDependency } from '../types.ts';
+import {
+  analyseTerragruntModule,
+  gitTagsRefMatchRegex,
+  githubRefMatchRegex,
+} from './modules.ts';
+import type { TerraformManagerData } from './types.ts';
 
 describe('modules/manager/terragrunt/modules', () => {
   describe('githubRefMatchRegex', () => {
@@ -76,5 +82,19 @@ describe('modules/manager/terragrunt/modules', () => {
         tag: 'v1.0.0',
       });
     });
+  });
+});
+
+describe('modules/manager/terragrunt/modules', () => {
+  it('sets skipReason for invalid git tags URL', () => {
+    const dep: PackageDependency<TerraformManagerData> = {
+      managerData: {
+        source: 'ssh://[/path?ref=v1.0.0',
+        terragruntDependencyType: 'terraform',
+        moduleName: 'terragrunt',
+      },
+    };
+    analyseTerragruntModule(dep);
+    expect(dep.skipReason).toBe('invalid-url');
   });
 });

--- a/lib/modules/manager/terragrunt/modules.ts
+++ b/lib/modules/manager/terragrunt/modules.ts
@@ -72,7 +72,13 @@ export function analyseTerragruntModule(
     dep.datasource = GithubTagsDatasource.id;
   } else if (gitTagsRefMatch?.groups) {
     const { url, tag } = gitTagsRefMatch.groups;
-    const { hostname, host, pathname, protocol } = parseUrl(url)!;
+    const parsedUrl = parseUrl(url);
+    if (!parsedUrl) {
+      logger.debug({ url }, 'Terragrunt module has invalid URL, skipping');
+      dep.skipReason = 'invalid-url';
+      return;
+    }
+    const { hostname, host, pathname, protocol } = parsedUrl;
     const containsSubDirectory = pathname.includes('//');
     if (containsSubDirectory) {
       logger.debug('Terragrunt module contains subdirectory');

--- a/lib/modules/manager/terragrunt/modules.ts
+++ b/lib/modules/manager/terragrunt/modules.ts
@@ -1,6 +1,7 @@
 import { logger } from '../../../logger/index.ts';
 import { detectPlatform } from '../../../util/common.ts';
 import { regEx } from '../../../util/regex.ts';
+import { parseUrl } from '../../../util/url.ts';
 import { BitbucketTagsDatasource } from '../../datasource/bitbucket-tags/index.ts';
 import { GitTagsDatasource } from '../../datasource/git-tags/index.ts';
 import { GiteaTagsDatasource } from '../../datasource/gitea-tags/index.ts';
@@ -71,7 +72,7 @@ export function analyseTerragruntModule(
     dep.datasource = GithubTagsDatasource.id;
   } else if (gitTagsRefMatch?.groups) {
     const { url, tag } = gitTagsRefMatch.groups;
-    const { hostname, host, pathname, protocol } = new URL(url);
+    const { hostname, host, pathname, protocol } = parseUrl(url)!;
     const containsSubDirectory = pathname.includes('//');
     if (containsSubDirectory) {
       logger.debug('Terragrunt module contains subdirectory');

--- a/lib/modules/platform/bitbucket-server/index.spec.ts
+++ b/lib/modules/platform/bitbucket-server/index.spec.ts
@@ -10,7 +10,7 @@ import {
 } from '../../../constants/error-messages.ts';
 import * as repoCache from '../../../util/cache/repository/index.ts';
 import type { LongCommitSha } from '../../../util/git/types.ts';
-import { ensureTrailingSlash } from '../../../util/url.ts';
+import { ensureTrailingSlash, parseUrl } from '../../../util/url.ts';
 import type { ReattemptPlatformAutomergeConfig } from '../types.ts';
 import * as bitbucket from './index.ts';
 
@@ -171,8 +171,8 @@ function prMock(
   };
 }
 
-const endpointWithNoPath = new URL('https://stash.renovatebot.com');
-const endpointWithPath = new URL('https://stash.renovatebot.com/vcs');
+const endpointWithNoPath = parseUrl('https://stash.renovatebot.com')!;
+const endpointWithPath = parseUrl('https://stash.renovatebot.com/vcs')!;
 
 describe('modules/platform/bitbucket-server/index', () => {
   describe('endpoint with path', () => {

--- a/lib/modules/platform/bitbucket-server/pr-cache.spec.ts
+++ b/lib/modules/platform/bitbucket-server/pr-cache.spec.ts
@@ -8,6 +8,7 @@ import {
   BitbucketServerHttp,
   setBaseUrl,
 } from '../../../util/http/bitbucket-server.ts';
+import { parseUrl } from '../../../util/url.ts';
 import { BbsPrCache } from './pr-cache.ts';
 import type { BbsRestPr } from './types.ts';
 import { prInfo } from './utils.ts';
@@ -51,7 +52,7 @@ const pr2: BbsRestPr = {
   description: 'a merge request',
 };
 
-const baseUrl = new URL('https://stash.renovatebot.com');
+const baseUrl = parseUrl('https://stash.renovatebot.com')!;
 setBaseUrl('https://stash.renovatebot.com');
 const urlHost = baseUrl.origin;
 const urlPath = baseUrl.pathname === '/' ? '' : baseUrl.pathname;

--- a/lib/modules/platform/bitbucket-server/utils.spec.ts
+++ b/lib/modules/platform/bitbucket-server/utils.spec.ts
@@ -1,6 +1,7 @@
 import type { Response } from 'got';
 import { partial } from '~test/util.ts';
 import { CONFIG_GIT_URL_UNAVAILABLE } from '../../../constants/error-messages.ts';
+import { parseUrl } from '../../../util/url.ts';
 import type {
   BbsRestRepo,
   BitbucketError,
@@ -116,7 +117,7 @@ describe('modules/platform/bitbucket-server/utils', () => {
 
   describe('getRepoGitUrl', () => {
     describe('endpoint with path', () => {
-      const url = new URL('https://stash.renovatebot.com/vcs/');
+      const url = parseUrl('https://stash.renovatebot.com/vcs/')!;
       const username = 'abc';
       const password = '123';
       const opts = {
@@ -283,7 +284,7 @@ describe('modules/platform/bitbucket-server/utils', () => {
     });
 
     describe('endpoint with no path', () => {
-      const url = new URL('https://stash.renovatebot.com');
+      const url = parseUrl('https://stash.renovatebot.com')!;
       const username = 'abc';
       const password = '123';
       const opts = {

--- a/lib/modules/platform/bitbucket-server/utils.spec.ts
+++ b/lib/modules/platform/bitbucket-server/utils.spec.ts
@@ -329,6 +329,18 @@ describe('modules/platform/bitbucket-server/utils', () => {
         ),
       ).toBe(httpLink('https://some.external.url/', 'SOME', 'repo'));
     });
+
+    it('throws on invalid endpoint URL', () => {
+      expect(() =>
+        getRepoGitUrl(
+          'SOME/repo',
+          'not-a-valid-url',
+          'endpoint',
+          infoMock('https://stash.renovatebot.com/vcs/', 'SOME', 'repo'),
+          {},
+        ),
+      ).toThrow('Invalid Bitbucket Server endpoint: not-a-valid-url');
+    });
   });
 
   describe('getExtraCloneOpts', () => {

--- a/lib/modules/platform/bitbucket-server/utils.ts
+++ b/lib/modules/platform/bitbucket-server/utils.ts
@@ -83,7 +83,10 @@ function generateUrlFromEndpoint(
   opts: HostRule,
   repository: string,
 ): string {
-  const url = parseUrl(defaultEndpoint)!;
+  const url = parseUrl(defaultEndpoint);
+  if (!url) {
+    throw new Error(`Invalid Bitbucket Server endpoint: ${defaultEndpoint}`);
+  }
   const authString =
     opts.username && opts.password
       ? `${opts.username}:${opts.password}`
@@ -101,7 +104,7 @@ function generateUrlFromEndpoint(
 }
 
 function injectAuth(url: string, opts: HostRule): string {
-  const repoUrl = parseUrl(url)!;
+  const repoUrl = parseUrl(url);
   if (!repoUrl) {
     logger.debug(`Invalid url: ${url}`);
     throw new Error(CONFIG_GIT_URL_UNAVAILABLE);

--- a/lib/modules/platform/bitbucket-server/utils.ts
+++ b/lib/modules/platform/bitbucket-server/utils.ts
@@ -83,7 +83,7 @@ function generateUrlFromEndpoint(
   opts: HostRule,
   repository: string,
 ): string {
-  const url = new URL(defaultEndpoint);
+  const url = parseUrl(defaultEndpoint)!;
   const authString =
     opts.username && opts.password
       ? `${opts.username}:${opts.password}`

--- a/lib/modules/platform/bitbucket/index.ts
+++ b/lib/modules/platform/bitbucket/index.ts
@@ -287,6 +287,7 @@ export async function initRepo({
   }
 
   const parsedEndpoint = parseUrl(defaults.endpoint);
+  // istanbul ignore if: endpoint is a constant
   if (!parsedEndpoint) {
     throw new Error(`Invalid Bitbucket endpoint: ${defaults.endpoint}`);
   }

--- a/lib/modules/platform/bitbucket/index.ts
+++ b/lib/modules/platform/bitbucket/index.ts
@@ -287,7 +287,7 @@ export async function initRepo({
   }
 
   const parsedEndpoint = parseUrl(defaults.endpoint);
-  // istanbul ignore if: endpoint is a constant
+  // v8 ignore if: endpoint is a constant
   if (!parsedEndpoint) {
     throw new Error(`Invalid Bitbucket endpoint: ${defaults.endpoint}`);
   }

--- a/lib/modules/platform/bitbucket/index.ts
+++ b/lib/modules/platform/bitbucket/index.ts
@@ -18,6 +18,7 @@ import * as promises from '../../../util/promises.ts';
 import { regEx } from '../../../util/regex.ts';
 import { sanitize } from '../../../util/sanitize.ts';
 import { UUIDRegex, matchRegexOrGlobList } from '../../../util/string-match.ts';
+import { parseUrl } from '../../../util/url.ts';
 import type {
   AutodiscoverConfig,
   BranchStatusConfig,
@@ -285,7 +286,7 @@ export async function initRepo({
     throw err;
   }
 
-  const { hostname } = new URL(defaults.endpoint);
+  const { hostname } = parseUrl(defaults.endpoint)!;
 
   // Converts API hostnames to their respective HTTP git hosts:
   // `api.bitbucket.org`  to `bitbucket.org`

--- a/lib/modules/platform/bitbucket/index.ts
+++ b/lib/modules/platform/bitbucket/index.ts
@@ -286,7 +286,11 @@ export async function initRepo({
     throw err;
   }
 
-  const { hostname } = parseUrl(defaults.endpoint)!;
+  const parsedEndpoint = parseUrl(defaults.endpoint);
+  if (!parsedEndpoint) {
+    throw new Error(`Invalid Bitbucket endpoint: ${defaults.endpoint}`);
+  }
+  const { hostname } = parsedEndpoint;
 
   // Converts API hostnames to their respective HTTP git hosts:
   // `api.bitbucket.org`  to `bitbucket.org`

--- a/lib/modules/platform/forgejo/index.spec.ts
+++ b/lib/modules/platform/forgejo/index.spec.ts
@@ -15,6 +15,7 @@ import {
 import * as memCache from '../../../util/cache/memory/index.ts';
 import * as repoCache from '../../../util/cache/repository/index.ts';
 import type { LongCommitSha } from '../../../util/git/types.ts';
+import { parseUrl } from '../../../util/url.ts';
 import type { EnsureIssueConfig, RepoParams } from '../index.ts';
 import * as helper from './forgejo-helper.ts';
 import * as forgejo from './index.ts';
@@ -785,7 +786,7 @@ describe('modules/platform/forgejo/index', () => {
       };
       await forgejo.initRepo(repoCfg);
 
-      const url = new URL(`${mockRepo.clone_url}`);
+      const url = parseUrl(`${mockRepo.clone_url}`)!;
       url.username = token;
       expect(git.initRepo).toHaveBeenCalledExactlyOnceWith(
         expect.objectContaining({
@@ -815,7 +816,7 @@ describe('modules/platform/forgejo/index', () => {
       };
       await forgejo.initRepo(repoCfg);
 
-      const url = new URL(`${mockRepo.clone_url}`);
+      const url = parseUrl(`${mockRepo.clone_url}`)!;
       url.username = token;
       expect(git.initRepo).toHaveBeenCalledExactlyOnceWith(
         expect.objectContaining({ url: url.toString() }),

--- a/lib/modules/platform/gitea/index.spec.ts
+++ b/lib/modules/platform/gitea/index.spec.ts
@@ -15,6 +15,7 @@ import {
 import * as memCache from '../../../util/cache/memory/index.ts';
 import * as repoCache from '../../../util/cache/repository/index.ts';
 import type { LongCommitSha } from '../../../util/git/types.ts';
+import { parseUrl } from '../../../util/url.ts';
 import type { EnsureIssueConfig, RepoParams } from '../index.ts';
 import * as helper from './gitea-helper.ts';
 import * as gitea from './index.ts';
@@ -747,7 +748,7 @@ describe('modules/platform/gitea/index', () => {
       };
       await gitea.initRepo(repoCfg);
 
-      const url = new URL(`${mockRepo.clone_url}`);
+      const url = parseUrl(`${mockRepo.clone_url}`)!;
       url.username = token;
       expect(git.initRepo).toHaveBeenCalledExactlyOnceWith(
         expect.objectContaining({
@@ -775,7 +776,7 @@ describe('modules/platform/gitea/index', () => {
       };
       await gitea.initRepo(repoCfg);
 
-      const url = new URL(`${mockRepo.clone_url}`);
+      const url = parseUrl(`${mockRepo.clone_url}`)!;
       url.username = token;
       expect(git.initRepo).toHaveBeenCalledExactlyOnceWith(
         expect.objectContaining({ url: url.toString() }),

--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -67,6 +67,15 @@ describe('modules/platform/github/index', () => {
       );
     });
 
+    it('should throw if endpoint is invalid URL', async () => {
+      await expect(
+        github.initPlatform({
+          endpoint: 'https://[invalid',
+          token: 'abc',
+        }),
+      ).rejects.toThrow('Invalid GitHub endpoint: https://[invalid/');
+    });
+
     it('should throw if using fine-grained token with GHE <3.10', async () => {
       httpMock
         .scope('https://ghe.renovatebot.com')

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -129,7 +129,11 @@ export function isGHApp(): boolean {
 }
 
 export async function detectGhe(token: string): Promise<void> {
-  const host = parseUrl(platformConfig.endpoint)!.host;
+  const parsedEndpoint = parseUrl(platformConfig.endpoint);
+  if (!parsedEndpoint) {
+    throw new Error(`Invalid GitHub endpoint: ${platformConfig.endpoint}`);
+  }
+  const host = parsedEndpoint.host;
   platformConfig.isGhe = host !== 'api.github.com';
   platformConfig.isGheCloud = host.endsWith('.ghe.com');
   if (platformConfig.isGhe) {
@@ -204,7 +208,13 @@ export async function initPlatform({
       if (platformConfig.isGheCloud) {
         ghHostname = 'ghe.com';
       } else if (platformConfig.isGhe) {
-        ghHostname = parseUrl(platformConfig.endpoint)!.hostname;
+        const parsedEndpoint = parseUrl(platformConfig.endpoint);
+        if (!parsedEndpoint) {
+          throw new Error(
+            `Invalid GitHub endpoint: ${platformConfig.endpoint}`,
+          );
+        }
+        ghHostname = parsedEndpoint.hostname;
       } else {
         ghHostname = 'github.com';
       }
@@ -727,7 +737,10 @@ export async function initRepo({
     }
   }
 
-  const parsedEndpoint = parseUrl(platformConfig.endpoint)!;
+  const parsedEndpoint = parseUrl(platformConfig.endpoint);
+  if (!parsedEndpoint) {
+    throw new Error(`Invalid GitHub endpoint: ${platformConfig.endpoint}`);
+  }
   let authToken: string | null;
   if (forkToken) {
     logger.debug('Using forkToken for git init');

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -209,6 +209,7 @@ export async function initPlatform({
         ghHostname = 'ghe.com';
       } else if (platformConfig.isGhe) {
         const parsedEndpoint = parseUrl(platformConfig.endpoint);
+        // istanbul ignore if: endpoint is validated before initPlatform, this is here for defensive purposes
         if (!parsedEndpoint) {
           throw new Error(
             `Invalid GitHub endpoint: ${platformConfig.endpoint}`,
@@ -738,6 +739,7 @@ export async function initRepo({
   }
 
   const parsedEndpoint = parseUrl(platformConfig.endpoint);
+  // istanbul ignore if: endpoint is validated during initPlatform
   if (!parsedEndpoint) {
     throw new Error(`Invalid GitHub endpoint: ${platformConfig.endpoint}`);
   }

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -47,7 +47,7 @@ import { coerceObject } from '../../../util/object.ts';
 import { regEx } from '../../../util/regex.ts';
 import { sanitize } from '../../../util/sanitize.ts';
 import { fromBase64, looseEquals } from '../../../util/string.ts';
-import { ensureTrailingSlash } from '../../../util/url.ts';
+import { ensureTrailingSlash, parseUrl } from '../../../util/url.ts';
 import { incLimitedValue } from '../../../workers/global/limits.ts';
 import { normalizePythonDepName } from '../../datasource/pypi/common.ts';
 import type {
@@ -130,7 +130,7 @@ export function isGHApp(): boolean {
 
 export async function detectGhe(token: string): Promise<void> {
   platformConfig.isGhe =
-    new URL(platformConfig.endpoint).host !== 'api.github.com';
+    parseUrl(platformConfig.endpoint)!.host !== 'api.github.com';
   if (platformConfig.isGhe) {
     const gheHeaderKey = 'x-github-enterprise-version';
     const gheQueryRes = await githubApi.headJson('/', { token });
@@ -201,7 +201,7 @@ export async function initPlatform({
       platformConfig.userDetails ??= await getAppDetails(token);
       // v8 ignore next -- TODO: add test #40625
       const ghHostname = platformConfig.isGhe
-        ? new URL(platformConfig.endpoint).hostname
+        ? parseUrl(platformConfig.endpoint)!.hostname
         : 'github.com';
       discoveredGitAuthor = `${platformConfig.userDetails.name} <${platformConfig.userDetails.id}+${platformConfig.userDetails.username}@users.noreply.${ghHostname}>`;
     } else {
@@ -722,7 +722,7 @@ export async function initRepo({
     }
   }
 
-  const parsedEndpoint = new URL(platformConfig.endpoint);
+  const parsedEndpoint = parseUrl(platformConfig.endpoint)!;
   let authToken: string | null;
   if (forkToken) {
     logger.debug('Using forkToken for git init');

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -209,7 +209,7 @@ export async function initPlatform({
         ghHostname = 'ghe.com';
       } else if (platformConfig.isGhe) {
         const parsedEndpoint = parseUrl(platformConfig.endpoint);
-        // istanbul ignore if: endpoint is validated before initPlatform, this is here for defensive purposes
+        // v8 ignore if: endpoint is validated before initPlatform, this is here for defensive purposes
         if (!parsedEndpoint) {
           throw new Error(
             `Invalid GitHub endpoint: ${platformConfig.endpoint}`,
@@ -739,7 +739,7 @@ export async function initRepo({
   }
 
   const parsedEndpoint = parseUrl(platformConfig.endpoint);
-  // istanbul ignore if: endpoint is validated during initPlatform
+  // v8 ignore if: endpoint is validated during initPlatform
   if (!parsedEndpoint) {
     throw new Error(`Invalid GitHub endpoint: ${platformConfig.endpoint}`);
   }

--- a/lib/modules/platform/gitlab/utils.spec.ts
+++ b/lib/modules/platform/gitlab/utils.spec.ts
@@ -1,0 +1,58 @@
+import type { HttpResponse } from '../../../util/http/types.ts';
+import type { RepoResponse } from './types.ts';
+import { defaults, getRepoUrl } from './utils.ts';
+
+function makeRes(
+  overrides: Partial<RepoResponse> = {},
+): HttpResponse<RepoResponse> {
+  return {
+    statusCode: 200,
+    headers: {},
+    body: {
+      id: 1,
+      archived: false,
+      mirror: false,
+      default_branch: 'main',
+      empty_repo: false,
+      ssh_url_to_repo: null,
+      http_url_to_repo: null,
+      forked_from_project: false,
+      repository_access_level: 'enabled',
+      merge_requests_access_level: 'enabled',
+      merge_method: 'merge',
+      path_with_namespace: 'group/repo',
+      ...overrides,
+    },
+  };
+}
+
+describe('modules/platform/gitlab/utils', () => {
+  describe('getRepoUrl()', () => {
+    let savedEndpoint: string;
+
+    beforeEach(() => {
+      savedEndpoint = defaults.endpoint;
+      defaults.endpoint = 'not-a-valid-url';
+    });
+
+    afterEach(() => {
+      defaults.endpoint = savedEndpoint;
+    });
+
+    it('throws on invalid endpoint when gitUrl is endpoint', () => {
+      expect(() => getRepoUrl('group/repo', 'endpoint', makeRes())).toThrow(
+        'Invalid GitLab endpoint: not-a-valid-url',
+      );
+    });
+
+    it('throws on invalid endpoint when http_url_to_repo is null', () => {
+      expect(() =>
+        getRepoUrl(
+          'group/repo',
+          undefined,
+          makeRes({ http_url_to_repo: null }),
+        ),
+      ).toThrow('Invalid GitLab endpoint: not-a-valid-url');
+    });
+  });
+});

--- a/lib/modules/platform/gitlab/utils.ts
+++ b/lib/modules/platform/gitlab/utils.ts
@@ -91,7 +91,11 @@ export function getRepoUrl(
     }
 
     // TODO: null check (#22198)
-    const { protocol, host, pathname } = parseUrl(defaults.endpoint)!;
+    const parsedEndpoint = parseUrl(defaults.endpoint);
+    if (!parsedEndpoint) {
+      throw new Error(`Invalid GitLab endpoint: ${defaults.endpoint}`);
+    }
+    const { protocol, host, pathname } = parsedEndpoint;
     const newPathname = pathname.slice(0, pathname.indexOf('/api'));
     const uri = url.format({
       /* v8 ignore start: should never happen (#40625) */

--- a/lib/modules/platform/gitlab/utils.ts
+++ b/lib/modules/platform/gitlab/utils.ts
@@ -90,7 +90,6 @@ export function getRepoUrl(
       );
     }
 
-    // TODO: null check (#22198)
     const parsedEndpoint = parseUrl(defaults.endpoint);
     if (!parsedEndpoint) {
       throw new Error(`Invalid GitLab endpoint: ${defaults.endpoint}`);

--- a/lib/util/git/url.ts
+++ b/lib/util/git/url.ts
@@ -3,6 +3,7 @@ import { logger } from '../../logger/index.ts';
 import { detectPlatform } from '../common.ts';
 import * as hostRules from '../host-rules.ts';
 import { regEx } from '../regex.ts';
+import { parseUrl } from '../url.ts';
 
 export function parseGitUrl(url: string): gitUrlParse.GitUrl {
   return gitUrlParse(url);
@@ -50,7 +51,7 @@ export function getHttpUrl(url: string, token?: string): string {
       break;
   }
 
-  return new URL(parsedUrl.toString(protocol)).href;
+  return parseUrl(parsedUrl.toString(protocol))!.href;
 }
 
 export function getRemoteUrlWithToken(url: string, hostType?: string): string {

--- a/lib/util/git/url.ts
+++ b/lib/util/git/url.ts
@@ -52,6 +52,7 @@ export function getHttpUrl(url: string, token?: string): string {
   }
 
   const httpUrl = parseUrl(parsedUrl.toString(protocol));
+  // istanbul ignore if: git-url-parse always produces a parseable URL string
   if (!httpUrl) {
     throw new Error(`Failed to parse git URL: ${parsedUrl.toString(protocol)}`);
   }

--- a/lib/util/git/url.ts
+++ b/lib/util/git/url.ts
@@ -52,7 +52,7 @@ export function getHttpUrl(url: string, token?: string): string {
   }
 
   const httpUrl = parseUrl(parsedUrl.toString(protocol));
-  // istanbul ignore if: git-url-parse always produces a parseable URL string
+  // v8 ignore if: git-url-parse always produces a parseable URL string
   if (!httpUrl) {
     throw new Error(`Failed to parse git URL: ${parsedUrl.toString(protocol)}`);
   }

--- a/lib/util/git/url.ts
+++ b/lib/util/git/url.ts
@@ -51,7 +51,11 @@ export function getHttpUrl(url: string, token?: string): string {
       break;
   }
 
-  return parseUrl(parsedUrl.toString(protocol))!.href;
+  const httpUrl = parseUrl(parsedUrl.toString(protocol));
+  if (!httpUrl) {
+    throw new Error(`Failed to parse git URL: ${parsedUrl.toString(protocol)}`);
+  }
+  return httpUrl.href;
 }
 
 export function getRemoteUrlWithToken(url: string, hostType?: string): string {

--- a/lib/util/http/github.ts
+++ b/lib/util/http/github.ts
@@ -338,7 +338,7 @@ export class GithubHttp extends HttpBase<GithubHttpOptions> {
     opts: InternalHttpOptions & GithubBaseHttpOptions,
   ): void {
     if (!opts.token) {
-      const authUrl = new URL(url);
+      const authUrl = parseUrl(url.toString())!;
 
       if (opts.repository) {
         // set authUrl to https://api.github.com/repos/org/repo or https://gihub.domain.com/api/v3/repos/org/repo
@@ -421,7 +421,7 @@ export class GithubHttp extends HttpBase<GithubHttpOptions> {
         const queue = [...range(2, lastPage)].map(
           (pageNumber) => (): Promise<HttpResponse<T>> => {
             // copy before modifying searchParams
-            const nextUrl = new URL(firstPageUrl);
+            const nextUrl = parseUrl(firstPageUrl.toString())!;
             nextUrl.searchParams.set('page', String(pageNumber));
             return super.requestJsonUnsafe<T>(method, {
               ...opts,

--- a/lib/util/http/github.ts
+++ b/lib/util/http/github.ts
@@ -338,6 +338,7 @@ export class GithubHttp extends HttpBase<GithubHttpOptions> {
     opts: InternalHttpOptions & GithubBaseHttpOptions,
   ): void {
     if (!opts.token) {
+      // create a mutable copy of `url`
       const authUrl = parseUrl(url.toString())!;
 
       if (opts.repository) {
@@ -421,7 +422,7 @@ export class GithubHttp extends HttpBase<GithubHttpOptions> {
         const queue = [...range(2, lastPage)].map(
           (pageNumber) => (): Promise<HttpResponse<T>> => {
             // copy before modifying searchParams
-            const nextUrl = parseUrl(firstPageUrl.toString())!;
+            const nextUrl = parseUrl(firstPageUrl.toString()) ?? firstPageUrl;
             nextUrl.searchParams.set('page', String(pageNumber));
             return super.requestJsonUnsafe<T>(method, {
               ...opts,

--- a/lib/util/http/github.ts
+++ b/lib/util/http/github.ts
@@ -422,7 +422,7 @@ export class GithubHttp extends HttpBase<GithubHttpOptions> {
         const queue = [...range(2, lastPage)].map(
           (pageNumber) => (): Promise<HttpResponse<T>> => {
             // copy before modifying searchParams
-            const nextUrl = parseUrl(firstPageUrl.toString()) ?? firstPageUrl;
+            const nextUrl = parseUrl(firstPageUrl.toString())!;
             nextUrl.searchParams.set('page', String(pageNumber));
             return super.requestJsonUnsafe<T>(method, {
               ...opts,

--- a/lib/util/http/gitlab.ts
+++ b/lib/util/http/gitlab.ts
@@ -55,7 +55,7 @@ export class GitlabHttp extends HttpBase<GitlabHttpOptions> {
           : null;
         if (nextUrl) {
           if (getEnv().GITLAB_IGNORE_REPO_URL) {
-            const defaultEndpoint = new URL(baseUrl);
+            const defaultEndpoint = parseUrl(baseUrl)!;
             nextUrl.protocol = defaultEndpoint.protocol;
             nextUrl.host = defaultEndpoint.host;
           }

--- a/lib/util/merge-confidence/index.ts
+++ b/lib/util/merge-confidence/index.ts
@@ -246,23 +246,19 @@ function getApiBaseUrl(mergeConfidenceEndpoint: string | undefined): string {
   const defaultBaseUrl = 'https://developer.mend.io/';
   const baseFromEnv = mergeConfidenceEndpoint ?? defaultBaseUrl;
 
-  try {
-    const parsedBaseUrl = parseUrl(baseFromEnv)?.toString();
-    if (!parsedBaseUrl) {
-      throw new Error('invalid URL');
-    }
-    logger.trace(
-      { baseUrl: parsedBaseUrl },
-      'using merge confidence API base found in environment variables',
-    );
-    return ensureTrailingSlash(parsedBaseUrl);
-  } catch (err) {
+  const parsedBaseUrl = parseUrl(baseFromEnv)?.toString();
+  if (!parsedBaseUrl) {
     logger.warn(
-      { err, baseFromEnv },
+      { baseFromEnv },
       'invalid merge confidence API base URL found in environment variables - using default value instead',
     );
     return defaultBaseUrl;
   }
+  logger.trace(
+    { baseUrl: parsedBaseUrl },
+    'using merge confidence API base found in environment variables',
+  );
+  return ensureTrailingSlash(parsedBaseUrl);
 }
 
 export function getApiToken(): string | undefined {

--- a/lib/util/merge-confidence/index.ts
+++ b/lib/util/merge-confidence/index.ts
@@ -13,7 +13,7 @@ import * as hostRules from '../host-rules.ts';
 import { memCacheProvider } from '../http/cache/memory-http-cache-provider.ts';
 import { Http } from '../http/index.ts';
 import { regEx } from '../regex.ts';
-import { ensureTrailingSlash, joinUrlParts } from '../url.ts';
+import { ensureTrailingSlash, joinUrlParts, parseUrl } from '../url.ts';
 import { MERGE_CONFIDENCE } from './common.ts';
 import type { MergeConfidence } from './types.ts';
 
@@ -247,7 +247,10 @@ function getApiBaseUrl(mergeConfidenceEndpoint: string | undefined): string {
   const baseFromEnv = mergeConfidenceEndpoint ?? defaultBaseUrl;
 
   try {
-    const parsedBaseUrl = new URL(baseFromEnv).toString();
+    const parsedBaseUrl = parseUrl(baseFromEnv)?.toString();
+    if (!parsedBaseUrl) {
+      throw new Error('invalid URL');
+    }
     logger.trace(
       { baseUrl: parsedBaseUrl },
       'using merge confidence API base found in environment variables',

--- a/lib/util/s3.spec.ts
+++ b/lib/util/s3.spec.ts
@@ -1,4 +1,5 @@
 import { getS3Client, parseS3Url } from './s3.ts';
+import { parseUrl } from './url.ts';
 
 describe('util/s3', () => {
   afterEach(() => {
@@ -13,7 +14,7 @@ describe('util/s3', () => {
   });
 
   it('returns null for non-S3 URLs', () => {
-    expect(parseS3Url(new URL('http://example.com/key/path'))).toBeNull();
+    expect(parseS3Url(parseUrl('http://example.com/key/path')!)).toBeNull();
   });
 
   it('returns null for invalid URLs', () => {

--- a/lib/util/url.spec.ts
+++ b/lib/util/url.spec.ts
@@ -91,7 +91,7 @@ describe('util/url', () => {
     ${'http://foo.io'}      | ${'aaa/?bbb=z'}         | ${'http://foo.io/aaa?bbb=z'}
   `('replaceUrlPath("$baseUrl", "$x") => $result', ({ baseUrl, x, result }) => {
     expect(replaceUrlPath(baseUrl, x)).toBe(result);
-    expect(replaceUrlPath(new URL(baseUrl), x)).toBe(result);
+    expect(replaceUrlPath(parseUrl(baseUrl)!, x)).toBe(result);
   });
 
   it('getQueryString', () => {
@@ -106,7 +106,7 @@ describe('util/url', () => {
     expect(isHttpUrl('ssh://github.com')).toBeFalse();
     expect(isHttpUrl('http://github.com')).toBeTrue();
     expect(isHttpUrl('https://github.com')).toBeTrue();
-    expect(isHttpUrl(new URL('https://github.com'))).toBeTrue();
+    expect(isHttpUrl(parseUrl('https://github.com')!)).toBeTrue();
   });
 
   it('parses URL', () => {
@@ -179,10 +179,10 @@ describe('util/url', () => {
 
   it('createURLFromHostOrURL', () => {
     expect(createURLFromHostOrURL('https://some.test')).toEqual(
-      new URL('https://some.test/'),
+      parseUrl('https://some.test/')!,
     );
     expect(createURLFromHostOrURL('some.test')).toEqual(
-      new URL('https://some.test/'),
+      parseUrl('https://some.test/')!,
     );
   });
 

--- a/lib/workers/repository/update/pr/changelog/github/source.ts
+++ b/lib/workers/repository/update/pr/changelog/github/source.ts
@@ -1,6 +1,7 @@
 import { GlobalConfig } from '../../../../../../config/global.ts';
 import { logger } from '../../../../../../logger/index.ts';
 import * as hostRules from '../../../../../../util/host-rules.ts';
+import { parseUrl } from '../../../../../../util/url.ts';
 import type { BranchUpgradeConfig } from '../../../../../types.ts';
 import { ChangeLogSource } from '../source.ts';
 import type { ChangeLogError } from '../types.ts';
@@ -41,7 +42,7 @@ export class GitHubChangeLogSource extends ChangeLogSource {
     error?: ChangeLogError;
   } {
     const sourceUrl = config.sourceUrl!;
-    const { host } = new URL(sourceUrl);
+    const { host } = parseUrl(sourceUrl)!;
     const manager = config.manager;
     const packageName = config.packageName;
 

--- a/lib/workers/repository/update/pr/changelog/github/source.ts
+++ b/lib/workers/repository/update/pr/changelog/github/source.ts
@@ -42,7 +42,7 @@ export class GitHubChangeLogSource extends ChangeLogSource {
     error?: ChangeLogError;
   } {
     const sourceUrl = config.sourceUrl!;
-    const { host } = parseUrl(sourceUrl)!;
+    const host = parseUrl(sourceUrl)?.host;
     const manager = config.manager;
     const packageName = config.packageName;
 

--- a/tools/lint/rules.js
+++ b/tools/lint/rules.js
@@ -1,4 +1,5 @@
 import enforceTsExtension from './rules/enforce-ts-extension.js';
+import noNewUrl from './rules/no-new-url.js';
 import noToolsImport from './rules/no-tools-import.js';
 import testRootDescribe from './rules/test-root-describe.js';
 
@@ -8,6 +9,7 @@ export default {
   },
   rules: {
     'enforce-ts-extension': enforceTsExtension,
+    'no-new-url': noNewUrl,
     'no-tools-import': noToolsImport,
     'test-root-describe': testRootDescribe,
   },

--- a/tools/lint/rules/no-new-url.js
+++ b/tools/lint/rules/no-new-url.js
@@ -1,0 +1,29 @@
+/** @type {import('eslint').Rule.RuleModule} */
+export default {
+  meta: {
+    type: 'problem',
+    messages: {
+      noNewUrl:
+        "Use parseUrl() from 'lib/util/url.ts' instead of 'new URL()' to avoid unhandled exceptions on invalid URLs.",
+    },
+  },
+  create(context) {
+    const filename = context.filename ?? context.physicalFilename ?? '';
+    // Only enforce in lib/, but not in the parseUrl implementation itself
+    if (!filename.includes('/lib/') || filename.endsWith('lib/util/url.ts')) {
+      return {};
+    }
+    return {
+      NewExpression(node) {
+        if (
+          node.callee.type === 'Identifier' &&
+          node.callee.name === 'URL' &&
+          // only consider newURL(arg) and not newURL(arg, base) as parseUrl does not allow this
+          node.arguments.length === 1
+        ) {
+          context.report({ node, messageId: 'noNewUrl' });
+        }
+      },
+    };
+  },
+};

--- a/tools/lint/rules/no-new-url.js
+++ b/tools/lint/rules/no-new-url.js
@@ -18,7 +18,7 @@ export default {
         if (
           node.callee.type === 'Identifier' &&
           node.callee.name === 'URL' &&
-          // only consider newURL(arg) and not newURL(arg, base) as parseUrl does not allow this
+          // only consider new URL(arg) and not new URL(arg, base) as parseUrl does not allow this
           node.arguments.length === 1
         ) {
           context.report({ node, messageId: 'noNewUrl' });


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Add a new eslint/oxlint rule to enforce usage of `parseUrl` instead of `new URL` 

<!-- Describe what behavior is changed by this PR. -->

## Context

Had to point it out in the last reviews a lot 

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
