### PR TITLE
fix(mise): avoid debug log noise for  mise files with no tools

### DIFF
--- a/lib/modules/manager/mise/schema.spec.ts
+++ b/lib/modules/manager/mise/schema.spec.ts
@@ -1,0 +1,27 @@
+import { codeBlock } from 'common-tags';
+import { MiseFile } from './schema.ts';
+
+describe('modules/manager/mise/schema', () => {
+  describe('MiseFile', () => {
+    it('defaults tools to empty object when [tools] is absent', () => {
+      const content = codeBlock`
+        min_version = "2024.11.1"
+      `;
+      expect(MiseFile.parse(content)).toEqual({ tools: {} });
+    });
+
+    it('defaults tools to empty object for empty TOML', () => {
+      expect(MiseFile.parse('')).toEqual({ tools: {} });
+    });
+
+    it('parses [tools] when present', () => {
+      const content = codeBlock`
+        [tools]
+        node = "20"
+      `;
+      expect(MiseFile.parse(content)).toEqual({
+        tools: { node: '20' },
+      });
+    });
+  });
+});

--- a/lib/modules/manager/mise/schema.ts
+++ b/lib/modules/manager/mise/schema.ts
@@ -25,7 +25,7 @@ export type MiseTool = z.infer<typeof MiseTool>;
 
 export const MiseFile = Toml.pipe(
   z.object({
-    tools: z.record(MiseTool),
+    tools: z.record(MiseTool).default({}),
   }),
 );
 export type MiseFile = z.infer<typeof MiseFile>;

--- a/lib/modules/manager/mise/utils.spec.ts
+++ b/lib/modules/manager/mise/utils.spec.ts
@@ -35,7 +35,9 @@ describe('modules/manager/mise/utils', () => {
       node = '16'
     `;
       const actual = parseTomlFile(content, miseFilename);
-      expect(actual).toBeNull();
+      expect(actual).toMatchObject({
+        tools: {},
+      });
     });
   });
 });


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Set tools to be an empty map when not present in the mise.toml file.

No behavioural change but avoids the log

```
DEBUG: Error parsing Mise file. (repository=xxx, packageFile=xxx/mise.toml)
       "err": {"message": "Schema error", "issues": {"tools": "Required"}}
       ZodError: Schema error
           at Object.get error [as error] (file:///usr/local/renovate/node_modules/.pnpm/zod@4.4.2/node_modules/zod/v3/types.js:39:31)
```



Especially likely in [Mise Monorepo Tasks](https://mise.jdx.dev/tasks/monorepo.html) where the tools are defined in the root `mise.toml`


## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [X] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [X] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Used Cursor with prompts "tools is optional in a mise file - how do I change this to parse as empty rather than an error? (zod) "& could we add a schema.spec.ts with a test for this change?"

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [X] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
