### PR TITLE
docs(templates): correctly render list, wrap in code blocks and sort

### DIFF
--- a/tools/docs/templates.ts
+++ b/tools/docs/templates.ts
@@ -44,7 +44,7 @@ export async function generateTemplates(dist: string): Promise<void> {
   runtimeText += '\n\n';
 
   let supportsTemplatingText =
-    'The following configuration options accept Handlebars template syntax in their values:\n';
+    'The following configuration options accept Handlebars template syntax in their values:\n\n';
   supportsTemplatingText += options
     .filter((o) => o.supportsTemplating)
     .map((o) => getOptionLink(o.name, optionParentMap, optionGlobalOnly))

--- a/tools/docs/templates.ts
+++ b/tools/docs/templates.ts
@@ -16,7 +16,7 @@ function getOptionLink(
   const page = optionGlobalOnly.has(name)
     ? 'self-hosted-configuration.md'
     : 'configuration-options.md';
-  return ` - [${name}](${page}#${anchor})`;
+  return ` - [\`${name}\`](${page}#${anchor})`;
 }
 
 export async function generateTemplates(dist: string): Promise<void> {

--- a/tools/docs/templates.ts
+++ b/tools/docs/templates.ts
@@ -33,6 +33,7 @@ export async function generateTemplates(dist: string): Promise<void> {
   let exposedConfigOptionsText =
     'The following configuration options are passed through for templating: \n\n';
   exposedConfigOptionsText += exposedConfigOptions
+    .sort()
     .map((field) => getOptionLink(field, optionParentMap, optionGlobalOnly))
     .join('\n');
 
@@ -47,6 +48,7 @@ export async function generateTemplates(dist: string): Promise<void> {
     'The following configuration options accept Handlebars template syntax in their values:\n\n';
   supportsTemplatingText += options
     .filter((o) => o.supportsTemplating)
+    .sort((a, b) => a.name.localeCompare(b.name))
     .map((o) => getOptionLink(o.name, optionParentMap, optionGlobalOnly))
     .join('\n');
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Previously:

<img width="769" height="429" alt="Screenshot 2026-05-12 at 10 59 40" src="https://github.com/user-attachments/assets/4c3884a8-52a8-4016-af05-b22c105bc61b" />

Now:

<img width="706" height="417" alt="Screenshot 2026-05-12 at 10 59 37" src="https://github.com/user-attachments/assets/45b92722-5a37-4c2a-bf8f-2c0f7d885f15" />


## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
