### PR TITLE
chore(utils): set unsafe flags for SimpleGit

### DIFF
--- a/lib/util/git/config.spec.ts
+++ b/lib/util/git/config.spec.ts
@@ -13,7 +13,6 @@ describe('util/git/config', () => {
       unsafe: {
         allowUnsafeSshCommand: true,
         allowUnsafeConfigEnvCount: true,
-        allowUnsafePager: true,
       },
     });
   });
@@ -29,7 +28,6 @@ describe('util/git/config', () => {
       unsafe: {
         allowUnsafeSshCommand: true,
         allowUnsafeConfigEnvCount: true,
-        allowUnsafePager: true,
       },
     });
   });

--- a/lib/util/git/config.spec.ts
+++ b/lib/util/git/config.spec.ts
@@ -10,6 +10,11 @@ describe('util/git/config', () => {
     expect(simpleGitConfig()).toEqual({
       completion: { onClose: true, onExit: false },
       config: ['core.quotePath=false'],
+      unsafe: {
+        allowUnsafeSshCommand: true,
+        allowUnsafeConfigEnvCount: true,
+        allowUnsafePager: true,
+      },
     });
   });
 
@@ -21,6 +26,11 @@ describe('util/git/config', () => {
         block: 50000,
       },
       config: ['core.quotePath=false'],
+      unsafe: {
+        allowUnsafeSshCommand: true,
+        allowUnsafeConfigEnvCount: true,
+        allowUnsafePager: true,
+      },
     });
   });
 

--- a/lib/util/git/config.ts
+++ b/lib/util/git/config.ts
@@ -21,7 +21,6 @@ export function simpleGitConfig(): Partial<SimpleGitOptions> {
   const unsafe: SimpleGitOptions['unsafe'] = {
     allowUnsafeSshCommand: true, // For custom `GIT_SSH_COMMAND`.
     allowUnsafeConfigEnvCount: true, // For custom `GIT_CONFIG_COUNT`, `GIT_CONFIG_KEY_*` and `GIT_CONFIG_VALUE_*`.
-    allowUnsafePager: true,
   };
   if (getEnv().RENOVATE_X_CLEAR_HOOKS) {
     unsafe.allowUnsafeHooksPath = true;

--- a/lib/util/git/config.ts
+++ b/lib/util/git/config.ts
@@ -18,18 +18,23 @@ export function getNoVerify(): GitNoVerifyOption[] {
 }
 
 export function simpleGitConfig(): Partial<SimpleGitOptions> {
+  const unsafe: SimpleGitOptions['unsafe'] = {
+    allowUnsafeSshCommand: true, // For custom `GIT_SSH_COMMAND`.
+    allowUnsafeConfigEnvCount: true, // For custom `GIT_CONFIG_COUNT`, `GIT_CONFIG_KEY_*` and `GIT_CONFIG_VALUE_*`.
+    allowUnsafePager: true,
+  };
+  if (getEnv().RENOVATE_X_CLEAR_HOOKS) {
+    unsafe.allowUnsafeHooksPath = true;
+  }
   const config: Partial<SimpleGitOptions> = {
     completion: {
       onClose: true,
       onExit: false,
     },
     config: ['core.quotePath=false'],
+    unsafe,
   };
-  if (getEnv().RENOVATE_X_CLEAR_HOOKS) {
-    config.unsafe = {
-      allowUnsafeHooksPath: true,
-    };
-  }
+
   // https://github.com/steveukx/git-js/pull/591
   const gitTimeout = GlobalConfig.get('gitTimeout');
   if (isNumber(gitTimeout) && gitTimeout > 0) {

--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -1553,25 +1553,6 @@ describe('util/git/index', { timeout: 10000 }, () => {
       );
     });
 
-    it('should work when PAGER is explicitly configured', async () => {
-      // Self-hosted users can opt into passing PAGER via customEnvVariables.
-      // simple-git >=3.36.0 blocks git operations when PAGER is present unless
-      // allowUnsafePager is enabled.
-      setCustomEnv({ PAGER: 'less' });
-
-      const envSpy = vi.spyOn(SimpleGit.prototype, 'env');
-      await git.initRepo({ url: origin.path });
-      await expect(git.syncGit()).resolves.toBeUndefined();
-      expect(envSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          PAGER: 'less',
-          LANG: 'C.UTF-8',
-          LC_ALL: 'C.UTF-8',
-          GIT_SSH_COMMAND: 'ssh -o BatchMode=yes',
-        }),
-      );
-    });
-
     it('should allow customEnvVariables to override GIT_SSH_COMMAND', async () => {
       // Self-hosted users may inject a custom GIT_SSH_COMMAND via
       // customEnvVariables to configure SSH authentication (e.g. a


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds the "unsafe" flags to SimpleGit that Renovate requires.

The only flag I'm not sure about is `allowUnsafePager`. It was required to get the tests to pass, but I'm not sure if Renovate is actually expecting a custom `PAGER` environment variable to be used, or whether that was just an example test added in #42944 to show that upgrading `simple-git` would break.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

> [!NOTE]
> This is merging into the branch for #43122 

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/reduckted/test-renovate/actions/runs/25728233467/job/75546470636

Ran by checking out this fork: https://github.com/reduckted/test-renovate/actions/runs/25728233467/job/75546470636#step:2:4

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
