### PR TITLE
feat(datasource/github-runners): Update macOS 26

### DIFF
--- a/lib/modules/datasource/github-runners/index.spec.ts
+++ b/lib/modules/datasource/github-runners/index.spec.ts
@@ -44,8 +44,8 @@ describe('modules/datasource/github-runners/index', () => {
           { version: '15-xlarge' },
           { version: '15-large' },
           { version: '15' },
-          { version: '26-xlarge', isStable: false },
-          { version: '26', isStable: false },
+          { version: '26-xlarge' },
+          { version: '26' },
         ],
         sourceUrl: 'https://github.com/actions/runner-images',
       });

--- a/lib/modules/datasource/github-runners/index.ts
+++ b/lib/modules/datasource/github-runners/index.ts
@@ -27,8 +27,8 @@ export class GithubRunnersDatasource extends Datasource {
       { version: '16.04', isDeprecated: true },
     ],
     macos: [
-      { version: '26', isStable: false },
-      { version: '26-xlarge', isStable: false },
+      { version: '26' },
+      { version: '26-xlarge' },
       { version: '15' },
       { version: '15-large' },
       { version: '15-xlarge' },


### PR DESCRIPTION

## Changes

Mark `macos-26` as stable (see https://github.com/actions/runner-images/issues/13739).

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>
