### PR TITLE
fix(workers/repository): treat branch-based automerge as `activated`

### DIFF
--- a/lib/workers/repository/index.ts
+++ b/lib/workers/repository/index.ts
@@ -158,10 +158,14 @@ export async function renovateRepository(
       if (res === 'automerged') {
         if (canRetry) {
           logger.info('Restarting repository job after automerge result');
-          const recursiveRes = await renovateRepository(repoConfig, false);
+          const recursiveRes = await renovateRepository(
+            { ...repoConfig, repoIsActivated: true },
+            false,
+          );
           return recursiveRes;
         }
         logger.debug(`Automerged but already retried once`);
+        config.repoIsActivated = true;
       } else {
         const configMigrationRes = await configMigration(config, branchList);
         await ensureDependencyDashboard(


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
As noted in #40635, if a repository is using branch-based automerge, we
incorrectly categorise the repository as "onboarded" instead of
"activated", as we do not update the repository status.

We can fix this by ensuring the repository is classed as `activated` if
we have successfully automerged any branches during a Renovate run.


## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
