### PR TITLE
fix(vulnerability): set datasource if overriding `allowedVersions`

### DIFF
--- a/lib/workers/repository/process/vulnerabilities.spec.ts
+++ b/lib/workers/repository/process/vulnerabilities.spec.ts
@@ -1114,6 +1114,10 @@ describe('workers/repository/process/vulnerabilities', () => {
       );
 
       expect(logger.logger.debug).toHaveBeenCalledWith(
+        {
+          datasource: 'go',
+          versioning: 'semver',
+        },
         'Setting allowed version >= 1.7.6 to fix vulnerability GO-2022-0187 in stdlib 1.7.5',
       );
       expect(config.packageRules).toHaveLength(1);
@@ -1123,6 +1127,77 @@ describe('workers/repository/process/vulnerabilities', () => {
           matchPackageNames: ['stdlib'],
           matchCurrentVersion: '1.7.5',
           allowedVersions: '>= 1.7.6',
+          isVulnerabilityAlert: true,
+        },
+      ]);
+    });
+
+    it('sets default datasource versioning to align with allowedVersions on packageRule', async () => {
+      const packageFiles: Record<string, PackageFile[]> = {
+        gomod: [
+          {
+            deps: [
+              {
+                depName:
+                  'software.amazon.encryption.s3:amazon-s3-encryption-client-java',
+                currentValue: '3.4.0',
+                datasource: 'maven',
+              },
+            ],
+            packageFile: 'pom.xml',
+          },
+        ],
+      };
+
+      getVulnerabilitiesMock.mockResolvedValueOnce([
+        {
+          id: 'GHSA-x44p-gvrj-pj2r',
+          modified: '',
+          aliases: ['CVE-2025-14763'],
+          affected: [
+            {
+              package: {
+                ecosystem: 'Maven',
+                name: 'software.amazon.encryption.s3:amazon-s3-encryption-client-java',
+                purl: 'pkg:maven/software.amazon.encryption.s3/amazon-s3-encryption-client-java',
+              },
+              ranges: [
+                {
+                  type: 'ECOSYSTEM',
+                  events: [{ introduced: '0' }, { fixed: '4.0.0' }],
+                },
+              ],
+            },
+          ],
+        },
+      ]);
+
+      await vulnerabilities.appendVulnerabilityPackageRules(
+        config,
+        packageFiles,
+      );
+
+      expect(logger.logger.debug).toHaveBeenCalledWith(
+        'Vulnerability GHSA-x44p-gvrj-pj2r affects software.amazon.encryption.s3:amazon-s3-encryption-client-java 3.4.0',
+      );
+
+      expect(logger.logger.debug).toHaveBeenCalledWith(
+        {
+          datasource: 'maven',
+          versioning: 'maven',
+        },
+        'Setting allowed version [4.0.0,) to fix vulnerability GHSA-x44p-gvrj-pj2r in software.amazon.encryption.s3:amazon-s3-encryption-client-java 3.4.0',
+      );
+      expect(config.packageRules).toHaveLength(1);
+      expect(config.packageRules).toMatchObject([
+        {
+          matchDatasources: ['maven'],
+          matchPackageNames: [
+            'software.amazon.encryption.s3:amazon-s3-encryption-client-java',
+          ],
+          matchCurrentVersion: '3.4.0',
+          allowedVersions: '[4.0.0,)',
+          versioning: 'maven',
           isVulnerabilityAlert: true,
         },
       ]);

--- a/lib/workers/repository/process/vulnerabilities.ts
+++ b/lib/workers/repository/process/vulnerabilities.ts
@@ -567,7 +567,15 @@ export class Vulnerabilities {
       return null;
     }
 
+    // we don't know if the dependency has a `versioning` applied to it already, so we have to use the default for the datasource
+    const versioning = getDefaultVersioning(datasource);
+
     logger.debug(
+      {
+        datasource,
+        versioning,
+      },
+
       `Setting allowed version ${fixedVersion} to fix vulnerability ${vulnerability.id} in ${packageName} ${depVersion}`,
     );
 
@@ -580,6 +588,7 @@ export class Vulnerabilities {
       matchDatasources: [datasource],
       matchPackageNames: [packageName],
       matchCurrentVersion: depVersion,
+      versioning,
       allowedVersions: fixedVersion,
       isVulnerabilityAlert: true,
       vulnerabilitySeverity: severityDetails.severityLevel,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

As noted in #43304, when using `osvVulnerabilityAlerts`, we can
sometimes produce an `allowedVersions` that is valid for the ecosystem,
but without setting the `versioning`, we produce an invalid rule, which
then results in a `config-validation` result, breaking any updates on
the repo.

We should therefore wire in the default `versioning` for the given
datasource.

## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/JamieTanna-Mend-testing/renovate-discussions-43304

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
