### PR TITLE
fix(cache): increase SQLite busy timeout from 100ms to 5000ms

### DIFF
--- a/docs/usage/self-hosted-experimental.md
+++ b/docs/usage/self-hosted-experimental.md
@@ -127,16 +127,16 @@ If set, Renovate will rewrite GitHub Enterprise Server's pagination responses to
 !!! note
     For the GitHub Enterprise Server platform only.
 
-## `RENOVATE_X_SQLITE_PACKAGE_CACHE`
-
-If set, Renovate will use SQLite as the backend for the package cache.
-Don't combine with `redisUrl`, Redis would be preferred over SQlite.
-
 ## `RENOVATE_X_SQLITE_BUSY_TIMEOUT`
 
 Set the SQLite busy timeout in milliseconds. Defaults to `5000`.
 
 Only applies when `RENOVATE_X_SQLITE_PACKAGE_CACHE` is set.
+
+## `RENOVATE_X_SQLITE_PACKAGE_CACHE`
+
+If set, Renovate will use SQLite as the backend for the package cache.
+Don't combine with `redisUrl`, Redis would be preferred over SQlite.
 
 ## `RENOVATE_X_STATIC_REPO_CONFIG_FILE`
 

--- a/docs/usage/self-hosted-experimental.md
+++ b/docs/usage/self-hosted-experimental.md
@@ -132,6 +132,12 @@ If set, Renovate will rewrite GitHub Enterprise Server's pagination responses to
 If set, Renovate will use SQLite as the backend for the package cache.
 Don't combine with `redisUrl`, Redis would be preferred over SQlite.
 
+## `RENOVATE_X_SQLITE_BUSY_TIMEOUT`
+
+Set the SQLite busy timeout in milliseconds. Defaults to `5000`.
+
+Only applies when `RENOVATE_X_SQLITE_PACKAGE_CACHE` is set.
+
 ## `RENOVATE_X_STATIC_REPO_CONFIG_FILE`
 
 If set to a valid path pointing to a file containing a _valid_ Renovate configuration in `JSON` format, it will be applied to the repository config before resolving the actual configuration file within the repository.

--- a/lib/util/cache/package/impl/sqlite.ts
+++ b/lib/util/cache/package/impl/sqlite.ts
@@ -4,7 +4,9 @@ import zlib, { constants } from 'node:zlib';
 import fs from 'fs-extra';
 import upath from 'upath';
 import { logger } from '../../../../logger/index.ts';
+import { getEnv } from '../../../env.ts';
 import { ensureDir } from '../../../fs/index.ts';
+import { parseInteger } from '../../../number.ts';
 import type { PackageCacheNamespace } from '../types.ts';
 import { PackageCacheBase } from './base.ts';
 
@@ -29,8 +31,6 @@ async function decompress<T>(input: Buffer): Promise<T> {
 }
 
 export class PackageCacheSqlite extends PackageCacheBase {
-  private static readonly busyTimeoutMs = 5000;
-
   static async create(cacheDir: string): Promise<PackageCacheSqlite> {
     const { DatabaseSync: Sqlite } = await import('node:sqlite');
     const sqliteDir = upath.join(cacheDir, 'renovate/renovate-cache-sqlite');
@@ -43,9 +43,10 @@ export class PackageCacheSqlite extends PackageCacheBase {
       logger.debug(`Creating SQLite package cache: ${sqliteFile}`);
     }
 
-    const client = new Sqlite(sqliteFile, {
-      timeout: PackageCacheSqlite.busyTimeoutMs,
-    });
+    const { RENOVATE_X_SQLITE_BUSY_TIMEOUT } = getEnv();
+    const timeout = parseInteger(RENOVATE_X_SQLITE_BUSY_TIMEOUT, 5000);
+
+    const client = new Sqlite(sqliteFile, { timeout });
     return new PackageCacheSqlite(client);
   }
 

--- a/lib/util/cache/package/impl/sqlite.ts
+++ b/lib/util/cache/package/impl/sqlite.ts
@@ -29,7 +29,7 @@ async function decompress<T>(input: Buffer): Promise<T> {
 }
 
 export class PackageCacheSqlite extends PackageCacheBase {
-  private static readonly busyTimeoutMs = 100;
+  private static readonly busyTimeoutMs = 5000;
 
   static async create(cacheDir: string): Promise<PackageCacheSqlite> {
     const { DatabaseSync: Sqlite } = await import('node:sqlite');


### PR DESCRIPTION
## Changes

Increase SQLite `busyTimeoutMs` from 100ms to 5000ms to reduce "database is locked" errors under concurrent access.

## Context

- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).

## Documentation (please check one with an [x])

- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Newly added/modified unit tests, or

The public repository: <URL>