### PR TITLE
fix(git): allow customEnvVariables to override GIT_SSH_COMMAND

### DIFF
--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -1571,6 +1571,38 @@ describe('util/git/index', { timeout: 10000 }, () => {
         }),
       );
     });
+
+    it('should allow customEnvVariables to override GIT_SSH_COMMAND', async () => {
+      const customSshCommand =
+        'ssh -i /path/to/deploy-key -o StrictHostKeyChecking=no';
+      setCustomEnv({ GIT_SSH_COMMAND: customSshCommand });
+
+      const envSpy = vi.spyOn(SimpleGit.prototype, 'env');
+      await git.initRepo({ url: origin.path });
+      await expect(git.syncGit()).resolves.toBeUndefined();
+      expect(envSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          LANG: 'C.UTF-8',
+          LC_ALL: 'C.UTF-8',
+          GIT_SSH_COMMAND: customSshCommand,
+        }),
+      );
+    });
+
+    it('should allow process.env GIT_SSH_COMMAND to override the default', async () => {
+      // GIT_SSH_COMMAND is declared in extraEnv, so the key is inherited
+      // from process.env via parentEnv (higher priority than extraEnv).
+      process.env.GIT_SSH_COMMAND = 'ssh -o SomeHostOption=yes';
+
+      const envSpy = vi.spyOn(SimpleGit.prototype, 'env');
+      await git.initRepo({ url: origin.path });
+      await expect(git.syncGit()).resolves.toBeUndefined();
+      expect(envSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          GIT_SSH_COMMAND: 'ssh -o SomeHostOption=yes',
+        }),
+      );
+    });
   });
 
   describe('pushCommit', () => {

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -95,6 +95,12 @@ export function createSimpleGit({
 } = {}): SimpleGit {
   return simpleGit({ ...simpleGitConfig(), ...config }).env(
     getChildEnv({
+      extraEnv: {
+        // Git will prompt for known hosts or passwords, unless we activate BatchMode.
+        // Set as extraEnv (lowest priority) so that process.env and
+        // customEnvVariables can override it.
+        GIT_SSH_COMMAND: 'ssh -o BatchMode=yes',
+      },
       env: {
         ...env,
         // To ensure the simple-git parsers match correctly, we need
@@ -106,8 +112,6 @@ export function createSimpleGit({
         // https://github.com/renovatebot/renovate/pull/18963
         LANG: 'C.UTF-8',
         LC_ALL: 'C.UTF-8',
-        // Git will prompt for known hosts or passwords, unless we activate BatchMode.
-        GIT_SSH_COMMAND: 'ssh -o BatchMode=yes',
       },
     }),
   );


### PR DESCRIPTION
## Changes

Move `GIT_SSH_COMMAND` from `forcedEnv` (highest priority) to `extraEnv` (lowest priority) in `createSimpleGit()`, so that both `process.env` and `customEnvVariables` can override the default `'ssh -o BatchMode=yes'` value.

Priority chain: `extraEnv < parentEnv < globalConfigEnv (customEnvVariables) < userConfiguredEnv < forcedEnv`

**Before (broken):** `forcedEnv` always sets `GIT_SSH_COMMAND` → user's value from `customEnvVariables` is overridden.
**After (fixed):** `extraEnv` provides the default at the lowest priority layer → `customEnvVariables` and `process.env` both win naturally.

Implements the approach suggested by @viceice in https://github.com/renovatebot/renovate/pull/43293#discussion_r2509127960.

## Context

- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

See https://github.com/renovatebot/renovate/discussions/43292

## AI assistance disclosure

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Used AI to assist with code analysis, test authoring, and PR description drafting.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

Added two test cases:
- `should allow customEnvVariables to override GIT_SSH_COMMAND` — verifies a custom value set via `setCustomEnv()` takes precedence over the default.
- `should allow process.env GIT_SSH_COMMAND to override the default` — verifies the host process's `GIT_SSH_COMMAND` is inherited and overrides the extraEnv default.