### PR TITLE
chore(workers/repository): improve error for invalid `allowedVersions`

### DIFF
--- a/lib/workers/repository/process/lookup/filter.ts
+++ b/lib/workers/repository/process/lookup/filter.ts
@@ -162,7 +162,7 @@ export function filterVersions(
       error.validationSource = 'config';
       error.validationError = 'Invalid `allowedVersions`';
       error.validationMessage =
-        'The following allowedVersions does not parse as a valid version or range: ' +
+        `The following allowedVersions does not parse as a valid version or range with versioning=${JSON.stringify(config.versioning)}: ` +
         JSON.stringify(allowedVersions);
       throw error;
     }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
As noted in #43304, when using `osvVulnerabilityAlerts`, we can
sometimes produce an `allowedVersions` that is valid for the ecosystem,
but without setting the `versioning`, we produce an invalid rule, which
then results in a `config-validation` result, breaking any updates on
the repo.

When this happens, it's unclear which `versioning` is used to validate
this, so we should add this to the error message.


## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: https://github.com/JamieTanna-Mend-testing/renovate-discussions-43304

```
 WARN: Configuration Warning (repository=JamieTanna-Mend-testing/renovate-discussions-43304)
       "configError": {
         "validationSource": "config",
         "validationError": "Invalid `allowedVersions`",
         "validationMessage": "The following allowedVersions does not parse as a valid version or range with versioning=\"regex:^v?(?<major>\\\\d+)(\\\\.(?<minor>\\\\d+)\\\\.(?<patch>\\\\d+))?$\": \"[4.0.0,)\"",
         "message": "config-validation",
         "stack": "Error: config-validation\n    at filterVersions (file:///Users/jamietanna/workspaces/renovatebot/renovate/lib/workers/repository/process/lookup/filter.ts:161:21)\n    at lookupUpdates (file:///Users/jamietanna/workspaces
/renovatebot/renovate/lib/workers/repository/process/lookup/index.ts:393:30)\n    at file:///Users/jamietanna/workspaces/renovatebot/renovate/lib/workers/repository/process/fetch.ts:81:12\n    at LookupStats.wrap (file:///Users/jamietanna/
workspaces/renovatebot/renovate/lib/util/stats.ts:39:20)\n    at file:///Users/jamietanna/workspaces/renovatebot/renovate/lib/workers/repository/process/fetch.ts:140:23\n    at file:///Users/jamietanna/workspaces/renovatebot/renovate/node_
modules/.pnpm/p-map@6.0.0/node_modules/p-map/index.js:139:20"
       },
       "res": "updated",
       "trace_id": "7dcdecd5b2a739f5fea52a63b9fde1eb",
       "span_id": "248dc88ecad5e387",
       "trace_flags": "01"
```
<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
