### PR TITLE
fix(manager/ant): skip property/import files with placeholders in path or outside of `baseDir`

### DIFF
--- a/lib/modules/manager/ant/extract.spec.ts
+++ b/lib/modules/manager/ant/extract.spec.ts
@@ -5,6 +5,10 @@ import { extractAllPackageFiles, extractPackageFile } from './extract.ts';
 vi.mock('../../../util/fs/index.ts');
 
 describe('modules/manager/ant/extract', () => {
+  beforeEach(() => {
+    fs.isValidLocalPath.mockReturnValue(true);
+  });
+
   describe('extractPackageFile', () => {
     it('extracts inline version dependencies from build.xml', () => {
       expect(
@@ -1195,6 +1199,110 @@ describe('modules/manager/ant/extract', () => {
             <project>
               <property file="\${included.basedir}/../\${user.name}.properties"/>
               <artifact:dependencies>
+                <dependency groupId="junit" artifactId="junit" version="4.13.2" />
+              </artifact:dependencies>
+            </project>
+          `);
+        }
+        return Promise.resolve(null);
+      });
+
+      const result = await extractAllPackageFiles({}, ['build.xml']);
+
+      expect(fs.readLocalFile).toHaveBeenCalledTimes(1);
+      expect(fs.readLocalFile).toHaveBeenCalledWith('build.xml', 'utf8');
+      expect(result).toEqual([
+        {
+          packageFile: 'build.xml',
+          deps: [
+            expect.objectContaining({
+              depName: 'junit:junit',
+              currentValue: '4.13.2',
+            }),
+          ],
+        },
+      ]);
+    });
+
+    it('skips property file references that resolve outside the repository', async () => {
+      fs.isValidLocalPath.mockImplementation(
+        (file: string) => !file.includes('..'),
+      );
+      fs.readLocalFile.mockImplementation((file: string) => {
+        if (file === 'build.xml') {
+          return Promise.resolve(codeBlock`
+            <project>
+              <property file="/../../../some.properties"/>
+              <artifact:dependencies>
+                <dependency groupId="junit" artifactId="junit" version="4.13.2" />
+              </artifact:dependencies>
+            </project>
+          `);
+        }
+        return Promise.resolve(null);
+      });
+
+      const result = await extractAllPackageFiles({}, ['build.xml']);
+
+      expect(fs.readLocalFile).toHaveBeenCalledTimes(1);
+      expect(fs.readLocalFile).toHaveBeenCalledWith('build.xml', 'utf8');
+      expect(result).toEqual([
+        {
+          packageFile: 'build.xml',
+          deps: [
+            expect.objectContaining({
+              depName: 'junit:junit',
+              currentValue: '4.13.2',
+            }),
+          ],
+        },
+      ]);
+    });
+
+    it('skips import file references that resolve outside the repository', async () => {
+      fs.isValidLocalPath.mockImplementation(
+        (file: string) => !file.includes('..'),
+      );
+      fs.readLocalFile.mockImplementation((file: string) => {
+        if (file === 'build.xml') {
+          return Promise.resolve(codeBlock`
+            <project>
+              <import file="../../../outside/build.xml"/>
+              <artifact:dependencies>
+                <dependency groupId="junit" artifactId="junit" version="4.13.2" />
+              </artifact:dependencies>
+            </project>
+          `);
+        }
+        return Promise.resolve(null);
+      });
+
+      const result = await extractAllPackageFiles({}, ['build.xml']);
+
+      expect(fs.readLocalFile).toHaveBeenCalledTimes(1);
+      expect(fs.readLocalFile).toHaveBeenCalledWith('build.xml', 'utf8');
+      expect(result).toEqual([
+        {
+          packageFile: 'build.xml',
+          deps: [
+            expect.objectContaining({
+              depName: 'junit:junit',
+              currentValue: '4.13.2',
+            }),
+          ],
+        },
+      ]);
+    });
+
+    it('skips settingsFile references that resolve outside the repository', async () => {
+      fs.isValidLocalPath.mockImplementation(
+        (file: string) => !file.includes('..'),
+      );
+      fs.readLocalFile.mockImplementation((file: string) => {
+        if (file === 'build.xml') {
+          return Promise.resolve(codeBlock`
+            <project>
+              <artifact:dependencies settingsFile="/../../etc/settings.xml">
                 <dependency groupId="junit" artifactId="junit" version="4.13.2" />
               </artifact:dependencies>
             </project>

--- a/lib/modules/manager/ant/extract.spec.ts
+++ b/lib/modules/manager/ant/extract.spec.ts
@@ -1188,6 +1188,70 @@ describe('modules/manager/ant/extract', () => {
       ]);
     });
 
+    it('skips property file references with unresolved placeholders in path', async () => {
+      fs.readLocalFile.mockImplementation((file: string) => {
+        if (file === 'build.xml') {
+          return Promise.resolve(codeBlock`
+            <project>
+              <property file="\${included.basedir}/../\${user.name}.properties"/>
+              <artifact:dependencies>
+                <dependency groupId="junit" artifactId="junit" version="4.13.2" />
+              </artifact:dependencies>
+            </project>
+          `);
+        }
+        return Promise.resolve(null);
+      });
+
+      const result = await extractAllPackageFiles({}, ['build.xml']);
+
+      expect(fs.readLocalFile).toHaveBeenCalledTimes(1);
+      expect(fs.readLocalFile).toHaveBeenCalledWith('build.xml', 'utf8');
+      expect(result).toEqual([
+        {
+          packageFile: 'build.xml',
+          deps: [
+            expect.objectContaining({
+              depName: 'junit:junit',
+              currentValue: '4.13.2',
+            }),
+          ],
+        },
+      ]);
+    });
+
+    it('skips import file references with unresolved placeholders in path', async () => {
+      fs.readLocalFile.mockImplementation((file: string) => {
+        if (file === 'build.xml') {
+          return Promise.resolve(codeBlock`
+            <project>
+              <import file="\${user.name}/build.xml"/>
+              <artifact:dependencies>
+                <dependency groupId="junit" artifactId="junit" version="4.13.2" />
+              </artifact:dependencies>
+            </project>
+          `);
+        }
+        return Promise.resolve(null);
+      });
+
+      const result = await extractAllPackageFiles({}, ['build.xml']);
+
+      expect(fs.readLocalFile).toHaveBeenCalledTimes(1);
+      expect(fs.readLocalFile).toHaveBeenCalledWith('build.xml', 'utf8');
+      expect(result).toEqual([
+        {
+          packageFile: 'build.xml',
+          deps: [
+            expect.objectContaining({
+              depName: 'junit:junit',
+              currentValue: '4.13.2',
+            }),
+          ],
+        },
+      ]);
+    });
+
     it('handles chain referencing undefined property', async () => {
       fs.readLocalFile.mockResolvedValue(codeBlock`
         <project>

--- a/lib/modules/manager/ant/extract.ts
+++ b/lib/modules/manager/ant/extract.ts
@@ -14,6 +14,7 @@ import type {
 } from '../types.ts';
 import {
   applyProps,
+  containsPlaceholder,
   findAttrValuePosition,
   parsePropertiesFile,
   resolveChainedProps,
@@ -246,27 +247,39 @@ async function walkNodeInOrder(
       // Handle property file reference
       const file = child.attr.file;
       if (file) {
-        const propFilePath = file.startsWith('/')
-          ? file
-          : upath.join(baseDir, file);
+        if (containsPlaceholder(file)) {
+          logger.debug(
+            `ant manager: skipping properties file with unresolved placeholders in path: ${file}`,
+          );
+        } else {
+          const propFilePath = file.startsWith('/')
+            ? file
+            : upath.join(baseDir, file);
 
-        if (!visitedFiles.has(propFilePath)) {
-          visitedFiles.add(propFilePath);
-          const propContent = await readLocalFile(propFilePath, 'utf8');
-          if (propContent) {
-            parsePropertiesFile(propContent, propFilePath, allProps);
-          } else {
-            logger.debug(
-              `ant manager: could not read properties file ${propFilePath}`,
-            );
+          if (!visitedFiles.has(propFilePath)) {
+            visitedFiles.add(propFilePath);
+            const propContent = await readLocalFile(propFilePath, 'utf8');
+            if (propContent) {
+              parsePropertiesFile(propContent, propFilePath, allProps);
+            } else {
+              logger.debug(
+                `ant manager: could not read properties file ${propFilePath}`,
+              );
+            }
           }
         }
       }
     } else if (child.name === 'import' && child.attr.file) {
-      const importedFile = upath.normalize(
-        upath.join(baseDir, child.attr.file),
-      );
-      await walkXmlFile(importedFile, visitedFiles, allProps, allRawDeps);
+      if (containsPlaceholder(child.attr.file)) {
+        logger.debug(
+          `ant manager: skipping import file with unresolved placeholders in path: ${child.attr.file}`,
+        );
+      } else {
+        const importedFile = upath.normalize(
+          upath.join(baseDir, child.attr.file),
+        );
+        await walkXmlFile(importedFile, visitedFiles, allProps, allRawDeps);
+      }
     } else if (child.name === 'dependency') {
       const rawDep = collectDependency(
         child,

--- a/lib/modules/manager/ant/extract.ts
+++ b/lib/modules/manager/ant/extract.ts
@@ -2,7 +2,7 @@ import upath from 'upath';
 import type { XmlElement } from 'xmldoc';
 import { XmlDocument } from 'xmldoc';
 import { logger } from '../../../logger/index.ts';
-import { readLocalFile } from '../../../util/fs/index.ts';
+import { isValidLocalPath, readLocalFile } from '../../../util/fs/index.ts';
 import { MavenDatasource } from '../../datasource/maven/index.ts';
 import { extractRegistries } from '../maven/extract.ts';
 import { isXmlElement } from '../nuget/util.ts';
@@ -77,27 +77,41 @@ interface RawDep {
   depPackageFile: string;
 }
 
+async function readSettingsRegistries(
+  settingsFile: string,
+  baseDir: string,
+): Promise<string[]> {
+  const settingsPath = settingsFile.startsWith('/')
+    ? settingsFile
+    : upath.join(baseDir, settingsFile);
+
+  if (!isValidLocalPath(settingsPath)) {
+    logger.debug(
+      `ant manager: skipping settings file outside repository: ${settingsPath}`,
+    );
+    return [];
+  }
+
+  const settingsContent = await readLocalFile(settingsPath, 'utf8');
+  if (!settingsContent) {
+    logger.debug(`ant manager: could not read settings file ${settingsPath}`);
+    return [];
+  }
+
+  return extractRegistries(settingsContent);
+}
+
 async function collectRegistryUrls(
   node: XmlElement,
   baseDir: string,
 ): Promise<string[]> {
   const urls: string[] = [];
 
-  // Read registry URLs from settingsFile attribute
   const settingsFile = node.attr.settingsFile;
   if (settingsFile) {
-    const settingsPath = settingsFile.startsWith('/')
-      ? settingsFile
-      : upath.join(baseDir, settingsFile);
-    const settingsContent = await readLocalFile(settingsPath, 'utf8');
-    if (settingsContent) {
-      urls.push(...extractRegistries(settingsContent));
-    } else {
-      logger.debug(`ant manager: could not read settings file ${settingsPath}`);
-    }
+    urls.push(...(await readSettingsRegistries(settingsFile, baseDir)));
   }
 
-  // Collect inline <remoteRepository url="..." /> elements
   for (const child of node.children) {
     if (
       isXmlElement(child) &&
@@ -215,6 +229,67 @@ export function extractPackageFile(
   return { deps };
 }
 
+async function loadPropertyFile(
+  file: string,
+  baseDir: string,
+  visitedFiles: Set<string>,
+  allProps: Record<string, AntProp>,
+): Promise<void> {
+  if (containsPlaceholder(file)) {
+    logger.debug(
+      `ant manager: skipping properties file with unresolved placeholders in path: ${file}`,
+    );
+    return;
+  }
+
+  const propFilePath = file.startsWith('/') ? file : upath.join(baseDir, file);
+
+  if (!isValidLocalPath(propFilePath)) {
+    logger.debug(
+      `ant manager: skipping properties file outside repository: ${propFilePath}`,
+    );
+    return;
+  }
+
+  if (visitedFiles.has(propFilePath)) {
+    return;
+  }
+  visitedFiles.add(propFilePath);
+
+  const propContent = await readLocalFile(propFilePath, 'utf8');
+  if (!propContent) {
+    logger.debug(`ant manager: could not read properties file ${propFilePath}`);
+    return;
+  }
+
+  parsePropertiesFile(propContent, propFilePath, allProps);
+}
+
+async function loadImportedFile(
+  file: string,
+  baseDir: string,
+  visitedFiles: Set<string>,
+  allProps: Record<string, AntProp>,
+  allRawDeps: RawDep[],
+): Promise<void> {
+  if (containsPlaceholder(file)) {
+    logger.debug(
+      `ant manager: skipping import file with unresolved placeholders in path: ${file}`,
+    );
+    return;
+  }
+
+  const importedFile = upath.normalize(upath.join(baseDir, file));
+  if (!isValidLocalPath(importedFile)) {
+    logger.debug(
+      `ant manager: skipping import file outside repository: ${importedFile}`,
+    );
+    return;
+  }
+
+  await walkXmlFile(importedFile, visitedFiles, allProps, allRawDeps);
+}
+
 /**
  * Walk an XML node tree in document order, processing properties,
  * property file references, and dependencies as they appear.
@@ -236,7 +311,6 @@ async function walkNodeInOrder(
     }
 
     if (child.name === 'property') {
-      // Handle inline property definition
       const name = child.attr.name;
       const value = child.attr.value;
       if (name && value && !(name in allProps)) {
@@ -244,42 +318,22 @@ async function walkNodeInOrder(
         allProps[name] = { val: value, fileReplacePosition: pos, packageFile };
       }
 
-      // Handle property file reference
-      const file = child.attr.file;
-      if (file) {
-        if (containsPlaceholder(file)) {
-          logger.debug(
-            `ant manager: skipping properties file with unresolved placeholders in path: ${file}`,
-          );
-        } else {
-          const propFilePath = file.startsWith('/')
-            ? file
-            : upath.join(baseDir, file);
-
-          if (!visitedFiles.has(propFilePath)) {
-            visitedFiles.add(propFilePath);
-            const propContent = await readLocalFile(propFilePath, 'utf8');
-            if (propContent) {
-              parsePropertiesFile(propContent, propFilePath, allProps);
-            } else {
-              logger.debug(
-                `ant manager: could not read properties file ${propFilePath}`,
-              );
-            }
-          }
-        }
+      if (child.attr.file) {
+        await loadPropertyFile(
+          child.attr.file,
+          baseDir,
+          visitedFiles,
+          allProps,
+        );
       }
     } else if (child.name === 'import' && child.attr.file) {
-      if (containsPlaceholder(child.attr.file)) {
-        logger.debug(
-          `ant manager: skipping import file with unresolved placeholders in path: ${child.attr.file}`,
-        );
-      } else {
-        const importedFile = upath.normalize(
-          upath.join(baseDir, child.attr.file),
-        );
-        await walkXmlFile(importedFile, visitedFiles, allProps, allRawDeps);
-      }
+      await loadImportedFile(
+        child.attr.file,
+        baseDir,
+        visitedFiles,
+        allProps,
+        allRawDeps,
+      );
     } else if (child.name === 'dependency') {
       const rawDep = collectDependency(
         child,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
- Skip property/import files with placeholders in path 
eg. `<property file="${included.basedir}/../${user.name}.properties"/>`
<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository



<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
