### PR TITLE
fix(config-validator): Allow warnings to flush before process.exit

### DIFF
--- a/lib/config-validator.ts
+++ b/lib/config-validator.ts
@@ -259,10 +259,11 @@ If you have specified global self-hosted configuration (https://docs.renovatebot
         // ignore
       }
     }
-    if (returnVal !== 0) {
-      process.exit(returnVal);
+    if (returnVal === 0) {
+      logger.info('Config validated successfully');
     }
-    logger.info('Config validated successfully');
+    // Use exitCode (not process.exit) so async log streams can flush
+    process.exitCode = returnVal;
   });
 
   await program.parseAsync();


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Fix for `renovate-config-validator` returning an non-zero error code without displaying any output for the relevant warnings.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [X] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [X] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Used Claude Code CLI with Opus 4.7 to reproduce the failure locally with the renovate source and track down the root cause of the failure. Then I had it implement a fix and validate that the warning was no longer triggered. I edited the comment to be a single line instead of 5 (lol).

I looked at implementing this in other places where process.exit was called directly but was not familiar enough with the dozens of call sites where that is called and so focused on just fixing my issue. I wasn't sure if some of those call sites could also have subprocess failures and thus should support `RENOVATE_X_HARD_EXIT` as was needed to fix https://github.com/renovatebot/renovate/issues/8660.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

Example GitHub actions run which shows retcode 1 but no WARN output:
- https://github.com/oxidecomputer/renovate-config/actions/runs/25810206116/job/75824086193

Reproduced locally on https://github.com/oxidecomputer/renovate-config/pull/76/commits/672ae8e8fb895ced5c04c6c3b9dbf5c7555518d6 with `rust/toolchain.json`

Now correctly shows the output:
```shell
# LOG_LEVEL=info node ~/source/renovate/lib/config-validator.ts --strict rust/toolchain.json
   INFO: Validating /tmp/rc-test/toolchain.json as global config
   WARN: Config migration necessary
         "oldConfig": { ... "fileMatch": ["^rust-toolchain\\.toml?$"] ... }
         "newConfig": { ... "managerFilePatterns": ["/^rust-toolchain\\.toml?$/"] ... }
   WARN: Config migration diff:
           {
             ...
         -       "fileMatch": [
         -         "^rust-toolchain\\.toml?$"
         +       "managerFilePatterns": [
         +         "/^rust-toolchain\\.toml?$/"
                 ],
             ...
           }
```

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
