### PR TITLE
feat(vulnerabilities): support golang-version toolchain directive for OSV vulnerability alerts

### DIFF
--- a/lib/util/vulnerability/ecosystem.ts
+++ b/lib/util/vulnerability/ecosystem.ts
@@ -3,6 +3,7 @@ import { ClojureDatasource } from '../../modules/datasource/clojure/index.ts';
 import { CrateDatasource } from '../../modules/datasource/crate/index.ts';
 import { GithubTagsDatasource } from '../../modules/datasource/github-tags/index.ts';
 import { GoDatasource } from '../../modules/datasource/go/index.ts';
+import { GolangVersionDatasource } from '../../modules/datasource/golang-version/index.ts';
 import { HackageDatasource } from '../../modules/datasource/hackage/index.ts';
 import { HexDatasource } from '../../modules/datasource/hex/index.ts';
 import { MavenDatasource } from '../../modules/datasource/maven/index.ts';
@@ -27,6 +28,7 @@ export const datasourceToOsvEcosystem: Record<
   [ClojureDatasource.id]: 'Maven',
   [CrateDatasource.id]: 'crates.io',
   [GoDatasource.id]: 'Go',
+  [GolangVersionDatasource.id]: 'Go',
   [HackageDatasource.id]: 'Hackage',
   [HexDatasource.id]: 'Hex',
   [MavenDatasource.id]: 'Maven',

--- a/lib/workers/repository/process/types.ts
+++ b/lib/workers/repository/process/types.ts
@@ -6,6 +6,7 @@ import type { VersioningApi } from '../../../modules/versioning/index.ts';
 export interface Vulnerability {
   packageFileConfig: RenovateConfig & PackageFile;
   packageName: string;
+  osvPackageName: string;
   depVersion: string;
   fixedVersion: string | null;
   datasource: string;

--- a/lib/workers/repository/process/vulnerabilities.spec.ts
+++ b/lib/workers/repository/process/vulnerabilities.spec.ts
@@ -1132,6 +1132,92 @@ describe('workers/repository/process/vulnerabilities', () => {
       ]);
     });
 
+    it('creates vulnerability alert for go toolchain directive using stdlib', async () => {
+      const packageFiles: Record<string, PackageFile[]> = {
+        gomod: [
+          {
+            deps: [
+              {
+                depName: 'go',
+                depType: 'toolchain',
+                currentValue: '1.23.6',
+                datasource: 'golang-version',
+              },
+            ],
+            packageFile: 'go.mod',
+          },
+        ],
+      };
+
+      getVulnerabilitiesMock.mockResolvedValueOnce([
+        {
+          id: 'GO-2025-3563',
+          modified: '',
+          aliases: ['CVE-2025-22871'],
+          affected: [
+            {
+              package: {
+                name: 'stdlib',
+                ecosystem: 'Go',
+                purl: 'pkg:golang/stdlib',
+              },
+              ranges: [
+                {
+                  type: 'SEMVER',
+                  events: [{ introduced: '1.23.0' }, { fixed: '1.23.8' }],
+                },
+              ],
+            },
+          ],
+        },
+      ]);
+
+      await vulnerabilities.appendVulnerabilityPackageRules(
+        config,
+        packageFiles,
+      );
+
+      expect(logger.logger.debug).toHaveBeenCalledWith(
+        'Vulnerability GO-2025-3563 affects go 1.23.6',
+      );
+
+      expect(config.packageRules).toHaveLength(1);
+      expect(config.packageRules).toMatchObject([
+        {
+          matchDatasources: ['golang-version'],
+          matchPackageNames: ['go'],
+          matchCurrentVersion: '1.23.6',
+          allowedVersions: '>= 1.23.8',
+          isVulnerabilityAlert: true,
+        },
+      ]);
+    });
+
+    it('skips vulnerability lookup for go module directive', async () => {
+      const packageFiles: Record<string, PackageFile[]> = {
+        gomod: [
+          {
+            deps: [
+              {
+                depName: 'go',
+                depType: 'golang',
+                currentValue: '1.23.5',
+                datasource: 'golang-version',
+              },
+            ],
+            packageFile: 'go.mod',
+          },
+        ],
+      };
+
+      await vulnerabilities.appendVulnerabilityPackageRules(
+        config,
+        packageFiles,
+      );
+
+      expect(config.packageRules).toHaveLength(0);
+    });
+
     it('sets default datasource versioning to align with allowedVersions on packageRule', async () => {
       const packageFiles: Record<string, PackageFile[]> = {
         gomod: [

--- a/lib/workers/repository/process/vulnerabilities.ts
+++ b/lib/workers/repository/process/vulnerabilities.ts
@@ -168,19 +168,28 @@ export class Vulnerabilities {
       return null;
     }
 
-    let packageName = dep.packageName ?? dep.depName!;
+    const packageName = dep.packageName ?? dep.depName!;
+    let osvPackageName = packageName;
     if (ecosystem === 'PyPI') {
       // https://peps.python.org/pep-0503/#normalized-names
-      packageName = packageName.toLowerCase().replace(regEx(/[_.-]+/g), '-');
+      osvPackageName = osvPackageName
+        .toLowerCase()
+        .replace(regEx(/[_.-]+/g), '-');
+    } else if (ecosystem === 'Go' && packageName === 'go') {
+      if (dep.depType !== 'toolchain') {
+        // The `go` directive is source compatibility, not the build toolchain, so we skip it
+        return null;
+      }
+      osvPackageName = 'stdlib';
     }
 
     try {
       const osvVulnerabilities = await instrument(
         'get OSV vulnerabilities',
-        () => this.osvOffline.getVulnerabilities(ecosystem, packageName),
+        () => this.osvOffline.getVulnerabilities(ecosystem, osvPackageName),
         {
           attributes: {
-            packageName,
+            osvPackageName,
             ecosystem,
           },
         },
@@ -219,7 +228,7 @@ export class Vulnerabilities {
 
         this.skipMaliciousPackages(
           ecosystem,
-          packageName,
+          osvPackageName,
           depVersion,
           versioningApi,
           dep,
@@ -231,7 +240,7 @@ export class Vulnerabilities {
         for (const affected of osvVulnerability.affected ?? []) {
           const isVulnerable = this.isPackageVulnerable(
             ecosystem,
-            packageName,
+            osvPackageName,
             depVersion,
             affected,
             versioningApi,
@@ -252,6 +261,7 @@ export class Vulnerabilities {
 
           vulnerabilities.push({
             packageName,
+            osvPackageName,
             vulnerability: osvVulnerability,
             affected,
             depVersion,
@@ -274,7 +284,7 @@ export class Vulnerabilities {
 
   private skipMaliciousPackages(
     ecosystem: Ecosystem,
-    packageName: string,
+    osvPackageName: string,
     depVersion: string,
     versioningApi: VersioningApi,
     dep: PackageDependency,
@@ -289,7 +299,7 @@ export class Vulnerabilities {
         // is the current dependency vulnerable?
         const isVulnerable = this.isPackageVulnerable(
           ecosystem,
-          packageName,
+          osvPackageName,
           depVersion,
           affected,
           versioningApi,
@@ -317,7 +327,7 @@ export class Vulnerabilities {
 
           const isUpdateVulnerable = this.isPackageVulnerable(
             ecosystem,
-            packageName,
+            osvPackageName,
             newVersion,
             affected,
             versioningApi,
@@ -393,11 +403,11 @@ export class Vulnerabilities {
 
   private isPackageAffected(
     ecosystem: Ecosystem,
-    packageName: string,
+    osvPackageName: string,
     affected: Osv.Affected,
   ): boolean {
     return (
-      affected.package?.name === packageName &&
+      affected.package?.name === osvPackageName &&
       affected.package?.ecosystem === ecosystem
     );
   }
@@ -451,13 +461,13 @@ export class Vulnerabilities {
   // https://ossf.github.io/osv-schema/#evaluation
   private isPackageVulnerable(
     ecosystem: Ecosystem,
-    packageName: string,
+    osvPackageName: string,
     depVersion: string,
     affected: Osv.Affected,
     versioningApi: VersioningApi,
   ): boolean {
     return (
-      this.isPackageAffected(ecosystem, packageName, affected) &&
+      this.isPackageAffected(ecosystem, osvPackageName, affected) &&
       (this.includedInVersions(depVersion, affected) ||
         this.includedInRanges(depVersion, affected, versioningApi))
     );


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds support for vulnerability alerts on the `toolchain` directive in go.mod files. When `osvVulnerabilityAlerts` is enabled, Renovate now queries the OSV database under the Go `stdlib` package for deps with `datasource: golang-version` and `depType: toolchain`, and generates the appropriate package rule to raise a fix PR.

The go directive is intentionally skipped as it represents source compatibility of the module, not the toolchain used to build it. 

_Note_: the rename of `packageName` to `osvPackageName` (= OSV ecosystem lookup name) may seem like a refactor but it actually corrects a latent semantic confusion. It was accurate as long as these two were the same but especially now with `go` (= `packageName`) vs `stdlib` (= `osvPackageName`), it ensures that we don't create an ineffective package rule that never matches the dep.

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: https://github.com/renovatebot/renovate/issues/43235 <!-- NOTE that this should NOT be a Discussion -->
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/renovate-demo/43235-golang-toolchain-osv/pull/1

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
