### PR TITLE
fix(datasource/maven): don't look up potential Gradle Plugins in Maven Central

### DIFF
--- a/lib/modules/datasource/maven/common.ts
+++ b/lib/modules/datasource/maven/common.ts
@@ -1,3 +1,5 @@
 export const id = 'maven';
 
 export const MAVEN_REPO = 'https://repo.maven.apache.org/maven2';
+export const MAVEN_CENTRAL_MIRROR = 'https://repo1.maven.org/maven2';
+export const MAVEN_CENTRAL_URLS = [MAVEN_REPO, MAVEN_CENTRAL_MIRROR];

--- a/lib/modules/datasource/maven/index.spec.ts
+++ b/lib/modules/datasource/maven/index.spec.ts
@@ -13,7 +13,7 @@ import { id as versioning } from '../../versioning/maven/index.ts';
 import type { Release, ReleaseResult } from '../index.ts';
 import { getPkgReleases } from '../index.ts';
 import { postprocessRelease } from '../postprocess-release.ts';
-import { MAVEN_REPO } from './common.ts';
+import { MAVEN_CENTRAL_MIRROR, MAVEN_REPO } from './common.ts';
 import { MavenDatasource } from './index.ts';
 
 const googleAuth = vi.mocked(_googleAuth);
@@ -129,6 +129,62 @@ describe('modules/datasource/maven/index', () => {
     const res = await get();
 
     expect(res).toBeNull();
+  });
+
+  describe('skips Maven Central for suspected Gradle plugins', () => {
+    describe('when in groupId', () => {
+      it('when using primary registry URL', async () => {
+        const res = await get(
+          'io.github.ramanji025.gradle.plugin:typescript-gradle-plugin',
+          MAVEN_REPO,
+        );
+
+        expect(res).toBeNull();
+      });
+
+      it('when using mirror URL', async () => {
+        const res = await get(
+          'io.github.ramanji025.gradle.plugin:typescript-gradle-plugin',
+          MAVEN_CENTRAL_MIRROR,
+        );
+
+        expect(res).toBeNull();
+      });
+    });
+
+    describe('when in artifactId', () => {
+      it('when using primary registry URL', async () => {
+        const res = await get(
+          'org.example:org.example.gradle.plugin',
+          MAVEN_REPO,
+        );
+
+        expect(res).toBeNull();
+      });
+
+      it('when using mirror URL', async () => {
+        const res = await get(
+          'org.example:org.example.gradle.plugin',
+          MAVEN_CENTRAL_MIRROR,
+        );
+
+        expect(res).toBeNull();
+      });
+    });
+  });
+
+  it('fetches Gradle plugins from non-Maven-Central registries', async () => {
+    mockGenericPackage({
+      dep: 'org.example:org.example.gradle.plugin',
+      base: baseUrlCustom,
+    });
+
+    const res = await get(
+      'org.example:org.example.gradle.plugin',
+      baseUrlCustom,
+    );
+
+    expect(res).not.toBeNull();
   });
 
   it('returns releases', async () => {

--- a/lib/modules/datasource/maven/index.ts
+++ b/lib/modules/datasource/maven/index.ts
@@ -14,7 +14,7 @@ import type {
   Release,
   ReleaseResult,
 } from '../types.ts';
-import { MAVEN_REPO } from './common.ts';
+import { MAVEN_CENTRAL_URLS, MAVEN_REPO } from './common.ts';
 import type { MavenDependency, MetadataResults } from './types.ts';
 import {
   createUrlForDependencyPom,
@@ -113,6 +113,19 @@ export class MavenDatasource extends Datasource {
 
     const dependency = getDependencyParts(packageName);
     const repoUrl = ensureTrailingSlash(registryUrl);
+
+    if (
+      // groupId
+      (packageName.includes('.gradle.plugin:') ||
+        // artifactId
+        packageName.endsWith('.gradle.plugin')) &&
+      MAVEN_CENTRAL_URLS.some((url) => repoUrl === ensureTrailingSlash(url))
+    ) {
+      logger.debug(
+        `Maven: skipping Maven Central for suspected Gradle plugin "${packageName}"`,
+      );
+      return null;
+    }
 
     logger.debug(`Looking up ${dependency.display} in repository ${repoUrl}`);
 

--- a/lib/modules/datasource/maven/readme.md
+++ b/lib/modules/datasource/maven/readme.md
@@ -20,6 +20,10 @@ If you continue to experience rate limiting issues after implementing persistent
 - Reduce the frequency of Renovate runs
 - Consider using a Maven repository proxy with its own caching layer
 
+<!-- prettier-ignore -->
+!!! note
+    Dependencies that appear to be Gradle plugins (where the artifactId ends with `.gradle.plugin`) will **not** be looked up in Maven Central.
+
 #### Making your changelogs fetchable
 
 In case you are publishing artifacts and you want to ensure that your changelogs are fetchable by `Renovate`, you need to configure the [scm section](https://maven.apache.org/scm/git.html) on their `pom.xml` file.

--- a/lib/modules/datasource/maven/readme.md
+++ b/lib/modules/datasource/maven/readme.md
@@ -22,7 +22,7 @@ If you continue to experience rate limiting issues after implementing persistent
 
 <!-- prettier-ignore -->
 !!! note
-    Dependencies that appear to be Gradle plugins (where the artifactId ends with `.gradle.plugin`) will **not** be looked up in Maven Central.
+    Dependencies that appear to be Gradle plugins (where the groupId or artifactId ends with `.gradle.plugin`) will **not** be looked up in Maven Central.
 
 #### Making your changelogs fetchable
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
As part of efforts to reduce the general overload on Maven Central[0]
from Renovate, we can look to avoid lookups that we know are likely to
never resolve.

For instance, via #43146, we can skip any packages that appear to be a
Gradle Plugin, as they will only ever be sourced from the  Gradle Plugin
Portal.

This may have some false positives - [we can see 137 `gradle.plugin` results on Maven Central](https://mvnrepository.com/search?q=gradle.plugin&), but I'm happy with these dependencies being skipped. If we need to, we can re-add an override for them in the future.

For instance, in the last 24 hours, Mend-hosted Renovate has seen 3507 rate limit errors related to `gradle.plugin` (out of a total 27137 events)

[0]: https://www.sonatype.com/blog/maven-central-and-the-tragedy-of-the-commons


## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
