### PR TITLE
fix(workers/repository): skip pending-version check when re-extracted dep lacks resolved version

### DIFF
--- a/lib/workers/repository/update/branch/get-updated.spec.ts
+++ b/lib/workers/repository/update/branch/get-updated.spec.ts
@@ -1667,8 +1667,7 @@ describe('workers/repository/update/branch/get-updated', () => {
       });
     });
 
-    // should never happen, but our types allow this
-    it('rejects when an updated dependency has no new version', async () => {
+    it('skips the pending-version check when re-extracted dep has no resolvable version', async () => {
       config.upgrades.push({
         packageFile: 'composer.json',
         manager: 'composer',
@@ -1699,19 +1698,16 @@ describe('workers/repository/update/branch/get-updated', () => {
         ],
       });
 
-      await expect(getUpdatedPackageFiles(config)).rejects.toThrowError(
-        'update-failure',
-      );
-
-      expect(logger.logger.error).toHaveBeenCalledWith(
+      const res = await getUpdatedPackageFiles(config);
+      expect(res.artifactErrors).toHaveLength(0);
+      expect(logger.logger.warn).toHaveBeenCalledWith(
         {
           packageFile: 'composer.json',
           manager: 'composer',
           branchName: 'renovate/pin',
           depName: 'some-dep',
-          newVersion: undefined,
         },
-        "No new version found for 'some-dep' after updating 'composer.json'",
+        "Could not determine resolved version for 'some-dep' after updating 'composer.json'; skipping pending-version check",
       );
     });
 

--- a/lib/workers/repository/update/branch/get-updated.ts
+++ b/lib/workers/repository/update/branch/get-updated.ts
@@ -602,17 +602,16 @@ async function checkForPendingVersions(
       dep.currentVersion ??
       dep.currentValue;
     if (!resolvedVersion) {
-      logger.error(
+      logger.warn(
         {
           packageFile: packageFileName,
           manager,
           branchName: config.branchName,
           depName,
-          newVersion: resolvedVersion,
         },
-        `No new version found for '${depName}' after updating '${packageFileName}'`,
+        `Could not determine resolved version for '${depName}' after updating '${packageFileName}'; skipping pending-version check`,
       );
-      throw new Error(WORKER_FILE_UPDATE_FAILED);
+      continue;
     }
 
     if (resolvedVersion && upgradeInfo.pendingVersions.has(resolvedVersion)) {


### PR DESCRIPTION
## Changes

`checkForPendingVersions` (introduced in #41629) currently throws `WORKER_FILE_UPDATE_FAILED` when the re-extracted dep has none of `lockedVersion`, `newVersion`, `currentVersion`, or `currentValue` populated. That throw aborts the entire `getUpdatedPackageFiles` flow for a single dep we cannot verify — which is disproportionate to the intent of the check (flag artifact updates that introduced a pending version).

This PR demotes the abort to **warn-and-continue**: if the resolved version for a single dep cannot be determined, the pending-version check is skipped for that dep only and the rest of the update proceeds.

```diff
 if (!resolvedVersion) {
-  logger.error(
-    { ..., depName, newVersion: resolvedVersion },
-    `No new version found for '${depName}' after updating '${packageFileName}'`,
-  );
-  throw new Error(WORKER_FILE_UPDATE_FAILED);
+  logger.warn(
+    { ..., depName },
+    `Could not determine resolved version for '${depName}' after updating '${packageFileName}'; skipping pending-version check`,
+  );
+  continue;
 }
```

### Concrete scenario observed

Triggered with `minimumReleaseAge: '7 days'` + the `terraform` manager / `terraform-provider` datasource. The upgrade object Renovate built for `DataDog/datadog` at the cooldown boundary:

```json
{
  "depName": "datadog",
  "datasource": "terraform-provider",
  "packageName": "datadog/datadog",
  "currentValue": "4.6.0",
  "currentVersion": "4.6.0",
  "updates": [{
    "newVersion": "4.7.0",
    "newVersionAgeInDays": 7,
    "pendingVersions": ["4.8.0", "4.9.0"]
  }]
}
```

The relevant log sequence:

```text
DEBUG: terraform.updateArtifacts(main.tf)
DEBUG: Found 1 provider deps
DEBUG: Pinning constraint for "datadog/datadog" to "4.7.0"
DEBUG: Creating hashes for datadog/datadog@4.7.0 (https://registry.terraform.io)
DEBUG: Writing updates to .terraform.lock.hcl
ERROR: No new version found for 'datadog' after updating 'main.tf'
       newVersion: undefined
WARN : Error updating branch: update failure
Error: The process '/usr/bin/docker' failed with exit code 1
```

The `.tf` file *is* successfully rewritten 4.6.0 → 4.7.0 — the `Contents updated` debug log fires earlier in the same run for the same file, and the lockfile artifact write begins. Then `checkForPendingVersions` re-extracts the updated content and, somehow, the re-extracted dep object surfaces no `lockedVersion` / `newVersion` / `currentVersion` / `currentValue`, so `resolvedVersion` is undefined and the function throws.

From the function's own perspective this is a false negative: it cannot determine whether 4.7.0 falls into `pendingVersions: ["4.8.0", "4.9.0"]` (it doesn't), but instead of skipping the check it aborts the whole worker. The actual package-file update succeeded; what failed is only this optional verification pass.

### Why warn-and-continue is the right behavior here

The check exists to surface a soft warning when an artifact update has resolved to a pending version. If the four version fields on the re-extracted dep are all undefined, the function simply cannot perform the comparison for that dep. The remaining deps in the same file can still be verified normally, and a `logger.warn` keeps the skip visible without taking down the update.

Investigating *why* the terraform re-extract surfaces an unpopulated dep here is out of scope — the goal of this PR is just to make `checkForPendingVersions` resilient so a single unverifiable dep does not abort the whole flow.

The existing `it('rejects when an updated dependency has no new version', ...)` test is updated to reflect the new warn-and-continue behavior.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).

Used Claude (Anthropic) to locate the throw site and draft the code/test change. Reviewed and verified locally.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Newly added/modified unit tests

`pnpm vitest run lib/workers/repository/update/branch/get-updated.spec.ts` → all 58 tests pass.