### PR TITLE
feat(presets): stylelint packages group

### DIFF
--- a/lib/config/presets/internal/group.preset.ts
+++ b/lib/config/presets/internal/group.preset.ts
@@ -811,6 +811,17 @@ const staticGroups = {
       },
     ],
   },
+  stylelint: {
+    description: 'Group stylelint packages together.',
+    packageRules: [
+      {
+        extends: ['packages:stylelint'],
+        groupName: 'stylelint packages',
+        groupSlug: 'stylelint',
+        separateMajorMinor: false,
+      },
+    ],
+  },
   symfony: {
     description: 'Group PHP Symfony packages together.',
     packageRules: [


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Add a packages group for stylelint and its related config packages using the `packages:stylelint` preset.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

Stylelint come with two official config packages maintained separately.

However, some major release of one of the config packages require the latest major release of the stylelint tool and vice versa.

For exemple: 
 
- With stylelint v17: https://gitlab.com/ss-open/ci/recipes/-/merge_requests/155#note_3341542667
- With stylelint-config-standard v40 : https://gitlab.com/ss-open/ci/recipes/-/merge_requests/156#note_3341542986

On that case, Renovate will propose separated update merge requests that will never be solvable because of dependencies conflict during npm install.

Also, as stylelint is not a mono-repo and use a completly different releases history from its related config package, we MUST ensure major/minor separation is deactivated (`separateMajorMinor: false`) to get the group process working correctly.

Note: I MAY use the [`group:linters`](https://docs.renovatebot.com/presets-group/#grouplinters) preset instead but this will group all the linter onto one single update. This is not what I want, I need to keep tools update separated.

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: https://gitlab.com/ss-open/scheduling/-/merge_requests/84

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
