### PR TITLE
feat(preset): add customManagers:devEnginesPackageManager

### DIFF
--- a/lib/config/presets/internal/custom-managers.preset.ts
+++ b/lib/config/presets/internal/custom-managers.preset.ts
@@ -43,6 +43,21 @@ export const presets: Record<string, Preset> = {
     ],
     description: 'Update `_VERSION` variables in Bitbucket Pipelines',
   },
+  devEnginesPackageManager: {
+    customManagers: [
+      {
+        customType: 'jsonata',
+        datasourceTemplate: 'npm',
+        fileFormat: 'json',
+        managerFilePatterns: ['**/package.json'],
+        matchStrings: [
+          '{ "depName": devEngines.packageManager.name, "currentValue": devEngines.packageManager.version }',
+        ],
+      },
+    ],
+    description:
+      'Update `devEngines.packageManager.version` in `package.json` files (e.g. `npm`, `pnpm`, `yarn`).',
+  },
   dockerfileVersions: {
     customManagers: [
       {

--- a/lib/config/presets/internal/custom-managers.spec.ts
+++ b/lib/config/presets/internal/custom-managers.spec.ts
@@ -309,6 +309,56 @@ describe('config/presets/internal/custom-managers', () => {
     });
   });
 
+  describe('Update `devEngines.packageManager.version` in package.json', () => {
+    const customManager = presets.devEnginesPackageManager.customManagers?.[0];
+
+    it(`find dependencies in file`, async () => {
+      const fileContent = codeBlock`
+        {
+          "name": "example",
+          "devEngines": {
+            "packageManager": {
+              "name": "pnpm",
+              "version": "9.0.0",
+              "onFail": "error"
+            }
+          }
+        }
+      `;
+
+      const res = await extractPackageFile(
+        'jsonata',
+        fileContent,
+        'package.json',
+        customManager!,
+      );
+
+      expect(res?.deps).toMatchObject([
+        {
+          currentValue: '9.0.0',
+          datasource: 'npm',
+          depName: 'pnpm',
+        },
+      ]);
+    });
+
+    describe('matches regexes patterns', () => {
+      it.each`
+        path                      | expected
+        ${'package.json'}         | ${true}
+        ${'foo/package.json'}     | ${true}
+        ${'foo/bar/package.json'} | ${true}
+        ${'package.json5'}        | ${false}
+        ${'package.jsonc'}        | ${false}
+        ${'package.json.bak'}     | ${false}
+      `('$path', ({ path, expected }) => {
+        expect(
+          matchRegexOrGlobList(path, customManager!.managerFilePatterns),
+        ).toBe(expected);
+      });
+    });
+  });
+
   describe('Update `_VERSION` variables in Dockerfiles', () => {
     const customManager = presets.dockerfileVersions.customManagers?.[0];
 


### PR DESCRIPTION
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Adds a new internal custom-manager preset `custom-managers:devEnginesPackageManager` that updates the `devEngines.packageManager.version` field in `package.json` files.

npm's [`devEngines.packageManager`](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#devengines) is increasingly used alongside the top-level `packageManager` field (corepack) to enforce a specific package manager version during local development. The built-in `npm` manager already updates `packageManager`, but `devEngines.packageManager.version` is currently read-only (see #38067). When both fields are set, every pnpm / yarn bump leaves them out of sync and breaks corepack.

This preset is a JSONata-based workaround so users can opt in with a single `extends`:

```json
{
  "extends": ["custom-managers:devEnginesPackageManager"]
}
```

Users who narrow `enabledManagers` will need to include `custom.jsonata`.

This is intended as an interim solution. If/when #38067 is implemented natively in the `npm` manager, this preset can be deprecated via `removedPresets`.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

Related: #38067

## AI assistance disclosure

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

The preset entry, unit tests, and this description were authored primarily by Claude Code (Anthropic Claude Opus 4.7). All changes were reviewed by me before submission.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

The preset is documented automatically by `tools/docs/presets.ts`, which reads the `description` field at build time and emits `docs/usage/presets-customManagers.md`. Verified locally with `pnpm build:docs`.

## How I've tested my work (please select one)

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/eai04191/oxlint-config-react-hooks-js/pull/43 — the same JSONata customManager has been running there and produces the expected unified pnpm bump PRs (top-level packageManager and devEngines.packageManager.version in a single PR).

![by](https://img.shields.io/badge/-by-grey?style=flat-square)![Claude Code](https://img.shields.io/badge/Claude_Code-D97757?logo=claude&logoColor=fff&style=flat-square)