### PR TITLE
docs: add inline JSDoc for `RegistryStrategy`

### DIFF
--- a/lib/modules/datasource/types.ts
+++ b/lib/modules/datasource/types.ts
@@ -129,11 +129,32 @@ export interface PostprocessReleaseConfig {
 export type PostprocessReleaseResult = Release | 'reject';
 
 export type RegistryStrategy =
-  /** only the first registryUrl will be tried and others ignored */
+  /**
+   * Only the first registry URL is queried.
+   *
+   * If multiple URLs are configured a warning is logged and the rest are ignored. Returns whatever the first registry returns, including `null`.
+   */
   | 'first'
-  /** registryUrls will be tried in order until one returns a result */
+  /**
+   * Registries are tried in order, returning the first non-null result.
+   *
+   * `null` results and non-fatal errors (HTTP 401/403/404 and generic errors) are skipped and the next registry is tried.
+   * An `ExternalHostError` aborts immediately (unless the cause is `HOST_DISABLED`, which returns `null`).
+   *
+   * Returns `null` when all registries are exhausted without a result.
+   *
+   * The default when `registryStrategy` is `undefined`.
+   */
   | 'hunt'
-  /** all registryUrls will be tried and the results merged if more than one returns a result */
+  /**
+   * All registries are queried.
+   *
+   * Releases are merged and deduplicated by version; tags are merged with later registries' values taking precedence for duplicate keys.
+   *
+   * An `ExternalHostError` aborts immediately.
+   *
+   * Returns `null` when all registries fail.
+   */
   | 'merge';
 export type SourceUrlSupport = 'package' | 'release' | 'none';
 export interface DatasourceApi extends ModuleApi {

--- a/lib/modules/datasource/types.ts
+++ b/lib/modules/datasource/types.ts
@@ -128,7 +128,13 @@ export interface PostprocessReleaseConfig {
 
 export type PostprocessReleaseResult = Release | 'reject';
 
-export type RegistryStrategy = 'first' | 'hunt' | 'merge';
+export type RegistryStrategy =
+  /** only the first registryUrl will be tried and others ignored */
+  | 'first'
+  /** registryUrls will be tried in order until one returns a result */
+  | 'hunt'
+  /** all registryUrls will be tried and the results merged if more than one returns a result */
+  | 'merge';
 export type SourceUrlSupport = 'package' | 'release' | 'none';
 export interface DatasourceApi extends ModuleApi {
   id: string;
@@ -140,9 +146,8 @@ export interface DatasourceApi extends ModuleApi {
 
   /**
    * Strategy to use when multiple registryUrls are available to the datasource.
-   * - `first`: only the first registryUrl will be tried and others ignored
-   * - `hunt`: registryUrls will be tried in order until one returns a result
-   * - `merge`: all registryUrls will be tried and the results merged if more than one returns a result
+   *
+   * @see RegistryStrategy
    */
   registryStrategy?: RegistryStrategy | undefined;
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
Noticed while making other changes, that it wasn't clear looking at the
type what these values meant.

We can use a `@see` annotation to move the inline documentation from the
`DatasourceApi` to use our source-of-truth.

We can also update them in line with the implementation details, with help from Claude Sonnet.

## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
