### PR TITLE
fix(datasource/maven): cache 404s on `maven-metadata.xml` for 12h

### DIFF
--- a/lib/modules/datasource/maven/cache.spec.ts
+++ b/lib/modules/datasource/maven/cache.spec.ts
@@ -28,9 +28,12 @@ describe('modules/datasource/maven/cache', () => {
     vi.resetAllMocks();
     cache = {};
 
-    packageCache.get.mockImplementation((_namespace, key) =>
-      Promise.resolve(cache[key] as never),
-    );
+    packageCache.get.mockImplementation((namespace, key) => {
+      if (namespace === 'datasource-maven:metadata-not-found') {
+        return Promise.resolve(null as never);
+      }
+      return Promise.resolve(cache[key] as never);
+    });
     packageCache.getCacheType.mockReturnValue(undefined);
     packageCache.setWithRawTtl.mockImplementation((_namespace, key, value) => {
       cache[key] = value as HttpCache;

--- a/lib/modules/datasource/maven/util.spec.ts
+++ b/lib/modules/datasource/maven/util.spec.ts
@@ -318,7 +318,7 @@ describe('modules/datasource/maven/util', () => {
           'datasource-maven:metadata-not-found',
           metadataUrl,
           true,
-          60 * 24,
+          expect.toBeNumber(),
         );
       });
 

--- a/lib/modules/datasource/maven/util.spec.ts
+++ b/lib/modules/datasource/maven/util.spec.ts
@@ -289,5 +289,68 @@ describe('modules/datasource/maven/util', () => {
         err: { type: 'unsupported-host' } satisfies MavenFetchError,
       });
     });
+
+    describe('maven-metadata.xml 404 caching', () => {
+      const metadataUrl =
+        'https://repo.maven.apache.org/maven2/com/example/lib/maven-metadata.xml';
+      const nonMetadataUrl =
+        'https://repo.maven.apache.org/maven2/com/example/lib/1.0.0/lib-1.0.0.pom';
+
+      it('caches 404 for maven-metadata.xml URLs', async () => {
+        const setSpy = vi
+          .spyOn(packageCache, 'set')
+          .mockResolvedValue(undefined);
+        vi.spyOn(packageCache, 'get').mockResolvedValue(null);
+        const http = partial<Http>({
+          getText: () =>
+            Promise.reject(
+              httpError({ response: { statusCode: 404 } as never }),
+            ),
+        });
+
+        const res = await downloadHttpProtocol(http, metadataUrl);
+
+        expect(res.unwrap()).toEqual({
+          ok: false,
+          err: { type: 'not-found' } satisfies MavenFetchError,
+        });
+        expect(setSpy).toHaveBeenCalledWith(
+          'datasource-maven:metadata-not-found',
+          metadataUrl,
+          true,
+          60 * 24,
+        );
+      });
+
+      it('does not cache 404 for non-metadata URLs', async () => {
+        const setSpy = vi
+          .spyOn(packageCache, 'set')
+          .mockResolvedValue(undefined);
+        const http = partial<Http>({
+          getText: () =>
+            Promise.reject(
+              httpError({ response: { statusCode: 404 } as never }),
+            ),
+        });
+
+        await downloadHttpProtocol(http, nonMetadataUrl);
+
+        expect(setSpy).not.toHaveBeenCalled();
+      });
+
+      it('returns cached not-found without making HTTP request', async () => {
+        vi.spyOn(packageCache, 'get').mockResolvedValue(true);
+        const getText = vi.fn();
+        const http = partial<Http>({ getText });
+
+        const res = await downloadHttpProtocol(http, metadataUrl);
+
+        expect(res.unwrap()).toEqual({
+          ok: false,
+          err: { type: 'not-found' } satisfies MavenFetchError,
+        });
+        expect(getText).not.toHaveBeenCalled();
+      });
+    });
   });
 });

--- a/lib/modules/datasource/maven/util.ts
+++ b/lib/modules/datasource/maven/util.ts
@@ -4,7 +4,7 @@ import { XmlDocument } from 'xmldoc';
 import { HOST_DISABLED } from '../../../constants/error-messages.ts';
 import { logger } from '../../../logger/index.ts';
 import { ExternalHostError } from '../../../types/errors/external-host-error.ts';
-import { getCacheType } from '../../../util/cache/package/index.ts';
+import * as packageCache from '../../../util/cache/package/index.ts';
 import { PackageHttpCacheProvider } from '../../../util/http/cache/package-http-cache-provider.ts';
 import { type Http, HttpError } from '../../../util/http/index.ts';
 import type { HttpOptions, HttpResponse } from '../../../util/http/types.ts';
@@ -91,12 +91,35 @@ function selectCacheProvider(url: string): PackageHttpCacheProvider {
   return cacheProvider;
 }
 
+const METADATA_NOT_FOUND_NAMESPACE =
+  'datasource-maven:metadata-not-found' as const;
+const METADATA_NOT_FOUND_TTL_MINUTES = 60 * 24; // 24 hours
+
+function isMetadataUrl(url: string): boolean {
+  return url.endsWith('/maven-metadata.xml');
+}
+
 export async function downloadHttpProtocol(
   http: Http,
   pkgUrl: URL | string,
   opts: HttpOptions = {},
 ): Promise<MavenFetchResult> {
   const url = pkgUrl.toString();
+
+  if (isMetadataUrl(url)) {
+    const cacheHasNotFoundResponse = await packageCache.get<true>(
+      METADATA_NOT_FOUND_NAMESPACE,
+      url,
+    );
+    if (cacheHasNotFoundResponse) {
+      logger.trace(
+        { url },
+        'Returning cached 404 response for the metadata-metadata URL request',
+      );
+      return Result.err({ type: 'not-found' });
+    }
+  }
+
   const fetchResult = await Result.wrap<HttpResponse, Error>(
     http.getText(url, { ...opts, cacheProvider: selectCacheProvider(url) }),
   )
@@ -114,7 +137,7 @@ export async function downloadHttpProtocol(
 
       return result;
     })
-    .catch((err): MavenFetchResult => {
+    .catch(async (err): Promise<MavenFetchResult> => {
       /* v8 ignore next: never happens, needs for type narrowing */
       if (!(err instanceof HttpError)) {
         return Result.err({ type: 'unknown', err });
@@ -128,6 +151,14 @@ export async function downloadHttpProtocol(
 
       if (isNotFoundError(err)) {
         logger.trace({ failedUrl }, `Url not found`);
+        if (isMetadataUrl(failedUrl)) {
+          await packageCache.set(
+            METADATA_NOT_FOUND_NAMESPACE,
+            failedUrl,
+            true,
+            METADATA_NOT_FOUND_TTL_MINUTES,
+          );
+        }
         return Result.err({ type: 'not-found' });
       }
 
@@ -148,7 +179,7 @@ export async function downloadHttpProtocol(
         if (getHost(url) === getHost(MAVEN_REPO)) {
           const statusCode = err?.response?.statusCode;
           if (statusCode === 429) {
-            if (getCacheType() === 'redis') {
+            if (packageCache.getCacheType() === 'redis') {
               logger.once.warn(
                 { failedUrl },
                 'Maven Central rate limiting detected despite Redis caching.',

--- a/lib/modules/datasource/maven/util.ts
+++ b/lib/modules/datasource/maven/util.ts
@@ -95,6 +95,12 @@ const METADATA_NOT_FOUND_NAMESPACE =
   'datasource-maven:metadata-not-found' as const;
 const METADATA_NOT_FOUND_TTL_MINUTES = 60 * 12; // 12 hours
 
+/** introduces jitter to make sure that a given repo's cache expiring doesn't lead to many requests leading to high traffic and/or rate limits */
+function getMetadataNotFoundTtl(): number {
+  const jitter = Math.floor(Math.random() * 60 * 2); // 0–120 minutes
+  return METADATA_NOT_FOUND_TTL_MINUTES + jitter;
+}
+
 function isMetadataUrl(url: string): boolean {
   return url.endsWith('/maven-metadata.xml');
 }
@@ -156,7 +162,7 @@ export async function downloadHttpProtocol(
             METADATA_NOT_FOUND_NAMESPACE,
             failedUrl,
             true,
-            METADATA_NOT_FOUND_TTL_MINUTES,
+            getMetadataNotFoundTtl(),
           );
         }
         return Result.err({ type: 'not-found' });

--- a/lib/modules/datasource/maven/util.ts
+++ b/lib/modules/datasource/maven/util.ts
@@ -93,7 +93,7 @@ function selectCacheProvider(url: string): PackageHttpCacheProvider {
 
 const METADATA_NOT_FOUND_NAMESPACE =
   'datasource-maven:metadata-not-found' as const;
-const METADATA_NOT_FOUND_TTL_MINUTES = 60 * 24; // 24 hours
+const METADATA_NOT_FOUND_TTL_MINUTES = 60 * 12; // 12 hours
 
 function isMetadataUrl(url: string): boolean {
   return url.endsWith('/maven-metadata.xml');

--- a/lib/util/cache/package/namespaces.ts
+++ b/lib/util/cache/package/namespaces.ts
@@ -78,6 +78,7 @@ export const packageCacheNamespaces = [
   'datasource-jenkins-plugins',
   'datasource-jsr',
   'datasource-maven:cache-provider',
+  'datasource-maven:metadata-not-found',
   'datasource-maven:pom-cache-provider',
   'datasource-maven:postprocess-reject',
   'datasource-nextcloud',


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes
As part of efforts to reduce the general overload on Maven Central[0]
from Renovate, we can look to reduce unnecessary HTTP lookups.

The Maven Datasource will use the `registryStrategy=merge`, which leads
to looking up a package in each of our registries, and merging them if
present.

However, this means that when looking up a package that /will only ever
be in a given registry/ (such as in
01bcd4fd43b22612ddbd4ffda31981d1d41a5da9) we're hitting other registries
with packages they are unlikely to have.

This is unnecessary, significantly increases traffic to Maven Central,
and leads to us re-fetching the same 404s which count towards rate
limits, and increased, unnecessary, server load on Maven Central.

We can instead introduce a new cache for 404s for the
`maven-metadata.xml`, for 24 hours, which should reduce traffic to Maven
Central (and other configured registries) if they only have a subset of
dependencies.

[0]: https://www.sonatype.com/blog/maven-central-and-the-tragedy-of-the-commons


<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
