### PR TITLE
feat(self-hosted): make `user-agent` templatable

### DIFF
--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -1432,7 +1432,7 @@ You can control if Renovate should try to access these services with the `useClo
 
 ## `userAgent`
 
-Overrides the `user-agent` header sent with HTTP requests.
+Specifies the `user-agent` header sent with HTTP requests.
 Supports `{{renovateVersion}}` as a template variable for the current Renovate version.
 
 ## `username`

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -1432,8 +1432,8 @@ You can control if Renovate should try to access these services with the `useClo
 
 ## `userAgent`
 
-If set to any string, Renovate will use this as the `user-agent` it sends with HTTP requests.
-Otherwise, it will default to `Renovate/${renovateVersion} (https://github.com/renovatebot/renovate)`.
+Overrides the `user-agent` header sent with HTTP requests.
+Supports `{{renovateVersion}}` as a template variable for the current Renovate version.
 
 ## `username`
 

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -112,10 +112,11 @@ const options: Readonly<RenovateOptions>[] = [
   {
     name: 'userAgent',
     description:
-      'If set to any string, Renovate will use this as the `user-agent` it sends with HTTP requests.',
+      'Overrides the `user-agent` header sent with HTTP requests. Supports `{{renovateVersion}}` as a template variable for the current Renovate version.',
     type: 'string',
-    default: null,
+    default: `Renovate/{{renovateVersion}} (https://github.com/renovatebot/renovate)`,
     globalOnly: true,
+    supportsTemplating: true,
   },
   {
     name: 'allowedCommands',

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -112,7 +112,7 @@ const options: Readonly<RenovateOptions>[] = [
   {
     name: 'userAgent',
     description:
-      'Overrides the `user-agent` header sent with HTTP requests. Supports `{{renovateVersion}}` as a template variable for the current Renovate version.',
+      'Sets the `user-agent` header to be sent with HTTP requests. Supports `{{renovateVersion}}` as a template variable for the current Renovate version.',
     type: 'string',
     default: `Renovate/{{renovateVersion}} (https://github.com/renovatebot/renovate)`,
     globalOnly: true,

--- a/lib/util/http/http.ts
+++ b/lib/util/http/http.ts
@@ -16,6 +16,7 @@ import { acquireLock } from '../mutex.ts';
 import { type AsyncResult, Result } from '../result.ts';
 import { Toml } from '../schema-utils/index.ts';
 import { ObsoleteCacheHitLogger } from '../stats.ts';
+import { compile } from '../template/index.ts';
 import { isHttpUrl, parseUrl, resolveBaseUrl } from '../url.ts';
 import { parseSingleYaml } from '../yaml.ts';
 import { applyAuthorization } from './auth.ts';
@@ -63,12 +64,14 @@ export interface InternalHttpOptions extends HttpOptions {
 }
 
 export function applyDefaultHeaders(options: OptionsInit): void {
-  const renovateVersion = pkg.version;
+  const userAgentTemplate =
+    GlobalConfig.get('userAgent') ??
+    `Renovate/{{renovateVersion}} (https://github.com/renovatebot/renovate)`;
   options.headers = {
     ...options.headers,
-    'user-agent':
-      GlobalConfig.get('userAgent') ??
-      `Renovate/${renovateVersion} (https://github.com/renovatebot/renovate)`,
+    'user-agent': compile(userAgentTemplate, {
+      renovateVersion: pkg.version,
+    }),
   };
 }
 

--- a/lib/util/http/http.ts
+++ b/lib/util/http/http.ts
@@ -64,9 +64,7 @@ export interface InternalHttpOptions extends HttpOptions {
 }
 
 export function applyDefaultHeaders(options: OptionsInit): void {
-  const userAgentTemplate =
-    GlobalConfig.get('userAgent') ??
-    `Renovate/{{renovateVersion}} (https://github.com/renovatebot/renovate)`;
+  const userAgentTemplate = GlobalConfig.get('userAgent');
   options.headers = {
     ...options.headers,
     'user-agent': compile(userAgentTemplate, {

--- a/lib/util/http/index.spec.ts
+++ b/lib/util/http/index.spec.ts
@@ -1,13 +1,16 @@
 import { ZodError, z } from 'zod/v3';
 import * as httpMock from '~test/http-mock.ts';
 import { logger } from '~test/util.ts';
+import { GlobalConfig } from '../../config/global.ts';
 import {
   EXTERNAL_HOST_ERROR,
   HOST_DISABLED,
 } from '../../constants/error-messages.ts';
+import { pkg } from '../../expose.ts';
 import * as memCache from '../cache/memory/index.ts';
 import { resetCache } from '../cache/repository/index.ts';
 import * as hostRules from '../host-rules.ts';
+import { applyDefaultHeaders } from './http.ts';
 import { Http, HttpError } from './index.ts';
 import * as queue from './queue.ts';
 import * as throttle from './throttle.ts';
@@ -24,6 +27,85 @@ describe('util/http/index', () => {
     queue.clear();
     throttle.clear();
     resetCache();
+  });
+
+  describe('applyDefaultHeaders', () => {
+    afterEach(() => {
+      GlobalConfig.reset();
+    });
+
+    it('sets default user-agent', () => {
+      const options = {};
+      applyDefaultHeaders(options);
+      expect(options).toMatchObject({
+        headers: {
+          'user-agent': `Renovate/${pkg.version} (https://github.com/renovatebot/renovate)`,
+        },
+      });
+    });
+
+    it('uses userAgent when set as a plain string', () => {
+      GlobalConfig.set({ userAgent: 'custom-agent/1.0' });
+      const options = {};
+      applyDefaultHeaders(options);
+      expect(options).toMatchObject({
+        headers: { 'user-agent': 'custom-agent/1.0' },
+      });
+    });
+
+    it('interpolates {{renovateVersion}} in a custom userAgent template', () => {
+      GlobalConfig.set({
+        userAgent: 'MyRenovate/{{renovateVersion}} (my-instance)',
+      });
+      const options = {};
+      applyDefaultHeaders(options);
+      expect(options).toMatchObject({
+        headers: {
+          'user-agent': `MyRenovate/${pkg.version} (my-instance)`,
+        },
+      });
+    });
+
+    it('renders unknown template variables as empty string', () => {
+      GlobalConfig.set({ userAgent: 'my-agent/{{unknownVar}}' });
+      const options = {};
+      applyDefaultHeaders(options);
+      expect(options).toMatchObject({
+        headers: { 'user-agent': 'my-agent/' },
+      });
+    });
+
+    it('supports Handlebars helpers in userAgent template', () => {
+      GlobalConfig.set({
+        userAgent: '{{lowercase "MyRenovate"}}/{{renovateVersion}}',
+      });
+      const options = {};
+      applyDefaultHeaders(options);
+      expect(options).toMatchObject({
+        headers: { 'user-agent': `myrenovate/${pkg.version}` },
+      });
+    });
+
+    it('supports conditional Handlebars syntax in userAgent template', () => {
+      GlobalConfig.set({
+        userAgent:
+          '{{#if renovateVersion}}Renovate/{{renovateVersion}}{{else}}Renovate{{/if}}',
+      });
+      const options = {};
+      applyDefaultHeaders(options);
+      expect(options).toMatchObject({
+        headers: { 'user-agent': `Renovate/${pkg.version}` },
+      });
+    });
+
+    it('preserves existing headers', () => {
+      const options = { headers: { authorization: 'Bearer token' } };
+      applyDefaultHeaders(options);
+      expect(options.headers).toMatchObject({
+        authorization: 'Bearer token',
+        'user-agent': `Renovate/${pkg.version} (https://github.com/renovatebot/renovate)`,
+      });
+    });
   });
 
   it('get', async () => {

--- a/lib/util/template/index.ts
+++ b/lib/util/template/index.ts
@@ -238,7 +238,8 @@ export const allowedFields = {
   releases: 'An array of releases for an upgrade',
   releaseNotes: 'A ChangeLogNotes object for the release',
   releaseTimestamp: 'The timestamp of the release',
-  renovateVersion: 'The currently running Renovate version',
+  renovateVersion:
+    'The currently running Renovate version. Only supported in the `user-agent` configuration option.',
   repository: 'The current repository',
   semanticPrefix: 'The fully generated semantic prefix for commit messages',
   sourceRepo: 'The repository in the sourceUrl, if present',

--- a/lib/util/template/index.ts
+++ b/lib/util/template/index.ts
@@ -238,6 +238,7 @@ export const allowedFields = {
   releases: 'An array of releases for an upgrade',
   releaseNotes: 'A ChangeLogNotes object for the release',
   releaseTimestamp: 'The timestamp of the release',
+  renovateVersion: 'The currently running Renovate version',
   repository: 'The current repository',
   semanticPrefix: 'The fully generated semantic prefix for commit messages',
   sourceRepo: 'The repository in the sourceUrl, if present',


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes


For Mend-hosted apps, it would be useful to provide a little bit more
information for where a Renovate HTTP request is coming from.

To provide more control over the generated field, we can make it
templatable, with the option to specify the `renovateVersion`.

As this now exposes Handlebars syntax to the user, we should be clear
that this `supportsTemplating`, and document with tests what this
allows.

Co-authored-by: Claude Sonnet 4.6 <jamie.tanna+claude-code@mend.io>



## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
