### PR TITLE
feat(managers/pep621): add support for security updates of indirect uv dependencies

### DIFF
--- a/lib/modules/manager/pep621/processors/uv.spec.ts
+++ b/lib/modules/manager/pep621/processors/uv.spec.ts
@@ -12,7 +12,11 @@ import { GithubTagsDatasource } from '../../../datasource/github-tags/index.ts';
 import { GitlabTagsDatasource } from '../../../datasource/gitlab-tags/index.ts';
 import { getPkgReleases as _getPkgReleases } from '../../../datasource/index.ts';
 import { PypiDatasource } from '../../../datasource/pypi/index.ts';
-import type { PackageDependency, UpdateArtifact, UpdateArtifactsConfig } from '../../types.ts';
+import type {
+  PackageDependency,
+  UpdateArtifact,
+  UpdateArtifactsConfig,
+} from '../../types.ts';
 import { parsePyProject } from '../extract.ts';
 import { depTypes } from '../utils.ts';
 import { UvProcessor } from './uv.ts';

--- a/lib/modules/manager/pep621/processors/uv.spec.ts
+++ b/lib/modules/manager/pep621/processors/uv.spec.ts
@@ -12,7 +12,7 @@ import { GithubTagsDatasource } from '../../../datasource/github-tags/index.ts';
 import { GitlabTagsDatasource } from '../../../datasource/gitlab-tags/index.ts';
 import { getPkgReleases as _getPkgReleases } from '../../../datasource/index.ts';
 import { PypiDatasource } from '../../../datasource/pypi/index.ts';
-import type { UpdateArtifact, UpdateArtifactsConfig } from '../../types.ts';
+import type { PackageDependency, UpdateArtifact, UpdateArtifactsConfig } from '../../types.ts';
 import { parsePyProject } from '../extract.ts';
 import { depTypes } from '../utils.ts';
 import { UvProcessor } from './uv.ts';
@@ -356,6 +356,82 @@ describe('modules/manager/pep621/processors/uv', () => {
         'No uv lock file found',
       );
     });
+
+    it('adds indirect deps from lock file not present in direct deps', async () => {
+      fs.findLocalSiblingOrParent.mockResolvedValueOnce('uv.lock');
+      fs.readLocalFile.mockResolvedValueOnce(codeBlock`
+        version = 1
+        requires-python = ">=3.11"
+
+        [[package]]
+        name = "dep1"
+        version = "1.2.3"
+
+        [[package]]
+        name = "mako"
+        version = "1.3.10"
+
+        [[package]]
+        name = "markupsafe"
+        version = "2.1.5"
+      `);
+
+      const deps: PackageDependency[] = [
+        { packageName: 'dep1', depType: depTypes.dependencies },
+      ];
+
+      const result = await processor.extractLockedVersions(
+        partial(),
+        deps,
+        'pyproject.toml',
+      );
+
+      expect(result).toMatchObject([
+        { packageName: 'dep1', lockedVersion: '1.2.3' },
+        {
+          packageName: 'mako',
+          depName: 'mako',
+          datasource: PypiDatasource.id,
+          lockedVersion: '1.3.10',
+          depType: 'indirect',
+          enabled: false,
+        },
+        {
+          packageName: 'markupsafe',
+          depName: 'markupsafe',
+          datasource: PypiDatasource.id,
+          lockedVersion: '2.1.5',
+          depType: 'indirect',
+          enabled: false,
+        },
+      ]);
+    });
+
+    it('does not add indirect dep if already present as direct dep', async () => {
+      fs.findLocalSiblingOrParent.mockResolvedValueOnce('uv.lock');
+      fs.readLocalFile.mockResolvedValueOnce(codeBlock`
+        version = 1
+        requires-python = ">=3.11"
+
+        [[package]]
+        name = "dep1"
+        version = "1.2.3"
+      `);
+
+      const deps: PackageDependency[] = [
+        { packageName: 'dep1', depType: depTypes.dependencies },
+      ];
+
+      const result = await processor.extractLockedVersions(
+        partial(),
+        deps,
+        'pyproject.toml',
+      );
+
+      // dep1 should not be duplicated as indirect
+      expect(result.filter((d) => d.packageName === 'dep1')).toHaveLength(1);
+      expect(result).toHaveLength(1);
+    });
   });
 
   describe('updateArtifacts()', () => {
@@ -532,6 +608,50 @@ describe('modules/manager/pep621/processors/uv', () => {
       expect(execSnapshots).toMatchObject([
         {
           cmd: 'uv lock --upgrade-package dep1 --upgrade-package dep2 --upgrade-package dep3 --upgrade-package dep4 --upgrade-package dep5 --upgrade-package dep6',
+        },
+      ]);
+    });
+
+    it('includes indirect deps in upgrade command', async () => {
+      const execSnapshots = mockExecAll();
+      GlobalConfig.set(adminConfig);
+      fs.findLocalSiblingOrParent.mockResolvedValueOnce('uv.lock');
+      fs.readLocalFile.mockResolvedValueOnce('test content');
+      fs.readLocalFile.mockResolvedValueOnce('changed test content');
+      // python
+      getPkgReleases.mockResolvedValueOnce({
+        releases: [{ version: '3.11.1' }],
+      });
+      // uv
+      getPkgReleases.mockResolvedValueOnce({
+        releases: [{ version: '0.2.35' }],
+      });
+
+      const updatedDeps = [
+        { packageName: 'dep1', depType: depTypes.dependencies },
+        { packageName: 'mako', depType: 'indirect' },
+      ];
+      const result = await processor.updateArtifacts(
+        {
+          packageFileName: 'pyproject.toml',
+          newPackageFileContent: '',
+          config: {},
+          updatedDeps,
+        },
+        parsePyProject('')!,
+      );
+      expect(result).toEqual([
+        {
+          file: {
+            contents: 'changed test content',
+            path: 'uv.lock',
+            type: 'addition',
+          },
+        },
+      ]);
+      expect(execSnapshots).toMatchObject([
+        {
+          cmd: 'uv lock --upgrade-package dep1 --upgrade-package mako',
         },
       ]);
     });

--- a/lib/modules/manager/pep621/processors/uv.spec.ts
+++ b/lib/modules/manager/pep621/processors/uv.spec.ts
@@ -369,7 +369,7 @@ describe('modules/manager/pep621/processors/uv', () => {
       ];
       const result = await processor.extractLockedVersions(
         partial(),
-        deps,
+        [...deps],
         'pyproject.toml',
       );
       expect(result).toEqual(deps);

--- a/lib/modules/manager/pep621/processors/uv.spec.ts
+++ b/lib/modules/manager/pep621/processors/uv.spec.ts
@@ -361,6 +361,27 @@ describe('modules/manager/pep621/processors/uv', () => {
       );
     });
 
+    it('logs debug and returns deps unchanged if lock file fails to parse', async () => {
+      fs.findLocalSiblingOrParent.mockResolvedValueOnce('uv.lock');
+      fs.readLocalFile.mockResolvedValueOnce('not valid toml [[[');
+      const deps: PackageDependency[] = [
+        { packageName: 'dep1', depType: depTypes.dependencies },
+      ];
+      const result = await processor.extractLockedVersions(
+        partial(),
+        deps,
+        'pyproject.toml',
+      );
+      expect(result).toEqual(deps);
+      expect(logger.logger.debug).toHaveBeenCalledWith(
+        expect.objectContaining({
+          packageFile: 'pyproject.toml',
+          err: expect.anything(),
+        }),
+        'Error parsing uv lock file',
+      );
+    });
+
     it('adds indirect deps from lock file not present in direct deps', async () => {
       fs.findLocalSiblingOrParent.mockResolvedValueOnce('uv.lock');
       fs.readLocalFile.mockResolvedValueOnce(codeBlock`

--- a/lib/modules/manager/pep621/processors/uv.ts
+++ b/lib/modules/manager/pep621/processors/uv.ts
@@ -134,9 +134,7 @@ export class UvProcessor extends BasePyProjectProcessor {
       packageFile,
       this.lockfileName,
     );
-    if (lockFileName === null) {
-      logger.debug({ packageFile }, `No uv lock file found`);
-    } else {
+    if (lockFileName) {
       const lockFileContent = await readLocalFile(lockFileName, 'utf8');
       if (lockFileContent) {
         const { val: lockFileMapping, err } = Result.parse(
@@ -163,6 +161,8 @@ export class UvProcessor extends BasePyProjectProcessor {
           }
         }
       }
+    } else {
+      logger.debug({ packageFile }, `No uv lock file found`);
     }
 
     return Promise.resolve(deps);

--- a/lib/modules/manager/pep621/processors/uv.ts
+++ b/lib/modules/manager/pep621/processors/uv.ts
@@ -153,6 +153,12 @@ export class UvProcessor extends BasePyProjectProcessor {
               dep.lockedVersion = lockFileMapping[packageName];
             }
           }
+
+          for (const [name, version] of Object.entries(lockFileMapping)) {
+            if (!deps.find((dep) => dep.packageName === name)) {
+              deps.push(indirectDep(name, version));
+            }
+          }
         }
       }
     }
@@ -275,6 +281,26 @@ function generateCMD(updatedDeps: Upgrade[]): string {
   }
 
   return `${uvUpdateCMD} ${deps.map((dep) => `--upgrade-package ${quote(dep)}`).join(' ')}`;
+}
+
+/**
+ * As indirect dependencies don't exist in the package file, we create them
+ * from the lock file. By omitting currentValue and currentVersion they are
+ * treated as unconstrained dependencies with a locked version, meaning they
+ * are updated via 'update-lockfile' strategy.
+ *
+ * They are disabled by default to avoid noise. When a vulnerability alert
+ * matches one of them, the alert system force-enables the update.
+ */
+function indirectDep(name: string, version: string): PackageDependency {
+  return {
+    packageName: name,
+    depName: name,
+    datasource: PypiDatasource.id,
+    lockedVersion: version,
+    depType: 'indirect',
+    enabled: false,
+  };
 }
 
 function getMatchingHostRule(url: string | undefined): HostRule {

--- a/lib/modules/manager/pep621/processors/uv.ts
+++ b/lib/modules/manager/pep621/processors/uv.ts
@@ -134,35 +134,35 @@ export class UvProcessor extends BasePyProjectProcessor {
       packageFile,
       this.lockfileName,
     );
-    if (lockFileName) {
-      const lockFileContent = await readLocalFile(lockFileName, 'utf8');
-      if (lockFileContent) {
-        const { val: lockFileMapping, err } = Result.parse(
-          lockFileContent,
-          UvLockfile,
-        ).unwrap();
+    if (!lockFileName) {
+      logger.debug({ packageFile }, `No uv lock file found`);
+      return Promise.resolve(deps);
+    }
+    const lockFileContent = await readLocalFile(lockFileName, 'utf8');
+    if (lockFileContent) {
+      const { val: lockFileMapping, err } = Result.parse(
+        lockFileContent,
+        UvLockfile,
+      ).unwrap();
 
-        if (err) {
-          logger.debug({ packageFile, err }, `Error parsing uv lock file`);
-        } else {
-          for (const dep of deps) {
-            const packageName = dep.packageName;
-            if (packageName && packageName in lockFileMapping) {
-              dep.lockedVersion = lockFileMapping[packageName].version;
-            }
+      if (err) {
+        logger.debug({ packageFile, err }, `Error parsing uv lock file`);
+      } else {
+        for (const dep of deps) {
+          const packageName = dep.packageName;
+          if (packageName && packageName in lockFileMapping) {
+            dep.lockedVersion = lockFileMapping[packageName].version;
           }
+        }
 
-          for (const [name, { version, virtual }] of Object.entries(
-            lockFileMapping,
-          )) {
-            if (!virtual && !deps.find((dep) => dep.packageName === name)) {
-              deps.push(indirectDep(name, version));
-            }
+        for (const [name, { version, virtual }] of Object.entries(
+          lockFileMapping,
+        )) {
+          if (!virtual && !deps.find((dep) => dep.packageName === name)) {
+            deps.push(indirectDep(name, version));
           }
         }
       }
-    } else {
-      logger.debug({ packageFile }, `No uv lock file found`);
     }
 
     return Promise.resolve(deps);

--- a/lib/modules/manager/pep621/processors/uv.ts
+++ b/lib/modules/manager/pep621/processors/uv.ts
@@ -150,12 +150,14 @@ export class UvProcessor extends BasePyProjectProcessor {
           for (const dep of deps) {
             const packageName = dep.packageName;
             if (packageName && packageName in lockFileMapping) {
-              dep.lockedVersion = lockFileMapping[packageName];
+              dep.lockedVersion = lockFileMapping[packageName].version;
             }
           }
 
-          for (const [name, version] of Object.entries(lockFileMapping)) {
-            if (!deps.find((dep) => dep.packageName === name)) {
+          for (const [name, { version, virtual }] of Object.entries(
+            lockFileMapping,
+          )) {
+            if (!virtual && !deps.find((dep) => dep.packageName === name)) {
               deps.push(indirectDep(name, version));
             }
           }

--- a/lib/modules/manager/pep621/processors/uv.ts
+++ b/lib/modules/manager/pep621/processors/uv.ts
@@ -134,37 +134,36 @@ export class UvProcessor extends BasePyProjectProcessor {
       packageFile,
       this.lockfileName,
     );
-    if (!lockFileName) {
-      logger.debug({ packageFile }, `No uv lock file found`);
-      return Promise.resolve(deps);
-    }
-    const lockFileContent = await readLocalFile(lockFileName, 'utf8');
-    if (lockFileContent) {
-      const { val: lockFileMapping, err } = Result.parse(
-        lockFileContent,
-        UvLockfile,
-      ).unwrap();
+    if (lockFileName) {
+      const lockFileContent = await readLocalFile(lockFileName, 'utf8');
+      if (lockFileContent) {
+        const { val: lockFileMapping, err } = Result.parse(
+          lockFileContent,
+          UvLockfile,
+        ).unwrap();
 
-      if (err) {
-        logger.debug({ packageFile, err }, `Error parsing uv lock file`);
-      } else {
-        for (const dep of deps) {
-          const packageName = dep.packageName;
-          if (packageName && packageName in lockFileMapping) {
-            dep.lockedVersion = lockFileMapping[packageName].version;
+        if (err) {
+          logger.debug({ packageFile, err }, `Error parsing uv lock file`);
+        } else {
+          for (const dep of deps) {
+            const packageName = dep.packageName;
+            if (packageName && packageName in lockFileMapping) {
+              dep.lockedVersion = lockFileMapping[packageName].version;
+            }
           }
-        }
 
-        for (const [name, { version, virtual }] of Object.entries(
-          lockFileMapping,
-        )) {
-          if (!virtual && !deps.find((dep) => dep.packageName === name)) {
-            deps.push(indirectDep(name, version));
+          for (const [name, { version, virtual }] of Object.entries(
+            lockFileMapping,
+          )) {
+            if (!virtual && !deps.find((dep) => dep.packageName === name)) {
+              deps.push(indirectDep(name, version));
+            }
           }
         }
       }
+    } else {
+      logger.debug({ packageFile }, `No uv lock file found`);
     }
-
     return Promise.resolve(deps);
   }
 

--- a/lib/modules/manager/pep621/processors/uv.ts
+++ b/lib/modules/manager/pep621/processors/uv.ts
@@ -164,6 +164,7 @@ export class UvProcessor extends BasePyProjectProcessor {
     } else {
       logger.debug({ packageFile }, `No uv lock file found`);
     }
+
     return Promise.resolve(deps);
   }
 

--- a/lib/modules/manager/pep621/schema.ts
+++ b/lib/modules/manager/pep621/schema.ts
@@ -225,11 +225,21 @@ export const UvLockfile = Toml.pipe(
       z.object({
         name: z.string(),
         version: z.string(),
+        source: z.record(z.string(), z.unknown()).optional(),
       }),
     ),
   }),
 ).transform(({ package: pkg }) =>
   Object.fromEntries(
-    pkg.map(({ name, version }): [string, string] => [name, version]),
+    pkg.map(
+      ({
+        name,
+        version,
+        source,
+      }): [string, { version: string; virtual: boolean }] => [
+        name,
+        { version, virtual: 'virtual' in (source ?? {}) },
+      ],
+    ),
   ),
 );


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

This adds support for `vulnerabilityAlerts` driven updates to transitive dependencies managed via the uv package manager. I took inspiration from https://github.com/renovatebot/renovate/pull/27561 which does similar change for the pip-compile manager.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

Related discussion: https://github.com/renovatebot/renovate/discussions/22049

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

I used `opencode` with claude sonnet. I basically asked it to replicate the PR, then I manually reviewed and cleaned up the mess it created.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
