### PR TITLE
refactor: generate all global config options' defaults

### DIFF
--- a/tools/generate-imports.mjs
+++ b/tools/generate-imports.mjs
@@ -225,6 +225,28 @@ export type DatasourceName = typeof AllDatasourcesListLiteral[number];
   await updateFile(`lib/datasource-list.generated.ts`, content);
 }
 
+async function generateGlobalConfigOptionDefaults() {
+  const { getOptions } = await import('../lib/config/options/index.ts');
+  const options = getOptions();
+
+  /** @type {Record<string, unknown>} */
+  const defaults = {};
+  for (const option of options
+    .filter((o) => o.globalOnly)
+    .filter((o) => 'default' in o)
+    // if the default is null, it means there is no default, so don't include it
+    .filter((o) => o.default !== null)
+    .sort((a, b) => a.name.localeCompare(b.name))) {
+    defaults[option.name] = option.default;
+  }
+
+  const content = `
+export const globalConfigOptionDefaults: Record<string, unknown> = ${JSON.stringify(defaults, null, 2)};
+`;
+
+  await updateFile('lib/global-config-option-defaults.generated.ts', content);
+}
+
 async function generateHash() {
   try {
     const hashMap = `export const hashMap = new Map<string, string>();`;
@@ -272,12 +294,22 @@ async function generateHash() {
 
 await (async () => {
   try {
+    // prevent import cycles when trying to generate config options
+    const stubFile = 'lib/global-config-option-defaults.generated.ts';
+    if (!fs.existsSync(stubFile)) {
+      await fs.writeFile(
+        stubFile,
+        '\nexport const globalConfigOptionDefaults: Record<string, unknown> = {};\n',
+      );
+    }
+
     // data-files
     await generateData();
     await generateManagerList();
     await generateManagerDefaultConfigs();
     await generateVersioningList();
     await generateDatasourceList();
+    await generateGlobalConfigOptionDefaults();
     await generateHash();
     await Promise.all(
       (await glob('lib/**/*.generated.ts'))


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
As part of future changes (https://github.com/renovatebot/renovate/pull/42113), we'll use this generated list to refactor
`GlobalConfig.get` to always return a configuration option's default
value.

Before we do this, we need to generate the defaults, otherwise we'll get
an import cycle when trying to call `getOptions()`.


## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
