### PR TITLE
test: ensure we set `binarySource=global`

### DIFF
--- a/lib/modules/manager/bazel-module/artifacts.spec.ts
+++ b/lib/modules/manager/bazel-module/artifacts.spec.ts
@@ -12,6 +12,7 @@ const adminConfig: RepoGlobalConfig = {
   localDir: upath.join('/tmp/github/some/repo'),
   cacheDir: upath.join('/tmp/cache'),
   containerbaseDir: upath.join('/tmp/cache/containerbase'),
+  binarySource: 'global',
 };
 
 const config: UpdateArtifactsConfig = {};

--- a/lib/modules/manager/bazelisk/artifacts.spec.ts
+++ b/lib/modules/manager/bazelisk/artifacts.spec.ts
@@ -12,6 +12,7 @@ const adminConfig: RepoGlobalConfig = {
   localDir: upath.join('/tmp/github/some/repo'),
   cacheDir: upath.join('/tmp/cache'),
   containerbaseDir: upath.join('/tmp/cache/containerbase'),
+  binarySource: 'global',
 };
 
 const config: UpdateArtifactsConfig = {};

--- a/lib/modules/manager/bun/artifacts.spec.ts
+++ b/lib/modules/manager/bun/artifacts.spec.ts
@@ -15,6 +15,7 @@ const fs = vi.mocked(_fs);
 
 const globalConfig: RepoGlobalConfig = {
   localDir: '',
+  binarySource: 'global',
 };
 
 describe('modules/manager/bun/artifacts', () => {

--- a/lib/modules/manager/bundler/artifacts.spec.ts
+++ b/lib/modules/manager/bundler/artifacts.spec.ts
@@ -33,6 +33,7 @@ const adminConfig: RepoGlobalConfig = {
   cacheDir: upath.join('/tmp/cache'),
   containerbaseDir: upath.join('/tmp/cache/containerbase'),
   dockerSidecarImage: 'ghcr.io/renovatebot/base-image',
+  binarySource: 'global',
 };
 
 const config: UpdateArtifactsConfig = {};

--- a/lib/modules/manager/cargo/artifacts.spec.ts
+++ b/lib/modules/manager/cargo/artifacts.spec.ts
@@ -26,6 +26,7 @@ const adminConfig: RepoGlobalConfig = {
   cacheDir: upath.join('/tmp/cache'),
   containerbaseDir: upath.join('/tmp/cache/containerbase'),
   dockerSidecarImage: 'ghcr.io/renovatebot/base-image',
+  binarySource: 'global',
 };
 
 describe('modules/manager/cargo/artifacts', () => {

--- a/lib/modules/manager/cocoapods/artifacts.spec.ts
+++ b/lib/modules/manager/cocoapods/artifacts.spec.ts
@@ -26,6 +26,7 @@ const adminConfig: RepoGlobalConfig = {
   cacheDir: upath.join('/tmp/cache'),
   containerbaseDir: upath.join('/tmp/cache/containerbase'),
   dockerSidecarImage: 'ghcr.io/renovatebot/base-image',
+  binarySource: 'global',
 };
 
 describe('modules/manager/cocoapods/artifacts', () => {

--- a/lib/modules/manager/composer/artifacts.spec.ts
+++ b/lib/modules/manager/composer/artifacts.spec.ts
@@ -34,6 +34,7 @@ const adminConfig: RepoGlobalConfig = {
   cacheDir: upath.join('/tmp/renovate/cache'),
   containerbaseDir: upath.join('/tmp/renovate/cache/containerbase'),
   dockerSidecarImage: 'ghcr.io/renovatebot/base-image',
+  binarySource: 'global',
 };
 
 const repoStatus = partial<StatusResult>({

--- a/lib/modules/manager/conan/artifacts.spec.ts
+++ b/lib/modules/manager/conan/artifacts.spec.ts
@@ -19,6 +19,7 @@ const adminConfig: RepoGlobalConfig = {
   cacheDir: upath.join('/tmp/cache'),
   containerbaseDir: upath.join('/tmp/cache/containerbase'),
   dockerSidecarImage: 'ghcr.io/renovatebot/base-image',
+  binarySource: 'global',
 };
 
 describe('modules/manager/conan/artifacts', () => {

--- a/lib/modules/manager/copier/artifacts.spec.ts
+++ b/lib/modules/manager/copier/artifacts.spec.ts
@@ -34,6 +34,7 @@ const adminConfig: RepoGlobalConfig = {
   cacheDir: upath.join('/tmp/cache'),
   containerbaseDir: upath.join('/tmp/renovate/cache/containerbase'),
   allowScripts: false,
+  binarySource: 'global',
 };
 
 describe('modules/manager/copier/artifacts', () => {

--- a/lib/modules/manager/deno/artifacts.spec.ts
+++ b/lib/modules/manager/deno/artifacts.spec.ts
@@ -28,7 +28,7 @@ describe('modules/manager/deno/artifacts', () => {
       localDirResult = await tmp.dir({ unsafeCleanup: true });
       localDir = localDirResult.path;
 
-      GlobalConfig.set({ localDir });
+      GlobalConfig.set({ localDir, binarySource: 'global' });
     });
 
     afterEach(async () => {

--- a/lib/modules/manager/devbox/artifacts.spec.ts
+++ b/lib/modules/manager/devbox/artifacts.spec.ts
@@ -12,6 +12,7 @@ vi.mock('../../../util/fs/index.ts');
 
 const globalConfig: RepoGlobalConfig = {
   localDir: '',
+  binarySource: 'global',
 };
 
 const devboxJson = codeBlock`

--- a/lib/modules/manager/flux/artifacts.spec.ts
+++ b/lib/modules/manager/flux/artifacts.spec.ts
@@ -9,6 +9,7 @@ describe('modules/manager/flux/artifacts', () => {
   beforeAll(() => {
     GlobalConfig.set({
       localDir: '',
+      binarySource: 'global',
     });
   });
 

--- a/lib/modules/manager/gleam/artifacts.spec.ts
+++ b/lib/modules/manager/gleam/artifacts.spec.ts
@@ -11,6 +11,7 @@ vi.mock('../../../util/fs/index.ts');
 
 const globalConfig: RepoGlobalConfig = {
   localDir: '',
+  binarySource: 'global',
 };
 
 describe('modules/manager/gleam/artifacts', () => {

--- a/lib/modules/manager/gomod/artifacts.spec.ts
+++ b/lib/modules/manager/gomod/artifacts.spec.ts
@@ -61,6 +61,7 @@ const adminConfig: RepoGlobalConfig = {
   cacheDir: upath.join('/tmp/renovate/cache'),
   containerbaseDir: upath.join('/tmp/renovate/cache/containerbase'),
   dockerSidecarImage: 'ghcr.io/renovatebot/base-image',
+  binarySource: 'global',
 };
 
 const config: UpdateArtifactsConfig = {

--- a/lib/modules/manager/gradle-wrapper/artifacts.spec.ts
+++ b/lib/modules/manager/gradle-wrapper/artifacts.spec.ts
@@ -31,6 +31,7 @@ const adminConfig: RepoGlobalConfig = {
 
   // although not enabled by default, let's assume it is
   allowedUnsafeExecutions: ['gradleWrapper'],
+  binarySource: 'global',
 };
 
 const config: UpdateArtifactsConfig = {

--- a/lib/modules/manager/gradle/artifacts.spec.ts
+++ b/lib/modules/manager/gradle/artifacts.spec.ts
@@ -28,6 +28,7 @@ const adminConfig: RepoGlobalConfig = {
 
   // although not enabled by default, let's assume it is
   allowedUnsafeExecutions: ['gradleWrapper'],
+  binarySource: 'global',
 };
 
 const osPlatformSpy = vi.spyOn(os, 'platform');

--- a/lib/modules/manager/helmfile/artifacts.spec.ts
+++ b/lib/modules/manager/helmfile/artifacts.spec.ts
@@ -25,6 +25,7 @@ const adminConfig: RepoGlobalConfig = {
   cacheDir: upath.join('/tmp/renovate/cache'),
   containerbaseDir: upath.join('/tmp/renovate/cache/containerbase'),
   dockerSidecarImage: 'ghcr.io/renovatebot/base-image',
+  binarySource: 'global',
 };
 
 const config: UpdateArtifactsConfig = {};

--- a/lib/modules/manager/helmv3/artifacts.spec.ts
+++ b/lib/modules/manager/helmv3/artifacts.spec.ts
@@ -28,6 +28,7 @@ const adminConfig: RepoGlobalConfig = {
   localDir: upath.join('/tmp/github/some/repo'), // `join` fixes Windows CI
   cacheDir: upath.join('/tmp/renovate/cache'),
   containerbaseDir: upath.join('/tmp/renovate/cache/containerbase'),
+  binarySource: 'global',
 };
 
 const config: UpdateArtifactsConfig = {};

--- a/lib/modules/manager/hermit/artifacts.spec.ts
+++ b/lib/modules/manager/hermit/artifacts.spec.ts
@@ -24,7 +24,7 @@ describe('modules/manager/hermit/artifacts', () => {
       lstatsMock.mockResolvedValue(true);
 
       readlinkMock.mockResolvedValue('hermit');
-      GlobalConfig.set({ localDir: '' });
+      GlobalConfig.set({ localDir: '', binarySource: 'global' });
 
       const execSnapshots = mockExecAll();
       getRepoStatusMock.mockResolvedValue(
@@ -141,7 +141,7 @@ describe('modules/manager/hermit/artifacts', () => {
       lstatsMock.mockResolvedValue(true);
 
       readlinkMock.mockResolvedValue('hermit');
-      GlobalConfig.set({ localDir: '' });
+      GlobalConfig.set({ localDir: '', binarySource: 'global' });
 
       const execSnapshots = mockExecAll();
       getRepoStatusMock.mockResolvedValue(
@@ -247,7 +247,7 @@ describe('modules/manager/hermit/artifacts', () => {
       lstatsMock.mockResolvedValue(true);
 
       readlinkMock.mockResolvedValue('hermit');
-      GlobalConfig.set({ localDir: '' });
+      GlobalConfig.set({ localDir: '', binarySource: 'global' });
 
       const execSnapshots = mockExecAll();
       getRepoStatusMock.mockResolvedValue(
@@ -322,7 +322,7 @@ describe('modules/manager/hermit/artifacts', () => {
       lstatsMock.mockResolvedValue(true);
 
       readlinkMock.mockResolvedValue(null);
-      GlobalConfig.set({ localDir: '' });
+      GlobalConfig.set({ localDir: '', binarySource: 'global' });
 
       mockExecAll(
         new ExecError('', {
@@ -372,7 +372,7 @@ describe('modules/manager/hermit/artifacts', () => {
       lstatsMock.mockResolvedValue(true);
 
       readlinkMock.mockResolvedValue(null);
-      GlobalConfig.set({ localDir: '' });
+      GlobalConfig.set({ localDir: '', binarySource: 'global' });
       mockExecAll();
 
       getRepoStatusMock.mockResolvedValue(
@@ -524,7 +524,7 @@ describe('modules/manager/hermit/artifacts', () => {
       lstatsMock.mockResolvedValue(true);
 
       readlinkMock.mockResolvedValue('hermit');
-      GlobalConfig.set({ localDir: '' });
+      GlobalConfig.set({ localDir: '', binarySource: 'global' });
       const execSnapshots = mockExecAll();
       await updateArtifacts({
         updatedDeps: [

--- a/lib/modules/manager/jsonnet-bundler/artifacts.spec.ts
+++ b/lib/modules/manager/jsonnet-bundler/artifacts.spec.ts
@@ -15,6 +15,7 @@ const adminConfig: RepoGlobalConfig = {
   localDir: upath.join('/tmp/github/some/repo'),
   cacheDir: upath.join('/tmp/renovate/cache'),
   containerbaseDir: upath.join('/tmp/renovate/cache/containerbase'),
+  binarySource: 'global',
 };
 const config: UpdateArtifactsConfig = {};
 

--- a/lib/modules/manager/kustomize/artifacts.spec.ts
+++ b/lib/modules/manager/kustomize/artifacts.spec.ts
@@ -22,6 +22,7 @@ const adminConfig: RepoGlobalConfig = {
   localDir: upath.join('/tmp/github/some/repo'), // `join` fixes Windows CI
   cacheDir: upath.join('/tmp/renovate/cache'),
   containerbaseDir: upath.join('/tmp/renovate/cache/containerbase'),
+  binarySource: 'global',
 };
 
 process.env.CONTAINERBASE = 'true';

--- a/lib/modules/manager/maven-wrapper/artifacts.spec.ts
+++ b/lib/modules/manager/maven-wrapper/artifacts.spec.ts
@@ -32,7 +32,10 @@ function mockMavenFileChangedInGit(fileName = 'maven-wrapper.properties') {
 describe('modules/manager/maven-wrapper/artifacts', () => {
   beforeEach(() => {
     osPlatformSpy.mockImplementation(() => 'linux');
-    GlobalConfig.set({ localDir: upath.join('/tmp/github/some/repo') });
+    GlobalConfig.set({
+      localDir: upath.join('/tmp/github/some/repo'),
+      binarySource: 'global',
+    });
     fs.statLocalFile.mockResolvedValue(
       partial<Stats>({
         isFile: () => true,

--- a/lib/modules/manager/mix/artifacts.spec.ts
+++ b/lib/modules/manager/mix/artifacts.spec.ts
@@ -21,6 +21,7 @@ const adminConfig: RepoGlobalConfig = {
   localDir: upath.join('/tmp/github/some/repo'),
   cacheDir: upath.join('/tmp/cache'),
   containerbaseDir: upath.join('/tmp/cache/containerbase'),
+  binarySource: 'global',
 };
 
 // support install mode

--- a/lib/modules/manager/nix/artifacts.spec.ts
+++ b/lib/modules/manager/nix/artifacts.spec.ts
@@ -18,6 +18,7 @@ const adminConfig: RepoGlobalConfig = {
   localDir: upath.join('/tmp/github/some/repo'),
   cacheDir: upath.join('/tmp/renovate/cache'),
   containerbaseDir: upath.join('/tmp/renovate/cache/containerbase'),
+  binarySource: 'global',
 };
 const dockerAdminConfig = {
   ...adminConfig,

--- a/lib/modules/manager/npm/artifacts.spec.ts
+++ b/lib/modules/manager/npm/artifacts.spec.ts
@@ -18,6 +18,7 @@ const adminConfig: RepoGlobalConfig = {
   localDir: upath.join('/tmp/github/some/repo'),
   cacheDir: upath.join('/tmp/renovate/cache'),
   containerbaseDir: upath.join('/tmp/renovate/cache/containerbase'),
+  binarySource: 'global',
 };
 const dockerAdminConfig = {
   ...adminConfig,

--- a/lib/modules/manager/npm/post-update/npm.spec.ts
+++ b/lib/modules/manager/npm/post-update/npm.spec.ts
@@ -16,7 +16,7 @@ process.env.CONTAINERBASE = 'true';
 describe('modules/manager/npm/post-update/npm', () => {
   beforeEach(() => {
     env.getChildProcessEnv.mockReturnValue(envMock.basic);
-    GlobalConfig.set({ localDir: '' });
+    GlobalConfig.set({ localDir: '', binarySource: 'global' });
     vi.mocked(getNodeToolConstraint).mockResolvedValueOnce({
       toolName: 'node',
       constraint: '16.16.0',
@@ -497,6 +497,7 @@ describe('modules/manager/npm/post-update/npm', () => {
         toolSettings: {
           nodeMaxMemory: 3456,
         },
+        binarySource: 'global',
       });
 
       const execSnapshots = mockExecAll();

--- a/lib/modules/manager/npm/post-update/pnpm.spec.ts
+++ b/lib/modules/manager/npm/post-update/pnpm.spec.ts
@@ -38,7 +38,7 @@ describe('modules/manager/npm/post-update/pnpm', () => {
   beforeEach(() => {
     config = partial<PostUpdateConfig>({ constraints: { pnpm: '^2.0.0' } });
     env.getChildProcessEnv.mockReturnValue(envMock.basic);
-    GlobalConfig.set({ localDir: '' });
+    GlobalConfig.set({ localDir: '', binarySource: 'global' });
     vi.mocked(getNodeToolConstraint).mockResolvedValueOnce({
       toolName: 'node',
       constraint: '16.16.0',
@@ -594,6 +594,7 @@ describe('modules/manager/npm/post-update/pnpm', () => {
         toolSettings: {
           nodeMaxMemory: 1234,
         },
+        binarySource: 'global',
       });
       const execSnapshots = mockExecAll();
       fs.readLocalFile.mockResolvedValue('package-lock-contents');

--- a/lib/modules/manager/npm/post-update/yarn.spec.ts
+++ b/lib/modules/manager/npm/post-update/yarn.spec.ts
@@ -46,7 +46,11 @@ describe('modules/manager/npm/post-update/yarn', () => {
     delete process.env.HTTPS_PROXY;
     delete process.env.RENOVATE_X_YARN_PROXY;
     Fixtures.reset();
-    GlobalConfig.set({ localDir: '.', cacheDir: '/tmp/cache' });
+    GlobalConfig.set({
+      localDir: '.',
+      cacheDir: '/tmp/cache',
+      binarySource: 'global',
+    });
     removeDockerContainer.mockResolvedValue();
     docker.resetPrefetchedImages();
     vi.mocked(getNodeToolConstraint).mockResolvedValueOnce({
@@ -70,7 +74,11 @@ describe('modules/manager/npm/post-update/yarn', () => {
         },
         '/some-dir',
       );
-      GlobalConfig.set({ localDir: '/', cacheDir: '/tmp/cache' });
+      GlobalConfig.set({
+        localDir: '/',
+        cacheDir: '/tmp/cache',
+        binarySource: 'global',
+      });
       const execSnapshots = mockExecAll({
         stdout: yarnVersion,
         stderr: '',
@@ -118,6 +126,7 @@ describe('modules/manager/npm/post-update/yarn', () => {
           toolSettings: {
             nodeMaxMemory: 2345,
           },
+          binarySource: 'global',
         });
         const execSnapshots = mockExecAll({
           stdout: yarnVersion,
@@ -153,7 +162,11 @@ describe('modules/manager/npm/post-update/yarn', () => {
           },
           '/some-dir',
         );
-        GlobalConfig.set({ localDir: '/', cacheDir: '/tmp/cache' });
+        GlobalConfig.set({
+          localDir: '/',
+          cacheDir: '/tmp/cache',
+          binarySource: 'global',
+        });
         const execSnapshots = mockExecAll({
           stdout: yarnVersion,
           stderr: '',
@@ -213,6 +226,7 @@ describe('modules/manager/npm/post-update/yarn', () => {
       localDir: '.',
       allowScripts: true,
       cacheDir: '/tmp/cache',
+      binarySource: 'global',
     });
     Fixtures.mock(
       {
@@ -243,6 +257,7 @@ describe('modules/manager/npm/post-update/yarn', () => {
       localDir: '.',
       allowScripts: true,
       cacheDir: '/tmp/cache',
+      binarySource: 'global',
     });
     Fixtures.mock(
       {
@@ -808,7 +823,11 @@ describe('modules/manager/npm/post-update/yarn', () => {
     // sanity check for later refactorings
     expect(plocktest1YarnLockV1).toBeTruthy();
     expect(plocktest1PackageJson).toBeTruthy();
-    GlobalConfig.set({ localDir: '.', cacheDir: '/tmp/cache' });
+    GlobalConfig.set({
+      localDir: '.',
+      cacheDir: '/tmp/cache',
+      binarySource: 'global',
+    });
     Fixtures.mock(
       {
         'package.json': plocktest1PackageJson,
@@ -906,7 +925,11 @@ describe('modules/manager/npm/post-update/yarn', () => {
         },
         '/',
       );
-      GlobalConfig.set({ localDir: '/tmp/renovate', cacheDir: '/tmp/cache' });
+      GlobalConfig.set({
+        localDir: '/tmp/renovate',
+        cacheDir: '/tmp/cache',
+        binarySource: 'global',
+      });
       expect(await yarnHelper.checkYarnrc('.')).toEqual({
         offlineMirror: true,
         yarnPath: '.yarn/cli.js',
@@ -934,7 +957,11 @@ describe('modules/manager/npm/post-update/yarn', () => {
         },
         '/',
       );
-      GlobalConfig.set({ localDir: '/tmp/renovate', cacheDir: '/tmp/cache' });
+      GlobalConfig.set({
+        localDir: '/tmp/renovate',
+        cacheDir: '/tmp/cache',
+        binarySource: 'global',
+      });
       expect(await yarnHelper.checkYarnrc('.')).toEqual({
         offlineMirror: true,
         yarnPath: null,
@@ -949,7 +976,11 @@ describe('modules/manager/npm/post-update/yarn', () => {
         },
         '/',
       );
-      GlobalConfig.set({ localDir: '/tmp', cacheDir: '/tmp/cache' });
+      GlobalConfig.set({
+        localDir: '/tmp',
+        cacheDir: '/tmp/cache',
+        binarySource: 'global',
+      });
       expect(await yarnHelper.checkYarnrc('renovate')).toEqual({
         offlineMirror: false,
         yarnPath: null,
@@ -963,7 +994,11 @@ describe('modules/manager/npm/post-update/yarn', () => {
         },
         '/tmp/renovate',
       );
-      GlobalConfig.set({ localDir: '/tmp/renovate', cacheDir: '/tmp/cache' });
+      GlobalConfig.set({
+        localDir: '/tmp/renovate',
+        cacheDir: '/tmp/cache',
+        binarySource: 'global',
+      });
       const { offlineMirror, yarnPath } = await yarnHelper.checkYarnrc('.');
       expect(offlineMirror).toBeFalse();
       expect(yarnPath).toBeNull();
@@ -977,7 +1012,11 @@ describe('modules/manager/npm/post-update/yarn', () => {
         },
         '/tmp/renovate',
       );
-      GlobalConfig.set({ localDir: '/tmp/renovate', cacheDir: '/tmp/cache' });
+      GlobalConfig.set({
+        localDir: '/tmp/renovate',
+        cacheDir: '/tmp/cache',
+        binarySource: 'global',
+      });
       await yarnHelper.checkYarnrc('/tmp/renovate');
       expect(Fixtures.toJSON()['/tmp/renovate/.yarnrc']).toBe('\n\n');
     });

--- a/lib/modules/manager/nuget/artifacts.spec.ts
+++ b/lib/modules/manager/nuget/artifacts.spec.ts
@@ -26,6 +26,7 @@ const adminConfig: RepoGlobalConfig = {
   localDir: upath.join('/tmp/github/some/repo'),
   cacheDir: upath.join('/tmp/renovate/cache'),
   containerbaseDir: upath.join('/tmp/renovate/cache/containerbase'),
+  binarySource: 'global',
 };
 
 const config: UpdateArtifactsConfig = {};

--- a/lib/modules/manager/pep621/artifacts.spec.ts
+++ b/lib/modules/manager/pep621/artifacts.spec.ts
@@ -19,6 +19,7 @@ const adminConfig: RepoGlobalConfig = {
   localDir: upath.join('/tmp/github/some/repo'),
   cacheDir: upath.join('/tmp/cache'),
   containerbaseDir: upath.join('/tmp/cache/containerbase'),
+  binarySource: 'global',
 };
 
 describe('modules/manager/pep621/artifacts', () => {

--- a/lib/modules/manager/pip-compile/artifacts.spec.ts
+++ b/lib/modules/manager/pip-compile/artifacts.spec.ts
@@ -58,6 +58,7 @@ const adminConfig: RepoGlobalConfig = {
   localDir: upath.join('/tmp/github/some/repo'),
   cacheDir: upath.join('/tmp/renovate/cache'),
   containerbaseDir: upath.join('/tmp/renovate/cache/containerbase'),
+  binarySource: 'global',
 };
 const dockerAdminConfig = {
   ...adminConfig,

--- a/lib/modules/manager/pip_requirements/artifacts.spec.ts
+++ b/lib/modules/manager/pip_requirements/artifacts.spec.ts
@@ -21,6 +21,7 @@ const adminConfig: RepoGlobalConfig = {
   localDir: upath.join('/tmp/github/some/repo'),
   cacheDir: upath.join('/tmp/renovate/cache'),
   containerbaseDir: upath.join('/tmp/renovate/cache/containerbase'),
+  binarySource: 'global',
 };
 
 const config: UpdateArtifactsConfig = {

--- a/lib/modules/manager/pipenv/artifacts.spec.ts
+++ b/lib/modules/manager/pipenv/artifacts.spec.ts
@@ -46,6 +46,7 @@ const adminConfig: RepoGlobalConfig = {
   localDir: upath.join(upath.join('/tmp/github/some/repo')),
   cacheDir: upath.join(upath.join('/tmp/renovate/cache')),
   containerbaseDir: upath.join(upath.join('/tmp/renovate/cache/containerbase')),
+  binarySource: 'global',
 };
 const dockerAdminConfig = {
   ...adminConfig,

--- a/lib/modules/manager/pixi/artifacts.spec.ts
+++ b/lib/modules/manager/pixi/artifacts.spec.ts
@@ -54,6 +54,7 @@ const adminConfig: RepoGlobalConfig = {
   cacheDir: upath.join('/tmp/cache'),
   containerbaseDir: upath.join('/tmp/cache/containerbase'),
   dockerSidecarImage: 'ghcr.io/renovatebot/base-image',
+  binarySource: 'global',
 };
 
 const config: UpdateArtifactsConfig = {};

--- a/lib/modules/manager/poetry/artifacts.spec.ts
+++ b/lib/modules/manager/poetry/artifacts.spec.ts
@@ -41,6 +41,7 @@ const adminConfig: RepoGlobalConfig = {
   localDir: upath.join('/tmp/github/some/repo'),
   cacheDir: upath.join('/tmp/cache'),
   containerbaseDir: upath.join('/tmp/cache/containerbase'),
+  binarySource: 'global',
 };
 
 const config: UpdateArtifactsConfig = {};

--- a/lib/modules/manager/pub/artifacts.spec.ts
+++ b/lib/modules/manager/pub/artifacts.spec.ts
@@ -30,6 +30,7 @@ const adminConfig: RepoGlobalConfig = {
   localDir: upath.join('/tmp/github/some/repo'),
   cacheDir: upath.join('/tmp/cache'),
   containerbaseDir: upath.join('/tmp/cache/containerbase'),
+  binarySource: 'global',
 };
 
 const config: UpdateArtifactsConfig = {};

--- a/lib/modules/manager/terragrunt/artifacts.spec.ts
+++ b/lib/modules/manager/terragrunt/artifacts.spec.ts
@@ -1,6 +1,6 @@
 import upath from 'upath';
 import { GlobalConfig } from '../../../config/global.ts';
-import type { UpdateType } from '../../../config/types.ts';
+import type { RepoGlobalConfig, UpdateType } from '../../../config/types.ts';
 import * as terraformLockfile from '../terraform/lockfile/index.ts';
 import type { UpdateArtifactsConfig } from '../types.ts';
 import { updateArtifacts } from './artifacts.ts';
@@ -11,11 +11,12 @@ const config = {
   constraints: {},
 };
 
-const adminConfig = {
+const adminConfig: RepoGlobalConfig = {
   // `join` fixes Windows CI
   localDir: upath.join('/tmp/github/some/repo'),
   cacheDir: upath.join('/tmp/renovate/cache'),
   containerbaseDir: upath.join('/tmp/renovate/cache/containerbase'),
+  binarySource: 'global',
 };
 
 describe('modules/manager/terragrunt/artifacts', () => {

--- a/lib/modules/manager/vendir/artifacts.spec.ts
+++ b/lib/modules/manager/vendir/artifacts.spec.ts
@@ -25,6 +25,7 @@ const adminConfig: RepoGlobalConfig = {
   cacheDir: upath.join('/tmp/renovate/cache'),
   containerbaseDir: upath.join('/tmp/cache/containerbase'),
   dockerSidecarImage: 'ghcr.io/renovatebot/base-image',
+  binarySource: 'global',
 };
 
 const config: UpdateArtifactsConfig = {};


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
As part of future changes (https://github.com/renovatebot/renovate/pull/42113), we'll correctly return the default value from
`GlobalConfig.get`, instead of `undefined` if no default is provided in
the `get` call.

As `binarySource=install` is the default, this then leads to these tests
failing, as they're intended to run with `binarySource=global`.


## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
