### PR TITLE
feat(manager/npm): walk up to find inherited packageManager

### DIFF
--- a/lib/modules/manager/npm/post-update/npm.spec.ts
+++ b/lib/modules/manager/npm/post-update/npm.spec.ts
@@ -27,6 +27,7 @@ describe('modules/manager/npm/post-update/npm', () => {
     const execSnapshots = mockExecAll();
     // package.json
     fs.readLocalFile.mockResolvedValueOnce('{}');
+    fs.readLocalFile.mockResolvedValueOnce('{}'); // ancestor package.json (walk-up)
     const packageLockContents = JSON.stringify({
       packages: {},
       lockfileVersion: 3,
@@ -45,7 +46,7 @@ describe('modules/manager/npm/post-update/npm', () => {
       { skipInstalls, postUpdateOptions },
       updates,
     );
-    expect(fs.readLocalFile).toHaveBeenCalledTimes(3);
+    expect(fs.readLocalFile).toHaveBeenCalledTimes(4);
     expect(res.error).toBeFalse();
     expect(res.lockFile).toBe(packageLockContents);
     expect(execSnapshots).toMatchSnapshot();
@@ -55,6 +56,7 @@ describe('modules/manager/npm/post-update/npm', () => {
     const execSnapshots = mockExecAll();
     // package.json
     fs.readLocalFile.mockResolvedValueOnce('{}');
+    fs.readLocalFile.mockResolvedValueOnce('{}'); // ancestor package.json (walk-up)
     const packageLockContents = JSON.stringify({
       packages: {},
       lockfileVersion: 3,
@@ -205,6 +207,7 @@ describe('modules/manager/npm/post-update/npm', () => {
     const execSnapshots = mockExecAll();
     // package.json
     fs.readLocalFile.mockResolvedValueOnce('{}');
+    fs.readLocalFile.mockResolvedValueOnce('{}'); // ancestor package.json (walk-up)
     const packageLockContents = JSON.stringify({
       dependencies: {},
       lockfileVersion: 2,
@@ -222,7 +225,7 @@ describe('modules/manager/npm/post-update/npm', () => {
       { postUpdateOptions },
       updates,
     );
-    expect(fs.readLocalFile).toHaveBeenCalledTimes(3);
+    expect(fs.readLocalFile).toHaveBeenCalledTimes(4);
     expect(res.error).toBeFalse();
     expect(res.lockFile).toBe(packageLockContents);
     expect(execSnapshots).toHaveLength(1);
@@ -237,6 +240,7 @@ describe('modules/manager/npm/post-update/npm', () => {
     const execSnapshots = mockExecAll();
     // package.json
     fs.readLocalFile.mockResolvedValueOnce('{}');
+    fs.readLocalFile.mockResolvedValueOnce('{}'); // ancestor package.json (walk-up)
     const packageLockContents = JSON.stringify({
       dependencies: {},
       lockfileVersion: 1,
@@ -254,7 +258,7 @@ describe('modules/manager/npm/post-update/npm', () => {
       { postUpdateOptions },
       updates,
     );
-    expect(fs.readLocalFile).toHaveBeenCalledTimes(3);
+    expect(fs.readLocalFile).toHaveBeenCalledTimes(4);
     expect(res.error).toBeFalse();
     expect(res.lockFile).toBe(packageLockContents);
     expect(execSnapshots).toHaveLength(2);
@@ -272,6 +276,7 @@ describe('modules/manager/npm/post-update/npm', () => {
     const execSnapshots = mockExecAll();
     // package.json
     fs.readLocalFile.mockResolvedValueOnce('{}');
+    fs.readLocalFile.mockResolvedValueOnce('{}'); // ancestor package.json (walk-up)
     const packageLockContents = JSON.stringify({
       dependencies: {},
       lockfileVersion: 1,
@@ -289,7 +294,7 @@ describe('modules/manager/npm/post-update/npm', () => {
       { postUpdateOptions },
       updates,
     );
-    expect(fs.readLocalFile).toHaveBeenCalledTimes(3);
+    expect(fs.readLocalFile).toHaveBeenCalledTimes(4);
 
     expect(fs.readLocalFile).toHaveBeenCalledWith(
       'some-dir/npm-shrinkwrap.json',
@@ -356,7 +361,8 @@ describe('modules/manager/npm/post-update/npm', () => {
       {},
       updates,
     );
-    expect(fs.readLocalFile).toHaveBeenCalledTimes(3);
+    // +1 read for the ancestor package.json walk-up
+    expect(fs.readLocalFile).toHaveBeenCalledTimes(4);
     expect(res.lockFile).toBe('package-lock-contents');
     // since there are no install npm commands, it means we are using the global npm
     expect(execSnapshots).toMatchObject([
@@ -393,7 +399,8 @@ describe('modules/manager/npm/post-update/npm', () => {
       {},
       [{ isLockFileMaintenance: true }],
     );
-    expect(fs.readLocalFile).toHaveBeenCalledTimes(3);
+    // +1 read for the ancestor package.json walk-up
+    expect(fs.readLocalFile).toHaveBeenCalledTimes(4);
     expect(fs.deleteLocalFile).toHaveBeenCalledTimes(1);
     expect(res.lockFile).toBe('package-lock-contents');
     expect(execSnapshots).toMatchSnapshot();
@@ -480,7 +487,8 @@ describe('modules/manager/npm/post-update/npm', () => {
       { constraints: {} },
       [{ isLockFileMaintenance: true }],
     );
-    expect(fs.readLocalFile).toHaveBeenCalledTimes(3);
+    // +1 read for the ancestor package.json walk-up
+    expect(fs.readLocalFile).toHaveBeenCalledTimes(4);
     expect(res.lockFile).toBe('package-lock-contents');
     expect(execSnapshots).toMatchObject([
       { cmd: 'install-tool node 16.16.0' },
@@ -706,7 +714,8 @@ describe('modules/manager/npm/post-update/npm', () => {
         { skipInstalls },
         updates,
       );
-      expect(fs.readLocalFile).toHaveBeenCalledTimes(3);
+      // +1 read for the ancestor package.json walk-up
+      expect(fs.readLocalFile).toHaveBeenCalledTimes(4);
       expect(res.error).toBeFalse();
       expect(execSnapshots).toMatchObject([
         {
@@ -886,6 +895,7 @@ describe('modules/manager/npm/post-update/npm', () => {
       // package.json
       fs.readLocalFile.mockResolvedValue('{}');
       fs.readLocalFile.mockResolvedValueOnce('package-lock content');
+      fs.readLocalFile.mockResolvedValueOnce('{}'); // ancestor package.json (walk-up)
       const skipInstalls = true;
       const res = await npmHelper.generateLockFile(
         'some-dir',
@@ -917,7 +927,8 @@ describe('modules/manager/npm/post-update/npm', () => {
           },
         ],
       );
-      expect(fs.readLocalFile).toHaveBeenCalledTimes(3);
+      // +1 read for the ancestor package.json walk-up
+      expect(fs.readLocalFile).toHaveBeenCalledTimes(4);
       expect(res.error).toBeFalse();
       expect(execSnapshots).toMatchObject([
         {
@@ -964,7 +975,8 @@ describe('modules/manager/npm/post-update/npm', () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date('2026-06-15T12:00:00.000Z'));
       execSnapshots = mockExecAll();
-      fs.readLocalFile.mockResolvedValueOnce('{}');
+      fs.readLocalFile.mockResolvedValueOnce('{}'); // sibling package.json
+      fs.readLocalFile.mockResolvedValueOnce('{}'); // ancestor package.json (walk-up)
       const packageLockContents = JSON.stringify({
         packages: {},
         lockfileVersion: 3,

--- a/lib/modules/manager/npm/post-update/npm.ts
+++ b/lib/modules/manager/npm/post-update/npm.ts
@@ -33,6 +33,7 @@ import { composeLockFile, parseLockFile } from '../utils.ts';
 import { getNodeToolConstraint } from './node-version.ts';
 import type { GenerateLockFileResult } from './types.ts';
 import {
+  getInheritedPackageManagerVersion,
   getNodeOptions,
   getPackageManagerVersion,
   lazyLoadPackageJson,
@@ -127,6 +128,7 @@ export async function generateLockFile(
       constraint:
         config.constraints?.npm ??
         getPackageManagerVersion('npm', await lazyPkgJson.getValue()) ??
+        (await getInheritedPackageManagerVersion('npm', lockFileDir)) ??
         (await getNpmConstraintFromPackageLock(lockFileDir, filename)) ??
         null,
     };

--- a/lib/modules/manager/npm/post-update/pnpm.spec.ts
+++ b/lib/modules/manager/npm/post-update/pnpm.spec.ts
@@ -426,6 +426,92 @@ describe('modules/manager/npm/post-update/pnpm', () => {
     ]);
   });
 
+  it('uses inherited packageManager from ancestor package.json when sibling has none', async () => {
+    const execSnapshots = mockExecAll();
+    const configTemp = partial<PostUpdateConfig>();
+    fs.readLocalFile.mockImplementation(
+      (fileName: string): Promise<string | null> => {
+        // Sibling package.json has no packageManager / engines.
+        if (fileName === 'frontend/package.json') {
+          return Promise.resolve('{}');
+        }
+        // Ancestor package.json (repo root) pins pnpm via packageManager.
+        if (fileName === 'package.json') {
+          return Promise.resolve(
+            codeBlock`
+            {
+              "name": "monorepo-root",
+              "packageManager": "pnpm@10.33.4"
+            }
+          `,
+          );
+        }
+        return Promise.resolve('package-lock-contents');
+      },
+    );
+
+    const res = await pnpmHelper.generateLockFile('frontend', {}, configTemp, [
+      {
+        depType: 'packageManager',
+        depName: 'pnpm',
+      },
+    ]);
+
+    expect(res.lockFile).toBe('package-lock-contents');
+    expect(execSnapshots).toMatchObject([
+      {
+        cmd: 'pnpm install --lockfile-only --ignore-scripts --ignore-pnpmfile',
+        options: {
+          cwd: 'frontend',
+        },
+      },
+    ]);
+  });
+
+  it('does not walk up when sibling packageManager satisfies constraint', async () => {
+    const execSnapshots = mockExecAll();
+    const configTemp = partial<PostUpdateConfig>();
+    const siblingPackageJson = codeBlock`
+      {
+        "name": "frontend",
+        "packageManager": "pnpm@9.0.0"
+      }
+    `;
+    const ancestorPackageJson = codeBlock`
+      {
+        "name": "monorepo-root",
+        "packageManager": "pnpm@10.33.4"
+      }
+    `;
+    fs.readLocalFile.mockImplementation(
+      (fileName: string): Promise<string | null> => {
+        if (fileName === 'frontend/package.json') {
+          return Promise.resolve(siblingPackageJson);
+        }
+        if (fileName === 'package.json') {
+          return Promise.resolve(ancestorPackageJson);
+        }
+        return Promise.resolve('package-lock-contents');
+      },
+    );
+
+    const res = await pnpmHelper.generateLockFile('frontend', {}, configTemp, [
+      {
+        depType: 'packageManager',
+        depName: 'pnpm',
+      },
+    ]);
+
+    expect(res.lockFile).toBe('package-lock-contents');
+    // Sibling pin wins; the ancestor package.json should never be read.
+    expect(fs.readLocalFile).not.toHaveBeenCalledWith('package.json', 'utf8');
+    expect(execSnapshots).toMatchObject([
+      {
+        cmd: 'pnpm install --lockfile-only --ignore-scripts --ignore-pnpmfile',
+      },
+    ]);
+  });
+
   it('uses volta version and puts it into constraint', async () => {
     const execSnapshots = mockExecAll();
     const configTemp = partial<PostUpdateConfig>();
@@ -495,7 +581,9 @@ describe('modules/manager/npm/post-update/pnpm', () => {
       configTemp,
       [],
     );
-    expect(fs.readLocalFile).toHaveBeenCalledTimes(3);
+    // 1: sibling package.json, 2: ancestor package.json (walk-up),
+    // 3: lockfile for constraint derivation, 4: final lockfile read
+    expect(fs.readLocalFile).toHaveBeenCalledTimes(4);
     expect(res.lockFile).toBe('lockfileVersion: 5.3\n');
   });
 

--- a/lib/modules/manager/npm/post-update/pnpm.ts
+++ b/lib/modules/manager/npm/post-update/pnpm.ts
@@ -25,6 +25,7 @@ import type { PnpmWorkspaceFile } from '../extract/types.ts';
 import { getNodeToolConstraint } from './node-version.ts';
 import type { GenerateLockFileResult, PnpmLockFile } from './types.ts';
 import {
+  getInheritedPackageManagerVersion,
   getNodeOptions,
   getPackageManagerVersion,
   lazyLoadPackageJson,
@@ -56,7 +57,8 @@ export async function generateLockFile(
       constraint:
         getPnpmConstraintFromUpgrades(upgrades) ?? // if pnpm is being upgraded, it comes first
         config.constraints?.pnpm ?? // from user config or extraction
-        getPackageManagerVersion('pnpm', await lazyPgkJson.getValue()) ?? // look in package.json > packageManager or engines
+        getPackageManagerVersion('pnpm', await lazyPgkJson.getValue()) ?? // look in sibling package.json > packageManager or engines
+        (await getInheritedPackageManagerVersion('pnpm', lockFileDir)) ?? // walk up to find an inherited packageManager (mirrors corepack)
         (await getConstraintFromLockFile(lockFileName)), // use lockfileVersion to find pnpm version range
     };
 

--- a/lib/modules/manager/npm/post-update/pnpm.ts
+++ b/lib/modules/manager/npm/post-update/pnpm.ts
@@ -51,13 +51,13 @@ export async function generateLockFile(
   let lockFile: string | null = null;
   const commands: string[] = [];
   try {
-    const lazyPgkJson = lazyLoadPackageJson(lockFileDir);
+    const lazyPkgJson = lazyLoadPackageJson(lockFileDir);
     const pnpmToolConstraint: ToolConstraint = {
       toolName: 'pnpm',
       constraint:
         getPnpmConstraintFromUpgrades(upgrades) ?? // if pnpm is being upgraded, it comes first
         config.constraints?.pnpm ?? // from user config or extraction
-        getPackageManagerVersion('pnpm', await lazyPgkJson.getValue()) ?? // look in sibling package.json > packageManager or engines
+        getPackageManagerVersion('pnpm', await lazyPkgJson.getValue()) ?? // look in sibling package.json > packageManager or engines
         (await getInheritedPackageManagerVersion('pnpm', lockFileDir)) ?? // walk up to find an inherited packageManager (mirrors corepack)
         (await getConstraintFromLockFile(lockFileName)), // use lockfileVersion to find pnpm version range
     };
@@ -86,7 +86,7 @@ export async function generateLockFile(
       extraEnv,
       docker: {},
       toolConstraints: [
-        await getNodeToolConstraint(config, upgrades, lockFileDir, lazyPgkJson),
+        await getNodeToolConstraint(config, upgrades, lockFileDir, lazyPkgJson),
         pnpmToolConstraint,
       ],
     };

--- a/lib/modules/manager/npm/post-update/utils.spec.ts
+++ b/lib/modules/manager/npm/post-update/utils.spec.ts
@@ -1,0 +1,158 @@
+import { codeBlock } from 'common-tags';
+import { fs } from '~test/util.ts';
+import { getInheritedPackageManagerVersion } from './utils.ts';
+
+vi.mock('../../../../util/fs/index.ts');
+
+describe('modules/manager/npm/post-update/utils', () => {
+  describe('getInheritedPackageManagerVersion', () => {
+    it('walks up to the repo root and returns packageManager version', async () => {
+      fs.readLocalFile.mockImplementation(
+        (fileName: string): Promise<string | null> => {
+          if (fileName === 'package.json') {
+            return Promise.resolve(
+              codeBlock`
+              {
+                "name": "monorepo-root",
+                "packageManager": "pnpm@10.33.4"
+              }
+            `,
+            );
+          }
+          return Promise.resolve(null);
+        },
+      );
+
+      const version = await getInheritedPackageManagerVersion(
+        'pnpm',
+        'frontend',
+      );
+      expect(version).toBe('10.33.4');
+    });
+
+    it('walks past intermediate directories without packageManager', async () => {
+      fs.readLocalFile.mockImplementation(
+        (fileName: string): Promise<string | null> => {
+          if (fileName === 'package.json') {
+            return Promise.resolve(
+              codeBlock`
+              {
+                "name": "monorepo-root",
+                "packageManager": "pnpm@10.33.4"
+              }
+            `,
+            );
+          }
+          // Intermediate package.json files exist but have no packageManager.
+          if (
+            fileName === 'infra/lambdas/package.json' ||
+            fileName === 'infra/package.json'
+          ) {
+            return Promise.resolve('{}');
+          }
+          return Promise.resolve(null);
+        },
+      );
+
+      const version = await getInheritedPackageManagerVersion(
+        'pnpm',
+        'infra/lambdas/statuspage-automation',
+      );
+      expect(version).toBe('10.33.4');
+    });
+
+    it('returns the closest ancestor when multiple ancestors define packageManager', async () => {
+      fs.readLocalFile.mockImplementation(
+        (fileName: string): Promise<string | null> => {
+          if (fileName === 'package.json') {
+            return Promise.resolve(
+              codeBlock`
+              { "packageManager": "pnpm@9.0.0" }
+            `,
+            );
+          }
+          if (fileName === 'group/package.json') {
+            return Promise.resolve(
+              codeBlock`
+              { "packageManager": "pnpm@10.33.4" }
+            `,
+            );
+          }
+          return Promise.resolve(null);
+        },
+      );
+
+      const version = await getInheritedPackageManagerVersion(
+        'pnpm',
+        'group/workspace',
+      );
+      expect(version).toBe('10.33.4');
+    });
+
+    it('returns null when no ancestor pins packageManager', async () => {
+      fs.readLocalFile.mockResolvedValue(null);
+
+      const version = await getInheritedPackageManagerVersion(
+        'pnpm',
+        'frontend',
+      );
+      expect(version).toBeNull();
+    });
+
+    it('returns null when lockFileDir is the repo root', async () => {
+      const version = await getInheritedPackageManagerVersion('pnpm', '.');
+      expect(version).toBeNull();
+      expect(fs.readLocalFile).not.toHaveBeenCalled();
+    });
+
+    it('returns null when lockFileDir is empty', async () => {
+      const version = await getInheritedPackageManagerVersion('pnpm', '');
+      expect(version).toBeNull();
+      expect(fs.readLocalFile).not.toHaveBeenCalled();
+    });
+
+    it('also reads engines fields from ancestor package.json', async () => {
+      fs.readLocalFile.mockImplementation(
+        (fileName: string): Promise<string | null> => {
+          if (fileName === 'package.json') {
+            return Promise.resolve(
+              codeBlock`
+              {
+                "engines": { "pnpm": "=8.10.0" }
+              }
+            `,
+            );
+          }
+          return Promise.resolve(null);
+        },
+      );
+
+      const version = await getInheritedPackageManagerVersion(
+        'pnpm',
+        'frontend',
+      );
+      expect(version).toBe('=8.10.0');
+    });
+
+    it('ignores ancestor packageManager pinning a different manager', async () => {
+      fs.readLocalFile.mockImplementation(
+        (fileName: string): Promise<string | null> => {
+          if (fileName === 'package.json') {
+            return Promise.resolve(
+              codeBlock`
+              { "packageManager": "yarn@4.0.0" }
+            `,
+            );
+          }
+          return Promise.resolve(null);
+        },
+      );
+
+      const version = await getInheritedPackageManagerVersion(
+        'pnpm',
+        'frontend',
+      );
+      expect(version).toBeNull();
+    });
+  });
+});

--- a/lib/modules/manager/npm/post-update/utils.spec.ts
+++ b/lib/modules/manager/npm/post-update/utils.spec.ts
@@ -111,6 +111,15 @@ describe('modules/manager/npm/post-update/utils', () => {
       expect(fs.readLocalFile).not.toHaveBeenCalled();
     });
 
+    it('treats nullish lockFileDir as repo root', async () => {
+      const version = await getInheritedPackageManagerVersion(
+        'pnpm',
+        undefined as unknown as string,
+      );
+      expect(version).toBeNull();
+      expect(fs.readLocalFile).not.toHaveBeenCalled();
+    });
+
     it('also reads engines fields from ancestor package.json', async () => {
       fs.readLocalFile.mockImplementation(
         (fileName: string): Promise<string | null> => {

--- a/lib/modules/manager/npm/post-update/utils.ts
+++ b/lib/modules/manager/npm/post-update/utils.ts
@@ -1,5 +1,6 @@
 import { isArray } from '@sindresorhus/is';
 import semver from 'semver';
+import upath from 'upath';
 import { logger } from '../../../../logger/index.ts';
 import { Lazy } from '../../../../util/lazy.ts';
 import type { PackageJson } from '../schema.ts';
@@ -58,4 +59,48 @@ export function getPackageManagerVersion(
 
 export function getNodeOptions(nodeMaxMemory: number): string {
   return `--max-old-space-size=${nodeMaxMemory}`;
+}
+
+/**
+ * Walk up the directory tree from `lockFileDir` looking for an ancestor
+ * `package.json` whose `packageManager` / `devEngines.packageManager` /
+ * `engines` / `volta` field pins `name`. Mirrors how corepack itself resolves
+ * the binary at runtime, so per-workspace lockfile generation honours a
+ * `packageManager` pin set only at the monorepo root.
+ *
+ * `lockFileDir` itself is intentionally skipped — the caller already loads the
+ * sibling `package.json` directly via {@link getPackageManagerVersion}.
+ */
+export async function getInheritedPackageManagerVersion(
+  name: string,
+  lockFileDir: string,
+): Promise<string | null> {
+  const startDir = upath.normalize(lockFileDir || '.');
+  let currentDir = upath.dirname(startDir);
+
+  // No ancestor to walk to — lockFileDir is already at the repo root.
+  if (currentDir === startDir) {
+    return null;
+  }
+
+  while (true) {
+    const pkg = await loadPackageJson(currentDir);
+    const version = getPackageManagerVersion(name, pkg);
+    if (version) {
+      const relPath =
+        currentDir === '.' ? 'package.json' : `${currentDir}/package.json`;
+      logger.debug(
+        `Found inherited ${name} constraint in ${relPath}: ${version}`,
+      );
+      return version;
+    }
+
+    const parent = upath.dirname(currentDir);
+    if (parent === currentDir) {
+      // We've already checked the repo root; nowhere left to walk.
+      break;
+    }
+    currentDir = parent;
+  }
+  return null;
 }

--- a/lib/modules/manager/npm/post-update/utils.ts
+++ b/lib/modules/manager/npm/post-update/utils.ts
@@ -87,8 +87,7 @@ export async function getInheritedPackageManagerVersion(
     const pkg = await loadPackageJson(currentDir);
     const version = getPackageManagerVersion(name, pkg);
     if (version) {
-      const relPath =
-        currentDir === '.' ? 'package.json' : `${currentDir}/package.json`;
+      const relPath = upath.join(currentDir, 'package.json');
       logger.debug(
         `Found inherited ${name} constraint in ${relPath}: ${version}`,
       );

--- a/lib/modules/manager/npm/post-update/utils.ts
+++ b/lib/modules/manager/npm/post-update/utils.ts
@@ -75,7 +75,7 @@ export async function getInheritedPackageManagerVersion(
   name: string,
   lockFileDir: string,
 ): Promise<string | null> {
-  const startDir = upath.normalize(lockFileDir || '.');
+  const startDir = upath.normalize(lockFileDir ?? '.');
   let currentDir = upath.dirname(startDir);
 
   // No ancestor to walk to — lockFileDir is already at the repo root.

--- a/lib/modules/manager/npm/post-update/yarn.spec.ts
+++ b/lib/modules/manager/npm/post-update/yarn.spec.ts
@@ -495,7 +495,8 @@ describe('modules/manager/npm/post-update/yarn', () => {
     Fixtures.mock({});
     const execSnapshots = mockExecAll(new Error('some-error'));
     const res = await yarnHelper.generateLockFile('some-dir', {});
-    expect(fs.readFile).toHaveBeenCalledTimes(3);
+    // +1 read for the ancestor package.json walk-up
+    expect(fs.readFile).toHaveBeenCalledTimes(4);
     expect(res.error).toBeTrue();
     expect(res.lockFile).toBeUndefined();
     expect(fixSnapshots(execSnapshots)).toMatchSnapshot();

--- a/lib/modules/manager/npm/post-update/yarn.ts
+++ b/lib/modules/manager/npm/post-update/yarn.ts
@@ -31,6 +31,7 @@ import type { NpmManagerData } from '../types.ts';
 import { getNodeToolConstraint } from './node-version.ts';
 import type { GenerateLockFileResult } from './types.ts';
 import {
+  getInheritedPackageManagerVersion,
   getNodeOptions,
   getPackageManagerVersion,
   lazyLoadPackageJson,
@@ -115,6 +116,7 @@ export async function generateLockFile(
     const yarnCompatibility =
       (yarnUpdate ? yarnUpdate.newValue : config.constraints?.yarn) ??
       getPackageManagerVersion('yarn', await lazyPgkJson.getValue()) ??
+      (await getInheritedPackageManagerVersion('yarn', lockFileDir)) ??
       getYarnVersionFromLock(await getYarnLock(lockFileName));
     const minYarnVersion =
       semver.validRange(yarnCompatibility) &&

--- a/lib/modules/manager/npm/post-update/yarn.ts
+++ b/lib/modules/manager/npm/post-update/yarn.ts
@@ -108,14 +108,14 @@ export async function generateLockFile(
   logger.debug(`Spawning yarn install to create ${lockFileName}`);
   let lockFile: string | null = null;
   try {
-    const lazyPgkJson = lazyLoadPackageJson(lockFileDir);
+    const lazyPkgJson = lazyLoadPackageJson(lockFileDir);
     const toolConstraints: ToolConstraint[] = [
-      await getNodeToolConstraint(config, upgrades, lockFileDir, lazyPgkJson),
+      await getNodeToolConstraint(config, upgrades, lockFileDir, lazyPkgJson),
     ];
     const yarnUpdate = upgrades.find(isYarnUpdate);
     const yarnCompatibility =
       (yarnUpdate ? yarnUpdate.newValue : config.constraints?.yarn) ??
-      getPackageManagerVersion('yarn', await lazyPgkJson.getValue()) ??
+      getPackageManagerVersion('yarn', await lazyPkgJson.getValue()) ??
       (await getInheritedPackageManagerVersion('yarn', lockFileDir)) ??
       getYarnVersionFromLock(await getYarnLock(lockFileName));
     const minYarnVersion =


### PR DESCRIPTION
## Summary

When generating a per-workspace lockfile, Renovate only checks the **sibling** `package.json` for a `packageManager` pin before falling back to the lockfile-derived constraint. In a monorepo where `packageManager` is set only on the root `package.json` (the standard recommendation), the gap silently routes Renovate onto whatever `pnpm@latest` / `npm@latest` / `yarn@latest` resolves to at the moment of the run.

This PR mirrors corepack's resolution semantics: walks parent directories from the lockfile directory looking for an ancestor `package.json` with a matching `packageManager` (or `devEngines.packageManager` / `engines` / `volta`) before falling through to the lockfile-derived fallback. Wired into pnpm, npm, and yarn — the same gap exists in all three managers.

Discussed in #43161; approved by @RahulGautamSingh.

## Why this matters

The original report (#43161) was triggered by a real regression: a monorepo with `packageManager: pnpm@10.33.4` set only on the root `package.json` had every Renovate dependency-update PR opened on 2026-05-07 silently switch to `pnpm@latest` (which had just rolled to pnpm 11.0.8 that day). Because pnpm 11 silently ignores `pnpm.overrides` and `pnpm.patchedDependencies` in `package.json` (filed upstream as pnpm/pnpm#11536), the regenerated lockfiles stripped CVE-remediation overrides — one PR merged before anyone caught it, restoring a known-vulnerable transitive dep to the develop branch.

The Renovate-side mitigation is independent of the pnpm-side bug: even if a future manager has no such silent breakage, allowing the lockfile-derived `latest` to win over a deliberate root-level pin is a recipe for cross-major surprises. Honouring the inherited pin matches how corepack itself resolves the binary at runtime.

## Change shape

- New `getInheritedPackageManagerVersion(name, lockFileDir)` in `lib/modules/manager/npm/post-update/utils.ts` — walks parent directories from `lockFileDir`, returns the first ancestor `packageManager` / `devEngines.packageManager` / `engines` / `volta` match for `name`. Skips `lockFileDir` itself (the sibling is already checked by the caller).
- Wired into the constraint chain in `pnpm.ts`, `npm.ts`, and `yarn.ts`, sitting between the sibling `getPackageManagerVersion` and the lockfile-derived fallback.
- New `utils.spec.ts` with 8 focused tests covering: simple walk-up, walking past intermediate directories, closest-ancestor-wins, no-pin-found, lockFileDir-is-repo-root, empty lockFileDir, `engines` field on ancestor, and ignoring a different manager pinned at the ancestor.
- Two new integration tests in `pnpm.spec.ts` exercising the walk-up via the full `generateLockFile` flow, including the "sibling pin wins, ancestor is never read" path.
- Existing tests in `npm.spec.ts`, `yarn.spec.ts`, and `pnpm.spec.ts` that count `readLocalFile` calls have been updated to reflect the extra ancestor read (3 → 4) and, where they used a chained `mockResolvedValueOnce` queue, a matching `'{}'` entry was added for the ancestor read.

## Test plan

- [x] `pnpm exec vitest run lib/modules/manager/npm` — 496 tests pass
- [x] `pnpm exec vitest run lib/modules/manager/npm/post-update --coverage --coverage.include='lib/modules/manager/npm/post-update/utils.ts'` — 100% statements / branches / functions / lines on the new helper
- [x] `pnpm exec biome check lib/modules/manager/npm/post-update/` — clean
- [x] `pnpm exec oxlint -c .oxlintrc.json lib/modules/manager/npm/post-update/` — 0 warnings, 0 errors
- [x] `pnpm exec tsc --noEmit` — clean

## AI assistance disclosure

Per the contributing guide: this PR was authored with assistance from Claude Code (Anthropic's CLI for Claude). Claude generated the implementation, the unit tests, the integration tests, the existing-test fixes for the new read count, the commit message, and this PR body. The design (walk-up that mirrors corepack, applied to pnpm/npm/yarn uniformly) was discussed and approved manually before implementation began, and the resulting code/tests were reviewed by me before push.