### PR TITLE
fix(managers/mise): don't support short names that aren't supported by mise

### DIFF
--- a/lib/modules/manager/mise/extract.spec.ts
+++ b/lib/modules/manager/mise/extract.spec.ts
@@ -67,7 +67,6 @@ describe('modules/manager/mise/extract', () => {
       hivemind = "1.1.0"
       hk = "1.1.2"
       jq = "1.7.1"
-      kafka = "apache-3.9.0"
       lefthook = "1.11.13"
       localstack = "4.3.0"
       lychee = "0.19.1"
@@ -207,12 +206,6 @@ describe('modules/manager/mise/extract', () => {
             depName: 'jq',
             extractVersion: '^jq-(?<version>\\S+)',
             packageName: 'jqlang/jq',
-          },
-          {
-            currentValue: '3.9.0',
-            datasource: 'github-tags',
-            depName: 'kafka',
-            packageName: 'apache/kafka',
           },
           {
             currentValue: '1.11.13',

--- a/lib/modules/manager/mise/upgradeable-tooling.spec.ts
+++ b/lib/modules/manager/mise/upgradeable-tooling.spec.ts
@@ -1,0 +1,21 @@
+import { miseTooling, parsedMiseRegistry } from './upgradeable-tooling.ts';
+
+describe('modules/manager/mise/upgradeable-tooling', () => {
+  describe('supported tools', () => {
+    it('should stay in sync with the mise registry', () => {
+      // currently supported
+      const allShortToolNames = new Set([
+        ...Object.keys(miseTooling),
+        // included in both, as it's the current set of supported
+        ...Object.keys(parsedMiseRegistry),
+      ]);
+
+      const miseRegistrySupported = new Set(Object.keys(parsedMiseRegistry));
+
+      expect(
+        allShortToolNames,
+        'Renovate should not support updating any short tool names that are not supported upstream by mise',
+      ).toEqual(miseRegistrySupported);
+    });
+  });
+});

--- a/lib/modules/manager/mise/upgradeable-tooling.ts
+++ b/lib/modules/manager/mise/upgradeable-tooling.ts
@@ -325,21 +325,6 @@ const miseRegistryTooling: Record<string, ToolingDefinition> = {
       extractVersion: '^jq-(?<version>\\S+)',
     },
   },
-  kafka: {
-    misePluginUrl: 'https://mise.jdx.dev/registry.html#tools',
-    config: (version) => {
-      const apacheMatches = /^apache-(?<version>\d\S+)/.exec(version)?.groups;
-      if (apacheMatches) {
-        return {
-          datasource: GithubTagsDatasource.id,
-          packageName: 'apache/kafka',
-          currentValue: apacheMatches.version,
-        };
-      }
-
-      return undefined;
-    },
-  },
   lefthook: {
     misePluginUrl: 'https://mise.jdx.dev/registry.html#tools',
     config: {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->
At some point in the past, mise's support for the short name `kafka` was
removed.

To ensure that Renovate stays in sync with mise, we can add a test to
verify that the values from the registry are always in sync with the
values we have from the mise tooling.

Related to https://github.com/renovatebot/renovate/pull/43399

## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
