### PR TITLE
fix: collect branch-mode postUpgradeTasks from all upgrades

### DIFF
--- a/lib/workers/repository/update/branch/execute-post-upgrade-commands.spec.ts
+++ b/lib/workers/repository/update/branch/execute-post-upgrade-commands.spec.ts
@@ -1180,4 +1180,382 @@ describe('workers/repository/update/branch/execute-post-upgrade-commands', () =>
       });
     });
   });
+
+  describe('executePostUpgradeCommands', () => {
+    beforeEach(() => {
+      GlobalConfig.reset();
+      gitAuth.getGitEnvironmentVariables.mockReturnValue({});
+    });
+
+    it('returns null when there are no changed files', async () => {
+      const config: BranchConfig = {
+        manager: 'some-manager',
+        updatedPackageFiles: [],
+        updatedArtifacts: [],
+        upgrades: [],
+        branchName: 'main',
+        baseBranch: 'base',
+      } as BranchConfig;
+
+      const res = await postUpgradeCommands.default(config);
+
+      expect(res).toBeNull();
+    });
+
+    it('executes branch-mode task when only a non-first upgrade defines it', async () => {
+      GlobalConfig.set({
+        localDir: '/localDir',
+        allowedCommands: ['^echo branch-task$'],
+      });
+      git.getRepoStatus.mockResolvedValueOnce(
+        partial<StatusResult>({
+          modified: [],
+          not_added: [],
+          deleted: [],
+        }),
+      );
+      fs.localPathIsFile.mockResolvedValue(true);
+
+      // Simulates generateBranchConfig spreading the first upgrade onto config.
+      // The first upgrade has default postUpgradeTasks (executionMode: 'update', empty commands).
+      // The second upgrade has executionMode: 'branch' with actual commands.
+      const config: BranchConfig = {
+        manager: 'some-manager',
+        branchName: 'renovate/some-branch',
+        baseBranch: 'main',
+        updatedPackageFiles: [
+          {
+            type: 'addition',
+            path: 'some-file',
+            contents: 'updated',
+          },
+        ],
+        updatedArtifacts: [],
+        // This comes from config.upgrades[0] via spread in generateBranchConfig
+        postUpgradeTasks: {
+          executionMode: 'update',
+          commands: [],
+          fileFilters: [],
+        },
+        upgrades: [
+          {
+            depName: 'some-dep-name',
+            manager: 'some-manager',
+            branchName: 'renovate/some-branch',
+            postUpgradeTasks: {
+              executionMode: 'update',
+              commands: [],
+              fileFilters: [],
+            },
+          },
+          {
+            depName: 'some-dep-name',
+            manager: 'some-manager',
+            branchName: 'renovate/some-branch',
+            postUpgradeTasks: {
+              executionMode: 'branch',
+              commands: ['echo branch-task'],
+              fileFilters: ['**/*'],
+            },
+          },
+        ],
+      } as BranchConfig;
+
+      const res = await postUpgradeCommands.default(config);
+
+      expect(res).not.toBeNull();
+      expect(exec.exec).toHaveBeenCalledWith(
+        'echo branch-task',
+        expect.objectContaining({
+          cwd: '/localDir',
+        }),
+      );
+    });
+
+    it('executes branch-mode task when other upgrades have no postUpgradeTasks', async () => {
+      GlobalConfig.set({
+        localDir: '/localDir',
+        allowedCommands: ['^echo branch-task$'],
+      });
+      git.getRepoStatus.mockResolvedValue(
+        partial<StatusResult>({
+          modified: [],
+          not_added: [],
+          deleted: [],
+        }),
+      );
+      fs.localPathIsFile.mockResolvedValue(true);
+
+      // First upgrade has no postUpgradeTasks at all (the common case).
+      // Second upgrade has executionMode: 'branch'.
+      // The branch-mode task should execute, and the first upgrade should
+      // be excluded from both update and branch command lists.
+      const config: BranchConfig = {
+        manager: 'some-manager',
+        branchName: 'renovate/some-branch',
+        baseBranch: 'main',
+        updatedPackageFiles: [
+          {
+            type: 'addition',
+            path: 'some-file',
+            contents: 'updated',
+          },
+        ],
+        updatedArtifacts: [],
+        postUpgradeTasks: {
+          executionMode: 'update',
+          commands: [],
+          fileFilters: [],
+        },
+        upgrades: [
+          {
+            depName: 'some-dep-name-1',
+            manager: 'some-manager',
+            branchName: 'renovate/some-branch',
+          },
+          {
+            depName: 'some-dep-name-2',
+            manager: 'some-manager',
+            branchName: 'renovate/some-branch',
+            postUpgradeTasks: {
+              executionMode: 'branch',
+              commands: ['echo branch-task'],
+              fileFilters: ['**/*'],
+            },
+          },
+        ],
+      } as BranchConfig;
+
+      const res = await postUpgradeCommands.default(config);
+
+      expect(res).not.toBeNull();
+      expect(exec.exec).toHaveBeenCalledWith(
+        'echo branch-task',
+        expect.objectContaining({
+          cwd: '/localDir',
+        }),
+      );
+      expect(exec.exec).toHaveBeenCalledTimes(1);
+    });
+
+    it('executes both tasks when first upgrade is branch-mode and second is update-mode', async () => {
+      GlobalConfig.set({
+        localDir: '/localDir',
+        allowedCommands: ['^echo'],
+      });
+      git.getRepoStatus.mockResolvedValue(
+        partial<StatusResult>({
+          modified: [],
+          not_added: [],
+          deleted: [],
+        }),
+      );
+      fs.localPathIsFile.mockResolvedValue(true);
+
+      // First upgrade has executionMode: 'branch', second has 'update'.
+      // Both tasks should execute.
+      const config: BranchConfig = {
+        manager: 'some-manager',
+        branchName: 'renovate/some-branch',
+        baseBranch: 'main',
+        updatedPackageFiles: [
+          {
+            type: 'addition',
+            path: 'some-file',
+            contents: 'updated',
+          },
+        ],
+        updatedArtifacts: [],
+        // From first upgrade via generateBranchConfig spread
+        postUpgradeTasks: {
+          executionMode: 'branch',
+          commands: ['echo branch-task'],
+          fileFilters: ['**/*'],
+        },
+        upgrades: [
+          {
+            depName: 'some-dep-name-1',
+            manager: 'some-manager',
+            branchName: 'renovate/some-branch',
+            postUpgradeTasks: {
+              executionMode: 'branch',
+              commands: ['echo branch-task'],
+              fileFilters: ['**/*'],
+            },
+          },
+          {
+            depName: 'some-dep-name-2',
+            manager: 'some-manager',
+            branchName: 'renovate/some-branch',
+            postUpgradeTasks: {
+              executionMode: 'update',
+              commands: ['echo update-task'],
+              fileFilters: ['**/*'],
+            },
+          },
+        ],
+      } as BranchConfig;
+
+      const res = await postUpgradeCommands.default(config);
+
+      expect(res).not.toBeNull();
+      expect(exec.exec).toHaveBeenCalledWith(
+        'echo update-task',
+        expect.anything(),
+      );
+      expect(exec.exec).toHaveBeenCalledWith(
+        'echo branch-task',
+        expect.objectContaining({
+          cwd: '/localDir',
+        }),
+      );
+      expect(exec.exec).toHaveBeenCalledTimes(2);
+    });
+
+    it('executes branch-mode commands from all upgrades that define them', async () => {
+      GlobalConfig.set({
+        localDir: '/localDir',
+        allowedCommands: ['^echo'],
+      });
+      git.getRepoStatus.mockResolvedValue(
+        partial<StatusResult>({
+          modified: [],
+          not_added: [],
+          deleted: [],
+        }),
+      );
+      fs.localPathIsFile.mockResolvedValue(true);
+
+      // Two upgrades both have executionMode: 'branch' but with different commands.
+      // Both sets of commands should execute.
+      const config: BranchConfig = {
+        manager: 'some-manager',
+        branchName: 'renovate/some-branch',
+        baseBranch: 'main',
+        updatedPackageFiles: [
+          {
+            type: 'addition',
+            path: 'some-file',
+            contents: 'updated',
+          },
+        ],
+        updatedArtifacts: [],
+        // From first upgrade via generateBranchConfig spread
+        postUpgradeTasks: {
+          executionMode: 'branch',
+          commands: ['echo branch-task-1'],
+          fileFilters: ['**/*'],
+        },
+        upgrades: [
+          {
+            depName: 'some-dep-name-1',
+            manager: 'some-manager',
+            branchName: 'renovate/some-branch',
+            postUpgradeTasks: {
+              executionMode: 'branch',
+              commands: ['echo branch-task-1'],
+              fileFilters: ['**/*'],
+            },
+          },
+          {
+            depName: 'some-dep-name-2',
+            manager: 'some-manager',
+            branchName: 'renovate/some-branch',
+            postUpgradeTasks: {
+              executionMode: 'branch',
+              commands: ['echo branch-task-2'],
+              fileFilters: ['**/*'],
+            },
+          },
+        ],
+      } as BranchConfig;
+
+      const res = await postUpgradeCommands.default(config);
+
+      expect(res).not.toBeNull();
+      expect(exec.exec).toHaveBeenCalledWith(
+        'echo branch-task-1',
+        expect.anything(),
+      );
+      expect(exec.exec).toHaveBeenCalledWith(
+        'echo branch-task-2',
+        expect.anything(),
+      );
+    });
+
+    it('executes branch-mode task when upgrades have mixed execution modes', async () => {
+      GlobalConfig.set({
+        localDir: '/localDir',
+        allowedCommands: ['^echo'],
+      });
+      git.getRepoStatus.mockResolvedValue(
+        partial<StatusResult>({
+          modified: [],
+          not_added: [],
+          deleted: [],
+        }),
+      );
+      fs.localPathIsFile.mockResolvedValue(true);
+
+      // First upgrade has executionMode: 'update' with commands.
+      // Second upgrade has executionMode: 'branch' with commands.
+      // Both should execute.
+      const config: BranchConfig = {
+        manager: 'some-manager',
+        branchName: 'renovate/some-branch',
+        baseBranch: 'main',
+        updatedPackageFiles: [
+          {
+            type: 'addition',
+            path: 'some-file',
+            contents: 'updated',
+          },
+        ],
+        updatedArtifacts: [],
+        // From first upgrade via generateBranchConfig spread
+        postUpgradeTasks: {
+          executionMode: 'update',
+          commands: ['echo update-task'],
+          fileFilters: ['**/*'],
+        },
+        upgrades: [
+          {
+            depName: 'some-dep-name-1',
+            manager: 'some-manager',
+            branchName: 'renovate/some-branch',
+            postUpgradeTasks: {
+              executionMode: 'update',
+              commands: ['echo update-task'],
+              fileFilters: ['**/*'],
+            },
+          },
+          {
+            depName: 'some-dep-name-2',
+            manager: 'some-manager',
+            branchName: 'renovate/some-branch',
+            postUpgradeTasks: {
+              executionMode: 'branch',
+              commands: ['echo branch-task'],
+              fileFilters: ['**/*'],
+            },
+          },
+        ],
+      } as BranchConfig;
+
+      const res = await postUpgradeCommands.default(config);
+
+      expect(res).not.toBeNull();
+      // The update-mode task should run for the first upgrade
+      expect(exec.exec).toHaveBeenCalledWith(
+        'echo update-task',
+        expect.anything(),
+      );
+      // The branch-mode task should also run
+      expect(exec.exec).toHaveBeenCalledWith(
+        'echo branch-task',
+        expect.anything(),
+      );
+      expect(exec.exec).toHaveBeenCalledTimes(2);
+    });
+  });
 });

--- a/lib/workers/repository/update/branch/execute-post-upgrade-commands.ts
+++ b/lib/workers/repository/update/branch/execute-post-upgrade-commands.ts
@@ -342,17 +342,37 @@ export default async function executePostUpgradeCommands(
     return null;
   }
 
-  const branchUpgradeCommands: BranchUpgradeConfig[] = [
-    {
+  const uniqueBranchTasks = new Map<string, BranchUpgradeConfig>();
+  for (const upgrade of config.upgrades) {
+    if (upgrade.postUpgradeTasks?.executionMode === 'branch') {
+      const key = JSON.stringify(upgrade.postUpgradeTasks);
+      if (!uniqueBranchTasks.has(key)) {
+        uniqueBranchTasks.set(key, {
+          manager: upgrade.manager,
+          depName: upgrade.depName,
+          branchName: config.branchName,
+          postUpgradeTasks: upgrade.postUpgradeTasks,
+        });
+      }
+    }
+  }
+
+  // Fall back to branch-level config when no individual upgrade defines
+  // executionMode: 'branch', e.g. when postUpgradeTasks is only set at the
+  // top level of the BranchConfig.
+  if (
+    uniqueBranchTasks.size === 0 &&
+    config.postUpgradeTasks?.executionMode === 'branch'
+  ) {
+    uniqueBranchTasks.set(JSON.stringify(config.postUpgradeTasks), {
       manager: config.manager,
       depName: config.upgrades.map(({ depName }) => depName).join(' '),
       branchName: config.branchName,
-      postUpgradeTasks:
-        config.postUpgradeTasks!.executionMode === 'branch'
-          ? config.postUpgradeTasks
-          : undefined,
-    },
-  ];
+      postUpgradeTasks: config.postUpgradeTasks,
+    });
+  }
+
+  const branchUpgradeCommands = [...uniqueBranchTasks.values()];
 
   const updateUpgradeCommands: BranchUpgradeConfig[] = config.upgrades.filter(
     ({ postUpgradeTasks }) =>


### PR DESCRIPTION
-  https://github.com/renovatebot/renovate/discussions/42704

### Problem

When a branch has multiple upgrades from different package files and only some define `postUpgradeTasks` with `executionMode: "branch"`, the task is silently skipped.

This happens because `executePostUpgradeCommands` reads `config.postUpgradeTasks` to determine the branch-level task. That property is inherited from `config.upgrades[0]` via the `generateBranchConfig` spread (`config = { ...config, ...config.upgrades[0] }`). If the first sorted upgrade doesn't have `executionMode: "branch"`, the branch-level task is set to `undefined`. Meanwhile, the `updateUpgradeCommands` filter excludes any upgrade with `executionMode: "branch"` — so the task falls through both code paths.

### Example

See https://github.com/renovatebot/renovate/discussions/42704

### Fix

Scan `config.upgrades` for branch-mode tasks instead of relying on `config.postUpgradeTasks`. Identical tasks (from the same packageRule matching multiple upgrades) are deduplicated via `JSON.stringify` to preserve the "run once per branch" semantics. Falls back to `config.postUpgradeTasks` when no individual upgrade defines `executionMode: "branch"`.

### Tests

Added 6 unit tests for `executePostUpgradeCommands` covering:

- No changed files → returns null
- Branch-mode task on a non-first upgrade (the core bug)
- Upgrade without `postUpgradeTasks` alongside one with branch-mode
- First upgrade is branch-mode, second is update-mode (regression guard)
- Multiple upgrades with different branch-mode commands
- Mixed execution modes (update + branch on different upgrades)



## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository


<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
