### PR TITLE
fix(logger): handle serialisation of fields too long for V8

### DIFF
--- a/lib/logger/with-sanitizer.spec.ts
+++ b/lib/logger/with-sanitizer.spec.ts
@@ -1,0 +1,114 @@
+import { Writable } from 'node:stream';
+import { partial } from '~test/util.ts';
+import { quickStringify } from '../util/stringify.ts';
+import type { BunyanRecord, BunyanStream } from './types.ts';
+import { withSanitizer } from './with-sanitizer.ts';
+
+vi.mock('../util/stringify.ts');
+
+const mockStringify = vi.mocked(quickStringify);
+
+function makeWritableStream(): { output: string[]; writable: Writable } {
+  const output: string[] = [];
+  const writable = new Writable({
+    write(chunk, _enc, cb) {
+      output.push(chunk.toString());
+      cb();
+    },
+  });
+  return { output, writable };
+}
+
+function makeStream(
+  writable: Writable,
+  type: string,
+): ReturnType<typeof withSanitizer> {
+  return withSanitizer(partial<BunyanStream>({ stream: writable, type }));
+}
+
+function write(
+  stream: ReturnType<typeof withSanitizer>,
+  record: Partial<BunyanRecord>,
+): void {
+  (stream.stream as any).write(
+    partial<BunyanRecord>({ level: 20, msg: 'test', ...record }),
+    'utf8',
+    vi.fn(),
+  );
+}
+
+describe('logger/with-sanitizer', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockStringify.mockImplementation((val) => JSON.stringify(val));
+  });
+
+  it('throws on rotating-file type', () => {
+    expect(() =>
+      withSanitizer(partial<BunyanStream>({ type: 'rotating-file' })),
+    ).toThrow("Rotating files aren't supported");
+  });
+
+  it('throws when stream and path are missing', () => {
+    expect(() => withSanitizer(partial<BunyanStream>({}))).toThrow(
+      "Missing 'stream' or 'path' for bunyan stream",
+    );
+  });
+
+  it('stringifies and writes records', () => {
+    const { output, writable } = makeWritableStream();
+    const stream = makeStream(writable, 'stream');
+    write(stream, { msg: 'hello' });
+    expect(output).toHaveLength(1);
+    expect(output[0]).toContain('"hello"');
+  });
+
+  it('passes record directly for raw type without stringifying', () => {
+    const received: unknown[] = [];
+    const rawWritable = {
+      writable: true,
+      write(chunk: unknown, _enc: BufferEncoding, cb: () => void) {
+        received.push(chunk);
+        cb();
+      },
+    };
+    const stream = withSanitizer(
+      partial<BunyanStream>({ stream: rawWritable as any, type: 'raw' }),
+    );
+    const record = partial<BunyanRecord>({ msg: 'raw record', level: 20 });
+    (stream.stream as any).write(record, 'utf8', vi.fn());
+    expect(received[0]).toMatchObject({ msg: 'raw record' });
+    expect(mockStringify).not.toHaveBeenCalled();
+  });
+
+  it('truncates fields that are too large to serialize', () => {
+    mockStringify
+      .mockImplementationOnce(() => {
+        throw new RangeError('Invalid string length');
+      })
+      .mockImplementation((val: unknown) => {
+        if (val === 'huge-value') {
+          throw new RangeError('Invalid string length');
+        }
+        return JSON.stringify(val);
+      });
+
+    const { output, writable } = makeWritableStream();
+    const stream = makeStream(writable, 'stream');
+    write(stream, { msg: 'test', bigField: 'huge-value' });
+
+    expect(output).toHaveLength(1);
+    const parsed = JSON.parse(output[0]);
+    expect(parsed.msg).toBe('test');
+    expect(parsed.bigField).toBe('[omitted: value too large to serialize]');
+  });
+
+  it('rethrows non-RangeError stringify failures', () => {
+    mockStringify.mockImplementationOnce(() => {
+      throw new TypeError('unexpected');
+    });
+    const { writable } = makeWritableStream();
+    const stream = makeStream(writable, 'stream');
+    expect(() => write(stream, { msg: 'test' })).toThrow(TypeError);
+  });
+});

--- a/lib/logger/with-sanitizer.ts
+++ b/lib/logger/with-sanitizer.ts
@@ -4,6 +4,20 @@ import { quickStringify } from '../util/stringify.ts';
 import type { BunyanNodeStream, BunyanRecord, BunyanStream } from './types.ts';
 import { sanitizeValue } from './utils.ts';
 
+function truncateLargeFields(record: BunyanRecord): BunyanRecord {
+  const result: BunyanRecord = { ...record };
+  for (const key of Object.keys(result)) {
+    try {
+      quickStringify(result[key]);
+    } catch (err) {
+      if (err instanceof RangeError) {
+        result[key] = '[omitted: value too large to serialize]';
+      }
+    }
+  }
+  return result;
+}
+
 export function withSanitizer(streamConfig: BunyanStream): BunyanStream {
   if (streamConfig.type === 'rotating-file') {
     throw new Error("Rotating files aren't supported");
@@ -17,10 +31,21 @@ export function withSanitizer(streamConfig: BunyanStream): BunyanStream {
       cb: (err?: Error | null) => void,
     ): void => {
       const raw = sanitizeValue(chunk);
-      const result =
-        streamConfig.type === 'raw'
-          ? raw
-          : quickStringify(raw)?.replace(regEx(/\n?$/), '\n');
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      let result = raw;
+      if (streamConfig.type !== 'raw') {
+        let serialized: string | undefined;
+        try {
+          serialized = quickStringify(raw);
+        } catch (err) {
+          if (err instanceof RangeError) {
+            serialized = quickStringify(truncateLargeFields(raw));
+          } else {
+            throw err;
+          }
+        }
+        result = serialized?.replace(regEx(/\n?$/), '\n');
+      }
       stream.write(result, enc, cb);
     };
 


### PR DESCRIPTION
In the case that a significantly large repository is **??**

On top of changes in 938829d5f492876befe6873d610f0e8931d60f15**??**

Co-authored-by: Claude Sonnet 4.6 <jamie.tanna+claude-code@mend.io>

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
