### PR TITLE
docs: AWS ECR and CodeArtifact authentication

### DIFF
--- a/docs/usage/docker.md
+++ b/docs/usage/docker.md
@@ -309,27 +309,31 @@ To make use of this authentication mechanism, specify the username as `AWS`:
 
 ##### Using ambient AWS credentials
 
-If you omit `username` and `password`, Renovate falls back to the [AWS SDK default credential provider chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html) when fetching the ECR authorization token.
-This means Renovate will automatically use credentials from any of the following sources, in order:
+If you omit `username` and `password`, Renovate fetches the ECR authorization token itself using the [AWS SDK default credential provider chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html).
+Renovate detects ECR registries from the host URL, so it picks up credentials automatically from any of the following sources, in order:
 
 - Environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`)
 - Web identity tokens (`AWS_WEB_IDENTITY_TOKEN_FILE` + `AWS_ROLE_ARN`) — set by [GitHub Actions OIDC](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services) via [`aws-actions/configure-aws-credentials`](https://github.com/aws-actions/configure-aws-credentials), [EKS IRSA](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html), and [EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html)
 - Container or EC2 instance roles
 
-When using ambient credentials you only need to declare the host so Renovate knows to fetch a token for it:
+In this mode no `hostRules` entry is required for authentication — Renovate finds the token from the credential chain.
+Add a `hostRules` entry only if you want to fetch the token yourself (for example to reuse a short-lived token across jobs) and inject it via `username: "AWS"`:
 
 ```json
 {
   "hostRules": [
     {
       "hostType": "docker",
-      "matchHost": "123456789012.dkr.ecr.us-east-1.amazonaws.com"
+      "matchHost": "123456789012.dkr.ecr.us-east-1.amazonaws.com",
+      "username": "AWS",
+      "password": "{{ env.AWS_ECR_TOKEN }}"
     }
   ]
 }
 ```
 
-The IAM role used must have at least `ecr:GetAuthorizationToken`, plus the standard ECR read actions (`ecr:BatchCheckLayerAvailability`, `ecr:BatchGetImage`, `ecr:DescribeImages`, `ecr:GetDownloadUrlForLayer`, `ecr:ListImages`) on the repositories you want Renovate to scan.
+Populate `AWS_ECR_TOKEN` from `aws ecr get-login-password` in your CI job; the CLI uses the same ambient credentials listed above.
+The identity used must have at least `ecr:GetAuthorizationToken`, plus the standard ECR read actions (`ecr:BatchCheckLayerAvailability`, `ecr:BatchGetImage`, `ecr:DescribeImages`, `ecr:GetDownloadUrlForLayer`, `ecr:ListImages`) on the repositories you want Renovate to scan.
 
 #### Google Container Registry / Google Artifact Registry
 

--- a/docs/usage/docker.md
+++ b/docs/usage/docker.md
@@ -307,7 +307,7 @@ To make use of this authentication mechanism, specify the username as `AWS`:
 }
 ```
 
-##### Using ambient AWS credentials
+##### Using the AWS SDK credential chain
 
 If you omit `username` and `password`, Renovate fetches the ECR authorization token itself using the [AWS SDK default credential provider chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html).
 Renovate detects ECR registries from the host URL, so it picks up credentials automatically from any of the following sources, in order:
@@ -317,7 +317,9 @@ Renovate detects ECR registries from the host URL, so it picks up credentials au
 - Container or EC2 instance roles
 
 In this mode no `hostRules` entry is required for authentication — Renovate finds the token from the credential chain.
-Add a `hostRules` entry only if you want to fetch the token yourself (for example to reuse a short-lived token across jobs) and inject it via `username: "AWS"`:
+This needs Renovate to run with access to AWS credentials, so it does not work on the Mend-hosted apps.
+
+There may be cases where you wish to specify the exact token - for example to reuse a short-lived token across jobs, or in the Mend-hosted apps - which you can do with a `hostRules` entry that sets `username: "AWS"`:
 
 ```json
 {
@@ -332,7 +334,7 @@ Add a `hostRules` entry only if you want to fetch the token yourself (for exampl
 }
 ```
 
-Populate `AWS_ECR_TOKEN` from `aws ecr get-login-password` in your CI job; the CLI uses the same ambient credentials listed above.
+Populate `AWS_ECR_TOKEN` from `aws ecr get-login-password` in your CI job (or store it as a secret for the Mend-hosted apps); the CLI uses the same credentials listed above.
 The identity used must have at least `ecr:GetAuthorizationToken`, plus the standard ECR read actions (`ecr:BatchCheckLayerAvailability`, `ecr:BatchGetImage`, `ecr:DescribeImages`, `ecr:GetDownloadUrlForLayer`, `ecr:ListImages`) on the repositories you want Renovate to scan.
 
 #### Google Container Registry / Google Artifact Registry

--- a/docs/usage/docker.md
+++ b/docs/usage/docker.md
@@ -307,6 +307,30 @@ To make use of this authentication mechanism, specify the username as `AWS`:
 }
 ```
 
+##### Using ambient AWS credentials
+
+If you omit `username` and `password`, Renovate falls back to the [AWS SDK default credential provider chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html) when fetching the ECR authorization token.
+This means Renovate will automatically use credentials from any of the following sources, in order:
+
+- Environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`)
+- Web identity tokens (`AWS_WEB_IDENTITY_TOKEN_FILE` + `AWS_ROLE_ARN`) — set by [GitHub Actions OIDC](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services) via [`aws-actions/configure-aws-credentials`](https://github.com/aws-actions/configure-aws-credentials), [EKS IRSA](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html), and [EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html)
+- Container or EC2 instance roles
+
+When using ambient credentials you only need to declare the host so Renovate knows to fetch a token for it:
+
+```json
+{
+  "hostRules": [
+    {
+      "hostType": "docker",
+      "matchHost": "123456789012.dkr.ecr.us-east-1.amazonaws.com"
+    }
+  ]
+}
+```
+
+The IAM role used must have at least `ecr:GetAuthorizationToken`, plus the standard ECR read actions (`ecr:BatchCheckLayerAvailability`, `ecr:BatchGetImage`, `ecr:DescribeImages`, `ecr:GetDownloadUrlForLayer`, `ecr:ListImages`) on the repositories you want Renovate to scan.
+
 #### Google Container Registry / Google Artifact Registry
 
 ##### Using Workload Identity

--- a/docs/usage/getting-started/private-packages.md
+++ b/docs/usage/getting-started/private-packages.md
@@ -572,10 +572,8 @@ aws codeartifact get-authorization-token \
 Inject the token into Renovate via an environment variable, then reference it from `hostRules`.
 You must refresh the token at least once every 12 hours, so most users obtain it as a step in their CI job, in an init container, or via a scheduled secret update for the Mend Renovate App.
 
-<!-- prettier-ignore -->
-!!! tip "Use the AWS SDK credential chain"
-  The AWS CLI command above will pick up credentials from the standard AWS credential provider chain.
-  This means you can authenticate to AWS via [GitHub Actions OIDC](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services), [EKS IRSA](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html), [EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html), or instance/task roles — no long-lived access keys required.
+The AWS CLI command above picks up credentials from the standard AWS credential provider chain.
+This means you can authenticate to AWS via [GitHub Actions OIDC](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services), [EKS IRSA](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html), [EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html), or instance/task roles — no long-lived access keys required.
 
 ### CodeArtifact hostRules per ecosystem
 
@@ -626,7 +624,7 @@ To direct lookups for a particular ecosystem at CodeArtifact, configure `package
 
 ### Mend Renovate App
 
-The hosted app cannot fetch CodeArtifact tokens for you because [it does not run user scripts](https://github.com/renovatebot/renovate/discussions/19651#discussioncomment-4602340).
+The hosted app cannot fetch CodeArtifact tokens for you, as it does not run user scripts.
 Store the token as a secret in your Mend organisation or repository settings and reference it via `{{ secrets.CODEARTIFACT_AUTH_TOKEN }}`, then refresh the secret on a schedule that runs at least every 12 hours.
 See [Using Secrets with Mend Cloud Apps](../mend-hosted/credentials.md) and [Automating secrets via APIs](../mend-hosted/credentials.md#automating-secrets-via-apis-github-only).
 

--- a/docs/usage/getting-started/private-packages.md
+++ b/docs/usage/getting-started/private-packages.md
@@ -574,8 +574,8 @@ You must refresh the token at least once every 12 hours, so most users obtain it
 
 <!-- prettier-ignore -->
 !!! tip "Use the AWS SDK credential chain"
-    The AWS CLI command above will pick up credentials from the standard AWS credential provider chain.
-    This means you can authenticate to AWS via [GitHub Actions OIDC](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services), [EKS IRSA](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html), [EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html), or instance/task roles — no long-lived access keys required.
+  The AWS CLI command above will pick up credentials from the standard AWS credential provider chain.
+  This means you can authenticate to AWS via [GitHub Actions OIDC](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services), [EKS IRSA](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html), [EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html), or instance/task roles — no long-lived access keys required.
 
 ### CodeArtifact hostRules per ecosystem
 

--- a/docs/usage/getting-started/private-packages.md
+++ b/docs/usage/getting-started/private-packages.md
@@ -551,6 +551,85 @@ module.exports = {
 };
 ```
 
+## AWS CodeArtifact
+
+[AWS CodeArtifact](https://docs.aws.amazon.com/codeartifact/) hosts private package repositories for `npm`, `maven`, `nuget`, `pypi`, and other ecosystems.
+Renovate does not call the AWS SDK to authenticate against CodeArtifact, so you must supply an authorization token via `hostRules`.
+
+### Fetch a CodeArtifact authorization token
+
+CodeArtifact uses short-lived authorization tokens (the maximum lifetime is 12 hours).
+Fetch one with the AWS CLI:
+
+```shell
+aws codeartifact get-authorization-token \
+  --domain <your-domain> \
+  --domain-owner <aws-account-id> \
+  --query authorizationToken \
+  --output text
+```
+
+Inject the token into Renovate via an environment variable, then reference it from `hostRules`.
+You must refresh the token at least once every 12 hours, so most users obtain it as a step in their CI job, in an init container, or via a scheduled secret update for the Mend Renovate App.
+
+<!-- prettier-ignore -->
+!!! tip "Use the AWS SDK credential chain"
+    The AWS CLI command above will pick up credentials from the standard AWS credential provider chain.
+    This means you can authenticate to AWS via [GitHub Actions OIDC](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services), [EKS IRSA](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html), [EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html), or instance/task roles — no long-lived access keys required.
+
+### CodeArtifact hostRules per ecosystem
+
+Set `matchHost` to your CodeArtifact endpoint and `hostType` to the matching ecosystem.
+The host follows the pattern `<domain>-<account-id>.d.codeartifact.<region>.amazonaws.com`.
+
+```json title="hostRules for AWS CodeArtifact"
+{
+  "hostRules": [
+    {
+      "hostType": "npm",
+      "matchHost": "my-domain-123456789012.d.codeartifact.us-east-1.amazonaws.com",
+      "token": "{{ env.CODEARTIFACT_AUTH_TOKEN }}"
+    },
+    {
+      "hostType": "maven",
+      "matchHost": "my-domain-123456789012.d.codeartifact.us-east-1.amazonaws.com",
+      "token": "{{ env.CODEARTIFACT_AUTH_TOKEN }}"
+    },
+    {
+      "hostType": "nuget",
+      "matchHost": "my-domain-123456789012.d.codeartifact.us-east-1.amazonaws.com",
+      "token": "{{ env.CODEARTIFACT_AUTH_TOKEN }}"
+    },
+    {
+      "hostType": "pypi",
+      "matchHost": "my-domain-123456789012.d.codeartifact.us-east-1.amazonaws.com",
+      "token": "{{ env.CODEARTIFACT_AUTH_TOKEN }}"
+    }
+  ]
+}
+```
+
+To direct lookups for a particular ecosystem at CodeArtifact, configure `packageRules.registryUrls`:
+
+```json title="Routing maven lookups to CodeArtifact"
+{
+  "packageRules": [
+    {
+      "matchDatasources": ["maven"],
+      "registryUrls": [
+        "https://my-domain-123456789012.d.codeartifact.us-east-1.amazonaws.com/maven/my-repo/"
+      ]
+    }
+  ]
+}
+```
+
+### Mend Renovate App
+
+The hosted app cannot fetch CodeArtifact tokens for you because [it does not run user scripts](https://github.com/renovatebot/renovate/discussions/19651#discussioncomment-4602340).
+Store the token as a secret in your Mend organisation or repository settings and reference it via `{{ secrets.CODEARTIFACT_AUTH_TOKEN }}`, then refresh the secret on a schedule that runs at least every 12 hours.
+See [Using Secrets with Mend Cloud Apps](../mend-hosted/credentials.md) and [Automating secrets via APIs](../mend-hosted/credentials.md#automating-secrets-via-apis-github-only).
+
 ## Automatic hostRules credentials for platform-hosted registries
 
 ### GitHub Packages

--- a/lib/modules/datasource/docker/readme.md
+++ b/lib/modules/datasource/docker/readme.md
@@ -22,4 +22,4 @@ See the [Docker package manager docs](../../../docker.md#registry-authentication
 - [Docker Hub](../../../docker.md#docker-hub)
 - [Self-hosted registries](../../../docker.md#self-hosted-docker-registry)
 - [AWS ECR](../../../docker.md#aws-ecr-amazon-web-services-elastic-container-registry) (including ambient AWS credentials via OIDC, IRSA, or Pod Identity)
-- [Google Container Registry / Google Artifact Registry](../../../docker.md#google-container-registry--google-artifact-registry)
+- [Google Container Registry / Google Artifact Registry](../../../docker.md#google-container-registry-google-artifact-registry)

--- a/lib/modules/datasource/docker/readme.md
+++ b/lib/modules/datasource/docker/readme.md
@@ -14,3 +14,12 @@ LABEL org.opencontainers.image.source="https://github.com/renovatebot/renovate"
 ```
 
 If you use [Harbor](https://goharbor.io/) as a proxy cache for Docker Hub, then you must use Harbor version `2.5.0` or higher.
+
+## Authenticating to private registries
+
+See the [Docker package manager docs](../../../docker.md#registry-authentication) for how to configure `hostRules` for private Docker registries, including:
+
+- [Docker Hub](../../../docker.md#docker-hub)
+- [Self-hosted registries](../../../docker.md#self-hosted-docker-registry)
+- [AWS ECR](../../../docker.md#aws-ecr-amazon-web-services-elastic-container-registry) (including ambient AWS credentials via OIDC, IRSA, or Pod Identity)
+- [Google Container Registry / Google Artifact Registry](../../../docker.md#google-container-registry--google-artifact-registry)


### PR DESCRIPTION
## Changes

- Document AWS CodeArtifact authentication in the private packages guide.
- Document ambient AWS credentials (OIDC / IRSA / Pod Identity) for ECR.
- Link the docker datasource readme back to the docker auth docs.

## Context

- [x] This closes an existing Issue, Closes: #13833

## AI assistance disclosure

- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).

## Documentation (please check one with an [x])

- [x] I have updated the documentation

## How I've tested my work (please select one)

- [x] Code inspection only

The public repository: N/A