### PR TITLE
fix(github-actions): add ARM and Intel runner labels

### DIFF
--- a/lib/modules/datasource/github-runners/index.spec.ts
+++ b/lib/modules/datasource/github-runners/index.spec.ts
@@ -43,8 +43,10 @@ describe('modules/datasource/github-runners/index', () => {
           { version: '14' },
           { version: '15-xlarge' },
           { version: '15-large' },
+          { version: '15-intel' },
           { version: '15' },
           { version: '26-xlarge' },
+          { version: '26-intel' },
           { version: '26' },
         ],
         sourceUrl: 'https://github.com/actions/runner-images',
@@ -59,6 +61,7 @@ describe('modules/datasource/github-runners/index', () => {
 
       expect(res).toMatchObject({
         releases: [
+          { version: '11-arm' },
           { version: '2016', isDeprecated: true },
           { version: '2019', isDeprecated: true },
           { version: '2022' },

--- a/lib/modules/datasource/github-runners/index.ts
+++ b/lib/modules/datasource/github-runners/index.ts
@@ -28,8 +28,10 @@ export class GithubRunnersDatasource extends Datasource {
     ],
     macos: [
       { version: '26' },
+      { version: '26-intel' },
       { version: '26-xlarge' },
       { version: '15' },
+      { version: '15-intel' },
       { version: '15-large' },
       { version: '15-xlarge' },
       { version: '14' },
@@ -46,6 +48,7 @@ export class GithubRunnersDatasource extends Datasource {
     windows: [
       { version: '2025' },
       { version: '2022' },
+      { version: '11-arm' },
       { version: '2019', isDeprecated: true },
       { version: '2016', isDeprecated: true },
     ],

--- a/lib/modules/manager/github-actions/extract.spec.ts
+++ b/lib/modules/manager/github-actions/extract.spec.ts
@@ -30,6 +30,14 @@ jobs:
        group: ubuntu-runners
        labels: ubuntu-20.04-16core
   test10:
+      runs-on: ubuntu-22.04-arm
+  test11:
+      runs-on: macos-15-intel
+  test12:
+      runs-on: macos-26-intel
+  test13:
+      runs-on: windows-11-arm
+  test14:
       runs-on: abc-123
 `;
 
@@ -744,10 +752,42 @@ describe('modules/manager/github-actions/extract', () => {
           datasource: 'github-runners',
           autoReplaceStringTemplate: '{{depName}}-{{newValue}}',
         },
+        {
+          depName: 'ubuntu',
+          currentValue: '22.04-arm',
+          replaceString: 'ubuntu-22.04-arm',
+          depType: 'github-runner',
+          datasource: 'github-runners',
+          autoReplaceStringTemplate: '{{depName}}-{{newValue}}',
+        },
+        {
+          depName: 'macos',
+          currentValue: '15-intel',
+          replaceString: 'macos-15-intel',
+          depType: 'github-runner',
+          datasource: 'github-runners',
+          autoReplaceStringTemplate: '{{depName}}-{{newValue}}',
+        },
+        {
+          depName: 'macos',
+          currentValue: '26-intel',
+          replaceString: 'macos-26-intel',
+          depType: 'github-runner',
+          datasource: 'github-runners',
+          autoReplaceStringTemplate: '{{depName}}-{{newValue}}',
+        },
+        {
+          depName: 'windows',
+          currentValue: '11-arm',
+          replaceString: 'windows-11-arm',
+          depType: 'github-runner',
+          datasource: 'github-runners',
+          autoReplaceStringTemplate: '{{depName}}-{{newValue}}',
+        },
       ]);
       expect(
         res?.deps.filter((d) => d.datasource === 'github-runners'),
-      ).toHaveLength(7);
+      ).toHaveLength(11);
     });
 
     it('extracts x-version from actions/setup-x', () => {


### PR DESCRIPTION
## Changes

Add missing GitHub-hosted runner labels to the `github-runners` datasource:

- `macos-15-intel`
- `macos-26-intel`
- `windows-11-arm`

This also extends the GitHub Actions manager extractor test to cover ARM Linux, Intel macOS, and ARM Windows runner labels. `ubuntu-22.04-arm` was already supported by the datasource; the new test coverage keeps that behavior visible next to the newly supported labels.

## Context

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

GitHub documents these as standard hosted runner labels:
https://docs.github.com/en/actions/how-tos/write-workflows/choose-where-workflows-run/choose-the-runner-for-a-job#standard-github-hosted-runners-for-public-repositories

Before this change, the extractor accepted `ubuntu-22.04-arm` but dropped `macos-15-intel`, `macos-26-intel`, and `windows-11-arm` because those labels were missing from the datasource release table.

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

This PR was prepared with Codex based on GPT-5.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

Commands run:

- `COREPACK_HOME=/tmp/corepack corepack pnpm exec vitest run --coverage false lib/modules/datasource/github-runners/index.spec.ts lib/modules/manager/github-actions/extract.spec.ts`
- `COREPACK_HOME=/tmp/corepack corepack pnpm exec prettier --check lib/modules/datasource/github-runners/index.ts lib/modules/datasource/github-runners/index.spec.ts lib/modules/manager/github-actions/extract.spec.ts`
- `COREPACK_HOME=/tmp/corepack corepack pnpm exec oxlint -c .oxlintrc.json lib/modules/datasource/github-runners/index.ts lib/modules/datasource/github-runners/index.spec.ts lib/modules/manager/github-actions/extract.spec.ts`

The public repository: N/A
