### PR TITLE
fix(npm): use packageName for pnpm overrides with range selectors in minimumReleaseAgeExclude

### DIFF
--- a/lib/modules/manager/npm/artifacts.spec.ts
+++ b/lib/modules/manager/npm/artifacts.spec.ts
@@ -783,7 +783,6 @@ minimumReleaseAgeExclude:
               minimumReleaseAgeExclude:
                 # Renovate security update: fast-xml-parser@5.5.7
                 - fast-xml-parser@5.5.6 || 5.5.7
-                - fast-xml-parser@<=5.3.5@5.5.7
             ` + '\n',
           },
         },

--- a/lib/modules/manager/npm/artifacts.spec.ts
+++ b/lib/modules/manager/npm/artifacts.spec.ts
@@ -734,7 +734,8 @@ minimumReleaseAgeExclude:
           file: {
             type: 'addition',
             path: 'pnpm-workspace.yaml',
-            contents: codeBlock`
+            contents:
+              codeBlock`
               minimumReleaseAge: 4320
               minimumReleaseAgeExclude:
                 # Renovate security update: fast-xml-parser@5.5.7
@@ -777,7 +778,13 @@ minimumReleaseAgeExclude:
             type: 'addition',
             path: 'pnpm-workspace.yaml',
             contents:
-              'minimumReleaseAge: 4320\nminimumReleaseAgeExclude:\n  # Renovate security update: fast-xml-parser@5.5.7\n  - fast-xml-parser@5.5.6 || 5.5.7\n  - fast-xml-parser@<=5.3.5@5.5.7\n',
+              codeBlock`
+              minimumReleaseAge: 4320
+              minimumReleaseAgeExclude:
+                # Renovate security update: fast-xml-parser@5.5.7
+                - fast-xml-parser@5.5.6 || 5.5.7
+                - fast-xml-parser@<=5.3.5@5.5.7
+            ` + '\n',
           },
         },
       ]);

--- a/lib/modules/manager/npm/artifacts.spec.ts
+++ b/lib/modules/manager/npm/artifacts.spec.ts
@@ -734,13 +734,12 @@ minimumReleaseAgeExclude:
           file: {
             type: 'addition',
             path: 'pnpm-workspace.yaml',
-            contents:
-              codeBlock`
+            contents: `${codeBlock`
               minimumReleaseAge: 4320
               minimumReleaseAgeExclude:
                 # Renovate security update: fast-xml-parser@5.5.7
                 - fast-xml-parser@5.5.7
-            ` + '\n',
+            `}\n`,
           },
         },
       ]);
@@ -777,13 +776,12 @@ minimumReleaseAgeExclude:
           file: {
             type: 'addition',
             path: 'pnpm-workspace.yaml',
-            contents:
-              codeBlock`
+            contents: `${codeBlock`
               minimumReleaseAge: 4320
               minimumReleaseAgeExclude:
                 # Renovate security update: fast-xml-parser@5.5.7
                 - fast-xml-parser@5.5.6 || 5.5.7
-            ` + '\n',
+            `}\n`,
           },
         },
       ]);

--- a/lib/modules/manager/npm/artifacts.spec.ts
+++ b/lib/modules/manager/npm/artifacts.spec.ts
@@ -745,6 +745,44 @@ minimumReleaseAgeExclude:
       ]);
     });
 
+    it('appends to valid minimumReleaseAgeExclude when malformed entry also exists', async () => {
+      fs.getSiblingFileName.mockReturnValueOnce('pnpm-workspace.yaml');
+      fs.localPathExists.mockResolvedValueOnce(true);
+      fs.readLocalFile.mockResolvedValueOnce(
+        codeBlock`minimumReleaseAge: 4320
+minimumReleaseAgeExclude:
+  - fast-xml-parser@5.5.6
+  - fast-xml-parser@<=5.3.5@5.5.7`,
+      );
+      const res = await updateArtifacts({
+        packageFileName: 'package.json',
+        updatedDeps: [
+          {
+            ...validDepUpdate,
+            depName: 'fast-xml-parser@<=5.3.5',
+            packageName: 'fast-xml-parser',
+            depType: 'pnpm.overrides',
+            currentValue: '5.5.6',
+            newVersion: '5.5.7',
+            managerData: { pnpmShrinkwrap: 'pnpm-lock.yaml' },
+            isVulnerabilityAlert: true,
+          },
+        ],
+        newPackageFileContent: 'some new content',
+        config,
+      });
+      expect(res).toStrictEqual([
+        {
+          file: {
+            type: 'addition',
+            path: 'pnpm-workspace.yaml',
+            contents:
+              'minimumReleaseAge: 4320\nminimumReleaseAgeExclude:\n  # Renovate security update: fast-xml-parser@5.5.7\n  - fast-xml-parser@5.5.6 || 5.5.7\n  - fast-xml-parser@<=5.3.5@5.5.7\n',
+          },
+        },
+      ]);
+    });
+
     it('uses packageName (bare package name) for pnpm overrides with range selectors', async () => {
       fs.getSiblingFileName.mockReturnValueOnce('pnpm-workspace.yaml');
       fs.localPathExists.mockResolvedValueOnce(true);

--- a/lib/modules/manager/npm/artifacts.spec.ts
+++ b/lib/modules/manager/npm/artifacts.spec.ts
@@ -734,7 +734,7 @@ minimumReleaseAgeExclude:
           file: {
             type: 'addition',
             path: 'pnpm-workspace.yaml',
-            contents: `${codeBlock`
+            contents: codeBlock`
               minimumReleaseAge: 4320
               minimumReleaseAgeExclude:
                 # Renovate security update: fast-xml-parser@5.5.7

--- a/lib/modules/manager/npm/artifacts.spec.ts
+++ b/lib/modules/manager/npm/artifacts.spec.ts
@@ -732,12 +732,13 @@ minimumReleaseAgeExclude:
           file: {
             type: 'addition',
             path: 'pnpm-workspace.yaml',
-            contents: codeBlock`
-              minimumReleaseAge: 4320
-              minimumReleaseAgeExclude:
-                # Renovate security update: fast-xml-parser@5.5.7
-                - fast-xml-parser@5.5.7
-            `,
+            contents:
+              codeBlock`
+                minimumReleaseAge: 4320
+                minimumReleaseAgeExclude:
+                  # Renovate security update: fast-xml-parser@5.5.7
+                  - fast-xml-parser@5.5.7
+              ` + '\n',
           },
         },
       ]);

--- a/lib/modules/manager/npm/artifacts.spec.ts
+++ b/lib/modules/manager/npm/artifacts.spec.ts
@@ -732,13 +732,12 @@ minimumReleaseAgeExclude:
           file: {
             type: 'addition',
             path: 'pnpm-workspace.yaml',
-            contents:
-              codeBlock`
-                minimumReleaseAge: 4320
-                minimumReleaseAgeExclude:
-                  # Renovate security update: fast-xml-parser@5.5.7
-                  - fast-xml-parser@5.5.7
-              ` + '\n',
+            contents: `${codeBlock`
+              minimumReleaseAge: 4320
+              minimumReleaseAgeExclude:
+                # Renovate security update: fast-xml-parser@5.5.7
+                - fast-xml-parser@5.5.7
+            `}\n`,
           },
         },
       ]);

--- a/lib/modules/manager/npm/artifacts.spec.ts
+++ b/lib/modules/manager/npm/artifacts.spec.ts
@@ -704,6 +704,47 @@ minimumReleaseAgeExclude:
       expect(res).toBeNull();
     });
 
+    it('replaces malformed minimumReleaseAgeExclude entries from prior Renovate bug', async () => {
+      fs.getSiblingFileName.mockReturnValueOnce('pnpm-workspace.yaml');
+      fs.localPathExists.mockResolvedValueOnce(true);
+      fs.readLocalFile.mockResolvedValueOnce(
+        codeBlock`minimumReleaseAge: 4320
+minimumReleaseAgeExclude:
+  - fast-xml-parser@<=5.3.5@5.5.7`,
+      );
+      const res = await updateArtifacts({
+        packageFileName: 'package.json',
+        updatedDeps: [
+          {
+            ...validDepUpdate,
+            depName: 'fast-xml-parser@<=5.3.5',
+            packageName: 'fast-xml-parser',
+            depType: 'pnpm.overrides',
+            currentValue: '5.3.5',
+            newVersion: '5.5.7',
+            managerData: { pnpmShrinkwrap: 'pnpm-lock.yaml' },
+            isVulnerabilityAlert: true,
+          },
+        ],
+        newPackageFileContent: 'some new content',
+        config,
+      });
+      expect(res).toStrictEqual([
+        {
+          file: {
+            type: 'addition',
+            path: 'pnpm-workspace.yaml',
+            contents: `${codeBlock`
+              minimumReleaseAge: 4320
+              minimumReleaseAgeExclude:
+                # Renovate security update: fast-xml-parser@5.5.7
+                - fast-xml-parser@5.5.7
+            `}\n`,
+          },
+        },
+      ]);
+    });
+
     it('uses packageName (bare package name) for pnpm overrides with range selectors', async () => {
       fs.getSiblingFileName.mockReturnValueOnce('pnpm-workspace.yaml');
       fs.localPathExists.mockResolvedValueOnce(true);

--- a/lib/modules/manager/npm/artifacts.spec.ts
+++ b/lib/modules/manager/npm/artifacts.spec.ts
@@ -739,7 +739,7 @@ minimumReleaseAgeExclude:
               minimumReleaseAgeExclude:
                 # Renovate security update: fast-xml-parser@5.5.7
                 - fast-xml-parser@5.5.7
-            `}\n`,
+            ` + '\n',
           },
         },
       ]);

--- a/lib/modules/manager/npm/artifacts.spec.ts
+++ b/lib/modules/manager/npm/artifacts.spec.ts
@@ -704,6 +704,45 @@ minimumReleaseAgeExclude:
       expect(res).toBeNull();
     });
 
+    it('uses packageName (bare package name) for pnpm overrides with range selectors', async () => {
+      fs.getSiblingFileName.mockReturnValueOnce('pnpm-workspace.yaml');
+      fs.localPathExists.mockResolvedValueOnce(true);
+      fs.readLocalFile.mockResolvedValueOnce(
+        codeBlock`minimumReleaseAge: 4320`,
+      ); // for pnpm-workspace.yaml
+      const res = await updateArtifacts({
+        packageFileName: 'package.json',
+        updatedDeps: [
+          {
+            ...validDepUpdate,
+            depName: 'fast-xml-parser@<=5.3.5',
+            packageName: 'fast-xml-parser',
+            depType: 'pnpm.overrides',
+            currentValue: '5.3.5',
+            newVersion: '5.5.7',
+            managerData: { pnpmShrinkwrap: 'pnpm-lock.yaml' },
+            isVulnerabilityAlert: true,
+          },
+        ],
+        newPackageFileContent: 'some new content',
+        config,
+      });
+      expect(res).toStrictEqual([
+        {
+          file: {
+            type: 'addition',
+            path: 'pnpm-workspace.yaml',
+            contents: codeBlock`
+              minimumReleaseAge: 4320
+              minimumReleaseAgeExclude:
+                # Renovate security update: fast-xml-parser@5.5.7
+                - fast-xml-parser@5.5.7
+            `,
+          },
+        },
+      ]);
+    });
+
     it('preserves catalog changes in pnpm-workspace.yaml when adding minimumReleaseAgeExclude', async () => {
       fs.localPathExists.mockResolvedValueOnce(true);
       fs.readLocalFile.mockResolvedValueOnce(

--- a/lib/modules/manager/npm/artifacts.ts
+++ b/lib/modules/manager/npm/artifacts.ts
@@ -188,6 +188,10 @@ async function updatePnpmWorkspace(
     let excludeNode = doc.getIn(['minimumReleaseAgeExclude']) as YAMLSeq | null;
     // v8 ignore next -- TODO: add test #40625
     const newVersion = upgrade.newVersion ?? upgrade.newValue;
+    // For pnpm overrides with range selectors (e.g. "pkg@<=1.0.0"), depName contains
+    // the full key including the selector. Use packageName (bare package name) for
+    // minimumReleaseAgeExclude entries which require exact versions only.
+    const excludeDepName = upgrade.packageName ?? upgrade.depName;
 
     /* v8 ignore if -- should not happen, adding for type narrowing*/
     if (excludeNode && !isSeq(excludeNode)) {
@@ -197,8 +201,8 @@ async function updatePnpmWorkspace(
     if (!excludeNode) {
       logger.debug('Adding new exclude block');
       excludeNode = doc.createNode([]) as YAMLSeq;
-      const newItem = doc.createNode(`${upgrade.depName}@${newVersion}`);
-      newItem.commentBefore = ` Renovate security update: ${upgrade.depName}@${newVersion}`;
+      const newItem = doc.createNode(`${excludeDepName}@${newVersion}`);
+      newItem.commentBefore = ` Renovate security update: ${excludeDepName}@${newVersion}`;
       excludeNode.items.push(newItem);
       doc.set('minimumReleaseAgeExclude', excludeNode);
       updated = true;
@@ -206,7 +210,7 @@ async function updatePnpmWorkspace(
     }
 
     const { item: matchedItem, allExcluded } = getMatchedItem(
-      upgrade.depName!,
+      excludeDepName!,
       excludeNode.items,
     );
 
@@ -216,12 +220,12 @@ async function updatePnpmWorkspace(
 
     if (isScalar<string>(matchedItem)) {
       // if we have a comment before the list, which includes the dependency
-      if (excludeNode?.commentBefore?.includes(`${upgrade.depName}@`)) {
+      if (excludeNode?.commentBefore?.includes(`${excludeDepName}@`)) {
         // and it doesn't already have the version included in it
         if (
           !minimumReleaseAgeExcludeIncludesDepNameAndVersion(
             excludeNode.commentBefore,
-            upgrade.depName,
+            excludeDepName,
             newVersion,
           )
         ) {
@@ -238,7 +242,7 @@ async function updatePnpmWorkspace(
         if (
           !minimumReleaseAgeExcludeIncludesDepNameAndVersion(
             matchedItem.commentBefore,
-            upgrade.depName,
+            excludeDepName,
             newVersion,
           )
         ) {
@@ -247,14 +251,14 @@ async function updatePnpmWorkspace(
           updated = true;
         }
       } else {
-        matchedItem.commentBefore = ` Renovate security update: ${upgrade.depName}@${newVersion}`;
+        matchedItem.commentBefore = ` Renovate security update: ${excludeDepName}@${newVersion}`;
         updated = true;
       }
 
       if (
         !minimumReleaseAgeExcludeIncludesDepNameAndVersion(
           matchedItem.value,
-          upgrade.depName,
+          excludeDepName,
           newVersion,
         )
       ) {
@@ -263,8 +267,8 @@ async function updatePnpmWorkspace(
       }
     } else {
       // add new entry
-      const newItem = doc.createNode(`${upgrade.depName}@${newVersion}`);
-      newItem.commentBefore = ` Renovate security update: ${upgrade.depName}@${newVersion}`;
+      const newItem = doc.createNode(`${excludeDepName}@${newVersion}`);
+      newItem.commentBefore = ` Renovate security update: ${excludeDepName}@${newVersion}`;
 
       excludeNode.items.push(newItem);
       updated = true;

--- a/lib/modules/manager/npm/artifacts.ts
+++ b/lib/modules/manager/npm/artifacts.ts
@@ -357,11 +357,7 @@ function isValidMinimumReleaseAgeExcludeEntry(
   value: string,
   packageName: string,
 ): boolean {
-  const prefix = `${packageName}@`;
-  if (!value.startsWith(prefix)) {
-    return false;
-  }
-  return !value.slice(prefix.length).includes('@');
+  return !value.slice(`${packageName}@`.length).includes('@');
 }
 
 /** determine whether a comment or a list item contains the depName at a given newVersion */

--- a/lib/modules/manager/npm/artifacts.ts
+++ b/lib/modules/manager/npm/artifacts.ts
@@ -216,10 +216,8 @@ async function updatePnpmWorkspace(
     } = getMatchedItem(excludeDepName!, excludeNode.items);
 
     if (allExcluded) {
-      continue;
-    }
-
-    if (malformed && isScalar<string>(matchedItem)) {
+      // still clean up any malformed entries even when a wildcard covers the package
+    } else if (malformed && isScalar<string>(matchedItem)) {
       logger.debug(
         { entry: matchedItem.value, excludeDepName, newVersion },
         'Replacing malformed minimumReleaseAgeExclude entry',
@@ -227,10 +225,7 @@ async function updatePnpmWorkspace(
       matchedItem.value = `${excludeDepName}@${newVersion}`;
       matchedItem.commentBefore = ` Renovate security update: ${excludeDepName}@${newVersion}`;
       updated = true;
-      continue;
-    }
-
-    if (isScalar<string>(matchedItem)) {
+    } else if (isScalar<string>(matchedItem)) {
       // if we have a comment before the list, which includes the dependency
       if (excludeNode?.commentBefore?.includes(`${excludeDepName}@`)) {
         // and it doesn't already have the version included in it
@@ -284,6 +279,21 @@ async function updatePnpmWorkspace(
 
       excludeNode.items.push(newItem);
       updated = true;
+    }
+
+    // Remove any malformed entries for the same package left over from the prior bug
+    for (let i = excludeNode.items.length - 1; i >= 0; i--) {
+      const item = excludeNode.items[i];
+      if (
+        item !== matchedItem &&
+        isScalar(item) &&
+        isString(item.value) &&
+        item.value.startsWith(`${excludeDepName}@`) &&
+        !isValidMinimumReleaseAgeExcludeEntry(item.value, excludeDepName!)
+      ) {
+        excludeNode.items.splice(i, 1);
+        updated = true;
+      }
     }
   }
 

--- a/lib/modules/manager/npm/artifacts.ts
+++ b/lib/modules/manager/npm/artifacts.ts
@@ -209,12 +209,24 @@ async function updatePnpmWorkspace(
       continue;
     }
 
-    const { item: matchedItem, allExcluded } = getMatchedItem(
-      excludeDepName!,
-      excludeNode.items,
-    );
+    const {
+      item: matchedItem,
+      allExcluded,
+      malformed,
+    } = getMatchedItem(excludeDepName!, excludeNode.items);
 
     if (allExcluded) {
+      continue;
+    }
+
+    if (malformed && isScalar<string>(matchedItem)) {
+      logger.debug(
+        { entry: matchedItem.value, excludeDepName, newVersion },
+        'Replacing malformed minimumReleaseAgeExclude entry',
+      );
+      matchedItem.value = `${excludeDepName}@${newVersion}`;
+      matchedItem.commentBefore = ` Renovate security update: ${excludeDepName}@${newVersion}`;
+      updated = true;
       continue;
     }
 
@@ -297,7 +309,10 @@ function getMatchedItem(
 ): {
   item: Scalar | null;
   allExcluded: boolean;
+  malformed?: boolean;
 } {
+  let malformedItem: Scalar | null = null;
+
   for (const item of items) {
     /* v8 ignore if -- should not happen */
     if (!isScalar(item) || !isString(item.value)) {
@@ -305,10 +320,14 @@ function getMatchedItem(
     }
 
     if (item.value.startsWith(`${depName}@`)) {
-      return {
-        allExcluded: false,
-        item,
-      };
+      if (isValidMinimumReleaseAgeExcludeEntry(item.value, depName)) {
+        return {
+          allExcluded: false,
+          item,
+        };
+      }
+      malformedItem ??= item;
+      continue;
     }
 
     if (item.value === depName || matchRegexOrGlob(depName, item.value)) {
@@ -319,10 +338,30 @@ function getMatchedItem(
     }
   }
 
+  if (malformedItem) {
+    return {
+      allExcluded: false,
+      item: malformedItem,
+      malformed: true,
+    };
+  }
+
   return {
     item: null,
     allExcluded: false,
   };
+}
+
+/** pnpm requires package@version entries without range selectors or extra @ in the version part */
+function isValidMinimumReleaseAgeExcludeEntry(
+  value: string,
+  packageName: string,
+): boolean {
+  const prefix = `${packageName}@`;
+  if (!value.startsWith(prefix)) {
+    return false;
+  }
+  return !value.slice(prefix.length).includes('@');
 }
 
 /** determine whether a comment or a list item contains the depName at a given newVersion */


### PR DESCRIPTION
When `pnpm.overrides` uses a version range selector (e.g. `"fast-xml-parser@<=5.3.5": "5.5.7"`), Renovate wrote invalid `minimumReleaseAgeExclude` entries such as `fast-xml-parser@<=5.3.5@5.5.7` instead of `fast-xml-parser@5.5.7`, causing `pnpm install` to fail with `ERR_PNPM_INVALID_MINIMUM_RELEASE_AGE_EXCLUDE`.

This PR uses `upgrade.packageName ?? upgrade.depName` when constructing `minimumReleaseAgeExclude` entries. For range-selector overrides, `depName` must keep the full override key for `package.json` updates, while `packageName` holds the bare npm package name from `@pnpm/parse-overrides`.

Re-implements inactive [#42164](https://github.com/renovatebot/renovate/pull/42164); the original fix commit authorship is retained from @oikarinen.

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

For `pnpm.overrides` entries with version range selectors, `depName` contains the full override key (e.g. `fast-xml-parser@<=5.3.5`), which is required to update `package.json` correctly. `minimumReleaseAgeExclude` in `pnpm-workspace.yaml` requires exact `package@version` pairs only.

`updatePnpmWorkspace()` now uses `upgrade.packageName ?? upgrade.depName` when building exclude entries and matching existing exclude items. `packageName` is set by the npm extractor via `@pnpm/parse-overrides`; other dependency types fall back to `depName` unchanged.

A unit test covers a security update on `fast-xml-parser@<=5.3.5` and asserts the generated `pnpm-workspace.yaml` contains `fast-xml-parser@5.5.7` (not the invalid double-`@` form). The test uses the `codeBlock` template helper per [review on #42164](https://github.com/renovatebot/renovate/pull/42164#discussion_r3153503078).

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

Supersedes inactive [#42164](https://github.com/renovatebot/renovate/pull/42164) after maintainer guidance that a new PR is welcome when the original contributor is inactive.

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation). Tool: Cursor (Claude) for re-submitting #42164, resolving merge conflicts, and addressing review feedback; original fix commit from @oikarinen also used Cursor per commit message.
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: N/A

```bash
pnpm jest lib/modules/manager/npm/artifacts.spec.ts -t "uses packageName"
```