### PR TITLE
feat(pip-compile): support --constraint alias and --overrides for uv

### DIFF
--- a/lib/modules/manager/pip-compile/common.spec.ts
+++ b/lib/modules/manager/pip-compile/common.spec.ts
@@ -55,6 +55,7 @@ describe('modules/manager/pip-compile/common', () => {
       `--no-strip-extras`,
       '--universal',
       '--constraints=constraints.txt',
+      '--constraint=constraints.txt',
       '--python-version=3.13',
       '--no-emit-package=cffi',
       '--prerelease=if-necessary',
@@ -64,6 +65,8 @@ describe('modules/manager/pip-compile/common', () => {
       '--exclude-newer=2025-11-01',
       '--exclude-newer-package="tqdm=2022-04-04T00:00:00Z"',
       '--group=docs',
+      '--override=overrides.txt',
+      '--overrides=overrides.txt',
     ])('returns object on correct uv options', (argument: string) => {
       expect(
         extractHeaderCommand(

--- a/lib/modules/manager/pip-compile/common.ts
+++ b/lib/modules/manager/pip-compile/common.ts
@@ -131,6 +131,7 @@ const pipOptionsWithArguments = [
 ];
 const uvOptionsWithArguments = [
   '--constraints',
+  '--constraint', // singular alias accepted by uv
   '--python-version',
   '--no-emit-package',
   '--prerelease',
@@ -140,6 +141,8 @@ const uvOptionsWithArguments = [
   '--exclude-newer',
   '--exclude-newer-package',
   '--group',
+  '--override',
+  '--overrides',
   ...commonOptionsWithArguments,
 ];
 export const optionsWithArguments = [
@@ -235,6 +238,9 @@ export function extractHeaderCommand(
       } else if (['--constraint', '--constraints'].includes(option)) {
         result.constraintsFiles = result.constraintsFiles ?? [];
         result.constraintsFiles.push(value);
+      } else if (['--override', '--overrides'].includes(option)) {
+        result.overridesFiles = result.overridesFiles ?? [];
+        result.overridesFiles.push(value);
       } else if (option === '--output-file') {
         if (result.outputFile) {
           throw new Error('Cannot use multiple --output-file options');

--- a/lib/modules/manager/pip-compile/extract.spec.ts
+++ b/lib/modules/manager/pip-compile/extract.spec.ts
@@ -158,6 +158,23 @@ describe('modules/manager/pip-compile/extract', () => {
       });
     });
 
+    it('no override files in returned package files', async () => {
+      fs.readLocalFile.mockResolvedValueOnce(
+        getSimpleRequirementsFile(
+          'uv pip compile --output-file=requirements.txt --overrides=overrides.txt requirements.in',
+          ['foo==1.0.1'],
+        ),
+      );
+      fs.readLocalFile.mockResolvedValueOnce('foo>=1.0.0');
+
+      const lockFiles = ['requirements.txt'];
+      const packageFiles = await extractAllPackageFiles({}, lockFiles);
+      expect(packageFiles).not.toBeNull();
+      packageFiles!.forEach((packageFile) => {
+        expect(packageFile).not.toHaveProperty('packageFile', 'overrides.txt');
+      });
+    });
+
     // TODO(not7cd): update when constraints are supported
     it('no constraint files in returned package files', async () => {
       fs.readLocalFile.mockResolvedValueOnce(

--- a/lib/modules/manager/pip-compile/extract.ts
+++ b/lib/modules/manager/pip-compile/extract.ts
@@ -84,6 +84,13 @@ export async function extractAllPackageFiles(
         type: 'constraint',
       });
     }
+    for (const override of coerceArray(compileArgs.overridesFiles)) {
+      depsBetweenFiles.push({
+        sourceFile: override,
+        outputFile: matchedFile,
+        type: 'override',
+      });
+    }
     const lockedDeps = extractRequirementsFile(fileContent)?.deps;
     if (!lockedDeps) {
       logger.debug(

--- a/lib/modules/manager/pip-compile/types.ts
+++ b/lib/modules/manager/pip-compile/types.ts
@@ -12,6 +12,7 @@ export interface PipCompileArgs {
   command: string;
   commandType: CommandType;
   constraintsFiles?: string[];
+  overridesFiles?: string[];
   pythonVersion?: string;
   extra?: string[];
   allExtras?: boolean;
@@ -26,5 +27,5 @@ export interface PipCompileArgs {
 export interface DependencyBetweenFiles {
   sourceFile: string;
   outputFile: string;
-  type: 'requirement' | 'constraint';
+  type: 'requirement' | 'constraint' | 'override';
 }

--- a/lib/modules/manager/pip-compile/utils.ts
+++ b/lib/modules/manager/pip-compile/utils.ts
@@ -48,7 +48,7 @@ export function generateMermaidGraph(
     lockFiles.push(`  ${lockFile}[[${lockFile}]]`);
   }
   const edges = depsBetweenFiles.map(({ sourceFile, outputFile, type }) => {
-    return `  ${sourceFile} -${type === 'constraint' ? '.' : ''}-> ${outputFile}`;
+    return `  ${sourceFile} -${type === 'requirement' ? '' : '.'}-> ${outputFile}`;
   });
   return `graph TD\n${lockFiles.join('\n')}\n${edges.join('\n')}`;
 }


### PR DESCRIPTION
uv accepts both --constraint and --constraints (clap aliases) and records the exact form used into lockfile headers. Only --constraints was in the uv allowlist, so --constraint headers were rejected.

Similarly, uv supports --override/--overrides for version overrides, but neither form was recognized by Renovate at all.

This commit:
- adds --constraint to uvOptionsWithArguments (value handler already handles both forms)
- adds --override and --overrides to uvOptionsWithArguments with a value handler that parses overridesFiles
- tracks override files as dependencies in the file graph (like constraints) so lockfiles are recompiled when overrides change
- uses dotted mermaid edges for overrides (same as constraints)

Ref: https://github.com/renovatebot/renovate/discussions/39488

## Changes

`uv pip compile` accepts both singular and plural forms of several options (e.g. `--constraint`/`--constraints`, `--override`/`--overrides`) and records the exact form into lockfile headers. The pip-compile manager's uv allowlist was missing `--constraint` (singular) entirely, and had no support for `--override`/`--overrides` at all. This caused "Option ... not supported (yet)" errors for valid uv-generated lockfiles.

This PR adds the missing options to `uvOptionsWithArguments`, parses `overridesFiles` from headers (mirroring the existing `constraintsFiles` pattern), tracks override files as dependencies in the file graph, and uses dotted mermaid edges for them (same as constraints, since overrides are semantically similar -- file-level version directives).

Prior art: #39167 (added 6 uv options following the same pattern).

## Context

- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation). Cursor Agent (Claude Opus 4) was used to research the uv/pip-compile/Renovate option compatibility, write the code changes, and run tests.

## Documentation (please check one with an [x])

- [x] No documentation update is required

## How I've tested my work (please select one)

- [x] Newly added/modified unit tests