### PR TITLE
perf(workers/repository): log reconfigure branch cache at TRACE

### DIFF
--- a/lib/workers/repository/reconfigure/reconfigure-cache.ts
+++ b/lib/workers/repository/reconfigure/reconfigure-cache.ts
@@ -14,9 +14,23 @@ export function setReconfigureBranchCache(
     ...(extractResult && { extractResult }),
   };
   if (cache.reconfigureBranchCache) {
-    logger.debug({ reconfigureBranchCache }, 'Update reconfigure branch cache');
+    logger.debug(
+      {
+        reconfigureBranchSha,
+        isConfigValid,
+      },
+      'Update reconfigure branch cache',
+    );
+    logger.trace({ reconfigureBranchCache }, 'Update reconfigure branch cache');
   } else {
-    logger.debug({ reconfigureBranchCache }, 'Create reconfigure branch cache');
+    logger.debug(
+      {
+        reconfigureBranchSha,
+        isConfigValid,
+      },
+      'Create reconfigure branch cache',
+    );
+    logger.trace({ reconfigureBranchCache }, 'Create reconfigure branch cache');
   }
   cache.reconfigureBranchCache = reconfigureBranchCache;
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

<!-- Describe what behavior is changed by this PR. -->
On a sufficiently large repository, this log line would lead to the Node
process being killed due to reaching the Node VM's maximum string
length, as per:

  import { constants } from 'node:buffer';
  console.log(constants.MAX_STRING_LENGTH); // ~536MB

This happens because for each update we're including in
`reconfigureBranchCache.ExtractResult`, we include the `BranchConfig`
which is effectively all Renovate config options.

On a sufficiently large repository, this hits size limits, but given
this isn't a particularly widely used log line for debugging, moving
this to a TRACE is a sufficient step.

We can continue to keep the `reconfigureBranchSha` and `isConfigValid`
fields in the original log line (albeit now top-level).

Replaces #43454


## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
