### PR TITLE
fix(platform/gitlab): handle CODEOWNERS ! exclusion patterns correctly

### DIFF
--- a/lib/modules/platform/gitlab/code-owners.spec.ts
+++ b/lib/modules/platform/gitlab/code-owners.spec.ts
@@ -145,8 +145,14 @@ describe('modules/platform/gitlab/code-owners', () => {
       const lines = ['[Docs] @docs-team', 'docs/', '!docs/internal/'];
       const rules = extractRulesFromCodeOwnersLines(lines);
 
-      expect(rules[0]).toMatchObject({ pattern: 'docs/', usernames: ['@docs-team'] });
-      expect(rules[1]).toMatchObject({ pattern: '!docs/internal/', usernames: [] });
+      expect(rules[0]).toMatchObject({
+        pattern: 'docs/',
+        usernames: ['@docs-team'],
+      });
+      expect(rules[1]).toMatchObject({
+        pattern: '!docs/internal/',
+        usernames: [],
+      });
     });
 
     it('should match excluded paths via the ! exclusion rule', () => {

--- a/lib/modules/platform/gitlab/code-owners.spec.ts
+++ b/lib/modules/platform/gitlab/code-owners.spec.ts
@@ -127,5 +127,35 @@ describe('modules/platform/gitlab/code-owners', () => {
         },
       ]);
     });
+
+    it('should treat a ! exclusion line as an empty rule (no usernames)', () => {
+      const rules = extractRulesFromCodeOwnersLines(['!excluded/path/']);
+
+      expect(rules).toEqual([
+        {
+          pattern: '!excluded/path/',
+          usernames: [],
+          score: 15,
+          match: expect.any(Function),
+        },
+      ]);
+    });
+
+    it('should not inherit section default usernames for ! exclusion lines', () => {
+      const lines = ['[Docs] @docs-team', 'docs/', '!docs/internal/'];
+      const rules = extractRulesFromCodeOwnersLines(lines);
+
+      expect(rules[0]).toMatchObject({ pattern: 'docs/', usernames: ['@docs-team'] });
+      expect(rules[1]).toMatchObject({ pattern: '!docs/internal/', usernames: [] });
+    });
+
+    it('should match excluded paths via the ! exclusion rule', () => {
+      const lines = ['[Docs] @docs-team', 'docs/', '!docs/internal/'];
+      const rules = extractRulesFromCodeOwnersLines(lines);
+      const exclusionRule = rules[1];
+
+      expect(exclusionRule.match('docs/internal/README.md')).toBe(true);
+      expect(exclusionRule.match('docs/public/README.md')).toBe(false);
+    });
   });
 });

--- a/lib/modules/platform/gitlab/code-owners.ts
+++ b/lib/modules/platform/gitlab/code-owners.ts
@@ -49,7 +49,11 @@ function extractOwnersFromLine(
     isExclusion ? pattern.substring(1) : pattern,
   );
   return {
-    usernames: isExclusion ? [] : usernames.length > 0 ? usernames : defaultUsernames,
+    usernames: isExclusion
+      ? []
+      : usernames.length > 0
+        ? usernames
+        : defaultUsernames,
     pattern,
     score: pattern.length,
     match: (path: string) => matchPattern.ignores(path),

--- a/lib/modules/platform/gitlab/code-owners.ts
+++ b/lib/modules/platform/gitlab/code-owners.ts
@@ -44,9 +44,12 @@ function extractOwnersFromLine(
   defaultUsernames: string[],
 ): FileOwnerRule {
   const [pattern, ...usernames] = line.split(regEx(/\s+/));
-  const matchPattern = ignore().add(pattern);
+  const isExclusion = pattern.startsWith('!');
+  const matchPattern = ignore().add(
+    isExclusion ? pattern.substring(1) : pattern,
+  );
   return {
-    usernames: usernames.length > 0 ? usernames : defaultUsernames,
+    usernames: isExclusion ? [] : usernames.length > 0 ? usernames : defaultUsernames,
     pattern,
     score: pattern.length,
     match: (path: string) => matchPattern.ignores(path),


### PR DESCRIPTION
Strip the leading ! before passing to ignore().add() so path matching works correctly. Also return empty usernames for ! exclusion rules instead of inheriting section-default owners.

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Fixes !-prefixed exclusion path rules in GitLab CODEOWNERS handling. The ! was being passed directly to the ignore library (which treats it as a negation, not a path prefix), and exclusion lines were incorrectly inheriting section-default usernames instead of having no owners.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
