### PR TITLE
feat(datasource): Add `vcpkg`

### DIFF
--- a/lib/modules/datasource/api.ts
+++ b/lib/modules/datasource/api.ts
@@ -80,6 +80,7 @@ import type { DatasourceApi } from './types.ts';
 import { TypstDatasource } from './typst/index.ts';
 import { Unity3dDatasource } from './unity3d/index.ts';
 import { Unity3dPackagesDatasource } from './unity3d-packages/index.ts';
+import { VcpkgDatasource } from './vcpkg/index.ts';
 
 const api = new Map<string, DatasourceApi>();
 export default api;
@@ -168,3 +169,4 @@ api.set(TerraformProviderDatasource.id, new TerraformProviderDatasource());
 api.set(TypstDatasource.id, new TypstDatasource());
 api.set(Unity3dDatasource.id, new Unity3dDatasource());
 api.set(Unity3dPackagesDatasource.id, new Unity3dPackagesDatasource());
+api.set(VcpkgDatasource.id, new VcpkgDatasource());

--- a/lib/modules/datasource/vcpkg/__fixtures__/unparseable.json
+++ b/lib/modules/datasource/vcpkg/__fixtures__/unparseable.json
@@ -1,0 +1,1 @@
+{ not valid json

--- a/lib/modules/datasource/vcpkg/__fixtures__/zlib.json
+++ b/lib/modules/datasource/vcpkg/__fixtures__/zlib.json
@@ -1,0 +1,31 @@
+{
+  "versions": [
+    {
+      "git-tree": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "version": "1.3.1",
+      "port-version": 0
+    },
+    {
+      "git-tree": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      "version": "1.3",
+      "port-version": 1
+    },
+    {
+      "git-tree": "cccccccccccccccccccccccccccccccccccccccc",
+      "version": "1.3",
+      "port-version": 0
+    },
+    {
+      "git-tree": "dddddddddddddddddddddddddddddddddddddddd",
+      "version-semver": "1.2.13"
+    },
+    {
+      "git-tree": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+      "version-date": "2022-09-15"
+    },
+    {
+      "git-tree": "ffffffffffffffffffffffffffffffffffffffff",
+      "version-string": "1.2.12"
+    }
+  ]
+}

--- a/lib/modules/datasource/vcpkg/index.spec.ts
+++ b/lib/modules/datasource/vcpkg/index.spec.ts
@@ -1,0 +1,279 @@
+import fs from 'fs-extra';
+import type { SimpleGit } from 'simple-git';
+import { setTimeout } from 'timers/promises';
+import type { DirectoryResult } from 'tmp-promise';
+import { dir } from 'tmp-promise';
+import upath from 'upath';
+import type { MockedFunction } from 'vitest';
+import { Fixtures } from '~test/fixtures.ts';
+import { partial } from '~test/util.ts';
+import { GlobalConfig } from '../../../config/global.ts';
+import type { RepoGlobalConfig } from '../../../config/types.ts';
+import * as memCache from '../../../util/cache/memory/index.ts';
+import * as git from '../../../util/git/index.ts';
+import { getPkgReleases } from '../index.ts';
+import { VcpkgDatasource } from './index.ts';
+
+vi.unmock('../../../util/mutex.ts');
+const createSimpleGit = vi.mocked(git.createSimpleGit);
+
+const datasource = VcpkgDatasource.id;
+
+function setupGitMocks(
+  portName: string,
+  firstLetter: string,
+  fixtureName: string,
+  delayMs?: number,
+): { mockClone: MockedFunction<SimpleGit['clone']> } {
+  const mockClone = vi
+    .fn()
+    .mockName('clone')
+    .mockImplementation(
+      async (_registryUrl: string, clonePath: string, _opts) => {
+        if (delayMs && delayMs > 0) {
+          await setTimeout(delayMs);
+        }
+        const filePath = upath.join(
+          clonePath,
+          'versions',
+          `${firstLetter}-`,
+          `${portName}.json`,
+        );
+        fs.mkdirSync(upath.dirname(filePath), { recursive: true });
+        fs.writeFileSync(filePath, Fixtures.get(fixtureName), {
+          encoding: 'utf8',
+        });
+      },
+    );
+
+  const gitMock = partial<SimpleGit>({ clone: mockClone });
+  createSimpleGit.mockReturnValue(gitMock);
+  return { mockClone };
+}
+
+function setupEmptyGitMock(): {
+  mockClone: MockedFunction<SimpleGit['clone']>;
+} {
+  const mockClone = vi
+    .fn()
+    .mockName('clone')
+    .mockImplementation((_registryUrl: string, clonePath: string) => {
+      fs.mkdirSync(clonePath, { recursive: true });
+    });
+  const gitMock = partial<SimpleGit>({ clone: mockClone });
+  createSimpleGit.mockReturnValue(gitMock);
+  return { mockClone };
+}
+
+function setupErrorGitMock(): {
+  mockClone: MockedFunction<SimpleGit['clone']>;
+} {
+  const mockClone = vi
+    .fn()
+    .mockName('clone')
+    .mockImplementation(() => Promise.reject(new Error('mocked error')));
+
+  const gitMock = partial<SimpleGit>({ clone: mockClone });
+  createSimpleGit.mockReturnValue(gitMock);
+  return { mockClone };
+}
+
+describe('modules/datasource/vcpkg/index', () => {
+  let tmpDir: DirectoryResult | null;
+  let adminConfig: RepoGlobalConfig;
+
+  beforeEach(async () => {
+    tmpDir = await dir({ unsafeCleanup: true });
+
+    adminConfig = {
+      localDir: upath.join(tmpDir.path, 'local'),
+      cacheDir: upath.join(tmpDir.path, 'cache'),
+    };
+    GlobalConfig.set(adminConfig);
+
+    createSimpleGit.mockReset();
+    memCache.init();
+  });
+
+  afterEach(async () => {
+    await tmpDir?.cleanup();
+    tmpDir = null;
+    GlobalConfig.reset();
+  });
+
+  it('returns null for invalid registry url', async () => {
+    expect(
+      await getPkgReleases({
+        datasource,
+        packageName: 'zlib',
+        registryUrls: ['not a url'],
+      }),
+    ).toBeNull();
+  });
+
+  it('returns releases for the zlib fixture using the default registry url', async () => {
+    setupGitMocks('zlib', 'z', 'zlib.json');
+    const res = await getPkgReleases({
+      datasource,
+      packageName: 'zlib',
+    });
+    expect(res).not.toBeNull();
+    expect(res?.registryUrl).toBe('https://github.com/microsoft/vcpkg');
+    expect(res?.releases).toEqual(
+      expect.arrayContaining([
+        { version: '1.3.1', newDigest: 'a'.repeat(40) },
+        { version: '1.3#1', newDigest: 'b'.repeat(40) },
+        { version: '1.3', newDigest: 'c'.repeat(40) },
+        { version: '1.2.13', newDigest: 'd'.repeat(40) },
+        { version: '2022-09-15', newDigest: 'e'.repeat(40) },
+        { version: '1.2.12', newDigest: 'f'.repeat(40) },
+      ]),
+    );
+    expect(res?.releases).toHaveLength(6);
+  });
+
+  it('uses a custom registry url and uppercased port names', async () => {
+    setupGitMocks('Zlib', 'z', 'zlib.json');
+    const res = await getPkgReleases({
+      datasource,
+      packageName: 'Zlib',
+      registryUrls: ['https://example.com/my-vcpkg-registry'],
+    });
+    expect(res).not.toBeNull();
+    expect(res?.releases).toHaveLength(6);
+  });
+
+  it('returns null when the port file is missing', async () => {
+    setupEmptyGitMock();
+    const res = await getPkgReleases({
+      datasource,
+      packageName: 'nonexistent',
+    });
+    expect(res).toBeNull();
+  });
+
+  it('returns null when the port file is unparseable', async () => {
+    setupGitMocks('zlib', 'z', 'unparseable.json');
+    const res = await getPkgReleases({
+      datasource,
+      packageName: 'zlib',
+    });
+    expect(res).toBeNull();
+  });
+
+  it('clones once then reuses the cache for subsequent ports', async () => {
+    const mockClone = vi
+      .fn()
+      .mockName('clone')
+      .mockImplementation((_registryUrl: string, clonePath: string, _opts) => {
+        for (const name of ['zlib', 'zstd']) {
+          const filePath = upath.join(
+            clonePath,
+            'versions',
+            'z-',
+            `${name}.json`,
+          );
+          fs.mkdirSync(upath.dirname(filePath), { recursive: true });
+          fs.writeFileSync(filePath, Fixtures.get('zlib.json'), {
+            encoding: 'utf8',
+          });
+        }
+      });
+    const gitMock = partial<SimpleGit>({ clone: mockClone });
+    createSimpleGit.mockReturnValue(gitMock);
+
+    const res1 = await getPkgReleases({ datasource, packageName: 'zlib' });
+    const res2 = await getPkgReleases({ datasource, packageName: 'zstd' });
+    expect(res1).not.toBeNull();
+    expect(res2).not.toBeNull();
+    expect(mockClone).toHaveBeenCalledTimes(1);
+  });
+
+  it('guards against race conditions while cloning', async () => {
+    const { mockClone } = setupGitMocks('zlib', 'z', 'zlib.json', 250);
+    await Promise.all([
+      getPkgReleases({ datasource, packageName: 'zlib' }),
+      getPkgReleases({ datasource, packageName: 'zlib' }),
+    ]);
+    expect(mockClone).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null when git clone fails', async () => {
+    setupErrorGitMock();
+    const res = await getPkgReleases({
+      datasource,
+      packageName: 'zlib',
+    });
+    const res2 = await getPkgReleases({
+      datasource,
+      packageName: 'curl',
+    });
+    expect(res).toBeNull();
+    expect(res2).toBeNull();
+  });
+
+  it('retries if shallow fails because of a dumb http git repo', async () => {
+    const mockClone = vi
+      .fn()
+      .mockName('clone')
+      .mockImplementation((_registryUrl: string, clonePath: string, opts) => {
+        if (typeof opts !== 'undefined' && Object.hasOwn(opts, '--depth')) {
+          return Promise.reject(
+            new Error(
+              'fatal: dumb http transport does not support shallow capabilities',
+            ),
+          );
+        }
+        const filePath = upath.join(clonePath, 'versions', 'z-', 'zlib.json');
+        fs.mkdirSync(upath.dirname(filePath), { recursive: true });
+        fs.writeFileSync(filePath, Fixtures.get('zlib.json'), {
+          encoding: 'utf8',
+        });
+      });
+    const gitMock = partial<SimpleGit>({ clone: mockClone });
+    createSimpleGit.mockReturnValue(gitMock);
+
+    const res = await getPkgReleases({
+      datasource,
+      packageName: 'zlib',
+    });
+    expect(mockClone).toHaveBeenCalledTimes(2);
+    expect(res).not.toBeNull();
+  });
+
+  it('retries if shallow fails but retry can also fail', async () => {
+    const mockClone = vi
+      .fn()
+      .mockName('clone')
+      .mockImplementation((_registryUrl: string, _clonePath: string, opts) => {
+        if (typeof opts !== 'undefined' && Object.hasOwn(opts, '--depth')) {
+          return Promise.reject(
+            new Error(
+              'fatal: dumb http transport does not support shallow capabilities',
+            ),
+          );
+        }
+        return Promise.reject(new Error('mocked error'));
+      });
+    const gitMock = partial<SimpleGit>({ clone: mockClone });
+    createSimpleGit.mockReturnValue(gitMock);
+
+    const res = await getPkgReleases({
+      datasource,
+      packageName: 'zlib',
+    });
+    expect(mockClone).toHaveBeenCalledTimes(2);
+    expect(res).toBeNull();
+  });
+
+  it('respects the explicit gitTimeout setting', async () => {
+    const { mockClone } = setupGitMocks('zlib', 'z', 'zlib.json');
+    GlobalConfig.set({ ...adminConfig, gitTimeout: 30000 });
+    const res = await getPkgReleases({
+      datasource,
+      packageName: 'zlib',
+    });
+    expect(mockClone).toHaveBeenCalled();
+    expect(res).not.toBeNull();
+  });
+});

--- a/lib/modules/datasource/vcpkg/index.ts
+++ b/lib/modules/datasource/vcpkg/index.ts
@@ -1,0 +1,226 @@
+import upath from 'upath';
+import { GlobalConfig } from '../../../config/global.ts';
+import { logger } from '../../../logger/index.ts';
+import * as memCache from '../../../util/cache/memory/index.ts';
+import { withCache } from '../../../util/cache/package/with-cache.ts';
+import { privateCacheDir, readCacheFile } from '../../../util/fs/index.ts';
+import { createSimpleGit } from '../../../util/git/index.ts';
+import { toSha256 } from '../../../util/hash.ts';
+import { acquireLock } from '../../../util/mutex.ts';
+import { regEx } from '../../../util/regex.ts';
+import { Json } from '../../../util/schema-utils/index.ts';
+import { parseUrl } from '../../../util/url.ts';
+import { Datasource } from '../datasource.ts';
+import type { GetReleasesConfig, Release, ReleaseResult } from '../types.ts';
+import { VcpkgPortVersions } from './schema.ts';
+
+type CloneResult =
+  | {
+      err: Error;
+      clonePath?: undefined;
+    }
+  | {
+      clonePath: string;
+      err?: undefined;
+    };
+
+export class VcpkgDatasource extends Datasource {
+  static readonly id = 'vcpkg';
+
+  constructor() {
+    super(VcpkgDatasource.id);
+  }
+
+  override readonly defaultRegistryUrls = [
+    'https://github.com/microsoft/vcpkg',
+  ];
+
+  override readonly defaultVersioning = 'vcpkg';
+
+  override readonly customRegistrySupport = true;
+
+  override readonly releaseTimestampSupport = false;
+
+  override readonly sourceUrlSupport = 'none';
+
+  private async _getReleases({
+    packageName,
+    registryUrl,
+  }: GetReleasesConfig): Promise<ReleaseResult | null> {
+    /* v8 ignore if -- should never happen */
+    if (!registryUrl) {
+      logger.warn(
+        'vcpkg datasource: No registryUrl specified, cannot perform getReleases',
+      );
+      return null;
+    }
+
+    const url = parseUrl(registryUrl);
+    if (!url) {
+      logger.debug(`Could not parse registry URL ${registryUrl}`);
+      return null;
+    }
+
+    const clonePath = await VcpkgDatasource.fetchClonePath(registryUrl, url);
+    if (!clonePath) {
+      return null;
+    }
+
+    const firstLetter = packageName.charAt(0).toLowerCase();
+    const portPath = upath.join(
+      clonePath,
+      'versions',
+      `${firstLetter}-`,
+      `${packageName}.json`,
+    );
+
+    let parsed: VcpkgPortVersions;
+    try {
+      const content = await readCacheFile(portPath, 'utf8');
+      parsed = Json.pipe(VcpkgPortVersions).parse(content);
+    } catch (err) {
+      logger.debug(
+        { err, packageName, registryUrl },
+        'vcpkg datasource: could not read or parse port versions file',
+      );
+      return null;
+    }
+
+    const releases: Release[] = parsed.versions.map((entry) => {
+      const upstream =
+        entry.version ??
+        entry['version-semver'] ??
+        entry['version-date'] ??
+        /* v8 ignore next -- schema guarantees one is set */
+        entry['version-string']!;
+      const portVersion = entry['port-version'] ?? 0;
+      const version = portVersion > 0 ? `${upstream}#${portVersion}` : upstream;
+      const release: Release = {
+        version,
+        newDigest: entry['git-tree'],
+      };
+      return release;
+    });
+
+    return { releases };
+  }
+
+  override getReleases(
+    config: GetReleasesConfig,
+  ): Promise<ReleaseResult | null> {
+    return withCache(
+      {
+        namespace: `datasource-${VcpkgDatasource.id}`,
+        key: `getReleases:${config.registryUrl}/${config.packageName}`,
+        cacheable: true,
+      },
+      () => this._getReleases(config),
+    );
+  }
+
+  /**
+   * Given a Git URL, computes a semi-human-readable name for a folder in which
+   * to clone the repository.
+   */
+  private static cacheDirFromUrl(url: URL): string {
+    const proto = url.protocol.replace(regEx(/:$/), '');
+    const host = url.hostname;
+    const hash = toSha256(url.pathname).substring(0, 7);
+
+    return `vcpkg-registry-${proto}-${host}-${hash}`;
+  }
+
+  private static async fetchClonePath(
+    registryUrl: string,
+    url: URL,
+  ): Promise<string | null> {
+    const cacheKey = `vcpkg-datasource/registry-clone-path/${registryUrl}`;
+    const lockKey = registryUrl;
+
+    const executionTimeout = GlobalConfig.get('executionTimeout') * 60 * 1000;
+    const gitTimeout = GlobalConfig.get('gitTimeout') || executionTimeout;
+    const releaseLock = await acquireLock(
+      lockKey,
+      'vcpkg-registry',
+      gitTimeout,
+    );
+    try {
+      const cached = memCache.get<CloneResult>(cacheKey);
+
+      if (cached?.err) {
+        logger.warn(
+          { err: cached.err, registryUrl },
+          'Previous git clone failed, bailing out.',
+        );
+        return null;
+      }
+
+      if (cached?.clonePath) {
+        return cached.clonePath;
+      }
+
+      const clonePath = upath.join(
+        privateCacheDir(),
+        VcpkgDatasource.cacheDirFromUrl(url),
+      );
+
+      const result = await VcpkgDatasource.clone(registryUrl, clonePath);
+
+      memCache.set(cacheKey, result);
+
+      if (result.err) {
+        logger.warn(
+          { err: result.err, registryUrl },
+          'Git clone failed, bailing out.',
+        );
+        return null;
+      }
+
+      return result.clonePath;
+    } finally {
+      releaseLock();
+    }
+  }
+
+  private static async clone(
+    registryFetchUrl: string,
+    clonePath: string,
+  ): Promise<CloneResult> {
+    logger.info({ clonePath, registryFetchUrl }, `Cloning vcpkg registry`);
+
+    const git = createSimpleGit({
+      config: { maxConcurrentProcesses: 1 },
+    });
+
+    try {
+      await git.clone(registryFetchUrl, clonePath, {
+        '--depth': 1,
+      });
+      return { clonePath };
+    } catch (err) {
+      if (
+        err.message.includes(
+          'fatal: dumb http transport does not support shallow capabilities',
+        )
+      ) {
+        logger.info(
+          { registryFetchUrl },
+          'failed to shallow clone vcpkg registry, doing full clone',
+        );
+        try {
+          await git.clone(registryFetchUrl, clonePath);
+          return { clonePath };
+        } catch (err) {
+          logger.warn(
+            { err, registryFetchUrl },
+            'failed cloning vcpkg registry',
+          );
+          return { err };
+        }
+      } else {
+        logger.warn({ err, registryFetchUrl }, 'failed cloning vcpkg registry');
+        return { err };
+      }
+    }
+  }
+}

--- a/lib/modules/datasource/vcpkg/readme.md
+++ b/lib/modules/datasource/vcpkg/readme.md
@@ -1,0 +1,15 @@
+This datasource returns versions of [vcpkg](https://learn.microsoft.com/vcpkg/concepts/registries) ports.
+
+A vcpkg registry is a Git repository with a known on-disk layout.
+For a port named `<port>` the version history lives in `versions/<first-letter>-/<port>.json`, where `<first-letter>` is the first character of the port name in lowercase.
+Ports whose names start with a digit live under `versions/0-/`.
+
+The datasource clones the registry repository to a local cache directory and reads the per-port file from disk.
+The cache directory is derived from the registry URL, so each registry is cloned at most once per run.
+
+Custom registries are supported as first-class registries.
+Set `registryUrls` to the Git URL of any vcpkg registry.
+The default `registryUrl` is `https://github.com/microsoft/vcpkg`, the canonical vcpkg registry.
+
+Each release entry uses the upstream version string, with a `#N` suffix appended when the port revision (`port-version`) is greater than zero.
+The Git tree object id is exposed as `newDigest` so that lockfiles can pin to an exact tree.

--- a/lib/modules/datasource/vcpkg/schema.ts
+++ b/lib/modules/datasource/vcpkg/schema.ts
@@ -1,0 +1,41 @@
+import { z } from 'zod/v3';
+
+const VcpkgPortVersionEntry = z
+  .object({
+    'git-tree': z.string(),
+    'port-version': z.number().int().nonnegative().optional(),
+    version: z.string().optional(),
+    'version-semver': z.string().optional(),
+    'version-date': z.string().optional(),
+    'version-string': z.string().optional(),
+  })
+  .refine(
+    (entry) =>
+      typeof (
+        entry.version ??
+        entry['version-semver'] ??
+        entry['version-date'] ??
+        entry['version-string']
+      ) === 'string',
+    {
+      message:
+        'one of version, version-semver, version-date, version-string is required',
+    },
+  );
+
+export const VcpkgPortVersions = z.object({
+  versions: z.array(VcpkgPortVersionEntry).min(1),
+});
+
+export type VcpkgPortVersions = z.infer<typeof VcpkgPortVersions>;
+
+export const VcpkgBaseline = z.object({
+  default: z.record(
+    z.object({
+      baseline: z.string(),
+      'port-version': z.number().int().nonnegative(),
+    }),
+  ),
+});
+
+export type VcpkgBaseline = z.infer<typeof VcpkgBaseline>;

--- a/lib/util/cache/package/namespaces.ts
+++ b/lib/util/cache/package/namespaces.ts
@@ -102,6 +102,7 @@ export const packageCacheNamespaces = [
   'datasource-typst:registry-releases',
   'datasource-unity3d',
   'datasource-unity3d-packages',
+  'datasource-vcpkg',
   'github-branches-datasource-v1',
   'github-releases-datasource-v2',
   'github-tags-datasource-v2',


### PR DESCRIPTION
## Changes

Add a new `vcpkg` datasource that reads version metadata from a vcpkg registry. A vcpkg registry is a Git repository with a fixed on-disk layout: per-port version history lives in `versions/<first-letter>-/<port>.json` plus a registry-wide `versions/baseline.json` index.

The datasource clones the registry to a local cache directory and reads the per-port file from disk, with one cache entry per registry URL so multi-registry setups stay isolated. The pattern mirrors the existing [`crate`](https://github.com/renovatebot/renovate/tree/main/lib/modules/datasource/crate) datasource, which solves the same problem for Cargo registries.

Each entry in a port file uses one of four scheme keys: `version`, `version-semver`, `version-date`, `version-string`. The datasource normalizes all four into a single `Release` version string, and appends a `#N` suffix when `port-version` is greater than zero. Comparison and ordering of the resulting strings is delegated to the companion vcpkg versioning module (separate PR, linked below) via `defaultVersioning: 'vcpkg'`.

Custom registries are first-class citizens via `registryUrls`, matching the maintainer convention documented in https://learn.microsoft.com/vcpkg/maintainers/registries. The Git tree object id from each version entry is exposed as `newDigest` so downstream lockfiles can pin to an exact tree.

See https://learn.microsoft.com/vcpkg/concepts/registries for the registry model overview.

This is the first of three planned vcpkg PRs:

1. **This PR**, the `vcpkg` datasource.
1. The companion `vcpkg` versioning module that interprets the four scheme keys and the `>=` lower-bound semantics.
1. The `vcpkg` manager that extracts dependencies from `vcpkg.json` manifest files.

A registry-maintainer side companion (port `portfile.cmake` upstream tracking) is planned as a follow-up.

## Context

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

Related:

- #7135 (tracking issue for vcpkg support)
- #25217

## AI assistance disclosure

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

Added `lib/modules/datasource/vcpkg/readme.md`. Registered the `datasource-vcpkg` cache namespace in `lib/util/cache/package/namespaces.ts` (the user-facing list in `docs/usage/self-hosted-configuration.md` is auto-generated from that file, no manual edit needed).

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/stemann/renovate-vcpkg-example

**Unit tests:** 11 cases in `lib/modules/datasource/vcpkg/index.spec.ts` covering: successful read of a real-shaped port file (zlib fixture), missing file resolved to null, unparseable JSON resolved to null, port-version `#N` suffix encoding, all four scheme keys, custom and default registry URLs, clone-cache reuse, git-clone failure handling. 100% statements / branches / functions / lines.

**Real repository:** [`stemann/renovate-vcpkg-example@vcpkg-datasource`](https://github.com/stemann/renovate-vcpkg-example/tree/vcpkg-datasource) wires a `customManagers` regex on a `vcpkg.json` that pins `zlib` with `version>=: "1.2.13"`. The regex targets the just-introduced datasource directly so this PR can be exercised without the companion versioning or manager. Running Renovate against this branch produces:

    "managers": {"regex": {"fileCount": 1, "depCount": 1}}
    "depName": "zlib"
    "datasource": "vcpkg"
    "currentValue": "1.2.13"
    "newVersion": "1.3.2"
    "newValue": "1.3.2"
    "updateType": "minor"
    "registryUrl": "https://github.com/microsoft/vcpkg"

Reproducer:

    RENOVATE_TOKEN=<gh-pat> \
      RENOVATE_BASE_BRANCH_PATTERNS='["vcpkg-datasource"]' \
      RENOVATE_USE_BASE_BRANCH_CONFIG=merge \
      pnpm start \
        --platform=github \
        --dry-run=lookup \
        --autodiscover=false \
        stemann/renovate-vcpkg-example
