### PR TITLE
feat(versioning): Add `vcpkg` versioning

### DIFF
--- a/lib/modules/versioning/api.ts
+++ b/lib/modules/versioning/api.ts
@@ -52,6 +52,7 @@ import type { VersioningApi, VersioningApiConstructor } from './types.ts';
 import * as ubuntu from './ubuntu/index.ts';
 import * as unity3d from './unity3d/index.ts';
 import * as unity3dPackages from './unity3d-packages/index.ts';
+import * as vcpkg from './vcpkg/index.ts';
 
 const api = new Map<string, VersioningApi | VersioningApiConstructor>();
 export default api;
@@ -109,3 +110,4 @@ api.set(swift.id, swift.api);
 api.set(ubuntu.id, ubuntu.api);
 api.set(unity3d.id, unity3d.api);
 api.set(unity3dPackages.id, unity3dPackages.api);
+api.set(vcpkg.id, vcpkg.api);

--- a/lib/modules/versioning/vcpkg/index.spec.ts
+++ b/lib/modules/versioning/vcpkg/index.spec.ts
@@ -1,0 +1,340 @@
+import { coerce } from 'semver';
+import vcpkg from './index.ts';
+
+describe('modules/versioning/vcpkg/index', () => {
+  describe('.isValid(input)', () => {
+    it.each`
+      input                             | expected
+      ${'1.2.3'}                        | ${true}
+      ${'1.2.3-rc.1'}                   | ${true}
+      ${'1.2.3-rc.1+build.7'}           | ${true}
+      ${'1.2.3#1'}                      | ${true}
+      ${'1.2.3#0'}                      | ${true}
+      ${'1.2.3#42'}                     | ${true}
+      ${'1.2'}                          | ${true}
+      ${'1'}                            | ${true}
+      ${'1.2.3.4'}                      | ${true}
+      ${'1.2.3.4.5'}                    | ${true}
+      ${'1.2-alpha'}                    | ${true}
+      ${'2024-01-15'}                   | ${true}
+      ${'2024-01-15#3'}                 | ${true}
+      ${'2024-01-15.1'}                 | ${true}
+      ${'2024-01-15.0'}                 | ${true}
+      ${'2024-01-15.1.2.3'}             | ${true}
+      ${'2024-02-29'}                   | ${true}
+      ${'2023-02-29'}                   | ${false}
+      ${'2024-13-01'}                   | ${false}
+      ${'2024-02-31'}                   | ${false}
+      ${'2024-1-1'}                     | ${true}
+      ${'bla-bla-2024-08-fixed-typo'}   | ${true}
+      ${'bla-bla-2024-08-fixed-typo#2'} | ${true}
+      ${'2024.08.fixed'}                | ${true}
+      ${'opaque'}                       | ${true}
+      ${'opaque#5'}                     | ${true}
+      ${''}                             | ${false}
+      ${'   '}                          | ${false}
+      ${'#1'}                           | ${false}
+      ${'1.2.3#'}                       | ${true}
+      ${'1.2.3#abc'}                    | ${true}
+      ${null as unknown as string}      | ${false}
+      ${undefined as unknown as string} | ${false}
+    `('isValid("$input") === $expected', ({ input, expected }) => {
+      expect(vcpkg.isValid(input)).toBe(expected);
+    });
+
+    it('rejects non-string input', () => {
+      expect(vcpkg.isValid(123 as unknown as string)).toBeFalse();
+    });
+  });
+
+  describe('.isVersion(input)', () => {
+    it.each`
+      input                      | expected
+      ${'1.2.3'}                 | ${true}
+      ${'1.2'}                   | ${true}
+      ${'1.2.3.4'}               | ${true}
+      ${'2024-01-15'}            | ${true}
+      ${'2024-01-15#3'}          | ${true}
+      ${'bla-bla-2024-08-fixed'} | ${false}
+      ${'opaque#3'}              | ${false}
+      ${''}                      | ${false}
+      ${null}                    | ${false}
+      ${undefined}               | ${false}
+    `('isVersion("$input") === $expected', ({ input, expected }) => {
+      expect(vcpkg.isVersion(input)).toBe(expected);
+    });
+  });
+
+  describe('.isCompatible(version)', () => {
+    it('mirrors isValid', () => {
+      expect(vcpkg.isCompatible('1.2.3')).toBeTrue();
+      expect(vcpkg.isCompatible('1.2.3#7')).toBeTrue();
+      expect(vcpkg.isCompatible('opaque')).toBeTrue();
+      expect(vcpkg.isCompatible('')).toBeFalse();
+    });
+  });
+
+  describe('.isSingleVersion(version)', () => {
+    it('returns true for ordered schemes only', () => {
+      expect(vcpkg.isSingleVersion('1.2.3')).toBeTrue();
+      expect(vcpkg.isSingleVersion('1.2.3.4')).toBeTrue();
+      expect(vcpkg.isSingleVersion('2024-01-15')).toBeTrue();
+      expect(vcpkg.isSingleVersion('opaque')).toBeFalse();
+    });
+  });
+
+  describe('.isStable(version)', () => {
+    it.each`
+      input             | expected
+      ${'1.2.3'}        | ${true}
+      ${'1.2.3-rc.1'}   | ${false}
+      ${'1.2.3-rc.1#1'} | ${false}
+      ${'1.2'}          | ${true}
+      ${'1.2-alpha'}    | ${false}
+      ${'2024-01-15'}   | ${true}
+      ${'opaque-tag'}   | ${true}
+      ${'bogus_input!'} | ${true}
+      ${''}             | ${false}
+    `('isStable("$input") === $expected', ({ input, expected }) => {
+      expect(vcpkg.isStable(input)).toBe(expected);
+    });
+  });
+
+  describe('.getMajor/getMinor/getPatch(version)', () => {
+    it.each`
+      input           | major   | minor   | patch
+      ${'1.2.3'}      | ${1}    | ${2}    | ${3}
+      ${'1.2.3#4'}    | ${1}    | ${2}    | ${3}
+      ${'1.2.3-rc.1'} | ${1}    | ${2}    | ${3}
+      ${'1.2'}        | ${1}    | ${2}    | ${0}
+      ${'1.2.3.4'}    | ${1}    | ${2}    | ${3}
+      ${'5'}          | ${5}    | ${0}    | ${0}
+      ${'2024-01-15'} | ${null} | ${null} | ${null}
+      ${'opaque'}     | ${null} | ${null} | ${null}
+      ${''}           | ${null} | ${null} | ${null}
+    `('getMajor("$input")', ({ input, major, minor, patch }) => {
+      expect(vcpkg.getMajor(input)).toBe(major);
+      expect(vcpkg.getMinor(input)).toBe(minor);
+      expect(vcpkg.getPatch(input)).toBe(patch);
+    });
+
+    it('accepts SemVer object input', () => {
+      const sv = coerce('1.2.3')!;
+      expect(vcpkg.getMajor(sv)).toBe(1);
+      expect(vcpkg.getMinor(sv)).toBe(2);
+      expect(vcpkg.getPatch(sv)).toBe(3);
+    });
+  });
+
+  describe('.equals(a, b)', () => {
+    it.each`
+      a                  | b                  | expected
+      ${'1.2.3'}         | ${'1.2.3'}         | ${true}
+      ${'1.2.3'}         | ${'1.2.3#0'}       | ${true}
+      ${'1.2.3#0'}       | ${'1.2.3'}         | ${true}
+      ${'1.2.3#1'}       | ${'1.2.3#1'}       | ${true}
+      ${'1.2.3#1'}       | ${'1.2.3#2'}       | ${false}
+      ${'1.2.3'}         | ${'1.2.4'}         | ${false}
+      ${'1.2.3+build.7'} | ${'1.2.3+build.9'} | ${true}
+      ${'1.2'}           | ${'1.2.0'}         | ${false}
+      ${'2024-01-15'}    | ${'2024-01-15'}    | ${true}
+      ${'2024-01-15'}    | ${'2024-01-15#0'}  | ${true}
+      ${'2024-01-15#1'}  | ${'2024-01-16#1'}  | ${false}
+      ${'opaque'}        | ${'opaque'}        | ${true}
+      ${'opaque#1'}      | ${'opaque#1'}      | ${true}
+      ${'opaque#1'}      | ${'opaque#2'}      | ${false}
+      ${'opaque'}        | ${'other'}         | ${false}
+      ${'1.2.3'}         | ${'2024-01-15'}    | ${false}
+      ${'1.2.3'}         | ${'opaque'}        | ${false}
+      ${''}              | ${'1.2.3'}         | ${false}
+      ${'1.2.3'}         | ${''}              | ${false}
+    `('equals("$a", "$b") === $expected', ({ a, b, expected }) => {
+      expect(vcpkg.equals(a, b)).toBe(expected);
+    });
+  });
+
+  describe('.isGreaterThan(version, other)', () => {
+    it.each`
+      a                 | b               | expected
+      ${'1.2.4'}        | ${'1.2.3'}      | ${true}
+      ${'1.2.3'}        | ${'1.2.4'}      | ${false}
+      ${'1.2.3'}        | ${'1.2.3'}      | ${false}
+      ${'1.2.3#1'}      | ${'1.2.3#0'}    | ${true}
+      ${'1.2.3#1'}      | ${'1.2.3'}      | ${true}
+      ${'1.2.3'}        | ${'1.2.3#1'}    | ${false}
+      ${'1.2.4'}        | ${'1.2.3#1'}    | ${true}
+      ${'1.2.3#1'}      | ${'1.2.4'}      | ${false}
+      ${'1.2.3.4'}      | ${'1.2.3.3'}    | ${true}
+      ${'1.2.3.4'}      | ${'1.2.3'}      | ${true}
+      ${'2024-01-16'}   | ${'2024-01-15'} | ${true}
+      ${'2024-01-15'}   | ${'2024-01-16'} | ${false}
+      ${'2024-01-15#1'} | ${'2024-01-15'} | ${true}
+      ${'opaque'}       | ${'other'}      | ${false}
+      ${'opaque#2'}     | ${'opaque#1'}   | ${false}
+      ${'1.2.3'}        | ${'2024-01-15'} | ${false}
+      ${'1.2.3'}        | ${'opaque'}     | ${false}
+      ${''}             | ${'1.2.3'}      | ${false}
+      ${'1.2.3'}        | ${''}           | ${false}
+    `('isGreaterThan("$a", "$b") === $expected', ({ a, b, expected }) => {
+      expect(vcpkg.isGreaterThan(a, b)).toBe(expected);
+    });
+  });
+
+  describe('.sortVersions(a, b)', () => {
+    it('orders semver bases', () => {
+      const versions = ['1.10.0', '1.2.0', '1.2.1', '2.0.0'];
+      expect([...versions].sort(vcpkg.sortVersions)).toEqual([
+        '1.2.0',
+        '1.2.1',
+        '1.10.0',
+        '2.0.0',
+      ]);
+    });
+
+    it('orders relaxed-dotted bases', () => {
+      const versions = ['1.2', '1.2.3', '1.2.3.4', '1.10'];
+      expect([...versions].sort(vcpkg.sortVersions)).toEqual([
+        '1.2',
+        '1.2.3',
+        '1.2.3.4',
+        '1.10',
+      ]);
+    });
+
+    it('orders date bases lexicographically', () => {
+      const versions = ['2024-12-31', '2023-01-01', '2024-01-01'];
+      expect([...versions].sort(vcpkg.sortVersions)).toEqual([
+        '2023-01-01',
+        '2024-01-01',
+        '2024-12-31',
+      ]);
+    });
+
+    it('orders date disambiguation tails per the relaxed `version` rule', () => {
+      // Per the spec, a version with the smallest set of sections takes
+      // precedence, so a bare date sorts before any disambiguated form.
+      const versions = [
+        '2024-01-15.1.3',
+        '2024-01-15',
+        '2024-01-15.1.2',
+        '2024-01-15.2',
+        '2024-01-15.1',
+      ];
+      expect([...versions].sort(vcpkg.sortVersions)).toEqual([
+        '2024-01-15',
+        '2024-01-15.1',
+        '2024-01-15.1.2',
+        '2024-01-15.1.3',
+        '2024-01-15.2',
+      ]);
+    });
+
+    it('breaks date ties by date head before tail', () => {
+      expect(vcpkg.sortVersions('2024-01-15.99', '2024-01-16')).toBeLessThan(0);
+    });
+
+    it('uses port-version as a tie-breaker after equal base', () => {
+      expect(vcpkg.sortVersions('1.2.3#0', '1.2.3#1')).toBeLessThan(0);
+      expect(vcpkg.sortVersions('1.2.3#5', '1.2.3#2')).toBeGreaterThan(0);
+      expect(vcpkg.sortVersions('1.2.3#5', '1.2.3#5')).toBe(0);
+    });
+
+    it('returns 0 for unparseable inputs', () => {
+      expect(vcpkg.sortVersions('', '1.2.3')).toBe(0);
+      expect(vcpkg.sortVersions('1.2.3', '')).toBe(0);
+    });
+
+    it('returns 0 for cross-scheme base comparison', () => {
+      expect(vcpkg.sortVersions('1.2.3', '2024-01-15')).toBe(0);
+    });
+
+    it('orders opaque-string bases only by port-version', () => {
+      expect(vcpkg.sortVersions('foo#0', 'foo#1')).toBeLessThan(0);
+      expect(vcpkg.sortVersions('foo', 'bar')).toBe(0);
+    });
+  });
+
+  describe('.matches(version, range)', () => {
+    it.each`
+      version         | range           | expected
+      ${'1.2.3'}      | ${'1.2.3'}      | ${true}
+      ${'1.2.4'}      | ${'1.2.3'}      | ${true}
+      ${'1.2.3'}      | ${'1.2.4'}      | ${false}
+      ${'1.2.3#1'}    | ${'1.2.3#0'}    | ${true}
+      ${'1.2.3#0'}    | ${'1.2.3#1'}    | ${false}
+      ${'2024-02-01'} | ${'2024-01-15'} | ${true}
+      ${'2024-01-15'} | ${'2024-02-01'} | ${false}
+      ${'opaque'}     | ${'opaque'}     | ${true}
+      ${'opaque#3'}   | ${'opaque#1'}   | ${true}
+      ${'opaque#1'}   | ${'opaque#3'}   | ${false}
+      ${'opaque'}     | ${'other'}      | ${false}
+      ${'1.2.3'}      | ${'2024-01-15'} | ${false}
+      ${''}           | ${'1.2.3'}      | ${false}
+    `(
+      'matches("$version", "$range") === $expected',
+      ({ version, range, expected }) => {
+        expect(vcpkg.matches(version, range)).toBe(expected);
+      },
+    );
+  });
+
+  describe('.getSatisfyingVersion(versions, range)', () => {
+    it('returns the highest version satisfying the `>=` constraint', () => {
+      // Out-of-order list so the iteration exercises both the "new best" and
+      // the "already covered" branches of the loop.
+      const versions = ['1.2.3', '2.0.0', '1.2.3#1', '1.2.4'];
+      expect(vcpkg.getSatisfyingVersion(versions, '1.2.3')).toBe('2.0.0');
+      expect(vcpkg.getSatisfyingVersion(versions, '1.2.4')).toBe('2.0.0');
+      expect(vcpkg.getSatisfyingVersion(versions, '2.0.0')).toBe('2.0.0');
+      expect(vcpkg.getSatisfyingVersion(versions, '3.0.0')).toBeNull();
+    });
+
+    it('returns null for empty list', () => {
+      expect(vcpkg.getSatisfyingVersion([], '1.2.3')).toBeNull();
+    });
+
+    it('ignores unparseable candidates', () => {
+      const versions = ['1.2.3', '', '1.2.4'];
+      expect(vcpkg.getSatisfyingVersion(versions, '1.2.3')).toBe('1.2.4');
+    });
+  });
+
+  describe('.minSatisfyingVersion(versions, range)', () => {
+    it('returns the lowest version satisfying the `>=` constraint', () => {
+      const versions = ['1.2.4', '1.2.3', '1.2.3#1', '2.0.0'];
+      expect(vcpkg.minSatisfyingVersion(versions, '1.2.3')).toBe('1.2.3');
+      expect(vcpkg.minSatisfyingVersion(versions, '1.2.4')).toBe('1.2.4');
+      expect(vcpkg.minSatisfyingVersion(versions, '3.0.0')).toBeNull();
+    });
+
+    it('returns null for empty list', () => {
+      expect(vcpkg.minSatisfyingVersion([], '1.2.3')).toBeNull();
+    });
+  });
+
+  describe('.getNewValue(config)', () => {
+    it('returns newVersion unchanged for pinned values', () => {
+      expect(
+        vcpkg.getNewValue({
+          currentValue: '1.2.3',
+          newVersion: '1.2.4',
+          rangeStrategy: 'replace',
+        }),
+      ).toBe('1.2.4');
+      expect(
+        vcpkg.getNewValue({
+          currentValue: '1.2.3#0',
+          newVersion: '1.2.3#1',
+          rangeStrategy: 'replace',
+        }),
+      ).toBe('1.2.3#1');
+      expect(
+        vcpkg.getNewValue({
+          currentValue: '2024-01-15',
+          newVersion: '2024-02-20',
+          rangeStrategy: 'replace',
+        }),
+      ).toBe('2024-02-20');
+    });
+  });
+});

--- a/lib/modules/versioning/vcpkg/index.spec.ts
+++ b/lib/modules/versioning/vcpkg/index.spec.ts
@@ -1,4 +1,3 @@
-import { coerce } from 'semver';
 import vcpkg from './index.ts';
 
 describe('modules/versioning/vcpkg/index', () => {
@@ -36,8 +35,8 @@ describe('modules/versioning/vcpkg/index', () => {
       ${'#1'}                           | ${false}
       ${'1.2.3#'}                       | ${true}
       ${'1.2.3#abc'}                    | ${true}
-      ${null as unknown as string}      | ${false}
-      ${undefined as unknown as string} | ${false}
+      ${null}                           | ${false}
+      ${undefined}                      | ${false}
     `('isValid("$input") === $expected', ({ input, expected }) => {
       expect(vcpkg.isValid(input)).toBe(expected);
     });
@@ -55,8 +54,8 @@ describe('modules/versioning/vcpkg/index', () => {
       ${'1.2.3.4'}               | ${true}
       ${'2024-01-15'}            | ${true}
       ${'2024-01-15#3'}          | ${true}
-      ${'bla-bla-2024-08-fixed'} | ${false}
-      ${'opaque#3'}              | ${false}
+      ${'bla-bla-2024-08-fixed'} | ${true}
+      ${'opaque#3'}              | ${true}
       ${''}                      | ${false}
       ${null}                    | ${false}
       ${undefined}               | ${false}
@@ -75,11 +74,12 @@ describe('modules/versioning/vcpkg/index', () => {
   });
 
   describe('.isSingleVersion(version)', () => {
-    it('returns true for ordered schemes only', () => {
+    it('returns true for any valid version', () => {
       expect(vcpkg.isSingleVersion('1.2.3')).toBeTrue();
       expect(vcpkg.isSingleVersion('1.2.3.4')).toBeTrue();
       expect(vcpkg.isSingleVersion('2024-01-15')).toBeTrue();
-      expect(vcpkg.isSingleVersion('opaque')).toBeFalse();
+      expect(vcpkg.isSingleVersion('opaque')).toBeTrue();
+      expect(vcpkg.isSingleVersion('')).toBeFalse();
     });
   });
 
@@ -116,13 +116,6 @@ describe('modules/versioning/vcpkg/index', () => {
       expect(vcpkg.getMajor(input)).toBe(major);
       expect(vcpkg.getMinor(input)).toBe(minor);
       expect(vcpkg.getPatch(input)).toBe(patch);
-    });
-
-    it('accepts SemVer object input', () => {
-      const sv = coerce('1.2.3')!;
-      expect(vcpkg.getMajor(sv)).toBe(1);
-      expect(vcpkg.getMinor(sv)).toBe(2);
-      expect(vcpkg.getPatch(sv)).toBe(3);
     });
   });
 
@@ -170,7 +163,7 @@ describe('modules/versioning/vcpkg/index', () => {
       ${'2024-01-15'}   | ${'2024-01-16'} | ${false}
       ${'2024-01-15#1'} | ${'2024-01-15'} | ${true}
       ${'opaque'}       | ${'other'}      | ${false}
-      ${'opaque#2'}     | ${'opaque#1'}   | ${false}
+      ${'opaque#2'}     | ${'opaque#1'}   | ${true}
       ${'1.2.3'}        | ${'2024-01-15'} | ${false}
       ${'1.2.3'}        | ${'opaque'}     | ${false}
       ${''}             | ${'1.2.3'}      | ${false}

--- a/lib/modules/versioning/vcpkg/index.ts
+++ b/lib/modules/versioning/vcpkg/index.ts
@@ -1,0 +1,390 @@
+import type { SemVer } from 'semver';
+import { coerce } from 'semver';
+import { regEx } from '../../../util/regex.ts';
+import { api as loose } from '../loose/index.ts';
+import { api as semver } from '../semver/index.ts';
+import type { NewValueConfig, VersioningApi } from '../types.ts';
+
+export const id = 'vcpkg';
+export const displayName = 'vcpkg';
+export const urls = ['https://learn.microsoft.com/vcpkg/users/versioning'];
+export const supportsRanges = false;
+
+type Scheme = 'date' | 'numeric' | 'string' | 'invalid';
+
+interface ParsedVersion {
+  base: string;
+  portVersion: number;
+  scheme: Scheme;
+  strictSemver: boolean;
+  dateHead?: string;
+  dateTail?: number[];
+}
+
+const portVersionRegex = regEx(/^(?<base>.*)#(?<port>\d+)$/);
+const dateRegex = regEx(
+  /^(?<head>\d{4}-\d{2}-\d{2})(?<tail>(?:\.(?:0|[1-9]\d*))*)$/,
+);
+const numericRegex = regEx(
+  /^\d+(?:\.\d+)*(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/,
+);
+const numericPrereleaseRegex = regEx(/-[0-9A-Za-z.-]+(?:\+[0-9A-Za-z.-]+)?$/);
+const numericBuildRegex = regEx(/\+[0-9A-Za-z.-]+$/);
+const strictSemverRegex = regEx(
+  /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/,
+);
+
+function splitPortVersion(input: string): {
+  base: string;
+  portVersion: number;
+} {
+  const match = portVersionRegex.exec(input);
+  if (match?.groups) {
+    return {
+      base: match.groups.base,
+      portVersion: Number.parseInt(match.groups.port, 10),
+    };
+  }
+  return { base: input, portVersion: 0 };
+}
+
+function isValidDateHead(head: string): boolean {
+  // Caller guarantees `head` matches the YYYY-MM-DD prefix, so the split
+  // always yields three numeric parts.
+  const [yearStr, monthStr, dayStr] = head.split('-');
+  const year = Number.parseInt(yearStr, 10);
+  const month = Number.parseInt(monthStr, 10);
+  const day = Number.parseInt(dayStr, 10);
+  if (month < 1 || month > 12 || day < 1) {
+    return false;
+  }
+  // Manually validate day-of-month against actual month length.
+  const daysInMonth = new Date(Date.UTC(year, month, 0)).getUTCDate();
+  return day <= daysInMonth;
+}
+
+function matchDate(base: string): { head: string; tail: number[] } | null {
+  const match = dateRegex.exec(base);
+  if (!match?.groups) {
+    return null;
+  }
+  const tail = match.groups.tail
+    ? match.groups.tail
+        .slice(1)
+        .split('.')
+        .map((s) => Number.parseInt(s, 10))
+    : [];
+  return { head: match.groups.head, tail };
+}
+
+function detectScheme(base: string): Scheme {
+  const dateParts = matchDate(base);
+  if (dateParts) {
+    // A date-shaped base must parse as a real calendar date, otherwise the
+    // whole version is rejected rather than falling back to another scheme.
+    return isValidDateHead(dateParts.head) ? 'date' : 'invalid';
+  }
+  if (numericRegex.test(base)) {
+    return 'numeric';
+  }
+  return 'string';
+}
+
+function parse(input: string | undefined | null): ParsedVersion | null {
+  if (typeof input !== 'string') {
+    return null;
+  }
+  const trimmed = input.trim();
+  if (trimmed === '') {
+    return null;
+  }
+  const { base, portVersion } = splitPortVersion(trimmed);
+  if (base === '') {
+    return null;
+  }
+  const scheme = detectScheme(base);
+  if (scheme === 'invalid') {
+    return null;
+  }
+  const strictSemver =
+    scheme === 'numeric' &&
+    strictSemverRegex.test(base) &&
+    semver.isValid(base);
+  if (scheme === 'date') {
+    const dateParts = matchDate(base);
+    /* v8 ignore next 3 -- detectScheme guarantees matchDate succeeds */
+    if (!dateParts) {
+      return null;
+    }
+    return {
+      base,
+      portVersion,
+      scheme,
+      strictSemver,
+      dateHead: dateParts.head,
+      dateTail: dateParts.tail,
+    };
+  }
+  return { base, portVersion, scheme, strictSemver };
+}
+
+function compareBase(a: ParsedVersion, b: ParsedVersion): number {
+  if (a.scheme !== b.scheme) {
+    // Cross-scheme bases are not orderable in vcpkg, callers fall back to
+    // port-version which is also of limited meaning across schemes.
+    return 0;
+  }
+  if (a.scheme === 'date') {
+    // `parse` guarantees `dateHead` and `dateTail` are populated for the
+    // `date` scheme, so the non-null assertions are safe.
+    const aHead = a.dateHead!;
+    const bHead = b.dateHead!;
+    if (aHead !== bHead) {
+      return aHead < bHead ? -1 : 1;
+    }
+    // Same date head, compare disambiguation tail per the relaxed `version`
+    // scheme rule, so a version with the smaller set of sections takes
+    // precedence (i.e. sorts earlier).
+    const aTail = a.dateTail!;
+    const bTail = b.dateTail!;
+    const minLen = Math.min(aTail.length, bTail.length);
+    for (let i = 0; i < minLen; i += 1) {
+      if (aTail[i] !== bTail[i]) {
+        return aTail[i] < bTail[i] ? -1 : 1;
+      }
+    }
+    if (aTail.length !== bTail.length) {
+      return aTail.length < bTail.length ? -1 : 1;
+    }
+    return 0;
+  }
+  if (a.scheme === 'numeric') {
+    if (a.strictSemver && b.strictSemver) {
+      return semver.sortVersions(a.base, b.base);
+    }
+    return loose.sortVersions(a.base, b.base);
+  }
+  // Opaque strings have no ordering.
+  return 0;
+}
+
+function compare(a: ParsedVersion, b: ParsedVersion): number {
+  const baseResult = compareBase(a, b);
+  if (baseResult !== 0) {
+    return baseResult;
+  }
+  return a.portVersion - b.portVersion;
+}
+
+function isValid(input: string): boolean {
+  return parse(input) !== null;
+}
+
+function isVersion(input: string | undefined | null): boolean {
+  const parsed = parse(input ?? '');
+  if (!parsed) {
+    return false;
+  }
+  return parsed.scheme !== 'string';
+}
+
+function isCompatible(version: string): boolean {
+  return isValid(version);
+}
+
+function isSingleVersion(version: string): boolean {
+  return isVersion(version);
+}
+
+function isStable(version: string): boolean {
+  const parsed = parse(version);
+  if (!parsed) {
+    return false;
+  }
+  if (parsed.scheme === 'numeric') {
+    // A pre-release suffix (`-...`) marks the version as unstable.
+    // Pure build metadata (`+...`) is ignored, matching SemVer.
+    const withoutBuild = parsed.base.replace(numericBuildRegex, '');
+    return !numericPrereleaseRegex.test(withoutBuild);
+  }
+  // Date and opaque-string versions have no prerelease concept, treat as stable.
+  return true;
+}
+
+function coerceNumeric(base: string, strictSemver: boolean): SemVer | null {
+  if (strictSemver) {
+    return coerce(base);
+  }
+  // Strip any pre-release or build suffix before coercion so loose forms like
+  // `1.2-alpha` map to `1.2.0` instead of failing.
+  const stripped = base
+    .replace(numericBuildRegex, '')
+    .replace(numericPrereleaseRegex, '');
+  return coerce(stripped);
+}
+
+function getMajor(version: string | SemVer): number | null {
+  const input = typeof version === 'string' ? version : version.version;
+  const parsed = parse(input);
+  if (parsed?.scheme !== 'numeric') {
+    return null;
+  }
+  /* v8 ignore next -- coerce always succeeds for `numeric` bases */
+  return coerceNumeric(parsed.base, parsed.strictSemver)?.major ?? null;
+}
+
+function getMinor(version: string | SemVer): number | null {
+  const input = typeof version === 'string' ? version : version.version;
+  const parsed = parse(input);
+  if (parsed?.scheme !== 'numeric') {
+    return null;
+  }
+  /* v8 ignore next -- coerce always succeeds for `numeric` bases */
+  return coerceNumeric(parsed.base, parsed.strictSemver)?.minor ?? null;
+}
+
+function getPatch(version: string | SemVer): number | null {
+  const input = typeof version === 'string' ? version : version.version;
+  const parsed = parse(input);
+  if (parsed?.scheme !== 'numeric') {
+    return null;
+  }
+  /* v8 ignore next -- coerce always succeeds for `numeric` bases */
+  return coerceNumeric(parsed.base, parsed.strictSemver)?.patch ?? null;
+}
+
+function equals(version: string, other: string): boolean {
+  const a = parse(version);
+  const b = parse(other);
+  if (!a || !b) {
+    return false;
+  }
+  if (a.scheme !== b.scheme) {
+    return false;
+  }
+  if (a.portVersion !== b.portVersion) {
+    return false;
+  }
+  if (a.scheme === 'numeric') {
+    if (a.strictSemver && b.strictSemver) {
+      return semver.equals(a.base, b.base);
+    }
+    return loose.equals(a.base, b.base);
+  }
+  // Both date and opaque-string compare by exact string equality on the base.
+  return a.base === b.base;
+}
+
+function isGreaterThan(version: string, other: string): boolean {
+  const a = parse(version);
+  const b = parse(other);
+  if (!a || !b) {
+    return false;
+  }
+  if (a.scheme !== b.scheme) {
+    return false;
+  }
+  // Opaque strings have no ordering beyond equality.
+  if (a.scheme === 'string') {
+    return false;
+  }
+  return compare(a, b) > 0;
+}
+
+function sortVersions(version: string, other: string): number {
+  const a = parse(version);
+  const b = parse(other);
+  if (!a || !b) {
+    return 0;
+  }
+  return compare(a, b);
+}
+
+function matches(version: string, range: string): boolean {
+  // vcpkg manifest dependencies use a `>=` lower-bound operator. For numeric
+  // and date schemes that is a real ordering; for opaque strings the base must
+  // match exactly because string ordering is undefined, but the port-version
+  // still provides a `>=` comparison once the base matches.
+  const v = parse(version);
+  const r = parse(range);
+  if (!v || !r) {
+    return false;
+  }
+  if (v.scheme !== r.scheme) {
+    return false;
+  }
+  if (v.scheme === 'string') {
+    return v.base === r.base && v.portVersion >= r.portVersion;
+  }
+  return compare(v, r) >= 0;
+}
+
+function getSatisfyingVersion(
+  versions: string[],
+  range: string,
+): string | null {
+  let bestStr: string | null = null;
+  let bestParsed: ParsedVersion | null = null;
+  for (const version of versions) {
+    if (!matches(version, range)) {
+      continue;
+    }
+    const parsed = parse(version);
+    /* v8 ignore next 3 -- parse succeeds for any matches-accepted input */
+    if (!parsed) {
+      continue;
+    }
+    if (!bestParsed || compare(parsed, bestParsed) > 0) {
+      bestParsed = parsed;
+      bestStr = version;
+    }
+  }
+  return bestStr;
+}
+
+function minSatisfyingVersion(
+  versions: string[],
+  range: string,
+): string | null {
+  let bestStr: string | null = null;
+  let bestParsed: ParsedVersion | null = null;
+  for (const version of versions) {
+    if (!matches(version, range)) {
+      continue;
+    }
+    const parsed = parse(version);
+    /* v8 ignore next 3 -- parse succeeds for any matches-accepted input */
+    if (!parsed) {
+      continue;
+    }
+    if (!bestParsed || compare(parsed, bestParsed) < 0) {
+      bestParsed = parsed;
+      bestStr = version;
+    }
+  }
+  return bestStr;
+}
+
+function getNewValue({ newVersion }: NewValueConfig): string {
+  return newVersion;
+}
+
+export const api: VersioningApi = {
+  equals,
+  getMajor,
+  getMinor,
+  getPatch,
+  isCompatible,
+  isGreaterThan,
+  isSingleVersion,
+  isStable,
+  isValid,
+  isVersion,
+  matches,
+  getSatisfyingVersion,
+  minSatisfyingVersion,
+  getNewValue,
+  sortVersions,
+};
+
+export default api;

--- a/lib/modules/versioning/vcpkg/index.ts
+++ b/lib/modules/versioning/vcpkg/index.ts
@@ -1,3 +1,5 @@
+import { isString } from '@sindresorhus/is';
+import { DateTime } from 'luxon';
 import type { SemVer } from 'semver';
 import { coerce } from 'semver';
 import { regEx } from '../../../util/regex.ts';
@@ -7,7 +9,9 @@ import type { NewValueConfig, VersioningApi } from '../types.ts';
 
 export const id = 'vcpkg';
 export const displayName = 'vcpkg';
-export const urls = ['https://learn.microsoft.com/vcpkg/users/versioning'];
+export const urls = [
+  '[vcpkg - Versioning](https://learn.microsoft.com/vcpkg/users/versioning)',
+];
 export const supportsRanges = false;
 
 type Scheme = 'date' | 'numeric' | 'string' | 'invalid';
@@ -49,18 +53,7 @@ function splitPortVersion(input: string): {
 }
 
 function isValidDateHead(head: string): boolean {
-  // Caller guarantees `head` matches the YYYY-MM-DD prefix, so the split
-  // always yields three numeric parts.
-  const [yearStr, monthStr, dayStr] = head.split('-');
-  const year = Number.parseInt(yearStr, 10);
-  const month = Number.parseInt(monthStr, 10);
-  const day = Number.parseInt(dayStr, 10);
-  if (month < 1 || month > 12 || day < 1) {
-    return false;
-  }
-  // Manually validate day-of-month against actual month length.
-  const daysInMonth = new Date(Date.UTC(year, month, 0)).getUTCDate();
-  return day <= daysInMonth;
+  return DateTime.fromISO(head, { zone: 'utc' }).isValid;
 }
 
 function matchDate(base: string): { head: string; tail: number[] } | null {
@@ -91,7 +84,7 @@ function detectScheme(base: string): Scheme {
 }
 
 function parse(input: string | undefined | null): ParsedVersion | null {
-  if (typeof input !== 'string') {
+  if (!isString(input)) {
     return null;
   }
   const trimmed = input.trim();
@@ -111,11 +104,8 @@ function parse(input: string | undefined | null): ParsedVersion | null {
     strictSemverRegex.test(base) &&
     semver.isValid(base);
   if (scheme === 'date') {
-    const dateParts = matchDate(base);
-    /* v8 ignore next 3 -- detectScheme guarantees matchDate succeeds */
-    if (!dateParts) {
-      return null;
-    }
+    // detectScheme guarantees matchDate succeeds
+    const dateParts = matchDate(base)!;
     return {
       base,
       portVersion,
@@ -128,11 +118,9 @@ function parse(input: string | undefined | null): ParsedVersion | null {
   return { base, portVersion, scheme, strictSemver };
 }
 
-function compareBase(a: ParsedVersion, b: ParsedVersion): number {
+function compareBase(a: ParsedVersion, b: ParsedVersion): number | null {
   if (a.scheme !== b.scheme) {
-    // Cross-scheme bases are not orderable in vcpkg, callers fall back to
-    // port-version which is also of limited meaning across schemes.
-    return 0;
+    return null;
   }
   if (a.scheme === 'date') {
     // `parse` guarantees `dateHead` and `dateTail` are populated for the
@@ -164,12 +152,15 @@ function compareBase(a: ParsedVersion, b: ParsedVersion): number {
     }
     return loose.sortVersions(a.base, b.base);
   }
-  // Opaque strings have no ordering.
-  return 0;
+  // Opaque strings order only against an identical base.
+  return a.base === b.base ? 0 : null;
 }
 
-function compare(a: ParsedVersion, b: ParsedVersion): number {
+function compare(a: ParsedVersion, b: ParsedVersion): number | null {
   const baseResult = compareBase(a, b);
+  if (baseResult === null) {
+    return null;
+  }
   if (baseResult !== 0) {
     return baseResult;
   }
@@ -181,11 +172,7 @@ function isValid(input: string): boolean {
 }
 
 function isVersion(input: string | undefined | null): boolean {
-  const parsed = parse(input ?? '');
-  if (!parsed) {
-    return false;
-  }
-  return parsed.scheme !== 'string';
+  return parse(input) !== null;
 }
 
 function isCompatible(version: string): boolean {
@@ -223,56 +210,37 @@ function coerceNumeric(base: string, strictSemver: boolean): SemVer | null {
   return coerce(stripped);
 }
 
-function getMajor(version: string | SemVer): number | null {
-  const input = typeof version === 'string' ? version : version.version;
-  const parsed = parse(input);
+function getMajor(version: string): number | null {
+  const parsed = parse(version);
   if (parsed?.scheme !== 'numeric') {
     return null;
   }
-  /* v8 ignore next -- coerce always succeeds for `numeric` bases */
-  return coerceNumeric(parsed.base, parsed.strictSemver)?.major ?? null;
+  /* coerce always succeeds for `numeric` bases */
+  return coerceNumeric(parsed.base, parsed.strictSemver)!.major;
 }
 
-function getMinor(version: string | SemVer): number | null {
-  const input = typeof version === 'string' ? version : version.version;
-  const parsed = parse(input);
+function getMinor(version: string): number | null {
+  const parsed = parse(version);
   if (parsed?.scheme !== 'numeric') {
     return null;
   }
-  /* v8 ignore next -- coerce always succeeds for `numeric` bases */
-  return coerceNumeric(parsed.base, parsed.strictSemver)?.minor ?? null;
+  /* coerce always succeeds for `numeric` bases */
+  return coerceNumeric(parsed.base, parsed.strictSemver)!.minor;
 }
 
-function getPatch(version: string | SemVer): number | null {
-  const input = typeof version === 'string' ? version : version.version;
-  const parsed = parse(input);
+function getPatch(version: string): number | null {
+  const parsed = parse(version);
   if (parsed?.scheme !== 'numeric') {
     return null;
   }
-  /* v8 ignore next -- coerce always succeeds for `numeric` bases */
-  return coerceNumeric(parsed.base, parsed.strictSemver)?.patch ?? null;
+  /* coerce always succeeds for `numeric` bases */
+  return coerceNumeric(parsed.base, parsed.strictSemver)!.patch;
 }
 
 function equals(version: string, other: string): boolean {
   const a = parse(version);
   const b = parse(other);
-  if (!a || !b) {
-    return false;
-  }
-  if (a.scheme !== b.scheme) {
-    return false;
-  }
-  if (a.portVersion !== b.portVersion) {
-    return false;
-  }
-  if (a.scheme === 'numeric') {
-    if (a.strictSemver && b.strictSemver) {
-      return semver.equals(a.base, b.base);
-    }
-    return loose.equals(a.base, b.base);
-  }
-  // Both date and opaque-string compare by exact string equality on the base.
-  return a.base === b.base;
+  return !!a && !!b && compare(a, b) === 0;
 }
 
 function isGreaterThan(version: string, other: string): boolean {
@@ -281,14 +249,8 @@ function isGreaterThan(version: string, other: string): boolean {
   if (!a || !b) {
     return false;
   }
-  if (a.scheme !== b.scheme) {
-    return false;
-  }
-  // Opaque strings have no ordering beyond equality.
-  if (a.scheme === 'string') {
-    return false;
-  }
-  return compare(a, b) > 0;
+  const result = compare(a, b);
+  return result !== null && result > 0;
 }
 
 function sortVersions(version: string, other: string): number {
@@ -297,26 +259,18 @@ function sortVersions(version: string, other: string): number {
   if (!a || !b) {
     return 0;
   }
-  return compare(a, b);
+  return compare(a, b) ?? 0;
 }
 
 function matches(version: string, range: string): boolean {
-  // vcpkg manifest dependencies use a `>=` lower-bound operator. For numeric
-  // and date schemes that is a real ordering; for opaque strings the base must
-  // match exactly because string ordering is undefined, but the port-version
-  // still provides a `>=` comparison once the base matches.
+  // vcpkg has no range syntax; manifest dependencies are a `>=` lower bound.
   const v = parse(version);
   const r = parse(range);
   if (!v || !r) {
     return false;
   }
-  if (v.scheme !== r.scheme) {
-    return false;
-  }
-  if (v.scheme === 'string') {
-    return v.base === r.base && v.portVersion >= r.portVersion;
-  }
-  return compare(v, r) >= 0;
+  const result = compare(v, r);
+  return result !== null && result >= 0;
 }
 
 function getSatisfyingVersion(
@@ -329,12 +283,9 @@ function getSatisfyingVersion(
     if (!matches(version, range)) {
       continue;
     }
-    const parsed = parse(version);
-    /* v8 ignore next 3 -- parse succeeds for any matches-accepted input */
-    if (!parsed) {
-      continue;
-    }
-    if (!bestParsed || compare(parsed, bestParsed) > 0) {
+    // parse succeeds for any matches-accepted input
+    const parsed = parse(version)!;
+    if (!bestParsed || compare(parsed, bestParsed)! > 0) {
       bestParsed = parsed;
       bestStr = version;
     }
@@ -352,12 +303,9 @@ function minSatisfyingVersion(
     if (!matches(version, range)) {
       continue;
     }
-    const parsed = parse(version);
-    /* v8 ignore next 3 -- parse succeeds for any matches-accepted input */
-    if (!parsed) {
-      continue;
-    }
-    if (!bestParsed || compare(parsed, bestParsed) < 0) {
+    // parse succeeds for any matches-accepted input
+    const parsed = parse(version)!;
+    if (!bestParsed || compare(parsed, bestParsed)! < 0) {
       bestParsed = parsed;
       bestStr = version;
     }

--- a/lib/modules/versioning/vcpkg/readme.md
+++ b/lib/modules/versioning/vcpkg/readme.md
@@ -1,0 +1,16 @@
+Renovate vcpkg versioning targets the per-port version schemes used by the [vcpkg package manager](https://learn.microsoft.com/vcpkg/users/versioning).
+
+A vcpkg port declares one of four version fields, and Renovate dispatches the comparison logic according to which field is in use:
+
+- `version` is a relaxed dotted-number scheme that allows extra components, like `3.1.4` or `1.2.3.4`
+- `version-semver` is strict [Semantic Versioning](https://semver.org), like `3.1.4-rc.1`
+- `version-date` is an ISO calendar date in `YYYY-MM-DD` form, optionally followed by dot-separated disambiguation identifiers like `2024-01-15.1.2`
+- `version-string` is opaque text without a defined ordering, like `bla-bla-2024-08-fixed-typo`
+
+Renovate detects which scheme applies by inspecting the input, then delegates to the matching underlying versioning module (`semver`, `loose`, or a direct date comparison).
+
+A vcpkg port can also carry a `port-version` integer for changes that affect packaging without changing the upstream source.
+The canonical text form combines the base version and port-version with a `#` separator, like `1.2.3#1`, and the port-version is omitted when zero.
+Renovate treats the port-version as a tie-breaker after the base versions compare equal, so `1.2.3#1` is greater than `1.2.3#0`, while `1.2.4` is still greater than `1.2.3#1` because the base version wins.
+
+Vcpkg has no range expression syntax. Manifest `dependencies` carry a single `version>=` lower bound, and `overrides` carry an exact pin. Renovate treats `matches` as a `>=` comparison for the numeric and date schemes, so any candidate version at or above the constraint satisfies. Opaque strings have no ordering on the base, so only versions with the same base satisfy, with port-version still providing the `>=` comparison once the base matches.

--- a/lib/modules/versioning/vcpkg/readme.md
+++ b/lib/modules/versioning/vcpkg/readme.md
@@ -13,4 +13,7 @@ A vcpkg port can also carry a `port-version` integer for changes that affect pac
 The canonical text form combines the base version and port-version with a `#` separator, like `1.2.3#1`, and the port-version is omitted when zero.
 Renovate treats the port-version as a tie-breaker after the base versions compare equal, so `1.2.3#1` is greater than `1.2.3#0`, while `1.2.4` is still greater than `1.2.3#1` because the base version wins.
 
-Vcpkg has no range expression syntax. Manifest `dependencies` carry a single `version>=` lower bound, and `overrides` carry an exact pin. Renovate treats `matches` as a `>=` comparison for the numeric and date schemes, so any candidate version at or above the constraint satisfies. Opaque strings have no ordering on the base, so only versions with the same base satisfy, with port-version still providing the `>=` comparison once the base matches.
+Vcpkg has no range expression syntax.
+Manifest `dependencies` carry a single `version>=` lower bound, and `overrides` carry an exact pin.
+Renovate treats `matches` as a `>=` comparison for the numeric and date schemes, so any candidate version at or above the constraint satisfies.
+Opaque strings have no ordering on the base, so only versions with the same base satisfy, with port-version still providing the `>=` comparison once the base matches.


### PR DESCRIPTION
## Changes

Add a `vcpkg` versioning module for [vcpkg](https://learn.microsoft.com/vcpkg/) per-port version schemes. The vcpkg registry per-port JSON declares one of four schemes:

- `version` is a relaxed dotted-number form like `3.1.4` or `1.2.3.4`, with an optional prerelease tail.
- `version-semver` is strict [Semantic Versioning](https://semver.org).
- `version-date` is an ISO calendar date in `YYYY-MM-DD` form, optionally followed by dot-separated disambiguation identifiers like `2024-01-15.1.2`.
- `version-string` is opaque text without a defined ordering.

Each entry can also carry a `port-version` integer for packaging-only changes, written as `<base>#<port-version>` and omitted when zero. The port-version acts as a tie-breaker after the base versions compare equal, so `1.2.3#1` is greater than `1.2.3#0`, while `1.2.4` is still greater than `1.2.3#1` because the base version wins.

The module detects the scheme heuristically from the input, validates dates against the calendar, and delegates ordered numeric comparison to the existing `semver` or `loose` modules so the underlying schemes do not need to be reimplemented.

vcpkg has no range expression syntax. Manifest `dependencies` carry a single `version>=` lower bound, and `overrides` carry an exact pin. The `matches`, `getSatisfyingVersion`, and `minSatisfyingVersion` functions implement the `>=` constraint for numeric and date schemes. Opaque strings have no ordering on the base, so a constraint over an opaque string is satisfied only by versions with the same base, with port-version still providing a `>=` comparison once the base matches.

This is a building block for the planned `vcpkg` datasource and manager.

Reference: https://learn.microsoft.com/vcpkg/users/versioning

## Context

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

Related:

- #7135 (tracking issue for vcpkg support)
- #25217

## AI assistance disclosure

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

Added `lib/modules/versioning/vcpkg/readme.md`.

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/stemann/renovate-vcpkg-example

**Unit tests:** 131 table-driven cases covering each scheme, cross-scheme behavior, port-version interactions, date disambiguation tails, and the `>=` matches semantics. 100 % statements / lines / functions / branches.

**Real repository:** [`stemann/renovate-vcpkg-example@vcpkg-versioning`](https://github.com/stemann/renovate-vcpkg-example/tree/vcpkg-versioning) wires a `customManagers` regex on a `vcpkg.json` that pins `zlib` with `version>=: "1.2.13"`, with both `datasourceTemplate: vcpkg` and `versioningTemplate: vcpkg` set. The regex targets the companion `vcpkg` datasource ([#43494](https://github.com/renovatebot/renovate/pull/43494)) so the versioning module is exercised in its production context, with the `>=` matches semantics selecting the highest satisfying release. Running Renovate from a local branch combining this PR with #43494 produces:

    "managers": {"regex": {"fileCount": 1, "depCount": 1}}
    "depName": "zlib"
    "datasource": "vcpkg"
    "versioning": "vcpkg"
    "currentValue": "1.2.13"
    "newVersion": "1.3.2"
    "newValue": "1.3.2"
    "updateType": "minor"
    "registryUrl": "https://github.com/microsoft/vcpkg"

Reproducer:

    RENOVATE_TOKEN=<gh-pat> \
      RENOVATE_BASE_BRANCH_PATTERNS='["vcpkg-versioning"]' \
      RENOVATE_USE_BASE_BRANCH_CONFIG=merge \
      pnpm start \
        --platform=github \
        --dry-run=lookup \
        --autodiscover=false \
        stemann/renovate-vcpkg-example
