### PR TITLE
fix(datasource/rust-version): skip blank lines in manifests.txt

### DIFF
--- a/lib/modules/datasource/rust-version/index.spec.ts
+++ b/lib/modules/datasource/rust-version/index.spec.ts
@@ -1,4 +1,5 @@
 import * as httpMock from '~test/http-mock.ts';
+import { logger } from '~test/util.ts';
 import { getPkgReleases } from '../index.ts';
 import { RustVersionDatasource } from './index.ts';
 
@@ -86,6 +87,32 @@ static.rust-lang.org/dist/2024-10-17/channel-rust-1.82.0.toml`;
           releaseTimestamp: '2024-10-17T00:00:00.000Z',
         },
       ]);
+    });
+
+    it('ignores blank lines silently (no spurious warning)', async () => {
+      // `manifests.txt` ends with a trailing newline upstream, so the
+      // body's `split('\n')` always yields an empty final element. Also
+      // exercise a whitespace-only line in case upstream introduces one.
+      const manifestsContent =
+        'static.rust-lang.org/dist/2024-10-17/channel-rust-1.82.0.toml\n\n   \n';
+
+      httpMock
+        .scope('https://static.rust-lang.org')
+        .get('/manifests.txt')
+        .reply(200, manifestsContent);
+
+      const res = await getPkgReleases({
+        datasource,
+        packageName: 'rust',
+      });
+
+      expect(res?.releases).toEqual([
+        {
+          version: '1.82.0',
+          releaseTimestamp: '2024-10-17T00:00:00.000Z',
+        },
+      ]);
+      expect(logger.logger.warn).not.toHaveBeenCalled();
     });
 
     it('throws for network error', async () => {

--- a/lib/modules/datasource/rust-version/index.ts
+++ b/lib/modules/datasource/rust-version/index.ts
@@ -34,7 +34,6 @@ export class RustVersionDatasource extends Datasource {
     const parsedResults = [];
     for (const line of lines) {
       // skip trailing empty element from .split('\n') upstream
-
       if (!line.trim()) {
         continue;
       }

--- a/lib/modules/datasource/rust-version/index.ts
+++ b/lib/modules/datasource/rust-version/index.ts
@@ -33,6 +33,13 @@ export class RustVersionDatasource extends Datasource {
 
     const parsedResults = [];
     for (const line of lines) {
+      // Skip blank/whitespace-only lines silently. `manifests.txt` ends
+      // with a trailing newline, so `split('\n')` always yields an empty
+      // final element — warning on it produces a spurious "Repository
+      // Problems" entry on every Dependency Dashboard.
+      if (!line.trim()) {
+        continue;
+      }
       const parsed = parseManifestUrl(line);
       if (parsed) {
         parsedResults.push(parsed);

--- a/lib/modules/datasource/rust-version/index.ts
+++ b/lib/modules/datasource/rust-version/index.ts
@@ -33,10 +33,8 @@ export class RustVersionDatasource extends Datasource {
 
     const parsedResults = [];
     for (const line of lines) {
-      // Skip blank/whitespace-only lines silently. `manifests.txt` ends
-      // with a trailing newline, so `split('\n')` always yields an empty
-      // final element — warning on it produces a spurious "Repository
-      // Problems" entry on every Dependency Dashboard.
+      // skip trailing empty element from .split('\n') upstream
+
       if (!line.trim()) {
         continue;
       }


### PR DESCRIPTION
## Summary

Skip blank / whitespace-only lines in `manifests.txt` silently. Stops a spurious `WARN: Failed to parse manifest URL` with `line: ""` that surfaces on the Dependency Dashboard as a `Repository Problems` entry on every run for any repo with a `rust-version`-tracked dep (e.g. `rust-toolchain.toml`).

Discussion: **#43500**.

## Root cause

`response.body.split('\n')` always yields an empty final element because `https://static.rust-lang.org/manifests.txt` ends with a trailing `\n`. `parseManifestUrl("")` returns `null` → the warning fires once per run.

`curl`'ing the file confirms there are no blank lines mid-body — only the trailing newline.

## Change

`lib/modules/datasource/rust-version/index.ts`:

```diff
   for (const line of lines) {
+    if (!line.trim()) {
+      continue;
+    }
     const parsed = parseManifestUrl(line);
     ...
```

New unit test `ignores blank lines silently (no spurious warning)` exercises both an empty line and a whitespace-only line, and asserts `logger.warn` was not called. The existing `ignores unexpected URLs` test continues to assert that warning still fires on genuinely malformed non-empty input.

## Test plan

- `pnpm vitest --run lib/modules/datasource/rust-version` — all 18 tests pass (13 in `parse.spec.ts`, 5 in `index.spec.ts` including the new case).
- `pnpm check lib/modules/datasource/rust-version` — prettier ✓, biome ✓, oxlint ✓, test ✓.

## Discovered while

Migrating a private monorepo from Mend-hosted Renovate to self-hosted via `renovatebot/github-action`. The `Repository Problems` entry on the Dependency Dashboard pointed straight at this.

## AI assistance disclosure

This PR was written primarily by **Claude Code**, supervised end-to-end by the author. Specifically: root-cause analysis, code change, and the new test were drafted by Claude Code; I reviewed the diff, ran `pnpm check` locally, and verified the upstream `manifests.txt` ends with `\n` (and contains no blank lines mid-body) before pushing.

Marking as **draft** until I sign the [Renovate CLA](https://cla-assistant.io/renovateapp/renovate) and confirm the maintainers prefer a PR-first approach to this small fix vs. discussion-first round-trip.