### PR TITLE
fix(manager/npm): use multi-doc parsing to get pnpm lockfile

### DIFF
--- a/lib/modules/manager/npm/extract/pnpm.spec.ts
+++ b/lib/modules/manager/npm/extract/pnpm.spec.ts
@@ -343,6 +343,60 @@ describe('modules/manager/npm/extract/pnpm', () => {
       const res = await getPnpmLock('package.json');
       expect(res.lockedVersionsWithPath).toBeUndefined();
     });
+
+    it('extracts version from multi-document lockfile (configDependencies)', async () => {
+      const lockfileContent = codeBlock`
+        ---
+        lockfileVersion: '9.0'
+
+        importers:
+
+          .:
+            configDependencies:
+              '@scope/pnpm-plugin-defaults':
+                specifier: 0.1.0
+                version: 0.1.0
+
+        packages:
+
+          '@scope/pnpm-plugin-defaults@0.1.0':
+            resolution: {integrity: sha512-aaa==}
+
+        snapshots:
+
+          '@scope/pnpm-plugin-defaults@0.1.0': {}
+
+        ---
+        lockfileVersion: '9.0'
+
+        settings:
+          autoInstallPeers: true
+          excludeLinksFromLockfile: false
+
+        importers:
+
+          .:
+            dependencies:
+              lodash:
+                specifier: ^4.17.20
+                version: 4.18.1
+
+        packages:
+
+          lodash@4.18.1:
+            resolution: {integrity: sha512-bbb==}
+
+        snapshots:
+
+          lodash@4.18.1: {}
+      `;
+      fs.readLocalFile.mockResolvedValueOnce(lockfileContent);
+      const res = await getPnpmLock('package.json');
+      expect(Object.keys(res.lockedVersionsWithPath!)).toHaveLength(1);
+      expect(res.lockedVersionsWithPath!['.'].dependencies.lodash).toBe(
+        '4.18.1',
+      );
+    });
   });
 
   describe('.extractPnpmWorkspaceFile()', () => {

--- a/lib/modules/manager/npm/extract/pnpm.ts
+++ b/lib/modules/manager/npm/extract/pnpm.ts
@@ -16,7 +16,7 @@ import {
   localPathExists,
   readLocalFile,
 } from '../../../../util/fs/index.ts';
-import { parseSingleYaml } from '../../../../util/yaml.ts';
+import { parseSingleYaml, parseYaml } from '../../../../util/yaml.ts';
 import type { PackageFile, PackageFileContent } from '../../types.ts';
 import { pnpmWorkspaceOverrides } from '../dep-types.ts';
 import type { PnpmDependency, PnpmLockFile } from '../post-update/types.ts';
@@ -160,7 +160,13 @@ export async function getPnpmLock(filePath: string): Promise<LockFile> {
       throw new Error('Unable to read pnpm-lock.yaml');
     }
 
-    const lockParsed = parseSingleYaml(pnpmLockRaw);
+    // pnpm writes a multi-document YAML lockfile when `pnpm-workspace.yaml`
+    // declares `configDependencies`; the env document (config-deps + integrity
+    // metadata) is unconditionally prepended before the main lockfile, so the
+    // main lockfile is always the last document.
+    // https://pnpm.io/config-dependencies.
+    const parsedDocs = parseYaml(pnpmLockRaw);
+    const lockParsed = parsedDocs[parsedDocs.length - 1];
     if (!isPnpmLockfile(lockParsed)) {
       throw new Error('Invalid or empty lockfile');
     }

--- a/lib/modules/manager/npm/extract/pnpm.ts
+++ b/lib/modules/manager/npm/extract/pnpm.ts
@@ -166,7 +166,7 @@ export async function getPnpmLock(filePath: string): Promise<LockFile> {
     // main lockfile is always the last document.
     // https://pnpm.io/config-dependencies.
     const parsedDocs = parseYaml(pnpmLockRaw);
-    const lockParsed = parsedDocs[parsedDocs.length - 1];
+    const lockParsed = parsedDocs.at(-1);
     if (!isPnpmLockfile(lockParsed)) {
       throw new Error('Invalid or empty lockfile');
     }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

- Use multi-doc parsing and pick the last document as the lockfile

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #43502
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
